### PR TITLE
feat(custody): align Fireblocks setup and switch provider flows

### DIFF
--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -351,6 +351,11 @@ export const getSwitchProviderOptions = async (c: AppContext) => {
   const response: SwitchProviderOptionsResponse = {
     providers: [
       {
+        provider: "fireblocks",
+        hasReusableWallet: false,
+        needsWalletLabel: false,
+      },
+      {
         provider: "privy",
         hasReusableWallet: reuseState.privy,
         needsWalletLabel: !reuseState.privy,

--- a/apps/sdp-api/src/routes/custody/schemas.ts
+++ b/apps/sdp-api/src/routes/custody/schemas.ts
@@ -155,7 +155,7 @@ export interface CustodyWalletsResponse {
 
 export interface SwitchProviderOptionsResponse {
   providers: Array<{
-    provider: "privy" | "coinbase_cdp" | "para" | "turnkey" | "local";
+    provider: "fireblocks" | "privy" | "coinbase_cdp" | "para" | "turnkey" | "local";
     hasReusableWallet: boolean;
     needsWalletLabel: boolean;
   }>;

--- a/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
@@ -7,6 +7,7 @@ interface OnboardingStatusResponse {
 
 interface WalletConfigResponse {
   config: {
+    provider: "privy" | "local" | "fireblocks" | "coinbase_cdp" | "para" | "turnkey";
     status: "active" | "inactive";
   };
 }
@@ -22,12 +23,16 @@ export async function GET() {
     if (!onboarding.linked) {
       return NextResponse.json({
         custodyEnabled: false,
+        walletProvisioningEnabled: false,
+        walletProvisioningReason: "Enable wallets first in the Signing configuration section.",
       });
     }
 
     if (configResponse.status === 404) {
       return NextResponse.json({
         custodyEnabled: false,
+        walletProvisioningEnabled: false,
+        walletProvisioningReason: "Enable wallets first in the Signing configuration section.",
       });
     }
 
@@ -37,10 +42,28 @@ export async function GET() {
     }
 
     const parsed = (await configResponse.json()) as { data?: WalletConfigResponse };
-    const custodyEnabled = parsed.data?.config.status === "active";
+    const config = parsed.data?.config;
+    const custodyEnabled = config?.status === "active";
+    const walletProvisioningSupportedProviders = new Set([
+      "privy",
+      "coinbase_cdp",
+      "para",
+      "turnkey",
+    ]);
+    const walletProvisioningEnabled =
+      custodyEnabled &&
+      typeof config?.provider === "string" &&
+      walletProvisioningSupportedProviders.has(config.provider);
+    const walletProvisioningReason = walletProvisioningEnabled
+      ? ""
+      : custodyEnabled
+        ? `Provider '${config?.provider ?? "unknown"}' does not support additional wallet provisioning yet.`
+        : "Enable wallets first in the Signing configuration section.";
 
     return NextResponse.json({
       custodyEnabled,
+      walletProvisioningEnabled,
+      walletProvisioningReason,
     });
   } catch (error) {
     return NextResponse.json(

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -93,25 +93,57 @@ export async function initializeCustody(formData: FormData) {
   const provider = (getString(formData, "provider") || "privy") as
     | "privy"
     | "local"
+    | "fireblocks"
     | "coinbase_cdp"
     | "para"
     | "turnkey";
   const walletLabel = getOptionalString(formData, "walletLabel");
   const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
+  const fireblocksApiKey = getOptionalString(formData, "apiKey");
+  const fireblocksApiSecretPem = getOptionalString(formData, "apiSecretPem");
+  const fireblocksVaultAccountId = getOptionalString(formData, "vaultAccountId");
+  const fireblocksAssetId = getOptionalString(formData, "assetId");
   const network = getOptionalString(formData, "network");
   const walletAddress = getOptionalString(formData, "walletAddress");
   const accountPolicy = getOptionalString(formData, "accountPolicy");
 
+  const payload: Record<string, unknown> = {
+    provider,
+    walletLabel,
+  };
+
+  if (provider === "fireblocks") {
+    if (!fireblocksApiKey || !fireblocksApiSecretPem || !fireblocksVaultAccountId) {
+      throw new Error("Fireblocks requires apiKey, apiSecretPem, and vaultAccountId");
+    }
+
+    payload.apiKey = fireblocksApiKey;
+    payload.apiSecretPem = fireblocksApiSecretPem;
+    payload.vaultAccountId = fireblocksVaultAccountId;
+    if (fireblocksAssetId) {
+      payload.assetId = fireblocksAssetId;
+    }
+    if (apiBaseUrl) {
+      payload.apiBaseUrl = apiBaseUrl;
+    }
+  } else {
+    if (apiBaseUrl) {
+      payload.apiBaseUrl = apiBaseUrl;
+    }
+    if (network) {
+      payload.network = network;
+    }
+    if (walletAddress) {
+      payload.walletAddress = walletAddress;
+    }
+    if (accountPolicy) {
+      payload.accountPolicy = accountPolicy;
+    }
+  }
+
   await sdpApiFetch("/v1/wallets/initialize", {
     method: "POST",
-    body: JSON.stringify({
-      provider,
-      walletLabel,
-      ...(apiBaseUrl ? { apiBaseUrl } : {}),
-      ...(network ? { network } : {}),
-      ...(walletAddress ? { walletAddress } : {}),
-      ...(accountPolicy ? { accountPolicy } : {}),
-    }),
+    body: JSON.stringify(payload),
   });
 
   revalidatePath("/dashboard/custody");
@@ -123,12 +155,17 @@ export async function switchCustodyProvider(formData: FormData) {
   const provider = (getString(formData, "provider") || "privy") as
     | "privy"
     | "local"
+    | "fireblocks"
     | "coinbase_cdp"
     | "para"
     | "turnkey";
   const confirm = getString(formData, "confirm");
   const walletLabel = getOptionalString(formData, "walletLabel");
   const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
+  const fireblocksApiKey = getOptionalString(formData, "apiKey");
+  const fireblocksApiSecretPem = getOptionalString(formData, "apiSecretPem");
+  const fireblocksVaultAccountId = getOptionalString(formData, "vaultAccountId");
+  const fireblocksAssetId = getOptionalString(formData, "assetId");
   const network = getOptionalString(formData, "network");
   const walletAddress = getOptionalString(formData, "walletAddress");
   const accountPolicy = getOptionalString(formData, "accountPolicy");
@@ -137,16 +174,43 @@ export async function switchCustodyProvider(formData: FormData) {
     throw new Error("Type SWITCH to confirm provider change");
   }
 
+  const payload: Record<string, unknown> = {
+    provider,
+    walletLabel,
+  };
+
+  if (provider === "fireblocks") {
+    if (!fireblocksApiKey || !fireblocksApiSecretPem || !fireblocksVaultAccountId) {
+      throw new Error("Fireblocks requires apiKey, apiSecretPem, and vaultAccountId");
+    }
+
+    payload.apiKey = fireblocksApiKey;
+    payload.apiSecretPem = fireblocksApiSecretPem;
+    payload.vaultAccountId = fireblocksVaultAccountId;
+    if (fireblocksAssetId) {
+      payload.assetId = fireblocksAssetId;
+    }
+    if (apiBaseUrl) {
+      payload.apiBaseUrl = apiBaseUrl;
+    }
+  } else {
+    if (apiBaseUrl) {
+      payload.apiBaseUrl = apiBaseUrl;
+    }
+    if (network) {
+      payload.network = network;
+    }
+    if (walletAddress) {
+      payload.walletAddress = walletAddress;
+    }
+    if (accountPolicy) {
+      payload.accountPolicy = accountPolicy;
+    }
+  }
+
   await sdpApiFetch("/v1/wallets/switch", {
     method: "POST",
-    body: JSON.stringify({
-      provider,
-      walletLabel,
-      ...(apiBaseUrl ? { apiBaseUrl } : {}),
-      ...(network ? { network } : {}),
-      ...(walletAddress ? { walletAddress } : {}),
-      ...(accountPolicy ? { accountPolicy } : {}),
-    }),
+    body: JSON.stringify(payload),
   });
 
   revalidatePath("/dashboard/custody");

--- a/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
@@ -37,14 +37,15 @@ export default async function CustodySetupPage() {
                 defaultValue="privy"
               >
                 <option value="privy">Privy (recommended)</option>
+                <option value="fireblocks">Fireblocks</option>
                 <option value="coinbase_cdp">Coinbase CDP</option>
                 <option value="para">Para</option>
                 <option value="turnkey">Turnkey</option>
                 <option value="local">Local (development only)</option>
               </select>
               <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                Privy, Coinbase CDP, Para, and Turnkey are managed by SDP server credentials. Local
-                provider mode generates a key stored in the database and should not be used in
+                Fireblocks, Privy, Coinbase CDP, Para, and Turnkey are supported custody providers.
+                Local provider mode generates a key stored in the database and should not be used in
                 production.
               </p>
             </div>
@@ -52,6 +53,50 @@ export default async function CustodySetupPage() {
             <div className="grid gap-2">
               <Label htmlFor="walletLabel">Wallet label</Label>
               <Input id="walletLabel" name="walletLabel" placeholder="Master wallet" />
+            </div>
+
+            <div className="grid gap-4 rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-[#1c1c1d]">Fireblocks credentials</p>
+                <p className="text-xs text-[rgba(28,28,29,0.64)]">
+                  Required only when provider is Fireblocks. Ignored for other providers.
+                </p>
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="apiKey">API key</Label>
+                <Input id="apiKey" name="apiKey" placeholder="Fireblocks API key" />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="apiSecretPem">API secret PEM</Label>
+                <textarea
+                  id="apiSecretPem"
+                  name="apiSecretPem"
+                  className="min-h-28 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 py-2 text-sm text-[#1c1c1d]"
+                  placeholder="-----BEGIN PRIVATE KEY-----"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="vaultAccountId">Vault account ID</Label>
+                <Input id="vaultAccountId" name="vaultAccountId" placeholder="Vault account ID" />
+              </div>
+
+              <div className="grid gap-2 md:grid-cols-2 md:gap-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="assetId">Asset ID (optional)</Label>
+                  <Input id="assetId" name="assetId" placeholder="SOL" />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="apiBaseUrl">API base URL (optional)</Label>
+                  <Input
+                    id="apiBaseUrl"
+                    name="apiBaseUrl"
+                    placeholder="https://api.fireblocks.io"
+                  />
+                </div>
+              </div>
             </div>
 
             <div className="flex flex-wrap items-center gap-3">

--- a/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
@@ -1,11 +1,8 @@
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { auth } from "@clerk/nextjs/server";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import { initializeCustody } from "../actions";
+import { CustodySetupForm } from "./setup-form";
 
 export default async function CustodySetupPage() {
   const { userId, orgId } = await auth();
@@ -27,87 +24,7 @@ export default async function CustodySetupPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          <form action={initializeCustody} className="grid gap-5">
-            <div className="grid gap-2">
-              <Label htmlFor="provider">Provider</Label>
-              <select
-                id="provider"
-                name="provider"
-                className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
-                defaultValue="privy"
-              >
-                <option value="privy">Privy (recommended)</option>
-                <option value="fireblocks">Fireblocks</option>
-                <option value="coinbase_cdp">Coinbase CDP</option>
-                <option value="para">Para</option>
-                <option value="turnkey">Turnkey</option>
-                <option value="local">Local (development only)</option>
-              </select>
-              <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                Fireblocks, Privy, Coinbase CDP, Para, and Turnkey are supported custody providers.
-                Local provider mode generates a key stored in the database and should not be used in
-                production.
-              </p>
-            </div>
-
-            <div className="grid gap-2">
-              <Label htmlFor="walletLabel">Wallet label</Label>
-              <Input id="walletLabel" name="walletLabel" placeholder="Master wallet" />
-            </div>
-
-            <div className="grid gap-4 rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-[#1c1c1d]">Fireblocks credentials</p>
-                <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                  Required only when provider is Fireblocks. Ignored for other providers.
-                </p>
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="apiKey">API key</Label>
-                <Input id="apiKey" name="apiKey" placeholder="Fireblocks API key" />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="apiSecretPem">API secret PEM</Label>
-                <textarea
-                  id="apiSecretPem"
-                  name="apiSecretPem"
-                  className="min-h-28 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 py-2 text-sm text-[#1c1c1d]"
-                  placeholder="-----BEGIN PRIVATE KEY-----"
-                />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="vaultAccountId">Vault account ID</Label>
-                <Input id="vaultAccountId" name="vaultAccountId" placeholder="Vault account ID" />
-              </div>
-
-              <div className="grid gap-2 md:grid-cols-2 md:gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="assetId">Asset ID (optional)</Label>
-                  <Input id="assetId" name="assetId" placeholder="SOL" />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="apiBaseUrl">API base URL (optional)</Label>
-                  <Input
-                    id="apiBaseUrl"
-                    name="apiBaseUrl"
-                    placeholder="https://api.fireblocks.io"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-3">
-              <Button type="submit">Provision wallet</Button>
-              <Link href="/dashboard/wallets">
-                <Button type="button" variant="secondary">
-                  Cancel
-                </Button>
-              </Link>
-            </div>
-          </form>
+          <CustodySetupForm action={initializeCustody} />
 
           <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] px-3 py-2 text-xs text-[rgba(28,28,29,0.64)]">
             This step provisions wallet signing for your organization. It does not automatically

--- a/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import Link from "next/link";
+import { useState } from "react";
+
+type SetupProvider = "fireblocks" | "privy" | "coinbase_cdp" | "para" | "turnkey" | "local";
+
+interface CustodySetupFormProps {
+  action: (formData: FormData) => void | Promise<void>;
+}
+
+export function CustodySetupForm({ action }: CustodySetupFormProps) {
+  const [selectedProvider, setSelectedProvider] = useState<SetupProvider>("privy");
+  const isFireblocks = selectedProvider === "fireblocks";
+
+  return (
+    <form action={action} className="grid gap-5">
+      <div className="grid gap-2">
+        <Label htmlFor="provider">Provider</Label>
+        <select
+          id="provider"
+          name="provider"
+          className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
+          defaultValue="privy"
+          onChange={(event) => {
+            setSelectedProvider(event.target.value as SetupProvider);
+          }}
+        >
+          <option value="privy">Privy (recommended)</option>
+          <option value="fireblocks">Fireblocks</option>
+          <option value="coinbase_cdp">Coinbase CDP</option>
+          <option value="para">Para</option>
+          <option value="turnkey">Turnkey</option>
+          <option value="local">Local (development only)</option>
+        </select>
+        <p className="text-xs text-[rgba(28,28,29,0.64)]">
+          Fireblocks, Privy, Coinbase CDP, Para, and Turnkey are supported custody providers. Local
+          provider mode generates a key stored in the database and should not be used in production.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="walletLabel">Wallet label</Label>
+        <Input id="walletLabel" name="walletLabel" placeholder="Master wallet" />
+      </div>
+
+      {isFireblocks ? (
+        <div className="grid gap-4 rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-[#1c1c1d]">Fireblocks credentials</p>
+            <p className="text-xs text-[rgba(28,28,29,0.64)]">
+              Required when provider is Fireblocks.
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="apiKey">API key</Label>
+            <Input id="apiKey" name="apiKey" placeholder="Fireblocks API key" required />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="apiSecretPem">API secret PEM</Label>
+            <textarea
+              id="apiSecretPem"
+              name="apiSecretPem"
+              className="min-h-28 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 py-2 text-sm text-[#1c1c1d]"
+              placeholder="-----BEGIN PRIVATE KEY-----"
+              required
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="vaultAccountId">Vault account ID</Label>
+            <Input
+              id="vaultAccountId"
+              name="vaultAccountId"
+              placeholder="Vault account ID"
+              required
+            />
+          </div>
+
+          <div className="grid gap-2 md:grid-cols-2 md:gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="assetId">Asset ID (optional)</Label>
+              <Input id="assetId" name="assetId" placeholder="SOL" />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="apiBaseUrl">API base URL (optional)</Label>
+              <Input id="apiBaseUrl" name="apiBaseUrl" placeholder="https://api.fireblocks.io" />
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button type="submit">Provision wallet</Button>
+        <Link href="/dashboard/wallets">
+          <Button type="button" variant="secondary">
+            Cancel
+          </Button>
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/switch/page.tsx
@@ -7,13 +7,24 @@ import { type SwitchProvider, SwitchProviderForm } from "./switch-provider-form"
 
 const PROVIDER_OPTIONS: Array<{ value: SwitchProvider; label: string }> = [
   { value: "privy", label: "Privy" },
+  { value: "fireblocks", label: "Fireblocks" },
   { value: "coinbase_cdp", label: "Coinbase CDP" },
   { value: "para", label: "Para" },
   { value: "turnkey", label: "Turnkey" },
   { value: "local", label: "Local (development only)" },
 ];
 
+const DEFAULT_HAS_REUSABLE_WALLET_BY_PROVIDER: Record<SwitchProvider, boolean> = {
+  fireblocks: false,
+  privy: false,
+  coinbase_cdp: false,
+  para: false,
+  turnkey: false,
+  local: false,
+};
+
 const DEFAULT_NEEDS_WALLET_LABEL_BY_PROVIDER: Record<SwitchProvider, boolean> = {
+  fireblocks: false,
   privy: true,
   coinbase_cdp: true,
   para: true,
@@ -48,33 +59,49 @@ async function getCurrentProvider(): Promise<string | null> {
   return payload.data?.config?.provider ?? null;
 }
 
-async function getNeedsWalletLabelByProvider(): Promise<Record<SwitchProvider, boolean>> {
+async function getProviderCapabilities(): Promise<{
+  hasReusableWalletByProvider: Record<SwitchProvider, boolean>;
+  needsWalletLabelByProvider: Record<SwitchProvider, boolean>;
+}> {
   const response = await sdpApiRequest("/v1/wallets/switch-options");
   if (!response.ok) {
-    return DEFAULT_NEEDS_WALLET_LABEL_BY_PROVIDER;
+    return {
+      hasReusableWalletByProvider: DEFAULT_HAS_REUSABLE_WALLET_BY_PROVIDER,
+      needsWalletLabelByProvider: DEFAULT_NEEDS_WALLET_LABEL_BY_PROVIDER,
+    };
   }
 
   const payload = (await response.json()) as {
     data?: {
       providers?: Array<{
         provider?: string;
+        hasReusableWallet?: boolean;
         needsWalletLabel?: boolean;
       }>;
     };
   };
 
-  const next = { ...DEFAULT_NEEDS_WALLET_LABEL_BY_PROVIDER };
+  const hasReusableWalletByProvider = { ...DEFAULT_HAS_REUSABLE_WALLET_BY_PROVIDER };
+  const needsWalletLabelByProvider = { ...DEFAULT_NEEDS_WALLET_LABEL_BY_PROVIDER };
   for (const provider of payload.data?.providers ?? []) {
-    if (
-      provider.provider &&
-      provider.provider in next &&
-      typeof provider.needsWalletLabel === "boolean"
-    ) {
-      next[provider.provider as SwitchProvider] = provider.needsWalletLabel;
+    if (!provider.provider || !(provider.provider in needsWalletLabelByProvider)) {
+      continue;
+    }
+
+    const key = provider.provider as SwitchProvider;
+    if (typeof provider.hasReusableWallet === "boolean") {
+      hasReusableWalletByProvider[key] = provider.hasReusableWallet;
+    }
+
+    if (typeof provider.needsWalletLabel === "boolean") {
+      needsWalletLabelByProvider[key] = provider.needsWalletLabel;
     }
   }
 
-  return next;
+  return {
+    hasReusableWalletByProvider,
+    needsWalletLabelByProvider,
+  };
 }
 
 export default async function CustodySwitchPage() {
@@ -87,7 +114,8 @@ export default async function CustodySwitchPage() {
   }
 
   const currentProvider = await getCurrentProvider();
-  const needsWalletLabelByProvider = await getNeedsWalletLabelByProvider();
+  const { hasReusableWalletByProvider, needsWalletLabelByProvider } =
+    await getProviderCapabilities();
   const selectableOptions = PROVIDER_OPTIONS.filter((option) => option.value !== currentProvider);
   const defaultProvider = selectableOptions[0]?.value ?? PROVIDER_OPTIONS[0].value;
   const providerOptions = PROVIDER_OPTIONS.map((option) => ({
@@ -124,6 +152,7 @@ export default async function CustodySwitchPage() {
             options={providerOptions}
             defaultProvider={defaultProvider}
             disableSubmit={selectableOptions.length === 0}
+            hasReusableWalletByProvider={hasReusableWalletByProvider}
             needsWalletLabelByProvider={needsWalletLabelByProvider}
           />
         </CardContent>

--- a/apps/sdp-web/src/app/dashboard/custody/switch/switch-provider-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/switch/switch-provider-form.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import Link from "next/link";
 import { useState } from "react";
 
-export type SwitchProvider = "privy" | "coinbase_cdp" | "para" | "turnkey" | "local";
+export type SwitchProvider = "fireblocks" | "privy" | "coinbase_cdp" | "para" | "turnkey" | "local";
 
 interface SwitchProviderFormProps {
   action: (formData: FormData) => void | Promise<void>;
@@ -17,6 +17,7 @@ interface SwitchProviderFormProps {
   }>;
   defaultProvider: SwitchProvider;
   disableSubmit: boolean;
+  hasReusableWalletByProvider: Record<SwitchProvider, boolean>;
   needsWalletLabelByProvider: Record<SwitchProvider, boolean>;
 }
 
@@ -25,9 +26,12 @@ export function SwitchProviderForm({
   options,
   defaultProvider,
   disableSubmit,
+  hasReusableWalletByProvider,
   needsWalletLabelByProvider,
 }: SwitchProviderFormProps) {
   const [selectedProvider, setSelectedProvider] = useState<SwitchProvider>(defaultProvider);
+  const isFireblocks = selectedProvider === "fireblocks";
+  const hasReusableWallet = hasReusableWalletByProvider[selectedProvider] ?? false;
   const needsWalletLabel = needsWalletLabelByProvider[selectedProvider] ?? true;
 
   return (
@@ -52,16 +56,62 @@ export function SwitchProviderForm({
         </select>
       </div>
 
+      {isFireblocks ? (
+        <div className="grid gap-4 rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-[#1c1c1d]">Fireblocks credentials</p>
+            <p className="text-xs text-[rgba(28,28,29,0.64)]">Required to switch to Fireblocks.</p>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="apiKey">API key</Label>
+            <Input id="apiKey" name="apiKey" placeholder="Fireblocks API key" required />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="apiSecretPem">API secret PEM</Label>
+            <textarea
+              id="apiSecretPem"
+              name="apiSecretPem"
+              className="min-h-28 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 py-2 text-sm text-[#1c1c1d]"
+              placeholder="-----BEGIN PRIVATE KEY-----"
+              required
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="vaultAccountId">Vault account ID</Label>
+            <Input
+              id="vaultAccountId"
+              name="vaultAccountId"
+              placeholder="Vault account ID"
+              required
+            />
+          </div>
+
+          <div className="grid gap-2 md:grid-cols-2 md:gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="assetId">Asset ID (optional)</Label>
+              <Input id="assetId" name="assetId" placeholder="SOL" />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="apiBaseUrl">API base URL (optional)</Label>
+              <Input id="apiBaseUrl" name="apiBaseUrl" placeholder="https://api.fireblocks.io" />
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       {needsWalletLabel ? (
         <div className="grid gap-2">
           <Label htmlFor="walletLabel">Default wallet label</Label>
           <Input id="walletLabel" name="walletLabel" placeholder="Default" />
         </div>
-      ) : (
+      ) : hasReusableWallet ? (
         <p className="text-xs text-[rgba(28,28,29,0.64)]">
           Existing root wallet found for this provider. Switching will reuse it.
         </p>
-      )}
+      ) : null}
 
       <div className="grid gap-2">
         <Label htmlFor="confirm">Confirmation</Label>

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -87,6 +87,8 @@ function WalletQuickAction() {
 
         const payload = (await response.json()) as {
           custodyEnabled?: boolean;
+          walletProvisioningEnabled?: boolean;
+          walletProvisioningReason?: string;
         };
 
         if (cancelled) {
@@ -94,10 +96,26 @@ function WalletQuickAction() {
         }
 
         const custodyEnabled = payload.custodyEnabled === true;
-        setDisabled(!custodyEnabled);
-        setDisabledReason(
-          custodyEnabled ? "" : "Enable wallets first in the Signing configuration section."
-        );
+        const walletProvisioningEnabled = payload.walletProvisioningEnabled !== false;
+        const walletProvisioningReason = payload.walletProvisioningReason?.trim();
+
+        if (!custodyEnabled) {
+          setDisabled(true);
+          setDisabledReason("Enable wallets first in the Signing configuration section.");
+          return;
+        }
+
+        if (!walletProvisioningEnabled) {
+          setDisabled(true);
+          setDisabledReason(
+            walletProvisioningReason ||
+              "This provider does not support additional wallet provisioning yet."
+          );
+          return;
+        }
+
+        setDisabled(false);
+        setDisabledReason("");
       } catch {
         if (cancelled) {
           return;


### PR DESCRIPTION
## Summary
- add Fireblocks to custody switch provider options and API response schema
- wire Fireblocks-specific payload handling in custody initialize/switch server actions (`apiKey`, `apiSecretPem`, `vaultAccountId`, optional `assetId`/`apiBaseUrl`)
- expose Fireblocks as a selectable provider in setup/switch UI and add required Fireblocks credential inputs
- add provider capability handling in switch UI (`hasReusableWallet` + `needsWalletLabel`) with Fireblocks defaults
- prevent broken wallet quick-action paths by disabling "New wallet" when active provider does not support additional wallet provisioning

## Validation
- `pnpm lint`
- `pnpm typecheck`
