### PR TITLE
Payments PR3: confidential transfer + fee quote endpoints

### DIFF
--- a/apps/sdp-api/src/db/drizzle/schema/sqlite.ts
+++ b/apps/sdp-api/src/db/drizzle/schema/sqlite.ts
@@ -568,3 +568,67 @@ export const custodyWallets = sqliteTable(
     ),
   })
 );
+
+export const paymentWalletPolicies = sqliteTable(
+  "payment_wallet_policies",
+  {
+    id: text("id").primaryKey(),
+    custodyWalletId: text("custody_wallet_id")
+      .notNull()
+      .references(() => custodyWallets.id, { onDelete: "cascade" }),
+    mode: text("mode").notNull().default("none"),
+    destinationAllowlist: text("destination_allowlist").notNull().default("[]"),
+    maxTransferAmount: text("max_transfer_amount"),
+    maxDailyAmount: text("max_daily_amount"),
+    createdAt: text("created_at").notNull().default(sql`(STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))`),
+    updatedAt: text("updated_at").notNull().default(sql`(STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))`),
+  },
+  (table) => ({
+    walletUnique: uniqueIndex("payment_wallet_policies_custody_wallet_id_unique").on(
+      table.custodyWalletId
+    ),
+    walletIdx: index("idx_payment_wallet_policies_wallet").on(table.custodyWalletId),
+  })
+);
+
+export const paymentTransfers = sqliteTable(
+  "payment_transfers",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    walletId: text("wallet_id").notNull(),
+    sourceAddress: text("source_address").notNull(),
+    destinationAddress: text("destination_address").notNull(),
+    token: text("token").notNull(),
+    amount: text("amount").notNull(),
+    memo: text("memo"),
+    type: text("type").notNull(),
+    direction: text("direction").notNull(),
+    status: text("status").notNull(),
+    signature: text("signature"),
+    serializedTx: text("serialized_tx"),
+    slot: integer("slot"),
+    blockTime: text("block_time"),
+    fee: integer("fee"),
+    error: text("error"),
+    initiatedByKeyId: text("initiated_by_key_id"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => ({
+    signatureUnique: uniqueIndex("payment_transfers_signature_unique").on(table.signature),
+    orgCreatedIdx: index("idx_payment_transfers_org_created").on(
+      table.organizationId,
+      table.createdAt
+    ),
+    projectCreatedIdx: index("idx_payment_transfers_project_created").on(
+      table.projectId,
+      table.createdAt
+    ),
+    walletIdx: index("idx_payment_transfers_wallet").on(table.walletId),
+    statusIdx: index("idx_payment_transfers_status").on(table.status),
+  })
+);

--- a/apps/sdp-api/src/db/drizzle/schema/sqlite.ts
+++ b/apps/sdp-api/src/db/drizzle/schema/sqlite.ts
@@ -576,16 +576,15 @@ export const paymentWalletPolicies = sqliteTable(
     custodyWalletId: text("custody_wallet_id")
       .notNull()
       .references(() => custodyWallets.id, { onDelete: "cascade" }),
-    destinationAllowlist: text("destination_allowlist").notNull().default("[]"),
-    maxTransferAmount: text("max_transfer_amount"),
-    maxDailyAmount: text("max_daily_amount"),
+    policyType: text("policy_type").notNull(),
+    policy: text("policy").notNull(),
     createdAt: text("created_at").notNull().default(sql`(STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))`),
     updatedAt: text("updated_at").notNull().default(sql`(STRFTIME('%Y-%m-%dT%H:%M:%fZ','now'))`),
   },
   (table) => ({
-    walletUnique: uniqueIndex("payment_wallet_policies_custody_wallet_id_unique").on(
-      table.custodyWalletId
-    ),
+    walletPolicyTypeUnique: uniqueIndex(
+      "payment_wallet_policies_custody_wallet_id_policy_type_unique"
+    ).on(table.custodyWalletId, table.policyType),
     walletIdx: index("idx_payment_wallet_policies_wallet").on(table.custodyWalletId),
   })
 );

--- a/apps/sdp-api/src/db/drizzle/schema/sqlite.ts
+++ b/apps/sdp-api/src/db/drizzle/schema/sqlite.ts
@@ -576,7 +576,6 @@ export const paymentWalletPolicies = sqliteTable(
     custodyWalletId: text("custody_wallet_id")
       .notNull()
       .references(() => custodyWallets.id, { onDelete: "cascade" }),
-    mode: text("mode").notNull().default("none"),
     destinationAllowlist: text("destination_allowlist").notNull().default("[]"),
     maxTransferAmount: text("max_transfer_amount"),
     maxDailyAmount: text("max_daily_amount"),

--- a/apps/sdp-api/src/db/migrations/0004_payment_wallet_policies.sql
+++ b/apps/sdp-api/src/db/migrations/0004_payment_wallet_policies.sql
@@ -1,7 +1,6 @@
 CREATE TABLE payment_wallet_policies (
     id TEXT PRIMARY KEY,
     custody_wallet_id TEXT NOT NULL UNIQUE,
-    mode TEXT NOT NULL DEFAULT 'none',
     destination_allowlist TEXT NOT NULL DEFAULT '[]',
     max_transfer_amount TEXT,
     max_daily_amount TEXT,

--- a/apps/sdp-api/src/db/migrations/0004_payment_wallet_policies.sql
+++ b/apps/sdp-api/src/db/migrations/0004_payment_wallet_policies.sql
@@ -1,11 +1,11 @@
 CREATE TABLE payment_wallet_policies (
     id TEXT PRIMARY KEY,
-    custody_wallet_id TEXT NOT NULL UNIQUE,
-    destination_allowlist TEXT NOT NULL DEFAULT '[]',
-    max_transfer_amount TEXT,
-    max_daily_amount TEXT,
+    custody_wallet_id TEXT NOT NULL,
+    policy_type TEXT NOT NULL,
+    policy TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
     updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ','now')),
-    FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id) ON DELETE CASCADE
+    FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id) ON DELETE CASCADE,
+    UNIQUE (custody_wallet_id, policy_type)
 );
 CREATE INDEX idx_payment_wallet_policies_wallet ON payment_wallet_policies(custody_wallet_id);

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -5,6 +5,7 @@ export type {
   PaymentTransferRow,
   PaymentTransferStatus,
   PaymentTransferType,
+  PaymentWalletPolicyType,
   PaymentWalletPolicyRow,
   PaymentsRepository,
   PaymentsRepositoryContext,

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -1,7 +1,21 @@
 export type { DrizzleDbClient } from "./base";
 export type {
+  CreatePaymentTransferInput,
+  PaymentTransferDirection,
+  PaymentTransferRow,
+  PaymentTransferStatus,
+  PaymentTransferType,
+  PaymentWalletPolicyMode,
+  PaymentWalletPolicyRow,
+  PaymentsRepository,
+  PaymentsRepositoryContext,
+  UpdatePaymentTransferInput,
+  UpsertPaymentWalletPolicyInput,
+} from "./payments.repository";
+export type {
   ListTokensOptions,
   TokenRepository,
   TokenRepositoryContext,
 } from "./token.repository";
+export { createD1PaymentsRepository } from "./payments.repository.d1";
 export { createD1TokenRepository } from "./token.repository.d1";

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -5,7 +5,6 @@ export type {
   PaymentTransferRow,
   PaymentTransferStatus,
   PaymentTransferType,
-  PaymentWalletPolicyMode,
   PaymentWalletPolicyRow,
   PaymentsRepository,
   PaymentsRepositoryContext,

--- a/apps/sdp-api/src/db/repositories/payments.repository.d1.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.d1.ts
@@ -1,0 +1,218 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { paymentTransfers, paymentWalletPolicies } from "../drizzle/schema/sqlite";
+import type {
+  PaymentTransferRow,
+  PaymentWalletPolicyRow,
+  PaymentsRepository,
+  PaymentsRepositoryContext,
+  UpdatePaymentTransferInput,
+} from "./payments.repository";
+
+const mapTransferRow = (row: typeof paymentTransfers.$inferSelect): PaymentTransferRow => ({
+  id: row.id,
+  organization_id: row.organizationId,
+  project_id: row.projectId,
+  wallet_id: row.walletId,
+  source_address: row.sourceAddress,
+  destination_address: row.destinationAddress,
+  token: row.token,
+  amount: row.amount,
+  memo: row.memo,
+  type: row.type as PaymentTransferRow["type"],
+  direction: row.direction as PaymentTransferRow["direction"],
+  status: row.status as PaymentTransferRow["status"],
+  signature: row.signature,
+  serialized_tx: row.serializedTx,
+  slot: row.slot,
+  block_time: row.blockTime,
+  fee: row.fee,
+  error: row.error,
+  initiated_by_key_id: row.initiatedByKeyId,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+});
+
+const mapPolicyRow = (row: typeof paymentWalletPolicies.$inferSelect): PaymentWalletPolicyRow => ({
+  mode: row.mode as PaymentWalletPolicyRow["mode"],
+  destination_allowlist: row.destinationAllowlist,
+  max_transfer_amount: row.maxTransferAmount,
+  max_daily_amount: row.maxDailyAmount,
+  created_at: row.createdAt,
+  updated_at: row.updatedAt,
+});
+
+const toTransferScopeWhere = (input: {
+  organizationId: string;
+  projectId: string | null;
+  extra: ReturnType<typeof eq>;
+}) =>
+  input.projectId
+    ? and(
+        input.extra,
+        eq(paymentTransfers.organizationId, input.organizationId),
+        eq(paymentTransfers.projectId, input.projectId)
+      )
+    : and(input.extra, eq(paymentTransfers.organizationId, input.organizationId));
+
+export const createD1PaymentsRepository = (
+  context: PaymentsRepositoryContext
+): PaymentsRepository => {
+  const { db } = context;
+
+  const getTransferByIdInternal = async (transferId: string) => {
+    return db.select().from(paymentTransfers).where(eq(paymentTransfers.id, transferId)).get();
+  };
+
+  const getWalletPolicyInternal = async (custodyWalletId: string) => {
+    return db
+      .select()
+      .from(paymentWalletPolicies)
+      .where(eq(paymentWalletPolicies.custodyWalletId, custodyWalletId))
+      .get();
+  };
+
+  const buildTransferUpdateSet = (
+    existing: typeof paymentTransfers.$inferSelect,
+    input: UpdatePaymentTransferInput
+  ) => ({
+    status: input.status ?? existing.status,
+    signature: input.signature ?? existing.signature,
+    serializedTx: input.serializedTx ?? existing.serializedTx,
+    slot: input.slot ?? existing.slot,
+    blockTime: input.blockTime ?? existing.blockTime,
+    fee: input.fee ?? existing.fee,
+    error: input.error ?? existing.error,
+    updatedAt: input.updatedAt,
+  });
+
+  return {
+    async createTransfer(input) {
+      await db
+        .insert(paymentTransfers)
+        .values({
+          id: input.id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          walletId: input.walletId,
+          sourceAddress: input.sourceAddress,
+          destinationAddress: input.destinationAddress,
+          token: input.token,
+          amount: input.amount,
+          memo: input.memo,
+          type: input.type,
+          direction: input.direction,
+          status: input.status,
+          serializedTx: input.serializedTx,
+          initiatedByKeyId: input.initiatedByKeyId,
+          createdAt: input.createdAt,
+          updatedAt: input.updatedAt,
+        })
+        .run();
+
+      const row = await getTransferByIdInternal(input.id);
+      return row ? mapTransferRow(row) : null;
+    },
+
+    async updateTransfer(input) {
+      const existing = await getTransferByIdInternal(input.transferId);
+      if (!existing) {
+        return null;
+      }
+
+      await db
+        .update(paymentTransfers)
+        .set(buildTransferUpdateSet(existing, input))
+        .where(eq(paymentTransfers.id, input.transferId))
+        .run();
+
+      const updated = await getTransferByIdInternal(input.transferId);
+      return updated ? mapTransferRow(updated) : null;
+    },
+
+    async getTransferById(params) {
+      const row = await db
+        .select()
+        .from(paymentTransfers)
+        .where(
+          toTransferScopeWhere({
+            organizationId: params.organizationId,
+            projectId: params.projectId,
+            extra: eq(paymentTransfers.id, params.transferId),
+          })
+        )
+        .get();
+
+      return row ? mapTransferRow(row) : null;
+    },
+
+    async getTransferBySignature(params) {
+      const row = await db
+        .select()
+        .from(paymentTransfers)
+        .where(
+          toTransferScopeWhere({
+            organizationId: params.organizationId,
+            projectId: params.projectId,
+            extra: eq(paymentTransfers.signature, params.signature),
+          })
+        )
+        .get();
+
+      return row ? mapTransferRow(row) : null;
+    },
+
+    async listTransfersBySignatures(params) {
+      if (params.signatures.length === 0) {
+        return [];
+      }
+
+      const rows = await db
+        .select()
+        .from(paymentTransfers)
+        .where(
+          toTransferScopeWhere({
+            organizationId: params.organizationId,
+            projectId: params.projectId,
+            extra: inArray(paymentTransfers.signature, params.signatures),
+          })
+        )
+        .all();
+
+      return rows.map(mapTransferRow);
+    },
+
+    async getWalletPolicyByCustodyWalletId(custodyWalletId) {
+      const row = await getWalletPolicyInternal(custodyWalletId);
+      return row ? mapPolicyRow(row) : null;
+    },
+
+    async upsertWalletPolicy(input) {
+      await db
+        .insert(paymentWalletPolicies)
+        .values({
+          id: input.id,
+          custodyWalletId: input.custodyWalletId,
+          mode: input.mode,
+          destinationAllowlist: input.destinationAllowlist,
+          maxTransferAmount: input.maxTransferAmount,
+          maxDailyAmount: input.maxDailyAmount,
+          createdAt: input.createdAt,
+          updatedAt: input.updatedAt,
+        })
+        .onConflictDoUpdate({
+          target: paymentWalletPolicies.custodyWalletId,
+          set: {
+            mode: input.mode,
+            destinationAllowlist: input.destinationAllowlist,
+            maxTransferAmount: input.maxTransferAmount,
+            maxDailyAmount: input.maxDailyAmount,
+            updatedAt: input.updatedAt,
+          },
+        })
+        .run();
+
+      const row = await getWalletPolicyInternal(input.custodyWalletId);
+      return row ? mapPolicyRow(row) : null;
+    },
+  };
+};

--- a/apps/sdp-api/src/db/repositories/payments.repository.d1.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.d1.ts
@@ -33,9 +33,10 @@ const mapTransferRow = (row: typeof paymentTransfers.$inferSelect): PaymentTrans
 });
 
 const mapPolicyRow = (row: typeof paymentWalletPolicies.$inferSelect): PaymentWalletPolicyRow => ({
-  destination_allowlist: row.destinationAllowlist,
-  max_transfer_amount: row.maxTransferAmount,
-  max_daily_amount: row.maxDailyAmount,
+  id: row.id,
+  custody_wallet_id: row.custodyWalletId,
+  policy_type: row.policyType,
+  policy: row.policy,
   created_at: row.createdAt,
   updated_at: row.updatedAt,
 });
@@ -62,12 +63,12 @@ export const createD1PaymentsRepository = (
     return db.select().from(paymentTransfers).where(eq(paymentTransfers.id, transferId)).get();
   };
 
-  const getWalletPolicyInternal = async (custodyWalletId: string) => {
+  const getWalletPoliciesInternal = async (custodyWalletId: string) => {
     return db
       .select()
       .from(paymentWalletPolicies)
       .where(eq(paymentWalletPolicies.custodyWalletId, custodyWalletId))
-      .get();
+      .all();
   };
 
   const buildTransferUpdateSet = (
@@ -180,36 +181,39 @@ export const createD1PaymentsRepository = (
       return rows.map(mapTransferRow);
     },
 
-    async getWalletPolicyByCustodyWalletId(custodyWalletId) {
-      const row = await getWalletPolicyInternal(custodyWalletId);
-      return row ? mapPolicyRow(row) : null;
+    async getWalletPoliciesByCustodyWalletId(custodyWalletId) {
+      const rows = await getWalletPoliciesInternal(custodyWalletId);
+      return rows.map(mapPolicyRow);
     },
 
-    async upsertWalletPolicy(input) {
-      await db
-        .insert(paymentWalletPolicies)
-        .values({
-          id: input.id,
-          custodyWalletId: input.custodyWalletId,
-          destinationAllowlist: input.destinationAllowlist,
-          maxTransferAmount: input.maxTransferAmount,
-          maxDailyAmount: input.maxDailyAmount,
-          createdAt: input.createdAt,
-          updatedAt: input.updatedAt,
-        })
-        .onConflictDoUpdate({
-          target: paymentWalletPolicies.custodyWalletId,
-          set: {
-            destinationAllowlist: input.destinationAllowlist,
-            maxTransferAmount: input.maxTransferAmount,
-            maxDailyAmount: input.maxDailyAmount,
-            updatedAt: input.updatedAt,
-          },
-        })
-        .run();
+    async upsertWalletPolicies(inputs) {
+      if (inputs.length === 0) {
+        return [];
+      }
 
-      const row = await getWalletPolicyInternal(input.custodyWalletId);
-      return row ? mapPolicyRow(row) : null;
+      for (const input of inputs) {
+        await db
+          .insert(paymentWalletPolicies)
+          .values({
+            id: input.id,
+            custodyWalletId: input.custodyWalletId,
+            policyType: input.policyType,
+            policy: input.policy,
+            createdAt: input.createdAt,
+            updatedAt: input.updatedAt,
+          })
+          .onConflictDoUpdate({
+            target: [paymentWalletPolicies.custodyWalletId, paymentWalletPolicies.policyType],
+            set: {
+              policy: input.policy,
+              updatedAt: input.updatedAt,
+            },
+          })
+          .run();
+      }
+
+      const rows = await getWalletPoliciesInternal(inputs[0].custodyWalletId);
+      return rows.map(mapPolicyRow);
     },
   };
 };

--- a/apps/sdp-api/src/db/repositories/payments.repository.d1.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.d1.ts
@@ -33,7 +33,6 @@ const mapTransferRow = (row: typeof paymentTransfers.$inferSelect): PaymentTrans
 });
 
 const mapPolicyRow = (row: typeof paymentWalletPolicies.$inferSelect): PaymentWalletPolicyRow => ({
-  mode: row.mode as PaymentWalletPolicyRow["mode"],
   destination_allowlist: row.destinationAllowlist,
   max_transfer_amount: row.maxTransferAmount,
   max_daily_amount: row.maxDailyAmount,
@@ -192,7 +191,6 @@ export const createD1PaymentsRepository = (
         .values({
           id: input.id,
           custodyWalletId: input.custodyWalletId,
-          mode: input.mode,
           destinationAllowlist: input.destinationAllowlist,
           maxTransferAmount: input.maxTransferAmount,
           maxDailyAmount: input.maxDailyAmount,
@@ -202,7 +200,6 @@ export const createD1PaymentsRepository = (
         .onConflictDoUpdate({
           target: paymentWalletPolicies.custodyWalletId,
           set: {
-            mode: input.mode,
             destinationAllowlist: input.destinationAllowlist,
             maxTransferAmount: input.maxTransferAmount,
             maxDailyAmount: input.maxDailyAmount,

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -3,10 +3,8 @@ import type { DrizzleDbClient } from "./base";
 export type PaymentTransferDirection = "inbound" | "outbound";
 export type PaymentTransferType = "transfer" | "transfer_confidential";
 export type PaymentTransferStatus = "pending" | "processing" | "confirmed" | "finalized" | "failed";
-export type PaymentWalletPolicyMode = "none" | "allowlist";
 
 export interface PaymentWalletPolicyRow {
-  mode: PaymentWalletPolicyMode;
   destination_allowlist: string;
   max_transfer_amount: string | null;
   max_daily_amount: string | null;
@@ -72,7 +70,6 @@ export interface UpdatePaymentTransferInput {
 export interface UpsertPaymentWalletPolicyInput {
   id: string;
   custodyWalletId: string;
-  mode: PaymentWalletPolicyMode;
   destinationAllowlist: string;
   maxTransferAmount: string | null;
   maxDailyAmount: string | null;

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -1,0 +1,107 @@
+import type { DrizzleDbClient } from "./base";
+
+export type PaymentTransferDirection = "inbound" | "outbound";
+export type PaymentTransferType = "transfer" | "transfer_confidential";
+export type PaymentTransferStatus = "pending" | "processing" | "confirmed" | "finalized" | "failed";
+export type PaymentWalletPolicyMode = "none" | "allowlist";
+
+export interface PaymentWalletPolicyRow {
+  mode: PaymentWalletPolicyMode;
+  destination_allowlist: string;
+  max_transfer_amount: string | null;
+  max_daily_amount: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaymentTransferRow {
+  id: string;
+  organization_id: string;
+  project_id: string | null;
+  wallet_id: string;
+  source_address: string;
+  destination_address: string;
+  token: string;
+  amount: string;
+  memo: string | null;
+  type: PaymentTransferType;
+  direction: PaymentTransferDirection;
+  status: PaymentTransferStatus;
+  signature: string | null;
+  serialized_tx: string | null;
+  slot: number | null;
+  block_time: string | null;
+  fee: number | null;
+  error: string | null;
+  initiated_by_key_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatePaymentTransferInput {
+  id: string;
+  organizationId: string;
+  projectId: string | null;
+  walletId: string;
+  sourceAddress: string;
+  destinationAddress: string;
+  token: string;
+  amount: string;
+  memo: string | null;
+  type: PaymentTransferType;
+  direction: PaymentTransferDirection;
+  status: PaymentTransferStatus;
+  serializedTx: string | null;
+  initiatedByKeyId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdatePaymentTransferInput {
+  transferId: string;
+  status?: PaymentTransferStatus;
+  signature?: string | null;
+  serializedTx?: string | null;
+  slot?: number | null;
+  blockTime?: string | null;
+  fee?: number | null;
+  error?: string | null;
+  updatedAt: string;
+}
+
+export interface UpsertPaymentWalletPolicyInput {
+  id: string;
+  custodyWalletId: string;
+  mode: PaymentWalletPolicyMode;
+  destinationAllowlist: string;
+  maxTransferAmount: string | null;
+  maxDailyAmount: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaymentsRepositoryContext {
+  db: DrizzleDbClient;
+}
+
+export interface PaymentsRepository {
+  createTransfer(input: CreatePaymentTransferInput): Promise<PaymentTransferRow | null>;
+  updateTransfer(input: UpdatePaymentTransferInput): Promise<PaymentTransferRow | null>;
+  getTransferById(params: {
+    transferId: string;
+    organizationId: string;
+    projectId: string | null;
+  }): Promise<PaymentTransferRow | null>;
+  getTransferBySignature(params: {
+    signature: string;
+    organizationId: string;
+    projectId: string | null;
+  }): Promise<PaymentTransferRow | null>;
+  listTransfersBySignatures(params: {
+    signatures: string[];
+    organizationId: string;
+    projectId: string | null;
+  }): Promise<PaymentTransferRow[]>;
+  getWalletPolicyByCustodyWalletId(custodyWalletId: string): Promise<PaymentWalletPolicyRow | null>;
+  upsertWalletPolicy(input: UpsertPaymentWalletPolicyInput): Promise<PaymentWalletPolicyRow | null>;
+}

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -3,11 +3,13 @@ import type { DrizzleDbClient } from "./base";
 export type PaymentTransferDirection = "inbound" | "outbound";
 export type PaymentTransferType = "transfer" | "transfer_confidential";
 export type PaymentTransferStatus = "pending" | "processing" | "confirmed" | "finalized" | "failed";
+export type PaymentWalletPolicyType = string;
 
 export interface PaymentWalletPolicyRow {
-  destination_allowlist: string;
-  max_transfer_amount: string | null;
-  max_daily_amount: string | null;
+  id: string;
+  custody_wallet_id: string;
+  policy_type: PaymentWalletPolicyType;
+  policy: string;
   created_at: string;
   updated_at: string;
 }
@@ -70,9 +72,8 @@ export interface UpdatePaymentTransferInput {
 export interface UpsertPaymentWalletPolicyInput {
   id: string;
   custodyWalletId: string;
-  destinationAllowlist: string;
-  maxTransferAmount: string | null;
-  maxDailyAmount: string | null;
+  policyType: PaymentWalletPolicyType;
+  policy: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -99,6 +100,6 @@ export interface PaymentsRepository {
     organizationId: string;
     projectId: string | null;
   }): Promise<PaymentTransferRow[]>;
-  getWalletPolicyByCustodyWalletId(custodyWalletId: string): Promise<PaymentWalletPolicyRow | null>;
-  upsertWalletPolicy(input: UpsertPaymentWalletPolicyInput): Promise<PaymentWalletPolicyRow | null>;
+  getWalletPoliciesByCustodyWalletId(custodyWalletId: string): Promise<PaymentWalletPolicyRow[]>;
+  upsertWalletPolicies(input: UpsertPaymentWalletPolicyInput[]): Promise<PaymentWalletPolicyRow[]>;
 }

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -205,7 +205,8 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     tags: ["Payments"],
     summary: "Create confidential transfer",
     operationId: "createConfidentialTransfer",
-    description: withDraft("Creates a confidential transfer using Token-2022."),
+    description:
+      "Executes a confidential transfer using server-side wallet signing for a wallet-managed source account.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -254,7 +255,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     tags: ["Payments"],
     summary: "Get fee quote",
     operationId: "getPaymentFeeQuote",
-    description: withDraft("Retrieves a fee quote for a transfer."),
+    description: "Retrieves a fee quote for a transfer.",
     security: [{ apiKeyAuth: [] }],
     request: {
       query: z.object({

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -89,7 +89,7 @@ export const walletPolicySchema = z
   })
   .openapi({
     description:
-      "Payment policy configuration for a wallet-managed account. Wallet lifecycle belongs to /v1/wallets.",
+      "Payment policy configuration for a wallet-managed account. Wallet lifecycle belongs to /v1/wallets, while payment controls are internally stored as typed policy records.",
   });
 
 export const updateWalletPolicyRequestSchema = z
@@ -105,7 +105,10 @@ export const updateWalletPolicyRequestSchema = z
       .optional()
       .openapi({ description: "Maximum total amount allowed per day." }),
   })
-  .openapi({ description: "Update wallet policy request payload." });
+  .openapi({
+    description:
+      "Update wallet policy request payload. Controls map to typed internal policy records for provider-specific extensibility.",
+  });
 
 export const tokenBalanceSchema = z
   .object({

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -125,7 +125,8 @@ export const tokenBalanceSchema = z
     decimals: z.number().int().openapi({ description: "Token decimals.", example: 6 }),
     confidential: z
       .boolean()
-      .openapi({ description: "Confidential balance flag.", example: false }),
+      .optional()
+      .openapi({ description: "Confidential balance flag (when applicable).", example: false }),
   })
   .openapi({ description: "Token balance details." });
 

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -62,21 +62,16 @@ export const walletSchema = z
   })
   .openapi({ description: "Managed wallet." });
 
-export const walletPolicyModeSchema = z.enum(["none", "allowlist"]).openapi({
-  description: "Policy mode for outbound destinations.",
-  example: "allowlist",
-});
-
 export const walletPolicySchema = z
   .object({
     walletId: walletIdParamSchema.openapi({
       description: "Wallet ID from /v1/wallets.",
       example: "wal_example",
     }),
-    mode: walletPolicyModeSchema,
-    destinationAllowlist: z
-      .array(solanaAddressSchema)
-      .openapi({ description: "Allowed destination addresses when allowlist mode is enabled." }),
+    destinationAllowlist: z.array(solanaAddressSchema).openapi({
+      description:
+        "Allowed destination addresses. An empty array means no destination restrictions.",
+    }),
     maxTransferAmount: tokenAmountSchema
       .optional()
       .openapi({ description: "Maximum amount allowed per transfer." }),
@@ -99,10 +94,10 @@ export const walletPolicySchema = z
 
 export const updateWalletPolicyRequestSchema = z
   .object({
-    mode: walletPolicyModeSchema,
-    destinationAllowlist: z
-      .array(solanaAddressSchema)
-      .openapi({ description: "Allowed destination addresses when allowlist mode is enabled." }),
+    destinationAllowlist: z.array(solanaAddressSchema).openapi({
+      description:
+        "Allowed destination addresses. An empty array means no destination restrictions.",
+    }),
     maxTransferAmount: tokenAmountSchema
       .optional()
       .openapi({ description: "Maximum amount allowed per transfer." }),

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -112,7 +112,7 @@ export const updateWalletPolicyRequestSchema = z
 
 export const tokenBalanceSchema = z
   .object({
-    token: z.string().openapi({ description: "Token symbol.", example: "USDC" }),
+    token: z.string().openapi({ description: "Token symbol or mint address.", example: "USDC" }),
     mint: solanaAddressSchema.openapi({
       description: "Token mint address.",
       example: "So11111111111111111111111111111111111111112",

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -328,10 +328,18 @@ export const prepareTransferResponseSchema = z
 
 export const createConfidentialTransferRequestSchema = z
   .object({
-    source: z.string().openapi({ description: "Source wallet ID." }),
-    destination: z.string().openapi({ description: "Destination wallet ID." }),
+    projectId: projectIdParamSchema
+      .optional()
+      .openapi({ description: "Project identifier for the transfer context." }),
+    source: z.string().openapi({ description: "Source wallet ID from /v1/wallets." }),
+    destination: z.string().openapi({ description: "Destination wallet ID from /v1/wallets." }),
     token: z.string().openapi({ description: "Token symbol or mint address." }),
     amount: tokenAmountSchema,
+    memo: z
+      .string()
+      .max(256)
+      .optional()
+      .openapi({ description: "Optional memo for the transfer." }),
   })
   .openapi({ description: "Create confidential transfer request payload." });
 

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -3,6 +3,7 @@ import { getAuth } from "@/lib/auth";
 import { AppError } from "@/lib/errors";
 import { paginated, success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
+import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { createSigningService } from "@/services/domain/signing.service";
 import { createMosaicService } from "@/services/mosaic";
 import { createOrgSigner } from "@/services/solana";
@@ -24,12 +25,14 @@ import {
   createNoopSigner,
   createTransactionMessage,
   getBase64EncodedWireTransaction,
+  getTransactionEncoder,
   pipe,
   setTransactionMessageFeePayer,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
 } from "@solana/kit";
+import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import type { Context } from "hono";
 import {
   createConfidentialTransferSchema,
@@ -428,6 +431,9 @@ async function prepareSolTransfer(
 
   const rpc = createRpc(c.env);
   const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
+  const feePayer = c.env.KORA_RPC_URL
+    ? await createFeePaymentAdapter(c.env).getFeePayer()
+    : sourceAddress;
 
   const instruction = getTransferSolInstruction({
     source: createNoopSigner(sourceAddress),
@@ -437,7 +443,7 @@ async function prepareSolTransfer(
 
   const message = pipe(
     createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayer(sourceAddress, m),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
     (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
     (m) => appendTransactionMessageInstructions([instruction], m)
   );
@@ -476,6 +482,8 @@ async function executeSolTransfer(
 
   const rpc = createRpc(c.env);
   const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
+  const feePayment = c.env.KORA_RPC_URL ? createFeePaymentAdapter(c.env) : undefined;
+  const feePayer = feePayment ? await feePayment.getFeePayer() : undefined;
 
   const instruction = getTransferSolInstruction({
     source: signer,
@@ -483,22 +491,38 @@ async function executeSolTransfer(
     amount: lamports,
   });
 
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayerSigner(signer, m),
-    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-    (m) => appendTransactionMessageInstructions([instruction], m),
-    (m) => addSignersToTransactionMessage([signer], m)
-  );
+  const message = feePayment
+    ? pipe(
+        createTransactionMessage({ version: 0 }),
+        (m) => setTransactionMessageFeePayer(feePayer as Address, m),
+        (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+        (m) => appendTransactionMessageInstructions([instruction], m),
+        (m) => addSignersToTransactionMessage([signer], m)
+      )
+    : pipe(
+        createTransactionMessage({ version: 0 }),
+        (m) => setTransactionMessageFeePayerSigner(signer, m),
+        (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+        (m) => appendTransactionMessageInstructions([instruction], m),
+        (m) => addSignersToTransactionMessage([signer], m)
+      );
 
-  const signed = await signTransactionMessageWithSigners(message);
-  const encoded = getBase64EncodedWireTransaction(signed);
-
-  const signature = await rpc
-    .sendTransaction(encoded, {
-      encoding: "base64",
-    })
-    .send();
+  const signature = feePayment
+    ? await (async () => {
+        const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+        const txEncoder = getTransactionEncoder();
+        const txBytes = new Uint8Array(txEncoder.encode(partiallySigned));
+        return feePayment.signAndSend(txBytes);
+      })()
+    : await (async () => {
+        const signed = await signTransactionMessageWithSigners(message);
+        const encoded = getBase64EncodedWireTransaction(signed);
+        return rpc
+          .sendTransaction(encoded, {
+            encoding: "base64",
+          })
+          .send();
+      })();
 
   const confirmation = await confirmTransaction(rpc, signature, {
     commitment: "confirmed",

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -32,7 +32,9 @@ import {
 } from "@solana/kit";
 import type { Context } from "hono";
 import {
+  createConfidentialTransferSchema,
   createTransferSchema,
+  feeQuoteQuerySchema,
   listTransfersQuerySchema,
   prepareTransferSchema,
   transferIdParamsSchema,
@@ -1209,6 +1211,107 @@ export async function getTransfer(c: AppContext) {
       ...(details.amount ? { amount: details.amount } : {}),
       createdAt: blockTimeIso,
       updatedAt: blockTimeIso,
+    },
+  });
+}
+
+export async function createConfidentialTransfer(c: AppContext) {
+  const body = await c.req.json();
+  const parsed = createConfidentialTransferSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid request body", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  if (isNativeSolToken(parsed.data.token)) {
+    throw new AppError("BAD_REQUEST", "Confidential transfers require a token mint, not SOL");
+  }
+
+  const scope = await resolveScope(c);
+  assertProjectContext(parsed.data.projectId, scope.auth.projectId);
+
+  const sourceWallet = resolveWallet(scope.wallets, parsed.data.source);
+  const destinationWallet = resolveWallet(scope.wallets, parsed.data.destination);
+  const sourceAddress = assertValidAddress(sourceWallet.publicKey, "source");
+  const destinationAddress = assertValidAddress(destinationWallet.publicKey, "destination");
+  const mintAddress = assertValidAddress(parsed.data.token, "token");
+
+  const transfer = await createTransferRecord(c, {
+    organizationId: scope.auth.organizationId,
+    projectId: scope.auth.projectId,
+    walletId: sourceWallet.walletId,
+    sourceAddress: sourceWallet.publicKey,
+    destinationAddress: destinationWallet.publicKey,
+    token: parsed.data.token,
+    amount: parsed.data.amount,
+    memo: parsed.data.memo,
+    type: "transfer_confidential",
+    status: "processing",
+    initiatedByKeyId: scope.auth.id,
+  });
+
+  try {
+    const signer = await createOrgSigner(
+      c.env,
+      scope.auth.organizationId,
+      scope.auth.projectId ?? undefined,
+      sourceWallet.walletId
+    );
+
+    const mosaic = createMosaicService(c.env, signer);
+    const result = await mosaic.transfer({
+      mint: mintAddress,
+      from: sourceAddress,
+      to: destinationAddress,
+      amount: parsed.data.amount,
+      memo: parsed.data.memo,
+      authority: signer,
+      feePayer: signer,
+    });
+
+    const updated = await updateTransferRecord(c, transfer.id, {
+      status: "confirmed",
+      signature: result.signature,
+      slot: Number(result.slot),
+      blockTime: new Date().toISOString(),
+      error: null,
+    });
+
+    return success(c, { transfer: mapTransferRow(updated) });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown confidential transfer error";
+    await updateTransferRecord(c, transfer.id, {
+      status: "failed",
+      error: message,
+      blockTime: new Date().toISOString(),
+    });
+
+    if (error instanceof AppError) {
+      throw error;
+    }
+
+    throw new AppError("SOLANA_RPC_ERROR", message);
+  }
+}
+
+export async function getFeeQuote(c: AppContext) {
+  const parsed = feeQuoteQuerySchema.safeParse(c.req.query());
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid query parameters", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const feeToken = parsed.data.token.toUpperCase() === "SOL" ? "SOL" : parsed.data.token;
+  const feeAmount = feeToken === "SOL" ? "0.000005" : "0.01";
+
+  return success(c, {
+    feeQuote: {
+      feeToken,
+      feeAmount,
     },
   });
 }

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -357,17 +357,8 @@ async function getTransferRowById(
   organizationId: string,
   projectId: string | null
 ): Promise<TransferRow | null> {
-  const baseSql = `SELECT id, organization_id, project_id, wallet_id, source_address, destination_address,
-                          token, amount, memo, type, direction, status, signature, serialized_tx,
-                          slot, block_time, fee, error, initiated_by_key_id, created_at, updated_at
-                   FROM payment_transfers
-                   WHERE id = ? AND organization_id = ?`;
-
-  return projectId
-    ? c.env.DB.prepare(`${baseSql} AND project_id = ? LIMIT 1`)
-        .bind(transferId, organizationId, projectId)
-        .first<TransferRow>()
-    : c.env.DB.prepare(`${baseSql} LIMIT 1`).bind(transferId, organizationId).first<TransferRow>();
+  const repository = getPaymentsRepository(c);
+  return repository.getTransferById({ transferId, organizationId, projectId });
 }
 
 async function getTransferRowBySignature(
@@ -376,17 +367,8 @@ async function getTransferRowBySignature(
   organizationId: string,
   projectId: string | null
 ): Promise<TransferRow | null> {
-  const baseSql = `SELECT id, organization_id, project_id, wallet_id, source_address, destination_address,
-                          token, amount, memo, type, direction, status, signature, serialized_tx,
-                          slot, block_time, fee, error, initiated_by_key_id, created_at, updated_at
-                   FROM payment_transfers
-                   WHERE signature = ? AND organization_id = ?`;
-
-  return projectId
-    ? c.env.DB.prepare(`${baseSql} AND project_id = ? LIMIT 1`)
-        .bind(signature, organizationId, projectId)
-        .first<TransferRow>()
-    : c.env.DB.prepare(`${baseSql} LIMIT 1`).bind(signature, organizationId).first<TransferRow>();
+  const repository = getPaymentsRepository(c);
+  return repository.getTransferBySignature({ signature, organizationId, projectId });
 }
 
 async function getTransferRowsBySignatures(
@@ -395,27 +377,15 @@ async function getTransferRowsBySignatures(
   organizationId: string,
   projectId: string | null
 ): Promise<Map<string, TransferRow>> {
-  if (signatures.length === 0) {
-    return new Map();
-  }
-
-  const placeholders = signatures.map(() => "?").join(", ");
-  const baseSql = `SELECT id, organization_id, project_id, wallet_id, source_address, destination_address,
-                          token, amount, memo, type, direction, status, signature, serialized_tx,
-                          slot, block_time, fee, error, initiated_by_key_id, created_at, updated_at
-                   FROM payment_transfers
-                   WHERE organization_id = ? AND signature IN (${placeholders})`;
-
-  const rows = projectId
-    ? await c.env.DB.prepare(`${baseSql} AND project_id = ?`)
-        .bind(organizationId, ...signatures, projectId)
-        .all<TransferRow>()
-    : await c.env.DB.prepare(baseSql)
-        .bind(organizationId, ...signatures)
-        .all<TransferRow>();
+  const repository = getPaymentsRepository(c);
+  const rows = await repository.listTransfersBySignatures({
+    signatures,
+    organizationId,
+    projectId,
+  });
 
   const bySignature = new Map<string, TransferRow>();
-  for (const row of rows.results ?? []) {
+  for (const row of rows) {
     if (row.signature) {
       bySignature.set(row.signature, row);
     }

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -589,7 +589,6 @@ export async function getWalletPolicy(c: AppContext) {
   if (!row) {
     const defaultPolicy = {
       walletId: wallet.walletId,
-      mode: "none",
       destinationAllowlist: [],
       createdAt: wallet.createdAt,
       updatedAt: wallet.createdAt,
@@ -600,7 +599,6 @@ export async function getWalletPolicy(c: AppContext) {
 
   const payload = {
     walletId: wallet.walletId,
-    mode: row.mode,
     destinationAllowlist: parseDestinationAllowlist(row.destination_allowlist),
     ...(row.max_transfer_amount ? { maxTransferAmount: row.max_transfer_amount } : {}),
     ...(row.max_daily_amount ? { maxDailyAmount: row.max_daily_amount } : {}),
@@ -625,13 +623,11 @@ export async function updateWalletPolicy(c: AppContext) {
   }
 
   const now = new Date().toISOString();
-  const mode = parsed.data.mode;
-  const allowlist = mode === "allowlist" ? parsed.data.destinationAllowlist : [];
+  const allowlist = parsed.data.destinationAllowlist;
 
   const row = await repository.upsertWalletPolicy({
     id: `pwp_${crypto.randomUUID()}`,
     custodyWalletId: wallet.id,
-    mode,
     destinationAllowlist: JSON.stringify(allowlist),
     maxTransferAmount: parsed.data.maxTransferAmount ?? null,
     maxDailyAmount: parsed.data.maxDailyAmount ?? null,
@@ -645,7 +641,6 @@ export async function updateWalletPolicy(c: AppContext) {
 
   const payload = {
     walletId: wallet.walletId,
-    mode: row.mode,
     destinationAllowlist: parseDestinationAllowlist(row.destination_allowlist),
     ...(row.max_transfer_amount ? { maxTransferAmount: row.max_transfer_amount } : {}),
     ...(row.max_daily_amount ? { maxDailyAmount: row.max_daily_amount } : {}),

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -57,6 +57,11 @@ import {
 type AppContext = Context<{ Bindings: Env }>;
 // biome-ignore lint/nursery/noSecrets: Solana native SOL mint address constant, not a secret.
 const SOL_MINT = "So11111111111111111111111111111111111111112";
+// biome-ignore lint/nursery/noSecrets: Solana SPL Token program ID, not a secret.
+const SPL_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
+// biome-ignore lint/nursery/noSecrets: Solana Token-2022 program ID, not a secret.
+const SPL_TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" as Address;
+const SPL_TOKEN_PROGRAM_IDS = [SPL_TOKEN_PROGRAM_ID, SPL_TOKEN_2022_PROGRAM_ID] as const;
 const PAYMENT_POLICY_VERSION = 1;
 const DESTINATION_ALLOWLIST_POLICY_TYPE = "destination_allowlist";
 const TRANSFER_LIMITS_POLICY_TYPE = "transfer_limits";
@@ -203,6 +208,123 @@ function mapTransferRow(row: TransferRow) {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function parseTokenAmountInfo(
+  value: unknown
+): { mint: string; amount: bigint; decimals: number; uiAmount?: string } | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const info = value as Record<string, unknown>;
+  const mint = typeof info.mint === "string" ? info.mint : null;
+  if (!mint) {
+    return null;
+  }
+
+  const tokenAmount =
+    typeof info.tokenAmount === "object" && info.tokenAmount !== null
+      ? (info.tokenAmount as Record<string, unknown>)
+      : null;
+  if (!tokenAmount) {
+    return null;
+  }
+
+  const rawAmount = tokenAmount.amount;
+  const rawDecimals = tokenAmount.decimals;
+
+  if (
+    (typeof rawAmount !== "string" && typeof rawAmount !== "number") ||
+    typeof rawDecimals !== "number"
+  ) {
+    return null;
+  }
+
+  let amount: bigint;
+  try {
+    amount = BigInt(String(rawAmount));
+  } catch {
+    return null;
+  }
+
+  const decimals = Number(rawDecimals);
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    return null;
+  }
+
+  const uiAmount =
+    typeof tokenAmount.uiAmountString === "string" ? tokenAmount.uiAmountString : undefined;
+
+  return { mint, amount, decimals, uiAmount };
+}
+
+async function getSplTokenBalances(
+  rpc: ReturnType<typeof createRpc>,
+  owner: Address
+): Promise<
+  Array<{ token: string; mint: string; amount: string; uiAmount: string; decimals: number }>
+> {
+  const balancesByMint = new Map<string, { amount: bigint; decimals: number; uiAmount?: string }>();
+
+  for (const programId of SPL_TOKEN_PROGRAM_IDS) {
+    const response = await (
+      rpc as unknown as {
+        getTokenAccountsByOwner: (
+          address: Address,
+          filter: { programId: Address },
+          config: { encoding: "jsonParsed"; commitment: "confirmed" }
+        ) => {
+          send: () => Promise<{
+            value?: Array<{
+              account?: {
+                data?: {
+                  parsed?: {
+                    info?: unknown;
+                  };
+                };
+              };
+            }>;
+          }>;
+        };
+      }
+    )
+      .getTokenAccountsByOwner(
+        owner,
+        { programId },
+        { encoding: "jsonParsed", commitment: "confirmed" }
+      )
+      .send();
+
+    for (const account of response.value ?? []) {
+      const parsed = parseTokenAmountInfo(account.account?.data?.parsed?.info);
+      if (!parsed || parsed.amount <= 0n) {
+        continue;
+      }
+
+      const existing = balancesByMint.get(parsed.mint);
+      if (existing) {
+        existing.amount += parsed.amount;
+        continue;
+      }
+
+      balancesByMint.set(parsed.mint, {
+        amount: parsed.amount,
+        decimals: parsed.decimals,
+        uiAmount: parsed.uiAmount,
+      });
+    }
+  }
+
+  return Array.from(balancesByMint.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([mint, balance]) => ({
+      token: mint,
+      mint,
+      amount: balance.amount.toString(),
+      uiAmount: balance.uiAmount ?? formatDecimalAmount(balance.amount, balance.decimals),
+      decimals: balance.decimals,
+    }));
 }
 
 async function resolveScope(c: AppContext) {
@@ -626,6 +748,7 @@ export async function getWalletBalances(c: AppContext) {
 
   const rpc = createRpc(c.env);
   const accountInfo = await getAccountInfo(rpc, wallet.publicKey as Address);
+  const splBalances = await getSplTokenBalances(rpc, wallet.publicKey as Address);
 
   const lamports = accountInfo?.lamports ?? 0n;
 
@@ -640,6 +763,7 @@ export async function getWalletBalances(c: AppContext) {
         uiAmount: formatDecimalAmount(lamports, 9),
         decimals: 9,
       },
+      ...splBalances,
     ],
   };
 

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -639,7 +639,6 @@ export async function getWalletBalances(c: AppContext) {
         amount: lamports.toString(),
         uiAmount: formatDecimalAmount(lamports, 9),
         decimals: 9,
-        confidential: false,
       },
     ],
   };

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -248,6 +248,57 @@ async function getTokenAccountsByOwnerJsonParsed(
     .send();
 }
 
+type SignatureStatusRow = {
+  signature: string;
+  slot: number;
+  err: unknown;
+  confirmationStatus?: string | null;
+  blockTime?: number | null;
+};
+
+type SignaturesForAddressRpc = {
+  getSignaturesForAddress: (
+    address: string,
+    options: { limit: number; commitment: "confirmed" }
+  ) => {
+    send: () => Promise<SignatureStatusRow[]>;
+  };
+};
+
+async function getSignaturesForAddressConfirmed(
+  rpc: ReturnType<typeof createRpc>,
+  address: string,
+  limit: number
+): Promise<SignatureStatusRow[]> {
+  return (rpc as unknown as SignaturesForAddressRpc)
+    .getSignaturesForAddress(address, { limit, commitment: "confirmed" })
+    .send();
+}
+
+type TransactionBySignatureRpc = {
+  getTransaction: (
+    signature: string,
+    options: {
+      commitment: "confirmed";
+      maxSupportedTransactionVersion: number;
+      encoding: "jsonParsed";
+    }
+  ) => { send: () => Promise<unknown> };
+};
+
+async function getTransactionJsonParsed(
+  rpc: ReturnType<typeof createRpc>,
+  signature: string
+): Promise<unknown> {
+  return (rpc as unknown as TransactionBySignatureRpc)
+    .getTransaction(signature, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+      encoding: "jsonParsed",
+    })
+    .send();
+}
+
 function parseTokenAmountInfo(
   value: unknown
 ): { mint: string; amount: bigint; decimals: number; uiAmount?: string } | null {
@@ -1053,25 +1104,7 @@ export async function listTransfers(c: AppContext) {
 
   const signatureRows = await Promise.all(
     addressList.map(async (address) => {
-      const rows = (await (
-        rpc as unknown as {
-          getSignaturesForAddress: (
-            addr: string,
-            options: { limit: number; commitment: "confirmed" }
-          ) => { send: () => Promise<Array<Record<string, unknown>>> };
-        }
-      )
-        .getSignaturesForAddress(address, {
-          limit: fetchLimit,
-          commitment: "confirmed",
-        })
-        .send()) as Array<{
-        signature: string;
-        slot: number;
-        err: unknown;
-        confirmationStatus?: string | null;
-        blockTime?: number | null;
-      }>;
+      const rows = await getSignaturesForAddressConfirmed(rpc, address, fetchLimit);
 
       return rows.map((row) => ({ ...row, queriedAddress: address }));
     })
@@ -1131,24 +1164,7 @@ export async function listTransfers(c: AppContext) {
 
   const transfers = await Promise.all(
     pageItems.map(async (row) => {
-      const tx = await (
-        rpc as unknown as {
-          getTransaction: (
-            signature: string,
-            options: {
-              commitment: "confirmed";
-              maxSupportedTransactionVersion: number;
-              encoding: "jsonParsed";
-            }
-          ) => { send: () => Promise<unknown> };
-        }
-      )
-        .getTransaction(row.signature, {
-          commitment: "confirmed",
-          maxSupportedTransactionVersion: 0,
-          encoding: "jsonParsed",
-        })
-        .send();
+      const tx = await getTransactionJsonParsed(rpc, row.signature);
 
       const details = inferOnChainTransferDetails(tx, row.queriedAddress);
       const blockTimeIso = unixSecondsToIso(row.blockTime) ?? new Date().toISOString();
@@ -1241,24 +1257,7 @@ export async function getTransfer(c: AppContext) {
   const scope = await resolveScope(c);
   const rpc = createRpc(c.env);
 
-  const tx = await (
-    rpc as unknown as {
-      getTransaction: (
-        signature: string,
-        options: {
-          commitment: "confirmed";
-          maxSupportedTransactionVersion: number;
-          encoding: "jsonParsed";
-        }
-      ) => { send: () => Promise<unknown> };
-    }
-  )
-    .getTransaction(transferId, {
-      commitment: "confirmed",
-      maxSupportedTransactionVersion: 0,
-      encoding: "jsonParsed",
-    })
-    .send();
+  const tx = await getTransactionJsonParsed(rpc, transferId);
 
   if (!tx) {
     throw new AppError("NOT_FOUND", "Transfer not found");

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -37,9 +37,7 @@ import {
   getTransactionEncoder,
   pipe,
   setTransactionMessageFeePayer,
-  setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
 } from "@solana/kit";
 import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import type { Context } from "hono";
@@ -68,6 +66,14 @@ const TRANSFER_LIMITS_POLICY_TYPE = "transfer_limits";
 
 function getPaymentsRepository(c: AppContext) {
   return createD1PaymentsRepository({ db: createD1Drizzle(c.env.DB) });
+}
+
+function getFeePayment(c: AppContext) {
+  return createFeePaymentAdapter(c.env);
+}
+
+async function getSponsoredFeePayer(c: AppContext): Promise<Address> {
+  return getFeePayment(c).getFeePayer();
 }
 
 function isNativeSolToken(token: string): boolean {
@@ -592,9 +598,7 @@ async function prepareSolTransfer(
 
   const rpc = createRpc(c.env);
   const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
-  const feePayer = c.env.KORA_RPC_URL
-    ? await createFeePaymentAdapter(c.env).getFeePayer()
-    : sourceAddress;
+  const feePayer = await getSponsoredFeePayer(c);
 
   const instruction = getTransferSolInstruction({
     source: createNoopSigner(sourceAddress),
@@ -643,8 +647,8 @@ async function executeSolTransfer(
 
   const rpc = createRpc(c.env);
   const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
-  const feePayment = c.env.KORA_RPC_URL ? createFeePaymentAdapter(c.env) : undefined;
-  const feePayer = feePayment ? await feePayment.getFeePayer() : undefined;
+  const feePayment = getFeePayment(c);
+  const feePayer = await feePayment.getFeePayer();
 
   const instruction = getTransferSolInstruction({
     source: signer,
@@ -652,38 +656,18 @@ async function executeSolTransfer(
     amount: lamports,
   });
 
-  const message = feePayment
-    ? pipe(
-        createTransactionMessage({ version: 0 }),
-        (m) => setTransactionMessageFeePayer(feePayer as Address, m),
-        (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-        (m) => appendTransactionMessageInstructions([instruction], m),
-        (m) => addSignersToTransactionMessage([signer], m)
-      )
-    : pipe(
-        createTransactionMessage({ version: 0 }),
-        (m) => setTransactionMessageFeePayerSigner(signer, m),
-        (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-        (m) => appendTransactionMessageInstructions([instruction], m),
-        (m) => addSignersToTransactionMessage([signer], m)
-      );
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions([instruction], m),
+    (m) => addSignersToTransactionMessage([signer], m)
+  );
 
-  const signature = feePayment
-    ? await (async () => {
-        const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
-        const txEncoder = getTransactionEncoder();
-        const txBytes = new Uint8Array(txEncoder.encode(partiallySigned));
-        return feePayment.signAndSend(txBytes);
-      })()
-    : await (async () => {
-        const signed = await signTransactionMessageWithSigners(message);
-        const encoded = getBase64EncodedWireTransaction(signed);
-        return rpc
-          .sendTransaction(encoded, {
-            encoding: "base64",
-          })
-          .send();
-      })();
+  const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+  const txEncoder = getTransactionEncoder();
+  const txBytes = new Uint8Array(txEncoder.encode(partiallySigned));
+  const signature = await feePayment.signAndSend(txBytes);
 
   const confirmation = await confirmTransaction(rpc, signature, {
     commitment: "confirmed",
@@ -923,6 +907,7 @@ export async function prepareTransfer(c: AppContext) {
     );
 
     const mosaic = createMosaicService(c.env, signer);
+    const feePayer = await getSponsoredFeePayer(c);
     const preparedTokenTransfer = await mosaic.prepareTransfer({
       mint: mintAddress,
       from: sourceAddress,
@@ -930,7 +915,7 @@ export async function prepareTransfer(c: AppContext) {
       amount: parsed.data.amount,
       memo: parsed.data.memo,
       authority: signer.address,
-      feePayer: signer.address,
+      feePayer,
     });
 
     prepared = {
@@ -1037,6 +1022,7 @@ export async function createTransfer(c: AppContext) {
     );
 
     const mosaic = createMosaicService(c.env, signer);
+    const feePayer = await getSponsoredFeePayer(c);
     const result = await mosaic.transfer({
       mint: mintAddress,
       from: sourceAddress,
@@ -1044,7 +1030,7 @@ export async function createTransfer(c: AppContext) {
       amount: parsed.data.amount,
       memo: parsed.data.memo,
       authority: signer,
-      feePayer: signer,
+      feePayer: createNoopSigner(feePayer),
     });
 
     const updated = await updateTransferRecord(c, transfer.id, {
@@ -1345,6 +1331,7 @@ export async function createConfidentialTransfer(c: AppContext) {
     );
 
     const mosaic = createMosaicService(c.env, signer);
+    const feePayer = await getSponsoredFeePayer(c);
     const result = await mosaic.transfer({
       mint: mintAddress,
       from: sourceAddress,
@@ -1352,7 +1339,7 @@ export async function createConfidentialTransfer(c: AppContext) {
       amount: parsed.data.amount,
       memo: parsed.data.memo,
       authority: signer,
-      feePayer: signer,
+      feePayer: createNoopSigner(feePayer),
     });
 
     const updated = await updateTransferRecord(c, transfer.id, {

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -210,6 +210,44 @@ function mapTransferRow(row: TransferRow) {
   };
 }
 
+type JsonParsedTokenAccountEntry = {
+  account?: {
+    data?: {
+      parsed?: {
+        info?: unknown;
+      };
+    };
+  };
+};
+
+type JsonParsedTokenAccountsByOwnerResponse = {
+  value?: JsonParsedTokenAccountEntry[];
+};
+
+type TokenAccountsByOwnerRpc = {
+  getTokenAccountsByOwner: (
+    address: Address,
+    filter: { programId: Address },
+    config: { encoding: "jsonParsed"; commitment: "confirmed" }
+  ) => {
+    send: () => Promise<JsonParsedTokenAccountsByOwnerResponse>;
+  };
+};
+
+async function getTokenAccountsByOwnerJsonParsed(
+  rpc: ReturnType<typeof createRpc>,
+  owner: Address,
+  programId: Address
+): Promise<JsonParsedTokenAccountsByOwnerResponse> {
+  return (rpc as unknown as TokenAccountsByOwnerRpc)
+    .getTokenAccountsByOwner(
+      owner,
+      { programId },
+      { encoding: "jsonParsed", commitment: "confirmed" }
+    )
+    .send();
+}
+
 function parseTokenAmountInfo(
   value: unknown
 ): { mint: string; amount: bigint; decimals: number; uiAmount?: string } | null {
@@ -268,33 +306,7 @@ async function getSplTokenBalances(
   const balancesByMint = new Map<string, { amount: bigint; decimals: number; uiAmount?: string }>();
 
   for (const programId of SPL_TOKEN_PROGRAM_IDS) {
-    const response = await (
-      rpc as unknown as {
-        getTokenAccountsByOwner: (
-          address: Address,
-          filter: { programId: Address },
-          config: { encoding: "jsonParsed"; commitment: "confirmed" }
-        ) => {
-          send: () => Promise<{
-            value?: Array<{
-              account?: {
-                data?: {
-                  parsed?: {
-                    info?: unknown;
-                  };
-                };
-              };
-            }>;
-          }>;
-        };
-      }
-    )
-      .getTokenAccountsByOwner(
-        owner,
-        { programId },
-        { encoding: "jsonParsed", commitment: "confirmed" }
-      )
-      .send();
+    const response = await getTokenAccountsByOwnerJsonParsed(rpc, owner, programId);
 
     for (const account of response.value ?? []) {
       const parsed = parseTokenAmountInfo(account.account?.data?.parsed?.info);

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -4,6 +4,7 @@ import type {
   PaymentTransferRow as TransferRow,
   PaymentTransferStatus as TransferStatus,
   PaymentTransferType as TransferType,
+  PaymentWalletPolicyRow as WalletPolicyRow,
 } from "@/db/repositories/payments.repository";
 import { createD1PaymentsRepository } from "@/db/repositories/payments.repository.d1";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
@@ -56,6 +57,9 @@ import {
 type AppContext = Context<{ Bindings: Env }>;
 // biome-ignore lint/nursery/noSecrets: Solana native SOL mint address constant, not a secret.
 const SOL_MINT = "So11111111111111111111111111111111111111112";
+const PAYMENT_POLICY_VERSION = 1;
+const DESTINATION_ALLOWLIST_POLICY_TYPE = "destination_allowlist";
+const TRANSFER_LIMITS_POLICY_TYPE = "transfer_limits";
 
 function getPaymentsRepository(c: AppContext) {
   return createD1PaymentsRepository({ db: createD1Drizzle(c.env.DB) });
@@ -66,14 +70,107 @@ function isNativeSolToken(token: string): boolean {
   return normalized.toUpperCase() === "SOL" || normalized === SOL_MINT;
 }
 
-function parseDestinationAllowlist(raw: string): string[] {
+function parsePolicyDocument(raw: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((value): value is string => typeof value === "string");
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
   } catch {
+    return null;
+  }
+}
+
+function parseDestinationAllowlistPolicy(raw: string): string[] {
+  const document = parsePolicyDocument(raw);
+  if (!document || document.version !== PAYMENT_POLICY_VERSION) {
     return [];
   }
+
+  const value = document.destinationAllowlist;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function parseTransferLimitsPolicy(raw: string): {
+  maxTransferAmount?: string;
+  maxDailyAmount?: string;
+} {
+  const document = parsePolicyDocument(raw);
+  if (!document || document.version !== PAYMENT_POLICY_VERSION) {
+    return {};
+  }
+
+  const payload: { maxTransferAmount?: string; maxDailyAmount?: string } = {};
+  if (typeof document.maxTransferAmount === "string") {
+    payload.maxTransferAmount = document.maxTransferAmount;
+  }
+  if (typeof document.maxDailyAmount === "string") {
+    payload.maxDailyAmount = document.maxDailyAmount;
+  }
+
+  return payload;
+}
+
+function buildWalletPolicyPayload(
+  walletId: string,
+  rows: WalletPolicyRow[],
+  fallbackTimestamp: string
+): {
+  walletId: string;
+  destinationAllowlist: string[];
+  maxTransferAmount?: string;
+  maxDailyAmount?: string;
+  createdAt: string;
+  updatedAt: string;
+} {
+  if (rows.length === 0) {
+    return {
+      walletId,
+      destinationAllowlist: [],
+      createdAt: fallbackTimestamp,
+      updatedAt: fallbackTimestamp,
+    };
+  }
+
+  let destinationAllowlist: string[] = [];
+  let maxTransferAmount: string | undefined;
+  let maxDailyAmount: string | undefined;
+
+  for (const row of rows) {
+    if (row.policy_type === DESTINATION_ALLOWLIST_POLICY_TYPE) {
+      destinationAllowlist = parseDestinationAllowlistPolicy(row.policy);
+      continue;
+    }
+
+    if (row.policy_type === TRANSFER_LIMITS_POLICY_TYPE) {
+      const parsed = parseTransferLimitsPolicy(row.policy);
+      maxTransferAmount = parsed.maxTransferAmount;
+      maxDailyAmount = parsed.maxDailyAmount;
+    }
+  }
+
+  const createdAt = rows.reduce(
+    (earliest, row) => (row.created_at < earliest ? row.created_at : earliest),
+    rows[0].created_at
+  );
+  const updatedAt = rows.reduce(
+    (latest, row) => (row.updated_at > latest ? row.updated_at : latest),
+    rows[0].updated_at
+  );
+
+  return {
+    walletId,
+    destinationAllowlist,
+    ...(maxTransferAmount ? { maxTransferAmount } : {}),
+    ...(maxDailyAmount ? { maxDailyAmount } : {}),
+    createdAt,
+    updatedAt,
+  };
 }
 
 function mapTransferRow(row: TransferRow) {
@@ -584,27 +681,8 @@ export async function getWalletPolicy(c: AppContext) {
   const { wallet } = await resolveWalletFromParams(c);
   const repository = getPaymentsRepository(c);
 
-  const row = await repository.getWalletPolicyByCustodyWalletId(wallet.id);
-
-  if (!row) {
-    const defaultPolicy = {
-      walletId: wallet.walletId,
-      destinationAllowlist: [],
-      createdAt: wallet.createdAt,
-      updatedAt: wallet.createdAt,
-    };
-
-    return success(c, { policy: defaultPolicy });
-  }
-
-  const payload = {
-    walletId: wallet.walletId,
-    destinationAllowlist: parseDestinationAllowlist(row.destination_allowlist),
-    ...(row.max_transfer_amount ? { maxTransferAmount: row.max_transfer_amount } : {}),
-    ...(row.max_daily_amount ? { maxDailyAmount: row.max_daily_amount } : {}),
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
+  const rows = await repository.getWalletPoliciesByCustodyWalletId(wallet.id);
+  const payload = buildWalletPolicyPayload(wallet.walletId, rows, wallet.createdAt);
 
   return success(c, { policy: payload });
 }
@@ -623,30 +701,37 @@ export async function updateWalletPolicy(c: AppContext) {
   }
 
   const now = new Date().toISOString();
-  const allowlist = parsed.data.destinationAllowlist;
+  const rows = await repository.upsertWalletPolicies([
+    {
+      id: `pwp_${crypto.randomUUID()}`,
+      custodyWalletId: wallet.id,
+      policyType: DESTINATION_ALLOWLIST_POLICY_TYPE,
+      policy: JSON.stringify({
+        version: PAYMENT_POLICY_VERSION,
+        destinationAllowlist: parsed.data.destinationAllowlist,
+      }),
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: `pwp_${crypto.randomUUID()}`,
+      custodyWalletId: wallet.id,
+      policyType: TRANSFER_LIMITS_POLICY_TYPE,
+      policy: JSON.stringify({
+        version: PAYMENT_POLICY_VERSION,
+        maxTransferAmount: parsed.data.maxTransferAmount ?? null,
+        maxDailyAmount: parsed.data.maxDailyAmount ?? null,
+      }),
+      createdAt: now,
+      updatedAt: now,
+    },
+  ]);
 
-  const row = await repository.upsertWalletPolicy({
-    id: `pwp_${crypto.randomUUID()}`,
-    custodyWalletId: wallet.id,
-    destinationAllowlist: JSON.stringify(allowlist),
-    maxTransferAmount: parsed.data.maxTransferAmount ?? null,
-    maxDailyAmount: parsed.data.maxDailyAmount ?? null,
-    createdAt: now,
-    updatedAt: now,
-  });
-
-  if (!row) {
+  if (rows.length === 0) {
     throw new AppError("INTERNAL_ERROR", "Failed to persist wallet policy");
   }
 
-  const payload = {
-    walletId: wallet.walletId,
-    destinationAllowlist: parseDestinationAllowlist(row.destination_allowlist),
-    ...(row.max_transfer_amount ? { maxTransferAmount: row.max_transfer_amount } : {}),
-    ...(row.max_daily_amount ? { maxDailyAmount: row.max_daily_amount } : {}),
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
+  const payload = buildWalletPolicyPayload(wallet.walletId, rows, now);
 
   return success(c, { policy: payload });
 }

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -14,6 +14,7 @@ import { paginated, success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { createSigningService } from "@/services/domain/signing.service";
+import { createMosaicService } from "@/services/mosaic";
 import { createOrgSigner } from "@/services/solana";
 import {
   confirmTransaction,

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -1,3 +1,11 @@
+import { createD1Drizzle } from "@/db/drizzle";
+import type {
+  PaymentTransferDirection as TransferDirection,
+  PaymentTransferRow as TransferRow,
+  PaymentTransferStatus as TransferStatus,
+  PaymentTransferType as TransferType,
+} from "@/db/repositories/payments.repository";
+import { createD1PaymentsRepository } from "@/db/repositories/payments.repository.d1";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { getAuth } from "@/lib/auth";
 import { AppError } from "@/lib/errors";
@@ -44,43 +52,13 @@ import {
   updateWalletPolicySchema,
   walletIdParamsSchema,
 } from "./schemas";
+
 type AppContext = Context<{ Bindings: Env }>;
 // biome-ignore lint/nursery/noSecrets: Solana native SOL mint address constant, not a secret.
 const SOL_MINT = "So11111111111111111111111111111111111111112";
-type TransferDirection = "inbound" | "outbound";
-type TransferType = "transfer" | "transfer_confidential";
-type TransferStatus = "pending" | "processing" | "confirmed" | "finalized" | "failed";
-interface PolicyRow {
-  mode: "none" | "allowlist";
-  destination_allowlist: string;
-  max_transfer_amount: string | null;
-  max_daily_amount: string | null;
-  created_at: string;
-  updated_at: string;
-}
 
-interface TransferRow {
-  id: string;
-  organization_id: string;
-  project_id: string | null;
-  wallet_id: string;
-  source_address: string;
-  destination_address: string;
-  token: string;
-  amount: string;
-  memo: string | null;
-  type: TransferType;
-  direction: TransferDirection;
-  status: TransferStatus;
-  signature: string | null;
-  serialized_tx: string | null;
-  slot: number | null;
-  block_time: string | null;
-  fee: number | null;
-  error: string | null;
-  initiated_by_key_id: string | null;
-  created_at: string;
-  updated_at: string;
+function getPaymentsRepository(c: AppContext) {
+  return createD1PaymentsRepository({ db: createD1Drizzle(c.env.DB) });
 }
 
 function isNativeSolToken(token: string): boolean {
@@ -211,59 +189,28 @@ async function createTransferRecord(
     initiatedByKeyId?: string;
   }
 ): Promise<TransferRow> {
+  const repository = getPaymentsRepository(c);
   const id = `xfr_${crypto.randomUUID()}`;
   const now = new Date().toISOString();
 
-  await c.env.DB.prepare(
-    `INSERT INTO payment_transfers (
-       id,
-       organization_id,
-       project_id,
-       wallet_id,
-       source_address,
-       destination_address,
-       token,
-       amount,
-       memo,
-       type,
-       direction,
-       status,
-       serialized_tx,
-       initiated_by_key_id,
-       created_at,
-       updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  )
-    .bind(
-      id,
-      input.organizationId,
-      input.projectId,
-      input.walletId,
-      input.sourceAddress,
-      input.destinationAddress,
-      input.token,
-      input.amount,
-      input.memo ?? null,
-      input.type ?? "transfer",
-      input.direction ?? "outbound",
-      input.status ?? "pending",
-      input.serializedTx ?? null,
-      input.initiatedByKeyId ?? null,
-      now,
-      now
-    )
-    .run();
-
-  const createdRow = await c.env.DB.prepare(
-    `SELECT id, organization_id, project_id, wallet_id, source_address, destination_address,
-            token, amount, memo, type, direction, status, signature, serialized_tx,
-            slot, block_time, fee, error, initiated_by_key_id, created_at, updated_at
-     FROM payment_transfers
-     WHERE id = ?
-     LIMIT 1`
-  )
-    .bind(id)
-    .first<TransferRow>();
+  const createdRow = await repository.createTransfer({
+    id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    walletId: input.walletId,
+    sourceAddress: input.sourceAddress,
+    destinationAddress: input.destinationAddress,
+    token: input.token,
+    amount: input.amount,
+    memo: input.memo ?? null,
+    type: input.type ?? "transfer",
+    direction: input.direction ?? "outbound",
+    status: input.status ?? "pending",
+    serializedTx: input.serializedTx ?? null,
+    initiatedByKeyId: input.initiatedByKeyId ?? null,
+    createdAt: now,
+    updatedAt: now,
+  });
 
   if (!createdRow) {
     throw new AppError("INTERNAL_ERROR", "Failed to create payment transfer record");
@@ -285,61 +232,23 @@ async function updateTransferRecord(
     error?: string | null;
   }
 ): Promise<TransferRow> {
-  const existing = await c.env.DB.prepare(
-    `SELECT id, organization_id, project_id, wallet_id, source_address, destination_address,
-            token, amount, memo, type, direction, status, signature, serialized_tx,
-            slot, block_time, fee, error, initiated_by_key_id, created_at, updated_at
-     FROM payment_transfers
-     WHERE id = ?
-     LIMIT 1`
-  )
-    .bind(transferId)
-    .first<TransferRow>();
-
-  if (!existing) {
-    throw new AppError("INTERNAL_ERROR", "Payment transfer record not found for update");
-  }
-
+  const repository = getPaymentsRepository(c);
   const now = new Date().toISOString();
 
-  await c.env.DB.prepare(
-    `UPDATE payment_transfers
-     SET status = ?,
-         signature = ?,
-         serialized_tx = ?,
-         slot = ?,
-         block_time = ?,
-         fee = ?,
-         error = ?,
-         updated_at = ?
-     WHERE id = ?`
-  )
-    .bind(
-      patch.status ?? existing.status,
-      patch.signature ?? existing.signature,
-      patch.serializedTx ?? existing.serialized_tx,
-      patch.slot ?? existing.slot,
-      patch.blockTime ?? existing.block_time,
-      patch.fee ?? existing.fee,
-      patch.error ?? existing.error,
-      now,
-      transferId
-    )
-    .run();
-
-  const updated = await c.env.DB.prepare(
-    `SELECT id, organization_id, project_id, wallet_id, source_address, destination_address,
-            token, amount, memo, type, direction, status, signature, serialized_tx,
-            slot, block_time, fee, error, initiated_by_key_id, created_at, updated_at
-     FROM payment_transfers
-     WHERE id = ?
-     LIMIT 1`
-  )
-    .bind(transferId)
-    .first<TransferRow>();
+  const updated = await repository.updateTransfer({
+    transferId,
+    status: patch.status,
+    signature: patch.signature,
+    serializedTx: patch.serializedTx,
+    slot: patch.slot,
+    blockTime: patch.blockTime,
+    fee: patch.fee,
+    error: patch.error,
+    updatedAt: now,
+  });
 
   if (!updated) {
-    throw new AppError("INTERNAL_ERROR", "Failed to update payment transfer record");
+    throw new AppError("INTERNAL_ERROR", "Payment transfer record not found for update");
   }
 
   return updated;
@@ -673,15 +582,9 @@ export async function getWalletBalances(c: AppContext) {
 
 export async function getWalletPolicy(c: AppContext) {
   const { wallet } = await resolveWalletFromParams(c);
+  const repository = getPaymentsRepository(c);
 
-  const row = await c.env.DB.prepare(
-    `SELECT mode, destination_allowlist, max_transfer_amount, max_daily_amount, created_at, updated_at
-     FROM payment_wallet_policies
-     WHERE custody_wallet_id = ?
-     LIMIT 1`
-  )
-    .bind(wallet.id)
-    .first<PolicyRow>();
+  const row = await repository.getWalletPolicyByCustodyWalletId(wallet.id);
 
   if (!row) {
     const defaultPolicy = {
@@ -710,6 +613,7 @@ export async function getWalletPolicy(c: AppContext) {
 
 export async function updateWalletPolicy(c: AppContext) {
   const { wallet } = await resolveWalletFromParams(c);
+  const repository = getPaymentsRepository(c);
 
   const body = await c.req.json();
   const parsed = updateWalletPolicySchema.safeParse(body);
@@ -724,44 +628,16 @@ export async function updateWalletPolicy(c: AppContext) {
   const mode = parsed.data.mode;
   const allowlist = mode === "allowlist" ? parsed.data.destinationAllowlist : [];
 
-  await c.env.DB.prepare(
-    `INSERT INTO payment_wallet_policies (
-       id,
-       custody_wallet_id,
-       mode,
-       destination_allowlist,
-       max_transfer_amount,
-       max_daily_amount,
-       created_at,
-       updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(custody_wallet_id) DO UPDATE SET
-       mode = excluded.mode,
-       destination_allowlist = excluded.destination_allowlist,
-       max_transfer_amount = excluded.max_transfer_amount,
-       max_daily_amount = excluded.max_daily_amount,
-       updated_at = excluded.updated_at`
-  )
-    .bind(
-      `pwp_${crypto.randomUUID()}`,
-      wallet.id,
-      mode,
-      JSON.stringify(allowlist),
-      parsed.data.maxTransferAmount ?? null,
-      parsed.data.maxDailyAmount ?? null,
-      now,
-      now
-    )
-    .run();
-
-  const row = await c.env.DB.prepare(
-    `SELECT mode, destination_allowlist, max_transfer_amount, max_daily_amount, created_at, updated_at
-     FROM payment_wallet_policies
-     WHERE custody_wallet_id = ?
-     LIMIT 1`
-  )
-    .bind(wallet.id)
-    .first<PolicyRow>();
+  const row = await repository.upsertWalletPolicy({
+    id: `pwp_${crypto.randomUUID()}`,
+    custodyWalletId: wallet.id,
+    mode,
+    destinationAllowlist: JSON.stringify(allowlist),
+    maxTransferAmount: parsed.data.maxTransferAmount ?? null,
+    maxDailyAmount: parsed.data.maxDailyAmount ?? null,
+    createdAt: now,
+    updatedAt: now,
+  });
 
   if (!row) {
     throw new AppError("INTERNAL_ERROR", "Failed to persist wallet policy");

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -14,7 +14,6 @@ import { paginated, success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { createSigningService } from "@/services/domain/signing.service";
-import { createMosaicService } from "@/services/mosaic";
 import { createOrgSigner } from "@/services/solana";
 import {
   confirmTransaction,
@@ -26,6 +25,11 @@ import {
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { getTransferSolInstruction } from "@solana-program/system";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getTransferCheckedInstruction,
+} from "@solana-program/token-2022";
 import type { Address } from "@solana/kit";
 import {
   addSignersToTransactionMessage,
@@ -217,6 +221,7 @@ function mapTransferRow(row: TransferRow) {
 }
 
 type JsonParsedTokenAccountEntry = {
+  pubkey?: string;
   account?: {
     data?: {
       parsed?: {
@@ -394,6 +399,63 @@ async function getSplTokenBalances(
       uiAmount: balance.uiAmount ?? formatDecimalAmount(balance.amount, balance.decimals),
       decimals: balance.decimals,
     }));
+}
+
+function assertSupportedTokenProgram(program: string): Address {
+  if (program === SPL_TOKEN_PROGRAM_ID || program === SPL_TOKEN_2022_PROGRAM_ID) {
+    return program as Address;
+  }
+  throw new AppError("BAD_REQUEST", "Unsupported token program for mint");
+}
+
+async function resolveMintTokenProgram(
+  rpc: ReturnType<typeof createRpc>,
+  mint: Address
+): Promise<Address> {
+  const mintAccountInfo = await getAccountInfo(rpc, mint);
+  if (!mintAccountInfo) {
+    throw new AppError("BAD_REQUEST", "Token mint account does not exist");
+  }
+  return assertSupportedTokenProgram(mintAccountInfo.owner);
+}
+
+async function resolveSourceTokenAccount(
+  rpc: ReturnType<typeof createRpc>,
+  owner: Address,
+  mint: Address,
+  tokenProgram: Address
+): Promise<{ tokenAccount: Address; decimals: number }> {
+  const response = await getTokenAccountsByOwnerJsonParsed(rpc, owner, tokenProgram);
+  let selected: { tokenAccount: Address; decimals: number; amount: bigint } | null = null;
+
+  for (const account of response.value ?? []) {
+    if (typeof account.pubkey !== "string") {
+      continue;
+    }
+
+    const parsed = parseTokenAmountInfo(account.account?.data?.parsed?.info);
+    if (!parsed || parsed.mint !== mint) {
+      continue;
+    }
+
+    const tokenAccount = assertValidAddress(account.pubkey, "sourceToken");
+    if (!selected || parsed.amount > selected.amount) {
+      selected = {
+        tokenAccount,
+        decimals: parsed.decimals,
+        amount: parsed.amount,
+      };
+    }
+  }
+
+  if (!selected) {
+    throw new AppError("BAD_REQUEST", "Source wallet has no token account for this mint");
+  }
+
+  return {
+    tokenAccount: selected.tokenAccount,
+    decimals: selected.decimals,
+  };
 }
 
 async function resolveScope(c: AppContext) {
@@ -684,6 +746,169 @@ async function executeSolTransfer(
   };
 }
 
+async function prepareSplTransfer(
+  c: AppContext,
+  sourceAddress: Address,
+  destinationAddress: Address,
+  mintAddress: Address,
+  amount: string
+): Promise<{ serializedTx: string; blockhash: string; lastValidBlockHeight: string }> {
+  const rpc = createRpc(c.env);
+  const tokenProgram = await resolveMintTokenProgram(rpc, mintAddress);
+  const sourceTokenAccount = await resolveSourceTokenAccount(
+    rpc,
+    sourceAddress,
+    mintAddress,
+    tokenProgram
+  );
+  const transferAmount = parseDecimalAmount(amount, sourceTokenAccount.decimals);
+
+  if (transferAmount <= 0n) {
+    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+  }
+
+  const [destinationTokenAccount] = await findAssociatedTokenPda({
+    owner: destinationAddress,
+    tokenProgram,
+    mint: mintAddress,
+  });
+  const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
+  const feePayer = await getSponsoredFeePayer(c);
+  const feePayerSigner = createNoopSigner(feePayer);
+
+  const createDestinationAtaInstruction = getCreateAssociatedTokenIdempotentInstruction({
+    payer: feePayerSigner,
+    ata: destinationTokenAccount,
+    owner: destinationAddress,
+    mint: mintAddress,
+    tokenProgram,
+  });
+  const transferInstruction = getTransferCheckedInstruction(
+    {
+      source: sourceTokenAccount.tokenAccount,
+      mint: mintAddress,
+      destination: destinationTokenAccount,
+      authority: createNoopSigner(sourceAddress),
+      amount: transferAmount,
+      decimals: sourceTokenAccount.decimals,
+    },
+    { programAddress: tokenProgram }
+  );
+
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) =>
+      appendTransactionMessageInstructions(
+        [createDestinationAtaInstruction, transferInstruction],
+        m
+      )
+  );
+
+  const compiled = compileTransaction(message);
+
+  return {
+    serializedTx: getBase64EncodedWireTransaction(compiled),
+    blockhash: blockhash as string,
+    lastValidBlockHeight: lastValidBlockHeight.toString(),
+  };
+}
+
+async function executeSplTransfer(
+  c: AppContext,
+  sourceWallet: CustodyWallet,
+  destinationAddress: Address,
+  mintAddress: Address,
+  amount: string
+): Promise<{ signature: string; slot: number | null; blockTime: string | null }> {
+  const auth = getAuth(c);
+  const signer = await createOrgSigner(
+    c.env,
+    auth.organizationId,
+    auth.projectId ?? undefined,
+    sourceWallet.walletId
+  );
+
+  if (signer.address !== sourceWallet.publicKey) {
+    throw new AppError("BAD_REQUEST", "Resolved signing wallet does not match source wallet");
+  }
+
+  const rpc = createRpc(c.env);
+  const tokenProgram = await resolveMintTokenProgram(rpc, mintAddress);
+  const sourceTokenAccount = await resolveSourceTokenAccount(
+    rpc,
+    signer.address,
+    mintAddress,
+    tokenProgram
+  );
+  const transferAmount = parseDecimalAmount(amount, sourceTokenAccount.decimals);
+
+  if (transferAmount <= 0n) {
+    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+  }
+
+  const [destinationTokenAccount] = await findAssociatedTokenPda({
+    owner: destinationAddress,
+    tokenProgram,
+    mint: mintAddress,
+  });
+  const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
+  const feePayment = getFeePayment(c);
+  const feePayer = await feePayment.getFeePayer();
+  const feePayerSigner = createNoopSigner(feePayer);
+
+  const createDestinationAtaInstruction = getCreateAssociatedTokenIdempotentInstruction({
+    payer: feePayerSigner,
+    ata: destinationTokenAccount,
+    owner: destinationAddress,
+    mint: mintAddress,
+    tokenProgram,
+  });
+  const transferInstruction = getTransferCheckedInstruction(
+    {
+      source: sourceTokenAccount.tokenAccount,
+      mint: mintAddress,
+      destination: destinationTokenAccount,
+      authority: signer,
+      amount: transferAmount,
+      decimals: sourceTokenAccount.decimals,
+    },
+    { programAddress: tokenProgram }
+  );
+
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) =>
+      appendTransactionMessageInstructions(
+        [createDestinationAtaInstruction, transferInstruction],
+        m
+      ),
+    (m) => addSignersToTransactionMessage([signer], m)
+  );
+
+  const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+  const txEncoder = getTransactionEncoder();
+  const txBytes = new Uint8Array(txEncoder.encode(partiallySigned));
+  const signature = await feePayment.signAndSend(txBytes);
+
+  const confirmation = await confirmTransaction(rpc, signature, {
+    commitment: "confirmed",
+  });
+
+  if (confirmation.err) {
+    throw new AppError("TRANSACTION_FAILED", "SPL token transfer failed on-chain");
+  }
+
+  return {
+    signature,
+    slot: Number(confirmation.slot),
+    blockTime: new Date().toISOString(),
+  };
+}
+
 function mapOnChainStatus(input: { confirmationStatus?: string | null; err?: unknown }) {
   if (input.err) return "failed" as const;
   if (input.confirmationStatus === "finalized") return "finalized" as const;
@@ -899,30 +1124,13 @@ export async function prepareTransfer(c: AppContext) {
     prepared = await prepareSolTransfer(c, sourceAddress, destinationAddress, parsed.data.amount);
   } else {
     const mintAddress = assertValidAddress(parsed.data.token, "token");
-    const signer = await createOrgSigner(
-      c.env,
-      scope.auth.organizationId,
-      scope.auth.projectId ?? undefined,
-      sourceWallet.walletId
+    prepared = await prepareSplTransfer(
+      c,
+      sourceAddress,
+      destinationAddress,
+      mintAddress,
+      parsed.data.amount
     );
-
-    const mosaic = createMosaicService(c.env, signer);
-    const feePayer = await getSponsoredFeePayer(c);
-    const preparedTokenTransfer = await mosaic.prepareTransfer({
-      mint: mintAddress,
-      from: sourceAddress,
-      to: destinationAddress,
-      amount: parsed.data.amount,
-      memo: parsed.data.memo,
-      authority: signer.address,
-      feePayer,
-    });
-
-    prepared = {
-      serializedTx: preparedTokenTransfer.serializedTx,
-      blockhash: preparedTokenTransfer.blockhash,
-      lastValidBlockHeight: preparedTokenTransfer.lastValidBlockHeight.toString(),
-    };
   }
 
   const transfer = await createTransferRecord(c, {
@@ -979,7 +1187,6 @@ export async function createTransfer(c: AppContext) {
   assertProjectContext(parsed.data.projectId, scope.auth.projectId);
 
   const sourceWallet = resolveWallet(scope.wallets, parsed.data.source);
-  const sourceAddress = assertValidAddress(sourceWallet.publicKey, "source");
   const destinationAddress = assertValidAddress(parsed.data.destination, "destination");
 
   const transfer = await createTransferRecord(c, {
@@ -1014,30 +1221,19 @@ export async function createTransfer(c: AppContext) {
     }
 
     const mintAddress = assertValidAddress(parsed.data.token, "token");
-    const signer = await createOrgSigner(
-      c.env,
-      scope.auth.organizationId,
-      scope.auth.projectId ?? undefined,
-      sourceWallet.walletId
+    const result = await executeSplTransfer(
+      c,
+      sourceWallet,
+      destinationAddress,
+      mintAddress,
+      parsed.data.amount
     );
-
-    const mosaic = createMosaicService(c.env, signer);
-    const feePayer = await getSponsoredFeePayer(c);
-    const result = await mosaic.transfer({
-      mint: mintAddress,
-      from: sourceAddress,
-      to: destinationAddress,
-      amount: parsed.data.amount,
-      memo: parsed.data.memo,
-      authority: signer,
-      feePayer: createNoopSigner(feePayer),
-    });
 
     const updated = await updateTransferRecord(c, transfer.id, {
       status: "confirmed",
       signature: result.signature,
-      slot: Number(result.slot),
-      blockTime: new Date().toISOString(),
+      slot: result.slot,
+      blockTime: result.blockTime,
       error: null,
     });
 

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -2,7 +2,9 @@ import { authMiddleware, requirePermissions } from "@/middleware/auth";
 import type { Env } from "@/types/env";
 import { Hono } from "hono";
 import {
+  createConfidentialTransfer,
   createTransfer,
+  getFeeQuote,
   getTransfer,
   getWalletBalances,
   getWalletPolicy,
@@ -36,7 +38,13 @@ payments.post(
   prepareTransfer
 );
 payments.post("/transfers", requirePermissions("payments:write", "wallets:read"), createTransfer);
+payments.post(
+  "/transfers/confidential",
+  requirePermissions("payments:write", "wallets:read"),
+  createConfidentialTransfer
+);
 payments.get("/transfers", requirePermissions("payments:read"), listTransfers);
 payments.get("/transfers/:transferId", requirePermissions("payments:read"), getTransfer);
+payments.get("/fees/quote", requirePermissions("payments:read"), getFeeQuote);
 
 export default payments;

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -45,6 +45,19 @@ export const prepareTransferSchema = createTransferSchema.extend({
     .optional(),
 });
 
+export const createConfidentialTransferSchema = z.object({
+  projectId: z.string().min(1).optional(),
+  source: z.string().min(1),
+  destination: z.string().min(1),
+  token: z.string().min(1),
+  amount: transferAmountSchema,
+  memo: z.string().max(256).optional(),
+});
+
+export const feeQuoteQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
 export const listTransfersQuerySchema = z.object({
   wallet: z.string().min(1).optional(),
   walletAddress: z.string().min(32).max(44).optional(),

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -10,7 +10,6 @@ export const transferIdParamsSchema = z.object({
 });
 
 export const updateWalletPolicySchema = z.object({
-  mode: z.enum(["none", "allowlist"]),
   destinationAllowlist: z.array(z.string().min(32).max(44)).max(500),
   maxTransferAmount: z
     .string()

--- a/apps/sdp-api/src/services/mosaic/index.ts
+++ b/apps/sdp-api/src/services/mosaic/index.ts
@@ -16,7 +16,7 @@ import type { TransactionSigner } from "@solana/kit";
 import { MosaicService } from "./service";
 
 /**
- * Create a MosaicService with a signer and configured fee payment integration.
+ * Create a MosaicService with a signer and optional Kora fee payment integration.
  *
  * This is the primary factory function for creating token issuance services.
  * Use this instead of createToken2022Service for template-based tokens.
@@ -24,9 +24,10 @@ import { MosaicService } from "./service";
  * @param env - Environment bindings
  * @param signer - Transaction signer (from SigningService.getTransactionSigner)
  *
- * Fee payment defaults to Kora unless overridden by FEE_PAYMENT_PROVIDER.
+ * When KORA_RPC_URL is set in the environment, the service will use Kora
+ * to pay transaction fees (gasless for the custody wallet).
  */
 export function createMosaicService(env: Env, signer: TransactionSigner): MosaicService {
-  const feePayment = createFeePaymentAdapter(env);
+  const feePayment = env.KORA_RPC_URL ? createFeePaymentAdapter(env) : undefined;
   return new MosaicService(env, signer, feePayment);
 }

--- a/apps/sdp-api/src/services/mosaic/index.ts
+++ b/apps/sdp-api/src/services/mosaic/index.ts
@@ -16,7 +16,7 @@ import type { TransactionSigner } from "@solana/kit";
 import { MosaicService } from "./service";
 
 /**
- * Create a MosaicService with a signer and optional Kora fee payment integration.
+ * Create a MosaicService with a signer and configured fee payment integration.
  *
  * This is the primary factory function for creating token issuance services.
  * Use this instead of createToken2022Service for template-based tokens.
@@ -24,10 +24,9 @@ import { MosaicService } from "./service";
  * @param env - Environment bindings
  * @param signer - Transaction signer (from SigningService.getTransactionSigner)
  *
- * When KORA_RPC_URL is set in the environment, the service will use Kora
- * to pay transaction fees (gasless for the custody wallet).
+ * Fee payment defaults to Kora unless overridden by FEE_PAYMENT_PROVIDER.
  */
 export function createMosaicService(env: Env, signer: TransactionSigner): MosaicService {
-  const feePayment = env.KORA_RPC_URL ? createFeePaymentAdapter(env) : undefined;
+  const feePayment = createFeePaymentAdapter(env);
   return new MosaicService(env, signer, feePayment);
 }


### PR DESCRIPTION
## Scope (Payments Part 3)
Implements the remaining core transfer-adjacent endpoints in Payments for this phase.

### Endpoints implemented
- `POST /v1/payments/transfers/confidential`
- `GET /v1/payments/fees/quote`

## What this PR adds
- Runtime route registration for confidential transfer + fee quote.
- Confidential transfer request validation schema.
- Fee quote query validation schema.
- Confidential transfer handler with:
  - org/project scope enforcement
  - source/destination wallet resolution via `/v1/wallets`
  - transfer persistence in `payment_transfers` with `type=transfer_confidential`
  - execution path using Solana Kit/Mosaic signing flow
- Fee quote handler returning standardized `feeQuote` response envelope.
- OpenAPI updates: confidential transfer and fee quote moved from draft to implemented.

## Validation
- `pnpm --filter @sdp/api lint`
- `pnpm --filter @sdp/api typecheck`
