### PR TITLE
Fix Clerk webhook sync and custody permissions for admins

### DIFF
--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -254,7 +254,10 @@ async function ensureMembership(
     .run();
 }
 
-async function deactivateMembership(c: AppContext, params: { organizationId: string; userId: string }) {
+async function deactivateMembership(
+  c: AppContext,
+  params: { organizationId: string; userId: string }
+) {
   await c.env.DB.prepare(
     `UPDATE organization_members
      SET status = 'inactive'
@@ -383,9 +386,11 @@ export const handleClerkWebhook = async (c: AppContext) => {
     case "organizationMembership.created":
       await handleOrganizationMembershipCreated(c, data);
       break;
+    // biome-ignore lint/nursery/noSecrets: Webhook event type literal, not a secret.
     case "organizationMembership.updated":
       await handleOrganizationMembershipUpdated(c, data);
       break;
+    // biome-ignore lint/nursery/noSecrets: Webhook event type literal, not a secret.
     case "organizationMembership.deleted":
       await handleOrganizationMembershipDeleted(c, data);
       break;

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -239,25 +239,28 @@ async function ensureMembership(
   c: AppContext,
   params: { organizationId: string; userId: string; role: string | null }
 ) {
-  const existing = await c.env.DB.prepare(
-    `SELECT id
-     FROM organization_members
+  const role = mapClerkRoleToOrgRole(params.role);
+
+  const memberId = `mem_${crypto.randomUUID()}`;
+  await c.env.DB.prepare(
+    `INSERT INTO organization_members (id, organization_id, user_id, role, status)
+     VALUES (?, ?, ?, ?, 'active')
+     ON CONFLICT(organization_id, user_id)
+     DO UPDATE SET
+       role = excluded.role,
+       status = 'active'`
+  )
+    .bind(memberId, params.organizationId, params.userId, role)
+    .run();
+}
+
+async function deactivateMembership(c: AppContext, params: { organizationId: string; userId: string }) {
+  await c.env.DB.prepare(
+    `UPDATE organization_members
+     SET status = 'inactive'
      WHERE organization_id = ? AND user_id = ?`
   )
     .bind(params.organizationId, params.userId)
-    .first<{ id: string }>();
-
-  if (existing?.id) {
-    return;
-  }
-
-  const role = mapClerkRoleToOrgRole(params.role);
-
-  await c.env.DB.prepare(
-    `INSERT OR IGNORE INTO organization_members (id, organization_id, user_id, role, status)
-     VALUES (?, ?, ?, ?, 'active')`
-  )
-    .bind(`mem_${crypto.randomUUID()}`, params.organizationId, params.userId, role)
     .run();
 }
 
@@ -285,6 +288,55 @@ async function handleOrganizationMembershipCreated(c: AppContext, data: Record<s
   });
 
   await ensureMembership(c, { organizationId, userId, role: member.role });
+}
+
+async function handleOrganizationMembershipUpdated(c: AppContext, data: Record<string, unknown>) {
+  const org = extractOrganization(data);
+  const member = extractMember(data);
+
+  if (!org.id) {
+    throw badRequest("Clerk organization id missing");
+  }
+  if (!member.userId) {
+    throw badRequest("Clerk member user id missing");
+  }
+
+  const organizationId = await ensureOrganizationMapping(c, org);
+  const email = await resolveUserEmail(c.env, member);
+  const userId = await ensureUserMapping(c, {
+    clerkUserId: member.userId,
+    email,
+  });
+
+  await ensureMembership(c, { organizationId, userId, role: member.role });
+}
+
+async function handleOrganizationMembershipDeleted(c: AppContext, data: Record<string, unknown>) {
+  const org = extractOrganization(data);
+  const member = extractMember(data);
+
+  if (!org.id) {
+    return;
+  }
+
+  if (!member.userId) {
+    return;
+  }
+
+  const organizationId = await ensureOrganizationMapping(c, org);
+  const identity = await c.env.DB.prepare(
+    `SELECT user_id
+     FROM auth_user_identities
+     WHERE provider = 'clerk' AND provider_user_id = ?`
+  )
+    .bind(member.userId)
+    .first<{ user_id: string }>();
+
+  if (!identity?.user_id) {
+    return;
+  }
+
+  await deactivateMembership(c, { organizationId, userId: identity.user_id });
 }
 
 function requiredHeader(c: AppContext, name: string) {
@@ -330,6 +382,12 @@ export const handleClerkWebhook = async (c: AppContext) => {
     // biome-ignore lint/nursery/noSecrets: Webhook event type literal, not a secret.
     case "organizationMembership.created":
       await handleOrganizationMembershipCreated(c, data);
+      break;
+    case "organizationMembership.updated":
+      await handleOrganizationMembershipUpdated(c, data);
+      break;
+    case "organizationMembership.deleted":
+      await handleOrganizationMembershipDeleted(c, data);
       break;
     default:
       break;

--- a/packages/sdp-types/src/permissions.ts
+++ b/packages/sdp-types/src/permissions.ts
@@ -81,6 +81,8 @@ export const ORGANIZATION_ROLES = {
       "api-keys:read",
       "api-keys:write",
       "audit:read",
+      "custody:read",
+      "custody:admin",
     ] as Permission[],
   },
   developer: {


### PR DESCRIPTION
## Summary
- Sync Clerk membership webhook events with upsert semantics and add membership deactivate/update handlers
- Grant custody permissions to org admin role

## Changes
- apps/sdp-api/src/routes/webhooks/handlers.ts
  - Upsert organization_members on organizationMembership.created
  - Handle organizationMembership.updated by upserting role/status
  - Handle organizationMembership.deleted by deactivating membership
- packages/sdp-types/src/permissions.ts
  - Add custody:read and custody:admin to ORGANIZATION_ROLES.admin.permissions

## Impact
- Fixed stale org role mappings when Clerk membership updates/deletes
- Allows org admins to access custody endpoints and create wallets without insufficient permission errors.

## Verification
- Checked  user/org/member rows reflect expected Clerk-linked identity/role after user recreation.