### PR TITLE
feat(custody): web UI for provider + wallet management

### DIFF
--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -16,6 +16,8 @@ import {
   type InitializeSigningResponse,
   createWalletSchema,
   initializeSigningSchema,
+  setDefaultWalletSchema,
+  switchSigningSchema,
 } from "./schemas";
 
 type AppContext = Context<{ Bindings: Env }>;
@@ -98,6 +100,86 @@ export const initializeSigning = async (c: AppContext) => {
   }
 };
 
+/**
+ * Switch the signing provider for the organization (or project).
+ *
+ * This deactivates the existing active custody config for the requested scope and then
+ * initializes the requested provider. Existing on-chain authorities are NOT rotated.
+ *
+ * POST /custody/switch
+ */
+export const switchSigning = async (c: AppContext) => {
+  const auth = getAuth(c);
+
+  const body = await c.req.json();
+  const parsed = switchSigningSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid request body", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const signingService = createSigningService(c.env);
+
+  // Deactivate any active config for the requested scope so initialize* does not conflict.
+  const projectId = parsed.data.projectId;
+  if (projectId) {
+    await c.env.DB.prepare(
+      `UPDATE custody_configs
+       SET status = 'inactive', updated_at = datetime('now')
+       WHERE organization_id = ? AND project_id = ? AND status = 'active'`
+    )
+      .bind(auth.organizationId, projectId)
+      .run();
+  } else {
+    await c.env.DB.prepare(
+      `UPDATE custody_configs
+       SET status = 'inactive', updated_at = datetime('now')
+       WHERE organization_id = ? AND project_id IS NULL AND status = 'active'`
+    )
+      .bind(auth.organizationId)
+      .run();
+  }
+
+  try {
+    let result: { configId: string; publicKey: string; walletId: string };
+
+    if (parsed.data.provider === "local") {
+      result = await signingService.initializeLocalSigning(auth.organizationId, projectId, {
+        walletLabel: parsed.data.walletLabel,
+      });
+    } else if (parsed.data.provider === "fireblocks") {
+      result = await signingService.initializeFireblocksSigning(auth.organizationId, projectId, {
+        apiKey: parsed.data.apiKey,
+        apiSecretPem: parsed.data.apiSecretPem,
+        vaultAccountId: parsed.data.vaultAccountId,
+        assetId: parsed.data.assetId,
+        apiBaseUrl: parsed.data.apiBaseUrl,
+      });
+    } else {
+      result = await signingService.initializePrivySigning(auth.organizationId, projectId, {
+        apiBaseUrl: parsed.data.apiBaseUrl,
+        requestDelayMs: parsed.data.requestDelayMs,
+        walletLabel: parsed.data.walletLabel,
+      });
+    }
+
+    const response: InitializeSigningResponse = {
+      configId: result.configId,
+      publicKey: result.publicKey,
+      walletId: result.walletId,
+    };
+
+    return created(c, response);
+  } catch (error) {
+    if (error instanceof SigningError) {
+      throw new AppError("BAD_REQUEST", error.message);
+    }
+    throw error;
+  }
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Create Wallet
 // ═══════════════════════════════════════════════════════════════════════════
@@ -150,6 +232,70 @@ export const createWallet = async (c: AppContext) => {
     }
     throw error;
   }
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Set Default Wallet
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Set the default wallet for the active custody configuration.
+ *
+ * POST /custody/default-wallet
+ */
+export const setDefaultWallet = async (c: AppContext) => {
+  const auth = getAuth(c);
+
+  const body = await c.req.json();
+  const parsed = setDefaultWalletSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid request body", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const projectId = parsed.data.projectId ?? null;
+  const config = await c.env.DB.prepare(
+    projectId
+      ? `SELECT id FROM custody_configs
+         WHERE organization_id = ? AND project_id = ? AND status = 'active'
+         ORDER BY updated_at DESC
+         LIMIT 1`
+      : `SELECT id FROM custody_configs
+         WHERE organization_id = ? AND project_id IS NULL AND status = 'active'
+         ORDER BY updated_at DESC
+         LIMIT 1`
+  )
+    .bind(...(projectId ? [auth.organizationId, projectId] : [auth.organizationId]))
+    .first<{ id: string }>();
+
+  if (!config?.id) {
+    throw new AppError("CONFLICT", "Custody not initialized");
+  }
+
+  const wallet = await c.env.DB.prepare(
+    `SELECT id
+     FROM custody_wallets
+     WHERE custody_config_id = ? AND wallet_id = ? AND status = 'active'
+     LIMIT 1`
+  )
+    .bind(config.id, parsed.data.walletId)
+    .first<{ id: string }>();
+
+  if (!wallet) {
+    throw new AppError("BAD_REQUEST", "Unknown walletId for this custody configuration");
+  }
+
+  await c.env.DB.prepare(
+    `UPDATE custody_configs
+     SET default_wallet_id = ?, updated_at = datetime('now')
+     WHERE id = ?`
+  )
+    .bind(parsed.data.walletId, config.id)
+    .run();
+
+  return success(c, { defaultWalletId: parsed.data.walletId });
 };
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/apps/sdp-api/src/routes/custody/index.ts
+++ b/apps/sdp-api/src/routes/custody/index.ts
@@ -8,7 +8,15 @@
 import { authMiddleware, requirePermissions } from "@/middleware/auth";
 import type { Env } from "@/types/env";
 import { Hono } from "hono";
-import { createWallet, getConfig, getPublicKey, initializeSigning, listWallets } from "./handlers";
+import {
+  createWallet,
+  getConfig,
+  getPublicKey,
+  initializeSigning,
+  listWallets,
+  setDefaultWallet,
+  switchSigning,
+} from "./handlers";
 
 const custody = new Hono<{ Bindings: Env }>();
 
@@ -17,7 +25,9 @@ custody.use("*", authMiddleware());
 
 // Initialize signing (requires admin)
 custody.post("/initialize", requirePermissions("custody:admin"), initializeSigning);
+custody.post("/switch", requirePermissions("custody:admin"), switchSigning);
 custody.post("/wallets", requirePermissions("custody:admin"), createWallet);
+custody.post("/default-wallet", requirePermissions("custody:admin"), setDefaultWallet);
 
 // Read configuration and wallets
 custody.get("/config", requirePermissions("custody:read"), getConfig);

--- a/apps/sdp-api/src/routes/custody/schemas.ts
+++ b/apps/sdp-api/src/routes/custody/schemas.ts
@@ -56,6 +56,27 @@ export const createWalletSchema = z.object({
 export type CreateWalletRequest = z.infer<typeof createWalletSchema>;
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Switch Signing Provider
+// ═══════════════════════════════════════════════════════════════════════════
+
+// For now, switching uses the same shape as initialize. The handler deactivates the
+// existing config for the scope (org or project) and then runs the initializer.
+export const switchSigningSchema = initializeSigningSchema;
+
+export type SwitchSigningRequest = z.infer<typeof switchSigningSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Set Default Wallet
+// ═══════════════════════════════════════════════════════════════════════════
+
+export const setDefaultWalletSchema = z.object({
+  projectId: z.string().optional(),
+  walletId: z.string().min(1),
+});
+
+export type SetDefaultWalletRequest = z.infer<typeof setDefaultWalletSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Response Types
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -1,0 +1,107 @@
+"use server";
+
+import { sdpApiFetch } from "@/lib/sdp-api";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+function getString(formData: FormData, key: string): string {
+  return String(formData.get(key) ?? "").trim();
+}
+
+function getOptionalString(formData: FormData, key: string): string | undefined {
+  const value = getString(formData, key);
+  return value ? value : undefined;
+}
+
+function getOptionalNumber(formData: FormData, key: string): number | undefined {
+  const raw = getOptionalString(formData, key);
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed)) return undefined;
+  return parsed;
+}
+
+export async function initializeCustody(formData: FormData) {
+  const provider = (getString(formData, "provider") || "privy") as "privy" | "local";
+  const walletLabel = getOptionalString(formData, "walletLabel");
+  const requestDelayMs = getOptionalNumber(formData, "requestDelayMs");
+  const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
+
+  if (provider === "local") {
+    await sdpApiFetch("/v1/custody/initialize", {
+      method: "POST",
+      body: JSON.stringify({ provider, walletLabel }),
+    });
+  } else {
+    await sdpApiFetch("/v1/custody/initialize", {
+      method: "POST",
+      body: JSON.stringify({ provider, walletLabel, requestDelayMs, apiBaseUrl }),
+    });
+  }
+
+  revalidatePath("/dashboard/custody");
+  redirect("/dashboard/custody");
+}
+
+export async function switchCustodyProvider(formData: FormData) {
+  const provider = (getString(formData, "provider") || "privy") as "privy" | "local";
+  const confirm = getString(formData, "confirm");
+  const walletLabel = getOptionalString(formData, "walletLabel");
+  const requestDelayMs = getOptionalNumber(formData, "requestDelayMs");
+  const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
+
+  if (confirm.toLowerCase() !== "switch") {
+    throw new Error("Type SWITCH to confirm provider change");
+  }
+
+  if (provider === "local") {
+    await sdpApiFetch("/v1/custody/switch", {
+      method: "POST",
+      body: JSON.stringify({ provider, walletLabel }),
+    });
+  } else {
+    await sdpApiFetch("/v1/custody/switch", {
+      method: "POST",
+      body: JSON.stringify({ provider, walletLabel, requestDelayMs, apiBaseUrl }),
+    });
+  }
+
+  revalidatePath("/dashboard/custody");
+  redirect("/dashboard/custody");
+}
+
+export async function createCustodyWallet(formData: FormData) {
+  const label = getOptionalString(formData, "label");
+  const purpose = getOptionalString(formData, "purpose") as
+    | "root"
+    | "mint_authority"
+    | "freeze_authority"
+    | "fee_payer"
+    | "transfer"
+    | undefined;
+  const setDefault = getString(formData, "setDefault") === "on";
+
+  await sdpApiFetch("/v1/custody/wallets", {
+    method: "POST",
+    body: JSON.stringify({ label, purpose, setDefault }),
+  });
+
+  revalidatePath("/dashboard/custody");
+  redirect("/dashboard/custody");
+}
+
+export async function setDefaultCustodyWallet(formData: FormData) {
+  const walletId = getString(formData, "walletId");
+  if (!walletId) {
+    throw new Error("walletId is required");
+  }
+
+  await sdpApiFetch("/v1/custody/default-wallet", {
+    method: "POST",
+    body: JSON.stringify({ walletId }),
+  });
+
+  revalidatePath("/dashboard/custody");
+  redirect("/dashboard/custody");
+}
+

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -104,4 +104,3 @@ export async function setDefaultCustodyWallet(formData: FormData) {
   revalidatePath("/dashboard/custody");
   redirect("/dashboard/custody");
 }
-

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -94,7 +94,9 @@ export default async function CustodyPage() {
             <Card>
               <CardHeader>
                 <CardTitle>Signing configuration</CardTitle>
-                <CardDescription>Controls which custody wallet signs new API actions.</CardDescription>
+                <CardDescription>
+                  Controls which custody wallet signs new API actions.
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4 text-sm">
                 <div className="grid gap-2">
@@ -200,7 +202,9 @@ export default async function CustodyPage() {
                       return (
                         <TableRow key={w.id}>
                           <TableCell className="font-medium">{w.label ?? "Untitled"}</TableCell>
-                          <TableCell className="text-muted-foreground">{w.purpose ?? "-"}</TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {w.purpose ?? "-"}
+                          </TableCell>
                           <TableCell className="font-mono text-xs">{w.publicKey}</TableCell>
                           <TableCell className="font-mono text-xs text-muted-foreground">
                             {w.walletId}

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -1,0 +1,232 @@
+import { DashboardHeader } from "@/components/dashboard-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { sdpApiFetch, sdpApiRequest } from "@/lib/sdp-api";
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createCustodyWallet, setDefaultCustodyWallet } from "./actions";
+
+type CustodyProvider = "privy" | "local" | "fireblocks";
+
+interface CustodyConfig {
+  id: string;
+  organizationId: string;
+  projectId: string | null;
+  provider: CustodyProvider;
+  publicKey: string;
+  defaultWalletId: string | null;
+  status: "active" | "inactive";
+  createdAt: string;
+}
+
+interface CustodyWallet {
+  id: string;
+  walletId: string;
+  publicKey: string;
+  label: string | null;
+  purpose: string | null;
+  status: "active" | "inactive";
+  createdAt: string;
+}
+
+async function getCustodyConfig(): Promise<CustodyConfig | null> {
+  const res = await sdpApiRequest("/v1/custody/config");
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`SDP API request failed (${res.status}): ${body}`);
+  }
+  const json = (await res.json()) as { config: CustodyConfig };
+  return json.config;
+}
+
+export default async function CustodyPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  const [config, walletsResp] = await Promise.all([
+    getCustodyConfig(),
+    sdpApiFetch<{ wallets: CustodyWallet[] }>("/v1/custody/wallets"),
+  ]);
+  const wallets = walletsResp.wallets;
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-10 text-foreground">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8">
+        <DashboardHeader title="Custody" subtitle="Dashboard" backHref="/dashboard" />
+
+        {!config ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Enable custody</CardTitle>
+              <CardDescription>
+                Provision your first signing wallet to authorize API operations.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap items-center justify-between gap-4">
+              <div className="text-sm text-muted-foreground">
+                This creates a master signing wallet for your organization. You can add more wallets
+                later and choose which one signs by default.
+              </div>
+              <Link href="/dashboard/custody/setup">
+                <Button>Get started</Button>
+              </Link>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+            <Card>
+              <CardHeader>
+                <CardTitle>Signing configuration</CardTitle>
+                <CardDescription>Controls which custody wallet signs new API actions.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-muted-foreground">Provider</span>
+                    <span className="font-medium text-foreground">{config.provider}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-muted-foreground">Master address</span>
+                    <span className="font-mono text-xs text-foreground">{config.publicKey}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-muted-foreground">Default wallet</span>
+                    <span className="font-mono text-xs text-foreground">
+                      {config.defaultWalletId ?? "Not set"}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-3">
+                  <Link href="/dashboard/custody/switch">
+                    <Button variant="secondary">Change provider</Button>
+                  </Link>
+                </div>
+
+                <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                  Changing providers affects new actions only. Existing on-chain authorities are not
+                  automatically rotated.
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>New wallet</CardTitle>
+                <CardDescription>Create an additional signing wallet.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {config.provider !== "privy" ? (
+                  <p className="text-sm text-muted-foreground">
+                    Wallet provisioning is only available for the Privy provider right now.
+                  </p>
+                ) : (
+                  <form action={createCustodyWallet} className="grid gap-4">
+                    <div className="grid gap-2">
+                      <Label htmlFor="label">Label</Label>
+                      <Input id="label" name="label" placeholder="Signing wallet" />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="purpose">Purpose (optional)</Label>
+                      <select
+                        id="purpose"
+                        name="purpose"
+                        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                        defaultValue=""
+                      >
+                        <option value="">Not set</option>
+                        <option value="root">root</option>
+                        <option value="mint_authority">mint_authority</option>
+                        <option value="freeze_authority">freeze_authority</option>
+                        <option value="fee_payer">fee_payer</option>
+                        <option value="transfer">transfer</option>
+                      </select>
+                      <p className="text-xs text-muted-foreground">
+                        Purposes are used for future policy and UI grouping.
+                      </p>
+                    </div>
+                    <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <input type="checkbox" name="setDefault" />
+                      Make default
+                    </label>
+                    <Button type="submit">Create wallet</Button>
+                  </form>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Wallets</CardTitle>
+            <CardDescription>Signing wallets available to your organization.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {wallets.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No wallets found.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Label</TableHead>
+                      <TableHead>Purpose</TableHead>
+                      <TableHead>Public key</TableHead>
+                      <TableHead>Wallet id</TableHead>
+                      <TableHead className="text-right">Default</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {wallets.map((w) => {
+                      const isDefault = config?.defaultWalletId === w.walletId;
+                      return (
+                        <TableRow key={w.id}>
+                          <TableCell className="font-medium">{w.label ?? "Untitled"}</TableCell>
+                          <TableCell className="text-muted-foreground">{w.purpose ?? "-"}</TableCell>
+                          <TableCell className="font-mono text-xs">{w.publicKey}</TableCell>
+                          <TableCell className="font-mono text-xs text-muted-foreground">
+                            {w.walletId}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {isDefault ? (
+                              <span className="text-xs font-medium text-foreground">Default</span>
+                            ) : (
+                              <form action={setDefaultCustodyWallet}>
+                                <input type="hidden" name="walletId" value={w.walletId} />
+                                <Button type="submit" size="sm" variant="secondary">
+                                  Set
+                                </Button>
+                              </form>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
@@ -66,7 +66,12 @@ export default async function CustodySetupPage() {
 
               <div className="grid gap-2">
                 <Label htmlFor="requestDelayMs">Privy request delay (ms, optional)</Label>
-                <Input id="requestDelayMs" name="requestDelayMs" placeholder="0" inputMode="numeric" />
+                <Input
+                  id="requestDelayMs"
+                  name="requestDelayMs"
+                  placeholder="0"
+                  inputMode="numeric"
+                />
               </div>
 
               <div className="flex flex-wrap items-center gap-3">
@@ -89,4 +94,3 @@ export default async function CustodySetupPage() {
     </main>
   );
 }
-

--- a/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
@@ -1,0 +1,92 @@
+import { DashboardHeader } from "@/components/dashboard-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { initializeCustody } from "../actions";
+
+export default async function CustodySetupPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-10 text-foreground">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8">
+        <DashboardHeader title="Enable custody" subtitle="Custody" backHref="/dashboard/custody" />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Create your master signing wallet</CardTitle>
+            <CardDescription>
+              This wallet will be used to sign API operations by default. You can create additional
+              wallets later.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <form action={initializeCustody} className="grid gap-5">
+              <div className="grid gap-2">
+                <Label htmlFor="provider">Provider</Label>
+                <select
+                  id="provider"
+                  name="provider"
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                  defaultValue="privy"
+                >
+                  <option value="privy">Privy (recommended)</option>
+                  <option value="local">Local (development only)</option>
+                </select>
+                <p className="text-xs text-muted-foreground">
+                  Privy is managed by SDP. Local custody generates a key stored in the database and
+                  should not be used in production.
+                </p>
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="walletLabel">Wallet label</Label>
+                <Input id="walletLabel" name="walletLabel" placeholder="Master wallet" />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="apiBaseUrl">Privy API base URL (optional)</Label>
+                <Input
+                  id="apiBaseUrl"
+                  name="apiBaseUrl"
+                  placeholder="https://api.privy.io"
+                  inputMode="url"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="requestDelayMs">Privy request delay (ms, optional)</Label>
+                <Input id="requestDelayMs" name="requestDelayMs" placeholder="0" inputMode="numeric" />
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <Button type="submit">Provision wallet</Button>
+                <Link href="/dashboard/custody">
+                  <Button type="button" variant="secondary">
+                    Cancel
+                  </Button>
+                </Link>
+              </div>
+            </form>
+
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              This step provisions custody for your organization. It does not automatically rotate
+              on-chain authorities for existing assets.
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}
+

--- a/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
@@ -1,0 +1,96 @@
+import { DashboardHeader } from "@/components/dashboard-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { switchCustodyProvider } from "../actions";
+
+export default async function CustodySwitchPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-10 text-foreground">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8">
+        <DashboardHeader
+          title="Change provider"
+          subtitle="Custody"
+          backHref="/dashboard/custody"
+        />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Switch custody provider</CardTitle>
+            <CardDescription>
+              This updates which provider signs new API actions. It does not automatically rotate
+              existing on-chain authorities.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              Safeguard: type <span className="font-mono text-foreground">SWITCH</span> to confirm.
+            </div>
+
+            <form action={switchCustodyProvider} className="grid gap-5">
+              <div className="grid gap-2">
+                <Label htmlFor="provider">New provider</Label>
+                <select
+                  id="provider"
+                  name="provider"
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                  defaultValue="privy"
+                >
+                  <option value="privy">Privy</option>
+                  <option value="local">Local (development only)</option>
+                </select>
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="walletLabel">Default wallet label</Label>
+                <Input id="walletLabel" name="walletLabel" placeholder="Default" />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="apiBaseUrl">Privy API base URL (optional)</Label>
+                <Input
+                  id="apiBaseUrl"
+                  name="apiBaseUrl"
+                  placeholder="https://api.privy.io"
+                  inputMode="url"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="requestDelayMs">Privy request delay (ms, optional)</Label>
+                <Input id="requestDelayMs" name="requestDelayMs" placeholder="0" inputMode="numeric" />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="confirm">Confirmation</Label>
+                <Input id="confirm" name="confirm" placeholder="SWITCH" />
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <Button type="submit">Switch provider</Button>
+                <Link href="/dashboard/custody">
+                  <Button type="button" variant="secondary">
+                    Cancel
+                  </Button>
+                </Link>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}
+

--- a/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
@@ -20,11 +20,7 @@ export default async function CustodySwitchPage() {
   return (
     <main className="min-h-screen bg-background px-6 py-10 text-foreground">
       <div className="mx-auto flex max-w-3xl flex-col gap-8">
-        <DashboardHeader
-          title="Change provider"
-          subtitle="Custody"
-          backHref="/dashboard/custody"
-        />
+        <DashboardHeader title="Change provider" subtitle="Custody" backHref="/dashboard/custody" />
 
         <Card>
           <CardHeader>
@@ -70,7 +66,12 @@ export default async function CustodySwitchPage() {
 
               <div className="grid gap-2">
                 <Label htmlFor="requestDelayMs">Privy request delay (ms, optional)</Label>
-                <Input id="requestDelayMs" name="requestDelayMs" placeholder="0" inputMode="numeric" />
+                <Input
+                  id="requestDelayMs"
+                  name="requestDelayMs"
+                  placeholder="0"
+                  inputMode="numeric"
+                />
               </div>
 
               <div className="grid gap-2">
@@ -93,4 +94,3 @@ export default async function CustodySwitchPage() {
     </main>
   );
 }
-

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -104,7 +104,10 @@ export default function DashboardPage() {
           </CardHeader>
           <CardContent className="flex flex-wrap items-center justify-between gap-4 text-sm text-muted-foreground">
             <p>Manage your signing provider and custody wallets.</p>
-            <Link href="/dashboard/custody" className="text-foreground underline underline-offset-4">
+            <Link
+              href="/dashboard/custody"
+              className="text-foreground underline underline-offset-4"
+            >
               Open custody settings
             </Link>
           </CardContent>

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { OrganizationSwitcher, SignInButton, UserButton, useAuth } from "@clerk/nextjs";
+import Link from "next/link";
 
 export default function DashboardPage() {
   const { isLoaded, isSignedIn, orgId } = useAuth();
@@ -96,6 +97,18 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
         </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Custody</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center justify-between gap-4 text-sm text-muted-foreground">
+            <p>Manage your signing provider and custody wallets.</p>
+            <Link href="/dashboard/custody" className="text-foreground underline underline-offset-4">
+              Open custody settings
+            </Link>
+          </CardContent>
+        </Card>
       </div>
     </main>
   );

--- a/apps/sdp-web/src/components/dashboard-header.tsx
+++ b/apps/sdp-web/src/components/dashboard-header.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { OrganizationSwitcher, UserButton } from "@clerk/nextjs";
+import Link from "next/link";
+
+export function DashboardHeader({
+  title,
+  subtitle = "Dashboard",
+  backHref,
+}: {
+  title: string;
+  subtitle?: string;
+  backHref?: string;
+}) {
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-4">
+      <div className="space-y-1">
+        <div className="flex items-center gap-3">
+          {backHref ? (
+            <Link
+              href={backHref}
+              className="text-xs uppercase tracking-wide text-muted-foreground hover:text-foreground"
+            >
+              Back
+            </Link>
+          ) : null}
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">{subtitle}</p>
+        </div>
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <OrganizationSwitcher hidePersonal />
+        <UserButton />
+      </div>
+    </header>
+  );
+}
+

--- a/apps/sdp-web/src/components/dashboard-header.tsx
+++ b/apps/sdp-web/src/components/dashboard-header.tsx
@@ -36,4 +36,3 @@ export function DashboardHeader({
     </header>
   );
 }
-

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -49,11 +49,11 @@ async function getClerkToken(): Promise<string> {
   return token;
 }
 
-export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+export async function sdpApiRequest(path: string, options: RequestInit = {}): Promise<Response> {
   const token = await getClerkToken();
   const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
 
-  const res = await fetch(url, {
+  return fetch(url, {
     ...options,
     headers: {
       Authorization: `Bearer ${token}`,
@@ -62,6 +62,10 @@ export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): P
     },
     cache: "no-store",
   });
+}
+
+export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const res = await sdpApiRequest(path, options);
 
   if (!res.ok) {
     const body = await res.text();


### PR DESCRIPTION
## Summary
- Add custody settings pages under `/dashboard/custody` to enable custody, create wallets, set default wallet, and switch provider (Privy or local).
- Add API endpoints to support switching provider and setting the default wallet.
- Avoids any mention of Clerk vs SDP in UI copy; uses existing Clerk auth for access.

## Routes
- Web: `/dashboard/custody`, `/dashboard/custody/setup`, `/dashboard/custody/switch`
- API: `POST /v1/custody/switch`, `POST /v1/custody/default-wallet`

## Notes
- Targets `codex/privy-reseller-custody` because custody init schema differs from `main` (reseller Privy model: env-only Privy creds).
- Switching provider changes the default signer for new actions only; no on-chain authority rotation.

## Testing
- `pnpm -C apps/sdp-api typecheck`
- `pnpm -C apps/sdp-web typecheck`
- `pnpm exec biome check --changed --since=origin/main --no-errors-on-unmatched`