### PR TITLE
test(integration): fail-fast devnet/Kora + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,44 @@ jobs:
 
       - name: Build API (Wrangler dry-run)
         run: pnpm --filter ./apps/sdp-api build
+
+  integration_tests:
+    name: Integration Tests (Devnet/Kora)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Devnet configuration (override as needed via repository/organization secrets)
+      SOLANA_NETWORK: devnet
+      SOLANA_RPC_URL: ${{ secrets.SOLANA_RPC_URL || 'https://api.devnet.solana.com' }}
+
+      # Kora configuration (override as needed)
+      KORA_RPC_URL: ${{ secrets.KORA_RPC_URL || 'https://kora-devnet-315956366746.us-central1.run.app' }}
+      KORA_API_KEY: ${{ secrets.KORA_API_KEY }}
+
+      # Required: a signing key for the custody wallet (Base58-encoded 64-byte keypair)
+      CUSTODY_PRIVATE_KEY: ${{ secrets.CUSTODY_PRIVATE_KEY }}
+
+      # Optional: tighten/loosen the fail-fast sponsor-funds check (lamports)
+      KORA_MIN_BALANCE_LAMPORTS: ${{ secrets.KORA_MIN_BALANCE_LAMPORTS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Integration tests
+        run: pnpm test:integration

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Integration tests require:
   - Example: `https://api.devnet.solana.com`
 - `CUSTODY_PRIVATE_KEY`
   - Base58-encoded **64-byte** Solana keypair (same format as `solana-keygen` keypair JSON, but base58-encoded).
+- `KORA_RPC_URL`
+  - Example: `https://kora-devnet-315956366746.us-central1.run.app`
 
 Optional (recommended):
 
-- `KORA_RPC_URL`
-  - If set, Kora sponsors transaction fees (so your custody wallet does not need devnet SOL).
 - `KORA_API_KEY`
   - Only required if your Kora endpoint needs it.
 - `KORA_MIN_BALANCE_LAMPORTS`
@@ -67,7 +67,6 @@ From the repo root:
 export SOLANA_RPC_URL="https://api.devnet.solana.com"
 export CUSTODY_PRIVATE_KEY="..."
 
-# Optional (recommended): sponsor fees via Kora
 export KORA_RPC_URL="https://kora-devnet-315956366746.us-central1.run.app"
 # export KORA_API_KEY="..."
 
@@ -77,4 +76,7 @@ pnpm test:integration
 Notes:
 
 - The suite includes Kora tests. Kora connectivity/funding is validated up-front (fail-fast).
+- Even with Kora fee sponsorship, the custody authority account must exist on-chain (some downstream SDKs require this).
+  - The test preflight will attempt a small `requestAirdrop` on devnet if the custody account does not exist.
+  - If your `SOLANA_RPC_URL` provider disables airdrops, you must fund the custody public key once (any amount) and rerun.
 - If you want to run only the Kora smoke test: `pnpm kora:devnet:test`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Solana Developer Platform
+
+## Integration Tests (Devnet)
+
+The integration test suite runs against Solana **devnet** and signs real transactions using the **local custody** provider.
+
+### Prereqs
+
+- Node `>=20`
+- `pnpm` (repo pins `pnpm@10.15.1`)
+- Solana CLI (for generating a devnet keypair): `solana-keygen`
+
+### Required Environment Variables
+
+Integration tests require:
+
+- `SOLANA_RPC_URL`
+  - Example: `https://api.devnet.solana.com`
+- `CUSTODY_PRIVATE_KEY`
+  - Base58-encoded **64-byte** Solana keypair (same format as `solana-keygen` keypair JSON, but base58-encoded).
+
+Optional (recommended):
+
+- `KORA_RPC_URL`
+  - If set, Kora sponsors transaction fees (so your custody wallet does not need devnet SOL).
+- `KORA_API_KEY`
+  - Only required if your Kora endpoint needs it.
+- `KORA_MIN_BALANCE_LAMPORTS`
+  - Optional preflight threshold for the Kora fee payer balance.
+
+### Generate a Local Custody Key
+
+1. Create a new Solana keypair JSON:
+
+```bash
+solana-keygen new --no-bip39-passphrase --force -o /tmp/sdp-devnet-custody.json
+```
+
+2. Convert it to `CUSTODY_PRIVATE_KEY` base58 (64 bytes):
+
+```bash
+pnpm -C apps/sdp-api exec node --input-type=module - <<'NODE'
+import fs from "node:fs";
+import { getBase58Codec } from "@solana/codecs";
+
+const base58 = getBase58Codec();
+const bytes = Uint8Array.from(JSON.parse(fs.readFileSync("/tmp/sdp-devnet-custody.json", "utf8")));
+const privateKeyBase58 = base58.decode(bytes);
+
+console.log("CUSTODY_PRIVATE_KEY=" + privateKeyBase58);
+NODE
+```
+
+3. Fund the key (only needed if you do not use Kora fee sponsorship):
+
+```bash
+PUBLIC_KEY="$(solana-keygen pubkey /tmp/sdp-devnet-custody.json)"
+solana config set --url devnet
+solana airdrop 2 "$PUBLIC_KEY"
+```
+
+### Run Integration Tests
+
+From the repo root:
+
+```bash
+export SOLANA_RPC_URL="https://api.devnet.solana.com"
+export CUSTODY_PRIVATE_KEY="..."
+
+# Optional (recommended): sponsor fees via Kora
+export KORA_RPC_URL="https://kora-devnet-315956366746.us-central1.run.app"
+# export KORA_API_KEY="..."
+
+pnpm test:integration
+```
+
+Notes:
+
+- The suite includes Kora tests. Kora connectivity/funding is validated up-front (fail-fast).
+- If you want to run only the Kora smoke test: `pnpm kora:devnet:test`.

--- a/packages/sdp-api-integration/src/helpers/integration.ts
+++ b/packages/sdp-api-integration/src/helpers/integration.ts
@@ -7,8 +7,8 @@ import {
 import { clearTestDatabase, seedTestDatabase } from "@sdp/api-test/mocks/d1";
 import app from "@sdp/api/index";
 import { hashString } from "@sdp/api/lib/hash";
-import { Token2022Service, createSigner } from "@sdp/api/services/solana";
 import { createMosaicService } from "@sdp/api/services/mosaic";
+import { Token2022Service, createSigner, createToken2022Service } from "@sdp/api/services/solana";
 import { env } from "./env";
 
 const SOLANA_CONFIGURED = !!env.SOLANA_RPC_URL && !!env.CUSTODY_PRIVATE_KEY;
@@ -159,11 +159,24 @@ export async function cleanupIntegrationSuite() {
   await clearTestDatabase(env);
 }
 
+export function request(url: string, init?: RequestInit) {
+  return app.request(url, init, env);
+}
+
+export function requestWithApiKey(apiKey: string = TEST_PROJECT_API_KEY.raw) {
+  return (url: string, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${apiKey}`);
+    return request(url, { ...init, headers });
+  };
+}
+
 export {
   app,
   env,
   Token2022Service,
   createSigner,
+  createToken2022Service,
   createMosaicService,
   TEST_ORG,
   TEST_USER,

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -1,4 +1,5 @@
 import { KoraClient } from "@sdp/api/services/adapters";
+import { createSignerFromBase58 } from "@sdp/api/services/solana";
 import { env } from "./env";
 
 type SolanaRpcResponse<T> =
@@ -37,11 +38,26 @@ async function runPreflight(): Promise<void> {
     );
   }
 
+  // Narrow optional env vars to concrete strings (Biome forbids non-null assertions).
+  const solanaRpcUrl = env.SOLANA_RPC_URL;
+  const custodyPrivateKey = env.CUSTODY_PRIVATE_KEY;
+  const koraUrl = env.KORA_RPC_URL;
+  if (!solanaRpcUrl || !custodyPrivateKey || !koraUrl) {
+    // This should be unreachable because of the `missing` check above.
+    throw new Error("Integration preflight internal error: required env vars were missing.");
+  }
+
   // Validate Solana RPC connectivity early so failures are explicit.
-  await assertSolanaRpcHealthy(env.SOLANA_RPC_URL);
+  await assertSolanaRpcHealthy(solanaRpcUrl);
+
+  // Ensure the custody signer exists on-chain.
+  //
+  // Even with Kora fee sponsorship, some downstream libraries (ex: Mosaic SDK) expect the
+  // authority account to exist (ie. have been created with at least 1 lamport) and will error
+  // if RPC returns `null` for getAccountInfo(publicKey).
+  await ensureCustodyAccountExists(solanaRpcUrl, custodyPrivateKey);
 
   // Validate Kora connectivity and that it can sponsor transactions (fee payer exists and is funded).
-  const koraUrl = env.KORA_RPC_URL;
   const koraClient = new KoraClient({
     rpcUrl: koraUrl,
     ...(env.KORA_API_KEY ? { apiKey: env.KORA_API_KEY } : {}),
@@ -64,13 +80,36 @@ async function runPreflight(): Promise<void> {
     );
   }
 
-  const feePayerLamports = await solanaGetBalance(env.SOLANA_RPC_URL, feePayerAddress);
+  const feePayerLamports = await solanaGetBalance(solanaRpcUrl, feePayerAddress);
   const minLamports = getKoraMinBalanceLamports();
   if (feePayerLamports < minLamports) {
     throw new Error(
       `Kora preflight failed: fee payer balance too low (${feePayerLamports} lamports, min ${minLamports}).`
     );
   }
+}
+
+async function ensureCustodyAccountExists(rpcUrl: string, custodyPrivateKeyBase58: string) {
+  const signer = await createSignerFromBase58(custodyPrivateKeyBase58);
+  const custodyAddress = signer.address;
+
+  const exists = await solanaAccountExists(rpcUrl, custodyAddress);
+  if (exists) return;
+
+  // Devnet-only convenience: request a small airdrop so the account exists on-chain.
+  // If the RPC provider blocks airdrops, we fail fast with actionable instructions.
+  const airdropLamports = 1_000_000; // 0.001 SOL is enough to create the account.
+  // biome-ignore lint/nursery/noSecrets: label string (false positive).
+  await withLabel("Solana.requestAirdrop(custody)", async () => {
+    await solanaRequestAirdrop(rpcUrl, custodyAddress, airdropLamports);
+    await waitForAccountExistence(rpcUrl, custodyAddress, 30_000);
+  }).catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Custody signer does not exist on-chain (${custodyAddress}). ` +
+        `Fund it once on devnet (ex: request an airdrop) then rerun. Details: ${msg}`
+    );
+  });
 }
 
 function getKoraMinBalanceLamports(): number {
@@ -107,6 +146,49 @@ async function solanaGetBalance(rpcUrl: string, address: string): Promise<number
     { commitment: "confirmed" },
   ]);
   return resp.value ?? 0;
+}
+
+async function solanaAccountExists(rpcUrl: string, address: string): Promise<boolean> {
+  type AccountInfo = {
+    value: null | {
+      lamports: number;
+      owner: string;
+      executable: boolean;
+      rentEpoch: number;
+      data: [string, string];
+    };
+  };
+
+  const resp = await solanaRpc<AccountInfo>(rpcUrl, "getAccountInfo", [
+    address,
+    { encoding: "base64", commitment: "confirmed" },
+  ]);
+  return resp.value !== null;
+}
+
+async function solanaRequestAirdrop(
+  rpcUrl: string,
+  address: string,
+  lamports: number
+): Promise<string> {
+  // Many public RPC providers disable airdrops; we surface a clear error if so.
+  return await solanaRpc<string>(rpcUrl, "requestAirdrop", [address, lamports]);
+}
+
+async function waitForAccountExistence(rpcUrl: string, address: string, timeoutMs: number) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    // eslint-disable-next-line no-await-in-loop
+    const exists = await solanaAccountExists(rpcUrl, address);
+    if (exists) return;
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(1_000);
+  }
+  throw new Error(`Timed out waiting for account ${address} to exist on-chain.`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function solanaRpc<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -1,0 +1,153 @@
+import { KoraClient } from "@sdp/api/services/adapters";
+import { env } from "./env";
+
+type SolanaRpcResponse<T> =
+  | { jsonrpc: "2.0"; id: number; result: T }
+  | { jsonrpc: "2.0"; id: number; error: { code: number; message: string; data?: unknown } };
+
+const PRECHECK_CACHE_KEY = "__sdp_integration_preflight__";
+
+type PreflightState = {
+  promise: Promise<void>;
+};
+
+function getPreflightState(): PreflightState {
+  const g = globalThis as unknown as Record<string, unknown>;
+  let state = g[PRECHECK_CACHE_KEY] as PreflightState | undefined;
+  if (!state) {
+    state = { promise: runPreflight() };
+    g[PRECHECK_CACHE_KEY] = state;
+  }
+  return state;
+}
+
+export async function ensureIntegrationPreflight(): Promise<void> {
+  await getPreflightState().promise;
+}
+
+async function runPreflight(): Promise<void> {
+  const missing: string[] = [];
+  if (!env.SOLANA_RPC_URL) missing.push("SOLANA_RPC_URL");
+  if (!env.CUSTODY_PRIVATE_KEY) missing.push("CUSTODY_PRIVATE_KEY");
+  if (!env.KORA_RPC_URL) missing.push("KORA_RPC_URL");
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Integration tests require the following env vars to be set: ${missing.join(", ")}`
+    );
+  }
+
+  // Validate Solana RPC connectivity early so failures are explicit.
+  await assertSolanaRpcHealthy(env.SOLANA_RPC_URL);
+
+  // Validate Kora connectivity and that it can sponsor transactions (fee payer exists and is funded).
+  const koraUrl = env.KORA_RPC_URL;
+  const koraClient = new KoraClient({
+    rpcUrl: koraUrl,
+    ...(env.KORA_API_KEY ? { apiKey: env.KORA_API_KEY } : {}),
+  });
+
+  const config = await withLabel("Kora.getConfig", () => koraClient.getConfig());
+  if (!config?.validation_config?.allowed_programs) {
+    throw new Error("Kora preflight failed: missing validation_config.allowed_programs");
+  }
+
+  const payerSignerResp = await withLabel("Kora.getPayerSigner", () => koraClient.getPayerSigner());
+  const feePayerAddress =
+    (payerSignerResp as { signer_address?: string }).signer_address ??
+    (payerSignerResp as { payment_address?: string }).payment_address ??
+    (payerSignerResp as { payerSigner?: string }).payerSigner;
+
+  if (!feePayerAddress) {
+    throw new Error(
+      "Kora preflight failed: fee payer address missing (expected signer_address/payment_address/payerSigner)"
+    );
+  }
+
+  const feePayerLamports = await solanaGetBalance(env.SOLANA_RPC_URL, feePayerAddress);
+  const minLamports = getKoraMinBalanceLamports();
+  if (feePayerLamports < minLamports) {
+    throw new Error(
+      `Kora preflight failed: fee payer balance too low (${feePayerLamports} lamports, min ${minLamports}).`
+    );
+  }
+}
+
+function getKoraMinBalanceLamports(): number {
+  const raw = (env as unknown as Record<string, unknown>).KORA_MIN_BALANCE_LAMPORTS;
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+
+  // Default to 0.001 SOL which is enough for many transactions while avoiding false failures.
+  return 1_000_000;
+}
+
+async function assertSolanaRpcHealthy(rpcUrl: string): Promise<void> {
+  type LatestBlockhash = {
+    value: { blockhash: string; lastValidBlockHeight: number };
+  };
+  // biome-ignore lint/nursery/noSecrets: JSON-RPC method name (false positive).
+  const resp = await solanaRpc<LatestBlockhash>(rpcUrl, "getLatestBlockhash", [
+    { commitment: "confirmed" },
+  ]);
+  const blockhash = resp?.value?.blockhash;
+  if (!blockhash) {
+    throw new Error("Solana RPC preflight failed: missing blockhash");
+  }
+}
+
+async function solanaGetBalance(rpcUrl: string, address: string): Promise<number> {
+  type Balance = { value: number };
+  const resp = await solanaRpc<Balance>(rpcUrl, "getBalance", [
+    address,
+    { commitment: "confirmed" },
+  ]);
+  return resp.value ?? 0;
+}
+
+async function solanaRpc<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
+  const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params });
+  const res = await withTimeout(
+    15_000,
+    fetch(rpcUrl, { method: "POST", headers: { "Content-Type": "application/json" }, body })
+  );
+
+  const json = (await res.json()) as SolanaRpcResponse<T>;
+  if ("error" in json) {
+    throw new Error(`Solana RPC error calling ${method}: ${json.error.message}`);
+  }
+  return json.result;
+}
+
+async function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+
+  try {
+    // If the passed promise is a fetch, it will respect AbortController.
+    // If it's not, this still enforces an upper bound on the awaited time.
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) =>
+        controller.signal.addEventListener("abort", () =>
+          reject(new Error(`Timed out after ${ms}ms`))
+        )
+      ),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function withLabel<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await withTimeout(15_000, fn());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`${label} failed: ${msg}`);
+  }
+}

--- a/packages/sdp-api-integration/src/setup.ts
+++ b/packages/sdp-api-integration/src/setup.ts
@@ -1,3 +1,5 @@
+import { ensureIntegrationPreflight } from "./helpers/preflight";
+
 const globalWithSecureContext = globalThis as { isSecureContext?: boolean };
 
 if (!globalWithSecureContext.isSecureContext) {
@@ -10,3 +12,7 @@ if (!globalWithSecureContext.isSecureContext) {
     globalWithSecureContext.isSecureContext = true;
   }
 }
+
+// Fail fast when running integration tests in CI: validate Kora + Solana RPC
+// connectivity and basic funding assumptions before any test files are evaluated.
+await ensureIntegrationPreflight();

--- a/packages/sdp-api-integration/src/tests/burn.test.ts
+++ b/packages/sdp-api-integration/src/tests/burn.test.ts
@@ -3,11 +3,9 @@ import type { BurnApiResponse, TokenApiResponse } from "../helpers/api-types";
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
@@ -15,7 +13,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Burn Operations",
   let apiKeyHash: string;
   let custodyAddress = "";
   let deployedTokenId = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
@@ -34,7 +32,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Burn Operations",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Burn Test Token",
@@ -49,14 +46,12 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Burn Operations",
 
     await request(`/v1/issuance/tokens/${deployedTokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     await request(`/v1/issuance/tokens/${deployedTokenId}/mint`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         mint: {
@@ -72,7 +67,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Burn Operations",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         burn: {
@@ -90,9 +84,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Burn Operations",
 
     console.log(`Burn signature: ${burned.data.transaction.signature}`);
 
-    const tokenRes = await request(`/v1/issuance/tokens/${deployedTokenId}`, {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const tokenRes = await request(`/v1/issuance/tokens/${deployedTokenId}`);
 
     const token = (await tokenRes.json()) as TokenApiResponse;
     expect(token.data.token.totalSupply).toBe("4");

--- a/packages/sdp-api-integration/src/tests/custody-local.test.ts
+++ b/packages/sdp-api-integration/src/tests/custody-local.test.ts
@@ -1,16 +1,17 @@
+import { transferLamportsFromEnv } from "@/services/solana/funding";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { TokenApiResponse } from "../helpers/api-types";
 import {
+  KORA_CONFIGURED,
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
   env,
   initIntegrationSuite,
+  request as rawRequest,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
-import { transferLamportsFromEnv } from "@/services/solana/funding";
 
 async function callRpc<T>(method: string, params: unknown[]): Promise<T> {
   const rpcUrl = env.SOLANA_RPC_URL;
@@ -48,7 +49,7 @@ async function ensureFunded(recipient: string, minimumLamports: number) {
 
 describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Signing", () => {
   let apiKeyHash: string;
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
@@ -68,7 +69,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({ provider: "local", walletLabel: "Integration Wallet" }),
     });
@@ -81,11 +81,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
     const { configId, publicKey } = initBody.data;
     expect(publicKey).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
 
-    const configRes = await request("/v1/custody/config", {
-      headers: {
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
-      },
-    });
+    const configRes = await request("/v1/custody/config");
 
     expect(configRes.status).toBe(200);
     const configBody = (await configRes.json()) as {
@@ -105,13 +101,15 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
     expect(configRow?.config_encrypted).toBeTruthy();
     expect(() => JSON.parse(configRow?.config_encrypted ?? "")).toThrow();
 
-    await ensureFunded(publicKey, 500_000_000);
+    // If Kora is enabled, it sponsors transaction fees so the custody wallet doesn't need SOL.
+    if (!KORA_CONFIGURED) {
+      await ensureFunded(publicKey, 500_000_000);
+    }
 
     const createRes = await request("/v1/issuance/tokens", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Custody Token",
@@ -128,7 +126,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
 
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -137,10 +134,10 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
   });
 
   it("requires auth for custody endpoints", async () => {
-    const configRes = await request("/v1/custody/config");
+    const configRes = await rawRequest("/v1/custody/config");
     expect(configRes.status).toBe(401);
 
-    const initRes = await request("/v1/custody/initialize", {
+    const initRes = await rawRequest("/v1/custody/initialize", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "local" }),

--- a/packages/sdp-api-integration/src/tests/deploy.test.ts
+++ b/packages/sdp-api-integration/src/tests/deploy.test.ts
@@ -3,18 +3,16 @@ import type { DeployPrepareApiResponse, TokenApiResponse } from "../helpers/api-
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
 describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment", () => {
   let apiKeyHash: string;
   let custodyAddress = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
@@ -35,7 +33,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Devnet Test Token",
@@ -53,7 +50,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
 
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -74,7 +70,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Transfer Fee Token",
@@ -97,7 +92,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
 
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -112,7 +106,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Prepare Deploy Token",
@@ -126,7 +119,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
 
     const prepareRes = await request(`/v1/issuance/tokens/${tokenId}/deploy/prepare`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(prepareRes.status).toBe(200);
@@ -137,9 +129,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
     expect(prepared.data.mint).toBeTruthy();
     expect(prepared.data.simulation).toBeDefined();
 
-    const getRes = await request(`/v1/issuance/tokens/${tokenId}`, {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const getRes = await request(`/v1/issuance/tokens/${tokenId}`);
 
     const token = (await getRes.json()) as TokenApiResponse;
     expect(token.data.token.status).toBe("pending");
@@ -150,7 +140,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Already Deployed",
@@ -164,12 +153,10 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token Deployment"
 
     await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     const secondDeployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(secondDeployRes.status).toBe(400);

--- a/packages/sdp-api-integration/src/tests/freeze.test.ts
+++ b/packages/sdp-api-integration/src/tests/freeze.test.ts
@@ -8,11 +8,9 @@ import type {
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
@@ -21,7 +19,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Freeze/Unfreeze O
   let custodyAddress = "";
   let deployedTokenId = "";
   let tokenAccount = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
@@ -40,7 +38,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Freeze/Unfreeze O
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Freeze Test Token",
@@ -56,14 +53,12 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Freeze/Unfreeze O
 
     await request(`/v1/issuance/tokens/${deployedTokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     const mintRes = await request(`/v1/issuance/tokens/${deployedTokenId}/mint`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         mint: {
@@ -82,7 +77,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Freeze/Unfreeze O
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: tokenAccount,
@@ -103,7 +97,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Freeze/Unfreeze O
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: tokenAccount,
@@ -114,7 +107,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Freeze/Unfreeze O
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: tokenAccount,

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -10,11 +10,9 @@ import {
   KORA_CONFIGURED,
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
@@ -23,7 +21,7 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
   () => {
     let apiKeyHash: string;
     let custodyAddress = "";
-    const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+    const request = requestWithApiKey();
 
     beforeAll(async () => {
       const init = await initIntegrationSuite();
@@ -44,7 +42,6 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
         },
         body: JSON.stringify({
           name: "Kora Devnet Token",
@@ -61,7 +58,6 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
 
       const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
         method: "POST",
-        headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
       });
 
       expect(deployRes.status).toBe(200);
@@ -72,7 +68,6 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
         },
         body: JSON.stringify({
           mint: {
@@ -94,7 +89,6 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
         },
         body: JSON.stringify({ accountAddress: tokenAccount }),
       });
@@ -107,7 +101,6 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
         },
         body: JSON.stringify({ accountAddress: tokenAccount }),
       });
@@ -120,7 +113,6 @@ describe.skipIf(!KORA_CONFIGURED || !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
         },
         body: JSON.stringify({
           burn: {

--- a/packages/sdp-api-integration/src/tests/mint.test.ts
+++ b/packages/sdp-api-integration/src/tests/mint.test.ts
@@ -7,11 +7,9 @@ import type {
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
@@ -19,7 +17,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mint Operations",
   let apiKeyHash: string;
   let custodyAddress = "";
   let deployedTokenId = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
@@ -38,7 +36,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mint Operations",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Mint Test Token",
@@ -53,7 +50,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mint Operations",
 
     await request(`/v1/issuance/tokens/${deployedTokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
   }, 60000);
 
@@ -62,7 +58,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mint Operations",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         mint: {
@@ -81,9 +76,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mint Operations",
 
     console.log(`Mint signature: ${minted.data.transaction.signature}`);
 
-    const tokenRes = await request(`/v1/issuance/tokens/${deployedTokenId}`, {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const tokenRes = await request(`/v1/issuance/tokens/${deployedTokenId}`);
 
     const token = (await tokenRes.json()) as TokenApiResponse;
     expect(token.data.token.totalSupply).toBe("1");
@@ -94,7 +87,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mint Operations",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         mint: {

--- a/packages/sdp-api-integration/src/tests/mosaic-abl.test.ts
+++ b/packages/sdp-api-integration/src/tests/mosaic-abl.test.ts
@@ -10,15 +10,13 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import type { TokenApiResponse, TokenAllowlistResponse } from "../helpers/api-types";
+import type { TokenAllowlistResponse, TokenApiResponse } from "../helpers/api-types";
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
@@ -34,13 +32,11 @@ const TEST_WALLETS = {
 
 describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operations", () => {
   let apiKeyHash: string;
-  let custodyAddress = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
     apiKeyHash = init.apiKeyHash;
-    custodyAddress = init.custodyAddress;
   });
 
   afterAll(async () => {
@@ -57,7 +53,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "ABL Test Token",
@@ -79,7 +74,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         address: TEST_WALLETS.wallet1,
@@ -100,7 +94,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "List Test Token",
@@ -120,7 +113,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
         },
         body: JSON.stringify({
           address,
@@ -130,9 +122,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
     }
 
     // List allowlist entries
-    const listRes = await request(`/v1/issuance/tokens/${tokenId}/allowlist`, {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const listRes = await request(`/v1/issuance/tokens/${tokenId}/allowlist`);
 
     expect(listRes.status).toBe(200);
     const list = (await listRes.json()) as {
@@ -155,7 +145,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Remove Test Token",
@@ -174,7 +163,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         address: TEST_WALLETS.wallet1,
@@ -188,15 +176,12 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
     // Remove wallet
     const removeRes = await request(`/v1/issuance/tokens/${tokenId}/allowlist/${entryId}`, {
       method: "DELETE",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(removeRes.status).toBe(204);
 
     // Verify removal
-    const listRes = await request(`/v1/issuance/tokens/${tokenId}/allowlist`, {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const listRes = await request(`/v1/issuance/tokens/${tokenId}/allowlist`);
 
     const list = (await listRes.json()) as {
       data: Array<{ address: string; status: string }>;
@@ -216,7 +201,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Dupe Test Token",
@@ -235,7 +219,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         address: TEST_WALLETS.wallet1,
@@ -248,7 +231,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         address: TEST_WALLETS.wallet1,
@@ -265,7 +247,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Invalid Addr Token",
@@ -284,7 +265,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic ABL Operat
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         address: "not-a-valid-solana-address",

--- a/packages/sdp-api-integration/src/tests/mosaic-templates.test.ts
+++ b/packages/sdp-api-integration/src/tests/mosaic-templates.test.ts
@@ -10,18 +10,16 @@ import type { TokenApiResponse } from "../helpers/api-types";
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
 describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template Deployment", () => {
   let apiKeyHash: string;
   let custodyAddress = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
@@ -43,7 +41,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Test Stablecoin",
@@ -64,7 +61,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
     // Deploy the token
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -85,7 +81,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Test Arcade Token",
@@ -107,7 +102,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
     // Deploy the token
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -131,7 +125,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Test Security Token",
@@ -152,7 +145,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
     // Deploy the token
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -171,7 +163,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Test Custom Token",
@@ -191,7 +182,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
     // Deploy the token
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     expect(deployRes.status).toBe(200);
@@ -205,9 +195,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
   });
 
   it("lists available templates", { timeout: 10000 }, async () => {
-    const res = await request("/v1/issuance/templates", {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const res = await request("/v1/issuance/templates");
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { data: { templates: Array<{ id: string; name: string }> } };
@@ -223,9 +211,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
   });
 
   it("gets specific template info", { timeout: 10000 }, async () => {
-    const res = await request("/v1/issuance/templates/stablecoin", {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const res = await request("/v1/issuance/templates/stablecoin");
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {

--- a/packages/sdp-api-integration/src/tests/mosaic-token-acl.test.ts
+++ b/packages/sdp-api-integration/src/tests/mosaic-token-acl.test.ts
@@ -20,11 +20,9 @@ import type {
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  TEST_PROJECT_API_KEY,
-  app,
   cleanupIntegrationSuite,
-  env,
   initIntegrationSuite,
+  requestWithApiKey,
   resetIntegrationState,
 } from "../helpers/integration";
 
@@ -38,13 +36,11 @@ const TEST_WALLETS = {
 
 describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL", () => {
   let apiKeyHash: string;
-  let custodyAddress = "";
-  const request = (url: string, init?: RequestInit) => app.request(url, init, env);
+  const request = requestWithApiKey();
 
   beforeAll(async () => {
     const init = await initIntegrationSuite();
     apiKeyHash = init.apiKeyHash;
-    custodyAddress = init.custodyAddress;
   });
 
   afterAll(async () => {
@@ -63,7 +59,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name,
@@ -80,14 +75,21 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
 
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     const deployed = (await deployRes.json()) as TokenApiResponse;
+    const mintAddress = deployed.data.token.mintAddress;
+    const freezeAuthority = deployed.data.token.freezeAuthority;
+    if (!mintAddress) {
+      throw new Error("Expected deployed token to include mintAddress");
+    }
+    if (!freezeAuthority) {
+      throw new Error("Expected deployed token to include freezeAuthority");
+    }
     return {
       tokenId,
-      mintAddress: deployed.data.token.mintAddress!,
-      freezeAuthority: deployed.data.token.freezeAuthority!,
+      mintAddress,
+      freezeAuthority,
     };
   }
 
@@ -99,7 +101,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         mint: {
@@ -131,7 +132,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: tokenAccount,
@@ -164,7 +164,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: tokenAccount,
@@ -180,7 +179,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: tokenAccount,
@@ -214,7 +212,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: mint1.data.tokenAccount,
@@ -226,7 +223,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: mint2.data.tokenAccount,
@@ -235,9 +231,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
     });
 
     // List frozen accounts
-    const listRes = await request(`/v1/issuance/tokens/${tokenId}/frozen`, {
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
-    });
+    const listRes = await request(`/v1/issuance/tokens/${tokenId}/frozen`);
 
     expect(listRes.status).toBe(200);
     const list = (await listRes.json()) as {
@@ -259,7 +253,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         name: "Non-Freezable Token",
@@ -277,7 +270,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
     // Deploy
     const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
     });
 
     const deployed = (await deployRes.json()) as TokenApiResponse;
@@ -291,7 +283,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: mintResult.data.tokenAccount,
@@ -316,7 +307,6 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Token ACL"
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
       },
       body: JSON.stringify({
         accountAddress: mintResult.data.tokenAccount,

--- a/packages/sdp-api-integration/src/tests/token2022.test.ts
+++ b/packages/sdp-api-integration/src/tests/token2022.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   RUN_INTEGRATION_TESTS,
   SOLANA_CONFIGURED,
-  Token2022Service,
   createSigner,
+  createToken2022Service,
   env,
 } from "../helpers/integration";
 
 describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Token2022Service Direct", () => {
   it("creates mint using service directly", { timeout: 60000 }, async () => {
     const signer = await createSigner(env as Env);
-    const token2022 = new Token2022Service(env as Env, signer);
+    const token2022 = createToken2022Service(env as Env, signer);
 
     const result = await token2022.createMint({
       metadata: {

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env", ".env.*"],
+  "globalEnv": [
+    "API_KEY_PEPPER",
+    "CUSTODY_PRIVATE_KEY",
+    "KORA_API_KEY",
+    "KORA_MIN_BALANCE_LAMPORTS",
+    "KORA_RPC_URL",
+    "KORA_TIMEOUT_MS",
+    "RUN_INTEGRATION_TESTS",
+    "SOLANA_NETWORK",
+    "SOLANA_RPC_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Add fail-fast preflight checks for integration tests (Solana RPC health, Kora health, Kora fee payer funding)
- Streamline integration test request helpers to reduce repeated auth/header boilerplate
- Add a CI job that runs the devnet integration suite on PRs and main

## CI Secrets
- `CUSTODY_PRIVATE_KEY` (required)
- `KORA_API_KEY` (optional)
- `SOLANA_RPC_URL` (optional, defaults to `https://api.devnet.solana.com`)
- `KORA_RPC_URL` (optional, defaults to `https://kora-devnet-315956366746.us-central1.run.app`)
- `KORA_MIN_BALANCE_LAMPORTS` (optional, defaults to `1000000`)

## Notes
- This is intended to become a required check via branch protection once secrets are set on the repo.