### PR TITLE
chore(sdp-api): setup Sentry monitoring for API worker

### DIFF
--- a/apps/sdp-api/.dev.vars.example
+++ b/apps/sdp-api/.dev.vars.example
@@ -1,5 +1,9 @@
 # SDP API local dev vars (copy to .dev.vars)
 
+# Sentry
+# SENTRY_DSN=https://examplePublicKey@o0.ingest.us.sentry.io/0
+# SENTRY_TRACES_SAMPLE_RATE=1.0
+
 # Solana RPC (devnet). Use your own provider key if possible.
 SOLANA_RPC_URL=https://api.devnet.solana.com
 SOLANA_RPC_DEFAULT_PROVIDER=default

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -32,6 +32,7 @@
     "@sdp/keychain-coinbase": "workspace:*",
     "@sdp/keychain-para": "workspace:*",
     "@sdp/types": "workspace:*",
+    "@sentry/cloudflare": "^10.42.0",
     "@solana-program/system": "catalog:",
     "@solana-program/token-2022": "catalog:",
     "@solana/addresses": "catalog:",

--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -73,7 +73,7 @@ function getSentryOptions(env: Env) {
 }
 
 function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void {
-  if (!c.env.SENTRY_DSN) {
+  if (!c.env.SENTRY_DSN?.trim()) {
     return;
   }
 
@@ -106,7 +106,7 @@ function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void
       if (clerk.orgSlug) {
         scope.setTag("organization_slug", clerk.orgSlug);
       }
-      scope.setUser({ id: clerk.userId, email: clerk.email ?? undefined });
+      scope.setUser({ id: clerk.userId });
     }
 
     Sentry.captureException(err);

--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -5,7 +5,8 @@
  * Built with Hono, D1, and KV
  */
 
-import { Hono } from "hono";
+import * as Sentry from "@sentry/cloudflare";
+import { type Context, Hono } from "hono";
 import { logger } from "hono/logger";
 import { prettyJSON } from "hono/pretty-json";
 import { secureHeaders } from "hono/secure-headers";
@@ -37,6 +38,80 @@ import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
 
 // Create app
 const app = new Hono<{ Bindings: Env }>();
+
+const SENTRY_PENDING_TRANSFERS_MONITOR = "sdp-api-track-pending-transfers";
+const PENDING_TRANSFERS_CRON = "* * * * *";
+
+function parseSentryTraceSampleRate(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function getSentryOptions(env: Env) {
+  const dsn = env.SENTRY_DSN?.trim();
+  const defaultTraceSampleRate = env.ENVIRONMENT === "production" ? 0.1 : 1;
+  const tracesSampleRate = parseSentryTraceSampleRate(
+    env.SENTRY_TRACES_SAMPLE_RATE,
+    defaultTraceSampleRate
+  );
+
+  return {
+    ...(dsn ? { dsn } : {}),
+    enabled: Boolean(dsn),
+    environment: env.ENVIRONMENT,
+    tracesSampleRate,
+    sendDefaultPii: false,
+  };
+}
+
+function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void {
+  if (!c.env.SENTRY_DSN) {
+    return;
+  }
+
+  const requestId = c.get("requestId");
+  const path = new URL(c.req.url).pathname;
+
+  Sentry.withScope((scope) => {
+    scope.setTag("request_id", requestId);
+    scope.setTag("http_method", c.req.method);
+    scope.setTag("http_path", path);
+
+    const apiKey = c.get("apiKey");
+    const session = c.get("session");
+    const clerk = c.get("clerk");
+
+    if (apiKey) {
+      scope.setTag("auth_type", "api_key");
+      scope.setTag("organization_id", apiKey.organizationId);
+      if (apiKey.projectId) {
+        scope.setTag("project_id", apiKey.projectId);
+      }
+      scope.setUser({ id: `api_key:${apiKey.id}` });
+    } else if (session) {
+      scope.setTag("auth_type", "session");
+      scope.setTag("organization_id", session.organizationId);
+      scope.setUser({ id: session.userId });
+    } else if (clerk) {
+      scope.setTag("auth_type", "clerk");
+      scope.setTag("organization_id", clerk.organizationId);
+      if (clerk.orgSlug) {
+        scope.setTag("organization_slug", clerk.orgSlug);
+      }
+      scope.setUser({ id: clerk.userId, email: clerk.email ?? undefined });
+    }
+
+    Sentry.captureException(err);
+  });
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Global Middleware
@@ -132,6 +207,7 @@ app.onError((err, c) => {
     error: err.message,
     stack: err.stack,
   });
+  captureUnexpectedError(err, c);
 
   return c.json(
     {
@@ -165,8 +241,33 @@ app.notFound((c) => {
 
 // Attach the scheduled handler to the Hono app so Cloudflare Workers can
 // invoke it for cron triggers, while preserving app.request() for tests.
-export default Object.assign(app, {
-  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
-    ctx.waitUntil(trackPendingTransfers(env));
+const worker = {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
+    return app.fetch(request, env, ctx);
   },
-});
+  async scheduled(
+    _controller: ScheduledController,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<void> {
+    const runPendingTransferTracking = () => trackPendingTransfers(env);
+    if (!env.SENTRY_DSN) {
+      ctx.waitUntil(runPendingTransferTracking());
+      return;
+    }
+
+    ctx.waitUntil(
+      Sentry.withMonitor(SENTRY_PENDING_TRANSFERS_MONITOR, runPendingTransferTracking, {
+        schedule: {
+          type: "crontab",
+          value: PENDING_TRANSFERS_CRON,
+        },
+      })
+    );
+  },
+  request: app.request.bind(app),
+} satisfies ExportedHandler<Env> & {
+  request: typeof app.request;
+};
+
+export default Sentry.withSentry(getSentryOptions, worker);

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -24,6 +24,8 @@ export interface Env {
   // Secrets (set via wrangler secret)
   API_KEY_PEPPER?: string;
   CUSTODY_ENCRYPTION_KEY?: string; // For encrypting org private keys in DB
+  SENTRY_DSN?: string;
+  SENTRY_TRACES_SAMPLE_RATE?: string;
 
   // Email configuration
   EMAIL_PROVIDER?: "resend" | "console";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@sdp/types':
         specifier: workspace:*
         version: link:../../packages/sdp-types
+      '@sentry/cloudflare':
+        specifier: ^10.42.0
+        version: 10.42.0(@cloudflare/workers-types@4.20260123.0)
       '@solana-program/system':
         specifier: 'catalog:'
         version: 0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
@@ -2920,6 +2923,15 @@ packages:
     resolution: {integrity: sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@sentry/cloudflare@10.42.0':
+    resolution: {integrity: sha512-EfovCbS4Xi8+epXilN6CzplxPzk+GxJZq574LaW8HJhIRnkF8/qfJ3iuh966EgKGCnVMF7c9EQsnfgcRKe8dog==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.x
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
 
   '@sentry/core@10.42.0':
     resolution: {integrity: sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==}
@@ -9286,6 +9298,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@sentry/cloudflare@10.42.0(@cloudflare/workers-types@4.20260123.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@sentry/core': 10.42.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260123.0
 
   '@sentry/core@10.42.0': {}
 


### PR DESCRIPTION
## Summary
- add `@sentry/cloudflare` to `@sdp/api`
- wrap the Cloudflare worker export with `Sentry.withSentry` using env-driven options
- capture unexpected `app.onError` exceptions with request/auth tags
- instrument the scheduled pending-transfer cron with `Sentry.withMonitor`
- document local Sentry vars in `.dev.vars.example`

## Config
- new env bindings: `SENTRY_DSN` and optional `SENTRY_TRACES_SAMPLE_RATE`
- default trace sampling: `1.0` outside production, `0.1` in production
- `sendDefaultPii` is disabled

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @sdp/api lint`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter @sdp/api test`
- `pnpm --filter @sdp/api build`
