### PR TITLE
Fix Clerk redirect deprecation and hosted API key creation failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 # Build outputs
 dist/
 .turbo/
+.next/
+apps/**/.next/
 
 # Cloudflare
 .wrangler/

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -23,6 +23,7 @@ function resolveActor(c: AppContext): {
   organizationId: string;
   permissions: Permission[];
   apiKeyId: string | null;
+  userId: string | null;
 } {
   const apiKey = c.get("apiKey");
   if (apiKey) {
@@ -30,6 +31,7 @@ function resolveActor(c: AppContext): {
       organizationId: apiKey.organizationId,
       permissions: apiKey.permissions,
       apiKeyId: apiKey.id,
+      userId: null,
     };
   }
 
@@ -39,6 +41,7 @@ function resolveActor(c: AppContext): {
       organizationId: clerk.organizationId,
       permissions: clerk.permissions,
       apiKeyId: null,
+      userId: clerk.userId,
     };
   }
 
@@ -48,6 +51,7 @@ function resolveActor(c: AppContext): {
       organizationId: session.organizationId,
       permissions: session.permissions,
       apiKeyId: null,
+      userId: session.userId,
     };
   }
 
@@ -162,7 +166,8 @@ export const createApiKey = async (c: AppContext) => {
   const apiKeyService = new ApiKeyService(c.env.DB);
   const createdKey = await apiKeyService.createApiKey({
     organizationId: orgId,
-    createdByKeyId: actor.apiKeyId ?? "system",
+    createdByKeyId: actor.apiKeyId ?? undefined,
+    createdByUserId: actor.userId ?? undefined,
     name,
     description,
     role,

--- a/apps/sdp-api/src/services/api-key.service.ts
+++ b/apps/sdp-api/src/services/api-key.service.ts
@@ -5,6 +5,7 @@
  */
 
 import { hashString } from "@/lib/hash";
+import { AppError } from "@/lib/errors";
 import type { ApiKeyEnvironment, ApiKeyRole, ApiKeyStatus, Permission } from "@sdp/types";
 import { createApiKeyMaterial, parseJsonArray } from "./api-key.utils";
 
@@ -33,7 +34,8 @@ export interface ApiKeyDetails extends ApiKeyListItem {
 export interface CreateApiKeyInput {
   organizationId: string;
   projectId?: string | null;
-  createdByKeyId: string;
+  createdByKeyId?: string;
+  createdByUserId?: string;
   name: string;
   description?: string | null;
   role: ApiKeyRole;
@@ -162,12 +164,19 @@ export class ApiKeyService {
     const { key, prefix } = createApiKeyMaterial(input.environment);
     const keyHash = await hashString(key, input.pepper);
 
-    const creatorKey = await this.db
-      .prepare("SELECT created_by FROM api_keys WHERE id = ?")
-      .bind(input.createdByKeyId)
-      .first<{ created_by: string }>();
+    let createdBy = input.createdByUserId?.trim() || "";
 
-    const createdBy = creatorKey?.created_by ?? "system";
+    if (!createdBy && input.createdByKeyId) {
+      const creatorKey = await this.db
+        .prepare("SELECT created_by FROM api_keys WHERE id = ?")
+        .bind(input.createdByKeyId)
+        .first<{ created_by: string }>();
+      createdBy = creatorKey?.created_by || "";
+    }
+
+    if (!createdBy) {
+      throw new AppError("INTERNAL_ERROR", "Unable to resolve API key creator");
+    }
 
     await this.db
       .prepare(

--- a/apps/sdp-api/src/services/api-key.service.ts
+++ b/apps/sdp-api/src/services/api-key.service.ts
@@ -4,8 +4,8 @@
  * Shared data access for API key operations.
  */
 
-import { hashString } from "@/lib/hash";
 import { AppError } from "@/lib/errors";
+import { hashString } from "@/lib/hash";
 import type { ApiKeyEnvironment, ApiKeyRole, ApiKeyStatus, Permission } from "@sdp/types";
 import { createApiKeyMaterial, parseJsonArray } from "./api-key.utils";
 

--- a/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
@@ -45,13 +45,16 @@ export async function consumeApiKeyFlash(): Promise<ApiKeyFlash | null> {
   const raw = jar.get(API_KEY_FLASH_COOKIE)?.value;
   if (!raw) return null;
 
-  jar.delete(API_KEY_FLASH_COOKIE);
-
   try {
     return JSON.parse(raw) as ApiKeyFlash;
   } catch {
     return null;
   }
+}
+
+export async function clearApiKeyFlashAction() {
+  const jar = await cookies();
+  jar.delete(API_KEY_FLASH_COOKIE);
 }
 
 export async function createApiKeyAction(formData: FormData) {

--- a/apps/sdp-web/src/app/dashboard/api-keys/flash-clear-trigger.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/flash-clear-trigger.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { clearApiKeyFlashAction } from "./actions";
+
+export function FlashClearTrigger() {
+  const cleared = useRef(false);
+
+  useEffect(() => {
+    if (cleared.current) return;
+    cleared.current = true;
+    void clearApiKeyFlashAction();
+  }, []);
+
+  return null;
+}

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -15,6 +15,7 @@ import { sdpApiFetch } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { consumeApiKeyFlash, createApiKeyAction, rotateApiKeyAction } from "./actions";
+import { FlashClearTrigger } from "./flash-clear-trigger";
 
 type ApiKeyRole = "api_admin" | "api_developer" | "api_readonly";
 type ApiKeyEnvironment = "sandbox" | "production";
@@ -62,27 +63,30 @@ export default async function ApiKeysPage() {
       <DashboardHeader title="API keys" />
 
       {flash ? (
-        <Card className={flash.level === "error" ? "border-[#c71f37]/25" : "border-[#1c1c1d]/12"}>
-          <CardHeader>
-            <CardTitle>{flash.level === "error" ? "Action failed" : "Key ready"}</CardTitle>
-            <CardDescription>{flash.message}</CardDescription>
-          </CardHeader>
-          {flash.key ? (
-            <CardContent className="space-y-2">
-              <Label htmlFor="generated-key">One-time secret key</Label>
-              <Input
-                id="generated-key"
-                readOnly
-                value={flash.key}
-                className="font-mono text-xs"
-                onFocus={(event) => event.currentTarget.select()}
-              />
-              <p className="text-xs text-[rgba(28,28,29,0.72)]">
-                Store this key securely now. SDP only shows it once.
-              </p>
-            </CardContent>
-          ) : null}
-        </Card>
+        <>
+          <FlashClearTrigger />
+          <Card className={flash.level === "error" ? "border-[#c71f37]/25" : "border-[#1c1c1d]/12"}>
+            <CardHeader>
+              <CardTitle>{flash.level === "error" ? "Action failed" : "Key ready"}</CardTitle>
+              <CardDescription>{flash.message}</CardDescription>
+            </CardHeader>
+            {flash.key ? (
+              <CardContent className="space-y-2">
+                <Label htmlFor="generated-key">One-time secret key</Label>
+                <Input
+                  id="generated-key"
+                  readOnly
+                  value={flash.key}
+                  className="font-mono text-xs"
+                  onFocus={(event) => event.currentTarget.select()}
+                />
+                <p className="text-xs text-[rgba(28,28,29,0.72)]">
+                  Store this key securely now. SDP only shows it once.
+                </p>
+              </CardContent>
+            ) : null}
+          </Card>
+        </>
       ) : null}
 
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -18,8 +18,8 @@ export default function RootLayout({
         <ClerkProvider
           signInUrl="/sign-in"
           signUpUrl="/sign-up"
-          afterSignInUrl="/dashboard"
-          afterSignUpUrl="/dashboard"
+          signInFallbackRedirectUrl="/dashboard"
+          signUpFallbackRedirectUrl="/dashboard"
         >
           {children}
         </ClerkProvider>

--- a/biome.json
+++ b/biome.json
@@ -73,7 +73,7 @@
     }
   ],
   "files": {
-    "ignore": ["node_modules", ".wrangler", "dist", "*.d.ts", "pnpm-lock.yaml"]
+    "ignore": ["node_modules", ".wrangler", ".next", "dist", "*.d.ts", "pnpm-lock.yaml"]
   },
   "vcs": {
     "enabled": true,

--- a/packages/sdp-api-integration/vitest.config.ts
+++ b/packages/sdp-api-integration/vitest.config.ts
@@ -29,8 +29,7 @@ function loadEnvFile(filePath: string): Record<string, string> {
 }
 
 const fileEnv = loadEnvFile(DEV_VARS_PATH);
-const getEnv = (key: string, fallback?: string) =>
-  process.env[key] ?? fileEnv[key] ?? fallback;
+const getEnv = (key: string, fallback?: string) => process.env[key] ?? fileEnv[key] ?? fallback;
 
 const custodyEncryptionKey =
   getEnv("CUSTODY_ENCRYPTION_KEY") ?? Buffer.alloc(32).toString("base64");


### PR DESCRIPTION
## Summary
- replace deprecated Clerk redirect props in the web root layout (`afterSignInUrl`/`afterSignUpUrl` -> fallback redirect props)
- fix API key flash cookie lifecycle so cookie deletion happens in a Server Action (not during Server Component render)
- resolve `api_keys.created_by` safely for non-API-key actors by passing user id through route actor resolution and API key service create flow

## Why
- hosted dashboard failed with `Cookies can only be modified in a Server Action or Route Handler` during `/dashboard/api-keys` render
- hosted API key creation could fail D1 foreign key checks when `created_by` fell back to `"system"`
- Clerk warned about deprecated redirect props in runtime logs

## Notes
- no test run was performed in this step
