### PR TITLE
feat(api): add Clerk webhook alias /webhooks/clerk/link-orgs

### DIFF
--- a/apps/sdp-api/src/routes/webhooks/index.ts
+++ b/apps/sdp-api/src/routes/webhooks/index.ts
@@ -9,5 +9,7 @@ import { handleClerkWebhook } from "./handlers";
 const webhooks = new Hono<{ Bindings: Env }>();
 
 webhooks.post("/clerk", handleClerkWebhook);
+// Alias for clearer intent (org linking). Keep `/clerk` for backwards compatibility.
+webhooks.post("/clerk/link-orgs", handleClerkWebhook);
 
 export default webhooks;


### PR DESCRIPTION
## Summary
- add `/webhooks/clerk/link-orgs` as an alias to the existing Clerk webhook handler
- keep `/webhooks/clerk` for backwards compatibility

## Testing
- `pnpm exec biome check --changed --since=origin/main --no-errors-on-unmatched`
- `pnpm --filter ./apps/sdp-api typecheck`
- `pnpm test`
- `pnpm --filter ./apps/sdp-api build`