### PR TITLE
Clerk-native invite flow + preview-dynamic redirect config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Solana Developer Platform
 
+## Clerk URL Configuration
+
+Configure Clerk URLs through environment variables so invite/login links never resolve to localhost in deployed environments.
+
+- `apps/sdp-web` (`.env.local` or deployment environment):
+  - `NEXT_PUBLIC_CLERK_SIGN_IN_URL`
+  - `NEXT_PUBLIC_CLERK_SIGN_UP_URL`
+  - `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL`
+  - `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL`
+  - Optional: `NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL`, `NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL`
+- `apps/sdp-api` (Cloudflare Worker variables per environment):
+  - `FRONTEND_URL` (example: `https://app.example.com`)
+  - `CLERK_INVITATION_REDIRECT_URL` (recommended, example: `https://app.example.com/sign-in`)
+
+For local Worker development, copy `apps/sdp-api/.dev.vars.example` to `apps/sdp-api/.dev.vars`.
+
 ## Integration Tests (Devnet)
 
 The integration test suite runs against Solana **devnet** and signs real transactions using the **local custody** provider.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Configure Clerk URLs through environment variables so invite/login links never r
 - `apps/sdp-api` (Cloudflare Worker variables per environment):
   - `FRONTEND_URL` (example: `https://app.example.com`)
   - `CLERK_INVITATION_REDIRECT_URL` (recommended, example: `https://app.example.com/sign-in`)
+  - Optional: `CLERK_INVITATION_REDIRECT_ALLOWED_HOST_SUFFIXES` (comma-separated suffixes for dynamic web-origin redirects, example: `-solana-foundation.vercel.app`)
 
 For local Worker development, copy `apps/sdp-api/.dev.vars.example` to `apps/sdp-api/.dev.vars`.
 

--- a/apps/sdp-api/.dev.vars.example
+++ b/apps/sdp-api/.dev.vars.example
@@ -10,3 +10,7 @@ FEE_PAYMENT_PROVIDER=kora
 
 # Clerk webhook (required for Clerk org linking)
 CLERK_WEBHOOK_SECRET=whsec_...
+
+# Clerk invitation redirect settings
+FRONTEND_URL=http://localhost:3000
+CLERK_INVITATION_REDIRECT_URL=http://localhost:3000/sign-in

--- a/apps/sdp-api/src/middleware/clerk-auth.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.ts
@@ -98,7 +98,6 @@ async function ensureMembership(
   params: {
     organizationId: string;
     userId: string;
-    email: string;
     clerkRole?: string | null;
   }
 ): Promise<OrganizationRole> {
@@ -106,34 +105,7 @@ async function ensureMembership(
   if (existing?.role) {
     return existing.role as OrganizationRole;
   }
-
-  const pendingInvite = await db
-    .prepare(
-      `SELECT id, role, expires_at
-       FROM invitations
-       WHERE organization_id = ? AND email = ? AND status = 'pending'
-       ORDER BY created_at DESC
-       LIMIT 1`
-    )
-    .bind(params.organizationId, params.email.toLowerCase())
-    .first<{ id: string; role: string; expires_at: string }>();
-
-  let role: OrganizationRole | null = null;
-
-  if (pendingInvite) {
-    if (new Date(pendingInvite.expires_at) >= new Date()) {
-      role = pendingInvite.role as OrganizationRole;
-    } else {
-      await db
-        .prepare("UPDATE invitations SET status = 'expired' WHERE id = ?")
-        .bind(pendingInvite.id)
-        .run();
-    }
-  }
-
-  if (!role) {
-    role = mapClerkRoleToOrgRole(params.clerkRole);
-  }
+  const role = mapClerkRoleToOrgRole(params.clerkRole);
 
   const memberId = `mem_${crypto.randomUUID()}`;
   try {
@@ -149,15 +121,6 @@ async function ensureMembership(
     if (existingAfterInsert?.role) {
       return existingAfterInsert.role as OrganizationRole;
     }
-  }
-
-  if (pendingInvite && role === (pendingInvite.role as OrganizationRole)) {
-    await db
-      .prepare(
-        "UPDATE invitations SET status = 'accepted', accepted_at = datetime('now') WHERE id = ?"
-      )
-      .bind(pendingInvite.id)
-      .run();
   }
 
   return role;
@@ -181,7 +144,6 @@ async function buildClerkContext(c: Context<{ Bindings: Env }>, payload: ClerkJw
   const role = await ensureMembership(c.env.DB, {
     organizationId: orgIdentity.organization_id,
     userId: userIdentity.userId,
-    email,
     clerkRole: payload.org_role,
   });
 

--- a/apps/sdp-api/src/openapi/paths/members.ts
+++ b/apps/sdp-api/src/openapi/paths/members.ts
@@ -1,14 +1,9 @@
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
-import {
-  acceptInvitationRequestSchema,
-  errorResponseSchema,
-  inviteMemberRequestSchema,
-  memberIdParamSchema,
-} from "../schemas";
+import { errorResponseSchema, inviteMemberRequestSchema, memberIdParamSchema } from "../schemas";
 import { errorResponses, jsonContent } from "./helpers";
-import { actionSuccessResponse, inviteMemberResponse, listMembersResponse } from "./responses";
+import { inviteMemberResponse, listMembersResponse } from "./responses";
 
 export function registerMemberPaths(registry: OpenAPIRegistry) {
   registry.registerPath({
@@ -48,28 +43,6 @@ export function registerMemberPaths(registry: OpenAPIRegistry) {
         content: jsonContent(inviteMemberResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 409, 500]),
-    },
-  });
-
-  registry.registerPath({
-    method: "post",
-    path: "/v1/members/accept",
-    tags: ["Members"],
-    summary: "Accept invitation",
-    operationId: "acceptInvitation",
-    description: "Accepts an invitation token and activates membership.",
-    request: {
-      body: {
-        required: true,
-        content: jsonContent(acceptInvitationRequestSchema),
-      },
-    },
-    responses: {
-      200: {
-        description: "Invitation accepted",
-        content: jsonContent(actionSuccessResponse),
-      },
-      ...errorResponses(errorResponseSchema, [400, 404, 500]),
     },
   });
 

--- a/apps/sdp-api/src/openapi/schemas/organizations.ts
+++ b/apps/sdp-api/src/openapi/schemas/organizations.ts
@@ -1,7 +1,4 @@
-import {
-  acceptSchema as acceptSchemaBase,
-  inviteSchema as inviteSchemaBase,
-} from "../../routes/members/schemas";
+import { inviteSchema as inviteSchemaBase } from "../../routes/members/schemas";
 import {
   createOrgSchema as createOrgSchemaBase,
   updateOrgSchema as updateOrgSchemaBase,
@@ -111,9 +108,13 @@ export const invitationSchema = z
     role: z
       .enum(["owner", "admin", "developer", "viewer"])
       .openapi({ description: "Role offered to the invitee.", example: "developer" }),
-    expiresAt: isoDateTimeSchema.openapi({
-      description: "Invitation expiration timestamp.",
-      example: "2025-02-01T00:00:00.000Z",
+    status: z.string().openapi({
+      description: "Invitation status returned by Clerk.",
+      example: "pending",
+    }),
+    createdAt: isoDateTimeSchema.optional().openapi({
+      description: "Invitation creation timestamp.",
+      example: "2025-01-01T00:00:00.000Z",
     }),
   })
   .openapi({ description: "Invitation summary." });
@@ -202,16 +203,3 @@ export const inviteMemberRequestSchema = inviteSchemaBase
     }),
   })
   .openapi({ description: "Invite member request body." });
-
-export const acceptInvitationRequestSchema = acceptSchemaBase
-  .extend({
-    token: acceptSchemaBase.shape.token.openapi({
-      description: "Invitation token from email.",
-      example: "invitation_token",
-    }),
-    name: acceptSchemaBase.shape.name.openapi({
-      description: "Optional name to set for the user.",
-      example: "Example User",
-    }),
-  })
-  .openapi({ description: "Accept invitation request body." });

--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -66,11 +66,48 @@ async function getClerkOrgId(db: D1Database, organizationId: string): Promise<st
 }
 
 function resolveInviteRedirectUrl(env: Env): string | undefined {
-  const base = env.FRONTEND_URL?.replace(/\/$/, "");
+  const configured = env.CLERK_INVITATION_REDIRECT_URL?.trim();
+  if (configured) {
+    return configured;
+  }
+
+  const base = env.FRONTEND_URL?.trim().replace(/\/$/, "");
   if (!base) {
     return undefined;
   }
-  return `${base}/members`;
+  return `${base}/sign-in`;
+}
+
+function assertInviteRedirectUrl(env: Env, redirectUrl: string | undefined): string | undefined {
+  if (env.ENVIRONMENT === "development") {
+    return redirectUrl;
+  }
+
+  if (!redirectUrl) {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "Invite redirect URL is missing. Set CLERK_INVITATION_REDIRECT_URL or FRONTEND_URL."
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUrl);
+  } catch {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "Invite redirect URL is invalid. Set CLERK_INVITATION_REDIRECT_URL to a full https URL."
+    );
+  }
+
+  if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "Invite redirect URL points to localhost in a non-development environment."
+    );
+  }
+
+  return redirectUrl;
 }
 
 function randomBase64Url(byteLength: number): string {
@@ -189,7 +226,7 @@ export const inviteMember = async (c: AppContext) => {
   const inviterUserId = userId || inviterKey?.created_by || null;
 
   const clerkService = new ClerkOrganizationsService(c.env);
-  const redirectUrl = resolveInviteRedirectUrl(c.env);
+  const redirectUrl = assertInviteRedirectUrl(c.env, resolveInviteRedirectUrl(c.env));
   const clerkInvitation = await clerkService.createOrganizationInvitation({
     organizationId: clerkOrgId,
     inviterUserId: clerk.clerkUserId,

--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -64,7 +64,65 @@ async function getClerkOrgId(db: D1Database, organizationId: string): Promise<st
   return row?.provider_org_id ?? null;
 }
 
-function resolveInviteRedirectUrl(env: Env): string | undefined {
+function parseHostname(urlValue: string | undefined): string | undefined {
+  const value = urlValue?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveDynamicInviteRedirectUrl(c: AppContext): string | undefined {
+  const originHeader = c.req.header("x-sdp-web-origin")?.trim();
+  if (!originHeader) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(originHeader);
+  } catch {
+    return undefined;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const isLocal = host === "localhost" || host === "127.0.0.1";
+  if (!isLocal && parsed.protocol !== "https:") {
+    return undefined;
+  }
+
+  const exactAllowedHosts = [
+    parseHostname(c.env.CLERK_INVITATION_REDIRECT_URL),
+    parseHostname(c.env.FRONTEND_URL),
+  ].filter((value): value is string => Boolean(value));
+
+  const suffixes = c.env.CLERK_INVITATION_REDIRECT_ALLOWED_HOST_SUFFIXES?.split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+
+  const hostAllowed =
+    exactAllowedHosts.includes(host) ||
+    Boolean(suffixes?.some((suffix) => host.endsWith(suffix.replace(/^\*\./, "."))));
+
+  if (!hostAllowed) {
+    return undefined;
+  }
+
+  return `${parsed.origin}/sign-in`;
+}
+
+function resolveInviteRedirectUrl(c: AppContext): string | undefined {
+  const dynamic = resolveDynamicInviteRedirectUrl(c);
+  if (dynamic) {
+    return dynamic;
+  }
+
+  const env = c.env;
   const configured = env.CLERK_INVITATION_REDIRECT_URL?.trim();
   if (configured) {
     return configured;
@@ -187,7 +245,7 @@ export const inviteMember = async (c: AppContext) => {
   const inviterUserId = userId || inviterKey?.created_by || null;
 
   const clerkService = new ClerkOrganizationsService(c.env);
-  const redirectUrl = assertInviteRedirectUrl(c.env, resolveInviteRedirectUrl(c.env));
+  const redirectUrl = assertInviteRedirectUrl(c.env, resolveInviteRedirectUrl(c));
   const clerkInvitation = await clerkService.createOrganizationInvitation({
     organizationId: clerkOrgId,
     inviterUserId: clerk.clerkUserId,

--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -157,10 +157,25 @@ function assertInviteRedirectUrl(env: Env, redirectUrl: string | undefined): str
     );
   }
 
-  if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+  if (parsed.protocol !== "https:") {
     throw new AppError(
       "INTERNAL_ERROR",
-      "Invite redirect URL points to localhost in a non-development environment."
+      "Invite redirect URL must use https in a non-development environment."
+    );
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const isLoopback =
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "0.0.0.0" ||
+    host === "::1" ||
+    host === "[::1]";
+
+  if (isLoopback) {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "Invite redirect URL points to a loopback host in a non-development environment."
     );
   }
 

--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -1,12 +1,11 @@
 import { AppError, notFound } from "@/lib/errors";
-import { hashString } from "@/lib/hash";
 import { created, noContent, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { ClerkOrganizationsService } from "@/services/clerk-organizations.service";
 import type { Env } from "@/types/env";
 import type { OrganizationRole } from "@sdp/types";
 import type { Context } from "hono";
-import { acceptSchema, inviteSchema } from "./schemas";
+import { inviteSchema } from "./schemas";
 
 type AppContext = Context<{ Bindings: Env }>;
 
@@ -110,32 +109,6 @@ function assertInviteRedirectUrl(env: Env, redirectUrl: string | undefined): str
   return redirectUrl;
 }
 
-function randomBase64Url(byteLength: number): string {
-  const bytes = new Uint8Array(byteLength);
-  crypto.getRandomValues(bytes);
-
-  const globalWithBuffer = globalThis as {
-    Buffer?: {
-      from: (input: Uint8Array) => { toString: (encoding: "base64") => string };
-    };
-  };
-
-  if (globalWithBuffer.Buffer) {
-    return globalWithBuffer.Buffer.from(bytes)
-      .toString("base64")
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=+$/g, "");
-  }
-
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
-}
-
 export const listMembers = async (c: AppContext) => {
   const { organizationId } = resolveActor(c);
 
@@ -195,18 +168,6 @@ export const inviteMember = async (c: AppContext) => {
     throw new AppError("CONFLICT", "User is already a member of this organization");
   }
 
-  // Check for pending invitation
-  const existingInvite = await c.env.DB.prepare(
-    `SELECT id FROM invitations
-     WHERE organization_id = ? AND email = ? AND status = 'pending'`
-  )
-    .bind(organizationId, normalizedEmail)
-    .first();
-
-  if (existingInvite) {
-    throw new AppError("CONFLICT", "Invitation already sent to this email");
-  }
-
   if (!clerk?.clerkUserId) {
     throw new AppError("UNAUTHORIZED", "Clerk user required to send invites");
   }
@@ -239,33 +200,12 @@ export const inviteMember = async (c: AppContext) => {
     },
   });
 
-  // Create local invitation record for role mapping
-  const invitationId = `inv_${crypto.randomUUID()}`;
-  const token = randomBase64Url(32);
-  const tokenHash = await hashString(token);
-  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // 7 days
-
-  await c.env.DB.prepare(
-    `INSERT INTO invitations (id, organization_id, email, role, invited_by, token_hash, expires_at, status)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')`
-  )
-    .bind(
-      invitationId,
-      organizationId,
-      normalizedEmail,
-      role,
-      inviterUserId || "system",
-      tokenHash,
-      expiresAt
-    )
-    .run();
-
   // Audit log
   const auditService = new AuditService(c.env.DB);
   await auditService.log(c, {
     action: "invite",
     resourceType: "invitation",
-    resourceId: invitationId,
+    resourceId: clerkInvitation.id,
     metadata: {
       email: normalizedEmail,
       role,
@@ -277,105 +217,17 @@ export const inviteMember = async (c: AppContext) => {
     apiKeyId: apiKeyId || undefined,
   });
 
-  const response = {
+  return created(c, {
     invitation: {
-      id: invitationId,
+      id: clerkInvitation.id,
       email: normalizedEmail,
       role,
-      expiresAt,
-      clerkInvitationId: clerkInvitation.id,
+      status: clerkInvitation.status,
+      createdAt: clerkInvitation.created_at
+        ? new Date(clerkInvitation.created_at).toISOString()
+        : undefined,
     },
-    ...(c.env.ENVIRONMENT === "development" && { token }),
-  };
-
-  return created(c, response);
-};
-
-export const acceptInvitation = async (c: AppContext) => {
-  const body = await c.req.json();
-  const parsed = acceptSchema.safeParse(body);
-
-  if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
-    });
-  }
-
-  const { token, name } = parsed.data;
-  const tokenHash = await hashString(token);
-
-  // Get invitation
-  const invitation = await c.env.DB.prepare(
-    `SELECT id, organization_id, email, role, expires_at, status
-     FROM invitations
-     WHERE token_hash = ?`
-  )
-    .bind(tokenHash)
-    .first<{
-      id: string;
-      organization_id: string;
-      email: string;
-      role: string;
-      expires_at: string;
-      status: string;
-    }>();
-
-  if (!invitation) {
-    throw new AppError("INVALID_INVITATION", "Invalid invitation token");
-  }
-
-  if (invitation.status !== "pending") {
-    throw new AppError("INVALID_INVITATION", "Invitation is no longer valid");
-  }
-
-  if (new Date(invitation.expires_at) < new Date()) {
-    throw new AppError("EXPIRED_INVITATION", "Invitation has expired");
-  }
-
-  // Check if user exists
-  let user = await c.env.DB.prepare("SELECT id, email FROM users WHERE email = ?")
-    .bind(invitation.email)
-    .first<{ id: string; email: string }>();
-
-  if (!user) {
-    // Create new user
-    const userId = `usr_${crypto.randomUUID()}`;
-    await c.env.DB.prepare(
-      `INSERT INTO users (id, email, name, email_verified, status)
-       VALUES (?, ?, ?, 1, 'active')`
-    )
-      .bind(userId, invitation.email, name ?? null)
-      .run();
-
-    user = { id: userId, email: invitation.email };
-  }
-
-  // Create membership
-  const memberId = `mem_${crypto.randomUUID()}`;
-  await c.env.DB.prepare(
-    `INSERT INTO organization_members (id, organization_id, user_id, role, status)
-     VALUES (?, ?, ?, ?, 'active')`
-  )
-    .bind(memberId, invitation.organization_id, user.id, invitation.role)
-    .run();
-
-  // Mark invitation as accepted
-  await c.env.DB.prepare(
-    "UPDATE invitations SET status = 'accepted', accepted_at = datetime('now') WHERE id = ?"
-  )
-    .bind(invitation.id)
-    .run();
-
-  // Audit log
-  const auditService = new AuditService(c.env.DB);
-  await auditService.log(c, {
-    action: "accept_invite",
-    resourceType: "invitation",
-    resourceId: invitation.id,
-    metadata: { email: invitation.email },
   });
-
-  return success(c, { success: true });
 };
 
 export const removeMember = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/members/index.ts
+++ b/apps/sdp-api/src/routes/members/index.ts
@@ -5,7 +5,7 @@
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import type { Env } from "@/types/env";
 import { Hono } from "hono";
-import { acceptInvitation, inviteMember, listMembers, removeMember } from "./handlers";
+import { inviteMember, listMembers, removeMember } from "./handlers";
 
 const members = new Hono<{ Bindings: Env }>();
 
@@ -14,9 +14,6 @@ members.use("*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true })
 
 members.get("/", requirePermissions("org:read"), listMembers);
 members.post("/invite", requirePermissions("org:write"), inviteMember);
-
-// Accept invitation does not require auth
-members.post("/accept", acceptInvitation);
 
 members.delete("/:memberId", requirePermissions("org:admin"), removeMember);
 

--- a/apps/sdp-api/src/routes/members/schemas.ts
+++ b/apps/sdp-api/src/routes/members/schemas.ts
@@ -4,8 +4,3 @@ export const inviteSchema = z.object({
   email: z.string().email(),
   role: z.enum(["admin", "developer", "viewer"]),
 });
-
-export const acceptSchema = z.object({
-  token: z.string().min(1),
-  name: z.string().min(1).max(100).optional(),
-});

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -31,6 +31,7 @@ export interface Env {
   RESEND_API_KEY?: string;
   FRONTEND_URL?: string;
   CLERK_INVITATION_REDIRECT_URL?: string;
+  CLERK_INVITATION_REDIRECT_ALLOWED_HOST_SUFFIXES?: string;
 
   // Clerk configuration
   CLERK_ISSUER?: string;

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -30,6 +30,7 @@ export interface Env {
   EMAIL_FROM?: string;
   RESEND_API_KEY?: string;
   FRONTEND_URL?: string;
+  CLERK_INVITATION_REDIRECT_URL?: string;
 
   // Clerk configuration
   CLERK_ISSUER?: string;

--- a/apps/sdp-api/wrangler.toml
+++ b/apps/sdp-api/wrangler.toml
@@ -31,6 +31,7 @@ id = "local-sessions"
 ENVIRONMENT = "development"
 API_VERSION = "v1"
 EMAIL_FROM = "noreply@mail.solana.org"
+# Local-only defaults for invitation redirects are defined in .dev.vars (see .dev.vars.example).
 
 # Dev environment
 [env.dev]
@@ -62,6 +63,7 @@ id = "56172f4bd6484367af2eaf0039246802"
 ENVIRONMENT = "development"
 API_VERSION = "v1"
 EMAIL_FROM = "noreply@mail.solana.org"
+# Set FRONTEND_URL and/or CLERK_INVITATION_REDIRECT_URL in Cloudflare for this environment.
 SOLANA_NETWORK = "devnet"
 SOLANA_RPC_URL = "https://api.devnet.solana.com"
 FEE_PAYMENT_PROVIDER = "kora"
@@ -97,6 +99,7 @@ id = "d610bc5eecd74c3586b0a13c73e995fb"
 ENVIRONMENT = "staging"
 API_VERSION = "v1"
 EMAIL_FROM = "noreply@mail.solana.org"
+# Set FRONTEND_URL and/or CLERK_INVITATION_REDIRECT_URL in Cloudflare for this environment.
 
 # Production environment
 [env.production]
@@ -128,3 +131,4 @@ id = "67fb59b197f84084b42d595cb058a722"
 ENVIRONMENT = "production"
 API_VERSION = "v1"
 EMAIL_FROM = "noreply@mail.solana.org"
+# Set FRONTEND_URL and/or CLERK_INVITATION_REDIRECT_URL in Cloudflare for this environment.

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -7,6 +7,15 @@ export const metadata: Metadata = {
   description: "SDP dashboard",
 };
 
+const clerkSignInUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || "/sign-in";
+const clerkSignUpUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || "/sign-up";
+const clerkSignInFallbackRedirectUrl =
+  process.env.NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL || "/dashboard";
+const clerkSignUpFallbackRedirectUrl =
+  process.env.NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL || "/dashboard";
+const clerkSignInForceRedirectUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL;
+const clerkSignUpForceRedirectUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -16,10 +25,12 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <ClerkProvider
-          signInUrl="/sign-in"
-          signUpUrl="/sign-up"
-          signInFallbackRedirectUrl="/dashboard"
-          signUpFallbackRedirectUrl="/dashboard"
+          signInUrl={clerkSignInUrl}
+          signUpUrl={clerkSignUpUrl}
+          signInFallbackRedirectUrl={clerkSignInFallbackRedirectUrl}
+          signUpFallbackRedirectUrl={clerkSignUpFallbackRedirectUrl}
+          signInForceRedirectUrl={clerkSignInForceRedirectUrl}
+          signUpForceRedirectUrl={clerkSignUpForceRedirectUrl}
         >
           {children}
         </ClerkProvider>

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -1,4 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
+import { headers as nextHeaders } from "next/headers";
 
 function getApiBaseUrl(): string {
   const base =
@@ -38,15 +39,41 @@ async function getClerkToken(): Promise<string> {
 
 type SdpApiRequestFn = (path: string, options?: RequestInit) => Promise<Response>;
 
+async function resolveSdpWebOrigin(): Promise<string | undefined> {
+  try {
+    const requestHeaders = await nextHeaders();
+    const forwardedHost = requestHeaders.get("x-forwarded-host");
+    const host = forwardedHost || requestHeaders.get("host");
+
+    if (host) {
+      const forwardedProto = requestHeaders.get("x-forwarded-proto");
+      const isLocal = host.startsWith("localhost") || host.startsWith("127.0.0.1");
+      const protocol = forwardedProto || (isLocal ? "http" : "https");
+      return `${protocol}://${host}`;
+    }
+  } catch {
+    // Request headers may be unavailable in some server-only execution paths.
+  }
+
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) {
+    return `https://${vercelUrl}`;
+  }
+
+  return undefined;
+}
+
 function createSdpApiRequest(token: string): SdpApiRequestFn {
   return async (path: string, options: RequestInit = {}): Promise<Response> => {
     const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+    const webOrigin = await resolveSdpWebOrigin();
 
     return fetch(url, {
       ...options,
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
+        ...(webOrigin ? { "X-SDP-Web-Origin": webOrigin } : {}),
         ...(options.headers || {}),
       },
       cache: "no-store",


### PR DESCRIPTION
## Summary
- Parameterize Clerk auth routes/redirects in `apps/sdp-web` via env-backed config.
- Make member invitations fully Clerk-native in `apps/sdp-api`:
  - keep `POST /v1/members/invite` using Clerk organization invitations
  - remove legacy token-based acceptance flow (`POST /v1/members/accept`)
  - remove local invitation-token generation/acceptance handling in members handlers
- Simplify Clerk membership reconciliation to rely on Clerk org role mapping instead of local pending-invitation tokens.
- Add dynamic preview redirect support for invite links:
  - `sdp-web` forwards active web origin to API via `X-SDP-Web-Origin`
  - `sdp-api` validates and uses allowed preview origins for Clerk invite `redirect_url`
  - fallback remains `CLERK_INVITATION_REDIRECT_URL` / `FRONTEND_URL`

## Env / Config
- Web envs (Vercel):
  - `NEXT_PUBLIC_CLERK_SIGN_IN_URL`
  - `NEXT_PUBLIC_CLERK_SIGN_UP_URL`
  - `NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL`
  - `NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL`
- API envs (Cloudflare):
  - `CLERK_INVITATION_REDIRECT_URL`
  - `FRONTEND_URL`
  - `CLERK_INVITATION_REDIRECT_ALLOWED_HOST_SUFFIXES` (for preview host allowlist)

## OpenAPI Changes
- Removed `/v1/members/accept` path.
- Updated invite response schema to Clerk-oriented invitation payload fields.

## Validation
- `pnpm -C apps/sdp-web typecheck` ✅
- `pnpm -C apps/sdp-web exec eslint src/app/layout.tsx` ✅
- `pnpm -C apps/sdp-web exec eslint src/lib/sdp-api.ts` ✅
- `pnpm -C apps/sdp-api exec biome check src/routes/members/handlers.ts src/routes/members/index.ts src/routes/members/schemas.ts src/middleware/clerk-auth.ts src/openapi/paths/members.ts src/openapi/schemas/organizations.ts` ✅
- `pnpm -C apps/sdp-api typecheck` ❌ (pre-existing unrelated issuance/token errors)

## Deployment Notes
- Cloudflare `dev` worker deployed for testing:
  - `https://sdp-api-dev.solana.workers.dev`
  - Version `83b49748-ece3-4c73-8e4d-bd8783235105`
- Cloudflare secrets set for `dev`/`staging`/`production`:
  - `CLERK_INVITATION_REDIRECT_ALLOWED_HOST_SUFFIXES=-solana-foundation.vercel.app`
