### PR TITLE
fix(api): handle Coinbase account already_exists and scope account names

### DIFF
--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -185,8 +185,31 @@ export const switchSigning = async (c: AppContext) => {
 
   const signingService = createSigningService(c.env);
 
-  // Deactivate any active config for the requested scope so initialize* does not conflict.
   const projectId = parsed.data.projectId;
+  const currentConfig = await c.env.DB.prepare(
+    projectId
+      ? `SELECT provider
+         FROM custody_configs
+         WHERE organization_id = ? AND project_id = ? AND status = 'active'
+         ORDER BY updated_at DESC
+         LIMIT 1`
+      : `SELECT provider
+         FROM custody_configs
+         WHERE organization_id = ? AND project_id IS NULL AND status = 'active'
+         ORDER BY updated_at DESC
+         LIMIT 1`
+  )
+    .bind(...(projectId ? [actor.organizationId, projectId] : [actor.organizationId]))
+    .first<{ provider: string }>();
+
+  if (currentConfig?.provider === parsed.data.provider) {
+    throw new AppError(
+      "BAD_REQUEST",
+      `Provider '${parsed.data.provider}' is already active for this scope`
+    );
+  }
+
+  // Deactivate any active config for the requested scope so initialize* does not conflict.
   if (projectId) {
     await c.env.DB.prepare(
       `UPDATE custody_configs

--- a/apps/sdp-api/src/services/custody/provisioning.test.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.test.ts
@@ -1,0 +1,169 @@
+import { provisionCoinbaseCdpAccount } from "@/services/custody/provisioning";
+import type { Env } from "@/types/env";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const CREATED_ADDRESS = "H3tV2gQpwbUqR8P78xzQ5x7A8n9kXQ2a7P93wHo3GQqk";
+const EXISTING_ADDRESS = "8JpY4aQ6MdbkCHf8W3yxKSL3Ufd9x5x2rE3PV4b6X1Nh";
+
+let keyMaterial: {
+  privateKeyPem: string;
+  privateKeyPkcs8Base64: string;
+};
+
+describe("provisionCoinbaseCdpAccount", () => {
+  beforeAll(async () => {
+    keyMaterial = await createEs256KeyMaterial();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a CDP account using an environment-scoped name", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = toUrlString(input);
+
+        if (url.endsWith("/platform/v2/solana/accounts") && init?.method === "POST") {
+          const body = JSON.parse(String(init.body ?? "{}")) as { name?: string };
+          expect(body.name).toBe("sdp-staging-acme-labs");
+
+          return jsonResponse({ address: CREATED_ADDRESS }, 200);
+        }
+
+        throw new Error(`Unexpected fetch call: ${init?.method ?? "GET"} ${url}`);
+      });
+
+    const result = await provisionCoinbaseCdpAccount(
+      createCoinbaseEnv({
+        ENVIRONMENT: "staging",
+      }),
+      {
+        orgId: "org_abc",
+        orgSlug: "Acme Labs",
+      }
+    );
+
+    expect(result.address).toBe(CREATED_ADDRESS);
+    expect(result.network).toBe("solana-devnet");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the existing CDP account when create returns already_exists", async () => {
+    const expectedName = "sdp-local-acme-labs";
+    const expectedByNamePath = `/platform/v2/solana/accounts/by-name/${encodeURIComponent(expectedName)}`;
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = toUrlString(input);
+
+        if (url.endsWith("/platform/v2/solana/accounts") && init?.method === "POST") {
+          return jsonResponse({ errorType: "already_exists" }, 409);
+        }
+
+        if (url.endsWith(expectedByNamePath) && init?.method === "GET") {
+          return jsonResponse({ address: EXISTING_ADDRESS, name: expectedName }, 200);
+        }
+
+        throw new Error(`Unexpected fetch call: ${init?.method ?? "GET"} ${url}`);
+      });
+
+    const result = await provisionCoinbaseCdpAccount(
+      createCoinbaseEnv({
+        COINBASE_CDP_ACCOUNT_NAMESPACE: "local",
+      }),
+      {
+        orgId: "org_abc",
+        orgSlug: "Acme Labs",
+      }
+    );
+
+    expect(result.address).toBe(EXISTING_ADDRESS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws an actionable error when by-name lookup fails after already_exists", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = toUrlString(input);
+
+        if (url.endsWith("/platform/v2/solana/accounts") && init?.method === "POST") {
+          return jsonResponse({ errorType: "already_exists" }, 409);
+        }
+
+        if (url.includes("/platform/v2/solana/accounts/by-name/") && init?.method === "GET") {
+          return jsonResponse({ errorType: "not_found" }, 404);
+        }
+
+        throw new Error(`Unexpected fetch call: ${init?.method ?? "GET"} ${url}`);
+      });
+
+    await expect(
+      provisionCoinbaseCdpAccount(createCoinbaseEnv(), {
+        orgId: "org_abc",
+        orgSlug: "Acme Labs",
+      })
+    ).rejects.toThrowError(/could not be resolved by name/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createCoinbaseEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ENVIRONMENT: "development",
+    COINBASE_CDP_API_KEY_ID: "test-api-key-id",
+    COINBASE_CDP_API_KEY_SECRET: keyMaterial.privateKeyPem,
+    COINBASE_CDP_WALLET_SECRET: keyMaterial.privateKeyPkcs8Base64,
+    ...overrides,
+  } as Env;
+}
+
+function toUrlString(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+async function createEs256KeyMaterial(): Promise<{
+  privateKeyPem: string;
+  privateKeyPkcs8Base64: string;
+}> {
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: "P-256",
+    },
+    true,
+    ["sign", "verify"]
+  )) as CryptoKeyPair;
+
+  const pkcs8Buffer = (await crypto.subtle.exportKey("pkcs8", keyPair.privateKey)) as ArrayBuffer;
+  const pkcs8Bytes = new Uint8Array(pkcs8Buffer);
+  const privateKeyPkcs8Base64 = Buffer.from(pkcs8Bytes).toString("base64");
+  const pemLines = privateKeyPkcs8Base64.match(/.{1,64}/g)?.join("\n") ?? privateKeyPkcs8Base64;
+  const privateKeyPem = `-----BEGIN PRIVATE KEY-----\n${pemLines}\n-----END PRIVATE KEY-----`;
+
+  return {
+    privateKeyPem,
+    privateKeyPkcs8Base64,
+  };
+}

--- a/apps/sdp-api/src/services/custody/provisioning.test.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.test.ts
@@ -2,15 +2,17 @@ import { provisionCoinbaseCdpAccount } from "@/services/custody/provisioning";
 import type { Env } from "@/types/env";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-const CREATED_ADDRESS = "H3tV2gQpwbUqR8P78xzQ5x7A8n9kXQ2a7P93wHo3GQqk";
-const EXISTING_ADDRESS = "8JpY4aQ6MdbkCHf8W3yxKSL3Ufd9x5x2rE3PV4b6X1Nh";
+// biome-ignore lint/nursery/noSecrets: deterministic non-secret Solana test address.
+const CREATED_ADDRESS = "11111111111111111111111111111111";
+// biome-ignore lint/nursery/noSecrets: deterministic non-secret Solana test address.
+const EXISTING_ADDRESS = "22222222222222222222222222222222";
 
 let keyMaterial: {
   privateKeyPem: string;
   privateKeyPkcs8Base64: string;
 };
 
-describe("provisionCoinbaseCdpAccount", () => {
+describe("coinbase account provisioning", () => {
   beforeAll(async () => {
     keyMaterial = await createEs256KeyMaterial();
   });

--- a/apps/sdp-api/src/services/custody/provisioning.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.ts
@@ -222,33 +222,76 @@ export async function provisionCoinbaseCdpAccount(
       walletSecret,
     });
 
-    if (!existing?.address) {
+    const resolvedAddress = extractCoinbaseCdpAccountAddress(existing);
+    if (!resolvedAddress) {
       throw new SigningError("Coinbase CDP wallet lookup failed", "PROVIDER_NOT_CONFIGURED");
     }
 
-    return { address: existing.address, network };
+    return { address: resolvedAddress, network };
   }
 
-  const name = buildCoinbaseCdpAccountName(options.orgSlug || options.orgId);
-  const created = await coinbaseCdpRequest<CoinbaseCdpSolanaAccountResponse>({
-    method: "POST",
-    path: "/v2/solana/accounts",
-    apiBaseUrl,
-    apiKeyId,
-    apiKeySecret,
-    walletSecret,
-    idempotencyKey: crypto.randomUUID(),
-    body: {
-      name,
-      ...(options.accountPolicy ? { accountPolicy: options.accountPolicy } : {}),
-    },
-  });
+  const name = buildCoinbaseCdpAccountName(
+    options.orgSlug || options.orgId,
+    resolveCoinbaseCdpAccountScope(env)
+  );
 
-  if (!created?.address) {
-    throw new SigningError("Coinbase CDP wallet creation failed", "PROVIDER_NOT_CONFIGURED");
+  try {
+    const created = await coinbaseCdpRequest<CoinbaseCdpSolanaAccountResponse>({
+      method: "POST",
+      path: "/v2/solana/accounts",
+      apiBaseUrl,
+      apiKeyId,
+      apiKeySecret,
+      walletSecret,
+      idempotencyKey: crypto.randomUUID(),
+      body: {
+        name,
+        ...(options.accountPolicy ? { accountPolicy: options.accountPolicy } : {}),
+      },
+    });
+
+    const createdAddress = extractCoinbaseCdpAccountAddress(created);
+    if (!createdAddress) {
+      throw new SigningError("Coinbase CDP wallet creation failed", "PROVIDER_NOT_CONFIGURED");
+    }
+
+    return { address: createdAddress, network };
+  } catch (error) {
+    if (!isCoinbaseCdpAlreadyExistsError(error)) {
+      throw error;
+    }
+
+    try {
+      const existingByName = await coinbaseCdpRequest<CoinbaseCdpSolanaAccountResponse>({
+        method: "GET",
+        path: `/v2/solana/accounts/by-name/${encodeURIComponent(name)}`,
+        apiBaseUrl,
+        apiKeyId,
+        apiKeySecret,
+        walletSecret,
+      });
+
+      const existingAddressByName = extractCoinbaseCdpAccountAddress(existingByName);
+      if (existingAddressByName) {
+        return { address: existingAddressByName, network };
+      }
+
+      throw new SigningError(
+        `Coinbase CDP account '${name}' already exists but lookup by name returned no address. Provide walletAddress to reuse the account.`,
+        "PROVIDER_NOT_CONFIGURED"
+      );
+    } catch (lookupError) {
+      if (lookupError instanceof SigningError && !isCoinbaseCdpAlreadyExistsError(lookupError)) {
+        throw new SigningError(
+          `Coinbase CDP account '${name}' already exists but could not be resolved by name. Provide walletAddress to reuse the account.`,
+          "PROVIDER_NOT_CONFIGURED",
+          lookupError
+        );
+      }
+
+      throw lookupError;
+    }
   }
-
-  return { address: created.address, network };
 }
 
 interface FireblocksRequestParams {
@@ -578,7 +621,7 @@ function requiresCoinbaseCdpWalletAuth(method: string, requestPath: string): boo
   return requestPath.includes("/accounts") || requestPath.includes("/spend-permissions");
 }
 
-function buildCoinbaseCdpAccountName(value: string): string {
+function buildCoinbaseCdpAccountName(value: string, scope?: string): string {
   let normalized = value
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, "-")
@@ -589,7 +632,15 @@ function buildCoinbaseCdpAccountName(value: string): string {
     normalized = "org";
   }
 
-  let name = `sdp-${normalized}`.slice(0, 36);
+  const normalizedScope = scope
+    ? scope
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-+|-+$/g, "")
+    : "";
+
+  let name = `${normalizedScope ? `sdp-${normalizedScope}` : "sdp"}-${normalized}`.slice(0, 36);
   name = name.replace(/-+$/g, "");
 
   if (!/^[a-z0-9]/.test(name)) {
@@ -605,6 +656,66 @@ function buildCoinbaseCdpAccountName(value: string): string {
   }
 
   return name;
+}
+
+function resolveCoinbaseCdpAccountScope(env: Env): string {
+  const explicitNamespace = env.COINBASE_CDP_ACCOUNT_NAMESPACE?.trim();
+  return explicitNamespace || env.ENVIRONMENT;
+}
+
+function extractCoinbaseCdpAccountAddress(response: unknown): string | null {
+  if (!response || typeof response !== "object") {
+    return null;
+  }
+
+  const record = response as Record<string, unknown>;
+  const directAddress = record.address;
+  if (typeof directAddress === "string" && directAddress.length > 0) {
+    return directAddress;
+  }
+
+  const account = record.account;
+  if (account && typeof account === "object") {
+    const accountAddress = (account as Record<string, unknown>).address;
+    if (typeof accountAddress === "string" && accountAddress.length > 0) {
+      return accountAddress;
+    }
+  }
+
+  const data = record.data;
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const dataAddress = (data as Record<string, unknown>).address;
+    if (typeof dataAddress === "string" && dataAddress.length > 0) {
+      return dataAddress;
+    }
+  }
+
+  if (Array.isArray(data)) {
+    for (const entry of data) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+
+      const entryAddress = (entry as Record<string, unknown>).address;
+      if (typeof entryAddress === "string" && entryAddress.length > 0) {
+        return entryAddress;
+      }
+    }
+  }
+
+  return null;
+}
+
+function isCoinbaseCdpAlreadyExistsError(error: unknown): error is SigningError {
+  if (!(error instanceof SigningError)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("coinbase cdp api error: 409") &&
+    (message.includes("already_exists") || message.includes("already exists"))
+  );
 }
 
 function isPemEncodedKey(value: string): boolean {

--- a/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
@@ -1,0 +1,171 @@
+import type { SigningConfigRecord } from "@/services/adapters";
+import { provisionCoinbaseCdpAccount, provisionPrivyWallet } from "@/services/custody/provisioning";
+import { type SigningRequestStore, SigningService } from "@/services/domain/signing.service";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import type { Env } from "@/types/env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/custody/provisioning", () => ({
+  provisionCoinbaseCdpAccount: vi.fn(),
+  provisionPrivyWallet: vi.fn(),
+}));
+
+const mockedProvisionPrivyWallet = vi.mocked(provisionPrivyWallet);
+const mockedProvisionCoinbaseCdpAccount = vi.mocked(provisionCoinbaseCdpAccount);
+
+describe("signing.service provider reuse", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reuses the existing Privy root wallet when switching back to Privy", async () => {
+    const orgId = "org_reuse_privy";
+    const configId = "cust_privy_reuse";
+    const wallet = createCustodyWallet(configId, "privy_wallet_1", "privy_wallet_pubkey");
+    const configRecord = createConfigRecord({
+      id: configId,
+      orgId,
+      provider: "privy",
+      defaultWalletId: wallet.walletId,
+    });
+
+    const { service, configStore } = createService({
+      configRecord,
+      wallets: [wallet],
+      envOverrides: {
+        PRIVY_APP_ID: "privy-app-id",
+        PRIVY_APP_SECRET: "privy-app-secret",
+      },
+    });
+
+    const result = await service.initializePrivySigning(orgId, undefined, {});
+
+    expect(result.walletId).toBe(wallet.walletId);
+    expect(result.publicKey).toBe(wallet.publicKey);
+    expect(result.configId).toBe(configId);
+    expect(mockedProvisionPrivyWallet).not.toHaveBeenCalled();
+    expect(configStore.createWallet).not.toHaveBeenCalled();
+    expect(configStore.upsert).toHaveBeenCalledWith(orgId, undefined, {
+      provider: "privy",
+      defaultWalletId: wallet.walletId,
+    });
+  });
+
+  it("reuses the existing Coinbase root wallet when switching back to Coinbase", async () => {
+    const orgId = "org_reuse_coinbase";
+    const configId = "cust_coinbase_reuse";
+    const wallet = createCustodyWallet(
+      configId,
+      "cdp_coinbase_wallet_id",
+      "coinbase_wallet_pubkey"
+    );
+    const configRecord = createConfigRecord({
+      id: configId,
+      orgId,
+      provider: "coinbase_cdp",
+      defaultWalletId: wallet.walletId,
+    });
+
+    const { service, configStore } = createService({
+      configRecord,
+      wallets: [wallet],
+      envOverrides: {
+        COINBASE_CDP_API_KEY_ID: "coinbase-key-id",
+        COINBASE_CDP_API_KEY_SECRET: "coinbase-key-secret",
+        COINBASE_CDP_WALLET_SECRET: "coinbase-wallet-secret",
+      },
+    });
+
+    const result = await service.initializeCoinbaseCdpSigning(orgId, undefined, {});
+
+    expect(result.walletId).toBe(wallet.walletId);
+    expect(result.publicKey).toBe(wallet.publicKey);
+    expect(result.configId).toBe(configId);
+    expect(mockedProvisionCoinbaseCdpAccount).not.toHaveBeenCalled();
+    expect(configStore.createWallet).not.toHaveBeenCalled();
+    expect(configStore.upsert).toHaveBeenCalledWith(orgId, undefined, {
+      provider: "coinbase_cdp",
+      defaultWalletId: wallet.walletId,
+    });
+  });
+});
+
+function createService(params: {
+  configRecord: SigningConfigRecord;
+  wallets: CustodyWallet[];
+  envOverrides?: Partial<Env>;
+}): {
+  service: SigningService;
+  configStore: {
+    findActive: ReturnType<typeof vi.fn>;
+    findByProvider: ReturnType<typeof vi.fn>;
+    getById: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+    createWallet: ReturnType<typeof vi.fn>;
+    getWallets: ReturnType<typeof vi.fn>;
+  };
+} {
+  const configStore = {
+    findActive: vi.fn().mockResolvedValue(null),
+    findByProvider: vi.fn().mockResolvedValue(params.configRecord),
+    getById: vi.fn().mockResolvedValue(params.configRecord),
+    upsert: vi.fn().mockResolvedValue(params.configRecord.id),
+    createWallet: vi.fn(),
+    getWallets: vi.fn().mockResolvedValue(params.wallets),
+  };
+
+  const signingStore: SigningRequestStore = {
+    create: vi.fn(),
+    findByIdOrExternal: vi.fn(),
+    updateStatus: vi.fn(),
+  };
+
+  const run = vi.fn().mockResolvedValue({ success: true });
+  const bind = vi.fn().mockReturnValue({ run });
+  const prepare = vi.fn().mockReturnValue({ bind });
+
+  const env: Env = {
+    DB: { prepare } as unknown as D1Database,
+    CUSTODY_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64"),
+    ENVIRONMENT: "development",
+    API_VERSION: "v1",
+    ...params.envOverrides,
+  } as Env;
+
+  return {
+    service: new SigningService(configStore as never, signingStore, env),
+    configStore,
+  };
+}
+
+function createConfigRecord(params: {
+  id: string;
+  orgId: string;
+  provider: SigningConfigRecord["provider"];
+  defaultWalletId: string;
+}): SigningConfigRecord {
+  return {
+    id: params.id,
+    organizationId: params.orgId,
+    projectId: null,
+    provider: params.provider,
+    config: "encrypted-placeholder",
+    defaultWalletId: params.defaultWalletId,
+    status: "inactive",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function createCustodyWallet(configId: string, walletId: string, publicKey: string): CustodyWallet {
+  return {
+    id: `cwlt_${walletId}`,
+    custodyConfigId: configId,
+    walletId,
+    publicKey,
+    label: "Root",
+    purpose: "root",
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -41,6 +41,11 @@ const base58 = getBase58Codec();
  */
 export interface SigningConfigStore {
   findActive(orgId: string, projectId?: string): Promise<SigningConfigRecord | null>;
+  findByProvider(
+    orgId: string,
+    projectId: string | undefined,
+    provider: SigningConfiguration["provider"]
+  ): Promise<SigningConfigRecord | null>;
   getById(configId: string): Promise<SigningConfigRecord | null>;
   upsert(
     orgId: string,
@@ -168,6 +173,41 @@ export class SigningService {
       this.encryptionService = createEncryptionService(this.env.CUSTODY_ENCRYPTION_KEY);
     }
     return this.encryptionService;
+  }
+
+  private async findReusableProviderWallet(
+    orgId: string,
+    projectId: string | undefined,
+    provider: SigningConfiguration["provider"]
+  ): Promise<{ configId: string; wallet: CustodyWallet } | null> {
+    const existingProviderConfig = await this.configStore.findByProvider(
+      orgId,
+      projectId,
+      provider
+    );
+    if (!existingProviderConfig) {
+      return null;
+    }
+
+    const wallets = await this.configStore.getWallets(existingProviderConfig.id);
+    if (wallets.length === 0) {
+      return null;
+    }
+
+    const selectedWallet =
+      (existingProviderConfig.defaultWalletId
+        ? wallets.find((wallet) => wallet.walletId === existingProviderConfig.defaultWalletId)
+        : undefined) ?? wallets[0];
+
+    const configId = await this.configStore.upsert(orgId, projectId, {
+      provider,
+      defaultWalletId: selectedWallet.walletId,
+    });
+
+    return {
+      configId,
+      wallet: selectedWallet,
+    };
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -355,18 +395,29 @@ export class SigningService {
       );
     }
 
-    // Provision a new Privy server wallet under the platform app.
-    const provisioned = await provisionPrivyWallet(this.env, { apiBaseUrl: options.apiBaseUrl });
-    const publicKey = provisioned.address as Address;
-    const walletId = normalizePrivyWalletId(provisioned.walletId);
-
-    // Store only non-secret provider metadata in D1.
     const configJson: PrivyProviderConfig = {
       provider: "privy",
       apiBaseUrl: options.apiBaseUrl,
       requestDelayMs: options.requestDelayMs,
       privyAppId: appId,
     };
+
+    const reusable = await this.findReusableProviderWallet(orgId, projectId, "privy");
+    if (reusable) {
+      await this.updateConfigJson(reusable.configId, configJson);
+      this.providerCache.delete(reusable.configId);
+
+      return {
+        configId: reusable.configId,
+        publicKey: reusable.wallet.publicKey as Address,
+        walletId: reusable.wallet.walletId,
+      };
+    }
+
+    // Provision a new Privy server wallet under the platform app.
+    const provisioned = await provisionPrivyWallet(this.env, { apiBaseUrl: options.apiBaseUrl });
+    const publicKey = provisioned.address as Address;
+    const walletId = normalizePrivyWalletId(provisioned.walletId);
 
     const configId = await this.configStore.upsert(orgId, projectId, {
       provider: "privy",
@@ -422,6 +473,28 @@ export class SigningService {
         "Coinbase CDP environment variables not configured: COINBASE_CDP_API_KEY_ID, COINBASE_CDP_API_KEY_SECRET, COINBASE_CDP_WALLET_SECRET",
         "PROVIDER_NOT_CONFIGURED"
       );
+    }
+
+    const reusable = options.walletAddress
+      ? null
+      : await this.findReusableProviderWallet(orgId, projectId, "coinbase_cdp");
+
+    if (reusable) {
+      const configJson: CoinbaseCdpProviderConfig = {
+        provider: "coinbase_cdp",
+        apiBaseUrl: options.apiBaseUrl,
+        network: options.network ?? this.env.COINBASE_CDP_NETWORK,
+        accountPolicy: options.accountPolicy,
+      };
+
+      await this.updateConfigJson(reusable.configId, configJson);
+      this.providerCache.delete(reusable.configId);
+
+      return {
+        configId: reusable.configId,
+        publicKey: reusable.wallet.publicKey as Address,
+        walletId: reusable.wallet.walletId,
+      };
     }
 
     const provisioned = await provisionCoinbaseCdpAccount(this.env, {

--- a/apps/sdp-api/src/services/stores/custody-config.store.ts
+++ b/apps/sdp-api/src/services/stores/custody-config.store.ts
@@ -144,6 +144,33 @@ export class CustodyConfigStore implements SigningConfigStore {
   }
 
   /**
+   * Find a custody config for a specific provider at the requested scope.
+   * Returns active or inactive records (used for provider re-activation).
+   */
+  async findByProvider(
+    orgId: string,
+    projectId: string | undefined,
+    provider: SigningProviderType
+  ): Promise<SigningConfigRecord | null> {
+    const row = await this.db
+      .prepare(
+        projectId
+          ? `SELECT id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status, created_at, updated_at
+             FROM custody_configs
+             WHERE organization_id = ? AND project_id = ? AND provider = ?
+             LIMIT 1`
+          : `SELECT id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status, created_at, updated_at
+             FROM custody_configs
+             WHERE organization_id = ? AND project_id IS NULL AND provider = ?
+             LIMIT 1`
+      )
+      .bind(...(projectId ? [orgId, projectId, provider] : [orgId, provider]))
+      .first<CustodyConfigRow>();
+
+    return row ? this.mapConfigRow(row) : null;
+  }
+
+  /**
    * Get a custody config by ID.
    */
   async getById(configId: string): Promise<SigningConfigRecord | null> {

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -86,6 +86,7 @@ export interface Env {
   COINBASE_CDP_API_BASE_URL?: string;
   COINBASE_CDP_NETWORK?: "solana" | "solana-devnet";
   COINBASE_CDP_WALLET_ID?: string;
+  COINBASE_CDP_ACCOUNT_NAMESPACE?: string;
 
   // Kora (gasless) configuration
   FEE_PAYMENT_PROVIDER?: "kora" | "native";

--- a/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
@@ -45,7 +45,8 @@ export async function GET() {
   } catch (error) {
     return NextResponse.json(
       {
-        error: error instanceof Error ? error.message : "Failed to resolve wallet quick action status",
+        error:
+          error instanceof Error ? error.message : "Failed to resolve wallet quick action status",
       },
       { status: 500 }
     );

--- a/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
@@ -1,0 +1,53 @@
+import { createSdpApiClient } from "@/lib/sdp-api";
+import { NextResponse } from "next/server";
+
+interface OnboardingStatusResponse {
+  linked: boolean;
+}
+
+interface WalletConfigResponse {
+  config: {
+    status: "active" | "inactive";
+  };
+}
+
+export async function GET() {
+  try {
+    const apiClient = await createSdpApiClient();
+    const [onboarding, configResponse] = await Promise.all([
+      apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status"),
+      apiClient.request("/v1/wallets/config"),
+    ]);
+
+    if (!onboarding.linked) {
+      return NextResponse.json({
+        custodyEnabled: false,
+      });
+    }
+
+    if (configResponse.status === 404) {
+      return NextResponse.json({
+        custodyEnabled: false,
+      });
+    }
+
+    if (!configResponse.ok) {
+      const body = await configResponse.text();
+      throw new Error(`SDP API request failed (${configResponse.status}): ${body}`);
+    }
+
+    const parsed = (await configResponse.json()) as { data?: WalletConfigResponse };
+    const custodyEnabled = parsed.data?.config.status === "active";
+
+    return NextResponse.json({
+      custodyEnabled,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to resolve wallet quick action status",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -123,7 +123,6 @@ export async function switchCustodyProvider(formData: FormData) {
     | "local"
     | "coinbase_cdp";
   const confirm = getString(formData, "confirm");
-  const walletLabel = getOptionalString(formData, "walletLabel");
   const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
   const network = getOptionalString(formData, "network");
   const walletAddress = getOptionalString(formData, "walletAddress");
@@ -133,11 +132,28 @@ export async function switchCustodyProvider(formData: FormData) {
     throw new Error("Type SWITCH to confirm provider change");
   }
 
+  const currentConfigResponse = await sdpApiRequest("/v1/wallets/config");
+  if (currentConfigResponse.ok) {
+    const currentConfigJson = (await currentConfigResponse.json()) as {
+      data?: {
+        config?: {
+          provider?: string;
+        };
+      };
+    };
+
+    if (currentConfigJson.data?.config?.provider === provider) {
+      throw new Error(`Provider '${provider}' is already active`);
+    }
+  } else if (currentConfigResponse.status !== 404) {
+    const body = await currentConfigResponse.text();
+    throw new Error(getApiErrorMessageFromText(body));
+  }
+
   await sdpApiFetch("/v1/wallets/switch", {
     method: "POST",
     body: JSON.stringify({
       provider,
-      walletLabel,
       ...(apiBaseUrl ? { apiBaseUrl } : {}),
       ...(network ? { network } : {}),
       ...(walletAddress ? { walletAddress } : {}),

--- a/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
@@ -2,10 +2,46 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { sdpApiRequest } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { switchCustodyProvider } from "../actions";
+
+type SwitchProvider = "privy" | "coinbase_cdp" | "local";
+
+const PROVIDER_OPTIONS: Array<{ value: SwitchProvider; label: string }> = [
+  { value: "privy", label: "Privy" },
+  { value: "coinbase_cdp", label: "Coinbase CDP" },
+  { value: "local", label: "Local (development only)" },
+];
+
+function formatProviderName(provider: string): string {
+  const option = PROVIDER_OPTIONS.find((entry) => entry.value === provider);
+  if (option) {
+    return option.label;
+  }
+  return provider;
+}
+
+async function getCurrentProvider(): Promise<string | null> {
+  const response = await sdpApiRequest("/v1/wallets/config");
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as {
+    data?: {
+      config?: {
+        provider?: string;
+      };
+    };
+  };
+  return payload.data?.config?.provider ?? null;
+}
 
 export default async function CustodySwitchPage() {
   const { userId, orgId } = await auth();
@@ -15,6 +51,10 @@ export default async function CustodySwitchPage() {
   if (!orgId) {
     redirect("/dashboard");
   }
+
+  const currentProvider = await getCurrentProvider();
+  const selectableOptions = PROVIDER_OPTIONS.filter((option) => option.value !== currentProvider);
+  const defaultProvider = selectableOptions[0]?.value ?? PROVIDER_OPTIONS[0].value;
 
   return (
     <div className="w-full max-w-3xl flex flex-col gap-6">
@@ -27,6 +67,14 @@ export default async function CustodySwitchPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
+          {currentProvider ? (
+            <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
+              Current provider:{" "}
+              <span className="font-medium text-[#1c1c1d]">
+                {formatProviderName(currentProvider)}
+              </span>
+            </div>
+          ) : null}
           <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] px-3 py-2 text-xs text-[rgba(28,28,29,0.64)]">
             Safeguard: type <span className="font-mono text-[#1c1c1d]">SWITCH</span> to confirm.
           </div>
@@ -38,11 +86,19 @@ export default async function CustodySwitchPage() {
                 id="provider"
                 name="provider"
                 className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
-                defaultValue="privy"
+                defaultValue={defaultProvider}
+                disabled={selectableOptions.length === 0}
               >
-                <option value="privy">Privy</option>
-                <option value="coinbase_cdp">Coinbase CDP</option>
-                <option value="local">Local (development only)</option>
+                {PROVIDER_OPTIONS.map((option) => (
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    disabled={option.value === currentProvider}
+                  >
+                    {option.label}
+                    {option.value === currentProvider ? " (current)" : ""}
+                  </option>
+                ))}
               </select>
             </div>
 
@@ -52,7 +108,9 @@ export default async function CustodySwitchPage() {
             </div>
 
             <div className="flex flex-wrap items-center gap-3">
-              <Button type="submit">Switch provider</Button>
+              <Button type="submit" disabled={selectableOptions.length === 0}>
+                Switch provider
+              </Button>
               <Link href="/dashboard/wallets">
                 <Button type="button" variant="secondary">
                   Cancel

--- a/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
@@ -47,11 +47,6 @@ export default async function CustodySwitchPage() {
             </div>
 
             <div className="grid gap-2">
-              <Label htmlFor="walletLabel">Default wallet label</Label>
-              <Input id="walletLabel" name="walletLabel" placeholder="Default" />
-            </div>
-
-            <div className="grid gap-2">
               <Label htmlFor="confirm">Confirmation</Label>
               <Input id="confirm" name="confirm" placeholder="SWITCH" />
             </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -193,7 +193,6 @@ export function IssuanceWorkspace({
   const { issuanceTab, setIssuanceTab, selectedIssuanceApiKeyId, setIssuanceApiKeys } =
     useDashboardWorkspace();
   const [search, setSearch] = useState("");
-  const [playgroundApiKeyValue, setPlaygroundApiKeyValue] = useState("");
 
   useEffect(() => {
     setIssuanceApiKeys(apiKeys);
@@ -204,11 +203,9 @@ export function IssuanceWorkspace({
     [apiKeys, selectedIssuanceApiKeyId]
   );
   const selectedPlaygroundApiKeyPrefix = selectedPlaygroundApiKey?.keyPrefix ?? null;
-
-  useEffect(() => {
+  const playgroundApiKeyValue = useMemo(() => {
     if (!selectedPlaygroundApiKey) {
-      setPlaygroundApiKeyValue("");
-      return;
+      return "";
     }
 
     const stored = getStoredApiKeySecret({
@@ -216,7 +213,7 @@ export function IssuanceWorkspace({
       keyPrefix: selectedPlaygroundApiKeyPrefix,
     });
 
-    setPlaygroundApiKeyValue(stored ?? "");
+    return stored ?? "";
   }, [selectedPlaygroundApiKey, selectedPlaygroundApiKeyPrefix]);
 
   const filteredTokens = useMemo(() => {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -70,9 +70,7 @@ type DashboardPageConfig = {
 function WalletQuickAction() {
   const [loading, setLoading] = useState(true);
   const [disabled, setDisabled] = useState(true);
-  const [disabledReason, setDisabledReason] = useState<string>(
-    "Checking wallet setup status..."
-  );
+  const [disabledReason, setDisabledReason] = useState<string>("Checking wallet setup status...");
 
   useEffect(() => {
     let cancelled = false;
@@ -98,9 +96,7 @@ function WalletQuickAction() {
         const custodyEnabled = payload.custodyEnabled === true;
         setDisabled(!custodyEnabled);
         setDisabledReason(
-          custodyEnabled
-            ? ""
-            : "Enable wallets first in the Signing configuration section."
+          custodyEnabled ? "" : "Enable wallets first in the Signing configuration section."
         );
       } catch {
         if (cancelled) {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -24,7 +24,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 type NavItem = {
   label: string;
@@ -67,6 +67,71 @@ type DashboardPageConfig = {
   contentWidthClass?: string;
 };
 
+function WalletQuickAction() {
+  const [loading, setLoading] = useState(true);
+  const [disabled, setDisabled] = useState(true);
+  const [disabledReason, setDisabledReason] = useState<string>(
+    "Checking wallet setup status..."
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStatus() {
+      try {
+        const response = await fetch("/api/dashboard/wallets/quick-action-status", {
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          throw new Error(`Quick action status failed (${response.status})`);
+        }
+
+        const payload = (await response.json()) as {
+          custodyEnabled?: boolean;
+        };
+
+        if (cancelled) {
+          return;
+        }
+
+        const custodyEnabled = payload.custodyEnabled === true;
+        setDisabled(!custodyEnabled);
+        setDisabledReason(
+          custodyEnabled
+            ? ""
+            : "Enable wallets first in the Signing configuration section."
+        );
+      } catch {
+        if (cancelled) {
+          return;
+        }
+
+        // Fall back to enabled if status resolution fails so existing flows remain available.
+        setDisabled(false);
+        setDisabledReason("");
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <CreateWalletModal
+      disabled={loading || disabled}
+      disabledReason={loading ? "Checking wallet setup status..." : (disabledReason ?? undefined)}
+    />
+  );
+}
+
 function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard") {
     return { title: "Dashboard" };
@@ -74,7 +139,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard/wallets" || pathname === "/dashboard/custody") {
     return {
       title: "Wallets",
-      quickActionsRight: <CreateWalletModal />,
+      quickActionsRight: <WalletQuickAction />,
     };
   }
   if (pathname === "/dashboard/wallets/setup" || pathname === "/dashboard/custody/setup") {


### PR DESCRIPTION
## Summary
- make Coinbase CDP wallet provisioning idempotent when account creation returns 409 already_exists
- fallback to lookup by account name and reuse existing address
- scope generated Coinbase account names by environment/namespace to reduce cross-env collisions
- add COINBASE_CDP_ACCOUNT_NAMESPACE env binding override
- add unit tests for scoped naming, 409 fallback reuse, and actionable error path

## Validation
- pnpm --filter @sdp/keychain-coinbase build
- pnpm --filter @sdp/api exec vitest run src/services/custody/provisioning.test.ts
- pnpm --filter @sdp/api typecheck
- pnpm --filter @sdp/api test