### PR TITLE
feat(payments): integrate Lightspark Grid ramps

### DIFF
--- a/apps/sdp-api/.dev.vars.example
+++ b/apps/sdp-api/.dev.vars.example
@@ -47,3 +47,14 @@ FEE_PAYMENT_PROVIDER=kora
 
 # Clerk webhook (required for Clerk org linking)
 CLERK_WEBHOOK_SECRET=whsec_...
+
+# MoonPay ramps (widget-based)
+# MOONPAY_API_KEY=pk_test_...
+# MOONPAY_SECRET_KEY=sk_test_...
+# MOONPAY_ONRAMP_URL=https://buy-sandbox.moonpay.com
+# MOONPAY_OFFRAMP_URL=https://sell-sandbox.moonpay.com
+
+# Lightspark Grid ramps (API-based)
+# LIGHTSPARK_GRID_CLIENT_ID=YOUR_LIGHTSPARK_TOKEN_ID
+# LIGHTSPARK_GRID_CLIENT_SECRET=YOUR_LIGHTSPARK_CLIENT_SECRET
+# LIGHTSPARK_GRID_API_BASE_URL=https://api.lightspark.com/grid/2025-10-13

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -345,12 +345,13 @@ const moonpayCurrencyCodeSchema = z
   .string()
   .regex(/^[a-zA-Z0-9_]+$/)
   .openapi({
-    description: "MoonPay currency code (for example: `usdc_sol`).",
+    description: "Provider currency code (for example: `usdc_sol` for MoonPay, `BTC` for Grid).",
     example: "usdc_sol",
   });
 
 const rampProviderSchema = z.string().min(1).default("moonpay").openapi({
-  description: "Ramp provider identifier. Defaults to MoonPay.",
+  description:
+    "Ramp provider identifier. Supported values: moonpay, lightspark, auto. Defaults to moonpay.",
   example: "moonpay",
   default: "moonpay",
 });
@@ -412,6 +413,9 @@ export const executeOfframpRequestSchema = z
 export const onrampExecutionSchema = z
   .object({
     id: z.string().openapi({ description: "Ramp execution identifier.", example: "ramp_example" }),
+    provider: z
+      .string()
+      .openapi({ description: "Selected provider used for execution.", example: "moonpay" }),
     status: z
       .enum(["pending", "processing", "completed", "failed"])
       .openapi({ description: "Ramp execution status.", example: "pending" }),
@@ -420,12 +424,19 @@ export const onrampExecutionSchema = z
       .url()
       .optional()
       .openapi({ description: "Redirect URL for the ramp provider." }),
+    reference: z
+      .string()
+      .optional()
+      .openapi({ description: "Provider quote or transaction reference." }),
   })
   .openapi({ description: "On-ramp execution status." });
 
 export const offrampExecutionSchema = z
   .object({
     id: z.string().openapi({ description: "Ramp execution identifier.", example: "ramp_example" }),
+    provider: z
+      .string()
+      .openapi({ description: "Selected provider used for execution.", example: "moonpay" }),
     status: z
       .enum(["pending", "processing", "completed", "failed"])
       .openapi({ description: "Ramp execution status.", example: "pending" }),

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -99,6 +99,9 @@ const TEST_MOONPAY_API_KEY = "pk_test_moonpay";
 const TEST_MOONPAY_SECRET_KEY = "moonpay_secret_key";
 const TEST_MOONPAY_ONRAMP_URL = "https://buy-sandbox.moonpay.com";
 const TEST_MOONPAY_OFFRAMP_URL = "https://sell-sandbox.moonpay.com";
+const TEST_LIGHTSPARK_GRID_CLIENT_ID = "lightspark_token_id";
+const TEST_LIGHTSPARK_GRID_CLIENT_SECRET = "lightspark_client_secret";
+const TEST_LIGHTSPARK_GRID_API_BASE_URL = "https://api.lightspark.test/grid/2025-10-13";
 // biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
 const MOONPAY_PARAM_BASE_CURRENCY_AMOUNT = "baseCurrencyAmount";
 // biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
@@ -112,6 +115,9 @@ let originalMoonPayApiKey: string | undefined;
 let originalMoonPaySecretKey: string | undefined;
 let originalMoonPayOnrampUrl: string | undefined;
 let originalMoonPayOfframpUrl: string | undefined;
+let originalLightsparkGridClientId: string | undefined;
+let originalLightsparkGridClientSecret: string | undefined;
+let originalLightsparkGridApiBaseUrl: string | undefined;
 
 function assertMoonPaySignature(url: URL): void {
   const signature = url.searchParams.get("signature");
@@ -124,6 +130,11 @@ function assertMoonPaySignature(url: URL): void {
     .update(unsignedUrl.search)
     .digest("base64");
   expect(signature).toBe(expectedSignature);
+}
+
+function lightsparkBasicAuthHeader(): string {
+  const credentials = `${TEST_LIGHTSPARK_GRID_CLIENT_ID}:${TEST_LIGHTSPARK_GRID_CLIENT_SECRET}`;
+  return `Basic ${Buffer.from(credentials, "utf8").toString("base64")}`;
 }
 
 async function seedAuthAndWallet(): Promise<void> {
@@ -233,11 +244,17 @@ describe("Payments routes", () => {
     originalMoonPaySecretKey = env.MOONPAY_SECRET_KEY;
     originalMoonPayOnrampUrl = env.MOONPAY_ONRAMP_URL;
     originalMoonPayOfframpUrl = env.MOONPAY_OFFRAMP_URL;
+    originalLightsparkGridClientId = env.LIGHTSPARK_GRID_CLIENT_ID;
+    originalLightsparkGridClientSecret = env.LIGHTSPARK_GRID_CLIENT_SECRET;
+    originalLightsparkGridApiBaseUrl = env.LIGHTSPARK_GRID_API_BASE_URL;
 
     env.MOONPAY_API_KEY = TEST_MOONPAY_API_KEY;
     env.MOONPAY_SECRET_KEY = TEST_MOONPAY_SECRET_KEY;
     env.MOONPAY_ONRAMP_URL = TEST_MOONPAY_ONRAMP_URL;
     env.MOONPAY_OFFRAMP_URL = TEST_MOONPAY_OFFRAMP_URL;
+    env.LIGHTSPARK_GRID_CLIENT_ID = TEST_LIGHTSPARK_GRID_CLIENT_ID;
+    env.LIGHTSPARK_GRID_CLIENT_SECRET = TEST_LIGHTSPARK_GRID_CLIENT_SECRET;
+    env.LIGHTSPARK_GRID_API_BASE_URL = TEST_LIGHTSPARK_GRID_API_BASE_URL;
 
     await seedTestDatabase(env);
     await seedAuthAndWallet();
@@ -248,6 +265,9 @@ describe("Payments routes", () => {
     env.MOONPAY_SECRET_KEY = originalMoonPaySecretKey;
     env.MOONPAY_ONRAMP_URL = originalMoonPayOnrampUrl;
     env.MOONPAY_OFFRAMP_URL = originalMoonPayOfframpUrl;
+    env.LIGHTSPARK_GRID_CLIENT_ID = originalLightsparkGridClientId;
+    env.LIGHTSPARK_GRID_CLIENT_SECRET = originalLightsparkGridClientSecret;
+    env.LIGHTSPARK_GRID_API_BASE_URL = originalLightsparkGridApiBaseUrl;
 
     await clearTestDatabase(env);
     await clearKVNamespaces(env);
@@ -339,7 +359,20 @@ describe("Payments routes", () => {
     assertMoonPaySignature(redirect);
   });
 
-  it("returns bad request when provider is not supported", async () => {
+  it("creates a Lightspark on-ramp quote through the execute endpoint", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "Quote:ls_onramp_123",
+          quoteStatus: "PENDING",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
     const res = await app.request(
       "/v1/payments/ramps/onramp/execute",
       {
@@ -350,6 +383,138 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          destinationWallet: "ExternalAccount:acc_destination_123",
+          cryptoToken: "BTC",
+          fiatCurrency: "USD",
+          fiatAmount: "12.34",
+          kycReference: "Customer:cus_123",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { ramp: { id: string; provider: string; status: string; reference: string } };
+    };
+
+    expect(body.data.ramp.id.startsWith("ramp_")).toBe(true);
+    expect(body.data.ramp.provider).toBe("lightspark");
+    expect(body.data.ramp.status).toBe("pending");
+    expect(body.data.ramp.reference).toBe("Quote:ls_onramp_123");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const requestUrl = fetchSpy.mock.calls[0]?.[0];
+    const requestInit = fetchSpy.mock.calls[0]?.[1];
+    expect(String(requestUrl)).toBe(`${TEST_LIGHTSPARK_GRID_API_BASE_URL}/quotes`);
+    expect(requestInit?.method).toBe("POST");
+
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(lightsparkBasicAuthHeader());
+
+    const payload = JSON.parse(String(requestInit?.body)) as {
+      lockedCurrencyAmount: string;
+      source: { customerId: string; currency: string };
+      destination: { accountId: string; currency: string };
+    };
+    expect(payload.lockedCurrencyAmount).toBe("1234");
+    expect(payload.source.customerId).toBe("Customer:cus_123");
+    expect(payload.source.currency).toBe("USD");
+    expect(payload.destination.accountId).toBe("ExternalAccount:acc_destination_123");
+    expect(payload.destination.currency).toBe("BTC");
+    fetchSpy.mockRestore();
+  });
+
+  it("creates and executes a Lightspark off-ramp quote through the execute endpoint", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "Quote:ls_offramp_123",
+            quoteStatus: "PENDING",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "Quote:ls_offramp_123",
+            quoteStatus: "COMPLETED",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      );
+
+    const res = await app.request(
+      "/v1/payments/ramps/offramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "lightspark",
+          sourceWallet: "InternalAccount:acc_source_123",
+          cryptoToken: "BTC",
+          fiatCurrency: "USD",
+          cryptoAmount: "0.015",
+          kycReference: "ExternalAccount:acc_destination_456",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { ramp: { id: string; provider: string; status: string; reference: string } };
+    };
+
+    expect(body.data.ramp.id.startsWith("ramp_")).toBe(true);
+    expect(body.data.ramp.provider).toBe("lightspark");
+    expect(body.data.ramp.status).toBe("completed");
+    expect(body.data.ramp.reference).toBe("Quote:ls_offramp_123");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const quoteCallUrl = String(fetchSpy.mock.calls[0]?.[0]);
+    const executeCallUrl = String(fetchSpy.mock.calls[1]?.[0]);
+    expect(quoteCallUrl).toBe(`${TEST_LIGHTSPARK_GRID_API_BASE_URL}/quotes`);
+    expect(executeCallUrl).toBe(
+      `${TEST_LIGHTSPARK_GRID_API_BASE_URL}/quotes/Quote%3Als_offramp_123/execute`
+    );
+
+    const quoteCallPayload = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body)) as {
+      lockedCurrencyAmount: string;
+      source: { accountId: string; currency: string };
+      destination: { accountId: string; currency: string };
+    };
+    expect(quoteCallPayload.lockedCurrencyAmount).toBe("1500000");
+    expect(quoteCallPayload.source.accountId).toBe("InternalAccount:acc_source_123");
+    expect(quoteCallPayload.source.currency).toBe("BTC");
+    expect(quoteCallPayload.destination.accountId).toBe("ExternalAccount:acc_destination_456");
+    expect(quoteCallPayload.destination.currency).toBe("USD");
+    fetchSpy.mockRestore();
+  });
+
+  it("returns bad request when provider is not supported", async () => {
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "unsupported_provider",
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC_SOL",
           fiatCurrency: "USD",
@@ -390,6 +555,35 @@ describe("Payments routes", () => {
     const body = (await res.json()) as { error: { code: string; message: string } };
     expect(body.error.code).toBe("INTERNAL_ERROR");
     expect(body.error.message).toContain("MoonPay is not configured");
+  });
+
+  it("returns internal error when Lightspark credentials are not configured", async () => {
+    env.LIGHTSPARK_GRID_CLIENT_ID = undefined;
+
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "lightspark",
+          destinationWallet: "ExternalAccount:acc_destination_123",
+          cryptoToken: "BTC",
+          fiatCurrency: "USD",
+          fiatAmount: "10",
+          kycReference: "Customer:cus_123",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("Lightspark is not configured");
   });
 
   it("blocks prepare transfer when destination is outside allowlist", async () => {

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -413,13 +413,15 @@ describe("Payments routes", () => {
     expect(headers.Authorization).toBe(lightsparkBasicAuthHeader());
 
     const payload = JSON.parse(String(requestInit?.body)) as {
-      lockedCurrencyAmount: string;
-      source: { customerId: string; currency: string };
-      destination: { accountId: string; currency: string };
+      lockedCurrencyAmount: number;
+      source: { sourceType: string; customerId: string; currency: string };
+      destination: { destinationType: string; accountId: string; currency: string };
     };
-    expect(payload.lockedCurrencyAmount).toBe("1234");
+    expect(payload.lockedCurrencyAmount).toBe(1234);
+    expect(payload.source.sourceType).toBe("REALTIME_FUNDING");
     expect(payload.source.customerId).toBe("Customer:cus_123");
     expect(payload.source.currency).toBe("USD");
+    expect(payload.destination.destinationType).toBe("ACCOUNT");
     expect(payload.destination.accountId).toBe("ExternalAccount:acc_destination_123");
     expect(payload.destination.currency).toBe("BTC");
     fetchSpy.mockRestore();
@@ -492,13 +494,15 @@ describe("Payments routes", () => {
     );
 
     const quoteCallPayload = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body)) as {
-      lockedCurrencyAmount: string;
-      source: { accountId: string; currency: string };
-      destination: { accountId: string; currency: string };
+      lockedCurrencyAmount: number;
+      source: { sourceType: string; accountId: string; currency: string };
+      destination: { destinationType: string; accountId: string; currency: string };
     };
-    expect(quoteCallPayload.lockedCurrencyAmount).toBe("1500000");
+    expect(quoteCallPayload.lockedCurrencyAmount).toBe(1500000);
+    expect(quoteCallPayload.source.sourceType).toBe("ACCOUNT");
     expect(quoteCallPayload.source.accountId).toBe("InternalAccount:acc_source_123");
     expect(quoteCallPayload.source.currency).toBe("BTC");
+    expect(quoteCallPayload.destination.destinationType).toBe("ACCOUNT");
     expect(quoteCallPayload.destination.accountId).toBe("ExternalAccount:acc_destination_456");
     expect(quoteCallPayload.destination.currency).toBe("USD");
     fetchSpy.mockRestore();

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -427,6 +427,175 @@ describe("Payments routes", () => {
     fetchSpy.mockRestore();
   });
 
+  it("reuses an existing Lightspark external account for Solana wallet on-ramp destinations", async () => {
+    const destinationSolanaWallet = TEST_SOLANA_ADDRESSES.wallet2;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "ExternalAccount:acc_existing_123",
+                accountInfo: {
+                  accountType: "SOLANA_WALLET",
+                  address: destinationSolanaWallet,
+                },
+              },
+            ],
+            hasMore: false,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "Quote:ls_onramp_existing_123",
+            quoteStatus: "PENDING",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      );
+
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "lightspark",
+          destinationWallet: destinationSolanaWallet,
+          cryptoToken: "USDC",
+          fiatCurrency: "USD",
+          fiatAmount: "5.00",
+          kycReference: "Customer:cus_123",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { ramp: { provider: string; reference: string } };
+    };
+    expect(body.data.ramp.provider).toBe("lightspark");
+    expect(body.data.ramp.reference).toBe("Quote:ls_onramp_existing_123");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const listUrl = new URL(String(fetchSpy.mock.calls[0]?.[0]));
+    expect(listUrl.pathname).toBe("/grid/2025-10-13/customers/external-accounts");
+    expect(listUrl.searchParams.get("customerId")).toBe("Customer:cus_123");
+    expect(listUrl.searchParams.get("currency")).toBe("USDC");
+    expect(listUrl.searchParams.get("limit")).toBe("100");
+
+    const quotePayload = JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body)) as {
+      destination: { accountId: string };
+    };
+    expect(quotePayload.destination.accountId).toBe("ExternalAccount:acc_existing_123");
+    fetchSpy.mockRestore();
+  });
+
+  it("creates a Lightspark external account when Solana wallet destination is not found", async () => {
+    const destinationSolanaWallet = TEST_SOLANA_ADDRESSES.wallet3;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [],
+            hasMore: false,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "ExternalAccount:acc_created_123",
+            accountInfo: {
+              accountType: "SOLANA_WALLET",
+              address: destinationSolanaWallet,
+            },
+          }),
+          {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "Quote:ls_onramp_created_123",
+            quoteStatus: "PENDING",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      );
+
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "lightspark",
+          destinationWallet: destinationSolanaWallet,
+          cryptoToken: "USDC",
+          fiatCurrency: "USD",
+          fiatAmount: "5.00",
+          kycReference: "Customer:cus_123",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { ramp: { provider: string; reference: string } };
+    };
+    expect(body.data.ramp.provider).toBe("lightspark");
+    expect(body.data.ramp.reference).toBe("Quote:ls_onramp_created_123");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const createUrl = String(fetchSpy.mock.calls[1]?.[0]);
+    expect(createUrl).toBe(`${TEST_LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts`);
+    const createPayload = JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body)) as {
+      customerId: string;
+      currency: string;
+      accountInfo: { accountType: string; address: string };
+    };
+    expect(createPayload.customerId).toBe("Customer:cus_123");
+    expect(createPayload.currency).toBe("USDC");
+    expect(createPayload.accountInfo.accountType).toBe("SOLANA_WALLET");
+    expect(createPayload.accountInfo.address).toBe(destinationSolanaWallet);
+
+    const quotePayload = JSON.parse(String(fetchSpy.mock.calls[2]?.[1]?.body)) as {
+      destination: { accountId: string };
+    };
+    expect(quotePayload.destination.accountId).toBe("ExternalAccount:acc_created_123");
+    fetchSpy.mockRestore();
+  });
+
   it("creates and executes a Lightspark off-ramp quote through the execute endpoint", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -11,7 +11,7 @@ import { formatDecimalAmount, isDecimalString, parseDecimalAmount } from "@/lib/
 import { getAuth } from "@/lib/auth";
 import { AppError } from "@/lib/errors";
 import { paginated, success } from "@/lib/response";
-import { assertValidAddress } from "@/lib/solana";
+import { assertValidAddress, isAddress } from "@/lib/solana";
 import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { createSigningService } from "@/services/domain/signing.service";
 import { withHeliusApiKey } from "@/services/rpc-relay.service";
@@ -675,6 +675,14 @@ type LightsparkQuote = {
   };
 };
 
+type LightsparkExternalAccount = {
+  id?: string;
+  accountInfo?: {
+    accountType?: string;
+    address?: string;
+  };
+};
+
 const LIGHTSPARK_DEFAULT_GRID_API_URL = "https://api.lightspark.com/grid/2025-10-13";
 
 function getMoonPayConfig(c: AppContext): MoonPayConfig {
@@ -843,6 +851,143 @@ function assertLightsparkAccountId(value: string, fieldName: string): string {
   return normalized;
 }
 
+function parseLightsparkExternalAccount(payload: unknown): LightsparkExternalAccount {
+  if (typeof payload !== "object" || payload === null) {
+    return {};
+  }
+
+  const raw = payload as {
+    id?: unknown;
+    accountInfo?: {
+      accountType?: unknown;
+      address?: unknown;
+    };
+  };
+
+  return {
+    id: typeof raw.id === "string" ? raw.id : undefined,
+    accountInfo:
+      raw.accountInfo && typeof raw.accountInfo === "object"
+        ? {
+            accountType:
+              typeof raw.accountInfo.accountType === "string"
+                ? raw.accountInfo.accountType
+                : undefined,
+            address:
+              typeof raw.accountInfo.address === "string" ? raw.accountInfo.address : undefined,
+          }
+        : undefined,
+  };
+}
+
+async function listLightsparkCustomerExternalAccounts(
+  config: LightsparkConfig,
+  customerId: string,
+  currency: string
+): Promise<LightsparkExternalAccount[]> {
+  const externalAccounts: LightsparkExternalAccount[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < 10; page += 1) {
+    const query = new URLSearchParams();
+    query.set("customerId", customerId);
+    query.set("currency", currency);
+    query.set("limit", "100");
+    if (cursor) {
+      query.set("cursor", cursor);
+    }
+
+    const response = await lightsparkRequest(config, `customers/external-accounts?${query}`, {
+      method: "GET",
+    });
+
+    if (typeof response !== "object" || response === null) {
+      throw new AppError("BAD_REQUEST", "Lightspark external accounts response is invalid");
+    }
+
+    const payload = response as {
+      data?: unknown;
+      hasMore?: unknown;
+      nextCursor?: unknown;
+    };
+
+    const accounts = Array.isArray(payload.data) ? payload.data : [];
+    externalAccounts.push(...accounts.map(parseLightsparkExternalAccount));
+
+    const hasMore = payload.hasMore === true;
+    cursor =
+      typeof payload.nextCursor === "string" && payload.nextCursor.length > 0
+        ? payload.nextCursor
+        : undefined;
+
+    if (!hasMore || !cursor) {
+      break;
+    }
+  }
+
+  return externalAccounts;
+}
+
+async function resolveLightsparkOnrampDestinationAccountId(
+  config: LightsparkConfig,
+  customerId: string,
+  destinationWallet: string,
+  currency: string
+): Promise<string> {
+  const normalized = destinationWallet.trim();
+  if (normalized.length === 0) {
+    throw new AppError("BAD_REQUEST", "destinationWallet is required for lightspark");
+  }
+
+  if (normalized.includes(":")) {
+    return assertLightsparkAccountId(normalized, "destinationWallet");
+  }
+
+  if (!isAddress(normalized)) {
+    throw new AppError(
+      "BAD_REQUEST",
+      "destinationWallet must be a Lightspark account id (for example ExternalAccount:...) or a Solana wallet address"
+    );
+  }
+
+  const externalAccounts = await listLightsparkCustomerExternalAccounts(
+    config,
+    customerId,
+    currency
+  );
+  const existing = externalAccounts.find((account) => {
+    if (!account.id) {
+      return false;
+    }
+    const accountType = account.accountInfo?.accountType?.toUpperCase();
+    const address = account.accountInfo?.address;
+    return accountType === "SOLANA_WALLET" && address === normalized;
+  });
+
+  if (existing?.id) {
+    return existing.id;
+  }
+
+  const createResponse = await lightsparkRequest(config, "customers/external-accounts", {
+    method: "POST",
+    body: {
+      customerId,
+      currency,
+      accountInfo: {
+        accountType: "SOLANA_WALLET",
+        address: normalized,
+      },
+    },
+  });
+
+  const created = parseLightsparkExternalAccount(createResponse);
+  if (!created.id) {
+    throw new AppError("BAD_REQUEST", "Lightspark external account response is missing id");
+  }
+
+  return created.id;
+}
+
 function toLightsparkMinorUnitsInteger(value: bigint, fieldName: string): number {
   if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new AppError("BAD_REQUEST", `${fieldName} is too large for Lightspark quote minor units`);
@@ -983,16 +1128,18 @@ const lightsparkRampProvider: RampProviderExecutor = {
       );
     }
 
-    const destinationAccountId = assertLightsparkAccountId(
-      input.destinationWallet,
-      "destinationWallet"
-    );
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
     const fiatAmountMinorUnits = toLightsparkMinorUnitsInteger(
       parseDecimalAmount(input.fiatAmount, 2),
       "fiatAmount"
     );
     const config = getLightsparkConfig(c);
+    const destinationAccountId = await resolveLightsparkOnrampDestinationAccountId(
+      config,
+      customerId,
+      input.destinationWallet,
+      cryptoCurrency
+    );
 
     const quoteResponse = await lightsparkRequest(config, "quotes", {
       method: "POST",

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -787,8 +787,9 @@ async function lightsparkRequest(
   if (!response.ok) {
     const parsedMessage =
       parsed && typeof parsed === "object"
-        ? ((parsed as { message?: unknown; error?: unknown }).message ??
-          (parsed as { message?: unknown; error?: unknown }).error)
+        ? ((parsed as { message?: unknown; error?: unknown; reason?: unknown }).message ??
+          (parsed as { message?: unknown; error?: unknown; reason?: unknown }).error ??
+          (parsed as { message?: unknown; error?: unknown; reason?: unknown }).reason)
         : undefined;
 
     const message =
@@ -840,6 +841,14 @@ function assertLightsparkAccountId(value: string, fieldName: string): string {
     );
   }
   return normalized;
+}
+
+function toLightsparkMinorUnitsInteger(value: bigint, fieldName: string): number {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new AppError("BAD_REQUEST", `${fieldName} is too large for Lightspark quote minor units`);
+  }
+
+  return Number(value);
 }
 
 function mapLightsparkQuoteStatus(status: string | undefined): RampExecutionStatus {
@@ -979,17 +988,22 @@ const lightsparkRampProvider: RampProviderExecutor = {
       "destinationWallet"
     );
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
-    const fiatAmountMinorUnits = parseDecimalAmount(input.fiatAmount, 2).toString();
+    const fiatAmountMinorUnits = toLightsparkMinorUnitsInteger(
+      parseDecimalAmount(input.fiatAmount, 2),
+      "fiatAmount"
+    );
     const config = getLightsparkConfig(c);
 
     const quoteResponse = await lightsparkRequest(config, "quotes", {
       method: "POST",
       body: {
         source: {
+          sourceType: "REALTIME_FUNDING",
           customerId,
           currency: "USD",
         },
         destination: {
+          destinationType: "ACCOUNT",
           accountId: destinationAccountId,
           currency: cryptoCurrency,
         },
@@ -1016,20 +1030,22 @@ const lightsparkRampProvider: RampProviderExecutor = {
       "kycReference"
     );
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
-    const cryptoAmountMinorUnits = parseDecimalAmount(
-      input.cryptoAmount,
-      getLightsparkCurrencyDecimals(cryptoCurrency)
-    ).toString();
+    const cryptoAmountMinorUnits = toLightsparkMinorUnitsInteger(
+      parseDecimalAmount(input.cryptoAmount, getLightsparkCurrencyDecimals(cryptoCurrency)),
+      "cryptoAmount"
+    );
     const config = getLightsparkConfig(c);
 
     const quoteResponse = await lightsparkRequest(config, "quotes", {
       method: "POST",
       body: {
         source: {
+          sourceType: "ACCOUNT",
           accountId: sourceAccountId,
           currency: cryptoCurrency,
         },
         destination: {
+          destinationType: "ACCOUNT",
           accountId: destinationAccountId,
           currency: "USD",
         },

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -576,6 +576,7 @@ type RampExecutionStatus = "pending" | "processing" | "completed" | "failed";
 
 type RampExecutionResult = {
   id: string;
+  provider: string;
   status: RampExecutionStatus;
   redirectUrl?: string;
   reference?: string;
@@ -606,6 +607,7 @@ type ExecuteRampInput =
   | ({ direction: "offramp" } & ExecuteOfframpInput);
 
 type RampProviderExecutor = {
+  isConfigured: (c: AppContext) => boolean;
   executeOnramp: (
     c: AppContext,
     scope: ResolvedScope,
@@ -656,6 +658,25 @@ type MoonPayConfig = {
   offrampUrl: string;
 };
 
+type LightsparkConfig = {
+  tokenId: string;
+  clientSecret: string;
+  apiBaseUrl: string;
+};
+
+type LightsparkQuoteStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED" | "EXPIRED";
+
+type LightsparkQuote = {
+  id?: string;
+  quoteStatus?: LightsparkQuoteStatus;
+  status?: LightsparkQuoteStatus;
+  paymentInstructions?: {
+    url?: string;
+  };
+};
+
+const LIGHTSPARK_DEFAULT_GRID_API_URL = "https://api.lightspark.com/grid/2025-10-13";
+
 function getMoonPayConfig(c: AppContext): MoonPayConfig {
   const apiKey = c.env.MOONPAY_API_KEY?.trim();
   const secretKey = c.env.MOONPAY_SECRET_KEY?.trim();
@@ -687,6 +708,163 @@ function getMoonPayConfig(c: AppContext): MoonPayConfig {
     onrampUrl: onrampUrlRaw,
     offrampUrl: offrampUrlRaw,
   };
+}
+
+function isMoonPayConfigured(c: AppContext): boolean {
+  const apiKey = c.env.MOONPAY_API_KEY?.trim();
+  const secretKey = c.env.MOONPAY_SECRET_KEY?.trim();
+  return Boolean(apiKey && secretKey);
+}
+
+function getLightsparkConfig(c: AppContext): LightsparkConfig {
+  const tokenId = c.env.LIGHTSPARK_GRID_CLIENT_ID?.trim();
+  const clientSecret = c.env.LIGHTSPARK_GRID_CLIENT_SECRET?.trim();
+
+  if (!tokenId || !clientSecret) {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "Lightspark is not configured. Set LIGHTSPARK_GRID_CLIENT_ID and LIGHTSPARK_GRID_CLIENT_SECRET."
+    );
+  }
+
+  const apiBaseUrlRaw =
+    c.env.LIGHTSPARK_GRID_API_BASE_URL?.trim() || LIGHTSPARK_DEFAULT_GRID_API_URL;
+  try {
+    new URL(apiBaseUrlRaw);
+  } catch {
+    throw new AppError("INTERNAL_ERROR", "Lightspark API URL configuration is invalid.");
+  }
+
+  return {
+    tokenId,
+    clientSecret,
+    apiBaseUrl: apiBaseUrlRaw,
+  };
+}
+
+function isLightsparkConfigured(c: AppContext): boolean {
+  const tokenId = c.env.LIGHTSPARK_GRID_CLIENT_ID?.trim();
+  const clientSecret = c.env.LIGHTSPARK_GRID_CLIENT_SECRET?.trim();
+  return Boolean(tokenId && clientSecret);
+}
+
+function encodeBasicAuth(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64");
+}
+
+function safeParseJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function lightsparkRequest(
+  config: LightsparkConfig,
+  path: string,
+  init: {
+    method: "GET" | "POST";
+    body?: unknown;
+  }
+): Promise<unknown> {
+  const apiBaseUrl = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
+  const url = new URL(path, apiBaseUrl);
+  const auth = encodeBasicAuth(`${config.tokenId}:${config.clientSecret}`);
+
+  const response = await fetch(url.toString(), {
+    method: init.method,
+    headers: {
+      Authorization: `Basic ${auth}`,
+      "Content-Type": "application/json",
+    },
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+
+  const raw = await response.text();
+  const parsed = safeParseJson(raw);
+
+  if (!response.ok) {
+    const parsedMessage =
+      parsed && typeof parsed === "object"
+        ? ((parsed as { message?: unknown; error?: unknown }).message ??
+          (parsed as { message?: unknown; error?: unknown }).error)
+        : undefined;
+
+    const message =
+      typeof parsedMessage === "string" && parsedMessage.length > 0
+        ? parsedMessage
+        : `Lightspark request failed with status ${response.status}`;
+
+    throw new AppError("BAD_REQUEST", message);
+  }
+
+  return parsed ?? {};
+}
+
+function normalizeLightsparkCurrencyCode(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  if (!/^[A-Z0-9_]+$/.test(normalized)) {
+    throw new AppError("BAD_REQUEST", "cryptoToken must be a valid Lightspark currency code");
+  }
+  return normalized;
+}
+
+function getLightsparkCurrencyDecimals(currencyCode: string): number {
+  const normalized = currencyCode.trim().toUpperCase();
+  if (normalized === "BTC") {
+    return 8;
+  }
+  if (normalized === "SOL") {
+    return 9;
+  }
+  if (normalized === "USDC") {
+    return 6;
+  }
+
+  throw new AppError(
+    "BAD_REQUEST",
+    `Unsupported lightspark cryptoToken: ${currencyCode}. Supported values: BTC, SOL, USDC`
+  );
+}
+
+function assertLightsparkAccountId(value: string, fieldName: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new AppError("BAD_REQUEST", `${fieldName} is required for lightspark`);
+  }
+  if (!normalized.includes(":")) {
+    throw new AppError(
+      "BAD_REQUEST",
+      `${fieldName} must be a Lightspark account identifier (for example: ExternalAccount:...)`
+    );
+  }
+  return normalized;
+}
+
+function mapLightsparkQuoteStatus(status: string | undefined): RampExecutionStatus {
+  if (!status) {
+    return "pending";
+  }
+
+  const normalized = status.trim().toUpperCase();
+  if (normalized === "COMPLETED") {
+    return "completed";
+  }
+  if (normalized === "PROCESSING") {
+    return "processing";
+  }
+  if (normalized === "FAILED" || normalized === "EXPIRED") {
+    return "failed";
+  }
+  return "pending";
+}
+
+function parseLightsparkQuote(payload: unknown): LightsparkQuote {
+  if (typeof payload !== "object" || payload === null) {
+    throw new AppError("BAD_REQUEST", "Lightspark response payload is invalid");
+  }
+  return payload as LightsparkQuote;
 }
 
 async function createMoonPaySignature(unsignedQuery: string, secretKey: string): Promise<string> {
@@ -724,6 +902,8 @@ async function buildSignedMoonPayWidgetUrl(
 }
 
 const moonPayRampProvider: RampProviderExecutor = {
+  isConfigured: isMoonPayConfigured,
+
   async executeOnramp(c, scope, input) {
     const destinationWalletAddress = resolveWalletAddress(
       scope.wallets,
@@ -745,6 +925,7 @@ const moonPayRampProvider: RampProviderExecutor = {
 
     return {
       id: `ramp_${crypto.randomUUID()}`,
+      provider: "moonpay",
       status: "pending",
       redirectUrl,
     };
@@ -773,6 +954,7 @@ const moonPayRampProvider: RampProviderExecutor = {
 
     return {
       id: `ramp_${crypto.randomUUID()}`,
+      provider: "moonpay",
       status: "pending",
       redirectUrl,
       reference: externalTransactionId,
@@ -780,12 +962,128 @@ const moonPayRampProvider: RampProviderExecutor = {
   },
 };
 
-const RAMP_PROVIDER_REGISTRY: Record<string, RampProviderExecutor> = {
-  moonpay: moonPayRampProvider,
+const lightsparkRampProvider: RampProviderExecutor = {
+  isConfigured: isLightsparkConfigured,
+
+  async executeOnramp(c, _scope, input) {
+    const customerId = input.kycReference?.trim();
+    if (!customerId) {
+      throw new AppError(
+        "BAD_REQUEST",
+        "kycReference is required for lightspark onramp and must contain a Lightspark customer id"
+      );
+    }
+
+    const destinationAccountId = assertLightsparkAccountId(
+      input.destinationWallet,
+      "destinationWallet"
+    );
+    const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
+    const fiatAmountMinorUnits = parseDecimalAmount(input.fiatAmount, 2).toString();
+    const config = getLightsparkConfig(c);
+
+    const quoteResponse = await lightsparkRequest(config, "quotes", {
+      method: "POST",
+      body: {
+        source: {
+          customerId,
+          currency: "USD",
+        },
+        destination: {
+          accountId: destinationAccountId,
+          currency: cryptoCurrency,
+        },
+        lockedCurrencySide: "SENDING",
+        lockedCurrencyAmount: fiatAmountMinorUnits,
+        description: "SDP onramp",
+      },
+    });
+
+    const quote = parseLightsparkQuote(quoteResponse);
+    return {
+      id: `ramp_${crypto.randomUUID()}`,
+      provider: "lightspark",
+      status: mapLightsparkQuoteStatus(quote.quoteStatus ?? quote.status),
+      redirectUrl: quote.paymentInstructions?.url,
+      reference: quote.id,
+    };
+  },
+
+  async executeOfframp(c, _scope, input) {
+    const sourceAccountId = assertLightsparkAccountId(input.sourceWallet, "sourceWallet");
+    const destinationAccountId = assertLightsparkAccountId(
+      input.kycReference ?? "",
+      "kycReference"
+    );
+    const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
+    const cryptoAmountMinorUnits = parseDecimalAmount(
+      input.cryptoAmount,
+      getLightsparkCurrencyDecimals(cryptoCurrency)
+    ).toString();
+    const config = getLightsparkConfig(c);
+
+    const quoteResponse = await lightsparkRequest(config, "quotes", {
+      method: "POST",
+      body: {
+        source: {
+          accountId: sourceAccountId,
+          currency: cryptoCurrency,
+        },
+        destination: {
+          accountId: destinationAccountId,
+          currency: "USD",
+        },
+        lockedCurrencySide: "SENDING",
+        lockedCurrencyAmount: cryptoAmountMinorUnits,
+        description: "SDP offramp",
+      },
+    });
+
+    const quote = parseLightsparkQuote(quoteResponse);
+    if (!quote.id) {
+      throw new AppError("BAD_REQUEST", "Lightspark quote response is missing id");
+    }
+
+    const executeResponse = await lightsparkRequest(
+      config,
+      `quotes/${encodeURIComponent(quote.id)}/execute`,
+      {
+        method: "POST",
+      }
+    );
+    const executedQuote = parseLightsparkQuote(executeResponse);
+
+    return {
+      id: `ramp_${crypto.randomUUID()}`,
+      provider: "lightspark",
+      status: mapLightsparkQuoteStatus(executedQuote.quoteStatus ?? executedQuote.status),
+      redirectUrl: executedQuote.paymentInstructions?.url,
+      reference: quote.id,
+    };
+  },
 };
 
-function resolveRampProvider(providerId: string): RampProviderExecutor {
+const RAMP_PROVIDER_REGISTRY: Record<string, RampProviderExecutor> = {
+  moonpay: moonPayRampProvider,
+  lightspark: lightsparkRampProvider,
+};
+
+function resolveRampProvider(c: AppContext, providerId: string): RampProviderExecutor {
   const normalizedProvider = providerId.trim().toLowerCase();
+
+  if (normalizedProvider === "auto") {
+    if (lightsparkRampProvider.isConfigured(c)) {
+      return lightsparkRampProvider;
+    }
+    if (moonPayRampProvider.isConfigured(c)) {
+      return moonPayRampProvider;
+    }
+    throw new AppError(
+      "INTERNAL_ERROR",
+      "No ramp provider is configured. Configure MoonPay or Lightspark credentials."
+    );
+  }
+
   const provider = RAMP_PROVIDER_REGISTRY[normalizedProvider];
 
   if (!provider) {
@@ -800,7 +1098,7 @@ async function executeRampWithProvider(
   input: ExecuteRampInput
 ): Promise<RampExecutionResult> {
   const scope = await resolveScope(c);
-  const provider = resolveRampProvider(input.provider);
+  const provider = resolveRampProvider(c, input.provider);
 
   if (input.direction === "onramp") {
     return provider.executeOnramp(c, scope, input);

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -28,9 +28,9 @@ const moonpayAmountSchema = transferAmountSchema.refine(
 
 const rampProviderSchema = z.string().trim().min(1).default("moonpay");
 
-const moonpayCurrencyCodeSchema = z
+const rampCurrencyCodeSchema = z
   .string()
-  .regex(/^[a-zA-Z0-9_]+$/, { message: "Invalid MoonPay currency code" });
+  .regex(/^[a-zA-Z0-9_]+$/, { message: "Invalid ramp currency code" });
 
 export const createTransferSchema = z.object({
   projectId: z.string().min(1).optional(),
@@ -66,7 +66,7 @@ export const prepareTransferSchema = createTransferSchema.extend({
 export const executeOnrampSchema = z.object({
   provider: rampProviderSchema,
   destinationWallet: z.string().min(1),
-  cryptoToken: moonpayCurrencyCodeSchema,
+  cryptoToken: rampCurrencyCodeSchema,
   fiatCurrency: z.literal("USD").optional(),
   fiatAmount: moonpayAmountSchema,
   kycReference: z.string().max(128).optional(),
@@ -76,7 +76,7 @@ export const executeOnrampSchema = z.object({
 export const executeOfframpSchema = z.object({
   provider: rampProviderSchema,
   sourceWallet: z.string().min(1),
-  cryptoToken: moonpayCurrencyCodeSchema,
+  cryptoToken: rampCurrencyCodeSchema,
   fiatCurrency: z.literal("USD").optional(),
   cryptoAmount: moonpayAmountSchema,
   kycReference: z.string().max(128).optional(),

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -114,6 +114,11 @@ export interface Env {
   MOONPAY_SECRET_KEY?: string;
   MOONPAY_ONRAMP_URL?: string;
   MOONPAY_OFFRAMP_URL?: string;
+
+  // Lightspark Grid ramps configuration
+  LIGHTSPARK_GRID_CLIENT_ID?: string;
+  LIGHTSPARK_GRID_CLIENT_SECRET?: string;
+  LIGHTSPARK_GRID_API_BASE_URL?: string;
 }
 
 // Extend Hono's context with our bindings


### PR DESCRIPTION
## Summary
- add Lightspark Grid as a ramps provider for onramp/offramp execute endpoints
- align quote payloads with current Grid schema (`sourceType`/`destinationType`, integer minor units)
- surface Grid error `reason` in API responses
- auto-provision/reuse Grid `ExternalAccount` for onramp when `destinationWallet` is a raw Solana address
- keep existing account-id path intact for callers already using `ExternalAccount:` ids

## Testing
- pnpm -C apps/sdp-api lint
- pnpm -C apps/sdp-api typecheck
- pnpm -C apps/sdp-api test -- src/routes/payments.test.ts
- manual local sandbox call to `/v1/payments/ramps/onramp/execute` with raw Solana wallet now succeeds and returns a quote reference
