### PR TITLE
chore: switch to @solana/mosaic-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,5 @@ infra/kora/.env
 # Test coverage
 coverage/
 
-# External dependencies (local only)
-external/mosaic/
-
 # Misc
 *.tsbuildinfo

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -34,7 +34,7 @@
     "@solana/keychain-fireblocks": "0.2.1",
     "@solana/kit": "catalog:",
     "@solana/kora": "0.1.2",
-    "@solana/mosaic-sdk": "0.1.0",
+    "@solana/mosaic-sdk": "catalog:",
     "@solana/signers": "catalog:",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.7.0",

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -23,7 +23,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@mosaic/sdk": "link:../../external/mosaic/packages/sdk",
     "@react-email/components": "1.0.6",
     "@react-email/render": "2.0.4",
     "@sdp/types": "workspace:*",
@@ -35,6 +34,7 @@
     "@solana/keychain-fireblocks": "0.2.1",
     "@solana/kit": "catalog:",
     "@solana/kora": "0.1.2",
+    "@solana/mosaic-sdk": "0.1.0",
     "@solana/signers": "catalog:",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.7.0",

--- a/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
@@ -8,7 +8,7 @@ import { createRpc, simulateTransaction } from "@/services/solana/rpc";
 import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
 import type { TokenResponse } from "@sdp/types";
-import { TOKEN_ACL_PROGRAM_ID } from "@mosaic/sdk";
+import { TOKEN_ACL_PROGRAM_ID } from "@solana/mosaic-sdk";
 import type { Address } from "@solana/kit";
 import type { Context } from "hono";
 

--- a/apps/sdp-api/src/routes/issuance/handlers/pause.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/pause.ts
@@ -7,7 +7,7 @@ import { createMosaicService } from "@/services/mosaic";
 import { createOrgSigner } from "@/services/solana";
 import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { MINT_ALREADY_PAUSED_ERROR, MINT_NOT_PAUSED_ERROR } from "@mosaic/sdk";
+import { MINT_ALREADY_PAUSED_ERROR, MINT_NOT_PAUSED_ERROR } from "@solana/mosaic-sdk";
 import type { Context } from "hono";
 import { pauseTokenSchema } from "../schemas";
 

--- a/apps/sdp-api/src/services/mosaic/service.ts
+++ b/apps/sdp-api/src/services/mosaic/service.ts
@@ -1,7 +1,7 @@
 /**
  * Mosaic Service
  *
- * Template-based token issuance using @mosaic/sdk.
+ * Template-based token issuance using @solana/mosaic-sdk.
  * Replaces manual Token-2022 transaction building with Mosaic's
  * pre-configured templates and ABL integration.
  *
@@ -40,7 +40,7 @@ import {
   getThawTransaction,
   getRemoveAuthorityTransaction,
   getUpdateAuthorityTransaction,
-} from "@mosaic/sdk";
+} from "@solana/mosaic-sdk";
 import {
   type Address,
   type Rpc,

--- a/apps/sdp-api/src/services/solana/token-2022.ts
+++ b/apps/sdp-api/src/services/solana/token-2022.ts
@@ -9,7 +9,7 @@ import { parseDecimalAmount } from "@/lib/amount";
 import type { FeePaymentPort } from "@/services/ports";
 import type { Env } from "@/types/env";
 import type { TokenExtensionsConfig } from "@sdp/types";
-import type { FullTransaction } from "@mosaic/sdk";
+import type { FullTransaction } from "@solana/mosaic-sdk";
 import {
   createCustomTokenInitTransaction,
   createBurnTransaction,
@@ -17,7 +17,7 @@ import {
   getFreezeTransaction,
   getThawTransaction,
   resolveTokenAccount,
-} from "@mosaic/sdk";
+} from "@solana/mosaic-sdk";
 import {
   type Address,
   type Rpc,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
 
   apps/sdp-api:
     dependencies:
-      '@mosaic/sdk':
-        specifier: link:../../external/mosaic/packages/sdk
-        version: link:../../external/mosaic/packages/sdk
       '@react-email/components':
         specifier: 1.0.6
         version: 1.0.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -78,6 +75,9 @@ importers:
       '@solana/kora':
         specifier: 0.1.2
         version: 0.1.2(@solana-program/token@0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)))(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
+      '@solana/mosaic-sdk':
+        specifier: 0.1.0
+        version: 0.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
       '@solana/signers':
         specifier: 'catalog:'
         version: 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -1374,6 +1374,11 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@solana-program/memo@0.10.0':
+    resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
+    peerDependencies:
+      '@solana/kit': 5.0.0
+
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
     peerDependencies:
@@ -1609,6 +1614,11 @@ packages:
       '@solana-program/token': ^0.9.0
       '@solana/kit': 5.0.0
 
+  '@solana/mosaic-sdk@0.1.0':
+    resolution: {integrity: sha512-vH6ATgvboOHKzGAlOVXhZjfMI5htPjaO1rSQVCFqcc9ng216/nsAjWl2A5NwdyeVc82vLmLBzj/Y7zgYqW/G7A==}
+    peerDependencies:
+      typescript: ^5.0.0
+
   '@solana/nominal-types@5.0.0':
     resolution: {integrity: sha512-Qn7xH4UG2rDAv+wAyheP4jWvX3oQmbZ/woxFZwug7PaRLvyjUswGr38Hil+SjiQyFDo+un1UqWM9N9yusUeeZQ==}
     engines: {node: '>=20.18.0'}
@@ -1816,6 +1826,12 @@ packages:
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
+
+  '@token-acl/abl-sdk@0.2.0':
+    resolution: {integrity: sha512-uMBtNkBhRq4mXRQaIN90bluuQoBPfL3NDTYCqiQ8NBqyLShVehLqohqFxG2BUU8zUWwBxrFqBGNn8gElbLIUmg==}
+
+  '@token-acl/sdk@0.2.7':
+    resolution: {integrity: sha512-vNl4Ed9Y7Uw1jdyT+Nyb900E5/CTdwsechJ8a70PRyc5icDoIdVeOH3yqzx3iV6Y6r1QoHCwZgL48YsrzVi2sA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3395,6 +3411,10 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@solana-program/memo@0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))':
+    dependencies:
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+
   '@solana-program/system@0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))':
     dependencies:
       '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
@@ -3685,6 +3705,20 @@ snapshots:
     dependencies:
       '@solana-program/token': 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
       '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+
+  '@solana/mosaic-sdk@0.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+    dependencies:
+      '@solana-program/memo': 0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
+      '@solana-program/system': 0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))(@solana/sysvars@5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@solana/sysvars': 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@token-acl/abl-sdk': 0.2.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      '@token-acl/sdk': 0.2.7(@solana/sysvars@5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
 
   '@solana/nominal-types@5.0.0(typescript@5.9.3)':
     dependencies:
@@ -4024,6 +4058,24 @@ snapshots:
       - fastestsmallesttextencoderdecoder
 
   '@speed-highlight/core@1.2.14': {}
+
+  '@token-acl/abl-sdk@0.2.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+    dependencies:
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - ws
+
+  '@token-acl/sdk@0.2.7(@solana/sysvars@5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+    dependencies:
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))(@solana/sysvars@5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - ws
 
   '@types/chai@5.2.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  # Aligned with @mosaic/sdk v0.1.0 (uses @solana/kit ^5.0.0)
+  # Aligned with @solana/mosaic-sdk v0.1.0 (uses @solana/kit ^5.0.0)
   '@solana-program/system': ^0.10.0
   '@solana-program/token-2022': ^0.6.1
   '@solana/addresses': ^5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalog:
   '@solana/instructions': ^5.0.0
   '@solana/keys': ^5.0.0
   '@solana/kit': ^5.0.0
+  '@solana/mosaic-sdk': 0.1.0
   '@solana/programs': ^5.0.0
   '@solana/rpc': ^5.0.0
   '@solana/signers': ^5.0.0


### PR DESCRIPTION
## Summary
- switch @sdp/api to @solana/mosaic-sdk from local link
- use pnpm catalog entry for @solana/mosaic-sdk
- update Mosaic SDK imports to new package name
- remove external/mosaic ignore entry
- replace Kora README with a devnet deployment-focused runbook

## Notes
- Cloud Run service manifests are optional; the runbook uses `gcloud run deploy` and mounts `kora.toml`/`signers.toml` plus RPC and signer key secrets via Secret Manager.
