### PR TITLE
refactor(payments): provider dispatch for ramp execute endpoints

### DIFF
--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -278,7 +278,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     tags: ["Payments"],
     summary: "Execute on-ramp",
     operationId: "executePaymentOnramp",
-    description: "Creates a MoonPay fiat-to-crypto on-ramp session (USD-only).",
+    description: "Creates a fiat-to-crypto on-ramp session through the selected provider.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {
@@ -301,7 +301,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     tags: ["Payments"],
     summary: "Execute off-ramp",
     operationId: "executePaymentOfframp",
-    description: "Creates a MoonPay crypto-to-fiat off-ramp session (USD-only).",
+    description: "Creates a crypto-to-fiat off-ramp session through the selected provider.",
     security: [{ apiKeyAuth: [] }],
     request: {
       body: {

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -349,8 +349,15 @@ const moonpayCurrencyCodeSchema = z
     example: "usdc_sol",
   });
 
+const rampProviderSchema = z.string().min(1).default("moonpay").openapi({
+  description: "Ramp provider identifier. Defaults to MoonPay.",
+  example: "moonpay",
+  default: "moonpay",
+});
+
 export const executeOnrampRequestSchema = z
   .object({
+    provider: rampProviderSchema,
     destinationWallet: z.string().openapi({
       description: "Destination wallet ID or Solana address for purchased crypto.",
     }),
@@ -377,6 +384,7 @@ export const executeOnrampRequestSchema = z
 
 export const executeOfframpRequestSchema = z
   .object({
+    provider: rampProviderSchema,
     sourceWallet: z.string().openapi({
       description: "Source wallet ID or Solana address for crypto-to-fiat off-ramp.",
     }),

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -339,6 +339,32 @@ describe("Payments routes", () => {
     assertMoonPaySignature(redirect);
   });
 
+  it("returns bad request when provider is not supported", async () => {
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "lightspark",
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "USDC_SOL",
+          fiatCurrency: "USD",
+          fiatAmount: "10.00",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Unsupported ramp provider");
+  });
+
   it("returns internal error when MoonPay credentials are not configured", async () => {
     env.MOONPAY_API_KEY = undefined;
 

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -570,6 +570,54 @@ async function resolveScope(c: AppContext) {
   };
 }
 
+type ResolvedScope = Awaited<ReturnType<typeof resolveScope>>;
+
+type RampExecutionStatus = "pending" | "processing" | "completed" | "failed";
+
+type RampExecutionResult = {
+  id: string;
+  status: RampExecutionStatus;
+  redirectUrl?: string;
+  reference?: string;
+};
+
+type ExecuteOnrampInput = {
+  provider: string;
+  destinationWallet: string;
+  cryptoToken: string;
+  fiatCurrency?: "USD";
+  fiatAmount: string;
+  kycReference?: string;
+  redirectUrl?: string;
+};
+
+type ExecuteOfframpInput = {
+  provider: string;
+  sourceWallet: string;
+  cryptoToken: string;
+  fiatCurrency?: "USD";
+  cryptoAmount: string;
+  kycReference?: string;
+  redirectUrl?: string;
+};
+
+type ExecuteRampInput =
+  | ({ direction: "onramp" } & ExecuteOnrampInput)
+  | ({ direction: "offramp" } & ExecuteOfframpInput);
+
+type RampProviderExecutor = {
+  executeOnramp: (
+    c: AppContext,
+    scope: ResolvedScope,
+    input: ExecuteOnrampInput
+  ) => Promise<RampExecutionResult>;
+  executeOfframp: (
+    c: AppContext,
+    scope: ResolvedScope,
+    input: ExecuteOfframpInput
+  ) => Promise<RampExecutionResult>;
+};
+
 function resolveWallet(wallets: CustodyWallet[], walletId: string): CustodyWallet {
   const wallet = wallets.find((entry) => entry.walletId === walletId);
   if (!wallet) {
@@ -673,6 +721,92 @@ async function buildSignedMoonPayWidgetUrl(
   url.searchParams.set("signature", signature);
 
   return url.toString();
+}
+
+const moonPayRampProvider: RampProviderExecutor = {
+  async executeOnramp(c, scope, input) {
+    const destinationWalletAddress = resolveWalletAddress(
+      scope.wallets,
+      input.destinationWallet,
+      "destinationWallet"
+    );
+    const moonPay = getMoonPayConfig(c);
+
+    const redirectUrl = await buildSignedMoonPayWidgetUrl(moonPay.onrampUrl, moonPay.secretKey, {
+      apiKey: moonPay.apiKey,
+      baseCurrencyCode: "usd",
+      baseCurrencyAmount: input.fiatAmount,
+      currencyCode: normalizeMoonPayCurrencyCode(input.cryptoToken),
+      walletAddress: destinationWalletAddress,
+      redirectURL: input.redirectUrl,
+      externalCustomerId: input.kycReference,
+      externalTransactionId: `sdp_onramp_${crypto.randomUUID()}`,
+    });
+
+    return {
+      id: `ramp_${crypto.randomUUID()}`,
+      status: "pending",
+      redirectUrl,
+    };
+  },
+
+  async executeOfframp(c, scope, input) {
+    const sourceWalletAddress = resolveWalletAddress(
+      scope.wallets,
+      input.sourceWallet,
+      "sourceWallet"
+    );
+    const moonPay = getMoonPayConfig(c);
+    const externalTransactionId = `sdp_offramp_${crypto.randomUUID()}`;
+
+    const redirectUrl = await buildSignedMoonPayWidgetUrl(moonPay.offrampUrl, moonPay.secretKey, {
+      apiKey: moonPay.apiKey,
+      baseCurrencyCode: normalizeMoonPayCurrencyCode(input.cryptoToken),
+      baseCurrencyAmount: input.cryptoAmount,
+      quoteCurrencyCode: "usd",
+      walletAddress: sourceWalletAddress,
+      refundWalletAddress: sourceWalletAddress,
+      redirectURL: input.redirectUrl,
+      externalCustomerId: input.kycReference,
+      externalTransactionId,
+    });
+
+    return {
+      id: `ramp_${crypto.randomUUID()}`,
+      status: "pending",
+      redirectUrl,
+      reference: externalTransactionId,
+    };
+  },
+};
+
+const RAMP_PROVIDER_REGISTRY: Record<string, RampProviderExecutor> = {
+  moonpay: moonPayRampProvider,
+};
+
+function resolveRampProvider(providerId: string): RampProviderExecutor {
+  const normalizedProvider = providerId.trim().toLowerCase();
+  const provider = RAMP_PROVIDER_REGISTRY[normalizedProvider];
+
+  if (!provider) {
+    throw new AppError("BAD_REQUEST", `Unsupported ramp provider: ${providerId}`);
+  }
+
+  return provider;
+}
+
+async function executeRampWithProvider(
+  c: AppContext,
+  input: ExecuteRampInput
+): Promise<RampExecutionResult> {
+  const scope = await resolveScope(c);
+  const provider = resolveRampProvider(input.provider);
+
+  if (input.direction === "onramp") {
+    return provider.executeOnramp(c, scope, input);
+  }
+
+  return provider.executeOfframp(c, scope, input);
 }
 
 async function resolveWalletFromParams(c: AppContext) {
@@ -1477,32 +1611,12 @@ export async function executeOnramp(c: AppContext) {
     });
   }
 
-  const scope = await resolveScope(c);
-  const destinationWalletAddress = resolveWalletAddress(
-    scope.wallets,
-    parsed.data.destinationWallet,
-    "destinationWallet"
-  );
-  const moonPay = getMoonPayConfig(c);
-
-  const redirectUrl = await buildSignedMoonPayWidgetUrl(moonPay.onrampUrl, moonPay.secretKey, {
-    apiKey: moonPay.apiKey,
-    baseCurrencyCode: "usd",
-    baseCurrencyAmount: parsed.data.fiatAmount,
-    currencyCode: normalizeMoonPayCurrencyCode(parsed.data.cryptoToken),
-    walletAddress: destinationWalletAddress,
-    redirectURL: parsed.data.redirectUrl,
-    externalCustomerId: parsed.data.kycReference,
-    externalTransactionId: `sdp_onramp_${crypto.randomUUID()}`,
+  const ramp = await executeRampWithProvider(c, {
+    ...parsed.data,
+    direction: "onramp",
   });
 
-  return success(c, {
-    ramp: {
-      id: `ramp_${crypto.randomUUID()}`,
-      status: "pending",
-      redirectUrl,
-    },
-  });
+  return success(c, { ramp });
 }
 
 export async function executeOfframp(c: AppContext) {
@@ -1515,33 +1629,10 @@ export async function executeOfframp(c: AppContext) {
     });
   }
 
-  const scope = await resolveScope(c);
-  const sourceWalletAddress = resolveWalletAddress(
-    scope.wallets,
-    parsed.data.sourceWallet,
-    "sourceWallet"
-  );
-  const moonPay = getMoonPayConfig(c);
-  const externalTransactionId = `sdp_offramp_${crypto.randomUUID()}`;
-
-  const redirectUrl = await buildSignedMoonPayWidgetUrl(moonPay.offrampUrl, moonPay.secretKey, {
-    apiKey: moonPay.apiKey,
-    baseCurrencyCode: normalizeMoonPayCurrencyCode(parsed.data.cryptoToken),
-    baseCurrencyAmount: parsed.data.cryptoAmount,
-    quoteCurrencyCode: "usd",
-    walletAddress: sourceWalletAddress,
-    refundWalletAddress: sourceWalletAddress,
-    redirectURL: parsed.data.redirectUrl,
-    externalCustomerId: parsed.data.kycReference,
-    externalTransactionId,
+  const ramp = await executeRampWithProvider(c, {
+    ...parsed.data,
+    direction: "offramp",
   });
 
-  return success(c, {
-    ramp: {
-      id: `ramp_${crypto.randomUUID()}`,
-      status: "pending",
-      redirectUrl,
-      reference: externalTransactionId,
-    },
-  });
+  return success(c, { ramp });
 }

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -26,6 +26,8 @@ const moonpayAmountSchema = transferAmountSchema.refine(
   "Amount must be greater than zero"
 );
 
+const rampProviderSchema = z.string().trim().min(1).default("moonpay");
+
 const moonpayCurrencyCodeSchema = z
   .string()
   .regex(/^[a-zA-Z0-9_]+$/, { message: "Invalid MoonPay currency code" });
@@ -62,6 +64,7 @@ export const prepareTransferSchema = createTransferSchema.extend({
 });
 
 export const executeOnrampSchema = z.object({
+  provider: rampProviderSchema,
   destinationWallet: z.string().min(1),
   cryptoToken: moonpayCurrencyCodeSchema,
   fiatCurrency: z.literal("USD").optional(),
@@ -71,6 +74,7 @@ export const executeOnrampSchema = z.object({
 });
 
 export const executeOfframpSchema = z.object({
+  provider: rampProviderSchema,
   sourceWallet: z.string().min(1),
   cryptoToken: moonpayCurrencyCodeSchema,
   fiatCurrency: z.literal("USD").optional(),


### PR DESCRIPTION
## Summary
- keep the public ramp API surface as two endpoints: `/v1/payments/ramps/onramp/execute` and `/v1/payments/ramps/offramp/execute`
- refactor ramp execution internals to resolve a provider per request via a provider registry
- add `provider` to onramp/offramp request schemas (default `moonpay`) to prepare for additional providers
- keep USD-only flow semantics and fiat<->crypto directions unchanged
- add a test for unsupported providers returning `BAD_REQUEST`

## Validation
- `pnpm -C apps/sdp-api lint`
- `pnpm -C apps/sdp-api typecheck`
- `pnpm -C apps/sdp-api test -- src/routes/payments.test.ts`