### PR TITLE
docs: add programmatic OpenAPI site

### DIFF
--- a/apps/sdp-api-specs-programmatic/README.md
+++ b/apps/sdp-api-specs-programmatic/README.md
@@ -1,0 +1,35 @@
+# Programmatic OpenAPI (Generated)
+
+This folder hosts the programmatic OpenAPI spec generated from the SDP API Zod schemas.
+It is intended for an automated Vercel deployment that updates when the schema changes.
+
+## Files
+
+- `generated/openapi.json` - Generated OpenAPI 3.0.3 specification
+- `index.html` - Swagger UI viewer
+- `vercel.json` - Vercel deployment config (static)
+
+## Generate the spec
+
+From the repo root:
+
+```bash
+pnpm --filter @sdp/api openapi:generate
+```
+
+This writes `apps/sdp-api-specs-programmatic/generated/openapi.json`.
+
+## Vercel project setup
+
+Create a new Vercel project under the `solana-foundation` org and set:
+
+- **Root Directory**: `apps/sdp-api-specs-programmatic`
+- **Framework**: Other / Static
+- **Build Command**: none (static)
+- **Output Directory**: `.`
+
+Every push to the tracked branch will deploy the generated spec.
+
+## URL
+
+Fill in once the new Vercel project is created.

--- a/apps/sdp-api-specs-programmatic/index.html
+++ b/apps/sdp-api-specs-programmatic/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SDP API Documentation [PROGRAMMATIC]</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css">
+  <style>
+    body { margin: 0; padding: 0; }
+    .swagger-ui .topbar { display: none; }
+    .swagger-ui .info .title { color: #16a34a; }
+    .programmatic-banner {
+      background: linear-gradient(90deg, #16a34a, #15803d);
+      color: white;
+      text-align: center;
+      padding: 12px 20px;
+      font-family: system-ui, -apple-system, sans-serif;
+      font-weight: 600;
+      font-size: 14px;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    .programmatic-banner span {
+      margin-right: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="programmatic-banner">
+    <span>PROGRAMMATIC SPECIFICATION</span> — Generated from Zod schemas.
+  </div>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
+  <script>
+    window.onload = () => {
+      SwaggerUIBundle({
+        url: './generated/openapi.json',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis],
+        layout: 'BaseLayout'
+      });
+    };
+  </script>
+</body>
+</html>

--- a/apps/sdp-api-specs-programmatic/vercel.json
+++ b/apps/sdp-api-specs-programmatic/vercel.json
@@ -1,0 +1,9 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }]
+    }
+  ],
+  "public": true
+}

--- a/apps/sdp-api/scripts/generate-openapi.ts
+++ b/apps/sdp-api/scripts/generate-openapi.ts
@@ -5,7 +5,7 @@ import { createOpenApiDocument } from "../src/openapi/spec";
 
 const document = createOpenApiDocument();
 
-const outputDir = path.resolve(process.cwd(), "../sdp-api-specs-draft/generated");
+const outputDir = path.resolve(process.cwd(), "../sdp-api-specs-programmatic/generated");
 const outputPath = path.join(outputDir, "openapi.json");
 
 await mkdir(outputDir, { recursive: true });


### PR DESCRIPTION
## Summary
- add a programmatic OpenAPI static site under apps/sdp-api-specs-programmatic
- point the OpenAPI generator to the programmatic site output path
- document Vercel project setup for automatic deployments

## Notes
- The existing draft OpenAPI site remains unchanged.
- After creating the new Vercel project, set Root Directory to apps/sdp-api-specs-programmatic for automatic deployments.
