### PR TITLE
Issuance playground: shared key selector and execution flow

### DIFF
--- a/apps/sdp-web/src/app/api/playground/execute/route.ts
+++ b/apps/sdp-web/src/app/api/playground/execute/route.ts
@@ -1,0 +1,73 @@
+import { sdpApiRequest } from "@/lib/sdp-api";
+import { NextResponse } from "next/server";
+
+type PlaygroundMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+interface PlaygroundExecuteRequestBody {
+  method?: PlaygroundMethod;
+  path?: string;
+  body?: unknown;
+  apiKey?: string | null;
+}
+
+const ALLOWED_METHODS = new Set<PlaygroundMethod>(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+export async function POST(request: Request) {
+  try {
+    const payload = (await request.json()) as PlaygroundExecuteRequestBody;
+    const method = payload.method;
+    const path = payload.path;
+
+    if (!method || !ALLOWED_METHODS.has(method)) {
+      return NextResponse.json({ error: "Invalid method" }, { status: 400 });
+    }
+
+    if (!path || typeof path !== "string") {
+      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+    }
+    if (!path.startsWith("/")) {
+      return NextResponse.json({ error: "Path must start with '/'" }, { status: 400 });
+    }
+
+    const normalizedApiKey = typeof payload.apiKey === "string" ? payload.apiKey.trim() : "";
+    const headers: Record<string, string> = {};
+
+    if (normalizedApiKey) {
+      headers.Authorization = `Bearer ${normalizedApiKey}`;
+    }
+
+    const response = await sdpApiRequest(path, {
+      method,
+      headers,
+      body:
+        method !== "GET" && method !== "DELETE" && payload.body !== null && payload.body !== undefined
+          ? JSON.stringify(payload.body)
+          : undefined,
+    });
+
+    const text = await response.text();
+    const body = text
+      ? (() => {
+          try {
+            return JSON.parse(text) as unknown;
+          } catch {
+            return text;
+          }
+        })()
+      : {};
+
+    return NextResponse.json({
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      body,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Playground execution failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/api/playground/execute/route.ts
+++ b/apps/sdp-web/src/app/api/playground/execute/route.ts
@@ -40,7 +40,10 @@ export async function POST(request: Request) {
       method,
       headers,
       body:
-        method !== "GET" && method !== "DELETE" && payload.body !== null && payload.body !== undefined
+        method !== "GET" &&
+        method !== "DELETE" &&
+        payload.body !== null &&
+        payload.body !== undefined
           ? JSON.stringify(payload.body)
           : undefined,
     });

--- a/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
@@ -3,7 +3,8 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useState } from "react";
+import { storeApiKeySecret } from "@/lib/playground-api-keys";
+import { useEffect, useState } from "react";
 import { clearApiKeyFlashAction } from "./actions";
 import { GeneratedApiKeyInput } from "./generated-key-input";
 
@@ -16,6 +17,17 @@ interface GeneratedApiKeyModalProps {
 function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyModalProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [copyLabel, setCopyLabel] = useState("Copy");
+
+  useEffect(() => {
+    if (!keyValue) {
+      return;
+    }
+
+    storeApiKeySecret({
+      value: keyValue,
+      keyPrefix: keyPrefix ?? null,
+    });
+  }, [keyValue, keyPrefix]);
 
   if (!isOpen) {
     return null;

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-api-key-selector.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-api-key-selector.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+
+export function IssuanceApiKeySelector() {
+  const { issuanceApiKeys, selectedIssuanceApiKeyId, setSelectedIssuanceApiKeyId } =
+    useDashboardWorkspace();
+
+  if (issuanceApiKeys.length === 0) {
+    return (
+      <div className="inline-flex h-9 items-center rounded-[10px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-3 text-xs text-[rgba(28,28,29,0.56)]">
+        No API keys
+      </div>
+    );
+  }
+
+  return (
+    <Select
+      value={selectedIssuanceApiKeyId ?? issuanceApiKeys[0].id}
+      onValueChange={(value) => setSelectedIssuanceApiKeyId(value)}
+    >
+      <SelectTrigger className="h-9 min-w-[220px] rounded-[10px] border-[rgba(28,28,29,0.16)] bg-white text-xs">
+        <SelectValue placeholder="Select API key" />
+      </SelectTrigger>
+      <SelectContent>
+        {issuanceApiKeys.map((apiKey) => (
+          <SelectItem key={apiKey.id} value={apiKey.id}>
+            {apiKey.name} ({apiKey.keyPrefix})
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -1,13 +1,22 @@
 "use client";
-"use client";
 
-import {
-  ApiEndpointPlayground,
-  type ApiPlaygroundApiKeyOption,
-} from "@/components/api-endpoint-playground";
+import { ApiEndpointPlayground } from "@/components/api-endpoint-playground";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  getStoredApiKeySecret,
+  normalizeApiKeyInput,
+  storeApiKeySecret,
+} from "@/lib/playground-api-keys";
 import {
   Table,
   TableBody,
@@ -19,7 +28,7 @@ import {
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { AnimatePresence, motion } from "framer-motion";
 import { Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type IssuanceTemplateId, getTemplateCatalogEntry } from "./template-catalog";
 
 interface IssuanceTokenView {
@@ -145,9 +154,19 @@ const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
   },
 ];
 
+const CUSTOM_API_KEY_OPTION_ID = "__custom__";
+
+interface IssuanceApiKeyOption {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  role: string;
+  environment: string;
+}
+
 interface IssuanceWorkspaceProps {
   tokens: IssuanceTokenView[];
-  apiKeys: ApiPlaygroundApiKeyOption[];
+  apiKeys: IssuanceApiKeyOption[];
   apiBaseUrl: string | null;
   templatesError: string | null;
   tokensError: string | null;
@@ -187,6 +206,49 @@ export function IssuanceWorkspace({
 }: IssuanceWorkspaceProps) {
   const { issuanceTab, setIssuanceTab } = useDashboardWorkspace();
   const [search, setSearch] = useState("");
+  const [selectedPlaygroundApiKeyId, setSelectedPlaygroundApiKeyId] = useState<string>(
+    apiKeys[0]?.id ?? CUSTOM_API_KEY_OPTION_ID
+  );
+  const [playgroundApiKeyValue, setPlaygroundApiKeyValue] = useState("");
+
+  const selectedPlaygroundApiKey = useMemo(
+    () => apiKeys.find((key) => key.id === selectedPlaygroundApiKeyId) ?? null,
+    [apiKeys, selectedPlaygroundApiKeyId]
+  );
+  const selectedPlaygroundApiKeyPrefix = selectedPlaygroundApiKey?.keyPrefix ?? null;
+  const hasSelectedRealApiKey = selectedPlaygroundApiKeyId !== CUSTOM_API_KEY_OPTION_ID;
+
+  useEffect(() => {
+    if (!hasSelectedRealApiKey) {
+      return;
+    }
+
+    const stored = getStoredApiKeySecret({
+      apiKeyId: selectedPlaygroundApiKeyId,
+      keyPrefix: selectedPlaygroundApiKeyPrefix,
+    });
+
+    setPlaygroundApiKeyValue(stored ?? "");
+  }, [hasSelectedRealApiKey, selectedPlaygroundApiKeyId, selectedPlaygroundApiKeyPrefix]);
+
+  const onPlaygroundApiKeyValueChange = (value: string) => {
+    setPlaygroundApiKeyValue(value);
+
+    if (!hasSelectedRealApiKey || !selectedPlaygroundApiKey) {
+      return;
+    }
+
+    const normalized = normalizeApiKeyInput(value);
+    if (!normalized.startsWith("sk_test_") && !normalized.startsWith("sk_live_")) {
+      return;
+    }
+
+    storeApiKeySecret({
+      value: normalized,
+      apiKeyId: selectedPlaygroundApiKey.id,
+      keyPrefix: selectedPlaygroundApiKey.keyPrefix,
+    });
+  };
 
   const filteredTokens = useMemo(() => {
     const needle = search.trim().toLowerCase();
@@ -355,6 +417,49 @@ export function IssuanceWorkspace({
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>API key selector</Label>
+                    <Select
+                      value={selectedPlaygroundApiKeyId}
+                      onValueChange={setSelectedPlaygroundApiKeyId}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select API key profile" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={CUSTOM_API_KEY_OPTION_ID}>Custom API key</SelectItem>
+                        {apiKeys.map((apiKey) => (
+                          <SelectItem key={apiKey.id} value={apiKey.id}>
+                            {apiKey.name} ({apiKey.keyPrefix})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {selectedPlaygroundApiKey ? (
+                      <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                        {selectedPlaygroundApiKey.environment} · {selectedPlaygroundApiKey.role}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                        Use custom mode or select an active API key profile.
+                      </p>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <Label>API key value</Label>
+                    <Input
+                      type="password"
+                      value={playgroundApiKeyValue}
+                      onChange={(event) => onPlaygroundApiKeyValueChange(event.currentTarget.value)}
+                      placeholder="Paste the full secret once; Execute uses it automatically"
+                      autoComplete="off"
+                    />
+                    <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                      All endpoint Execute actions use this selected key automatically.
+                    </p>
+                  </div>
+                </div>
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
                   Endpoints with <code>{"{tokenId}"}</code> require a real token id in their configured
                   path before execution.
@@ -383,7 +488,7 @@ export function IssuanceWorkspace({
                   path={endpointConfig.path}
                   expectedResponse={endpointConfig.expectedResponse}
                   requestBodyExample={endpointConfig.requestBodyExample}
-                  apiKeys={apiKeys}
+                  apiKeyValue={playgroundApiKeyValue}
                   apiBaseUrl={apiBaseUrl}
                   defaultOpen={endpointConfig.path === "/v1/issuance/templates"}
                 />

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -362,9 +362,6 @@ export function IssuanceWorkspace({
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
-                  Available templates: {templates.map((template) => template.name).join(", ") || "None"}
-                </div>
-                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
                   Active API keys loaded: <span className="font-medium text-[#1c1c1d]">{apiKeys.length}</span>. Paste the selected key value to execute from the browser.
                 </div>
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -419,6 +419,7 @@ export function IssuanceWorkspace({
                   expectedResponse={endpointConfig.expectedResponse}
                   requestBodyExample={endpointConfig.requestBodyExample}
                   apiKeyValue={playgroundApiKeyValue}
+                  hasSelectedApiKey={Boolean(selectedPlaygroundApiKey)}
                   apiBaseUrl={apiBaseUrl}
                   defaultOpen={endpointConfig.path === "/v1/issuance/templates"}
                 />

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -4,7 +4,6 @@ import { ApiEndpointPlayground } from "@/components/api-endpoint-playground";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import {
   Table,
   TableBody,
@@ -14,6 +13,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import { AnimatePresence, motion } from "framer-motion";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -64,7 +64,7 @@ const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
     title: "List tokens",
     description: "Page through tokens in the active organization or project scope.",
     method: "GET",
-    path: "/v1/issuance/tokens?page=1&pageSize=20",
+    path: "/v1/issuance/tokens",
     expectedResponse: {
       data: [
         {
@@ -72,7 +72,7 @@ const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
           name: "Acme Dollar",
           symbol: "ACME",
           status: "active",
-          mintAddress: "So11111111111111111111111111111111111111112",
+          mintAddress: "mint_acme_primary",
           totalSupply: "1250000",
         },
       ],
@@ -123,7 +123,7 @@ const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
     title: "List token transactions",
     description: "Retrieve issuance transaction audit history for one token.",
     method: "GET",
-    path: "/v1/issuance/tokens/{tokenId}/transactions?page=1&pageSize=20",
+    path: "/v1/issuance/tokens/{tokenId}/transactions",
     expectedResponse: {
       data: {
         items: [
@@ -190,12 +190,8 @@ export function IssuanceWorkspace({
   templatesError,
   tokensError,
 }: IssuanceWorkspaceProps) {
-  const {
-    issuanceTab,
-    setIssuanceTab,
-    selectedIssuanceApiKeyId,
-    setIssuanceApiKeys,
-  } = useDashboardWorkspace();
+  const { issuanceTab, setIssuanceTab, selectedIssuanceApiKeyId, setIssuanceApiKeys } =
+    useDashboardWorkspace();
   const [search, setSearch] = useState("");
   const [playgroundApiKeyValue, setPlaygroundApiKeyValue] = useState("");
 
@@ -385,14 +381,14 @@ export function IssuanceWorkspace({
               <CardHeader>
                 <CardTitle>Issuance API playground</CardTitle>
                 <CardDescription>
-                  Reusable per-endpoint playground cards with expected responses, fetch snippet copy,
-                  API key selector, and live execution.
+                  Reusable per-endpoint playground cards with expected responses, fetch snippet
+                  copy, API key selector, and live execution.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
-                  Endpoints with <code>{"{tokenId}"}</code> require a real token id in their configured
-                  path before execution.
+                  Endpoints with <code>{"{tokenId}"}</code> require a real token id in their
+                  configured path before execution.
                 </div>
                 {templatesError ? (
                   <div className="rounded-xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] p-3 text-sm text-[#8a1f2a]">

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -368,8 +368,8 @@ export function IssuanceWorkspace({
                   Active API keys loaded: <span className="font-medium text-[#1c1c1d]">{apiKeys.length}</span>. Paste the selected key value to execute from the browser.
                 </div>
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
-                  Endpoints with <code>{"{tokenId}"}</code> require replacing the placeholder in the
-                  path input before execution.
+                  Endpoints with <code>{"{tokenId}"}</code> require a real token id in their configured
+                  path before execution.
                 </div>
                 {templatesError ? (
                   <div className="rounded-xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] p-3 text-sm text-[#8a1f2a]">

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -1,5 +1,10 @@
 "use client";
+"use client";
 
+import {
+  ApiEndpointPlayground,
+  type ApiPlaygroundApiKeyOption,
+} from "@/components/api-endpoint-playground";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -13,7 +18,7 @@ import {
 } from "@/components/ui/table";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { AnimatePresence, motion } from "framer-motion";
-import { Braces, Coins, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { type IssuanceTemplateId, getTemplateCatalogEntry } from "./template-catalog";
 
@@ -35,9 +40,121 @@ interface IssuanceTokenView {
   deployedAt: string | null;
 }
 
+interface IssuancePlaygroundEndpointConfig {
+  title: string;
+  description: string;
+  method: "GET" | "POST";
+  path: string;
+  expectedResponse: unknown;
+  requestBodyExample?: unknown;
+}
+
+const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
+  {
+    title: "List templates",
+    description: "Fetch supported issuance templates and defaults.",
+    method: "GET",
+    path: "/v1/issuance/templates",
+    expectedResponse: {
+      data: {
+        templates: [
+          {
+            id: "stablecoin",
+            name: "Stablecoin",
+            defaultDecimals: 6,
+            requiredExtensions: ["transferFee"],
+            optionalExtensions: ["pausable"],
+          },
+        ],
+      },
+    },
+  },
+  {
+    title: "List tokens",
+    description: "Page through tokens in the active organization or project scope.",
+    method: "GET",
+    path: "/v1/issuance/tokens?page=1&pageSize=20",
+    expectedResponse: {
+      data: [
+        {
+          id: "tok_abc123",
+          name: "Acme Dollar",
+          symbol: "ACME",
+          status: "active",
+          mintAddress: "So11111111111111111111111111111111111111112",
+          totalSupply: "1250000",
+        },
+      ],
+      meta: { page: 1, pageSize: 20, total: 1, totalPages: 1 },
+    },
+  },
+  {
+    title: "Create token",
+    description: "Create a new token record from a template before deployment.",
+    method: "POST",
+    path: "/v1/issuance/tokens",
+    requestBodyExample: {
+      name: "Acme Dollar",
+      symbol: "ACME",
+      template: "stablecoin",
+      decimals: 6,
+      description: "USD-backed settlement asset",
+      uri: "https://example.com/metadata/acme-usd.json",
+    },
+    expectedResponse: {
+      data: {
+        token: {
+          id: "tok_abc123",
+          name: "Acme Dollar",
+          symbol: "ACME",
+          status: "pending",
+          deployedAt: null,
+        },
+      },
+    },
+  },
+  {
+    title: "Refresh total supply",
+    description: "Force a read from chain and update cached total supply for a token.",
+    method: "POST",
+    path: "/v1/issuance/tokens/{tokenId}/supply/refresh",
+    expectedResponse: {
+      data: {
+        token: {
+          id: "tok_abc123",
+          totalSupply: "1250000",
+          totalSupplyUpdatedAt: "2026-02-17T12:00:00.000Z",
+        },
+      },
+    },
+  },
+  {
+    title: "List token transactions",
+    description: "Retrieve issuance transaction audit history for one token.",
+    method: "GET",
+    path: "/v1/issuance/tokens/{tokenId}/transactions?page=1&pageSize=20",
+    expectedResponse: {
+      data: {
+        items: [
+          {
+            id: "tx_abc123",
+            tokenId: "tok_abc123",
+            type: "mint",
+            status: "confirmed",
+            signature: "5P7B...",
+            createdAt: "2026-02-16T10:20:30.000Z",
+          },
+        ],
+      },
+      meta: { page: 1, pageSize: 20, total: 1, totalPages: 1 },
+    },
+  },
+];
+
 interface IssuanceWorkspaceProps {
   templates: IssuanceTemplateView[];
   tokens: IssuanceTokenView[];
+  apiKeys: ApiPlaygroundApiKeyOption[];
   templatesError: string | null;
   tokensError: string | null;
 }
@@ -70,6 +187,7 @@ function truncateAddress(value: string | null): string {
 export function IssuanceWorkspace({
   templates,
   tokens,
+  apiKeys,
   templatesError,
   tokensError,
 }: IssuanceWorkspaceProps) {
@@ -238,49 +356,49 @@ export function IssuanceWorkspace({
               <CardHeader>
                 <CardTitle>Issuance API playground</CardTitle>
                 <CardDescription>
-                  Reference requests for templates and token operations. Use project-scoped API keys
-                  for mutable token endpoints.
+                  Reusable per-endpoint playground cards with expected responses, fetch snippet copy,
+                  API key selector, and live execution.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
-                  <div className="mb-2 flex items-center gap-2">
-                    <Coins className="h-4 w-4 text-[rgba(28,28,29,0.72)]" />
-                    <p className="text-sm font-medium text-[#1c1c1d]">Create token from template</p>
-                  </div>
-                  <pre className="overflow-x-auto text-xs leading-5 text-[rgba(28,28,29,0.78)]">
-                    <code>{`POST /v1/issuance/tokens
-{
-  "name": "Acme Dollar",
-  "symbol": "ACME",
-  "template": "stablecoin",
-  "decimals": 6
-}`}</code>
-                  </pre>
+                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
+                  Available templates: {templates.map((template) => template.name).join(", ") || "None"}
                 </div>
-
-                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
-                  <div className="mb-2 flex items-center gap-2">
-                    <Braces className="h-4 w-4 text-[rgba(28,28,29,0.72)]" />
-                    <p className="text-sm font-medium text-[#1c1c1d]">List tokens</p>
-                  </div>
-                  <pre className="overflow-x-auto text-xs leading-5 text-[rgba(28,28,29,0.78)]">
-                    <code>{"GET /v1/issuance/tokens?page=1&" + "pageSize=50"}</code>
-                  </pre>
+                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
+                  Active API keys loaded: <span className="font-medium text-[#1c1c1d]">{apiKeys.length}</span>. Paste the selected key value to execute from the browser.
                 </div>
-
+                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
+                  Endpoints with <code>{"{tokenId}"}</code> require replacing the placeholder in the
+                  path input before execution.
+                </div>
                 {templatesError ? (
                   <div className="rounded-xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] p-3 text-sm text-[#8a1f2a]">
                     Templates status: {templatesError}
                   </div>
-                ) : (
-                  <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
-                    Available templates:{" "}
-                    {templates.map((template) => template.name).join(", ") || "None"}
+                ) : null}
+                {apiKeys.length === 0 ? (
+                  <div className="rounded-xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] p-3 text-sm text-[#8a1f2a]">
+                    No active API keys found. Create one in API keys before running mutable issuance
+                    endpoints.
                   </div>
-                )}
+                ) : null}
               </CardContent>
             </Card>
+
+            <div className="space-y-4">
+              {issuancePlaygroundEndpointConfigs.map((endpointConfig) => (
+                <ApiEndpointPlayground
+                  key={`${endpointConfig.method}-${endpointConfig.path}`}
+                  title={endpointConfig.title}
+                  description={endpointConfig.description}
+                  method={endpointConfig.method}
+                  path={endpointConfig.path}
+                  expectedResponse={endpointConfig.expectedResponse}
+                  requestBodyExample={endpointConfig.requestBodyExample}
+                  apiKeys={apiKeys}
+                />
+              ))}
+            </div>
 
             <div className="flex justify-end">
               <Button type="button" variant="secondary" onClick={() => setIssuanceTab("tokens")}>

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -4,19 +4,7 @@ import { ApiEndpointPlayground } from "@/components/api-endpoint-playground";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  getStoredApiKeySecret,
-  normalizeApiKeyInput,
-  storeApiKeySecret,
-} from "@/lib/playground-api-keys";
+import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import {
   Table,
   TableBody,
@@ -154,8 +142,6 @@ const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
   },
 ];
 
-const CUSTOM_API_KEY_OPTION_ID = "__custom__";
-
 interface IssuanceApiKeyOption {
   id: string;
   name: string;
@@ -204,51 +190,38 @@ export function IssuanceWorkspace({
   templatesError,
   tokensError,
 }: IssuanceWorkspaceProps) {
-  const { issuanceTab, setIssuanceTab } = useDashboardWorkspace();
+  const {
+    issuanceTab,
+    setIssuanceTab,
+    selectedIssuanceApiKeyId,
+    setIssuanceApiKeys,
+  } = useDashboardWorkspace();
   const [search, setSearch] = useState("");
-  const [selectedPlaygroundApiKeyId, setSelectedPlaygroundApiKeyId] = useState<string>(
-    apiKeys[0]?.id ?? CUSTOM_API_KEY_OPTION_ID
-  );
   const [playgroundApiKeyValue, setPlaygroundApiKeyValue] = useState("");
 
+  useEffect(() => {
+    setIssuanceApiKeys(apiKeys);
+  }, [apiKeys, setIssuanceApiKeys]);
+
   const selectedPlaygroundApiKey = useMemo(
-    () => apiKeys.find((key) => key.id === selectedPlaygroundApiKeyId) ?? null,
-    [apiKeys, selectedPlaygroundApiKeyId]
+    () => apiKeys.find((key) => key.id === selectedIssuanceApiKeyId) ?? null,
+    [apiKeys, selectedIssuanceApiKeyId]
   );
   const selectedPlaygroundApiKeyPrefix = selectedPlaygroundApiKey?.keyPrefix ?? null;
-  const hasSelectedRealApiKey = selectedPlaygroundApiKeyId !== CUSTOM_API_KEY_OPTION_ID;
 
   useEffect(() => {
-    if (!hasSelectedRealApiKey) {
+    if (!selectedPlaygroundApiKey) {
+      setPlaygroundApiKeyValue("");
       return;
     }
 
     const stored = getStoredApiKeySecret({
-      apiKeyId: selectedPlaygroundApiKeyId,
+      apiKeyId: selectedPlaygroundApiKey.id,
       keyPrefix: selectedPlaygroundApiKeyPrefix,
     });
 
     setPlaygroundApiKeyValue(stored ?? "");
-  }, [hasSelectedRealApiKey, selectedPlaygroundApiKeyId, selectedPlaygroundApiKeyPrefix]);
-
-  const onPlaygroundApiKeyValueChange = (value: string) => {
-    setPlaygroundApiKeyValue(value);
-
-    if (!hasSelectedRealApiKey || !selectedPlaygroundApiKey) {
-      return;
-    }
-
-    const normalized = normalizeApiKeyInput(value);
-    if (!normalized.startsWith("sk_test_") && !normalized.startsWith("sk_live_")) {
-      return;
-    }
-
-    storeApiKeySecret({
-      value: normalized,
-      apiKeyId: selectedPlaygroundApiKey.id,
-      keyPrefix: selectedPlaygroundApiKey.keyPrefix,
-    });
-  };
+  }, [selectedPlaygroundApiKey, selectedPlaygroundApiKeyPrefix]);
 
   const filteredTokens = useMemo(() => {
     const needle = search.trim().toLowerCase();
@@ -417,49 +390,6 @@ export function IssuanceWorkspace({
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="grid gap-3 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <Label>API key selector</Label>
-                    <Select
-                      value={selectedPlaygroundApiKeyId}
-                      onValueChange={setSelectedPlaygroundApiKeyId}
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select API key profile" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value={CUSTOM_API_KEY_OPTION_ID}>Custom API key</SelectItem>
-                        {apiKeys.map((apiKey) => (
-                          <SelectItem key={apiKey.id} value={apiKey.id}>
-                            {apiKey.name} ({apiKey.keyPrefix})
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    {selectedPlaygroundApiKey ? (
-                      <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                        {selectedPlaygroundApiKey.environment} · {selectedPlaygroundApiKey.role}
-                      </p>
-                    ) : (
-                      <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                        Use custom mode or select an active API key profile.
-                      </p>
-                    )}
-                  </div>
-                  <div className="space-y-2">
-                    <Label>API key value</Label>
-                    <Input
-                      type="password"
-                      value={playgroundApiKeyValue}
-                      onChange={(event) => onPlaygroundApiKeyValueChange(event.currentTarget.value)}
-                      placeholder="Paste the full secret once; Execute uses it automatically"
-                      autoComplete="off"
-                    />
-                    <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                      All endpoint Execute actions use this selected key automatically.
-                    </p>
-                  </div>
-                </div>
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
                   Endpoints with <code>{"{tokenId}"}</code> require a real token id in their configured
                   path before execution.

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -361,9 +361,6 @@ export function IssuanceWorkspace({
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
-                  Active API keys loaded: <span className="font-medium text-[#1c1c1d]">{apiKeys.length}</span>. Paste the selected key value to execute from the browser.
-                </div>
                 <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
                   Endpoints with <code>{"{tokenId}"}</code> require a real token id in their configured
                   path before execution.

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -419,7 +419,6 @@ export function IssuanceWorkspace({
                   expectedResponse={endpointConfig.expectedResponse}
                   requestBodyExample={endpointConfig.requestBodyExample}
                   apiKeyValue={playgroundApiKeyValue}
-                  hasSelectedApiKey={Boolean(selectedPlaygroundApiKey)}
                   apiBaseUrl={apiBaseUrl}
                   defaultOpen={endpointConfig.path === "/v1/issuance/templates"}
                 />

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -22,12 +22,6 @@ import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { type IssuanceTemplateId, getTemplateCatalogEntry } from "./template-catalog";
 
-interface IssuanceTemplateView {
-  id: string;
-  name: string;
-  description?: string;
-}
-
 interface IssuanceTokenView {
   id: string;
   name: string;
@@ -152,9 +146,9 @@ const issuancePlaygroundEndpointConfigs: IssuancePlaygroundEndpointConfig[] = [
 ];
 
 interface IssuanceWorkspaceProps {
-  templates: IssuanceTemplateView[];
   tokens: IssuanceTokenView[];
   apiKeys: ApiPlaygroundApiKeyOption[];
+  apiBaseUrl: string | null;
   templatesError: string | null;
   tokensError: string | null;
 }
@@ -185,9 +179,9 @@ function truncateAddress(value: string | null): string {
 }
 
 export function IssuanceWorkspace({
-  templates,
   tokens,
   apiKeys,
+  apiBaseUrl,
   templatesError,
   tokensError,
 }: IssuanceWorkspaceProps) {
@@ -390,6 +384,7 @@ export function IssuanceWorkspace({
                   expectedResponse={endpointConfig.expectedResponse}
                   requestBodyExample={endpointConfig.requestBodyExample}
                   apiKeys={apiKeys}
+                  apiBaseUrl={apiBaseUrl}
                   defaultOpen={endpointConfig.path === "/v1/issuance/templates"}
                 />
               ))}

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -396,6 +396,7 @@ export function IssuanceWorkspace({
                   expectedResponse={endpointConfig.expectedResponse}
                   requestBodyExample={endpointConfig.requestBodyExample}
                   apiKeys={apiKeys}
+                  defaultOpen={endpointConfig.path === "/v1/issuance/templates"}
                 />
               ))}
             </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -1,4 +1,4 @@
-import { sdpApiRequest } from "@/lib/sdp-api";
+import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { IssuanceWorkspace } from "./issuance-workspace";
@@ -50,8 +50,9 @@ function parseErrorMessage(body: string): string {
 }
 
 async function fetchTemplates(): Promise<FetchResult<IssuanceTemplateView[]>> {
+async function fetchTemplates(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceTemplateView[]>> {
   try {
-    const response = await sdpApiRequest("/v1/issuance/templates");
+    const response = await request("/v1/issuance/templates");
     if (!response.ok) {
       const body = await response.text();
       return {
@@ -87,12 +88,13 @@ async function fetchTemplates(): Promise<FetchResult<IssuanceTemplateView[]>> {
 }
 
 async function fetchTokens(): Promise<FetchResult<IssuanceTokenView[]>> {
+async function fetchTokens(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceTokenView[]>> {
   try {
     const tokensPath = `/v1/issuance/tokens?${new URLSearchParams({
       page: "1",
       pageSize: "100",
     }).toString()}`;
-    const response = await sdpApiRequest(tokensPath);
+    const response = await request(tokensPath);
     if (!response.ok) {
       const body = await response.text();
       return {
@@ -140,8 +142,9 @@ async function fetchTokens(): Promise<FetchResult<IssuanceTokenView[]>> {
 }
 
 async function fetchApiKeys(): Promise<FetchResult<IssuanceApiKeyView[]>> {
+async function fetchApiKeys(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceApiKeyView[]>> {
   try {
-    const response = await sdpApiRequest("/v1/api-keys");
+    const response = await request("/v1/api-keys");
     if (!response.ok) {
       const body = await response.text();
       return {
@@ -193,10 +196,11 @@ export default async function IssuancePage() {
     redirect("/dashboard");
   }
 
+  const apiClient = await createSdpApiClient();
   const [templatesResult, tokensResult, apiKeysResult] = await Promise.all([
-    fetchTemplates(),
-    fetchTokens(),
-    fetchApiKeys(),
+    fetchTemplates(apiClient.request),
+    fetchTokens(apiClient.request),
+    fetchApiKeys(apiClient.request),
   ]);
 
   const templates =

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -2,7 +2,6 @@ import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { IssuanceWorkspace } from "./issuance-workspace";
-import { issuanceTemplateCatalog } from "./template-catalog";
 
 interface IssuanceTemplateView {
   id: string;
@@ -193,21 +192,18 @@ export default async function IssuancePage() {
     redirect("/dashboard");
   }
 
+  const apiBaseUrl = (
+    process.env.SDP_API_BASE_URL ||
+    process.env.NEXT_PUBLIC_SDP_API_BASE_URL ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    ""
+  ).replace(/\/$/, "");
   const apiClient = await createSdpApiClient();
   const [templatesResult, tokensResult, apiKeysResult] = await Promise.all([
     fetchTemplates(apiClient.request),
     fetchTokens(apiClient.request),
     fetchApiKeys(apiClient.request),
   ]);
-
-  const templates =
-    templatesResult.data && templatesResult.data.length > 0
-      ? templatesResult.data
-      : issuanceTemplateCatalog.map((template) => ({
-          id: template.id,
-          name: template.name,
-          description: template.description,
-        }));
 
   const tokens = tokensResult.data ?? [];
   const apiKeys = apiKeysResult.data ?? [];
@@ -220,9 +216,9 @@ export default async function IssuancePage() {
 
   return (
     <IssuanceWorkspace
-      templates={templates}
       tokens={tokens}
       apiKeys={apiKeys}
+      apiBaseUrl={apiBaseUrl || null}
       templatesError={templatesError}
       tokensError={tokensError}
     />

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -49,7 +49,6 @@ function parseErrorMessage(body: string): string {
   }
 }
 
-async function fetchTemplates(): Promise<FetchResult<IssuanceTemplateView[]>> {
 async function fetchTemplates(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceTemplateView[]>> {
   try {
     const response = await request("/v1/issuance/templates");
@@ -87,7 +86,6 @@ async function fetchTemplates(request: SdpApiClient["request"]): Promise<FetchRe
   }
 }
 
-async function fetchTokens(): Promise<FetchResult<IssuanceTokenView[]>> {
 async function fetchTokens(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceTokenView[]>> {
   try {
     const tokensPath = `/v1/issuance/tokens?${new URLSearchParams({
@@ -141,7 +139,6 @@ async function fetchTokens(request: SdpApiClient["request"]): Promise<FetchResul
   }
 }
 
-async function fetchApiKeys(): Promise<FetchResult<IssuanceApiKeyView[]>> {
 async function fetchApiKeys(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceApiKeyView[]>> {
   try {
     const response = await request("/v1/api-keys");

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -1,4 +1,4 @@
-import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
+import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { IssuanceWorkspace } from "./issuance-workspace";
@@ -48,7 +48,9 @@ function parseErrorMessage(body: string): string {
   }
 }
 
-async function fetchTemplates(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceTemplateView[]>> {
+async function fetchTemplates(
+  request: SdpApiClient["request"]
+): Promise<FetchResult<IssuanceTemplateView[]>> {
   try {
     const response = await request("/v1/issuance/templates");
     if (!response.ok) {
@@ -85,7 +87,9 @@ async function fetchTemplates(request: SdpApiClient["request"]): Promise<FetchRe
   }
 }
 
-async function fetchTokens(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceTokenView[]>> {
+async function fetchTokens(
+  request: SdpApiClient["request"]
+): Promise<FetchResult<IssuanceTokenView[]>> {
   try {
     const tokensPath = `/v1/issuance/tokens?${new URLSearchParams({
       page: "1",
@@ -138,7 +142,9 @@ async function fetchTokens(request: SdpApiClient["request"]): Promise<FetchResul
   }
 }
 
-async function fetchApiKeys(request: SdpApiClient["request"]): Promise<FetchResult<IssuanceApiKeyView[]>> {
+async function fetchApiKeys(
+  request: SdpApiClient["request"]
+): Promise<FetchResult<IssuanceApiKeyView[]>> {
   try {
     const response = await request("/v1/api-keys");
     if (!response.ok) {

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -22,6 +22,14 @@ interface IssuanceTokenView {
   deployedAt: string | null;
 }
 
+interface IssuanceApiKeyView {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  role: string;
+  environment: string;
+}
+
 interface FetchResult<T> {
   ok: boolean;
   status?: number;
@@ -131,6 +139,51 @@ async function fetchTokens(): Promise<FetchResult<IssuanceTokenView[]>> {
   }
 }
 
+async function fetchApiKeys(): Promise<FetchResult<IssuanceApiKeyView[]>> {
+  try {
+    const response = await sdpApiRequest("/v1/api-keys");
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        ok: false,
+        status: response.status,
+        error: parseErrorMessage(body),
+      };
+    }
+
+    const json = (await response.json()) as {
+      data?: {
+        apiKeys?: Array<{
+          id?: string;
+          name?: string;
+          keyPrefix?: string;
+          role?: string;
+          environment?: string;
+          status?: string;
+        }>;
+      };
+    };
+
+    const apiKeys = (json?.data?.apiKeys ?? [])
+      .filter((apiKey): apiKey is NonNullable<typeof apiKey> => Boolean(apiKey?.id))
+      .filter((apiKey) => apiKey.status === "active")
+      .map((apiKey) => ({
+        id: apiKey.id ?? "",
+        name: apiKey.name ?? "Unnamed key",
+        keyPrefix: apiKey.keyPrefix ?? "sdp_...",
+        role: apiKey.role ?? "api_developer",
+        environment: apiKey.environment ?? "sandbox",
+      }));
+
+    return { ok: true, data: apiKeys };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unable to load API keys",
+    };
+  }
+}
+
 export default async function IssuancePage() {
   const { userId, orgId } = await auth();
   if (!userId) {
@@ -140,7 +193,11 @@ export default async function IssuancePage() {
     redirect("/dashboard");
   }
 
-  const [templatesResult, tokensResult] = await Promise.all([fetchTemplates(), fetchTokens()]);
+  const [templatesResult, tokensResult, apiKeysResult] = await Promise.all([
+    fetchTemplates(),
+    fetchTokens(),
+    fetchApiKeys(),
+  ]);
 
   const templates =
     templatesResult.data && templatesResult.data.length > 0
@@ -152,6 +209,7 @@ export default async function IssuancePage() {
         }));
 
   const tokens = tokensResult.data ?? [];
+  const apiKeys = apiKeysResult.data ?? [];
   const templatesError = templatesResult.ok
     ? null
     : `Template API ${templatesResult.status ?? "unavailable"}: ${templatesResult.error ?? "Unknown error"}`;
@@ -163,6 +221,7 @@ export default async function IssuancePage() {
     <IssuanceWorkspace
       templates={templates}
       tokens={tokens}
+      apiKeys={apiKeys}
       templatesError={templatesError}
       tokensError={tokensError}
     />

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -105,7 +105,6 @@ export function ApiEndpointPlayground({
   defaultOpen = false,
 }: ApiEndpointPlaygroundProps) {
   const defaultApiBaseUrl = useMemo(getDefaultApiBaseUrl, []);
-  const [pathValue, setPathValue] = useState(path);
   const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>(
     apiKeys[0]?.id ?? CUSTOM_KEY_OPTION_ID
   );
@@ -127,7 +126,7 @@ export function ApiEndpointPlayground({
   const selectedApiKeyMeta = apiKeys.find((apiKey) => apiKey.id === selectedApiKeyId) ?? null;
 
   const fetchSnippet = useMemo(() => {
-    const normalizedPath = formatPath(pathValue);
+    const normalizedPath = formatPath(path);
     const isAbsolute = normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://");
     const targetExpression = isAbsolute
       ? `"${normalizedPath}"`
@@ -157,7 +156,7 @@ export function ApiEndpointPlayground({
       "const payload = await response.json();",
       "console.log(payload);",
     ].join("\n");
-  }, [bodyEnabled, defaultApiBaseUrl, method, pathValue, requestBodyText]);
+  }, [bodyEnabled, defaultApiBaseUrl, method, path, requestBodyText]);
 
   const onApiKeyValueChange = (value: string) => {
     setApiKeyValuesById((previous) => ({
@@ -200,7 +199,7 @@ export function ApiEndpointPlayground({
     setIsExecuting(true);
 
     try {
-      const response = await fetch(resolveEndpointUrl(pathValue, defaultApiBaseUrl), {
+      const response = await fetch(resolveEndpointUrl(path, defaultApiBaseUrl), {
         method,
         headers: {
           Authorization: `Bearer ${apiKey}`,
@@ -312,20 +311,6 @@ export function ApiEndpointPlayground({
               autoComplete="off"
             />
           </div>
-        </div>
-
-        <div className="space-y-2">
-          <Label>Endpoint path</Label>
-          <Input
-            value={pathValue}
-            onChange={(event) => setPathValue(event.currentTarget.value)}
-            placeholder="/v1/issuance/templates"
-            autoComplete="off"
-          />
-          <p className="text-xs text-[rgba(28,28,29,0.64)]">
-            Use a full URL or a path relative to{" "}
-            <code>{defaultApiBaseUrl || "NEXT_PUBLIC_SDP_API_BASE_URL"}</code>.
-          </p>
         </div>
 
         {bodyEnabled ? (

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Check, Copy, Loader2, Play } from "lucide-react";
+import { Check, ChevronDown, Copy, Loader2, Play } from "lucide-react";
 import { useMemo, useState } from "react";
 
 const CUSTOM_KEY_OPTION_ID = "__custom__";
@@ -42,6 +42,7 @@ export interface ApiEndpointPlaygroundProps {
   expectedResponse: unknown;
   requestBodyExample?: unknown;
   apiKeys: ApiPlaygroundApiKeyOption[];
+  defaultOpen?: boolean;
 }
 
 function getDefaultApiBaseUrl(): string {
@@ -101,6 +102,7 @@ export function ApiEndpointPlayground({
   expectedResponse,
   requestBodyExample,
   apiKeys,
+  defaultOpen = false,
 }: ApiEndpointPlaygroundProps) {
   const defaultApiBaseUrl = useMemo(getDefaultApiBaseUrl, []);
   const [pathValue, setPathValue] = useState(path);
@@ -118,6 +120,7 @@ export function ApiEndpointPlayground({
   const [copied, setCopied] = useState(false);
   const [executeError, setExecuteError] = useState<string | null>(null);
   const [executionResult, setExecutionResult] = useState<ExecutionResult | null>(null);
+  const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const bodyEnabled = hasJsonBody(method);
   const selectedApiKeyValue = apiKeyValuesById[selectedApiKeyId] ?? "";
@@ -236,25 +239,42 @@ export function ApiEndpointPlayground({
             </code>
           </div>
           <div className="flex items-center gap-2">
-            <Button type="button" variant="secondary" size="sm" onClick={onCopyFetch}>
-              {copied ? <Check className="mr-1 h-4 w-4" /> : <Copy className="mr-1 h-4 w-4" />}
-              Copy as fetch
-            </Button>
-            <Button type="button" size="sm" onClick={onExecute} disabled={isExecuting}>
-              {isExecuting ? (
-                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-              ) : (
-                <Play className="mr-1 h-4 w-4" />
-              )}
-              Execute
+            {isOpen ? (
+              <>
+                <Button type="button" variant="secondary" size="sm" onClick={onCopyFetch}>
+                  {copied ? <Check className="mr-1 h-4 w-4" /> : <Copy className="mr-1 h-4 w-4" />}
+                  Copy as fetch
+                </Button>
+                <Button type="button" size="sm" onClick={onExecute} disabled={isExecuting}>
+                  {isExecuting ? (
+                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="mr-1 h-4 w-4" />
+                  )}
+                  Execute
+                </Button>
+              </>
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsOpen((current) => !current)}
+              aria-expanded={isOpen}
+              aria-label={isOpen ? "Collapse endpoint details" : "Expand endpoint details"}
+            >
+              <ChevronDown
+                className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : "rotate-0"}`}
+              />
             </Button>
           </div>
         </div>
         <CardTitle className="text-base">{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
+        {isOpen ? <CardDescription>{description}</CardDescription> : null}
       </CardHeader>
 
-      <CardContent className="space-y-4">
+      {isOpen ? (
+        <CardContent className="space-y-4">
         <div className="grid gap-3 md:grid-cols-2">
           <div className="space-y-2">
             <Label>API key selector</Label>
@@ -351,7 +371,8 @@ export function ApiEndpointPlayground({
             )}
           </div>
         </div>
-      </CardContent>
+        </CardContent>
+      ) : null}
     </Card>
   );
 }

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -25,6 +25,7 @@ export interface ApiEndpointPlaygroundProps {
   expectedResponse: unknown;
   requestBodyExample?: unknown;
   apiKeyValue: string;
+  hasSelectedApiKey?: boolean;
   apiBaseUrl?: string | null;
   defaultOpen?: boolean;
 }
@@ -84,6 +85,7 @@ export function ApiEndpointPlayground({
   expectedResponse,
   requestBodyExample,
   apiKeyValue,
+  hasSelectedApiKey = false,
   apiBaseUrl,
   defaultOpen = false,
 }: ApiEndpointPlaygroundProps) {
@@ -152,7 +154,13 @@ export function ApiEndpointPlayground({
 
     const apiKey = normalizeApiKeyInput(apiKeyValue);
     if (!apiKey) {
-      setExecuteError("Set the API key once in the top playground key selector before running.");
+      if (hasSelectedApiKey) {
+        setExecuteError(
+          "Selected API key is set, but its full secret is not available in this browser session. Rotate/create the key once to capture it."
+        );
+      } else {
+        setExecuteError("Select an API key in the top bar before running.");
+      }
       return;
     }
     if (!apiKey.startsWith("sk_test_") && !apiKey.startsWith("sk_live_")) {

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -92,12 +92,16 @@ export function ApiEndpointPlayground({
 
   const fetchSnippet = useMemo(() => {
     const normalizedPath = formatPath(path);
-    const isAbsolute = normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://");
+    const isAbsolute =
+      normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://");
     const targetExpression = isAbsolute
       ? `"${normalizedPath}"`
-      : "`" + "${API_BASE_URL}" + `${normalizedPath}` + "`";
+      : `\`\${API_BASE_URL}${normalizedPath}\``;
 
-    const headerLines = ['Authorization: `Bearer ${API_KEY}`', '"Content-Type": "application/json"'];
+    const headerLines = [
+      "Authorization: `Bearer ${API_KEY}`",
+      '"Content-Type": "application/json"',
+    ];
 
     let bodyLine = "";
     if (bodyEnabled && requestBodyText.trim()) {
@@ -110,8 +114,8 @@ export function ApiEndpointPlayground({
     }
 
     return [
-      "const API_BASE_URL = " + JSON.stringify(effectiveApiBaseUrl || "https://api.example.com") + ";",
-      "const API_KEY = \"<paste_api_key_here>\";",
+      `const API_BASE_URL = ${JSON.stringify(effectiveApiBaseUrl || "https://api.example.com")};`,
+      'const API_KEY = "<paste_api_key_here>";',
       "",
       `const response = await fetch(${targetExpression}, {`,
       `  method: "${method}",`,
@@ -140,7 +144,11 @@ export function ApiEndpointPlayground({
     const normalizedApiKey = normalizeApiKeyInput(apiKeyValue);
     const hasApiKey = Boolean(normalizedApiKey);
 
-    if (hasApiKey && !normalizedApiKey.startsWith("sk_test_") && !normalizedApiKey.startsWith("sk_live_")) {
+    if (
+      hasApiKey &&
+      !normalizedApiKey.startsWith("sk_test_") &&
+      !normalizedApiKey.startsWith("sk_live_")
+    ) {
       setExecuteError("Invalid API key format. Use a raw key value (sk_test_... or sk_live_...).");
       return;
     }

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -81,13 +81,14 @@ function resolveEndpointUrl(path: string, baseUrl: string): string {
     return normalizedPath;
   }
 
-  if (!baseUrl) {
-    throw new Error(
-      "Missing NEXT_PUBLIC_SDP_API_BASE_URL (or NEXT_PUBLIC_API_BASE_URL) for browser execution"
-    );
+  const runtimeBaseUrl =
+    baseUrl || (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
+
+  if (!runtimeBaseUrl) {
+    throw new Error("Missing API base URL for browser execution");
   }
 
-  return `${baseUrl}${normalizedPath}`;
+  return `${runtimeBaseUrl}${normalizedPath}`;
 }
 
 function hasJsonBody(method: ApiEndpointMethod): boolean {

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -14,6 +14,7 @@ interface ExecutionResult {
   status: number;
   statusText: string;
   durationMs: number;
+  authMode: "api_key" | "session";
   body: unknown;
 }
 
@@ -25,7 +26,6 @@ export interface ApiEndpointPlaygroundProps {
   expectedResponse: unknown;
   requestBodyExample?: unknown;
   apiKeyValue: string;
-  hasSelectedApiKey?: boolean;
   apiBaseUrl?: string | null;
   defaultOpen?: boolean;
 }
@@ -59,20 +59,6 @@ function formatPath(path: string): string {
   return path;
 }
 
-function resolveEndpointUrl(path: string, baseUrl: string): string {
-  const normalizedPath = formatPath(path);
-
-  if (normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://")) {
-    return normalizedPath;
-  }
-
-  if (!baseUrl) {
-    throw new Error("Missing API base URL for browser execution");
-  }
-
-  return `${baseUrl}${normalizedPath}`;
-}
-
 function hasJsonBody(method: ApiEndpointMethod): boolean {
   return method !== "GET" && method !== "DELETE";
 }
@@ -85,7 +71,6 @@ export function ApiEndpointPlayground({
   expectedResponse,
   requestBodyExample,
   apiKeyValue,
-  hasSelectedApiKey = false,
   apiBaseUrl,
   defaultOpen = false,
 }: ApiEndpointPlaygroundProps) {
@@ -152,18 +137,10 @@ export function ApiEndpointPlayground({
     setExecuteError(null);
     setExecutionResult(null);
 
-    const apiKey = normalizeApiKeyInput(apiKeyValue);
-    if (!apiKey) {
-      if (hasSelectedApiKey) {
-        setExecuteError(
-          "Selected API key is set, but its full secret is not available in this browser session. Rotate/create the key once to capture it."
-        );
-      } else {
-        setExecuteError("Select an API key in the top bar before running.");
-      }
-      return;
-    }
-    if (!apiKey.startsWith("sk_test_") && !apiKey.startsWith("sk_live_")) {
+    const normalizedApiKey = normalizeApiKeyInput(apiKeyValue);
+    const hasApiKey = Boolean(normalizedApiKey);
+
+    if (hasApiKey && !normalizedApiKey.startsWith("sk_test_") && !normalizedApiKey.startsWith("sk_live_")) {
       setExecuteError("Invalid API key format. Use a raw key value (sk_test_... or sk_live_...).");
       return;
     }
@@ -182,24 +159,39 @@ export function ApiEndpointPlayground({
     setIsExecuting(true);
 
     try {
-      const response = await fetch(resolveEndpointUrl(path, effectiveApiBaseUrl), {
-        method,
+      const proxyResponse = await fetch("/api/playground/execute", {
+        method: "POST",
         headers: {
-          Authorization: `Bearer ${apiKey}`,
           "Content-Type": "application/json",
         },
-        body: parsedBody !== undefined ? JSON.stringify(parsedBody) : undefined,
+        body: JSON.stringify({
+          method,
+          path: formatPath(path),
+          body: parsedBody !== undefined ? parsedBody : null,
+          apiKey: hasApiKey ? normalizedApiKey : null,
+        }),
       });
 
-      const text = await response.text();
-      const payload = text ? tryParseJson(text) : {};
+      const envelope = (await proxyResponse.json()) as {
+        ok?: boolean;
+        status?: number;
+        statusText?: string;
+        body?: unknown;
+        error?: string;
+      };
+
+      if (!proxyResponse.ok || envelope.status === undefined || envelope.statusText === undefined) {
+        setExecuteError(envelope.error ?? "Playground execution failed.");
+        return;
+      }
 
       setExecutionResult({
-        ok: response.ok,
-        status: response.status,
-        statusText: response.statusText,
+        ok: envelope.ok ?? false,
+        status: envelope.status,
+        statusText: envelope.statusText,
         durationMs: Date.now() - startedAt,
-        body: payload,
+        authMode: hasApiKey ? "api_key" : "session",
+        body: envelope.body ?? {},
       });
     } catch (error) {
       setExecuteError(error instanceof Error ? error.message : "Request execution failed.");
@@ -287,7 +279,8 @@ export function ApiEndpointPlayground({
                 <div className="space-y-2">
                   <p className="text-xs text-[rgba(28,28,29,0.72)]">
                     Status: {executionResult.status} {executionResult.statusText} ·{" "}
-                    {executionResult.durationMs}ms
+                    {executionResult.durationMs}ms · Auth:{" "}
+                    {executionResult.authMode === "api_key" ? "API key" : "Session"}
                   </p>
                   <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
                     <code>{prettyJson(executionResult.body)}</code>

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Check, Copy, Loader2, Play } from "lucide-react";
+import { useMemo, useState } from "react";
+
+const CUSTOM_KEY_OPTION_ID = "__custom__";
+
+export type ApiEndpointMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface ApiPlaygroundApiKeyOption {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  role: string;
+  environment: string;
+}
+
+interface ExecutionResult {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  durationMs: number;
+  body: unknown;
+}
+
+export interface ApiEndpointPlaygroundProps {
+  title: string;
+  description: string;
+  method: ApiEndpointMethod;
+  path: string;
+  expectedResponse: unknown;
+  requestBodyExample?: unknown;
+  apiKeys: ApiPlaygroundApiKeyOption[];
+}
+
+function getDefaultApiBaseUrl(): string {
+  const base = process.env.NEXT_PUBLIC_SDP_API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL;
+  return (base ?? "").replace(/\/$/, "");
+}
+
+function tryParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function prettyJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function formatPath(path: string): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path;
+  }
+
+  if (!path.startsWith("/")) {
+    return `/${path}`;
+  }
+
+  return path;
+}
+
+function resolveEndpointUrl(path: string, baseUrl: string): string {
+  const normalizedPath = formatPath(path);
+
+  if (normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://")) {
+    return normalizedPath;
+  }
+
+  if (!baseUrl) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SDP_API_BASE_URL (or NEXT_PUBLIC_API_BASE_URL) for browser execution"
+    );
+  }
+
+  return `${baseUrl}${normalizedPath}`;
+}
+
+function hasJsonBody(method: ApiEndpointMethod): boolean {
+  return method !== "GET" && method !== "DELETE";
+}
+
+export function ApiEndpointPlayground({
+  title,
+  description,
+  method,
+  path,
+  expectedResponse,
+  requestBodyExample,
+  apiKeys,
+}: ApiEndpointPlaygroundProps) {
+  const defaultApiBaseUrl = useMemo(getDefaultApiBaseUrl, []);
+  const [pathValue, setPathValue] = useState(path);
+  const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>(
+    apiKeys[0]?.id ?? CUSTOM_KEY_OPTION_ID
+  );
+  const [apiKeyValuesById, setApiKeyValuesById] = useState<Record<string, string>>({});
+  const [requestBodyText, setRequestBodyText] = useState<string>(() => {
+    if (!hasJsonBody(method) || requestBodyExample === undefined) {
+      return "";
+    }
+    return prettyJson(requestBodyExample);
+  });
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [executeError, setExecuteError] = useState<string | null>(null);
+  const [executionResult, setExecutionResult] = useState<ExecutionResult | null>(null);
+
+  const bodyEnabled = hasJsonBody(method);
+  const selectedApiKeyValue = apiKeyValuesById[selectedApiKeyId] ?? "";
+  const selectedApiKeyMeta = apiKeys.find((apiKey) => apiKey.id === selectedApiKeyId) ?? null;
+
+  const fetchSnippet = useMemo(() => {
+    const normalizedPath = formatPath(pathValue);
+    const isAbsolute = normalizedPath.startsWith("http://") || normalizedPath.startsWith("https://");
+    const targetExpression = isAbsolute
+      ? `"${normalizedPath}"`
+      : "`" + "${API_BASE_URL}" + `${normalizedPath}` + "`";
+
+    const headerLines = ['Authorization: `Bearer ${API_KEY}`', '"Content-Type": "application/json"'];
+
+    let bodyLine = "";
+    if (bodyEnabled && requestBodyText.trim()) {
+      const parsed = tryParseJson(requestBodyText);
+      if (typeof parsed === "string") {
+        bodyLine = `,\n  body: JSON.stringify(${JSON.stringify(parsed)})`;
+      } else {
+        bodyLine = `,\n  body: JSON.stringify(${prettyJson(parsed)})`;
+      }
+    }
+
+    return [
+      "const API_BASE_URL = " + JSON.stringify(defaultApiBaseUrl || "https://api.example.com") + ";",
+      "const API_KEY = \"<paste_api_key_here>\";",
+      "",
+      `const response = await fetch(${targetExpression}, {`,
+      `  method: "${method}",`,
+      `  headers: { ${headerLines.join(", ")} }${bodyLine},`,
+      "});",
+      "",
+      "const payload = await response.json();",
+      "console.log(payload);",
+    ].join("\n");
+  }, [bodyEnabled, defaultApiBaseUrl, method, pathValue, requestBodyText]);
+
+  const onApiKeyValueChange = (value: string) => {
+    setApiKeyValuesById((previous) => ({
+      ...previous,
+      [selectedApiKeyId]: value,
+    }));
+  };
+
+  const onCopyFetch = async () => {
+    try {
+      await navigator.clipboard.writeText(fetchSnippet);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const onExecute = async () => {
+    setExecuteError(null);
+    setExecutionResult(null);
+
+    const apiKey = selectedApiKeyValue.trim();
+    if (!apiKey) {
+      setExecuteError("API key value is required to execute a request.");
+      return;
+    }
+
+    let parsedBody: unknown;
+    if (bodyEnabled && requestBodyText.trim()) {
+      try {
+        parsedBody = JSON.parse(requestBodyText);
+      } catch {
+        setExecuteError("Request body must be valid JSON.");
+        return;
+      }
+    }
+
+    const startedAt = Date.now();
+    setIsExecuting(true);
+
+    try {
+      const response = await fetch(resolveEndpointUrl(pathValue, defaultApiBaseUrl), {
+        method,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: parsedBody !== undefined ? JSON.stringify(parsedBody) : undefined,
+      });
+
+      const text = await response.text();
+      const payload = text ? tryParseJson(text) : {};
+
+      setExecutionResult({
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        durationMs: Date.now() - startedAt,
+        body: payload,
+      });
+    } catch (error) {
+      setExecuteError(error instanceof Error ? error.message : "Request execution failed.");
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  return (
+    <Card className="border-[rgba(28,28,29,0.14)]">
+      <CardHeader className="gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="rounded-full border border-[rgba(28,28,29,0.16)] bg-[rgba(28,28,29,0.04)] px-2 py-0.5 text-xs font-semibold">
+              {method}
+            </span>
+            <code className="truncate rounded bg-[rgba(28,28,29,0.05)] px-2 py-1 text-xs">
+              {formatPath(path)}
+            </code>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="secondary" size="sm" onClick={onCopyFetch}>
+              {copied ? <Check className="mr-1 h-4 w-4" /> : <Copy className="mr-1 h-4 w-4" />}
+              Copy as fetch
+            </Button>
+            <Button type="button" size="sm" onClick={onExecute} disabled={isExecuting}>
+              {isExecuting ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="mr-1 h-4 w-4" />
+              )}
+              Execute
+            </Button>
+          </div>
+        </div>
+        <CardTitle className="text-base">{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label>API key selector</Label>
+            <Select value={selectedApiKeyId} onValueChange={setSelectedApiKeyId}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select API key profile" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={CUSTOM_KEY_OPTION_ID}>Custom API key</SelectItem>
+                {apiKeys.map((apiKey) => (
+                  <SelectItem key={apiKey.id} value={apiKey.id}>
+                    {apiKey.name} ({apiKey.keyPrefix})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selectedApiKeyMeta ? (
+              <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                {selectedApiKeyMeta.environment} · {selectedApiKeyMeta.role}
+              </p>
+            ) : (
+              <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                Use any active API key from the API keys page.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>API key value</Label>
+            <Input
+              type="password"
+              value={selectedApiKeyValue}
+              onChange={(event) => onApiKeyValueChange(event.currentTarget.value)}
+              placeholder="Paste secret key value (shown once at creation/rotation)"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Endpoint path</Label>
+          <Input
+            value={pathValue}
+            onChange={(event) => setPathValue(event.currentTarget.value)}
+            placeholder="/v1/issuance/templates"
+            autoComplete="off"
+          />
+          <p className="text-xs text-[rgba(28,28,29,0.64)]">
+            Use a full URL or a path relative to{" "}
+            <code>{defaultApiBaseUrl || "NEXT_PUBLIC_SDP_API_BASE_URL"}</code>.
+          </p>
+        </div>
+
+        {bodyEnabled ? (
+          <div className="space-y-2">
+            <Label>Request body (JSON)</Label>
+            <textarea
+              className="focus-visible:border-ring focus-visible:ring-ring/50 min-h-[152px] w-full rounded-md border border-[rgba(28,28,29,0.18)] bg-transparent p-3 font-mono text-xs leading-5 outline-none focus-visible:ring-[3px]"
+              value={requestBodyText}
+              onChange={(event) => setRequestBodyText(event.currentTarget.value)}
+              spellCheck={false}
+            />
+          </div>
+        ) : null}
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <div className="space-y-2">
+            <Label>Expected response</Label>
+            <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
+              <code>{prettyJson(expectedResponse)}</code>
+            </pre>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Last execution</Label>
+            {executeError ? (
+              <div className="rounded-lg border border-[#c71f37]/25 bg-[#c71f37]/[0.04] p-3 text-xs text-[#8a1f2a]">
+                {executeError}
+              </div>
+            ) : executionResult ? (
+              <div className="space-y-2">
+                <p className="text-xs text-[rgba(28,28,29,0.72)]">
+                  Status: {executionResult.status} {executionResult.statusText} ·{" "}
+                  {executionResult.durationMs}ms
+                </p>
+                <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
+                  <code>{prettyJson(executionResult.body)}</code>
+                </pre>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
+                Run Execute to inspect live API output.
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -11,8 +11,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getStoredApiKeySecret, normalizeApiKeyInput, storeApiKeySecret } from "@/lib/playground-api-keys";
 import { Check, ChevronDown, Copy, Loader2, Play } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const CUSTOM_KEY_OPTION_ID = "__custom__";
 
@@ -93,14 +94,6 @@ function hasJsonBody(method: ApiEndpointMethod): boolean {
   return method !== "GET" && method !== "DELETE";
 }
 
-function normalizeApiKeyInput(rawValue: string): string {
-  const trimmed = rawValue.trim();
-  if (trimmed.startsWith("Bearer ")) {
-    return trimmed.slice(7).trim();
-  }
-  return trimmed;
-}
-
 export function ApiEndpointPlayground({
   title,
   description,
@@ -117,7 +110,8 @@ export function ApiEndpointPlayground({
   const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>(
     apiKeys[0]?.id ?? CUSTOM_KEY_OPTION_ID
   );
-  const [apiKeyValuesById, setApiKeyValuesById] = useState<Record<string, string>>({});
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [attachedApiKey, setAttachedApiKey] = useState<string | null>(null);
   const [requestBodyText, setRequestBodyText] = useState<string>(() => {
     if (!hasJsonBody(method) || requestBodyExample === undefined) {
       return "";
@@ -131,8 +125,24 @@ export function ApiEndpointPlayground({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const bodyEnabled = hasJsonBody(method);
-  const selectedApiKeyValue = apiKeyValuesById[selectedApiKeyId] ?? "";
   const selectedApiKeyMeta = apiKeys.find((apiKey) => apiKey.id === selectedApiKeyId) ?? null;
+  const selectedApiKeyPrefix = selectedApiKeyMeta?.keyPrefix ?? null;
+  const isCustomApiKeySelection = selectedApiKeyId === CUSTOM_KEY_OPTION_ID;
+
+  useEffect(() => {
+    if (isCustomApiKeySelection) {
+      setAttachedApiKey(null);
+      return;
+    }
+
+    const stored = getStoredApiKeySecret({
+      apiKeyId: selectedApiKeyId,
+      keyPrefix: selectedApiKeyPrefix,
+    });
+
+    setAttachedApiKey(stored);
+    setApiKeyInput(stored ?? "");
+  }, [isCustomApiKeySelection, selectedApiKeyId, selectedApiKeyPrefix]);
 
   const fetchSnippet = useMemo(() => {
     const normalizedPath = formatPath(path);
@@ -167,13 +177,6 @@ export function ApiEndpointPlayground({
     ].join("\n");
   }, [bodyEnabled, effectiveApiBaseUrl, method, path, requestBodyText]);
 
-  const onApiKeyValueChange = (value: string) => {
-    setApiKeyValuesById((previous) => ({
-      ...previous,
-      [selectedApiKeyId]: value,
-    }));
-  };
-
   const onCopyFetch = async () => {
     try {
       await navigator.clipboard.writeText(fetchSnippet);
@@ -184,18 +187,59 @@ export function ApiEndpointPlayground({
     }
   };
 
+  const onAttachSelectedKey = () => {
+    if (isCustomApiKeySelection) {
+      return;
+    }
+
+    const normalized = normalizeApiKeyInput(apiKeyInput);
+    if (!normalized) {
+      setExecuteError("Paste the full key value before attaching it to the selected key.");
+      return;
+    }
+    if (!normalized.startsWith("sk_test_") && !normalized.startsWith("sk_live_")) {
+      setExecuteError("Invalid API key format. Paste the raw key value (sk_test_... or sk_live_...).");
+      return;
+    }
+
+    storeApiKeySecret({
+      value: normalized,
+      apiKeyId: selectedApiKeyId,
+      keyPrefix: selectedApiKeyPrefix,
+    });
+    setAttachedApiKey(normalized);
+    setApiKeyInput(normalized);
+    setExecuteError(null);
+  };
+
   const onExecute = async () => {
     setExecuteError(null);
     setExecutionResult(null);
 
-    const apiKey = normalizeApiKeyInput(selectedApiKeyValue);
+    const normalizedInput = normalizeApiKeyInput(apiKeyInput);
+    const apiKey = isCustomApiKeySelection
+      ? normalizedInput
+      : normalizedInput || normalizeApiKeyInput(attachedApiKey ?? "");
+
     if (!apiKey) {
-      setExecuteError("API key value is required to execute a request.");
+      setExecuteError(
+        isCustomApiKeySelection
+          ? "API key value is required to execute a request."
+          : "No key is attached to the selected API key. Paste it once and click Attach selected key."
+      );
       return;
     }
     if (!apiKey.startsWith("sk_test_") && !apiKey.startsWith("sk_live_")) {
       setExecuteError("Invalid API key format. Paste the raw key value (sk_test_... or sk_live_...).");
       return;
+    }
+    if (!isCustomApiKeySelection) {
+      storeApiKeySecret({
+        value: apiKey,
+        apiKeyId: selectedApiKeyId,
+        keyPrefix: selectedApiKeyPrefix,
+      });
+      setAttachedApiKey(apiKey);
     }
 
     let parsedBody: unknown;
@@ -318,11 +362,27 @@ export function ApiEndpointPlayground({
             <Label>API key value</Label>
             <Input
               type="password"
-              value={selectedApiKeyValue}
-              onChange={(event) => onApiKeyValueChange(event.currentTarget.value)}
+              value={apiKeyInput}
+              onChange={(event) => setApiKeyInput(event.currentTarget.value)}
               placeholder="Paste secret key value (shown once at creation/rotation)"
               autoComplete="off"
             />
+            {isCustomApiKeySelection ? (
+              <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                Custom mode uses this value directly for execution.
+              </p>
+            ) : (
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                  {attachedApiKey
+                    ? "A key is attached to this selection. Run executes a real authenticated call."
+                    : "No key attached yet. Paste the full key and attach it once."}
+                </p>
+                <Button type="button" size="sm" variant="secondary" onClick={onAttachSelectedKey}>
+                  Attach selected key
+                </Button>
+              </div>
+            )}
           </div>
         </div>
 

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -2,30 +2,12 @@
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { getStoredApiKeySecret, normalizeApiKeyInput, storeApiKeySecret } from "@/lib/playground-api-keys";
+import { normalizeApiKeyInput } from "@/lib/playground-api-keys";
 import { Check, ChevronDown, Copy, Loader2, Play } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-
-const CUSTOM_KEY_OPTION_ID = "__custom__";
+import { useMemo, useState } from "react";
 
 export type ApiEndpointMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-
-export interface ApiPlaygroundApiKeyOption {
-  id: string;
-  name: string;
-  keyPrefix: string;
-  role: string;
-  environment: string;
-}
 
 interface ExecutionResult {
   ok: boolean;
@@ -42,7 +24,7 @@ export interface ApiEndpointPlaygroundProps {
   path: string;
   expectedResponse: unknown;
   requestBodyExample?: unknown;
-  apiKeys: ApiPlaygroundApiKeyOption[];
+  apiKeyValue: string;
   apiBaseUrl?: string | null;
   defaultOpen?: boolean;
 }
@@ -101,17 +83,12 @@ export function ApiEndpointPlayground({
   path,
   expectedResponse,
   requestBodyExample,
-  apiKeys,
+  apiKeyValue,
   apiBaseUrl,
   defaultOpen = false,
 }: ApiEndpointPlaygroundProps) {
   const defaultApiBaseUrl = useMemo(getDefaultApiBaseUrl, []);
   const effectiveApiBaseUrl = (apiBaseUrl ?? defaultApiBaseUrl ?? "").replace(/\/$/, "");
-  const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>(
-    apiKeys[0]?.id ?? CUSTOM_KEY_OPTION_ID
-  );
-  const [apiKeyInput, setApiKeyInput] = useState("");
-  const [attachedApiKey, setAttachedApiKey] = useState<string | null>(null);
   const [requestBodyText, setRequestBodyText] = useState<string>(() => {
     if (!hasJsonBody(method) || requestBodyExample === undefined) {
       return "";
@@ -125,24 +102,6 @@ export function ApiEndpointPlayground({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const bodyEnabled = hasJsonBody(method);
-  const selectedApiKeyMeta = apiKeys.find((apiKey) => apiKey.id === selectedApiKeyId) ?? null;
-  const selectedApiKeyPrefix = selectedApiKeyMeta?.keyPrefix ?? null;
-  const isCustomApiKeySelection = selectedApiKeyId === CUSTOM_KEY_OPTION_ID;
-
-  useEffect(() => {
-    if (isCustomApiKeySelection) {
-      setAttachedApiKey(null);
-      return;
-    }
-
-    const stored = getStoredApiKeySecret({
-      apiKeyId: selectedApiKeyId,
-      keyPrefix: selectedApiKeyPrefix,
-    });
-
-    setAttachedApiKey(stored);
-    setApiKeyInput(stored ?? "");
-  }, [isCustomApiKeySelection, selectedApiKeyId, selectedApiKeyPrefix]);
 
   const fetchSnippet = useMemo(() => {
     const normalizedPath = formatPath(path);
@@ -187,59 +146,18 @@ export function ApiEndpointPlayground({
     }
   };
 
-  const onAttachSelectedKey = () => {
-    if (isCustomApiKeySelection) {
-      return;
-    }
-
-    const normalized = normalizeApiKeyInput(apiKeyInput);
-    if (!normalized) {
-      setExecuteError("Paste the full key value before attaching it to the selected key.");
-      return;
-    }
-    if (!normalized.startsWith("sk_test_") && !normalized.startsWith("sk_live_")) {
-      setExecuteError("Invalid API key format. Paste the raw key value (sk_test_... or sk_live_...).");
-      return;
-    }
-
-    storeApiKeySecret({
-      value: normalized,
-      apiKeyId: selectedApiKeyId,
-      keyPrefix: selectedApiKeyPrefix,
-    });
-    setAttachedApiKey(normalized);
-    setApiKeyInput(normalized);
-    setExecuteError(null);
-  };
-
   const onExecute = async () => {
     setExecuteError(null);
     setExecutionResult(null);
 
-    const normalizedInput = normalizeApiKeyInput(apiKeyInput);
-    const apiKey = isCustomApiKeySelection
-      ? normalizedInput
-      : normalizedInput || normalizeApiKeyInput(attachedApiKey ?? "");
-
+    const apiKey = normalizeApiKeyInput(apiKeyValue);
     if (!apiKey) {
-      setExecuteError(
-        isCustomApiKeySelection
-          ? "API key value is required to execute a request."
-          : "No key is attached to the selected API key. Paste it once and click Attach selected key."
-      );
+      setExecuteError("Set the API key once in the top playground key selector before running.");
       return;
     }
     if (!apiKey.startsWith("sk_test_") && !apiKey.startsWith("sk_live_")) {
-      setExecuteError("Invalid API key format. Paste the raw key value (sk_test_... or sk_live_...).");
+      setExecuteError("Invalid API key format. Use a raw key value (sk_test_... or sk_live_...).");
       return;
-    }
-    if (!isCustomApiKeySelection) {
-      storeApiKeySecret({
-        value: apiKey,
-        apiKeyId: selectedApiKeyId,
-        keyPrefix: selectedApiKeyPrefix,
-      });
-      setAttachedApiKey(apiKey);
     }
 
     let parsedBody: unknown;
@@ -331,105 +249,50 @@ export function ApiEndpointPlayground({
 
       {isOpen ? (
         <CardContent className="space-y-4">
-        <div className="grid gap-3 md:grid-cols-2">
-          <div className="space-y-2">
-            <Label>API key selector</Label>
-            <Select value={selectedApiKeyId} onValueChange={setSelectedApiKeyId}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select API key profile" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={CUSTOM_KEY_OPTION_ID}>Custom API key</SelectItem>
-                {apiKeys.map((apiKey) => (
-                  <SelectItem key={apiKey.id} value={apiKey.id}>
-                    {apiKey.name} ({apiKey.keyPrefix})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {selectedApiKeyMeta ? (
-              <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                {selectedApiKeyMeta.environment} · {selectedApiKeyMeta.role}
-              </p>
-            ) : (
-              <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                Use any active API key from the API keys page.
-              </p>
-            )}
-          </div>
+          {bodyEnabled ? (
+            <div className="space-y-2">
+              <Label>Request body (JSON)</Label>
+              <textarea
+                className="focus-visible:border-ring focus-visible:ring-ring/50 min-h-[152px] w-full rounded-md border border-[rgba(28,28,29,0.18)] bg-transparent p-3 font-mono text-xs leading-5 outline-none focus-visible:ring-[3px]"
+                value={requestBodyText}
+                onChange={(event) => setRequestBodyText(event.currentTarget.value)}
+                spellCheck={false}
+              />
+            </div>
+          ) : null}
 
-          <div className="space-y-2">
-            <Label>API key value</Label>
-            <Input
-              type="password"
-              value={apiKeyInput}
-              onChange={(event) => setApiKeyInput(event.currentTarget.value)}
-              placeholder="Paste secret key value (shown once at creation/rotation)"
-              autoComplete="off"
-            />
-            {isCustomApiKeySelection ? (
-              <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                Custom mode uses this value directly for execution.
-              </p>
-            ) : (
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                  {attachedApiKey
-                    ? "A key is attached to this selection. Run executes a real authenticated call."
-                    : "No key attached yet. Paste the full key and attach it once."}
-                </p>
-                <Button type="button" size="sm" variant="secondary" onClick={onAttachSelectedKey}>
-                  Attach selected key
-                </Button>
-              </div>
-            )}
-          </div>
-        </div>
+          <div className="grid gap-3 lg:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Expected response</Label>
+              <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
+                <code>{prettyJson(expectedResponse)}</code>
+              </pre>
+            </div>
 
-        {bodyEnabled ? (
-          <div className="space-y-2">
-            <Label>Request body (JSON)</Label>
-            <textarea
-              className="focus-visible:border-ring focus-visible:ring-ring/50 min-h-[152px] w-full rounded-md border border-[rgba(28,28,29,0.18)] bg-transparent p-3 font-mono text-xs leading-5 outline-none focus-visible:ring-[3px]"
-              value={requestBodyText}
-              onChange={(event) => setRequestBodyText(event.currentTarget.value)}
-              spellCheck={false}
-            />
+            <div className="space-y-2">
+              <Label>Last execution</Label>
+              {executeError ? (
+                <div className="rounded-lg border border-[#c71f37]/25 bg-[#c71f37]/[0.04] p-3 text-xs text-[#8a1f2a]">
+                  {executeError}
+                </div>
+              ) : executionResult ? (
+                <div className="space-y-2">
+                  <p className="text-xs text-[rgba(28,28,29,0.72)]">
+                    Status: {executionResult.status} {executionResult.statusText} ·{" "}
+                    {executionResult.durationMs}ms
+                  </p>
+                  <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
+                    <code>{prettyJson(executionResult.body)}</code>
+                  </pre>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
+                  Run Execute to inspect live API output.
+                </div>
+              )}
+            </div>
           </div>
-        ) : null}
-
-        <div className="grid gap-3 lg:grid-cols-2">
-          <div className="space-y-2">
-            <Label>Expected response</Label>
-            <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
-              <code>{prettyJson(expectedResponse)}</code>
-            </pre>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Last execution</Label>
-            {executeError ? (
-              <div className="rounded-lg border border-[#c71f37]/25 bg-[#c71f37]/[0.04] p-3 text-xs text-[#8a1f2a]">
-                {executeError}
-              </div>
-            ) : executionResult ? (
-              <div className="space-y-2">
-                <p className="text-xs text-[rgba(28,28,29,0.72)]">
-                  Status: {executionResult.status} {executionResult.statusText} ·{" "}
-                  {executionResult.durationMs}ms
-                </p>
-                <pre className="max-h-[280px] overflow-auto rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] p-3 text-xs leading-5 text-[rgba(28,28,29,0.82)]">
-                  <code>{prettyJson(executionResult.body)}</code>
-                </pre>
-              </div>
-            ) : (
-              <div className="rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.02)] p-3 text-xs text-[rgba(28,28,29,0.64)]">
-                Run Execute to inspect live API output.
-              </div>
-            )}
-          </div>
-        </div>
-      </CardContent>
+        </CardContent>
       ) : null}
     </Card>
   );

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -42,6 +42,7 @@ export interface ApiEndpointPlaygroundProps {
   expectedResponse: unknown;
   requestBodyExample?: unknown;
   apiKeys: ApiPlaygroundApiKeyOption[];
+  apiBaseUrl?: string | null;
   defaultOpen?: boolean;
 }
 
@@ -81,14 +82,11 @@ function resolveEndpointUrl(path: string, baseUrl: string): string {
     return normalizedPath;
   }
 
-  const runtimeBaseUrl =
-    baseUrl || (typeof window !== "undefined" ? window.location.origin.replace(/\/$/, "") : "");
-
-  if (!runtimeBaseUrl) {
+  if (!baseUrl) {
     throw new Error("Missing API base URL for browser execution");
   }
 
-  return `${runtimeBaseUrl}${normalizedPath}`;
+  return `${baseUrl}${normalizedPath}`;
 }
 
 function hasJsonBody(method: ApiEndpointMethod): boolean {
@@ -103,9 +101,11 @@ export function ApiEndpointPlayground({
   expectedResponse,
   requestBodyExample,
   apiKeys,
+  apiBaseUrl,
   defaultOpen = false,
 }: ApiEndpointPlaygroundProps) {
   const defaultApiBaseUrl = useMemo(getDefaultApiBaseUrl, []);
+  const effectiveApiBaseUrl = (apiBaseUrl ?? defaultApiBaseUrl ?? "").replace(/\/$/, "");
   const [selectedApiKeyId, setSelectedApiKeyId] = useState<string>(
     apiKeys[0]?.id ?? CUSTOM_KEY_OPTION_ID
   );
@@ -146,7 +146,7 @@ export function ApiEndpointPlayground({
     }
 
     return [
-      "const API_BASE_URL = " + JSON.stringify(defaultApiBaseUrl || "https://api.example.com") + ";",
+      "const API_BASE_URL = " + JSON.stringify(effectiveApiBaseUrl || "https://api.example.com") + ";",
       "const API_KEY = \"<paste_api_key_here>\";",
       "",
       `const response = await fetch(${targetExpression}, {`,
@@ -157,7 +157,7 @@ export function ApiEndpointPlayground({
       "const payload = await response.json();",
       "console.log(payload);",
     ].join("\n");
-  }, [bodyEnabled, defaultApiBaseUrl, method, path, requestBodyText]);
+  }, [bodyEnabled, effectiveApiBaseUrl, method, path, requestBodyText]);
 
   const onApiKeyValueChange = (value: string) => {
     setApiKeyValuesById((previous) => ({
@@ -200,7 +200,7 @@ export function ApiEndpointPlayground({
     setIsExecuting(true);
 
     try {
-      const response = await fetch(resolveEndpointUrl(path, defaultApiBaseUrl), {
+      const response = await fetch(resolveEndpointUrl(path, effectiveApiBaseUrl), {
         method,
         headers: {
           Authorization: `Bearer ${apiKey}`,
@@ -357,7 +357,7 @@ export function ApiEndpointPlayground({
             )}
           </div>
         </div>
-        </CardContent>
+      </CardContent>
       ) : null}
     </Card>
   );

--- a/apps/sdp-web/src/components/api-endpoint-playground.tsx
+++ b/apps/sdp-web/src/components/api-endpoint-playground.tsx
@@ -93,6 +93,14 @@ function hasJsonBody(method: ApiEndpointMethod): boolean {
   return method !== "GET" && method !== "DELETE";
 }
 
+function normalizeApiKeyInput(rawValue: string): string {
+  const trimmed = rawValue.trim();
+  if (trimmed.startsWith("Bearer ")) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+
 export function ApiEndpointPlayground({
   title,
   description,
@@ -180,9 +188,13 @@ export function ApiEndpointPlayground({
     setExecuteError(null);
     setExecutionResult(null);
 
-    const apiKey = selectedApiKeyValue.trim();
+    const apiKey = normalizeApiKeyInput(selectedApiKeyValue);
     if (!apiKey) {
       setExecuteError("API key value is required to execute a request.");
+      return;
+    }
+    if (!apiKey.startsWith("sk_test_") && !apiKey.startsWith("sk_live_")) {
+      setExecuteError("Invalid API key format. Paste the raw key value (sk_test_... or sk_live_...).");
       return;
     }
 

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -2,6 +2,7 @@
 
 import { CreateApiKeyModal } from "@/app/dashboard/api-keys/create-api-key-modal";
 import { CreateWalletModal } from "@/app/dashboard/custody/create-wallet-modal";
+import { IssuanceApiKeySelector } from "@/app/dashboard/issuance/issuance-api-key-selector";
 import { CreateIssuanceTokenModal } from "@/app/dashboard/issuance/create-token-modal";
 import { DashboardQuickActions } from "@/components/dashboard-quick-actions";
 import { IssuanceHeaderTabs } from "@/components/issuance-header-tabs";
@@ -92,7 +93,12 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
     return {
       title: "Issuance",
       quickActionsLeft: <IssuanceHeaderTabs />,
-      quickActionsRight: <CreateIssuanceTokenModal />,
+      quickActionsRight: (
+        <>
+          <IssuanceApiKeySelector />
+          <CreateIssuanceTokenModal />
+        </>
+      ),
     };
   }
   if (pathname.startsWith("/dashboard/payments")) {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -2,8 +2,8 @@
 
 import { CreateApiKeyModal } from "@/app/dashboard/api-keys/create-api-key-modal";
 import { CreateWalletModal } from "@/app/dashboard/custody/create-wallet-modal";
-import { IssuanceApiKeySelector } from "@/app/dashboard/issuance/issuance-api-key-selector";
 import { CreateIssuanceTokenModal } from "@/app/dashboard/issuance/create-token-modal";
+import { IssuanceApiKeySelector } from "@/app/dashboard/issuance/issuance-api-key-selector";
 import { DashboardQuickActions } from "@/components/dashboard-quick-actions";
 import { IssuanceHeaderTabs } from "@/components/issuance-header-tabs";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -4,10 +4,22 @@ import { type ReactNode, createContext, useCallback, useContext, useMemo, useSta
 
 export type IssuanceWorkspaceTab = "tokens" | "playground";
 
+export interface DashboardIssuanceApiKeyOption {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  role: string;
+  environment: string;
+}
+
 type DashboardWorkspaceContextValue = {
   isSidebarOpen: boolean;
   selectedProject: string;
   issuanceTab: IssuanceWorkspaceTab;
+  issuanceApiKeys: DashboardIssuanceApiKeyOption[];
+  selectedIssuanceApiKeyId: string | null;
+  setIssuanceApiKeys: (keys: DashboardIssuanceApiKeyOption[]) => void;
+  setSelectedIssuanceApiKeyId: (id: string | null) => void;
   setSelectedProject: (project: string) => void;
   setIssuanceTab: (tab: IssuanceWorkspaceTab) => void;
   setSidebarOpen: (open: boolean) => void;
@@ -32,9 +44,24 @@ export function DashboardWorkspaceProvider({
   const [isSidebarOpen, setSidebarOpenState] = useState(initialSidebarOpen);
   const [selectedProject, setSelectedProject] = useState(defaultProject);
   const [issuanceTab, setIssuanceTab] = useState<IssuanceWorkspaceTab>("tokens");
+  const [issuanceApiKeys, setIssuanceApiKeysState] = useState<DashboardIssuanceApiKeyOption[]>([]);
+  const [selectedIssuanceApiKeyId, setSelectedIssuanceApiKeyId] = useState<string | null>(null);
 
   const setSidebarOpen = useCallback((open: boolean) => {
     setSidebarOpenState(open);
+  }, []);
+
+  const setIssuanceApiKeys = useCallback((keys: DashboardIssuanceApiKeyOption[]) => {
+    setIssuanceApiKeysState(keys);
+    setSelectedIssuanceApiKeyId((current) => {
+      if (keys.length === 0) {
+        return null;
+      }
+      if (current && keys.some((key) => key.id === current)) {
+        return current;
+      }
+      return keys[0].id;
+    });
   }, []);
 
   const toggleSidebar = useCallback(() => {
@@ -46,12 +73,25 @@ export function DashboardWorkspaceProvider({
       isSidebarOpen,
       selectedProject,
       issuanceTab,
+      issuanceApiKeys,
+      selectedIssuanceApiKeyId,
+      setIssuanceApiKeys,
+      setSelectedIssuanceApiKeyId,
       setSelectedProject,
       setIssuanceTab,
       setSidebarOpen,
       toggleSidebar,
     }),
-    [isSidebarOpen, selectedProject, issuanceTab, setSidebarOpen, toggleSidebar]
+    [
+      isSidebarOpen,
+      issuanceApiKeys,
+      issuanceTab,
+      selectedIssuanceApiKeyId,
+      selectedProject,
+      setIssuanceApiKeys,
+      setSidebarOpen,
+      toggleSidebar,
+    ]
   );
 
   return (

--- a/apps/sdp-web/src/lib/playground-api-keys.ts
+++ b/apps/sdp-web/src/lib/playground-api-keys.ts
@@ -1,0 +1,93 @@
+"use client";
+
+const STORAGE_KEY = "sdp.playground.api-keys.v1";
+
+interface StoredApiKeys {
+  byId: Record<string, string>;
+  byPrefix: Record<string, string>;
+}
+
+function getEmptyStore(): StoredApiKeys {
+  return { byId: {}, byPrefix: {} };
+}
+
+function readStore(): StoredApiKeys {
+  if (typeof window === "undefined") {
+    return getEmptyStore();
+  }
+
+  const raw = window.sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return getEmptyStore();
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as StoredApiKeys;
+    return {
+      byId: parsed.byId ?? {},
+      byPrefix: parsed.byPrefix ?? {},
+    };
+  } catch {
+    return getEmptyStore();
+  }
+}
+
+function writeStore(store: StoredApiKeys) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function normalizeApiKeyInput(rawValue: string): string {
+  const trimmed = rawValue.trim();
+  if (trimmed.startsWith("Bearer ")) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+
+export function storeApiKeySecret(params: {
+  value: string;
+  apiKeyId?: string | null;
+  keyPrefix?: string | null;
+}) {
+  const normalized = normalizeApiKeyInput(params.value);
+  if (!normalized) {
+    return;
+  }
+
+  const store = readStore();
+  if (params.apiKeyId) {
+    store.byId[params.apiKeyId] = normalized;
+  }
+  if (params.keyPrefix) {
+    store.byPrefix[params.keyPrefix] = normalized;
+  }
+
+  writeStore(store);
+}
+
+export function getStoredApiKeySecret(params: {
+  apiKeyId?: string | null;
+  keyPrefix?: string | null;
+}): string | null {
+  const store = readStore();
+
+  if (params.apiKeyId) {
+    const byId = store.byId[params.apiKeyId];
+    if (byId) {
+      return byId;
+    }
+  }
+
+  if (params.keyPrefix) {
+    const byPrefix = store.byPrefix[params.keyPrefix];
+    if (byPrefix) {
+      return byPrefix;
+    }
+  }
+
+  return null;
+}

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -20,28 +20,15 @@ async function getClerkToken(): Promise<string> {
   }
 
   const template = process.env.CLERK_JWT_TEMPLATE;
-  let token: string | null = null;
-  let templateError: unknown;
-
   if (template) {
-    try {
-      token = await getToken({ template });
-    } catch (error) {
-      templateError = error;
+    const token = await getToken({ template });
+    if (!token) {
+      throw new Error(`Failed to acquire Clerk token from template '${template}'`);
     }
+    return token;
   }
 
-  if (!token) {
-    try {
-      token = await getToken();
-    } catch (error) {
-      if (templateError) {
-        throw templateError;
-      }
-      throw error;
-    }
-  }
-
+  const token = await getToken();
   if (!token) {
     throw new Error("Failed to acquire Clerk token");
   }


### PR DESCRIPTION
## Summary
- move issuance API key selector to quick actions next to Create token
- reuse selector state across issuance playground endpoints
- simplify endpoint cards and keep per-endpoint collapse/execute
- add server-side playground execution proxy with session fallback when key secret is unavailable
- improve execution feedback (auth mode shown)

## Notes
- PR #29 is already merged; this PR contains follow-up issuance playground work after that merge