### PR TITLE
fix: normalize custody wallet creation errors

### DIFF
--- a/apps/sdp-api/src/services/custody/provisioning.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.ts
@@ -284,29 +284,41 @@ interface PrivyRequestParams {
 }
 
 async function privyRequest<T>(params: PrivyRequestParams): Promise<T> {
-  const response = await fetch(`${params.apiBaseUrl}${params.path}`, {
-    method: params.method,
-    headers: {
-      Authorization: params.authHeader,
-      "privy-app-id": params.appId,
-      ...(params.body ? { "Content-Type": "application/json" } : {}),
-    },
-    body: params.body ? JSON.stringify(params.body) : undefined,
-  });
+  try {
+    const response = await fetch(`${params.apiBaseUrl}${params.path}`, {
+      method: params.method,
+      headers: {
+        Authorization: params.authHeader,
+        "privy-app-id": params.appId,
+        ...(params.body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: params.body ? JSON.stringify(params.body) : undefined,
+    });
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "Failed to read error response");
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Failed to read error response");
+      throw new SigningError(
+        `Privy API error: ${response.status} - ${errorText}`,
+        "PROVIDER_NOT_CONFIGURED"
+      );
+    }
+
+    if (response.status === 204 || response.headers.get("content-length") === "0") {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    if (error instanceof SigningError) {
+      throw error;
+    }
+
     throw new SigningError(
-      `Privy API error: ${response.status} - ${errorText}`,
-      "PROVIDER_NOT_CONFIGURED"
+      `Failed to call Privy API: ${error instanceof Error ? error.message : "Unknown error"}`,
+      "NETWORK_ERROR",
+      error instanceof Error ? error : undefined
     );
   }
-
-  if (response.status === 204 || response.headers.get("content-length") === "0") {
-    return undefined as T;
-  }
-
-  return (await response.json()) as T;
 }
 
 function encodeBasicAuth(value: string): string {

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -419,22 +419,53 @@ export class SigningService {
     const apiBaseUrl =
       parsed.provider === "privy" ? (parsed.apiBaseUrl ?? this.env.PRIVY_API_BASE_URL) : undefined;
 
-    const provisioned = await provisionPrivyWallet(this.env, { apiBaseUrl });
+    let provisioned: { walletId: string; address: string };
+    try {
+      provisioned = await provisionPrivyWallet(this.env, { apiBaseUrl });
+    } catch (error) {
+      if (error instanceof SigningError) {
+        throw error;
+      }
+
+      throw new SigningError(
+        `Failed to provision Privy wallet: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "NETWORK_ERROR",
+        error instanceof Error ? error : undefined
+      );
+    }
+
     const walletId = normalizePrivyWalletId(provisioned.walletId);
 
-    const wallet = await this.configStore.createWallet(config.id, {
-      walletId,
-      publicKey: provisioned.address,
-      label: params.label,
-      purpose: params.purpose,
-    });
+    let wallet: CustodyWallet;
+    try {
+      wallet = await this.configStore.createWallet(config.id, {
+        walletId,
+        publicKey: provisioned.address,
+        label: params.label,
+        purpose: params.purpose,
+      });
+    } catch (error) {
+      throw new SigningError(
+        `Failed to persist wallet record: ${error instanceof Error ? error.message : "Unknown error"}`,
+        "NETWORK_ERROR",
+        error instanceof Error ? error : undefined
+      );
+    }
 
     if (params.setDefault) {
-      await this.env.DB.prepare(
-        `UPDATE custody_configs SET default_wallet_id = ?, updated_at = datetime('now') WHERE id = ?`
-      )
-        .bind(walletId, config.id)
-        .run();
+      try {
+        await this.env.DB.prepare(
+          `UPDATE custody_configs SET default_wallet_id = ?, updated_at = datetime('now') WHERE id = ?`
+        )
+          .bind(walletId, config.id)
+          .run();
+      } catch (error) {
+        throw new SigningError(
+          `Failed to update default wallet: ${error instanceof Error ? error.message : "Unknown error"}`,
+          "NETWORK_ERROR",
+          error instanceof Error ? error : undefined
+        );
+      }
 
       this.providerCache.delete(config.id);
     }


### PR DESCRIPTION
## Summary
- Normalize Privy wallet creation errors to typed SigningError instead of raw runtime exceptions.
- Wrap Privy API request path with network-error handling.
- Add explicit error handling for DB insert/default-wallet update failures during wallet provisioning.

## Why
Wallet creation in /v1/wallets was returning opaque 500 INTERNAL_ERROR for non-SigningError failures in deployed environments, making root-cause unclear and preventing successful wallet provisioning.

## Validation
- Changes committed in .
- Deployed worker  was updated in the environment with these changes after deployment, and wallet creation now succeeds in hosted dev flow once secrets are properly configured.