### PR TITLE
Refactor custody endpoint group to wallets

### DIFF
--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -19,7 +19,7 @@ import type { Env } from "@/types/env";
 import allowlist from "@/routes/allowlist";
 import apiKeys from "@/routes/api-keys";
 import auth from "@/routes/auth";
-import custody from "@/routes/custody";
+import wallets from "@/routes/custody";
 import docs from "@/routes/docs";
 // Routes
 import health from "@/routes/health";
@@ -87,7 +87,7 @@ v1.route("/members", members);
 v1.route("/auth", auth);
 v1.route("/projects", projects);
 v1.route("/issuance", issuance);
-v1.route("/custody", custody);
+v1.route("/wallets", wallets);
 v1.route("/onboarding", onboarding);
 
 app.route("/v1", v1);

--- a/apps/sdp-api/src/openapi/paths/custody.ts
+++ b/apps/sdp-api/src/openapi/paths/custody.ts
@@ -19,12 +19,12 @@ import { custodyConfigResponse, custodyWalletResponse, custodyWalletsResponse } 
 export function registerCustodyPaths(registry: OpenAPIRegistry) {
   registry.registerPath({
     method: "post",
-    path: "/v1/custody/initialize",
-    tags: ["Custody"],
-    summary: "Initialize custody",
-    operationId: "initializeCustody",
+    path: "/v1/wallets/initialize",
+    tags: ["Wallets"],
+    summary: "Initialize wallet signing",
+    operationId: "initializeWalletSigning",
     description:
-      "Initializes custody for the organization or project by creating an active signing configuration.",
+      "Initializes wallet signing for the organization or project by creating an active signing configuration.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -34,7 +34,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
     },
     responses: {
       201: {
-        description: "Custody initialized",
+        description: "Wallet signing initialized",
         content: jsonContent(initializeSigningResponseSchema),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 409, 500]),
@@ -43,12 +43,12 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "post",
-    path: "/v1/custody/switch",
-    tags: ["Custody"],
-    summary: "Switch custody provider",
-    operationId: "switchCustodyProvider",
+    path: "/v1/wallets/switch",
+    tags: ["Wallets"],
+    summary: "Switch wallet signing provider",
+    operationId: "switchWalletSigningProvider",
     description:
-      "Switches the active custody provider for the organization or project without rotating existing on-chain authorities.",
+      "Switches the active wallet signing provider for the organization or project without rotating existing on-chain authorities.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -58,7 +58,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
     },
     responses: {
       201: {
-        description: "Custody provider switched",
+        description: "Wallet signing provider switched",
         content: jsonContent(initializeSigningResponseSchema),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
@@ -67,11 +67,11 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "post",
-    path: "/v1/custody/wallets",
-    tags: ["Custody"],
-    summary: "Create custody wallet",
-    operationId: "createCustodyWallet",
-    description: "Provisions a new wallet for the active custody provider configuration.",
+    path: "/v1/wallets",
+    tags: ["Wallets"],
+    summary: "Create wallet",
+    operationId: "createWallet",
+    description: "Provisions a new wallet for the active signing provider configuration.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -90,11 +90,11 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "post",
-    path: "/v1/custody/default-wallet",
-    tags: ["Custody"],
-    summary: "Set default custody wallet",
-    operationId: "setDefaultCustodyWallet",
-    description: "Sets the default wallet for the active custody configuration.",
+    path: "/v1/wallets/default-wallet",
+    tags: ["Wallets"],
+    summary: "Set default wallet",
+    operationId: "setDefaultWallet",
+    description: "Sets the default wallet for the active signing configuration.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -113,11 +113,11 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "get",
-    path: "/v1/custody/config",
-    tags: ["Custody"],
-    summary: "Get custody config",
-    operationId: "getCustodyConfig",
-    description: "Returns the active custody configuration for the organization or project.",
+    path: "/v1/wallets/config",
+    tags: ["Wallets"],
+    summary: "Get wallet signing config",
+    operationId: "getWalletConfig",
+    description: "Returns the active wallet signing configuration for the organization or project.",
     security: [{ apiKeyAuth: [] }],
     request: {
       query: z.object({
@@ -126,7 +126,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
     },
     responses: {
       200: {
-        description: "Custody config",
+        description: "Wallet signing config",
         content: jsonContent(custodyConfigResponse),
       },
       ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
@@ -135,11 +135,11 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "get",
-    path: "/v1/custody/wallets",
-    tags: ["Custody"],
-    summary: "List custody wallets",
-    operationId: "listCustodyWallets",
-    description: "Lists wallets for the active custody configuration.",
+    path: "/v1/wallets",
+    tags: ["Wallets"],
+    summary: "List wallets",
+    operationId: "listWallets",
+    description: "Lists wallets for the active signing configuration.",
     security: [{ apiKeyAuth: [] }],
     request: {
       query: z.object({
@@ -148,7 +148,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
     },
     responses: {
       200: {
-        description: "Custody wallets",
+        description: "Wallets",
         content: jsonContent(custodyWalletsResponse),
       },
       ...errorResponses(errorResponseSchema, [401, 403, 500]),
@@ -157,11 +157,11 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "get",
-    path: "/v1/custody/public-key",
-    tags: ["Custody"],
-    summary: "Get custody public key",
-    operationId: "getCustodyPublicKey",
-    description: "Returns the active custody public key for transaction construction.",
+    path: "/v1/wallets/public-key",
+    tags: ["Wallets"],
+    summary: "Get wallet public key",
+    operationId: "getWalletPublicKey",
+    description: "Returns the active wallet public key for transaction construction.",
     security: [{ apiKeyAuth: [] }],
     request: {
       query: z.object({
@@ -171,7 +171,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
     },
     responses: {
       200: {
-        description: "Custody public key",
+        description: "Wallet public key",
         content: jsonContent(custodyPublicKeyResponseSchema),
       },
       ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),

--- a/apps/sdp-api/src/openapi/schemas/base.ts
+++ b/apps/sdp-api/src/openapi/schemas/base.ts
@@ -36,7 +36,7 @@ export const tokenIdParamSchema = idSchema("Token identifier.", "tok_example");
 export const allowlistEntryIdParamSchema = idSchema("Allowlist entry identifier.", "al_example");
 export const sessionIdParamSchema = idSchema("Session identifier.", "ses_example");
 export const signingRequestIdParamSchema = idSchema(
-  "Custody signing request identifier.",
+  "Wallet signing request identifier.",
   "sigreq_example"
 );
 export const walletIdParamSchema = idSchema("Wallet identifier.", "wal_example");

--- a/apps/sdp-api/src/openapi/schemas/custody.ts
+++ b/apps/sdp-api/src/openapi/schemas/custody.ts
@@ -13,11 +13,11 @@ import {
 } from "./base";
 
 export const initializeSigningRequestSchema = initializeSigningSchemaBase.openapi({
-  description: "Initialize custody provider for the organization or project.",
+  description: "Initialize wallet signing provider for the organization or project.",
 });
 
 export const switchSigningRequestSchema = switchSigningSchemaBase.openapi({
-  description: "Switch the active custody provider for the organization or project.",
+  description: "Switch the active wallet signing provider for the organization or project.",
 });
 
 export const createCustodyWalletRequestSchema = createWalletSchemaBase
@@ -32,17 +32,17 @@ export const createCustodyWalletRequestSchema = createWalletSchemaBase
       example: "mint_authority",
     }),
     setDefault: createWalletSchemaBase.shape.setDefault.openapi({
-      description: "Set this wallet as the default signer for the active custody config.",
+      description: "Set this wallet as the default signer for the active wallet signing config.",
       example: true,
     }),
   })
-  .openapi({ description: "Create custody wallet request body." });
+  .openapi({ description: "Create wallet request body." });
 
 export const setDefaultWalletRequestSchema = setDefaultWalletSchemaBase
   .extend({
     projectId: projectIdParamSchema.optional(),
     walletId: walletIdParamSchema.openapi({
-      description: "Wallet ID to set as default for the active custody config.",
+      description: "Wallet ID to set as default for the active wallet signing config.",
       example: "privy_wallet_123",
     }),
   })
@@ -51,7 +51,7 @@ export const setDefaultWalletRequestSchema = setDefaultWalletSchemaBase
 export const initializeSigningResponseSchema = z
   .object({
     configId: z.string().openapi({
-      description: "Created custody config ID.",
+      description: "Created wallet signing config ID.",
       example: "cfg_example",
     }),
     publicKey: solanaAddressSchema.openapi({
@@ -62,15 +62,15 @@ export const initializeSigningResponseSchema = z
       example: "privy_wallet_123",
     }),
   })
-  .openapi({ description: "Custody initialization result." });
+  .openapi({ description: "Wallet signing initialization result." });
 
 export const orgCustodyProviderSchema = z
   .enum(["local", "fireblocks", "privy"])
-  .openapi({ description: "Custody provider.", example: "privy" });
+  .openapi({ description: "Wallet signing provider.", example: "privy" });
 
 export const custodyWalletSchema = z
   .object({
-    id: z.string().openapi({ description: "Custody wallet record ID.", example: "cw_example" }),
+    id: z.string().openapi({ description: "Wallet record ID.", example: "cw_example" }),
     walletId: walletIdParamSchema.openapi({
       description: "Provider wallet ID.",
       example: "privy_wallet_123",
@@ -90,25 +90,25 @@ export const custodyWalletSchema = z
     }),
     createdAt: isoDateTimeSchema,
   })
-  .openapi({ description: "Custody wallet details." });
+  .openapi({ description: "Wallet details." });
 
 export const custodyWalletResponseSchema = z
   .object({
     wallet: custodyWalletSchema,
   })
-  .openapi({ description: "Created custody wallet response payload." });
+  .openapi({ description: "Created wallet response payload." });
 
 export const custodyWalletsResponseSchema = z
   .object({
-    wallets: z.array(custodyWalletSchema).openapi({ description: "Custody wallets." }),
+    wallets: z.array(custodyWalletSchema).openapi({ description: "Wallets." }),
   })
-  .openapi({ description: "Custody wallets list response payload." });
+  .openapi({ description: "Wallets list response payload." });
 
 export const orgCustodyConfigSchema = z
   .object({
-    id: z.string().openapi({ description: "Custody config ID.", example: "cfg_example" }),
+    id: z.string().openapi({ description: "Wallet signing config ID.", example: "cfg_example" }),
     organizationId: z.string().openapi({
-      description: "Organization ID that owns this custody config.",
+      description: "Organization ID that owns this wallet signing config.",
       example: "org_example",
     }),
     projectId: projectIdParamSchema
@@ -127,13 +127,13 @@ export const orgCustodyConfigSchema = z
     }),
     createdAt: isoDateTimeSchema,
   })
-  .openapi({ description: "Custody configuration details." });
+  .openapi({ description: "Wallet signing configuration details." });
 
 export const custodyConfigResponseSchema = z
   .object({
     config: orgCustodyConfigSchema,
   })
-  .openapi({ description: "Custody configuration response payload." });
+  .openapi({ description: "Wallet signing configuration response payload." });
 
 export const setDefaultWalletResponseSchema = z
   .object({
@@ -148,4 +148,4 @@ export const custodyPublicKeyResponseSchema = z
   .object({
     publicKey: solanaAddressSchema,
   })
-  .openapi({ description: "Custody public key response payload." });
+  .openapi({ description: "Wallet public key response payload." });

--- a/apps/sdp-api/src/openapi/spec.ts
+++ b/apps/sdp-api/src/openapi/spec.ts
@@ -66,7 +66,10 @@ export function createOpenApiDocument(): OpenAPIObject {
       { name: "API Keys", description: "API key management endpoints." },
       { name: "Members", description: "Organization membership invitations and roles." },
       { name: "Auth", description: "Session authentication and management." },
-      { name: "Custody", description: "Custody provider configuration and wallet management." },
+      {
+        name: "Wallets",
+        description: "Wallet signing provider configuration and wallet management.",
+      },
       { name: "Projects", description: "Project and project member management." },
       { name: "Issuance", description: "Token issuance, allowlists, and lifecycle operations." },
       {

--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -1,5 +1,5 @@
 /**
- * Custody API Handlers
+ * Wallet API Handlers
  */
 
 import { AppError } from "@/lib/errors";
@@ -51,7 +51,7 @@ function resolveActor(c: AppContext): { organizationId: string } {
  * For "fireblocks" provider: Stores Fireblocks credentials and retrieves the public key.
  * For "privy" provider: Stores Privy credentials and retrieves the public key.
  *
- * POST /custody/initialize
+ * POST /wallets/initialize
  */
 export const initializeSigning = async (c: AppContext) => {
   const actor = resolveActor(c);
@@ -121,10 +121,10 @@ export const initializeSigning = async (c: AppContext) => {
 /**
  * Switch the signing provider for the organization (or project).
  *
- * This deactivates the existing active custody config for the requested scope and then
+ * This deactivates the existing active wallet signing config for the requested scope and then
  * initializes the requested provider. Existing on-chain authorities are NOT rotated.
  *
- * POST /custody/switch
+ * POST /wallets/switch
  */
 export const switchSigning = async (c: AppContext) => {
   const actor = resolveActor(c);
@@ -203,9 +203,9 @@ export const switchSigning = async (c: AppContext) => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
- * Provision a new custody wallet for the organization (or project).
+ * Provision a new wallet for the organization (or project).
  *
- * POST /custody/wallets
+ * POST /wallets
  */
 export const createWallet = async (c: AppContext) => {
   const actor = resolveActor(c);
@@ -257,9 +257,9 @@ export const createWallet = async (c: AppContext) => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
- * Set the default wallet for the active custody configuration.
+ * Set the default wallet for the active wallet signing configuration.
  *
- * POST /custody/default-wallet
+ * POST /wallets/default-wallet
  */
 export const setDefaultWallet = async (c: AppContext) => {
   const actor = resolveActor(c);
@@ -289,7 +289,7 @@ export const setDefaultWallet = async (c: AppContext) => {
     .first<{ id: string }>();
 
   if (!config?.id) {
-    throw new AppError("CONFLICT", "Custody not initialized");
+    throw new AppError("CONFLICT", "Wallet signing is not initialized");
   }
 
   const wallet = await c.env.DB.prepare(
@@ -302,7 +302,7 @@ export const setDefaultWallet = async (c: AppContext) => {
     .first<{ id: string }>();
 
   if (!wallet) {
-    throw new AppError("BAD_REQUEST", "Unknown walletId for this custody configuration");
+    throw new AppError("BAD_REQUEST", "Unknown walletId for this wallet signing configuration");
   }
 
   await c.env.DB.prepare(
@@ -321,9 +321,9 @@ export const setDefaultWallet = async (c: AppContext) => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
- * Get the current custody configuration for the organization.
+ * Get the current wallet signing configuration for the organization.
  *
- * GET /custody/config
+ * GET /wallets/config
  */
 export const getConfig = async (c: AppContext) => {
   const actor = resolveActor(c);
@@ -333,7 +333,7 @@ export const getConfig = async (c: AppContext) => {
   const config = await signingService.getConfiguration(actor.organizationId, projectId);
 
   if (!config) {
-    throw new AppError("NOT_FOUND", "No custody configuration found for this organization");
+    throw new AppError("NOT_FOUND", "No wallet signing configuration found for this organization");
   }
 
   // Get the public key from the adapter
@@ -360,9 +360,9 @@ export const getConfig = async (c: AppContext) => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
- * List wallets for the organization's custody configuration.
+ * List wallets for the organization's active signing configuration.
  *
- * GET /custody/wallets
+ * GET /wallets
  */
 export const listWallets = async (c: AppContext) => {
   const actor = resolveActor(c);
@@ -393,10 +393,10 @@ export const listWallets = async (c: AppContext) => {
 /**
  * Get the public key for the organization's signing wallet.
  *
- * This endpoint is useful for clients that need to know the custody address
+ * This endpoint is useful for clients that need to know the wallet address
  * for constructing transactions.
  *
- * GET /custody/public-key
+ * GET /wallets/public-key
  */
 export const getPublicKey = async (c: AppContext) => {
   const actor = resolveActor(c);

--- a/apps/sdp-api/src/routes/custody/index.ts
+++ b/apps/sdp-api/src/routes/custody/index.ts
@@ -1,8 +1,7 @@
 /**
- * Custody Routes
+ * Wallet Routes
  *
- * Manages organization-specific signing key configuration.
- * Enables per-org custody while maintaining backward compatibility with env-based signing.
+ * Manages organization-specific signing key configuration and wallet provisioning.
  */
 
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
@@ -18,20 +17,20 @@ import {
   switchSigning,
 } from "./handlers";
 
-const custody = new Hono<{ Bindings: Env }>();
+const wallets = new Hono<{ Bindings: Env }>();
 
 // All routes require authentication
-custody.use("*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true }));
+wallets.use("*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true }));
 
 // Initialize signing (requires admin)
-custody.post("/initialize", requirePermissions("custody:admin"), initializeSigning);
-custody.post("/switch", requirePermissions("custody:admin"), switchSigning);
-custody.post("/wallets", requirePermissions("custody:admin"), createWallet);
-custody.post("/default-wallet", requirePermissions("custody:admin"), setDefaultWallet);
+wallets.post("/initialize", requirePermissions("custody:admin"), initializeSigning);
+wallets.post("/switch", requirePermissions("custody:admin"), switchSigning);
+wallets.post("/", requirePermissions("custody:admin"), createWallet);
+wallets.post("/default-wallet", requirePermissions("custody:admin"), setDefaultWallet);
 
 // Read configuration and wallets
-custody.get("/config", requirePermissions("custody:read"), getConfig);
-custody.get("/wallets", requirePermissions("custody:read"), listWallets);
-custody.get("/public-key", requirePermissions("custody:read"), getPublicKey);
+wallets.get("/config", requirePermissions("custody:read"), getConfig);
+wallets.get("/", requirePermissions("custody:read"), listWallets);
+wallets.get("/public-key", requirePermissions("custody:read"), getPublicKey);
 
-export default custody;
+export default wallets;

--- a/apps/sdp-api/src/routes/custody/schemas.ts
+++ b/apps/sdp-api/src/routes/custody/schemas.ts
@@ -1,5 +1,5 @@
 /**
- * Custody API Schemas
+ * Wallet API Schemas
  */
 
 import { z } from "zod";

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -18,12 +18,12 @@ export async function initializeCustody(formData: FormData) {
   const walletLabel = getOptionalString(formData, "walletLabel");
 
   if (provider === "local") {
-    await sdpApiFetch("/v1/custody/initialize", {
+    await sdpApiFetch("/v1/wallets/initialize", {
       method: "POST",
       body: JSON.stringify({ provider, walletLabel }),
     });
   } else {
-    await sdpApiFetch("/v1/custody/initialize", {
+    await sdpApiFetch("/v1/wallets/initialize", {
       method: "POST",
       body: JSON.stringify({ provider, walletLabel }),
     });
@@ -43,12 +43,12 @@ export async function switchCustodyProvider(formData: FormData) {
   }
 
   if (provider === "local") {
-    await sdpApiFetch("/v1/custody/switch", {
+    await sdpApiFetch("/v1/wallets/switch", {
       method: "POST",
       body: JSON.stringify({ provider, walletLabel }),
     });
   } else {
-    await sdpApiFetch("/v1/custody/switch", {
+    await sdpApiFetch("/v1/wallets/switch", {
       method: "POST",
       body: JSON.stringify({ provider, walletLabel }),
     });
@@ -69,7 +69,7 @@ export async function createCustodyWallet(formData: FormData) {
     | undefined;
   const setDefault = getString(formData, "setDefault") === "on";
 
-  await sdpApiFetch("/v1/custody/wallets", {
+  await sdpApiFetch("/v1/wallets", {
     method: "POST",
     body: JSON.stringify({ label, purpose, setDefault }),
   });
@@ -84,7 +84,7 @@ export async function setDefaultCustodyWallet(formData: FormData) {
     throw new Error("walletId is required");
   }
 
-  await sdpApiFetch("/v1/custody/default-wallet", {
+  await sdpApiFetch("/v1/wallets/default-wallet", {
     method: "POST",
     body: JSON.stringify({ walletId }),
   });

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -48,7 +48,7 @@ interface ClerkOrganizationSummary {
 }
 
 async function getCustodyConfig(): Promise<CustodyConfig | null> {
-  const res = await sdpApiRequest("/v1/custody/config");
+  const res = await sdpApiRequest("/v1/wallets/config");
   if (res.status === 404) return null;
   if (!res.ok) {
     const body = await res.text();
@@ -139,7 +139,7 @@ export default async function CustodyPage() {
 
   const [config, walletsResp] = await Promise.all([
     getCustodyConfig(),
-    sdpApiFetch<{ wallets: CustodyWallet[] }>("/v1/custody/wallets"),
+    sdpApiFetch<{ wallets: CustodyWallet[] }>("/v1/wallets"),
   ]);
   const wallets = walletsResp.wallets;
 

--- a/packages/sdp-api-integration/src/tests/custody-local.test.ts
+++ b/packages/sdp-api-integration/src/tests/custody-local.test.ts
@@ -65,7 +65,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
   });
 
   it("initializes local custody and uses it for deployments", { timeout: 120000 }, async () => {
-    const initRes = await request("/v1/custody/initialize", {
+    const initRes = await request("/v1/wallets/initialize", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -81,7 +81,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
     const { configId, publicKey } = initBody.data;
     expect(publicKey).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
 
-    const configRes = await request("/v1/custody/config");
+    const configRes = await request("/v1/wallets/config");
 
     expect(configRes.status).toBe(200);
     const configBody = (await configRes.json()) as {
@@ -134,10 +134,10 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Local Sig
   });
 
   it("requires auth for custody endpoints", async () => {
-    const configRes = await rawRequest("/v1/custody/config");
+    const configRes = await rawRequest("/v1/wallets/config");
     expect(configRes.status).toBe(401);
 
-    const initRes = await rawRequest("/v1/custody/initialize", {
+    const initRes = await rawRequest("/v1/wallets/initialize", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "local" }),


### PR DESCRIPTION
## Summary
Refactors the external endpoint group from `custody` to `wallets` and updates first-party consumers accordingly.

## API Changes
- Route mount changed from `/v1/custody/*` to `/v1/wallets/*`.
- Wallet create/list endpoints now use the clean base path:
  - `POST /v1/wallets`
  - `GET /v1/wallets`
- Other wallet-signing endpoints:
  - `POST /v1/wallets/initialize`
  - `POST /v1/wallets/switch`
  - `POST /v1/wallets/default-wallet`
  - `GET /v1/wallets/config`
  - `GET /v1/wallets/public-key`

## Docs/OpenAPI
- OpenAPI tag renamed from `Custody` to `Wallets`.
- Path entries updated to `/v1/wallets/*` with wallet-focused summaries/descriptions.
- Wallet-signing schema descriptions updated to remove custody wording in the endpoint docs.

## Consumer Updates
- Updated dashboard custody actions/page API calls to `/v1/wallets/*`.
- Updated API integration tests to use `/v1/wallets/*`.

## Validation
- `pnpm --filter @sdp/api lint`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter sdp-web lint`
- `pnpm --filter sdp-web typecheck`
