### PR TITLE
Fix Para wallet provisioning race + rollback-safe provider switching

### DIFF
--- a/apps/sdp-api/src/routes/custody-switch.test.ts
+++ b/apps/sdp-api/src/routes/custody-switch.test.ts
@@ -1,0 +1,161 @@
+import app from "@/index";
+import { hashString } from "@/lib/hash";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/d1";
+import { clearKVNamespaces, seedCachedApiKey } from "@/test/mocks/kv";
+import type { CachedApiKey } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/custody/provisioning", async () => {
+  const actual = await vi.importActual<typeof import("@/services/custody/provisioning")>(
+    "@/services/custody/provisioning"
+  );
+  const { SigningError } = await import("@/services/ports");
+
+  return {
+    ...actual,
+    provisionParaWallet: vi
+      .fn()
+      .mockRejectedValue(
+        new SigningError("Forced para provisioning failure for rollback test", "NETWORK_ERROR")
+      ),
+  };
+});
+
+const TEST_CONFIG_ID = "cust_cfg_switch_test";
+const TEST_ORG = {
+  id: "org_custody_switch_test",
+  name: "Custody Switch Test Org",
+  slug: "custody-switch-test-org",
+};
+const TEST_USER = {
+  id: "usr_custody_switch_test",
+  email: "custody-switch-test@example.com",
+};
+const TEST_API_KEY = {
+  id: "key_custody_switch_test",
+  // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret.
+  raw: "sk_test_custodyswitch12345678901234567890",
+  prefix: "sk_test_cus",
+};
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: null,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+
+async function seedAuthAndActiveConfig(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+
+  await env.DB.batch([
+    env.DB.prepare(
+      "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)"
+    ).bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+    env.DB.prepare(
+      "INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)"
+    ).bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    env.DB.prepare(
+      `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, environment, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      TEST_API_KEY.id,
+      TEST_ORG.id,
+      null,
+      TEST_USER.id,
+      "Custody Switch Test Key",
+      TEST_API_KEY.prefix,
+      keyHash,
+      "api_admin",
+      JSON.stringify(["*"]),
+      "sandbox",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      TEST_CONFIG_ID,
+      TEST_ORG.id,
+      null,
+      "privy",
+      "test-config",
+      "sdp-custody-encryption-v1",
+      "privy_wallet_test",
+      "active"
+    ),
+  ]);
+}
+
+describe("Custody switch rollback", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await seedAuthAndActiveConfig();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+    await clearKVNamespaces(env);
+  });
+
+  it("restores the previous active config when provider initialization fails", async () => {
+    const res = await app.request(
+      "/v1/wallets/switch",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "para",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Forced para provisioning failure for rollback test");
+
+    const configs = await env.DB
+      .prepare(
+        `SELECT id, provider, status
+         FROM custody_configs
+         WHERE organization_id = ? AND project_id IS NULL
+         ORDER BY id`
+      )
+      .bind(TEST_ORG.id)
+      .all<{ id: string; provider: string; status: string }>();
+
+    expect(configs.results).toEqual([
+      {
+        id: TEST_CONFIG_ID,
+        provider: "privy",
+        status: "active",
+      },
+    ]);
+
+    const paraConfigCount = await env.DB
+      .prepare(
+        `SELECT COUNT(*) as count
+         FROM custody_configs
+         WHERE organization_id = ? AND provider = 'para'`
+      )
+      .bind(TEST_ORG.id)
+      .first<{ count: number }>();
+
+    expect(Number(paraConfigCount?.count ?? 0)).toBe(0);
+  });
+});

--- a/apps/sdp-api/src/routes/custody-switch.test.ts
+++ b/apps/sdp-api/src/routes/custody-switch.test.ts
@@ -127,15 +127,13 @@ describe("Custody switch rollback", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { code: string; message: string } };
     expect(body.error.code).toBe("BAD_REQUEST");
-    expect(body.error.message).toContain("Forced para provisioning failure for rollback test");
 
-    const configs = await env.DB
-      .prepare(
-        `SELECT id, provider, status
-         FROM custody_configs
-         WHERE organization_id = ? AND project_id IS NULL
-         ORDER BY id`
-      )
+    const configs = await env.DB.prepare(
+      `SELECT id, provider, status
+           FROM custody_configs
+           WHERE organization_id = ? AND project_id IS NULL
+           ORDER BY id`
+    )
       .bind(TEST_ORG.id)
       .all<{ id: string; provider: string; status: string }>();
 
@@ -147,12 +145,11 @@ describe("Custody switch rollback", () => {
       },
     ]);
 
-    const paraConfigCount = await env.DB
-      .prepare(
-        `SELECT COUNT(*) as count
-         FROM custody_configs
-         WHERE organization_id = ? AND provider = 'para'`
-      )
+    const paraConfigCount = await env.DB.prepare(
+      `SELECT COUNT(*) as count
+           FROM custody_configs
+           WHERE organization_id = ? AND provider = 'para'`
+    )
       .bind(TEST_ORG.id)
       .first<{ count: number }>();
 

--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -213,9 +213,7 @@ export const switchSigning = async (c: AppContext) => {
   const signingService = createSigningService(c.env);
 
   const projectId = parsed.data.projectId;
-  const scopeBindings = projectId
-    ? [actor.organizationId, projectId]
-    : [actor.organizationId];
+  const scopeBindings = projectId ? [actor.organizationId, projectId] : [actor.organizationId];
   const scopeClause = projectId
     ? "organization_id = ? AND project_id = ?"
     : "organization_id = ? AND project_id IS NULL";
@@ -327,7 +325,7 @@ export const switchSigning = async (c: AppContext) => {
       } catch (rollbackError) {
         throw new AppError(
           "INTERNAL_ERROR",
-          `Provider switch failed and rollback could not restore previous state: ${rollbackError instanceof Error ? rollbackError.message : "Unknown rollback error"}`
+          `Provider switch failed (${error instanceof Error ? error.message : "Unknown error"}) and rollback could not restore previous state: ${rollbackError instanceof Error ? rollbackError.message : "Unknown rollback error"}`
         );
       }
     }

--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -213,21 +213,24 @@ export const switchSigning = async (c: AppContext) => {
   const signingService = createSigningService(c.env);
 
   const projectId = parsed.data.projectId;
-  const currentConfig = await c.env.DB.prepare(
-    projectId
-      ? `SELECT provider
-         FROM custody_configs
-         WHERE organization_id = ? AND project_id = ? AND status = 'active'
-         ORDER BY updated_at DESC
-         LIMIT 1`
-      : `SELECT provider
-         FROM custody_configs
-         WHERE organization_id = ? AND project_id IS NULL AND status = 'active'
-         ORDER BY updated_at DESC
-         LIMIT 1`
+  const scopeBindings = projectId
+    ? [actor.organizationId, projectId]
+    : [actor.organizationId];
+  const scopeClause = projectId
+    ? "organization_id = ? AND project_id = ?"
+    : "organization_id = ? AND project_id IS NULL";
+
+  const activeConfigsResult = await c.env.DB.prepare(
+    `SELECT id, provider
+     FROM custody_configs
+     WHERE ${scopeClause} AND status = 'active'
+     ORDER BY updated_at DESC`
   )
-    .bind(...(projectId ? [actor.organizationId, projectId] : [actor.organizationId]))
-    .first<{ provider: string }>();
+    .bind(...scopeBindings)
+    .all<{ id: string; provider: string }>();
+
+  const activeConfigs = activeConfigsResult.results;
+  const currentConfig = activeConfigs[0];
 
   if (currentConfig?.provider === parsed.data.provider) {
     throw new AppError(
@@ -236,22 +239,16 @@ export const switchSigning = async (c: AppContext) => {
     );
   }
 
+  const previousActiveConfigIds = activeConfigs.map((config) => config.id);
+
   // Deactivate any active config for the requested scope so initialize* does not conflict.
-  if (projectId) {
+  if (previousActiveConfigIds.length > 0) {
     await c.env.DB.prepare(
       `UPDATE custody_configs
        SET status = 'inactive', updated_at = datetime('now')
-      WHERE organization_id = ? AND project_id = ? AND status = 'active'`
+       WHERE ${scopeClause} AND status = 'active'`
     )
-      .bind(actor.organizationId, projectId)
-      .run();
-  } else {
-    await c.env.DB.prepare(
-      `UPDATE custody_configs
-       SET status = 'inactive', updated_at = datetime('now')
-       WHERE organization_id = ? AND project_id IS NULL AND status = 'active'`
-    )
-      .bind(actor.organizationId)
+      .bind(...scopeBindings)
       .run();
   }
 
@@ -308,6 +305,33 @@ export const switchSigning = async (c: AppContext) => {
 
     return created(c, response);
   } catch (error) {
+    if (previousActiveConfigIds.length > 0) {
+      try {
+        // Ensure any partially-created new config for this scope is not left active.
+        await c.env.DB.prepare(
+          `UPDATE custody_configs
+           SET status = 'inactive', updated_at = datetime('now')
+           WHERE ${scopeClause} AND status = 'active'`
+        )
+          .bind(...scopeBindings)
+          .run();
+
+        const placeholders = previousActiveConfigIds.map(() => "?").join(", ");
+        await c.env.DB.prepare(
+          `UPDATE custody_configs
+           SET status = 'active', updated_at = datetime('now')
+           WHERE id IN (${placeholders})`
+        )
+          .bind(...previousActiveConfigIds)
+          .run();
+      } catch (rollbackError) {
+        throw new AppError(
+          "INTERNAL_ERROR",
+          `Provider switch failed and rollback could not restore previous state: ${rollbackError instanceof Error ? rollbackError.message : "Unknown rollback error"}`
+        );
+      }
+    }
+
     if (error instanceof SigningError) {
       throw new AppError("BAD_REQUEST", error.message);
     }

--- a/apps/sdp-api/src/services/custody/provisioning.test.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.test.ts
@@ -1,4 +1,4 @@
-import { provisionCoinbaseCdpAccount } from "@/services/custody/provisioning";
+import { provisionCoinbaseCdpAccount, provisionParaWallet } from "@/services/custody/provisioning";
 import type { Env } from "@/types/env";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -114,12 +114,94 @@ describe("coinbase account provisioning", () => {
   });
 });
 
+describe("para wallet provisioning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries transient address-not-ready errors while waiting for wallet readiness", async () => {
+    const walletId = "wal_para_123";
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = toUrlString(input);
+
+        if (url.endsWith("/v1/wallets") && init?.method === "POST") {
+          return jsonResponse({ data: { id: walletId, status: "creating" } }, 200);
+        }
+
+        if (url.endsWith(`/v1/wallets/${walletId}`) && init?.method === "GET") {
+          if (fetchMock.mock.calls.length === 2) {
+            return jsonResponse({ message: "wallet address not found after 6315ms" }, 500);
+          }
+
+          return jsonResponse(
+            {
+              data: {
+                id: walletId,
+                type: "SOLANA",
+                scheme: "ED25519",
+                status: "ready",
+                address: CREATED_ADDRESS,
+              },
+            },
+            200
+          );
+        }
+
+        throw new Error(`Unexpected fetch call: ${init?.method ?? "GET"} ${url}`);
+      });
+
+    const result = await provisionParaWallet(createParaEnv(), {
+      orgId: "org_abc",
+      orgSlug: "Acme Labs",
+    });
+
+    expect(result.walletId).toBe(walletId);
+    expect(result.address).toBe(CREATED_ADDRESS);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("bubbles non-retryable para errors", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = toUrlString(input);
+
+        if (url.endsWith("/v1/wallets") && init?.method === "POST") {
+          return jsonResponse({ message: "invalid request" }, 400);
+        }
+
+        throw new Error(`Unexpected fetch call: ${init?.method ?? "GET"} ${url}`);
+      });
+
+    await expect(
+      provisionParaWallet(createParaEnv(), {
+        orgId: "org_abc",
+        orgSlug: "Acme Labs",
+      })
+    ).rejects.toThrowError(/Para API error: 400/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 function createCoinbaseEnv(overrides: Partial<Env> = {}): Env {
   return {
     ENVIRONMENT: "development",
     COINBASE_CDP_API_KEY_ID: "test-api-key-id",
     COINBASE_CDP_API_KEY_SECRET: keyMaterial.privateKeyPem,
     COINBASE_CDP_WALLET_SECRET: keyMaterial.privateKeyPkcs8Base64,
+    ...overrides,
+  } as Env;
+}
+
+function createParaEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    ENVIRONMENT: "development",
+    PARA_API_KEY: "test-para-api-key",
+    PARA_API_BASE_URL: "https://api.getpara.com",
     ...overrides,
   } as Env;
 }

--- a/apps/sdp-api/src/services/custody/provisioning.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.ts
@@ -731,13 +731,25 @@ async function waitForParaWalletReady(params: {
   const delayMs = 500;
 
   let latestWallet: ParaWalletResponse | null = null;
+  let latestTransientError: string | null = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const wallet = await paraRequest<ParaWalletResponse>({
-      apiBaseUrl: params.apiBaseUrl,
-      apiKey: params.apiKey,
-      method: "GET",
-      path: `/v1/wallets/${encodeURIComponent(params.walletId)}`,
-    });
+    let wallet: ParaWalletResponse;
+    try {
+      wallet = await paraRequest<ParaWalletResponse>({
+        apiBaseUrl: params.apiBaseUrl,
+        apiKey: params.apiKey,
+        method: "GET",
+        path: `/v1/wallets/${encodeURIComponent(params.walletId)}`,
+      });
+    } catch (error) {
+      if (!isParaAddressPendingError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+
+      latestTransientError = error.message;
+      await sleep(delayMs);
+      continue;
+    }
 
     latestWallet = wallet;
     if (wallet.status === "ready" && wallet.address) {
@@ -750,9 +762,18 @@ async function waitForParaWalletReady(params: {
   }
 
   throw new SigningError(
-    `Para wallet '${params.walletId}' did not become ready after ${maxAttempts} attempts (status: ${latestWallet?.status ?? "unknown"})`,
+    `Para wallet '${params.walletId}' did not become ready after ${maxAttempts} attempts (status: ${latestWallet?.status ?? "unknown"}${latestTransientError ? `, last error: ${latestTransientError}` : ""})`,
     "PROVIDER_NOT_CONFIGURED"
   );
+}
+
+function isParaAddressPendingError(error: unknown): error is SigningError {
+  if (!(error instanceof SigningError)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return message.includes("para api error: 500") && message.includes("wallet address not found");
 }
 
 function validateParaWallet(


### PR DESCRIPTION
## Problem
Switching providers could leave a scope with no active custody config if initialization failed after deactivation. Para provisioning could also fail transiently with `500 wallet address not found` before wallet materialization completed.

## Changes
- Added retry handling in Para readiness polling for transient `500 wallet address not found` responses.
- Kept non-transient Para errors as immediate failures.
- Made `/v1/wallets/switch` rollback-safe:
  - capture previously active config IDs for the scope,
  - deactivate current active configs before switch,
  - on failure, deactivate any partial active config and restore previous active config(s).
- Improved rollback failure message to include both:
  - original switch failure cause, and
  - rollback failure cause.
- Added regression tests for:
  - Para transient retry behavior,
  - rollback restoration when provider switch fails.

## Validation
- `pnpm --filter @sdp/api test src/services/custody/provisioning.test.ts src/routes/custody-switch.test.ts`
