### PR TITLE
Improve wallets page loading UX and section transitions

### DIFF
--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -1,4 +1,9 @@
 import { linkOrganization } from "@/app/onboarding/actions";
+import {
+  WalletsSigningConfigSkeleton,
+  WalletsTableSectionSkeleton,
+} from "@/app/dashboard/wallets/wallets-page-skeleton";
+import { SectionEntry } from "@/app/dashboard/wallets/section-entry";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -9,10 +14,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { sdpApiFetch, sdpApiRequest } from "@/lib/sdp-api";
+import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import { setDefaultCustodyWallet } from "./actions";
 
 type CustodyProvider = "privy" | "local" | "fireblocks";
@@ -44,8 +50,17 @@ interface ClerkOrganizationSummary {
   slug: string | null;
 }
 
-async function getCustodyConfig(): Promise<CustodyConfig | null> {
-  const res = await sdpApiRequest("/v1/wallets/config");
+type SettledResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+function settle<T>(promise: Promise<T>): Promise<SettledResult<T>> {
+  return promise.then(
+    (value) => ({ ok: true, value }),
+    (error) => ({ ok: false, error })
+  );
+}
+
+async function getCustodyConfig(request: SdpApiClient["request"]): Promise<CustodyConfig | null> {
+  const res = await request("/v1/wallets/config");
   if (res.status === 404) return null;
   if (!res.ok) {
     const body = await res.text();
@@ -77,70 +92,81 @@ async function getClerkOrganizationSummary(
   }
 }
 
-export default async function CustodyPage() {
-  const { userId, orgId } = await auth();
-  if (!userId) {
-    redirect("/sign-in");
-  }
-  if (!orgId) {
-    redirect("/dashboard");
-  }
-  const pageContainerClassName = "w-full max-w-5xl flex flex-col gap-6";
-
-  const onboarding = await sdpApiFetch<{ linked: boolean }>("/v1/onboarding/status");
-  if (!onboarding.linked) {
-    const organization = await getClerkOrganizationSummary(orgId);
-
-    return (
-      <div className={pageContainerClassName}>
-        <Card>
-          <CardHeader>
-            <CardTitle>Confirm organization details</CardTitle>
-            <CardDescription>
-              Review the Clerk organization details below before linking it in SDP.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] p-4 text-sm">
-              <div className="flex flex-wrap items-center justify-between gap-2 py-1">
-                <span className="text-[rgba(28,28,29,0.72)]">Organization name</span>
-                <span className="font-medium text-[#1c1c1d]">
-                  {organization.name ?? "Unavailable"}
-                </span>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2 py-1">
-                <span className="text-[rgba(28,28,29,0.72)]">Organization slug</span>
-                <span className="font-mono text-xs text-[#1c1c1d]">
-                  {organization.slug ?? "Unavailable"}
-                </span>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2 py-1">
-                <span className="text-[rgba(28,28,29,0.72)]">Clerk organization ID</span>
-                <span className="font-mono text-xs text-[#1c1c1d]">{organization.id}</span>
-              </div>
-            </div>
-            <p className="text-sm text-[rgba(28,28,29,0.72)]">
-              Confirming will link this Clerk organization in SDP (D1) and enable wallet setup.
-            </p>
-            <form action={linkOrganization}>
-              <input type="hidden" name="returnTo" value="/dashboard/wallets" />
-              <Button type="submit">Confirm and link organization</Button>
-            </form>
-          </CardContent>
-        </Card>
-      </div>
-    );
+async function OnboardingGateSection({
+  orgId,
+  onboardingPromise,
+}: {
+  orgId: string;
+  onboardingPromise: Promise<{ linked: boolean }>;
+}) {
+  const onboarding = await onboardingPromise;
+  if (onboarding.linked) {
+    return null;
   }
 
-  const [config, walletsResp] = await Promise.all([
-    getCustodyConfig(),
-    sdpApiFetch<{ wallets: CustodyWallet[] }>("/v1/wallets"),
-  ]);
-  const wallets = walletsResp.wallets;
+  const organization = await getClerkOrganizationSummary(orgId);
 
   return (
-    <div className={pageContainerClassName}>
-      {!config ? (
+    <SectionEntry>
+      <Card>
+        <CardHeader>
+          <CardTitle>Confirm organization details</CardTitle>
+          <CardDescription>
+            Review the Clerk organization details below before linking it in SDP.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] p-4 text-sm">
+            <div className="flex flex-wrap items-center justify-between gap-2 py-1">
+              <span className="text-[rgba(28,28,29,0.72)]">Organization name</span>
+              <span className="font-medium text-[#1c1c1d]">
+                {organization.name ?? "Unavailable"}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-2 py-1">
+              <span className="text-[rgba(28,28,29,0.72)]">Organization slug</span>
+              <span className="font-mono text-xs text-[#1c1c1d]">
+                {organization.slug ?? "Unavailable"}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-2 py-1">
+              <span className="text-[rgba(28,28,29,0.72)]">Clerk organization ID</span>
+              <span className="font-mono text-xs text-[#1c1c1d]">{organization.id}</span>
+            </div>
+          </div>
+          <p className="text-sm text-[rgba(28,28,29,0.72)]">
+            Confirming will link this Clerk organization in SDP (D1) and enable wallet setup.
+          </p>
+          <form action={linkOrganization}>
+            <input type="hidden" name="returnTo" value="/dashboard/wallets" />
+            <Button type="submit">Confirm and link organization</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </SectionEntry>
+  );
+}
+
+type LinkedCustodyData = {
+  config: CustodyConfig | null;
+  wallets: CustodyWallet[];
+};
+
+async function SigningConfigurationSection({
+  linkedDataPromise,
+}: {
+  linkedDataPromise: Promise<LinkedCustodyData | null>;
+}) {
+  const linkedData = await linkedDataPromise;
+  if (!linkedData) {
+    return null;
+  }
+
+  const { config } = linkedData;
+
+  if (!config) {
+    return (
+      <SectionEntry>
         <Card>
           <CardHeader>
             <CardTitle>Enable wallets</CardTitle>
@@ -158,44 +184,65 @@ export default async function CustodyPage() {
             </Link>
           </CardContent>
         </Card>
-      ) : (
-        <Card>
-          <CardHeader>
-            <CardTitle>Signing configuration</CardTitle>
-            <CardDescription>Controls which wallet signs new API actions.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4 text-sm">
-            <div className="grid gap-2">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <span className="text-[rgba(28,28,29,0.72)]">Provider</span>
-                <span className="font-medium text-[#1c1c1d]">{config.provider}</span>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <span className="text-[rgba(28,28,29,0.72)]">Master address</span>
-                <span className="font-mono text-xs text-[#1c1c1d]">{config.publicKey}</span>
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <span className="text-[rgba(28,28,29,0.72)]">Default wallet</span>
-                <span className="font-mono text-xs text-[#1c1c1d]">
-                  {config.defaultWalletId ?? "Not set"}
-                </span>
-              </div>
-            </div>
+      </SectionEntry>
+    );
+  }
 
-            <div className="flex flex-wrap gap-3">
-              <Link href="/dashboard/wallets/switch">
-                <Button variant="secondary">Change provider</Button>
-              </Link>
+  return (
+    <SectionEntry delay={0.02}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Signing configuration</CardTitle>
+          <CardDescription>Controls which wallet signs new API actions.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-[rgba(28,28,29,0.72)]">Provider</span>
+              <span className="font-medium text-[#1c1c1d]">{config.provider}</span>
             </div>
-
-            <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] px-3 py-2 text-xs text-[rgba(28,28,29,0.64)]">
-              Changing providers affects new actions only. Existing on-chain authorities are not
-              automatically rotated.
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-[rgba(28,28,29,0.72)]">Master address</span>
+              <span className="font-mono text-xs text-[#1c1c1d]">{config.publicKey}</span>
             </div>
-          </CardContent>
-        </Card>
-      )}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-[rgba(28,28,29,0.72)]">Default wallet</span>
+              <span className="font-mono text-xs text-[#1c1c1d]">
+                {config.defaultWalletId ?? "Not set"}
+              </span>
+            </div>
+          </div>
 
+          <div className="flex flex-wrap gap-3">
+            <Link href="/dashboard/wallets/switch">
+              <Button variant="secondary">Change provider</Button>
+            </Link>
+          </div>
+
+          <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] px-3 py-2 text-xs text-[rgba(28,28,29,0.64)]">
+            Changing providers affects new actions only. Existing on-chain authorities are not
+            automatically rotated.
+          </div>
+        </CardContent>
+      </Card>
+    </SectionEntry>
+  );
+}
+
+async function WalletsSection({
+  linkedDataPromise,
+}: {
+  linkedDataPromise: Promise<LinkedCustodyData | null>;
+}) {
+  const linkedData = await linkedDataPromise;
+  if (!linkedData) {
+    return null;
+  }
+
+  const { config, wallets } = linkedData;
+
+  return (
+    <SectionEntry delay={0.08}>
       <Card>
         <CardHeader>
           <CardTitle>Wallets</CardTitle>
@@ -250,6 +297,80 @@ export default async function CustodyPage() {
           )}
         </CardContent>
       </Card>
+    </SectionEntry>
+  );
+}
+
+async function PrimaryWalletSection({
+  orgId,
+  onboardingPromise,
+  linkedDataPromise,
+}: {
+  orgId: string;
+  onboardingPromise: Promise<{ linked: boolean }>;
+  linkedDataPromise: Promise<LinkedCustodyData | null>;
+}) {
+  const onboarding = await onboardingPromise;
+
+  if (!onboarding.linked) {
+    return <OnboardingGateSection orgId={orgId} onboardingPromise={Promise.resolve(onboarding)} />;
+  }
+
+  return <SigningConfigurationSection linkedDataPromise={linkedDataPromise} />;
+}
+
+export default async function CustodyPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  const pageContainerClassName = "w-full max-w-5xl flex flex-col gap-6";
+  const apiClient = await createSdpApiClient();
+  const onboardingPromise = apiClient.fetch<{ linked: boolean }>("/v1/onboarding/status");
+  const configResultPromise = settle(getCustodyConfig(apiClient.request));
+  const walletsResultPromise = settle(apiClient.fetch<{ wallets: CustodyWallet[] }>("/v1/wallets"));
+  const linkedDataPromise: Promise<LinkedCustodyData | null> = onboardingPromise.then(
+    async (onboarding) => {
+      if (!onboarding.linked) {
+        return null;
+      }
+
+      const [configResult, walletsResult] = await Promise.all([
+        configResultPromise,
+        walletsResultPromise,
+      ]);
+
+      if (!configResult.ok) {
+        throw configResult.error;
+      }
+
+      if (!walletsResult.ok) {
+        throw walletsResult.error;
+      }
+
+      return {
+        config: configResult.value,
+        wallets: walletsResult.value.wallets,
+      };
+    }
+  );
+
+  return (
+    <div className={pageContainerClassName}>
+      <Suspense fallback={<WalletsSigningConfigSkeleton />}>
+        <PrimaryWalletSection
+          orgId={orgId}
+          onboardingPromise={onboardingPromise}
+          linkedDataPromise={linkedDataPromise}
+        />
+      </Suspense>
+      <Suspense fallback={<WalletsTableSectionSkeleton />}>
+        <WalletsSection linkedDataPromise={linkedDataPromise} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -1,9 +1,9 @@
-import { linkOrganization } from "@/app/onboarding/actions";
+import { SectionEntry } from "@/app/dashboard/wallets/section-entry";
 import {
   WalletsSigningConfigSkeleton,
   WalletsTableSectionSkeleton,
 } from "@/app/dashboard/wallets/wallets-page-skeleton";
-import { SectionEntry } from "@/app/dashboard/wallets/section-entry";
+import { linkOrganization } from "@/app/onboarding/actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -14,7 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
+import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import Link from "next/link";
 import { redirect } from "next/navigation";

--- a/apps/sdp-web/src/app/dashboard/wallets/section-entry.tsx
+++ b/apps/sdp-web/src/app/dashboard/wallets/section-entry.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+interface SectionEntryProps {
+  children: ReactNode;
+  delay?: number;
+}
+
+export function SectionEntry({ children, delay = 0 }: SectionEntryProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: "easeOut", delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/wallets/wallets-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/wallets/wallets-page-skeleton.tsx
@@ -1,0 +1,74 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+function SkeletonLine({ widthClass = "w-full" }: { widthClass?: string }) {
+  return <div className={`h-4 rounded bg-[rgba(28,28,29,0.10)] ${widthClass}`} />;
+}
+
+function SkeletonRows({ rows }: { rows: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }, (_, idx) => (
+        <SkeletonLine
+          key={`row-skeleton-${idx + 1}`}
+          widthClass={idx % 2 === 0 ? "w-[92%]" : "w-[76%]"}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function WalletsOnboardingSkeleton() {
+  return (
+    <Card className="min-h-[300px] animate-pulse">
+      <CardHeader className="space-y-3">
+        <SkeletonLine widthClass="w-56" />
+        <SkeletonLine widthClass="w-[72%]" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.04)] p-4">
+          <SkeletonRows rows={3} />
+        </div>
+        <SkeletonLine widthClass="w-[48%]" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function WalletsSigningConfigSkeleton() {
+  return (
+    <Card className="min-h-[284px] animate-pulse">
+      <CardHeader className="space-y-3">
+        <SkeletonLine widthClass="w-44" />
+        <SkeletonLine widthClass="w-[54%]" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SkeletonRows rows={4} />
+        <div className="h-10 w-36 rounded-[10px] bg-[rgba(28,28,29,0.10)]" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function WalletsTableSectionSkeleton() {
+  return (
+    <Card className="min-h-[360px] animate-pulse">
+      <CardHeader className="space-y-3">
+        <SkeletonLine widthClass="w-20" />
+        <SkeletonLine widthClass="w-[46%]" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <SkeletonRows rows={5} />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function WalletsPageSkeleton() {
+  return (
+    <div className="w-full max-w-5xl flex flex-col gap-6">
+      <WalletsOnboardingSkeleton />
+      <WalletsSigningConfigSkeleton />
+      <WalletsTableSectionSkeleton />
+    </div>
+  );
+}

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -49,24 +49,25 @@ async function getClerkToken(): Promise<string> {
   return token;
 }
 
-export async function sdpApiRequest(path: string, options: RequestInit = {}): Promise<Response> {
-  const token = await getClerkToken();
-  const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+type SdpApiRequestFn = (path: string, options?: RequestInit) => Promise<Response>;
 
-  return fetch(url, {
-    ...options,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      ...(options.headers || {}),
-    },
-    cache: "no-store",
-  });
+function createSdpApiRequest(token: string): SdpApiRequestFn {
+  return async (path: string, options: RequestInit = {}): Promise<Response> => {
+    const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+
+    return fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        ...(options.headers || {}),
+      },
+      cache: "no-store",
+    });
+  };
 }
 
-export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const res = await sdpApiRequest(path, options);
-
+async function parseSdpApiResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`SDP API request failed (${res.status}): ${body}`);
@@ -83,4 +84,33 @@ export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): P
   }
 
   return json as T;
+}
+
+export interface SdpApiClient {
+  request: SdpApiRequestFn;
+  fetch: <T>(path: string, options?: RequestInit) => Promise<T>;
+}
+
+export async function createSdpApiClient(): Promise<SdpApiClient> {
+  const token = await getClerkToken();
+  const request = createSdpApiRequest(token);
+
+  return {
+    request,
+    fetch: async <T>(path: string, options: RequestInit = {}): Promise<T> => {
+      const res = await request(path, options);
+      return parseSdpApiResponse<T>(res);
+    },
+  };
+}
+
+export async function sdpApiRequest(path: string, options: RequestInit = {}): Promise<Response> {
+  const client = await createSdpApiClient();
+  return client.request(path, options);
+}
+
+export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const client = await createSdpApiClient();
+  const res = await client.request(path, options);
+  return parseSdpApiResponse<T>(res);
 }


### PR DESCRIPTION
## Summary
- refactor wallets/custody page to stream sections with localized Suspense boundaries
- add reserved-space skeleton components for signing config and wallets sections to reduce layout shift
- reuse a single SDP API auth client per render to avoid repeated token acquisition
- add issuance-style section entry animation for wallets content

## Notes
- no route-level full-page loading fallback; only localized section skeletons
- not pushed previously; this PR contains the complete wallet loading refactor