### PR TITLE
Fix wallets page permissions for onboarded org members

### DIFF
--- a/apps/sdp-api/src/routes/custody/index.ts
+++ b/apps/sdp-api/src/routes/custody/index.ts
@@ -29,8 +29,8 @@ wallets.post("/", requirePermissions("custody:admin"), createWallet);
 wallets.post("/default-wallet", requirePermissions("custody:admin"), setDefaultWallet);
 
 // Read configuration and wallets
-wallets.get("/config", requirePermissions("custody:read"), getConfig);
-wallets.get("/", requirePermissions("custody:read"), listWallets);
-wallets.get("/public-key", requirePermissions("custody:read"), getPublicKey);
+wallets.get("/config", requirePermissions("wallets:read"), getConfig);
+wallets.get("/", requirePermissions("wallets:read"), listWallets);
+wallets.get("/public-key", requirePermissions("wallets:read"), getPublicKey);
 
 export default wallets;


### PR DESCRIPTION
## Summary
- fix a permission mismatch that blocked newly onboarded org members from loading the Wallets page
- update custody read endpoints to require `wallets:read` instead of `custody:read`
- keep mutating custody endpoints on `custody:admin`

## Root Cause
- org roles (developer/viewer) include `wallets:read`
- wallets page calls `/v1/wallets/config`, `/v1/wallets`, and `/v1/wallets/public-key`
- those endpoints were guarded by `custody:read`, causing `INSUFFICIENT_PERMISSIONS` for valid org members

## Files Changed
- `apps/sdp-api/src/routes/custody/index.ts`

## Validation
- `pnpm -C apps/sdp-api exec biome check src/routes/custody/index.ts` ✅
