### PR TITLE
fix(api): use org-aware rpc target for wallet signer check

### DIFF
--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -7,8 +7,14 @@ import { created, success } from "@/lib/response";
 import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { createSigningService } from "@/services/domain/signing.service";
 import { FeePaymentError, SigningError } from "@/services/ports";
+import { resolveRpcTarget } from "@/services/rpc-relay.service";
 import { createOrgSigner } from "@/services/solana";
-import { confirmTransaction, createRpc, getRecentBlockhash } from "@/services/solana/rpc";
+import {
+  type RpcClientOptions,
+  confirmTransaction,
+  createRpc,
+  getRecentBlockhash,
+} from "@/services/solana/rpc";
 import type { Env } from "@/types/env";
 import type { Address } from "@solana/kit";
 import {
@@ -516,7 +522,20 @@ export const signerCheck = async (c: AppContext) => {
 
     const feePayment = createFeePaymentAdapter(c.env);
     const feePayer = await feePayment.getFeePayer();
-    const rpc = createRpc(c.env);
+
+    const rpcTarget = await resolveRpcTarget({
+      env: c.env,
+      db: c.env.DB,
+      organizationId: apiKey.organizationId,
+      authProjectId: apiKey.projectId ?? null,
+      requestedProjectId: null,
+    });
+
+    const rpc = createRpc(c.env, {
+      rpcUrl: rpcTarget.endpoint,
+      headers: rpcTarget.headers as RpcClientOptions["headers"],
+    });
+
     const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");
 
     const memoInstruction = {

--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -9,12 +9,7 @@ import { createSigningService } from "@/services/domain/signing.service";
 import { FeePaymentError, SigningError } from "@/services/ports";
 import { resolveRpcTarget } from "@/services/rpc-relay.service";
 import { createOrgSigner } from "@/services/solana";
-import {
-  type RpcClientOptions,
-  confirmTransaction,
-  createRpc,
-  getRecentBlockhash,
-} from "@/services/solana/rpc";
+import { confirmTransaction, createRpc, getRecentBlockhash } from "@/services/solana/rpc";
 import type { Env } from "@/types/env";
 import type { Address } from "@solana/kit";
 import {
@@ -533,7 +528,7 @@ export const signerCheck = async (c: AppContext) => {
 
     const rpc = createRpc(c.env, {
       rpcUrl: rpcTarget.endpoint,
-      headers: rpcTarget.headers as RpcClientOptions["headers"],
+      headers: rpcTarget.headers,
     });
 
     const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(rpc, "confirmed");

--- a/apps/sdp-api/src/services/solana/rpc.ts
+++ b/apps/sdp-api/src/services/solana/rpc.ts
@@ -41,10 +41,50 @@ export interface SimulationResult {
 }
 
 type SolanaRpcConfig = NonNullable<Parameters<typeof createSolanaRpc>[1]>;
+type AllowedSolanaRpcHeaders = NonNullable<SolanaRpcConfig["headers"]>;
 
 export interface RpcClientOptions {
   rpcUrl?: string;
-  headers?: SolanaRpcConfig["headers"];
+  headers?: Readonly<Record<string, string>>;
+}
+
+const DISALLOWED_RPC_HEADERS = new Set([
+  "accept",
+  "accept-charset",
+  "access-control-request-headers",
+  "access-control-request-method",
+  "connection",
+  "content-length",
+  "content-type",
+  "cookie",
+  "date",
+  "dnt",
+  "expect",
+  "host",
+  "keep-alive",
+  "permissions-policy",
+  "referer",
+  "solana-client",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "via",
+]);
+
+function assertAllowedRpcHeaders(
+  headers: Readonly<Record<string, string>>
+): asserts headers is AllowedSolanaRpcHeaders {
+  for (const headerName of Object.keys(headers)) {
+    const normalizedHeaderName = headerName.toLowerCase();
+    if (
+      normalizedHeaderName.startsWith("proxy-") ||
+      normalizedHeaderName.startsWith("sec-") ||
+      DISALLOWED_RPC_HEADERS.has(normalizedHeaderName)
+    ) {
+      throw new Error(`Unsupported RPC header: ${headerName}`);
+    }
+  }
 }
 
 // Type for RPC client
@@ -62,6 +102,7 @@ export function createRpc(env: Env, options?: RpcClientOptions): SolanaRpc {
   const rpcUrl = options?.rpcUrl ?? config.rpcUrl;
 
   if (options?.headers && Object.keys(options.headers).length > 0) {
+    assertAllowedRpcHeaders(options.headers);
     return createSolanaRpc(rpcUrl, { headers: options.headers });
   }
 

--- a/apps/sdp-api/src/services/solana/rpc.ts
+++ b/apps/sdp-api/src/services/solana/rpc.ts
@@ -40,6 +40,13 @@ export interface SimulationResult {
   error: string | null;
 }
 
+type SolanaRpcConfig = NonNullable<Parameters<typeof createSolanaRpc>[1]>;
+
+export interface RpcClientOptions {
+  rpcUrl?: string;
+  headers?: SolanaRpcConfig["headers"];
+}
+
 // Type for RPC client
 type SolanaRpc = ReturnType<typeof createSolanaRpc>;
 
@@ -50,9 +57,15 @@ type SolanaRpc = ReturnType<typeof createSolanaRpc>;
 /**
  * Create a configured Solana RPC client from environment
  */
-export function createRpc(env: Env): SolanaRpc {
+export function createRpc(env: Env, options?: RpcClientOptions): SolanaRpc {
   const config = getSolanaConfig(env);
-  return createSolanaRpc(config.rpcUrl);
+  const rpcUrl = options?.rpcUrl ?? config.rpcUrl;
+
+  if (options?.headers && Object.keys(options.headers).length > 0) {
+    return createSolanaRpc(rpcUrl, { headers: options.headers });
+  }
+
+  return createSolanaRpc(rpcUrl);
 }
 
 /**


### PR DESCRIPTION
## Summary
- route `/v1/wallets/signer-check` RPC selection through `resolveRpcTarget`
- use the resolved endpoint + provider headers when building the Solana RPC client
- preserve existing fallback behavior while enabling managed-provider/round-robin selection for signer checks

## Why
Signer-check was using `SOLANA_RPC_URL` directly, which can fail when org/project RPC preference points to managed providers or when default endpoint auth differs.

## Validation
- `pnpm --filter @sdp/api typecheck`
- `pnpm exec biome check apps/sdp-api/src/routes/custody/handlers.ts apps/sdp-api/src/services/solana/rpc.ts`
