### PR TITLE
chore(turbo): expose Clerk/SDP env vars to Vercel builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ coverage/
 
 # Misc
 *.tsbuildinfo
+.vercel

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env", ".env.*"],
+  "globalEnv": [
+    "CLERK_JWT_TEMPLATE",
+    "CLERK_SECRET_KEY",
+    "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    "NEXT_PUBLIC_API_BASE_URL",
+    "NEXT_PUBLIC_SDP_API_BASE_URL",
+    "SDP_API_BASE_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Declare `CLERK_SECRET_KEY`, `CLERK_JWT_TEMPLATE`, and `SDP_API_BASE_URL` (plus related public vars) in `turbo.json` `globalEnv` so Vercel Turbo builds pass them through.
- Ignore local `.vercel` link metadata at repo root.

## Why
Vercel build logs for `sdp-web` warn that these env vars are set on the project but missing from `turbo.json`, which can result in the app not receiving them.

## Testing
- Not run locally (Biome currently picks up local build artifacts); relying on CI.
