### PR TITLE
chore(api): drop legacy /webhooks/clerk endpoint

### DIFF
--- a/apps/sdp-api/src/routes/webhooks/index.ts
+++ b/apps/sdp-api/src/routes/webhooks/index.ts
@@ -8,8 +8,6 @@ import { handleClerkWebhook } from "./handlers";
 
 const webhooks = new Hono<{ Bindings: Env }>();
 
-webhooks.post("/clerk", handleClerkWebhook);
-// Alias for clearer intent (org linking). Keep `/clerk` for backwards compatibility.
 webhooks.post("/clerk/link-orgs", handleClerkWebhook);
 
 export default webhooks;


### PR DESCRIPTION
## Summary
- remove the legacy `/webhooks/clerk` webhook endpoint
- keep only `/webhooks/clerk/link-orgs` (not in prod yet)

## Testing
- `pnpm exec biome check --changed --since=origin/main --no-errors-on-unmatched`
- `pnpm --filter ./apps/sdp-api typecheck`
- `pnpm test`
- `pnpm --filter ./apps/sdp-api build`