### PR TITLE
feat(payments): remove ramp quotes and add MoonPay execute flows

### DIFF
--- a/apps/sdp-api-specs-draft/sdp-api.yaml
+++ b/apps/sdp-api-specs-draft/sdp-api.yaml
@@ -1025,78 +1025,37 @@ components:
         - feeInLamports
         - validUntil
 
-    RampQuoteRequest:
-      type: object
-      properties:
-        direction:
-          type: string
-          enum: [onramp, offramp]
-        fiatCurrency:
-          type: string
-          pattern: '^[A-Z]{3}$'
-        fiatAmount:
-          $ref: '#/components/schemas/TokenAmount'
-        cryptoToken:
-          type: string
-        provider:
-          type: string
-          enum: [bridge, moonpay, ramp, transak]
-      required:
-        - direction
-        - fiatCurrency
-        - fiatAmount
-        - cryptoToken
-
-    RampQuote:
-      type: object
-      properties:
-        id:
-          type: string
-          pattern: '^quote_[a-zA-Z0-9]+$'
-        direction:
-          type: string
-          enum: [onramp, offramp]
-        fiatCurrency:
-          type: string
-        fiatAmount:
-          $ref: '#/components/schemas/TokenAmount'
-        cryptoToken:
-          type: string
-        cryptoAmount:
-          $ref: '#/components/schemas/TokenAmount'
-        exchangeRate:
-          $ref: '#/components/schemas/TokenAmount'
-        fees:
-          type: object
-          properties:
-            network:
-              $ref: '#/components/schemas/TokenAmount'
-            provider:
-              $ref: '#/components/schemas/TokenAmount'
-        expiresAt:
-          $ref: '#/components/schemas/Timestamp'
-      required:
-        - id
-        - direction
-        - fiatCurrency
-        - fiatAmount
-        - cryptoToken
-        - cryptoAmount
-        - expiresAt
-
     ExecuteRampRequest:
       type: object
       properties:
-        quoteId:
+        direction:
           type: string
+          enum: [onramp, offramp]
         destinationWallet:
           type: string
-          description: Wallet ID for crypto receipt/debit
+          description: Wallet ID or Solana address for on-ramp receipt
+        sourceWallet:
+          type: string
+          description: Wallet ID or Solana address for off-ramp source/refund
+        cryptoToken:
+          type: string
+          description: MoonPay currency code (for example usdc_sol)
+        fiatCurrency:
+          type: string
+          enum: [USD]
+        fiatAmount:
+          $ref: '#/components/schemas/TokenAmount'
+        cryptoAmount:
+          $ref: '#/components/schemas/TokenAmount'
         kycReference:
           type: string
+        redirectUrl:
+          type: string
+          format: uri
       required:
-        - quoteId
-        - destinationWallet
+        - direction
+        - cryptoToken
+        - fiatCurrency
 
     # Transaction Schemas
     SendTransactionRequest:
@@ -2493,42 +2452,11 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /payments/ramps/quote:
-    post:
-      tags: [Payments]
-      summary: Get Ramp Quote
-      description: Gets a quote for fiat on/off ramp
-      operationId: getRampQuote
-      parameters:
-        - $ref: '#/components/parameters/environmentHeader'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RampQuoteRequest'
-      responses:
-        '200':
-          description: Ramp quote retrieved successfully
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/SuccessResponse'
-                  - type: object
-                    properties:
-                      data:
-                        $ref: '#/components/schemas/RampQuote'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-
   /payments/ramps/execute:
     post:
       tags: [Payments]
       summary: Execute Ramp
-      description: Executes a fiat on/off ramp transaction
+      description: Creates a MoonPay fiat/crypto ramp session (USD only)
       operationId: executeRamp
       parameters:
         - $ref: '#/components/parameters/environmentHeader'

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -8,8 +8,6 @@ import {
   executeOfframpRequestSchema,
   executeOnrampRequestSchema,
   isoDateTimeSchema,
-  offrampQuoteRequestSchema,
-  onrampQuoteRequestSchema,
   pageQuerySchema,
   pageSizeQuerySchema,
   prepareTransferRequestSchema,
@@ -23,9 +21,7 @@ import { errorResponses, jsonContent } from "./helpers";
 import {
   feeQuoteResponse,
   offrampExecutionResponse,
-  offrampQuoteResponse,
   onrampExecutionResponse,
-  onrampQuoteResponse,
   prepareTransferResponse,
   transferListResponse,
   transferResponse,
@@ -278,34 +274,11 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "post",
-    path: "/v1/payments/ramps/onramp/quote",
-    tags: ["Payments"],
-    summary: "Get on-ramp quote",
-    operationId: "getPaymentOnrampQuote",
-    description: withDraft("Retrieves a fiat-to-crypto on-ramp quote."),
-    security: [{ apiKeyAuth: [] }],
-    request: {
-      body: {
-        required: true,
-        content: jsonContent(onrampQuoteRequestSchema),
-      },
-    },
-    responses: {
-      200: {
-        description: "On-ramp quote",
-        content: jsonContent(onrampQuoteResponse),
-      },
-      ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
-    },
-  });
-
-  registry.registerPath({
-    method: "post",
     path: "/v1/payments/ramps/onramp/execute",
     tags: ["Payments"],
     summary: "Execute on-ramp",
     operationId: "executePaymentOnramp",
-    description: withDraft("Executes a fiat-to-crypto on-ramp transaction."),
+    description: "Creates a MoonPay fiat-to-crypto on-ramp session (USD-only).",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -324,34 +297,11 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: "post",
-    path: "/v1/payments/ramps/offramp/quote",
-    tags: ["Payments"],
-    summary: "Get off-ramp quote",
-    operationId: "getPaymentOfframpQuote",
-    description: withDraft("Retrieves a crypto-to-fiat off-ramp quote."),
-    security: [{ apiKeyAuth: [] }],
-    request: {
-      body: {
-        required: true,
-        content: jsonContent(offrampQuoteRequestSchema),
-      },
-    },
-    responses: {
-      200: {
-        description: "Off-ramp quote",
-        content: jsonContent(offrampQuoteResponse),
-      },
-      ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
-    },
-  });
-
-  registry.registerPath({
-    method: "post",
     path: "/v1/payments/ramps/offramp/execute",
     tags: ["Payments"],
     summary: "Execute off-ramp",
     operationId: "executePaymentOfframp",
-    description: withDraft("Executes a crypto-to-fiat off-ramp transaction."),
+    description: "Creates a MoonPay crypto-to-fiat off-ramp session (USD-only).",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -31,10 +31,8 @@ import {
   listSessionsResponseSchema,
   listTemplatesResponseSchema,
   offrampExecutionResponseSchema,
-  offrampQuoteResponseSchema,
   onboardingStatusResponseSchema,
   onrampExecutionResponseSchema,
-  onrampQuoteResponseSchema,
   organizationSchema,
   paginatedResponseSchema,
   prepareBurnResponseSchema,
@@ -138,7 +136,5 @@ export const prepareTransferResponse = successResponseSchema(prepareTransferResp
 export const transferResponse = successResponseSchema(transferResponseSchema);
 export const transferListResponse = paginatedResponseSchema(transferSchema);
 export const feeQuoteResponse = successResponseSchema(feeQuoteResponseSchema);
-export const onrampQuoteResponse = successResponseSchema(onrampQuoteResponseSchema);
-export const offrampQuoteResponse = successResponseSchema(offrampQuoteResponseSchema);
 export const onrampExecutionResponse = successResponseSchema(onrampExecutionResponseSchema);
 export const offrampExecutionResponse = successResponseSchema(offrampExecutionResponseSchema);

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -341,97 +341,63 @@ export const feeQuoteSchema = z
   })
   .openapi({ description: "Fee quote details." });
 
-export const rampProviderSchema = z
-  .enum(["bridge", "moonpay", "ramp", "transak"])
-  .openapi({ description: "Ramp provider.", example: "moonpay" });
-
-export const onrampQuoteRequestSchema = z
-  .object({
-    fiatCurrency: z
-      .string()
-      .regex(/^[A-Z]{3}$/)
-      .openapi({ description: "Fiat currency code (ISO 4217).", example: "USD" }),
-    fiatAmount: tokenAmountSchema,
-    cryptoToken: z.string().openapi({ description: "Crypto token symbol.", example: "USDC" }),
-    provider: rampProviderSchema.optional(),
-  })
-  .openapi({ description: "On-ramp quote request payload." });
-
-export const offrampQuoteRequestSchema = z
-  .object({
-    fiatCurrency: z
-      .string()
-      .regex(/^[A-Z]{3}$/)
-      .openapi({ description: "Fiat currency code (ISO 4217).", example: "USD" }),
-    cryptoToken: z.string().openapi({ description: "Crypto token symbol.", example: "USDC" }),
-    cryptoAmount: tokenAmountSchema.openapi({
-      description: "Amount of crypto to off-ramp.",
-      example: "250.00",
-    }),
-    provider: rampProviderSchema.optional(),
-  })
-  .openapi({ description: "Off-ramp quote request payload." });
-
-export const onrampQuoteSchema = z
-  .object({
-    id: z.string().openapi({ description: "Ramp quote identifier.", example: "quote_example" }),
-    fiatCurrency: z.string().openapi({ description: "Fiat currency code.", example: "USD" }),
-    fiatAmount: tokenAmountSchema,
-    cryptoToken: z.string().openapi({ description: "Crypto token symbol.", example: "USDC" }),
-    cryptoAmount: tokenAmountSchema,
-    exchangeRate: tokenAmountSchema.optional().openapi({ description: "Exchange rate." }),
-    fees: z
-      .object({
-        network: tokenAmountSchema.optional().openapi({ description: "Network fee." }),
-        provider: tokenAmountSchema.optional().openapi({ description: "Provider fee." }),
-      })
-      .optional()
-      .openapi({ description: "Fee breakdown." }),
-    expiresAt: isoDateTimeSchema.openapi({ description: "Quote expiration." }),
-  })
-  .openapi({ description: "On-ramp quote details." });
-
-export const offrampQuoteSchema = z
-  .object({
-    id: z.string().openapi({ description: "Ramp quote identifier.", example: "quote_example" }),
-    fiatCurrency: z.string().openapi({ description: "Fiat currency code.", example: "USD" }),
-    fiatAmount: tokenAmountSchema.openapi({
-      description: "Fiat payout amount.",
-      example: "250.00",
-    }),
-    cryptoToken: z.string().openapi({ description: "Crypto token symbol.", example: "USDC" }),
-    cryptoAmount: tokenAmountSchema,
-    exchangeRate: tokenAmountSchema.optional().openapi({ description: "Exchange rate." }),
-    fees: z
-      .object({
-        network: tokenAmountSchema.optional().openapi({ description: "Network fee." }),
-        provider: tokenAmountSchema.optional().openapi({ description: "Provider fee." }),
-      })
-      .optional()
-      .openapi({ description: "Fee breakdown." }),
-    expiresAt: isoDateTimeSchema.openapi({ description: "Quote expiration." }),
-  })
-  .openapi({ description: "Off-ramp quote details." });
+const moonpayCurrencyCodeSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9_]+$/)
+  .openapi({
+    description: "MoonPay currency code (for example: `usdc_sol`).",
+    example: "usdc_sol",
+  });
 
 export const executeOnrampRequestSchema = z
   .object({
-    quoteId: z.string().openapi({ description: "Ramp quote identifier." }),
-    destinationWallet: z.string().openapi({ description: "Wallet ID for delivery/debit." }),
+    destinationWallet: z.string().openapi({
+      description: "Destination wallet ID or Solana address for purchased crypto.",
+    }),
+    cryptoToken: moonpayCurrencyCodeSchema,
+    fiatCurrency: z.literal("USD").optional().openapi({
+      description: "Fiat currency for on-ramp. USD only.",
+      example: "USD",
+    }),
+    fiatAmount: tokenAmountSchema.openapi({
+      description: "Fiat amount in USD to purchase crypto with.",
+      example: "100.00",
+    }),
     kycReference: z
       .string()
       .optional()
       .openapi({ description: "Optional KYC reference identifier." }),
+    redirectUrl: z
+      .string()
+      .url()
+      .optional()
+      .openapi({ description: "Optional redirect URL after provider flow completes." }),
   })
   .openapi({ description: "Execute on-ramp request payload." });
 
 export const executeOfframpRequestSchema = z
   .object({
-    quoteId: z.string().openapi({ description: "Ramp quote identifier." }),
-    sourceWallet: z.string().openapi({ description: "Wallet ID for debit." }),
+    sourceWallet: z.string().openapi({
+      description: "Source wallet ID or Solana address for crypto-to-fiat off-ramp.",
+    }),
+    cryptoToken: moonpayCurrencyCodeSchema,
+    fiatCurrency: z.literal("USD").optional().openapi({
+      description: "Fiat payout currency. USD only.",
+      example: "USD",
+    }),
+    cryptoAmount: tokenAmountSchema.openapi({
+      description: "Crypto amount to sell for fiat.",
+      example: "50.00",
+    }),
     kycReference: z
       .string()
       .optional()
       .openapi({ description: "Optional KYC reference identifier." }),
+    redirectUrl: z
+      .string()
+      .url()
+      .optional()
+      .openapi({ description: "Optional redirect URL after provider flow completes." }),
   })
   .openapi({ description: "Execute off-ramp request payload." });
 
@@ -455,6 +421,11 @@ export const offrampExecutionSchema = z
     status: z
       .enum(["pending", "processing", "completed", "failed"])
       .openapi({ description: "Ramp execution status.", example: "pending" }),
+    redirectUrl: z
+      .string()
+      .url()
+      .optional()
+      .openapi({ description: "Redirect URL for the ramp provider." }),
     reference: z.string().optional().openapi({ description: "Provider reference for the payout." }),
   })
   .openapi({ description: "Off-ramp execution status." });
@@ -488,18 +459,6 @@ export const feeQuoteResponseSchema = z
     feeQuote: feeQuoteSchema.openapi({ description: "Fee quote details." }),
   })
   .openapi({ description: "Fee quote response payload." });
-
-export const onrampQuoteResponseSchema = z
-  .object({
-    rampQuote: onrampQuoteSchema.openapi({ description: "On-ramp quote details." }),
-  })
-  .openapi({ description: "On-ramp quote response payload." });
-
-export const offrampQuoteResponseSchema = z
-  .object({
-    rampQuote: offrampQuoteSchema.openapi({ description: "Off-ramp quote details." }),
-  })
-  .openapi({ description: "Off-ramp quote response payload." });
 
 export const onrampExecutionResponseSchema = z
   .object({

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import app from "@/index";
 import { hashString } from "@/lib/hash";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
@@ -52,12 +53,12 @@ vi.mock("@/services/adapters/fee-payment", async () => {
 
 vi.mock("@/services/solana", async () => {
   const actual = await vi.importActual<typeof import("@/services/solana")>("@/services/solana");
-  const { createNoopSigner } = await import("@solana/kit");
+  const { address, createNoopSigner } = await import("@solana/kit");
   return {
     ...actual,
     createOrgSigner: vi.fn().mockResolvedValue(
       // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret.
-      createNoopSigner("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ")
+      createNoopSigner(address("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ"))
     ),
   };
 });
@@ -93,6 +94,37 @@ const TEST_CACHED_API_KEY: CachedApiKey = {
   status: "active",
   expiresAt: null,
 };
+
+const TEST_MOONPAY_API_KEY = "pk_test_moonpay";
+const TEST_MOONPAY_SECRET_KEY = "moonpay_secret_key";
+const TEST_MOONPAY_ONRAMP_URL = "https://buy-sandbox.moonpay.com";
+const TEST_MOONPAY_OFFRAMP_URL = "https://sell-sandbox.moonpay.com";
+// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
+const MOONPAY_PARAM_BASE_CURRENCY_AMOUNT = "baseCurrencyAmount";
+// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
+const MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID = "externalCustomerId";
+// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
+const MOONPAY_PARAM_QUOTE_CURRENCY_CODE = "quoteCurrencyCode";
+// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
+const MOONPAY_PARAM_REFUND_WALLET_ADDRESS = "refundWalletAddress";
+
+let originalMoonPayApiKey: string | undefined;
+let originalMoonPaySecretKey: string | undefined;
+let originalMoonPayOnrampUrl: string | undefined;
+let originalMoonPayOfframpUrl: string | undefined;
+
+function assertMoonPaySignature(url: URL): void {
+  const signature = url.searchParams.get("signature");
+  expect(signature).toBeTruthy();
+
+  const unsignedUrl = new URL(url.toString());
+  unsignedUrl.searchParams.delete("signature");
+
+  const expectedSignature = createHmac("sha256", TEST_MOONPAY_SECRET_KEY)
+    .update(unsignedUrl.search)
+    .digest("base64");
+  expect(signature).toBe(expectedSignature);
+}
 
 async function seedAuthAndWallet(): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
@@ -197,13 +229,141 @@ async function seedWalletPolicy(params: {
 
 describe("Payments routes", () => {
   beforeEach(async () => {
+    originalMoonPayApiKey = env.MOONPAY_API_KEY;
+    originalMoonPaySecretKey = env.MOONPAY_SECRET_KEY;
+    originalMoonPayOnrampUrl = env.MOONPAY_ONRAMP_URL;
+    originalMoonPayOfframpUrl = env.MOONPAY_OFFRAMP_URL;
+
+    env.MOONPAY_API_KEY = TEST_MOONPAY_API_KEY;
+    env.MOONPAY_SECRET_KEY = TEST_MOONPAY_SECRET_KEY;
+    env.MOONPAY_ONRAMP_URL = TEST_MOONPAY_ONRAMP_URL;
+    env.MOONPAY_OFFRAMP_URL = TEST_MOONPAY_OFFRAMP_URL;
+
     await seedTestDatabase(env);
     await seedAuthAndWallet();
   });
 
   afterEach(async () => {
+    env.MOONPAY_API_KEY = originalMoonPayApiKey;
+    env.MOONPAY_SECRET_KEY = originalMoonPaySecretKey;
+    env.MOONPAY_ONRAMP_URL = originalMoonPayOnrampUrl;
+    env.MOONPAY_OFFRAMP_URL = originalMoonPayOfframpUrl;
+
     await clearTestDatabase(env);
     await clearKVNamespaces(env);
+  });
+
+  it("creates a signed MoonPay on-ramp session URL", async () => {
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "USDC_SOL",
+          fiatCurrency: "USD",
+          fiatAmount: "120.50",
+          kycReference: "kyc_ref_123",
+          redirectUrl: "https://example.com/onramp-done",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { ramp: { id: string; status: string; redirectUrl: string } };
+    };
+
+    expect(body.data.ramp.id.startsWith("ramp_")).toBe(true);
+    expect(body.data.ramp.status).toBe("pending");
+
+    const redirect = new URL(body.data.ramp.redirectUrl);
+    expect(redirect.origin).toBe(TEST_MOONPAY_ONRAMP_URL);
+    expect(redirect.searchParams.get("apiKey")).toBe(TEST_MOONPAY_API_KEY);
+    expect(redirect.searchParams.get("baseCurrencyCode")).toBe("usd");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_BASE_CURRENCY_AMOUNT)).toBe("120.50");
+    expect(redirect.searchParams.get("currencyCode")).toBe("usdc_sol");
+    expect(redirect.searchParams.get("walletAddress")).toBe(TEST_SOLANA_ADDRESSES.wallet1);
+    expect(redirect.searchParams.get("redirectURL")).toBe("https://example.com/onramp-done");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("kyc_ref_123");
+    assertMoonPaySignature(redirect);
+  });
+
+  it("creates a signed MoonPay off-ramp session URL", async () => {
+    const res = await app.request(
+      "/v1/payments/ramps/offramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          sourceWallet: TEST_WALLET_ID,
+          cryptoToken: "USDC_SOL",
+          fiatCurrency: "USD",
+          cryptoAmount: "75.25",
+          kycReference: "kyc_ref_456",
+          redirectUrl: "https://example.com/offramp-done",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { ramp: { id: string; status: string; redirectUrl: string; reference: string } };
+    };
+
+    expect(body.data.ramp.id.startsWith("ramp_")).toBe(true);
+    expect(body.data.ramp.status).toBe("pending");
+    expect(body.data.ramp.reference.startsWith("sdp_offramp_")).toBe(true);
+
+    const redirect = new URL(body.data.ramp.redirectUrl);
+    expect(redirect.origin).toBe(TEST_MOONPAY_OFFRAMP_URL);
+    expect(redirect.searchParams.get("apiKey")).toBe(TEST_MOONPAY_API_KEY);
+    expect(redirect.searchParams.get("baseCurrencyCode")).toBe("usdc_sol");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_BASE_CURRENCY_AMOUNT)).toBe("75.25");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_QUOTE_CURRENCY_CODE)).toBe("usd");
+    expect(redirect.searchParams.get("walletAddress")).toBe(TEST_SOLANA_ADDRESSES.wallet1);
+    expect(redirect.searchParams.get(MOONPAY_PARAM_REFUND_WALLET_ADDRESS)).toBe(
+      TEST_SOLANA_ADDRESSES.wallet1
+    );
+    expect(redirect.searchParams.get("redirectURL")).toBe("https://example.com/offramp-done");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("kyc_ref_456");
+    assertMoonPaySignature(redirect);
+  });
+
+  it("returns internal error when MoonPay credentials are not configured", async () => {
+    env.MOONPAY_API_KEY = undefined;
+
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "usdc_sol",
+          fiatCurrency: "USD",
+          fiatAmount: "10",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("MoonPay is not configured");
   });
 
   it("blocks prepare transfer when destination is outside allowlist", async () => {

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -49,6 +49,8 @@ import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import type { Context } from "hono";
 import {
   createTransferSchema,
+  executeOfframpSchema,
+  executeOnrampSchema,
   listTransfersQuerySchema,
   prepareTransferSchema,
   updateWalletPolicySchema,
@@ -66,6 +68,10 @@ const SPL_TOKEN_PROGRAM_IDS = [SPL_TOKEN_PROGRAM_ID, SPL_TOKEN_2022_PROGRAM_ID] 
 const PAYMENT_POLICY_VERSION = 1;
 const DESTINATION_ALLOWLIST_POLICY_TYPE = "destination_allowlist";
 const TRANSFER_LIMITS_POLICY_TYPE = "transfer_limits";
+const MOONPAY_ONRAMP_URL = "https://buy.moonpay.com";
+const MOONPAY_OFFRAMP_URL = "https://sell.moonpay.com";
+const MOONPAY_SANDBOX_ONRAMP_URL = "https://buy-sandbox.moonpay.com";
+const MOONPAY_SANDBOX_OFFRAMP_URL = "https://sell-sandbox.moonpay.com";
 
 function getPaymentsRepository(c: AppContext) {
   return createD1PaymentsRepository({ db: createD1Drizzle(c.env.DB) });
@@ -573,6 +579,100 @@ function resolveWallet(wallets: CustodyWallet[], walletId: string): CustodyWalle
     );
   }
   return wallet;
+}
+
+function resolveWalletAddress(
+  wallets: CustodyWallet[],
+  walletIdOrAddress: string,
+  fieldName: string
+): string {
+  const matchingWallet = wallets.find((entry) => entry.walletId === walletIdOrAddress);
+  if (matchingWallet) {
+    return matchingWallet.publicKey;
+  }
+  return assertValidAddress(walletIdOrAddress, fieldName);
+}
+
+function normalizeMoonPayCurrencyCode(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-z0-9_]+$/.test(normalized)) {
+    throw new AppError("BAD_REQUEST", "cryptoToken must be a valid MoonPay currency code");
+  }
+  return normalized;
+}
+
+type MoonPayConfig = {
+  apiKey: string;
+  secretKey: string;
+  onrampUrl: string;
+  offrampUrl: string;
+};
+
+function getMoonPayConfig(c: AppContext): MoonPayConfig {
+  const apiKey = c.env.MOONPAY_API_KEY?.trim();
+  const secretKey = c.env.MOONPAY_SECRET_KEY?.trim();
+
+  if (!apiKey || !secretKey) {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "MoonPay is not configured. Set MOONPAY_API_KEY and MOONPAY_SECRET_KEY."
+    );
+  }
+
+  const useProduction = c.env.ENVIRONMENT === "production";
+  const defaultOnrampUrl = useProduction ? MOONPAY_ONRAMP_URL : MOONPAY_SANDBOX_ONRAMP_URL;
+  const defaultOfframpUrl = useProduction ? MOONPAY_OFFRAMP_URL : MOONPAY_SANDBOX_OFFRAMP_URL;
+
+  const onrampUrlRaw = c.env.MOONPAY_ONRAMP_URL ?? defaultOnrampUrl;
+  const offrampUrlRaw = c.env.MOONPAY_OFFRAMP_URL ?? defaultOfframpUrl;
+
+  try {
+    new URL(onrampUrlRaw);
+    new URL(offrampUrlRaw);
+  } catch {
+    throw new AppError("INTERNAL_ERROR", "MoonPay URL configuration is invalid.");
+  }
+
+  return {
+    apiKey,
+    secretKey,
+    onrampUrl: onrampUrlRaw,
+    offrampUrl: offrampUrlRaw,
+  };
+}
+
+async function createMoonPaySignature(unsignedQuery: string, secretKey: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secretKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(unsignedQuery));
+  return Buffer.from(signature).toString("base64");
+}
+
+async function buildSignedMoonPayWidgetUrl(
+  baseUrl: string,
+  secretKey: string,
+  params: Record<string, string | undefined>
+): Promise<string> {
+  const url = new URL(baseUrl);
+  const sortedEntries = Object.entries(params).sort(([left], [right]) => left.localeCompare(right));
+
+  for (const [key, value] of sortedEntries) {
+    if (!value) {
+      continue;
+    }
+    url.searchParams.set(key, value);
+  }
+
+  const signature = await createMoonPaySignature(url.search, secretKey);
+  url.searchParams.set("signature", signature);
+
+  return url.toString();
 }
 
 async function resolveWalletFromParams(c: AppContext) {
@@ -1349,4 +1449,83 @@ export async function getTransfer(c: AppContext) {
   if (!row) throw new AppError("NOT_FOUND", "Transfer not found");
 
   return success(c, { transfer: mapTransferRow(row) });
+}
+
+export async function executeOnramp(c: AppContext) {
+  const body = await c.req.json();
+  const parsed = executeOnrampSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid request body", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const scope = await resolveScope(c);
+  const destinationWalletAddress = resolveWalletAddress(
+    scope.wallets,
+    parsed.data.destinationWallet,
+    "destinationWallet"
+  );
+  const moonPay = getMoonPayConfig(c);
+
+  const redirectUrl = await buildSignedMoonPayWidgetUrl(moonPay.onrampUrl, moonPay.secretKey, {
+    apiKey: moonPay.apiKey,
+    baseCurrencyCode: "usd",
+    baseCurrencyAmount: parsed.data.fiatAmount,
+    currencyCode: normalizeMoonPayCurrencyCode(parsed.data.cryptoToken),
+    walletAddress: destinationWalletAddress,
+    redirectURL: parsed.data.redirectUrl,
+    externalCustomerId: parsed.data.kycReference,
+    externalTransactionId: `sdp_onramp_${crypto.randomUUID()}`,
+  });
+
+  return success(c, {
+    ramp: {
+      id: `ramp_${crypto.randomUUID()}`,
+      status: "pending",
+      redirectUrl,
+    },
+  });
+}
+
+export async function executeOfframp(c: AppContext) {
+  const body = await c.req.json();
+  const parsed = executeOfframpSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid request body", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const scope = await resolveScope(c);
+  const sourceWalletAddress = resolveWalletAddress(
+    scope.wallets,
+    parsed.data.sourceWallet,
+    "sourceWallet"
+  );
+  const moonPay = getMoonPayConfig(c);
+  const externalTransactionId = `sdp_offramp_${crypto.randomUUID()}`;
+
+  const redirectUrl = await buildSignedMoonPayWidgetUrl(moonPay.offrampUrl, moonPay.secretKey, {
+    apiKey: moonPay.apiKey,
+    baseCurrencyCode: normalizeMoonPayCurrencyCode(parsed.data.cryptoToken),
+    baseCurrencyAmount: parsed.data.cryptoAmount,
+    quoteCurrencyCode: "usd",
+    walletAddress: sourceWalletAddress,
+    refundWalletAddress: sourceWalletAddress,
+    redirectURL: parsed.data.redirectUrl,
+    externalCustomerId: parsed.data.kycReference,
+    externalTransactionId,
+  });
+
+  return success(c, {
+    ramp: {
+      id: `ramp_${crypto.randomUUID()}`,
+      status: "pending",
+      redirectUrl,
+      reference: externalTransactionId,
+    },
+  });
 }

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -3,6 +3,8 @@ import type { Env } from "@/types/env";
 import { Hono } from "hono";
 import {
   createTransfer,
+  executeOfframp,
+  executeOnramp,
   getTransfer,
   getWalletBalances,
   getWalletPolicy,
@@ -38,5 +40,15 @@ payments.post(
 payments.post("/transfers", requirePermissions("payments:write", "wallets:read"), createTransfer);
 payments.get("/transfers", requirePermissions("payments:read"), listTransfers);
 payments.get("/transfers/:transferId", requirePermissions("payments:read"), getTransfer);
+payments.post(
+  "/ramps/onramp/execute",
+  requirePermissions("payments:write", "wallets:read"),
+  executeOnramp
+);
+payments.post(
+  "/ramps/offramp/execute",
+  requirePermissions("payments:write", "wallets:read"),
+  executeOfframp
+);
 
 export default payments;

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -21,6 +21,15 @@ const transferAmountSchema = z
   .string()
   .refine((value) => isDecimalString(value), { message: "Invalid amount format" });
 
+const moonpayAmountSchema = transferAmountSchema.refine(
+  (value) => Number.parseFloat(value) > 0,
+  "Amount must be greater than zero"
+);
+
+const moonpayCurrencyCodeSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9_]+$/, { message: "Invalid MoonPay currency code" });
+
 export const createTransferSchema = z.object({
   projectId: z.string().min(1).optional(),
   source: z.string().min(1),
@@ -50,4 +59,22 @@ export const prepareTransferSchema = createTransferSchema.extend({
       simulate: z.boolean().optional(),
     })
     .optional(),
+});
+
+export const executeOnrampSchema = z.object({
+  destinationWallet: z.string().min(1),
+  cryptoToken: moonpayCurrencyCodeSchema,
+  fiatCurrency: z.literal("USD").optional(),
+  fiatAmount: moonpayAmountSchema,
+  kycReference: z.string().max(128).optional(),
+  redirectUrl: z.string().url().optional(),
+});
+
+export const executeOfframpSchema = z.object({
+  sourceWallet: z.string().min(1),
+  cryptoToken: moonpayCurrencyCodeSchema,
+  fiatCurrency: z.literal("USD").optional(),
+  cryptoAmount: moonpayAmountSchema,
+  kycReference: z.string().max(128).optional(),
+  redirectUrl: z.string().url().optional(),
 });

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -108,6 +108,12 @@ export interface Env {
   KORA_RPC_URL?: string;
   KORA_API_KEY?: string;
   KORA_TIMEOUT_MS?: string;
+
+  // MoonPay ramps configuration
+  MOONPAY_API_KEY?: string;
+  MOONPAY_SECRET_KEY?: string;
+  MOONPAY_ONRAMP_URL?: string;
+  MOONPAY_OFFRAMP_URL?: string;
 }
 
 // Extend Hono's context with our bindings


### PR DESCRIPTION
## Summary
- remove ramp quote API surfaces (onramp/offramp quote endpoints + related OpenAPI response/schema definitions)
- keep ramp execute surfaces and wire MoonPay for:
  - `POST /v1/payments/ramps/onramp/execute`
  - `POST /v1/payments/ramps/offramp/execute`
- enforce USD-only fiat for current rollout and normalize MoonPay crypto currency codes
- add MoonPay URL signing and redirect URL generation in payments handlers
- add MoonPay env bindings (`MOONPAY_API_KEY`, `MOONPAY_SECRET_KEY`, optional on/off-ramp URL overrides)
- update tests to validate signed URL params/signature and missing-config behavior

## Validation
- `pnpm -C apps/sdp-api lint`
- `pnpm -C apps/sdp-api typecheck`
- `pnpm -C apps/sdp-api test -- src/routes/payments.test.ts`
