### PR TITLE
PRO-981: Issuance overview grid + token management workspace

### DIFF
--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -1361,6 +1361,7 @@ export class TokenService {
       organizationId: row.organization_id,
       mintAddress: row.mint_address,
       mintAuthority: row.mint_authority,
+      metadataAuthority: row.mint_authority,
       freezeAuthority: row.freeze_authority,
       ablListAddress: row.abl_list_address,
       name: row.name,

--- a/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
@@ -6,6 +6,8 @@ import { useState } from "react";
 import { rotateApiKeyAction } from "./actions";
 import { DeleteApiKeyModal } from "./delete-api-key-modal";
 
+const DEFAULT_ROTATION_GRACE_HOURS = 24;
+
 interface ApiKeyActionsMenuProps {
   keyId: string;
   keyName: string;
@@ -40,18 +42,18 @@ export function ApiKeyActionsMenu({ keyId, keyName, canRotate }: ApiKeyActionsMe
               {canRotate ? (
                 <form action={rotateApiKeyAction}>
                   <input type="hidden" name="keyId" value={keyId} />
-                  <input type="hidden" name="grace" value="24" />
+                  <input type="hidden" name="grace" value={String(DEFAULT_ROTATION_GRACE_HOURS)} />
                   <button
                     type="submit"
                     onClick={() => setIsMenuOpen(false)}
                     className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
                   >
-                    Rotate key
+                    Rotate key ({DEFAULT_ROTATION_GRACE_HOURS}h grace)
                   </button>
                 </form>
               ) : (
                 <span className="flex w-full cursor-not-allowed items-center rounded-lg px-3 py-2 text-left text-sm text-[rgba(28,28,29,0.45)]">
-                  Rotate key
+                  Rotate key ({DEFAULT_ROTATION_GRACE_HOURS}h grace)
                 </span>
               )}
 

--- a/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { rotateApiKeyAction } from "./actions";
+import { DeleteApiKeyModal } from "./delete-api-key-modal";
+
+interface ApiKeyActionsMenuProps {
+  keyId: string;
+  keyName: string;
+  canRotate: boolean;
+}
+
+export function ApiKeyActionsMenu({ keyId, keyName, canRotate }: ApiKeyActionsMenuProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <div className="relative inline-flex">
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => setIsMenuOpen((open) => !open)}
+      >
+        Actions
+        <ChevronDown className="h-4 w-4" />
+      </Button>
+
+      {isMenuOpen ? (
+        <>
+          <button
+            type="button"
+            aria-label="Close actions menu"
+            className="fixed inset-0 z-20 cursor-default bg-transparent"
+            onClick={() => setIsMenuOpen(false)}
+          />
+          <div className="absolute top-[42px] right-0 z-30 w-[200px] overflow-hidden rounded-xl border border-[rgba(28,28,29,0.12)] bg-white shadow-[0_14px_28px_rgba(28,28,29,0.16)]">
+            <div className="p-1">
+              {canRotate ? (
+                <form action={rotateApiKeyAction}>
+                  <input type="hidden" name="keyId" value={keyId} />
+                  <input type="hidden" name="grace" value="24" />
+                  <button
+                    type="submit"
+                    onClick={() => setIsMenuOpen(false)}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Rotate key
+                  </button>
+                </form>
+              ) : (
+                <span className="flex w-full cursor-not-allowed items-center rounded-lg px-3 py-2 text-left text-sm text-[rgba(28,28,29,0.45)]">
+                  Rotate key
+                </span>
+              )}
+
+              <DeleteApiKeyModal
+                keyId={keyId}
+                keyName={keyName}
+                renderTrigger={(open) => (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsMenuOpen(false);
+                      open();
+                    }}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm text-[#c71f37] hover:bg-[#c71f37]/10"
+                  >
+                    Delete key
+                  </button>
+                )}
+              />
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/api-keys/delete-api-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/delete-api-key-modal.tsx
@@ -3,17 +3,23 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import type { ReactNode } from "react";
 import { useState } from "react";
 import { deactivateApiKeyAction } from "./actions";
 
 interface DeleteApiKeyModalProps {
   keyId: string;
   keyName: string;
+  renderTrigger?: (open: () => void) => ReactNode;
 }
 
-export function DeleteApiKeyModal({ keyId, keyName }: DeleteApiKeyModalProps) {
+export function DeleteApiKeyModal({ keyId, keyName, renderTrigger }: DeleteApiKeyModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [confirmation, setConfirmation] = useState("");
+
+  const open = () => {
+    setIsOpen(true);
+  };
 
   const close = () => {
     setIsOpen(false);
@@ -24,15 +30,19 @@ export function DeleteApiKeyModal({ keyId, keyName }: DeleteApiKeyModalProps) {
 
   return (
     <>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        className="border-[#c71f37] text-[#c71f37] hover:bg-[#c71f37]/10"
-        onClick={() => setIsOpen(true)}
-      >
-        Delete
-      </Button>
+      {renderTrigger ? (
+        renderTrigger(open)
+      ) : (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="border-[#c71f37] text-[#c71f37] hover:bg-[#c71f37]/10"
+          onClick={open}
+        >
+          Delete
+        </Button>
+      )}
 
       {isOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -1,6 +1,4 @@
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -12,8 +10,8 @@ import {
 import { sdpApiFetch } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { consumeApiKeyFlash, rotateApiKeyAction } from "./actions";
-import { DeleteApiKeyModal } from "./delete-api-key-modal";
+import { consumeApiKeyFlash } from "./actions";
+import { ApiKeyActionsMenu } from "./api-key-actions-menu";
 import { FlashClearTrigger } from "./flash-clear-trigger";
 import { GeneratedApiKeyModal } from "./generated-key-modal";
 
@@ -146,34 +144,12 @@ export default async function ApiKeysPage() {
                         <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
                           {formatDate(key.createdAt)}
                         </TableCell>
-                        <TableCell className="text-right whitespace-normal">
-                          <div className="flex flex-wrap items-center justify-end gap-2">
-                            {canRotate ? (
-                              <form
-                                action={rotateApiKeyAction}
-                                className="inline-flex flex-wrap items-center justify-end gap-2"
-                              >
-                                <input type="hidden" name="keyId" value={key.id} />
-                                <Input
-                                  type="number"
-                                  name="grace"
-                                  min={0}
-                                  max={168}
-                                  defaultValue={24}
-                                  className="h-8 w-[72px] text-xs"
-                                  aria-label={`Grace period hours for ${key.name}`}
-                                />
-                                <Button type="submit" size="sm" variant="secondary">
-                                  Rotate
-                                </Button>
-                              </form>
-                            ) : (
-                              <span className="text-xs text-[rgba(28,28,29,0.48)]">
-                                Unavailable
-                              </span>
-                            )}
-                            <DeleteApiKeyModal keyId={key.id} keyName={key.name} />
-                          </div>
+                        <TableCell className="text-right">
+                          <ApiKeyActionsMenu
+                            keyId={key.id}
+                            keyName={key.name}
+                            canRotate={canRotate}
+                          />
                         </TableCell>
                       </TableRow>
                     );

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -37,7 +37,11 @@ function formatDate(value: string | null): string {
   if (!value) return "Never";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  });
 }
 
 export default async function ApiKeysPage() {
@@ -98,19 +102,18 @@ export default async function ApiKeysPage() {
           {apiKeys.length === 0 ? (
             <p className="text-sm text-[rgba(28,28,29,0.72)]">No API keys found.</p>
           ) : (
-            <div className="overflow-x-auto">
-              <Table>
+            <Table className="table-fixed">
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Prefix</TableHead>
-                    <TableHead>Role</TableHead>
-                    <TableHead>Env</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Last used</TableHead>
-                    <TableHead>Expires</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
+                    <TableHead className="w-[14%]">Name</TableHead>
+                    <TableHead className="w-[14%]">Prefix</TableHead>
+                    <TableHead className="w-[10%]">Role</TableHead>
+                    <TableHead className="w-[8%]">Env</TableHead>
+                    <TableHead className="w-[10%]">Status</TableHead>
+                    <TableHead className="w-[11%]">Last used</TableHead>
+                    <TableHead className="w-[11%]">Expires</TableHead>
+                    <TableHead className="w-[11%]">Created</TableHead>
+                    <TableHead className="w-[21%] text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -119,11 +122,21 @@ export default async function ApiKeysPage() {
 
                     return (
                       <TableRow key={key.id}>
-                        <TableCell className="font-medium">{key.name}</TableCell>
-                        <TableCell className="font-mono text-xs">{key.keyPrefix}</TableCell>
-                        <TableCell>{key.role}</TableCell>
-                        <TableCell>{key.environment}</TableCell>
-                        <TableCell>{key.status}</TableCell>
+                        <TableCell className="font-medium">
+                          <span className="block truncate">{key.name}</span>
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          <span className="block truncate">{key.keyPrefix}</span>
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          <span className="block truncate">{key.role}</span>
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          <span className="block truncate">{key.environment}</span>
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          <span className="block truncate">{key.status}</span>
+                        </TableCell>
                         <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
                           {formatDate(key.lastUsedAt)}
                         </TableCell>
@@ -133,12 +146,12 @@ export default async function ApiKeysPage() {
                         <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
                           {formatDate(key.createdAt)}
                         </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex items-center justify-end gap-2">
+                        <TableCell className="text-right whitespace-normal">
+                          <div className="flex flex-wrap items-center justify-end gap-2">
                             {canRotate ? (
                               <form
                                 action={rotateApiKeyAction}
-                                className="inline-flex items-center justify-end gap-2"
+                                className="inline-flex flex-wrap items-center justify-end gap-2"
                               >
                                 <input type="hidden" name="keyId" value={key.id} />
                                 <Input
@@ -147,7 +160,7 @@ export default async function ApiKeysPage() {
                                   min={0}
                                   max={168}
                                   defaultValue={24}
-                                  className="h-8 w-[88px] text-xs"
+                                  className="h-8 w-[72px] text-xs"
                                   aria-label={`Grace period hours for ${key.name}`}
                                 />
                                 <Button type="submit" size="sm" variant="secondary">
@@ -167,7 +180,6 @@ export default async function ApiKeysPage() {
                   })}
                 </TableBody>
               </Table>
-            </div>
           )}
         </CardContent>
       </Card>

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -1,4 +1,11 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -12,6 +19,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { consumeApiKeyFlash } from "./actions";
 import { ApiKeyActionsMenu } from "./api-key-actions-menu";
+import { CreateApiKeyModal } from "./create-api-key-modal";
 import { FlashClearTrigger } from "./flash-clear-trigger";
 import { GeneratedApiKeyModal } from "./generated-key-modal";
 
@@ -89,6 +97,9 @@ export default async function ApiKeysPage() {
         <CardHeader>
           <CardTitle>Existing API keys</CardTitle>
           <CardDescription>Active and historical keys for this workspace.</CardDescription>
+          <CardAction>
+            <CreateApiKeyModal triggerLabel="New API key" />
+          </CardAction>
         </CardHeader>
         <CardContent>
           <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
@@ -101,61 +112,61 @@ export default async function ApiKeysPage() {
             <p className="text-sm text-[rgba(28,28,29,0.72)]">No API keys found.</p>
           ) : (
             <Table className="table-fixed">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[14%]">Name</TableHead>
-                    <TableHead className="w-[14%]">Prefix</TableHead>
-                    <TableHead className="w-[10%]">Role</TableHead>
-                    <TableHead className="w-[8%]">Env</TableHead>
-                    <TableHead className="w-[10%]">Status</TableHead>
-                    <TableHead className="w-[11%]">Last used</TableHead>
-                    <TableHead className="w-[11%]">Expires</TableHead>
-                    <TableHead className="w-[11%]">Created</TableHead>
-                    <TableHead className="w-[21%] text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {apiKeys.map((key) => {
-                    const canRotate = key.status === "active";
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[14%]">Name</TableHead>
+                  <TableHead className="w-[14%]">Prefix</TableHead>
+                  <TableHead className="w-[10%]">Role</TableHead>
+                  <TableHead className="w-[8%]">Env</TableHead>
+                  <TableHead className="w-[10%]">Status</TableHead>
+                  <TableHead className="w-[11%]">Last used</TableHead>
+                  <TableHead className="w-[11%]">Expires</TableHead>
+                  <TableHead className="w-[11%]">Created</TableHead>
+                  <TableHead className="w-[21%] text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {apiKeys.map((key) => {
+                  const canRotate = key.status === "active";
 
-                    return (
-                      <TableRow key={key.id}>
-                        <TableCell className="font-medium">
-                          <span className="block truncate">{key.name}</span>
-                        </TableCell>
-                        <TableCell className="font-mono text-xs">
-                          <span className="block truncate">{key.keyPrefix}</span>
-                        </TableCell>
-                        <TableCell className="text-xs">
-                          <span className="block truncate">{key.role}</span>
-                        </TableCell>
-                        <TableCell className="text-xs">
-                          <span className="block truncate">{key.environment}</span>
-                        </TableCell>
-                        <TableCell className="text-xs">
-                          <span className="block truncate">{key.status}</span>
-                        </TableCell>
-                        <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
-                          {formatDate(key.lastUsedAt)}
-                        </TableCell>
-                        <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
-                          {formatDate(key.expiresAt)}
-                        </TableCell>
-                        <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
-                          {formatDate(key.createdAt)}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <ApiKeyActionsMenu
-                            keyId={key.id}
-                            keyName={key.name}
-                            canRotate={canRotate}
-                          />
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
+                  return (
+                    <TableRow key={key.id}>
+                      <TableCell className="font-medium">
+                        <span className="block truncate">{key.name}</span>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        <span className="block truncate">{key.keyPrefix}</span>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        <span className="block truncate">{key.role}</span>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        <span className="block truncate">{key.environment}</span>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        <span className="block truncate">{key.status}</span>
+                      </TableCell>
+                      <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
+                        {formatDate(key.lastUsedAt)}
+                      </TableCell>
+                      <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
+                        {formatDate(key.expiresAt)}
+                      </TableCell>
+                      <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
+                        {formatDate(key.createdAt)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <ApiKeyActionsMenu
+                          keyId={key.id}
+                          keyName={key.name}
+                          canRotate={canRotate}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
           )}
         </CardContent>
       </Card>

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -104,8 +104,8 @@ export default async function ApiKeysPage() {
         <CardContent>
           <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
             <p className="text-xs text-[rgba(28,28,29,0.72)]">
-              Rotation hint: rotate active keys only, use a grace period between 0 and 168 hours,
-              and keep old key secrets secure. New key secrets are shown once.
+              Rotation hint: rotate active keys only. The dashboard uses a 24-hour grace period;
+              use the API for custom grace values (0-168h). New key secrets are shown once.
             </p>
           </div>
           {apiKeys.length === 0 ? (

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -60,7 +60,7 @@ export default async function ApiKeysPage() {
   const hasGeneratedKeyFlash = Boolean(flash?.key);
 
   return (
-    <div className="w-full max-w-5xl flex flex-col gap-6">
+    <div className="w-full flex flex-col gap-6">
       {flash ? (
         <>
           {!hasGeneratedKeyFlash ? <FlashClearTrigger /> : null}

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -104,8 +104,8 @@ export default async function ApiKeysPage() {
         <CardContent>
           <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
             <p className="text-xs text-[rgba(28,28,29,0.72)]">
-              Rotation hint: rotate active keys only. The dashboard uses a 24-hour grace period;
-              use the API for custom grace values (0-168h). New key secrets are shown once.
+              Rotation hint: rotate active keys only. The dashboard uses a 24-hour grace period; use
+              the API for custom grace values (0-168h). New key secrets are shown once.
             </p>
           </div>
           {apiKeys.length === 0 ? (

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -387,7 +387,7 @@ export default async function CustodyPage() {
     redirect("/dashboard");
   }
 
-  const pageContainerClassName = "w-full max-w-5xl flex flex-col gap-6";
+  const pageContainerClassName = "w-full flex flex-col gap-6";
   const apiClient = await createSdpApiClient();
   const onboardingPromise = apiClient.fetch<{ linked: boolean }>("/v1/onboarding/status");
   const configsResultPromise = settle(getCustodyConfigs(apiClient.request));

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -281,9 +281,16 @@ async function WalletsSection({
   return (
     <SectionEntry delay={0.08}>
       <Card>
-        <CardHeader>
-          <CardTitle>Wallets</CardTitle>
-          <CardDescription>Signing wallets available to your organization.</CardDescription>
+        <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Wallets</CardTitle>
+            <CardDescription>Signing wallets available to your organization.</CardDescription>
+          </div>
+          <Link href="/dashboard/wallets/setup">
+            <Button type="button" size="sm" className="shrink-0">
+              New wallet
+            </Button>
+          </Link>
         </CardHeader>
         <CardContent>
           {wallets.length === 0 ? (

--- a/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
@@ -251,11 +251,6 @@ export function CustodySetupForm({
         <Button type="submit" disabled={isConnected && !canCreateAdditionalWallet}>
           {isConnected ? "Create wallet" : "Connect provider & create wallet"}
         </Button>
-        <Link href="/dashboard/wallets/setup">
-          <Button type="button" variant="secondary">
-            Back to providers
-          </Button>
-        </Link>
         <Link href="/dashboard/wallets">
           <Button type="button" variant="secondary">
             Cancel

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
@@ -14,6 +14,13 @@ interface FetchResult<T> {
   status: number | null;
   data: T | null;
   error: string | null;
+  total: number | null;
+  hasMore: boolean;
+}
+
+interface PaginatedMeta {
+  total?: number;
+  hasMore?: boolean;
 }
 
 function parseErrorMessage(body: string): string {
@@ -41,23 +48,30 @@ async function fetchData<T>(
         status: response.status,
         data: null,
         error: parseErrorMessage(body),
+        total: null,
+        hasMore: false,
       };
     }
 
     const payload = (await response.json()) as {
       data?: unknown;
+      meta?: PaginatedMeta;
     };
 
     return {
       status: response.status,
       data: map(payload?.data),
       error: null,
+      total: typeof payload.meta?.total === "number" ? payload.meta.total : null,
+      hasMore: payload.meta?.hasMore === true,
     };
   } catch (error) {
     return {
       status: null,
       data: null,
       error: error instanceof Error ? error.message : "Request failed",
+      total: null,
+      hasMore: false,
     };
   }
 }
@@ -127,18 +141,24 @@ export default async function IssuanceTokenManagementPage({ params }: TokenManag
           ? `Transactions API ${transactionsResult.status ?? "unavailable"}: ${transactionsResult.error}`
           : null
       }
+      transactionsTotal={transactionsResult.total}
+      transactionsHasMore={transactionsResult.hasMore}
       allowlistEntries={allowlistResult.data ?? []}
       allowlistError={
         allowlistResult.error
           ? `Allowlist API ${allowlistResult.status ?? "unavailable"}: ${allowlistResult.error}`
           : null
       }
+      allowlistTotal={allowlistResult.total}
+      allowlistHasMore={allowlistResult.hasMore}
       frozenAccounts={frozenResult.data ?? []}
       frozenAccountsError={
         frozenResult.error
           ? `Frozen API ${frozenResult.status ?? "unavailable"}: ${frozenResult.error}`
           : null
       }
+      frozenAccountsTotal={frozenResult.total}
+      frozenAccountsHasMore={frozenResult.hasMore}
     />
   );
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
@@ -1,0 +1,144 @@
+import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
+import { auth } from "@clerk/nextjs/server";
+import type { FrozenAccount, Token, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
+import { notFound, redirect } from "next/navigation";
+import { TokenManagementWorkspace } from "./token-management-workspace";
+
+interface TokenManagementPageProps {
+  params: Promise<{
+    tokenId: string;
+  }>;
+}
+
+interface FetchResult<T> {
+  status: number | null;
+  data: T | null;
+  error: string | null;
+}
+
+function parseErrorMessage(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: string };
+      message?: string;
+    };
+    return parsed?.error?.message ?? parsed?.message ?? body;
+  } catch {
+    return body || "Unknown error";
+  }
+}
+
+async function fetchData<T>(
+  request: SdpApiClient["request"],
+  path: string,
+  map: (payload: unknown) => T
+): Promise<FetchResult<T>> {
+  try {
+    const response = await request(path);
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        status: response.status,
+        data: null,
+        error: parseErrorMessage(body),
+      };
+    }
+
+    const payload = (await response.json()) as {
+      data?: unknown;
+    };
+
+    return {
+      status: response.status,
+      data: map(payload?.data),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      status: null,
+      data: null,
+      error: error instanceof Error ? error.message : "Request failed",
+    };
+  }
+}
+
+function mapToken(payload: unknown): Token | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const token = (payload as { token?: Token }).token;
+  return token ?? null;
+}
+
+function mapList<T>(payload: unknown): T[] {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+  return payload as T[];
+}
+
+export default async function IssuanceTokenManagementPage({ params }: TokenManagementPageProps) {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  const { tokenId } = await params;
+  const apiClient = await createSdpApiClient();
+
+  const [tokenResult, transactionsResult, allowlistResult, frozenResult] = await Promise.all([
+    fetchData<Token | null>(apiClient.request, `/v1/issuance/tokens/${tokenId}`, mapToken),
+    fetchData<TokenTransaction[]>(
+      apiClient.request,
+      `/v1/issuance/tokens/${tokenId}/transactions?page=1&pageSize=100`,
+      (payload) => mapList<TokenTransaction>(payload)
+    ),
+    fetchData<TokenAllowlistEntry[]>(
+      apiClient.request,
+      `/v1/issuance/tokens/${tokenId}/allowlist?page=1&pageSize=100`,
+      (payload) => mapList<TokenAllowlistEntry>(payload)
+    ),
+    fetchData<FrozenAccount[]>(
+      apiClient.request,
+      `/v1/issuance/tokens/${tokenId}/frozen?page=1&pageSize=100`,
+      (payload) => mapList<FrozenAccount>(payload)
+    ),
+  ]);
+
+  if (tokenResult.status === 404 || !tokenResult.data) {
+    notFound();
+  }
+
+  return (
+    <TokenManagementWorkspace
+      token={tokenResult.data}
+      tokenError={
+        tokenResult.error
+          ? `Token API ${tokenResult.status ?? "unavailable"}: ${tokenResult.error}`
+          : null
+      }
+      transactions={transactionsResult.data ?? []}
+      transactionsError={
+        transactionsResult.error
+          ? `Transactions API ${transactionsResult.status ?? "unavailable"}: ${transactionsResult.error}`
+          : null
+      }
+      allowlistEntries={allowlistResult.data ?? []}
+      allowlistError={
+        allowlistResult.error
+          ? `Allowlist API ${allowlistResult.status ?? "unavailable"}: ${allowlistResult.error}`
+          : null
+      }
+      frozenAccounts={frozenResult.data ?? []}
+      frozenAccountsError={
+        frozenResult.error
+          ? `Frozen API ${frozenResult.status ?? "unavailable"}: ${frozenResult.error}`
+          : null
+      }
+    />
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -293,10 +293,7 @@ function getExplorerHref(mintAddress: string | null): string | null {
     return null;
   }
 
-  const cluster = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
-  const query =
-    cluster && cluster !== "mainnet-beta" ? `?cluster=${encodeURIComponent(cluster)}` : "";
-  return `https://explorer.solana.com/address/${mintAddress}${query}`;
+  return `https://explorer.solana.com/address/${mintAddress}?cluster=devnet`;
 }
 
 async function executeActionRequest(input: ActionExecutionInput): Promise<ActionExecutionResult> {

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -4,14 +4,16 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import type { FrozenAccount, Token, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
 import {
-  ArrowUpRight,
-  ChevronDown,
-  Copy,
-  Loader2,
-} from "lucide-react";
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { FrozenAccount, Token, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
+import { ArrowUpRight, ChevronDown, Copy, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { type ReactNode, useMemo, useState, useTransition } from "react";
@@ -287,7 +289,8 @@ function getExplorerHref(mintAddress: string | null): string | null {
   }
 
   const cluster = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
-  const query = cluster && cluster !== "mainnet-beta" ? `?cluster=${encodeURIComponent(cluster)}` : "";
+  const query =
+    cluster && cluster !== "mainnet-beta" ? `?cluster=${encodeURIComponent(cluster)}` : "";
   return `https://explorer.solana.com/address/${mintAddress}${query}`;
 }
 
@@ -362,11 +365,20 @@ function ActionCard({
   );
 }
 
-function OverviewRow({ label, value, monospace = false }: { label: string; value: string; monospace?: boolean }) {
+function OverviewRow({
+  label,
+  value,
+  monospace = false,
+}: { label: string; value: string; monospace?: boolean }) {
   return (
     <div className="flex items-center justify-between gap-4 border-b border-[rgba(28,28,29,0.08)] px-4 py-3 last:border-b-0">
       <p className="text-[15px] text-[rgba(28,28,29,0.68)]">{label}</p>
-      <p className={["text-right text-[15px] text-[#1c1c1d]", monospace ? "font-mono text-xs" : ""].join(" ")}>
+      <p
+        className={[
+          "text-right text-[15px] text-[#1c1c1d]",
+          monospace ? "font-mono text-xs" : "",
+        ].join(" ")}
+      >
         {value}
       </p>
     </div>
@@ -388,17 +400,25 @@ export function TokenManagementWorkspace({
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("permissions");
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [activeAction, setActiveAction] = useState<AdminAction | null>("update-metadata");
-  const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmationState | null>(null);
+  const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmationState | null>(
+    null
+  );
   const [metadataForm, setMetadataForm] = useState<MetadataFormState>(() =>
     createInitialMetadataForm(token)
   );
   const [mintForm, setMintForm] = useState<MintFormState>(createInitialMintForm);
   const [burnForm, setBurnForm] = useState<BurnFormState>(createInitialBurnForm);
   const [seizeForm, setSeizeForm] = useState<SeizeFormState>(createInitialSeizeForm);
-  const [forceBurnForm, setForceBurnForm] = useState<ForceBurnFormState>(createInitialForceBurnForm);
-  const [authorityForm, setAuthorityForm] = useState<AuthorityFormState>(createInitialAuthorityForm);
+  const [forceBurnForm, setForceBurnForm] = useState<ForceBurnFormState>(
+    createInitialForceBurnForm
+  );
+  const [authorityForm, setAuthorityForm] = useState<AuthorityFormState>(
+    createInitialAuthorityForm
+  );
   const [freezeForm, setFreezeForm] = useState<FreezeFormState>(createInitialFreezeForm);
-  const [allowlistForm, setAllowlistForm] = useState<AllowlistFormState>(createInitialAllowlistForm);
+  const [allowlistForm, setAllowlistForm] = useState<AllowlistFormState>(
+    createInitialAllowlistForm
+  );
   const [lastActionResult, setLastActionResult] = useState<ActionExecutionResult | null>(null);
 
   const tokenBasePath = useMemo(() => `/v1/issuance/tokens/${token.id}`, [token.id]);
@@ -587,22 +607,24 @@ export function TokenManagementWorkspace({
   };
 
   const handleDeploy = (mode: "prepare" | "execute") => {
-    runAction({
-      label: `Deploy token (${mode})`,
-      method: "POST",
-      path: `${tokenBasePath}/deploy${mode === "prepare" ? "/prepare" : ""}`,
-      body: {},
-    },
-    mode === "execute"
-      ? {
-          requiresConfirmation: true,
-          confirmationTitle: "Deploy token?",
-          confirmationDescription: "This will submit the deploy transaction on-chain.",
-          confirmButtonLabel: "Deploy now",
-          submitToast: "Submitting deploy transaction...",
-          successToast: "Deploy transaction finalized.",
-        }
-      : undefined);
+    runAction(
+      {
+        label: `Deploy token (${mode})`,
+        method: "POST",
+        path: `${tokenBasePath}/deploy${mode === "prepare" ? "/prepare" : ""}`,
+        body: {},
+      },
+      mode === "execute"
+        ? {
+            requiresConfirmation: true,
+            confirmationTitle: "Deploy token?",
+            confirmationDescription: "This will submit the deploy transaction on-chain.",
+            confirmButtonLabel: "Deploy now",
+            submitToast: "Submitting deploy transaction...",
+            successToast: "Deploy transaction finalized.",
+          }
+        : undefined
+    );
   };
 
   const handleRefreshSupply = () => {
@@ -622,28 +644,30 @@ export function TokenManagementWorkspace({
       return;
     }
 
-    runAction({
-      label: `Mint (${mode})`,
-      method: "POST",
-      path: `${tokenBasePath}/mint${mode === "prepare" ? "/prepare" : ""}`,
-      body: {
-        mint: {
-          destination,
-          amount,
-          memo: asOptionalString(mintForm.memo),
+    runAction(
+      {
+        label: `Mint (${mode})`,
+        method: "POST",
+        path: `${tokenBasePath}/mint${mode === "prepare" ? "/prepare" : ""}`,
+        body: {
+          mint: {
+            destination,
+            amount,
+            memo: asOptionalString(mintForm.memo),
+          },
         },
       },
-    },
-    mode === "execute"
-      ? {
-          requiresConfirmation: true,
-          confirmationTitle: "Mint tokens?",
-          confirmationDescription: "This will submit a mint transaction on-chain.",
-          confirmButtonLabel: "Mint now",
-          submitToast: "Submitting mint transaction...",
-          successToast: "Mint transaction finalized.",
-        }
-      : undefined);
+      mode === "execute"
+        ? {
+            requiresConfirmation: true,
+            confirmationTitle: "Mint tokens?",
+            confirmationDescription: "This will submit a mint transaction on-chain.",
+            confirmButtonLabel: "Mint now",
+            submitToast: "Submitting mint transaction...",
+            successToast: "Mint transaction finalized.",
+          }
+        : undefined
+    );
   };
 
   const handleBurn = (mode: "prepare" | "execute") => {
@@ -654,28 +678,30 @@ export function TokenManagementWorkspace({
       return;
     }
 
-    runAction({
-      label: `Burn (${mode})`,
-      method: "POST",
-      path: `${tokenBasePath}/burn${mode === "prepare" ? "/prepare" : ""}`,
-      body: {
-        burn: {
-          source,
-          amount,
-          memo: asOptionalString(burnForm.memo),
+    runAction(
+      {
+        label: `Burn (${mode})`,
+        method: "POST",
+        path: `${tokenBasePath}/burn${mode === "prepare" ? "/prepare" : ""}`,
+        body: {
+          burn: {
+            source,
+            amount,
+            memo: asOptionalString(burnForm.memo),
+          },
         },
       },
-    },
-    mode === "execute"
-      ? {
-          requiresConfirmation: true,
-          confirmationTitle: "Burn tokens?",
-          confirmationDescription: "This will submit a burn transaction on-chain.",
-          confirmButtonLabel: "Burn now",
-          submitToast: "Submitting burn transaction...",
-          successToast: "Burn transaction finalized.",
-        }
-      : undefined);
+      mode === "execute"
+        ? {
+            requiresConfirmation: true,
+            confirmationTitle: "Burn tokens?",
+            confirmationDescription: "This will submit a burn transaction on-chain.",
+            confirmButtonLabel: "Burn now",
+            submitToast: "Submitting burn transaction...",
+            successToast: "Burn transaction finalized.",
+          }
+        : undefined
+    );
   };
 
   const handleSeize = (mode: "prepare" | "execute") => {
@@ -687,30 +713,33 @@ export function TokenManagementWorkspace({
       return;
     }
 
-    runAction({
-      label: `Seize (${mode})`,
-      method: "POST",
-      path: `${tokenBasePath}/seize${mode === "prepare" ? "/prepare" : ""}`,
-      body: {
-        seize: {
-          source,
-          destination,
-          amount,
-          delegateAuthority: asOptionalString(seizeForm.delegateAuthority),
-          memo: asOptionalString(seizeForm.memo),
+    runAction(
+      {
+        label: `Seize (${mode})`,
+        method: "POST",
+        path: `${tokenBasePath}/seize${mode === "prepare" ? "/prepare" : ""}`,
+        body: {
+          seize: {
+            source,
+            destination,
+            amount,
+            delegateAuthority: asOptionalString(seizeForm.delegateAuthority),
+            memo: asOptionalString(seizeForm.memo),
+          },
         },
       },
-    },
-    mode === "execute"
-      ? {
-          requiresConfirmation: true,
-          confirmationTitle: "Force transfer?",
-          confirmationDescription: "This will submit a seize (force transfer) transaction on-chain.",
-          confirmButtonLabel: "Transfer now",
-          submitToast: "Submitting force transfer transaction...",
-          successToast: "Force transfer transaction finalized.",
-        }
-      : undefined);
+      mode === "execute"
+        ? {
+            requiresConfirmation: true,
+            confirmationTitle: "Force transfer?",
+            confirmationDescription:
+              "This will submit a seize (force transfer) transaction on-chain.",
+            confirmButtonLabel: "Transfer now",
+            submitToast: "Submitting force transfer transaction...",
+            successToast: "Force transfer transaction finalized.",
+          }
+        : undefined
+    );
   };
 
   const handleForceBurn = (mode: "prepare" | "execute") => {
@@ -721,73 +750,81 @@ export function TokenManagementWorkspace({
       return;
     }
 
-    runAction({
-      label: `Force Burn (${mode})`,
-      method: "POST",
-      path: `${tokenBasePath}/force-burn${mode === "prepare" ? "/prepare" : ""}`,
-      body: {
-        forceBurn: {
-          source,
-          amount,
-          delegateAuthority: asOptionalString(forceBurnForm.delegateAuthority),
-          memo: asOptionalString(forceBurnForm.memo),
+    runAction(
+      {
+        label: `Force Burn (${mode})`,
+        method: "POST",
+        path: `${tokenBasePath}/force-burn${mode === "prepare" ? "/prepare" : ""}`,
+        body: {
+          forceBurn: {
+            source,
+            amount,
+            delegateAuthority: asOptionalString(forceBurnForm.delegateAuthority),
+            memo: asOptionalString(forceBurnForm.memo),
+          },
         },
       },
-    },
-    mode === "execute"
-      ? {
-          requiresConfirmation: true,
-          confirmationTitle: "Force burn tokens?",
-          confirmationDescription: "This will submit a force-burn transaction on-chain.",
-          confirmButtonLabel: "Force burn now",
-          submitToast: "Submitting force-burn transaction...",
-          successToast: "Force-burn transaction finalized.",
-        }
-      : undefined);
+      mode === "execute"
+        ? {
+            requiresConfirmation: true,
+            confirmationTitle: "Force burn tokens?",
+            confirmationDescription: "This will submit a force-burn transaction on-chain.",
+            confirmButtonLabel: "Force burn now",
+            submitToast: "Submitting force-burn transaction...",
+            successToast: "Force-burn transaction finalized.",
+          }
+        : undefined
+    );
   };
 
   const handleAuthorityUpdate = (mode: "prepare" | "execute") => {
-    runAction({
-      label: `Update authority (${mode})`,
-      method: "POST",
-      path: `${tokenBasePath}/authority${mode === "prepare" ? "/prepare" : ""}`,
-      body: {
-        authority: {
-          role: authorityForm.role,
-          currentAuthority: asOptionalString(authorityForm.currentAuthority),
-          newAuthority: authorityForm.newAuthority.trim() || null,
+    runAction(
+      {
+        label: `Update authority (${mode})`,
+        method: "POST",
+        path: `${tokenBasePath}/authority${mode === "prepare" ? "/prepare" : ""}`,
+        body: {
+          authority: {
+            role: authorityForm.role,
+            currentAuthority: asOptionalString(authorityForm.currentAuthority),
+            newAuthority: authorityForm.newAuthority.trim() || null,
+          },
         },
       },
-    },
-    mode === "execute"
-      ? {
-          requiresConfirmation: true,
-          confirmationTitle: "Update authority?",
-          confirmationDescription: "This will submit an authority update transaction on-chain.",
-          confirmButtonLabel: "Update now",
-          submitToast: "Submitting authority update transaction...",
-          successToast: "Authority update finalized.",
-        }
-      : undefined);
+      mode === "execute"
+        ? {
+            requiresConfirmation: true,
+            confirmationTitle: "Update authority?",
+            confirmationDescription: "This will submit an authority update transaction on-chain.",
+            confirmButtonLabel: "Update now",
+            submitToast: "Submitting authority update transaction...",
+            successToast: "Authority update finalized.",
+          }
+        : undefined
+    );
   };
 
   const handlePause = (pause: boolean) => {
-    runAction({
-      label: pause ? "Pause token" : "Unpause token",
-      method: "POST",
-      path: `${tokenBasePath}/${pause ? "pause" : "unpause"}`,
-      body: {},
-    },
-    {
-      requiresConfirmation: true,
-      confirmationTitle: pause ? "Pause token?" : "Unpause token?",
-      confirmationDescription: pause
-        ? "This will submit a pause transaction on-chain."
-        : "This will submit an unpause transaction on-chain.",
-      confirmButtonLabel: pause ? "Pause now" : "Unpause now",
-      submitToast: pause ? "Submitting pause transaction..." : "Submitting unpause transaction...",
-      successToast: pause ? "Pause transaction finalized." : "Unpause transaction finalized.",
-    });
+    runAction(
+      {
+        label: pause ? "Pause token" : "Unpause token",
+        method: "POST",
+        path: `${tokenBasePath}/${pause ? "pause" : "unpause"}`,
+        body: {},
+      },
+      {
+        requiresConfirmation: true,
+        confirmationTitle: pause ? "Pause token?" : "Unpause token?",
+        confirmationDescription: pause
+          ? "This will submit a pause transaction on-chain."
+          : "This will submit an unpause transaction on-chain.",
+        confirmButtonLabel: pause ? "Pause now" : "Unpause now",
+        submitToast: pause
+          ? "Submitting pause transaction..."
+          : "Submitting unpause transaction...",
+        successToast: pause ? "Pause transaction finalized." : "Unpause transaction finalized.",
+      }
+    );
   };
 
   const handleFreeze = (unfreeze: boolean) => {
@@ -798,42 +835,46 @@ export function TokenManagementWorkspace({
     }
 
     if (unfreeze) {
-      runAction({
-        label: "Unfreeze account",
+      runAction(
+        {
+          label: "Unfreeze account",
+          method: "POST",
+          path: `${tokenBasePath}/unfreeze`,
+          body: {
+            accountAddress,
+          },
+        },
+        {
+          requiresConfirmation: true,
+          confirmationTitle: "Unfreeze account?",
+          confirmationDescription: "This will submit an unfreeze transaction on-chain.",
+          confirmButtonLabel: "Unfreeze now",
+          submitToast: "Submitting unfreeze transaction...",
+          successToast: "Unfreeze transaction finalized.",
+        }
+      );
+      return;
+    }
+
+    runAction(
+      {
+        label: "Freeze account",
         method: "POST",
-        path: `${tokenBasePath}/unfreeze`,
+        path: `${tokenBasePath}/freeze`,
         body: {
           accountAddress,
+          reason: asOptionalString(freezeForm.reason),
         },
       },
       {
         requiresConfirmation: true,
-        confirmationTitle: "Unfreeze account?",
-        confirmationDescription: "This will submit an unfreeze transaction on-chain.",
-        confirmButtonLabel: "Unfreeze now",
-        submitToast: "Submitting unfreeze transaction...",
-        successToast: "Unfreeze transaction finalized.",
-      });
-      return;
-    }
-
-    runAction({
-      label: "Freeze account",
-      method: "POST",
-      path: `${tokenBasePath}/freeze`,
-      body: {
-        accountAddress,
-        reason: asOptionalString(freezeForm.reason),
-      },
-    },
-    {
-      requiresConfirmation: true,
-      confirmationTitle: "Freeze account?",
-      confirmationDescription: "This will submit a freeze transaction on-chain.",
-      confirmButtonLabel: "Freeze now",
-      submitToast: "Submitting freeze transaction...",
-      successToast: "Freeze transaction finalized.",
-    });
+        confirmationTitle: "Freeze account?",
+        confirmationDescription: "This will submit a freeze transaction on-chain.",
+        confirmButtonLabel: "Freeze now",
+        submitToast: "Submitting freeze transaction...",
+        successToast: "Freeze transaction finalized.",
+      }
+    );
   };
 
   const handleAddAllowlist = () => {
@@ -875,7 +916,9 @@ export function TokenManagementWorkspace({
             {token.symbol.slice(0, 1) || "T"}
           </div>
           <div className="min-w-0">
-            <h2 className="truncate text-[30px] leading-[1.1] font-medium text-[#1c1c1d]">{token.name}</h2>
+            <h2 className="truncate text-[30px] leading-[1.1] font-medium text-[#1c1c1d]">
+              {token.name}
+            </h2>
             <p className="truncate text-[17px] text-[rgba(28,28,29,0.66)]">{token.symbol}</p>
           </div>
         </div>
@@ -1016,9 +1059,15 @@ export function TokenManagementWorkspace({
       ) : null}
 
       <section className="space-y-3">
-        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">Token Overview</h3>
+        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
+          Token Overview
+        </h3>
         <div className="overflow-hidden rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white">
-          <OverviewRow label="Token Address" value={token.mintAddress ?? "Not deployed"} monospace />
+          <OverviewRow
+            label="Token Address"
+            value={token.mintAddress ?? "Not deployed"}
+            monospace
+          />
           <OverviewRow label="Mint Authority" value={token.mintAuthority ?? "None"} monospace />
           <OverviewRow label="Supply" value={token.totalSupply} />
           <OverviewRow label="Created" value={formatDate(token.createdAt)} />
@@ -1028,7 +1077,9 @@ export function TokenManagementWorkspace({
       </section>
 
       <section className="space-y-3">
-        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">Settings</h3>
+        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
+          Settings
+        </h3>
         <div className="border-b border-[rgba(28,28,29,0.12)]">
           <div className="flex gap-8">
             <button
@@ -1145,7 +1196,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={metadataForm.description}
                 onChange={(event) =>
-                  setMetadataForm((previous) => ({ ...previous, description: event.currentTarget.value }))
+                  setMetadataForm((previous) => ({
+                    ...previous,
+                    description: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1163,7 +1217,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={metadataForm.imageUrl}
                 onChange={(event) =>
-                  setMetadataForm((previous) => ({ ...previous, imageUrl: event.currentTarget.value }))
+                  setMetadataForm((previous) => ({
+                    ...previous,
+                    imageUrl: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1176,7 +1233,12 @@ export function TokenManagementWorkspace({
 
       {activeAction === "refresh-supply" ? (
         <ActionCard title="Refresh Supply" description="Fetch supply from RPC and update cache.">
-          <Button type="button" variant="secondary" onClick={handleRefreshSupply} disabled={isPending}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleRefreshSupply}
+            disabled={isPending}
+          >
             Refresh supply
           </Button>
         </ActionCard>
@@ -1190,7 +1252,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={mintForm.destination}
                 onChange={(event) =>
-                  setMintForm((previous) => ({ ...previous, destination: event.currentTarget.value }))
+                  setMintForm((previous) => ({
+                    ...previous,
+                    destination: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1214,7 +1279,12 @@ export function TokenManagementWorkspace({
             </Label>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" onClick={() => handleMint("prepare")} disabled={isPending}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleMint("prepare")}
+              disabled={isPending}
+            >
               Mint (prepare)
             </Button>
             <Button type="button" onClick={() => handleMint("execute")} disabled={isPending}>
@@ -1256,7 +1326,12 @@ export function TokenManagementWorkspace({
             </Label>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" onClick={() => handleBurn("prepare")} disabled={isPending}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleBurn("prepare")}
+              disabled={isPending}
+            >
               Burn (prepare)
             </Button>
             <Button type="button" onClick={() => handleBurn("execute")} disabled={isPending}>
@@ -1267,7 +1342,10 @@ export function TokenManagementWorkspace({
       ) : null}
 
       {activeAction === "seize" ? (
-        <ActionCard title="Force Transfer" description="Administrative seizure transfer between accounts.">
+        <ActionCard
+          title="Force Transfer"
+          description="Administrative seizure transfer between accounts."
+        >
           <div className="grid gap-3 md:grid-cols-2">
             <Label>
               Source
@@ -1283,7 +1361,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={seizeForm.destination}
                 onChange={(event) =>
-                  setSeizeForm((previous) => ({ ...previous, destination: event.currentTarget.value }))
+                  setSeizeForm((previous) => ({
+                    ...previous,
+                    destination: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1301,7 +1382,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={seizeForm.delegateAuthority}
                 onChange={(event) =>
-                  setSeizeForm((previous) => ({ ...previous, delegateAuthority: event.currentTarget.value }))
+                  setSeizeForm((previous) => ({
+                    ...previous,
+                    delegateAuthority: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1316,7 +1400,12 @@ export function TokenManagementWorkspace({
             </Label>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" onClick={() => handleSeize("prepare")} disabled={isPending}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleSeize("prepare")}
+              disabled={isPending}
+            >
               Seize (prepare)
             </Button>
             <Button type="button" onClick={() => handleSeize("execute")} disabled={isPending}>
@@ -1327,14 +1416,20 @@ export function TokenManagementWorkspace({
       ) : null}
 
       {activeAction === "force-burn" ? (
-        <ActionCard title="Force Burn" description="Administrative forced burn from source account.">
+        <ActionCard
+          title="Force Burn"
+          description="Administrative forced burn from source account."
+        >
           <div className="grid gap-3 md:grid-cols-2">
             <Label>
               Source
               <Input
                 value={forceBurnForm.source}
                 onChange={(event) =>
-                  setForceBurnForm((previous) => ({ ...previous, source: event.currentTarget.value }))
+                  setForceBurnForm((previous) => ({
+                    ...previous,
+                    source: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1343,7 +1438,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={forceBurnForm.amount}
                 onChange={(event) =>
-                  setForceBurnForm((previous) => ({ ...previous, amount: event.currentTarget.value }))
+                  setForceBurnForm((previous) => ({
+                    ...previous,
+                    amount: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1352,7 +1450,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={forceBurnForm.delegateAuthority}
                 onChange={(event) =>
-                  setForceBurnForm((previous) => ({ ...previous, delegateAuthority: event.currentTarget.value }))
+                  setForceBurnForm((previous) => ({
+                    ...previous,
+                    delegateAuthority: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1420,7 +1521,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={authorityForm.newAuthority}
                 onChange={(event) =>
-                  setAuthorityForm((previous) => ({ ...previous, newAuthority: event.currentTarget.value }))
+                  setAuthorityForm((previous) => ({
+                    ...previous,
+                    newAuthority: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1434,7 +1538,11 @@ export function TokenManagementWorkspace({
             >
               Authority (prepare)
             </Button>
-            <Button type="button" onClick={() => handleAuthorityUpdate("execute")} disabled={isPending}>
+            <Button
+              type="button"
+              onClick={() => handleAuthorityUpdate("execute")}
+              disabled={isPending}
+            >
               Authority (execute)
             </Button>
           </div>
@@ -1444,7 +1552,12 @@ export function TokenManagementWorkspace({
       {activeAction === "pause" ? (
         <ActionCard title="Pause Controls" description="Pause or resume token-wide transfers.">
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" onClick={() => handlePause(true)} disabled={isPending}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handlePause(true)}
+              disabled={isPending}
+            >
               Pause token
             </Button>
             <Button type="button" onClick={() => handlePause(false)} disabled={isPending}>
@@ -1462,7 +1575,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={freezeForm.accountAddress}
                 onChange={(event) =>
-                  setFreezeForm((previous) => ({ ...previous, accountAddress: event.currentTarget.value }))
+                  setFreezeForm((previous) => ({
+                    ...previous,
+                    accountAddress: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1477,7 +1593,12 @@ export function TokenManagementWorkspace({
             </Label>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" onClick={() => handleFreeze(false)} disabled={isPending}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleFreeze(false)}
+              disabled={isPending}
+            >
               Freeze account
             </Button>
             <Button type="button" onClick={() => handleFreeze(true)} disabled={isPending}>
@@ -1495,7 +1616,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={allowlistForm.address}
                 onChange={(event) =>
-                  setAllowlistForm((previous) => ({ ...previous, address: event.currentTarget.value }))
+                  setAllowlistForm((previous) => ({
+                    ...previous,
+                    address: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1504,7 +1628,10 @@ export function TokenManagementWorkspace({
               <Input
                 value={allowlistForm.label}
                 onChange={(event) =>
-                  setAllowlistForm((previous) => ({ ...previous, label: event.currentTarget.value }))
+                  setAllowlistForm((previous) => ({
+                    ...previous,
+                    label: event.currentTarget.value,
+                  }))
                 }
               />
             </Label>
@@ -1526,7 +1653,9 @@ export function TokenManagementWorkspace({
                 >
                   <div className="min-w-0">
                     <p className="truncate font-mono text-xs text-[#1c1c1d]">{entry.address}</p>
-                    <p className="text-xs text-[rgba(28,28,29,0.62)]">{entry.label ?? "No label"}</p>
+                    <p className="text-xs text-[rgba(28,28,29,0.62)]">
+                      {entry.label ?? "No label"}
+                    </p>
                   </div>
                   <Button
                     type="button"
@@ -1593,7 +1722,9 @@ export function TokenManagementWorkspace({
               {allowlistError ? (
                 <p className="mt-1 text-sm text-[#8a1f2a]">{allowlistError}</p>
               ) : (
-                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">{allowlistEntries.length} entries</p>
+                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">
+                  {allowlistEntries.length} entries
+                </p>
               )}
             </div>
             <div className="rounded-xl border border-[rgba(28,28,29,0.12)] p-3">
@@ -1601,7 +1732,9 @@ export function TokenManagementWorkspace({
               {frozenAccountsError ? (
                 <p className="mt-1 text-sm text-[#8a1f2a]">{frozenAccountsError}</p>
               ) : (
-                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">{frozenAccounts.length} accounts</p>
+                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">
+                  {frozenAccounts.length} accounts
+                </p>
               )}
             </div>
           </CardContent>
@@ -1616,7 +1749,11 @@ export function TokenManagementWorkspace({
         <CardContent>
           {lastActionResult ? (
             <div className="space-y-2">
-              <p className={lastActionResult.ok ? "text-sm text-[#0f9b58]" : "text-sm text-[#8a1f2a]"}>
+              <p
+                className={
+                  lastActionResult.ok ? "text-sm text-[#0f9b58]" : "text-sm text-[#8a1f2a]"
+                }
+              >
                 {lastActionResult.message}
               </p>
               <pre className="max-h-[320px] overflow-auto rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-3 text-xs text-[#1c1c1d]">
@@ -1624,7 +1761,9 @@ export function TokenManagementWorkspace({
               </pre>
             </div>
           ) : (
-            <p className="text-sm text-[rgba(28,28,29,0.68)]">Select and run an action to inspect response data.</p>
+            <p className="text-sm text-[rgba(28,28,29,0.68)]">
+              Select and run an action to inspect response data.
+            </p>
           )}
         </CardContent>
       </Card>
@@ -1672,7 +1811,6 @@ export function TokenManagementWorkspace({
           Running action...
         </div>
       ) : null}
-
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -251,6 +251,11 @@ function asOptionalString(value: string): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function isPositiveAmount(value: string): boolean {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0;
+}
+
 function formatValue(value: string | null | undefined): string {
   if (!value) {
     return "None";
@@ -643,6 +648,10 @@ export function TokenManagementWorkspace({
       toast.error("Mint destination and amount are required.");
       return;
     }
+    if (!isPositiveAmount(amount)) {
+      toast.error("Amount must be a positive number.");
+      return;
+    }
 
     runAction(
       {
@@ -675,6 +684,10 @@ export function TokenManagementWorkspace({
     const amount = burnForm.amount.trim();
     if (!source || !amount) {
       toast.error("Burn source and amount are required.");
+      return;
+    }
+    if (!isPositiveAmount(amount)) {
+      toast.error("Amount must be a positive number.");
       return;
     }
 
@@ -712,6 +725,10 @@ export function TokenManagementWorkspace({
       toast.error("Seize source, destination, and amount are required.");
       return;
     }
+    if (!isPositiveAmount(amount)) {
+      toast.error("Amount must be a positive number.");
+      return;
+    }
 
     runAction(
       {
@@ -747,6 +764,10 @@ export function TokenManagementWorkspace({
     const amount = forceBurnForm.amount.trim();
     if (!source || !amount) {
       toast.error("Force-burn source and amount are required.");
+      return;
+    }
+    if (!isPositiveAmount(amount)) {
+      toast.error("Amount must be a positive number.");
       return;
     }
 
@@ -923,7 +944,7 @@ export function TokenManagementWorkspace({
           </div>
         </div>
 
-        <div className="relative flex items-center gap-2">
+        <div className="relative z-30 flex items-center gap-2">
           {explorerHref ? (
             <Button variant="outline" asChild>
               <Link href={explorerHref} target="_blank" rel="noopener noreferrer">
@@ -946,107 +967,115 @@ export function TokenManagementWorkspace({
           </Button>
 
           {isActionMenuOpen ? (
-            <div className="absolute top-[44px] right-0 z-20 w-[260px] overflow-hidden rounded-xl border border-[rgba(28,28,29,0.12)] bg-white shadow-[0_14px_28px_rgba(28,28,29,0.16)]">
-              <div className="border-b border-[rgba(28,28,29,0.08)] px-3 py-2 text-xs font-medium tracking-wide text-[rgba(28,28,29,0.6)] uppercase">
-                Token Actions
+            <>
+              <button
+                type="button"
+                aria-label="Close admin actions menu"
+                className="fixed inset-0 z-20 cursor-default bg-transparent"
+                onClick={() => setIsActionMenuOpen(false)}
+              />
+              <div className="absolute top-[44px] right-0 z-30 w-[260px] overflow-hidden rounded-xl border border-[rgba(28,28,29,0.12)] bg-white shadow-[0_14px_28px_rgba(28,28,29,0.16)]">
+                <div className="border-b border-[rgba(28,28,29,0.08)] px-3 py-2 text-xs font-medium tracking-wide text-[rgba(28,28,29,0.6)] uppercase">
+                  Token Actions
+                </div>
+                <div className="p-1">
+                  <button
+                    type="button"
+                    onClick={() => selectAction("mint")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Mint Tokens
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("burn")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Burn Tokens
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("update-metadata")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Update Metadata
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("refresh-supply")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Refresh Supply
+                  </button>
+                </div>
+                <div className="border-y border-[rgba(28,28,29,0.08)] px-3 py-2 text-xs font-medium tracking-wide text-[rgba(28,28,29,0.6)] uppercase">
+                  Administrative
+                </div>
+                <div className="p-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!canDeployToken) {
+                        return;
+                      }
+                      setIsActionMenuOpen(false);
+                      handleDeploy("execute");
+                    }}
+                    disabled={!canDeployToken || isPending}
+                    className={[
+                      "flex w-full items-center rounded-lg px-3 py-2 text-left text-sm",
+                      canDeployToken
+                        ? "hover:bg-[rgba(28,28,29,0.05)]"
+                        : "cursor-not-allowed text-[rgba(28,28,29,0.42)] opacity-60",
+                    ].join(" ")}
+                  >
+                    Deploy Token
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("seize")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Force Transfer
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("force-burn")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Force Burn
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("freeze")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Freeze / Unfreeze Account
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("pause")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Pause / Unpause Token
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("authority")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Update Authority
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectAction("allowlist")}
+                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                  >
+                    Manage Allowlist
+                  </button>
+                </div>
               </div>
-              <div className="p-1">
-                <button
-                  type="button"
-                  onClick={() => selectAction("mint")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Mint Tokens
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("burn")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Burn Tokens
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("update-metadata")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Update Metadata
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("refresh-supply")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Refresh Supply
-                </button>
-              </div>
-              <div className="border-y border-[rgba(28,28,29,0.08)] px-3 py-2 text-xs font-medium tracking-wide text-[rgba(28,28,29,0.6)] uppercase">
-                Administrative
-              </div>
-              <div className="p-1">
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (!canDeployToken) {
-                      return;
-                    }
-                    setIsActionMenuOpen(false);
-                    handleDeploy("execute");
-                  }}
-                  disabled={!canDeployToken || isPending}
-                  className={[
-                    "flex w-full items-center rounded-lg px-3 py-2 text-left text-sm",
-                    canDeployToken
-                      ? "hover:bg-[rgba(28,28,29,0.05)]"
-                      : "cursor-not-allowed text-[rgba(28,28,29,0.42)] opacity-60",
-                  ].join(" ")}
-                >
-                  Deploy Token
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("seize")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Force Transfer
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("force-burn")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Force Burn
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("freeze")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Freeze / Unfreeze Account
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("pause")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Pause / Unpause Token
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("authority")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Update Authority
-                </button>
-                <button
-                  type="button"
-                  onClick={() => selectAction("allowlist")}
-                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                >
-                  Manage Allowlist
-                </button>
-              </div>
-            </div>
+            </>
           ) : null}
         </div>
       </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -82,10 +82,16 @@ interface TokenManagementWorkspaceProps {
   tokenError: string | null;
   transactions: TokenTransaction[];
   transactionsError: string | null;
+  transactionsTotal: number | null;
+  transactionsHasMore: boolean;
   allowlistEntries: TokenAllowlistEntry[];
   allowlistError: string | null;
+  allowlistTotal: number | null;
+  allowlistHasMore: boolean;
   frozenAccounts: FrozenAccount[];
   frozenAccountsError: string | null;
+  frozenAccountsTotal: number | null;
+  frozenAccountsHasMore: boolean;
 }
 
 interface MetadataFormState {
@@ -293,7 +299,12 @@ function getExplorerHref(mintAddress: string | null): string | null {
     return null;
   }
 
-  return `https://explorer.solana.com/address/${mintAddress}?cluster=devnet`;
+  const cluster = process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim() || "devnet";
+  const clusterQuery =
+    cluster === "mainnet-beta" || cluster === "mainnet"
+      ? ""
+      : `?cluster=${encodeURIComponent(cluster)}`;
+  return `https://explorer.solana.com/address/${mintAddress}${clusterQuery}`;
 }
 
 async function executeActionRequest(input: ActionExecutionInput): Promise<ActionExecutionResult> {
@@ -392,10 +403,16 @@ export function TokenManagementWorkspace({
   tokenError,
   transactions,
   transactionsError,
+  transactionsTotal,
+  transactionsHasMore,
   allowlistEntries,
   allowlistError,
+  allowlistTotal,
+  allowlistHasMore,
   frozenAccounts,
   frozenAccountsError,
+  frozenAccountsTotal,
+  frozenAccountsHasMore,
 }: TokenManagementWorkspaceProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -426,6 +443,7 @@ export function TokenManagementWorkspace({
   const tokenBasePath = useMemo(() => `/v1/issuance/tokens/${token.id}`, [token.id]);
   const explorerHref = useMemo(() => getExplorerHref(token.mintAddress), [token.mintAddress]);
   const canDeployToken = token.status === "pending" && !token.mintAddress;
+  const metadataAuthority = token.metadataAuthority ?? token.mintAuthority;
 
   const permissionRows = useMemo<PermissionRow[]>(
     () => [
@@ -447,7 +465,7 @@ export function TokenManagementWorkspace({
         id: "metadata-authority",
         title: "Metadata Authority",
         helper: "Can update token metadata.",
-        value: token.mintAuthority,
+        value: metadataAuthority,
         action: "update-metadata",
       },
       {
@@ -465,7 +483,7 @@ export function TokenManagementWorkspace({
         action: "authority",
       },
     ],
-    [token]
+    [metadataAuthority, token]
   );
 
   const extensionRows = useMemo<ExtensionRow[]>(
@@ -1711,28 +1729,37 @@ export function TokenManagementWorkspace({
             ) : transactions.length === 0 ? (
               <p className="text-sm text-[rgba(28,28,29,0.68)]">No transactions yet.</p>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Signature</TableHead>
-                    <TableHead>Created</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {transactions.slice(0, 12).map((transaction) => (
-                    <TableRow key={transaction.id}>
-                      <TableCell>{transaction.type}</TableCell>
-                      <TableCell>{transaction.status}</TableCell>
-                      <TableCell className="max-w-[220px] truncate font-mono text-xs">
-                        {transaction.signature ?? "—"}
-                      </TableCell>
-                      <TableCell>{formatDate(transaction.createdAt)}</TableCell>
+              <div className="space-y-3">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Signature</TableHead>
+                      <TableHead>Created</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {transactions.slice(0, 12).map((transaction) => (
+                      <TableRow key={transaction.id}>
+                        <TableCell>{transaction.type}</TableCell>
+                        <TableCell>{transaction.status}</TableCell>
+                        <TableCell className="max-w-[220px] truncate font-mono text-xs">
+                          {transaction.signature ?? "—"}
+                        </TableCell>
+                        <TableCell>{formatDate(transaction.createdAt)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                {transactionsHasMore ? (
+                  <p className="text-xs text-[rgba(28,28,29,0.62)]">
+                    Showing first {transactions.length} transactions
+                    {transactionsTotal ? ` of ${transactionsTotal}` : ""}. Use pagination to view
+                    older records.
+                  </p>
+                ) : null}
+              </div>
             )}
           </CardContent>
         </Card>
@@ -1748,9 +1775,16 @@ export function TokenManagementWorkspace({
               {allowlistError ? (
                 <p className="mt-1 text-sm text-[#8a1f2a]">{allowlistError}</p>
               ) : (
-                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">
-                  {allowlistEntries.length} entries
-                </p>
+                <>
+                  <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">
+                    {(allowlistTotal ?? allowlistEntries.length).toLocaleString("en-US")} entries
+                  </p>
+                  {allowlistHasMore ? (
+                    <p className="mt-1 text-xs text-[rgba(28,28,29,0.62)]">
+                      Showing first {allowlistEntries.length.toLocaleString("en-US")} entries.
+                    </p>
+                  ) : null}
+                </>
               )}
             </div>
             <div className="rounded-xl border border-[rgba(28,28,29,0.12)] p-3">
@@ -1758,9 +1792,17 @@ export function TokenManagementWorkspace({
               {frozenAccountsError ? (
                 <p className="mt-1 text-sm text-[#8a1f2a]">{frozenAccountsError}</p>
               ) : (
-                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">
-                  {frozenAccounts.length} accounts
-                </p>
+                <>
+                  <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">
+                    {(frozenAccountsTotal ?? frozenAccounts.length).toLocaleString("en-US")}{" "}
+                    accounts
+                  </p>
+                  {frozenAccountsHasMore ? (
+                    <p className="mt-1 text-xs text-[rgba(28,28,29,0.62)]">
+                      Showing first {frozenAccounts.length.toLocaleString("en-US")} accounts.
+                    </p>
+                  ) : null}
+                </>
               )}
             </div>
           </CardContent>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -1,0 +1,1678 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { FrozenAccount, Token, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
+import {
+  ArrowUpRight,
+  ChevronDown,
+  Copy,
+  Loader2,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type ReactNode, useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+type HttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
+type SettingsTab = "permissions" | "extensions";
+type AdminAction =
+  | "update-metadata"
+  | "refresh-supply"
+  | "mint"
+  | "burn"
+  | "seize"
+  | "force-burn"
+  | "authority"
+  | "pause"
+  | "freeze"
+  | "allowlist";
+
+interface ActionExecutionInput {
+  label: string;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+}
+
+interface ExecuteRouteResponse {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+  error?: string;
+}
+
+interface ActionExecutionResult {
+  ok: boolean;
+  message: string;
+  status: number | null;
+  body: unknown;
+}
+
+interface RunActionOptions {
+  requiresConfirmation?: boolean;
+  confirmationTitle?: string;
+  confirmationDescription?: string;
+  confirmButtonLabel?: string;
+  submitToast?: string;
+  successToast?: string;
+}
+
+interface ActionConfirmationState {
+  input: ActionExecutionInput;
+  options: Required<
+    Pick<
+      RunActionOptions,
+      | "confirmationTitle"
+      | "confirmationDescription"
+      | "confirmButtonLabel"
+      | "submitToast"
+      | "successToast"
+    >
+  >;
+}
+
+interface TokenManagementWorkspaceProps {
+  token: Token;
+  tokenError: string | null;
+  transactions: TokenTransaction[];
+  transactionsError: string | null;
+  allowlistEntries: TokenAllowlistEntry[];
+  allowlistError: string | null;
+  frozenAccounts: FrozenAccount[];
+  frozenAccountsError: string | null;
+}
+
+interface MetadataFormState {
+  name: string;
+  description: string;
+  uri: string;
+  imageUrl: string;
+  status: "active" | "paused";
+}
+
+interface MintFormState {
+  destination: string;
+  amount: string;
+  memo: string;
+}
+
+interface BurnFormState {
+  source: string;
+  amount: string;
+  memo: string;
+}
+
+interface SeizeFormState {
+  source: string;
+  destination: string;
+  amount: string;
+  delegateAuthority: string;
+  memo: string;
+}
+
+interface ForceBurnFormState {
+  source: string;
+  amount: string;
+  delegateAuthority: string;
+  memo: string;
+}
+
+interface AuthorityFormState {
+  role: "mint" | "freeze" | "permanentDelegate" | "metadata";
+  currentAuthority: string;
+  newAuthority: string;
+}
+
+interface FreezeFormState {
+  accountAddress: string;
+  reason: string;
+}
+
+interface AllowlistFormState {
+  address: string;
+  label: string;
+}
+
+interface PermissionRow {
+  id: string;
+  title: string;
+  helper: string;
+  value: string | null;
+  action: AdminAction;
+}
+
+interface ExtensionRow {
+  id: string;
+  title: string;
+  helper: string;
+  value: string;
+}
+
+function createInitialMetadataForm(token: Token): MetadataFormState {
+  return {
+    name: token.name,
+    description: token.description ?? "",
+    uri: token.uri ?? "",
+    imageUrl: token.imageUrl ?? "",
+    status: token.status === "paused" ? "paused" : "active",
+  };
+}
+
+function createInitialMintForm(): MintFormState {
+  return {
+    destination: "",
+    amount: "",
+    memo: "",
+  };
+}
+
+function createInitialBurnForm(): BurnFormState {
+  return {
+    source: "",
+    amount: "",
+    memo: "",
+  };
+}
+
+function createInitialSeizeForm(): SeizeFormState {
+  return {
+    source: "",
+    destination: "",
+    amount: "",
+    delegateAuthority: "",
+    memo: "",
+  };
+}
+
+function createInitialForceBurnForm(): ForceBurnFormState {
+  return {
+    source: "",
+    amount: "",
+    delegateAuthority: "",
+    memo: "",
+  };
+}
+
+function createInitialAuthorityForm(): AuthorityFormState {
+  return {
+    role: "mint",
+    currentAuthority: "",
+    newAuthority: "",
+  };
+}
+
+function createInitialFreezeForm(): FreezeFormState {
+  return {
+    accountAddress: "",
+    reason: "",
+  };
+}
+
+function createInitialAllowlistForm(): AllowlistFormState {
+  return {
+    address: "",
+    label: "",
+  };
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) {
+    return "—";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  });
+}
+
+function stringifyBody(body: unknown): string {
+  try {
+    return JSON.stringify(body, null, 2);
+  } catch {
+    return String(body);
+  }
+}
+
+function asOptionalString(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function formatValue(value: string | null | undefined): string {
+  if (!value) {
+    return "None";
+  }
+
+  if (value.length <= 16) {
+    return value;
+  }
+
+  return `${value.slice(0, 6)}...${value.slice(-6)}`;
+}
+
+function extractApiError(body: unknown): string {
+  if (typeof body === "string") {
+    return body;
+  }
+
+  if (body && typeof body === "object") {
+    const maybeError = (body as { error?: { message?: string } }).error;
+    if (maybeError?.message) {
+      return maybeError.message;
+    }
+
+    const maybeMessage = (body as { message?: string }).message;
+    if (typeof maybeMessage === "string" && maybeMessage) {
+      return maybeMessage;
+    }
+  }
+
+  return "Unknown error";
+}
+
+function getExplorerHref(mintAddress: string | null): string | null {
+  if (!mintAddress) {
+    return null;
+  }
+
+  const cluster = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
+  const query = cluster && cluster !== "mainnet-beta" ? `?cluster=${encodeURIComponent(cluster)}` : "";
+  return `https://explorer.solana.com/address/${mintAddress}${query}`;
+}
+
+async function executeActionRequest(input: ActionExecutionInput): Promise<ActionExecutionResult> {
+  try {
+    const response = await fetch("/api/playground/execute", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        method: input.method,
+        path: input.path,
+        body: input.body,
+      }),
+    });
+
+    const payload = (await response.json()) as ExecuteRouteResponse;
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        message: payload.error ?? `Execution route failed (${response.status})`,
+        status: response.status,
+        body: payload,
+      };
+    }
+
+    if (!payload.ok) {
+      const status = payload.status ?? null;
+      return {
+        ok: false,
+        message: `${input.label} failed (${status ?? "unknown"}): ${extractApiError(payload.body)}`,
+        status,
+        body: payload.body,
+      };
+    }
+
+    return {
+      ok: true,
+      message: `${input.label} succeeded (${payload.status ?? "ok"})`,
+      status: payload.status ?? null,
+      body: payload.body ?? null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : "Request failed",
+      status: null,
+      body: null,
+    };
+  }
+}
+
+function ActionCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card className="gap-4">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+      </CardHeader>
+      <CardContent className="space-y-4">{children}</CardContent>
+    </Card>
+  );
+}
+
+function OverviewRow({ label, value, monospace = false }: { label: string; value: string; monospace?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-[rgba(28,28,29,0.08)] px-4 py-3 last:border-b-0">
+      <p className="text-[15px] text-[rgba(28,28,29,0.68)]">{label}</p>
+      <p className={["text-right text-[15px] text-[#1c1c1d]", monospace ? "font-mono text-xs" : ""].join(" ")}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function TokenManagementWorkspace({
+  token,
+  tokenError,
+  transactions,
+  transactionsError,
+  allowlistEntries,
+  allowlistError,
+  frozenAccounts,
+  frozenAccountsError,
+}: TokenManagementWorkspaceProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [settingsTab, setSettingsTab] = useState<SettingsTab>("permissions");
+  const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
+  const [activeAction, setActiveAction] = useState<AdminAction | null>("update-metadata");
+  const [actionConfirmation, setActionConfirmation] = useState<ActionConfirmationState | null>(null);
+  const [metadataForm, setMetadataForm] = useState<MetadataFormState>(() =>
+    createInitialMetadataForm(token)
+  );
+  const [mintForm, setMintForm] = useState<MintFormState>(createInitialMintForm);
+  const [burnForm, setBurnForm] = useState<BurnFormState>(createInitialBurnForm);
+  const [seizeForm, setSeizeForm] = useState<SeizeFormState>(createInitialSeizeForm);
+  const [forceBurnForm, setForceBurnForm] = useState<ForceBurnFormState>(createInitialForceBurnForm);
+  const [authorityForm, setAuthorityForm] = useState<AuthorityFormState>(createInitialAuthorityForm);
+  const [freezeForm, setFreezeForm] = useState<FreezeFormState>(createInitialFreezeForm);
+  const [allowlistForm, setAllowlistForm] = useState<AllowlistFormState>(createInitialAllowlistForm);
+  const [lastActionResult, setLastActionResult] = useState<ActionExecutionResult | null>(null);
+
+  const tokenBasePath = useMemo(() => `/v1/issuance/tokens/${token.id}`, [token.id]);
+  const explorerHref = useMemo(() => getExplorerHref(token.mintAddress), [token.mintAddress]);
+  const canDeployToken = token.status === "pending" && !token.mintAddress;
+
+  const permissionRows = useMemo<PermissionRow[]>(
+    () => [
+      {
+        id: "mint-authority",
+        title: "Mint Authority",
+        helper: "Can mint new tokens.",
+        value: token.mintAuthority,
+        action: "authority",
+      },
+      {
+        id: "freeze-authority",
+        title: "Freeze Authority",
+        helper: "Can freeze and unfreeze token accounts.",
+        value: token.freezeAuthority,
+        action: "freeze",
+      },
+      {
+        id: "metadata-authority",
+        title: "Metadata Authority",
+        helper: "Can update token metadata.",
+        value: token.mintAuthority,
+        action: "update-metadata",
+      },
+      {
+        id: "pausable-authority",
+        title: "Pausable Authority",
+        helper: "Can pause and unpause token transfers.",
+        value: token.extensions?.pausable?.authority ?? null,
+        action: "pause",
+      },
+      {
+        id: "permanent-delegate",
+        title: "Permanent Delegate Authority",
+        helper: "Can perform delegated transfer/burn operations.",
+        value: token.extensions?.permanentDelegate ?? null,
+        action: "authority",
+      },
+    ],
+    [token]
+  );
+
+  const extensionRows = useMemo<ExtensionRow[]>(
+    () => [
+      {
+        id: "template",
+        title: "Template",
+        helper: "Base template applied to this token.",
+        value: token.template,
+      },
+      {
+        id: "allowlist",
+        title: "Allowlist Enforcement",
+        helper: "Requires destination allowlisting for controlled actions.",
+        value: token.requiresAllowlist ? "Enabled" : "Disabled",
+      },
+      {
+        id: "mintable",
+        title: "Mintable",
+        helper: "Allows mint operations after deployment.",
+        value: token.isMintable ? "Enabled" : "Disabled",
+      },
+      {
+        id: "freezable",
+        title: "Freezable",
+        helper: "Allows freeze/unfreeze account controls.",
+        value: token.isFreezable ? "Enabled" : "Disabled",
+      },
+      {
+        id: "default-account-state",
+        title: "Default Account State",
+        helper: "Default state for newly created token accounts.",
+        value: token.extensions?.defaultAccountState ?? "initialized",
+      },
+      {
+        id: "transfer-fee",
+        title: "Transfer Fee",
+        helper: "Fee configuration for token transfers.",
+        value: token.extensions?.transferFee ? "Configured" : "Not configured",
+      },
+      {
+        id: "scaled-ui",
+        title: "Scaled UI Amount",
+        helper: "UI supply multiplier controls.",
+        value: token.extensions?.scaledUiAmount ? "Configured" : "Not configured",
+      },
+      {
+        id: "transfer-hook",
+        title: "Transfer Hook",
+        helper: "Custom transfer logic program hook.",
+        value: token.extensions?.transferHook ? "Configured" : "Not configured",
+      },
+      {
+        id: "interest-bearing",
+        title: "Interest Bearing",
+        helper: "Interest-rate based balance updates.",
+        value: token.extensions?.interestBearing ? "Configured" : "Not configured",
+      },
+      {
+        id: "non-transferable",
+        title: "Non-transferable",
+        helper: "Disables standard transfers between accounts.",
+        value: token.extensions?.nonTransferable ? "Enabled" : "Disabled",
+      },
+    ],
+    [token]
+  );
+
+  const executeAction = (input: ActionExecutionInput, options: RunActionOptions = {}) => {
+    const submitToast = options.submitToast ?? `Submitting ${input.label.toLowerCase()}...`;
+    const successToast = options.successToast ?? "Transaction finalized successfully.";
+    const toastId = toast.loading(submitToast);
+
+    startTransition(async () => {
+      const result = await executeActionRequest(input);
+      setLastActionResult(result);
+
+      if (result.ok) {
+        setActionConfirmation(null);
+        toast.success(successToast, { id: toastId });
+        router.refresh();
+        return;
+      }
+
+      toast.error(result.message, { id: toastId });
+    });
+  };
+
+  const runAction = (input: ActionExecutionInput, options: RunActionOptions = {}) => {
+    if (options.requiresConfirmation) {
+      setActionConfirmation({
+        input,
+        options: {
+          confirmationTitle: options.confirmationTitle ?? "Send transaction?",
+          confirmationDescription:
+            options.confirmationDescription ??
+            "This will submit an on-chain transaction. Do you want to continue?",
+          confirmButtonLabel: options.confirmButtonLabel ?? "Go ahead",
+          submitToast: options.submitToast ?? `Submitting ${input.label.toLowerCase()}...`,
+          successToast: options.successToast ?? "Transaction finalized successfully.",
+        },
+      });
+      return;
+    }
+
+    executeAction(input, options);
+  };
+
+  const handleCopy = async (value: string | null) => {
+    if (!value) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success("Copied");
+    } catch {
+      toast.error("Unable to copy");
+    }
+  };
+
+  const handleUpdateMetadata = () => {
+    const nextName = metadataForm.name.trim();
+    if (!nextName) {
+      toast.error("Token name is required.");
+      return;
+    }
+
+    runAction({
+      label: "Update token",
+      method: "PATCH",
+      path: tokenBasePath,
+      body: {
+        name: nextName,
+        description: metadataForm.description.trim() ? metadataForm.description.trim() : null,
+        uri: metadataForm.uri.trim() ? metadataForm.uri.trim() : null,
+        imageUrl: metadataForm.imageUrl.trim() ? metadataForm.imageUrl.trim() : null,
+        status: metadataForm.status,
+      },
+    });
+  };
+
+  const handleDeploy = (mode: "prepare" | "execute") => {
+    runAction({
+      label: `Deploy token (${mode})`,
+      method: "POST",
+      path: `${tokenBasePath}/deploy${mode === "prepare" ? "/prepare" : ""}`,
+      body: {},
+    },
+    mode === "execute"
+      ? {
+          requiresConfirmation: true,
+          confirmationTitle: "Deploy token?",
+          confirmationDescription: "This will submit the deploy transaction on-chain.",
+          confirmButtonLabel: "Deploy now",
+          submitToast: "Submitting deploy transaction...",
+          successToast: "Deploy transaction finalized.",
+        }
+      : undefined);
+  };
+
+  const handleRefreshSupply = () => {
+    runAction({
+      label: "Refresh supply",
+      method: "POST",
+      path: `${tokenBasePath}/supply/refresh`,
+      body: {},
+    });
+  };
+
+  const handleMint = (mode: "prepare" | "execute") => {
+    const destination = mintForm.destination.trim();
+    const amount = mintForm.amount.trim();
+    if (!destination || !amount) {
+      toast.error("Mint destination and amount are required.");
+      return;
+    }
+
+    runAction({
+      label: `Mint (${mode})`,
+      method: "POST",
+      path: `${tokenBasePath}/mint${mode === "prepare" ? "/prepare" : ""}`,
+      body: {
+        mint: {
+          destination,
+          amount,
+          memo: asOptionalString(mintForm.memo),
+        },
+      },
+    },
+    mode === "execute"
+      ? {
+          requiresConfirmation: true,
+          confirmationTitle: "Mint tokens?",
+          confirmationDescription: "This will submit a mint transaction on-chain.",
+          confirmButtonLabel: "Mint now",
+          submitToast: "Submitting mint transaction...",
+          successToast: "Mint transaction finalized.",
+        }
+      : undefined);
+  };
+
+  const handleBurn = (mode: "prepare" | "execute") => {
+    const source = burnForm.source.trim();
+    const amount = burnForm.amount.trim();
+    if (!source || !amount) {
+      toast.error("Burn source and amount are required.");
+      return;
+    }
+
+    runAction({
+      label: `Burn (${mode})`,
+      method: "POST",
+      path: `${tokenBasePath}/burn${mode === "prepare" ? "/prepare" : ""}`,
+      body: {
+        burn: {
+          source,
+          amount,
+          memo: asOptionalString(burnForm.memo),
+        },
+      },
+    },
+    mode === "execute"
+      ? {
+          requiresConfirmation: true,
+          confirmationTitle: "Burn tokens?",
+          confirmationDescription: "This will submit a burn transaction on-chain.",
+          confirmButtonLabel: "Burn now",
+          submitToast: "Submitting burn transaction...",
+          successToast: "Burn transaction finalized.",
+        }
+      : undefined);
+  };
+
+  const handleSeize = (mode: "prepare" | "execute") => {
+    const source = seizeForm.source.trim();
+    const destination = seizeForm.destination.trim();
+    const amount = seizeForm.amount.trim();
+    if (!source || !destination || !amount) {
+      toast.error("Seize source, destination, and amount are required.");
+      return;
+    }
+
+    runAction({
+      label: `Seize (${mode})`,
+      method: "POST",
+      path: `${tokenBasePath}/seize${mode === "prepare" ? "/prepare" : ""}`,
+      body: {
+        seize: {
+          source,
+          destination,
+          amount,
+          delegateAuthority: asOptionalString(seizeForm.delegateAuthority),
+          memo: asOptionalString(seizeForm.memo),
+        },
+      },
+    },
+    mode === "execute"
+      ? {
+          requiresConfirmation: true,
+          confirmationTitle: "Force transfer?",
+          confirmationDescription: "This will submit a seize (force transfer) transaction on-chain.",
+          confirmButtonLabel: "Transfer now",
+          submitToast: "Submitting force transfer transaction...",
+          successToast: "Force transfer transaction finalized.",
+        }
+      : undefined);
+  };
+
+  const handleForceBurn = (mode: "prepare" | "execute") => {
+    const source = forceBurnForm.source.trim();
+    const amount = forceBurnForm.amount.trim();
+    if (!source || !amount) {
+      toast.error("Force-burn source and amount are required.");
+      return;
+    }
+
+    runAction({
+      label: `Force Burn (${mode})`,
+      method: "POST",
+      path: `${tokenBasePath}/force-burn${mode === "prepare" ? "/prepare" : ""}`,
+      body: {
+        forceBurn: {
+          source,
+          amount,
+          delegateAuthority: asOptionalString(forceBurnForm.delegateAuthority),
+          memo: asOptionalString(forceBurnForm.memo),
+        },
+      },
+    },
+    mode === "execute"
+      ? {
+          requiresConfirmation: true,
+          confirmationTitle: "Force burn tokens?",
+          confirmationDescription: "This will submit a force-burn transaction on-chain.",
+          confirmButtonLabel: "Force burn now",
+          submitToast: "Submitting force-burn transaction...",
+          successToast: "Force-burn transaction finalized.",
+        }
+      : undefined);
+  };
+
+  const handleAuthorityUpdate = (mode: "prepare" | "execute") => {
+    runAction({
+      label: `Update authority (${mode})`,
+      method: "POST",
+      path: `${tokenBasePath}/authority${mode === "prepare" ? "/prepare" : ""}`,
+      body: {
+        authority: {
+          role: authorityForm.role,
+          currentAuthority: asOptionalString(authorityForm.currentAuthority),
+          newAuthority: authorityForm.newAuthority.trim() || null,
+        },
+      },
+    },
+    mode === "execute"
+      ? {
+          requiresConfirmation: true,
+          confirmationTitle: "Update authority?",
+          confirmationDescription: "This will submit an authority update transaction on-chain.",
+          confirmButtonLabel: "Update now",
+          submitToast: "Submitting authority update transaction...",
+          successToast: "Authority update finalized.",
+        }
+      : undefined);
+  };
+
+  const handlePause = (pause: boolean) => {
+    runAction({
+      label: pause ? "Pause token" : "Unpause token",
+      method: "POST",
+      path: `${tokenBasePath}/${pause ? "pause" : "unpause"}`,
+      body: {},
+    },
+    {
+      requiresConfirmation: true,
+      confirmationTitle: pause ? "Pause token?" : "Unpause token?",
+      confirmationDescription: pause
+        ? "This will submit a pause transaction on-chain."
+        : "This will submit an unpause transaction on-chain.",
+      confirmButtonLabel: pause ? "Pause now" : "Unpause now",
+      submitToast: pause ? "Submitting pause transaction..." : "Submitting unpause transaction...",
+      successToast: pause ? "Pause transaction finalized." : "Unpause transaction finalized.",
+    });
+  };
+
+  const handleFreeze = (unfreeze: boolean) => {
+    const accountAddress = freezeForm.accountAddress.trim();
+    if (!accountAddress) {
+      toast.error("Account address is required.");
+      return;
+    }
+
+    if (unfreeze) {
+      runAction({
+        label: "Unfreeze account",
+        method: "POST",
+        path: `${tokenBasePath}/unfreeze`,
+        body: {
+          accountAddress,
+        },
+      },
+      {
+        requiresConfirmation: true,
+        confirmationTitle: "Unfreeze account?",
+        confirmationDescription: "This will submit an unfreeze transaction on-chain.",
+        confirmButtonLabel: "Unfreeze now",
+        submitToast: "Submitting unfreeze transaction...",
+        successToast: "Unfreeze transaction finalized.",
+      });
+      return;
+    }
+
+    runAction({
+      label: "Freeze account",
+      method: "POST",
+      path: `${tokenBasePath}/freeze`,
+      body: {
+        accountAddress,
+        reason: asOptionalString(freezeForm.reason),
+      },
+    },
+    {
+      requiresConfirmation: true,
+      confirmationTitle: "Freeze account?",
+      confirmationDescription: "This will submit a freeze transaction on-chain.",
+      confirmButtonLabel: "Freeze now",
+      submitToast: "Submitting freeze transaction...",
+      successToast: "Freeze transaction finalized.",
+    });
+  };
+
+  const handleAddAllowlist = () => {
+    const address = allowlistForm.address.trim();
+    if (!address) {
+      toast.error("Allowlist address is required.");
+      return;
+    }
+
+    runAction({
+      label: "Add allowlist entry",
+      method: "POST",
+      path: `${tokenBasePath}/allowlist`,
+      body: {
+        address,
+        label: asOptionalString(allowlistForm.label),
+      },
+    });
+  };
+
+  const handleRemoveAllowlist = (entryId: string) => {
+    runAction({
+      label: "Remove allowlist entry",
+      method: "DELETE",
+      path: `${tokenBasePath}/allowlist/${entryId}`,
+    });
+  };
+
+  const selectAction = (action: AdminAction) => {
+    setActiveAction(action);
+    setIsActionMenuOpen(false);
+  };
+
+  return (
+    <div className="space-y-8 pb-8">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-[rgba(28,28,29,0.14)] bg-white text-[18px] font-semibold text-[rgba(28,28,29,0.66)]">
+            {token.symbol.slice(0, 1) || "T"}
+          </div>
+          <div className="min-w-0">
+            <h2 className="truncate text-[30px] leading-[1.1] font-medium text-[#1c1c1d]">{token.name}</h2>
+            <p className="truncate text-[17px] text-[rgba(28,28,29,0.66)]">{token.symbol}</p>
+          </div>
+        </div>
+
+        <div className="relative flex items-center gap-2">
+          {explorerHref ? (
+            <Button variant="outline" asChild>
+              <Link href={explorerHref} target="_blank" rel="noopener noreferrer">
+                Explorer
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          ) : (
+            <Button variant="outline" disabled>
+              Explorer
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => setIsActionMenuOpen((open) => !open)}
+          >
+            Admin Actions
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+
+          {isActionMenuOpen ? (
+            <div className="absolute top-[44px] right-0 z-20 w-[260px] overflow-hidden rounded-xl border border-[rgba(28,28,29,0.12)] bg-white shadow-[0_14px_28px_rgba(28,28,29,0.16)]">
+              <div className="border-b border-[rgba(28,28,29,0.08)] px-3 py-2 text-xs font-medium tracking-wide text-[rgba(28,28,29,0.6)] uppercase">
+                Token Actions
+              </div>
+              <div className="p-1">
+                <button
+                  type="button"
+                  onClick={() => selectAction("mint")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Mint Tokens
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("burn")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Burn Tokens
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("update-metadata")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Update Metadata
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("refresh-supply")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Refresh Supply
+                </button>
+              </div>
+              <div className="border-y border-[rgba(28,28,29,0.08)] px-3 py-2 text-xs font-medium tracking-wide text-[rgba(28,28,29,0.6)] uppercase">
+                Administrative
+              </div>
+              <div className="p-1">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!canDeployToken) {
+                      return;
+                    }
+                    setIsActionMenuOpen(false);
+                    handleDeploy("execute");
+                  }}
+                  disabled={!canDeployToken || isPending}
+                  className={[
+                    "flex w-full items-center rounded-lg px-3 py-2 text-left text-sm",
+                    canDeployToken
+                      ? "hover:bg-[rgba(28,28,29,0.05)]"
+                      : "cursor-not-allowed text-[rgba(28,28,29,0.42)] opacity-60",
+                  ].join(" ")}
+                >
+                  Deploy Token
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("seize")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Force Transfer
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("force-burn")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Force Burn
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("freeze")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Freeze / Unfreeze Account
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("pause")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Pause / Unpause Token
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("authority")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Update Authority
+                </button>
+                <button
+                  type="button"
+                  onClick={() => selectAction("allowlist")}
+                  className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
+                >
+                  Manage Allowlist
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {tokenError ? (
+        <div className="rounded-xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] px-4 py-3">
+          <p className="text-sm font-medium text-[#8a1f2a]">Token load warning</p>
+          <p className="mt-1 text-sm text-[#8a1f2a]">{tokenError}</p>
+        </div>
+      ) : null}
+
+      <section className="space-y-3">
+        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">Token Overview</h3>
+        <div className="overflow-hidden rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white">
+          <OverviewRow label="Token Address" value={token.mintAddress ?? "Not deployed"} monospace />
+          <OverviewRow label="Mint Authority" value={token.mintAuthority ?? "None"} monospace />
+          <OverviewRow label="Supply" value={token.totalSupply} />
+          <OverviewRow label="Created" value={formatDate(token.createdAt)} />
+          <OverviewRow label="Template" value={token.template} />
+          <OverviewRow label="Decimals" value={String(token.decimals)} />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">Settings</h3>
+        <div className="border-b border-[rgba(28,28,29,0.12)]">
+          <div className="flex gap-8">
+            <button
+              type="button"
+              onClick={() => setSettingsTab("permissions")}
+              className={[
+                "relative pb-3 text-[16px] leading-[24px] font-medium",
+                settingsTab === "permissions" ? "text-[#1c1c1d]" : "text-[rgba(28,28,29,0.58)]",
+              ].join(" ")}
+            >
+              Permissions
+              {settingsTab === "permissions" ? (
+                <span className="absolute right-0 bottom-[-1px] left-0 h-[2px] bg-[#1c1c1d]" />
+              ) : null}
+            </button>
+            <button
+              type="button"
+              onClick={() => setSettingsTab("extensions")}
+              className={[
+                "relative pb-3 text-[16px] leading-[24px] font-medium",
+                settingsTab === "extensions" ? "text-[#1c1c1d]" : "text-[rgba(28,28,29,0.58)]",
+              ].join(" ")}
+            >
+              Extensions
+              {settingsTab === "extensions" ? (
+                <span className="absolute right-0 bottom-[-1px] left-0 h-[2px] bg-[#1c1c1d]" />
+              ) : null}
+            </button>
+          </div>
+        </div>
+
+        {settingsTab === "permissions" ? (
+          <div className="overflow-hidden rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white">
+            {permissionRows.map((row) => (
+              <div
+                key={row.id}
+                className="flex flex-wrap items-center justify-between gap-3 border-b border-[rgba(28,28,29,0.08)] px-4 py-3 last:border-b-0"
+              >
+                <div>
+                  <p className="text-[17px] font-medium text-[#1c1c1d]">{row.title}</p>
+                  <p className="text-sm text-[rgba(28,28,29,0.62)]">{row.helper}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(row.value)}
+                    className="inline-flex items-center gap-1 rounded-full border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] px-3 py-1 text-xs font-mono text-[rgba(28,28,29,0.75)]"
+                  >
+                    {formatValue(row.value)}
+                    {row.value ? <Copy className="h-3 w-3" /> : null}
+                  </button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setActiveAction(row.action)}
+                  >
+                    Edit
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white">
+            {extensionRows.map((row) => (
+              <div
+                key={row.id}
+                className="flex flex-wrap items-center justify-between gap-3 border-b border-[rgba(28,28,29,0.08)] px-4 py-3 last:border-b-0"
+              >
+                <div>
+                  <p className="text-[17px] font-medium text-[#1c1c1d]">{row.title}</p>
+                  <p className="text-sm text-[rgba(28,28,29,0.62)]">{row.helper}</p>
+                </div>
+                <span className="rounded-full border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] px-3 py-1 text-sm text-[rgba(28,28,29,0.75)]">
+                  {row.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {activeAction === "update-metadata" ? (
+        <ActionCard title="Update Metadata" description="Edit token metadata and status.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Name
+              <Input
+                value={metadataForm.name}
+                onChange={(event) =>
+                  setMetadataForm((previous) => ({ ...previous, name: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Status
+              <select
+                className="h-10 w-full rounded-[10px] border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm"
+                value={metadataForm.status}
+                onChange={(event) =>
+                  setMetadataForm((previous) => ({
+                    ...previous,
+                    status: event.currentTarget.value as "active" | "paused",
+                  }))
+                }
+              >
+                <option value="active">active</option>
+                <option value="paused">paused</option>
+              </select>
+            </Label>
+            <Label>
+              Description
+              <Input
+                value={metadataForm.description}
+                onChange={(event) =>
+                  setMetadataForm((previous) => ({ ...previous, description: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              URI
+              <Input
+                value={metadataForm.uri}
+                onChange={(event) =>
+                  setMetadataForm((previous) => ({ ...previous, uri: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label className="md:col-span-2">
+              Image URL
+              <Input
+                value={metadataForm.imageUrl}
+                onChange={(event) =>
+                  setMetadataForm((previous) => ({ ...previous, imageUrl: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <Button type="button" onClick={handleUpdateMetadata} disabled={isPending}>
+            Save metadata
+          </Button>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "refresh-supply" ? (
+        <ActionCard title="Refresh Supply" description="Fetch supply from RPC and update cache.">
+          <Button type="button" variant="secondary" onClick={handleRefreshSupply} disabled={isPending}>
+            Refresh supply
+          </Button>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "mint" ? (
+        <ActionCard title="Mint Tokens" description="Mint to destination wallet/token account.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Destination
+              <Input
+                value={mintForm.destination}
+                onChange={(event) =>
+                  setMintForm((previous) => ({ ...previous, destination: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Amount
+              <Input
+                value={mintForm.amount}
+                onChange={(event) =>
+                  setMintForm((previous) => ({ ...previous, amount: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label className="md:col-span-2">
+              Memo
+              <Input
+                value={mintForm.memo}
+                onChange={(event) =>
+                  setMintForm((previous) => ({ ...previous, memo: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={() => handleMint("prepare")} disabled={isPending}>
+              Mint (prepare)
+            </Button>
+            <Button type="button" onClick={() => handleMint("execute")} disabled={isPending}>
+              Mint (execute)
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "burn" ? (
+        <ActionCard title="Burn Tokens" description="Burn from source wallet/token account.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Source
+              <Input
+                value={burnForm.source}
+                onChange={(event) =>
+                  setBurnForm((previous) => ({ ...previous, source: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Amount
+              <Input
+                value={burnForm.amount}
+                onChange={(event) =>
+                  setBurnForm((previous) => ({ ...previous, amount: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label className="md:col-span-2">
+              Memo
+              <Input
+                value={burnForm.memo}
+                onChange={(event) =>
+                  setBurnForm((previous) => ({ ...previous, memo: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={() => handleBurn("prepare")} disabled={isPending}>
+              Burn (prepare)
+            </Button>
+            <Button type="button" onClick={() => handleBurn("execute")} disabled={isPending}>
+              Burn (execute)
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "seize" ? (
+        <ActionCard title="Force Transfer" description="Administrative seizure transfer between accounts.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Source
+              <Input
+                value={seizeForm.source}
+                onChange={(event) =>
+                  setSeizeForm((previous) => ({ ...previous, source: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Destination
+              <Input
+                value={seizeForm.destination}
+                onChange={(event) =>
+                  setSeizeForm((previous) => ({ ...previous, destination: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Amount
+              <Input
+                value={seizeForm.amount}
+                onChange={(event) =>
+                  setSeizeForm((previous) => ({ ...previous, amount: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Delegate Authority (optional)
+              <Input
+                value={seizeForm.delegateAuthority}
+                onChange={(event) =>
+                  setSeizeForm((previous) => ({ ...previous, delegateAuthority: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label className="md:col-span-2">
+              Memo
+              <Input
+                value={seizeForm.memo}
+                onChange={(event) =>
+                  setSeizeForm((previous) => ({ ...previous, memo: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={() => handleSeize("prepare")} disabled={isPending}>
+              Seize (prepare)
+            </Button>
+            <Button type="button" onClick={() => handleSeize("execute")} disabled={isPending}>
+              Seize (execute)
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "force-burn" ? (
+        <ActionCard title="Force Burn" description="Administrative forced burn from source account.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Source
+              <Input
+                value={forceBurnForm.source}
+                onChange={(event) =>
+                  setForceBurnForm((previous) => ({ ...previous, source: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Amount
+              <Input
+                value={forceBurnForm.amount}
+                onChange={(event) =>
+                  setForceBurnForm((previous) => ({ ...previous, amount: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Delegate Authority (optional)
+              <Input
+                value={forceBurnForm.delegateAuthority}
+                onChange={(event) =>
+                  setForceBurnForm((previous) => ({ ...previous, delegateAuthority: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Memo
+              <Input
+                value={forceBurnForm.memo}
+                onChange={(event) =>
+                  setForceBurnForm((previous) => ({ ...previous, memo: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleForceBurn("prepare")}
+              disabled={isPending}
+            >
+              Force Burn (prepare)
+            </Button>
+            <Button type="button" onClick={() => handleForceBurn("execute")} disabled={isPending}>
+              Force Burn (execute)
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "authority" ? (
+        <ActionCard title="Update Authority" description="Rotate or remove token authorities.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Role
+              <select
+                className="h-10 w-full rounded-[10px] border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm"
+                value={authorityForm.role}
+                onChange={(event) =>
+                  setAuthorityForm((previous) => ({
+                    ...previous,
+                    role: event.currentTarget.value as AuthorityFormState["role"],
+                  }))
+                }
+              >
+                <option value="mint">mint</option>
+                <option value="freeze">freeze</option>
+                <option value="permanentDelegate">permanentDelegate</option>
+                <option value="metadata">metadata</option>
+              </select>
+            </Label>
+            <Label>
+              Current Authority (optional)
+              <Input
+                value={authorityForm.currentAuthority}
+                onChange={(event) =>
+                  setAuthorityForm((previous) => ({
+                    ...previous,
+                    currentAuthority: event.currentTarget.value,
+                  }))
+                }
+              />
+            </Label>
+            <Label className="md:col-span-2">
+              New Authority (empty to remove)
+              <Input
+                value={authorityForm.newAuthority}
+                onChange={(event) =>
+                  setAuthorityForm((previous) => ({ ...previous, newAuthority: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleAuthorityUpdate("prepare")}
+              disabled={isPending}
+            >
+              Authority (prepare)
+            </Button>
+            <Button type="button" onClick={() => handleAuthorityUpdate("execute")} disabled={isPending}>
+              Authority (execute)
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "pause" ? (
+        <ActionCard title="Pause Controls" description="Pause or resume token-wide transfers.">
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={() => handlePause(true)} disabled={isPending}>
+              Pause token
+            </Button>
+            <Button type="button" onClick={() => handlePause(false)} disabled={isPending}>
+              Unpause token
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "freeze" ? (
+        <ActionCard title="Freeze Controls" description="Freeze or thaw a token account.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Account Address
+              <Input
+                value={freezeForm.accountAddress}
+                onChange={(event) =>
+                  setFreezeForm((previous) => ({ ...previous, accountAddress: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Reason (freeze only)
+              <Input
+                value={freezeForm.reason}
+                onChange={(event) =>
+                  setFreezeForm((previous) => ({ ...previous, reason: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={() => handleFreeze(false)} disabled={isPending}>
+              Freeze account
+            </Button>
+            <Button type="button" onClick={() => handleFreeze(true)} disabled={isPending}>
+              Unfreeze account
+            </Button>
+          </div>
+        </ActionCard>
+      ) : null}
+
+      {activeAction === "allowlist" ? (
+        <ActionCard title="Allowlist" description="Add or remove allowlist addresses.">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Address
+              <Input
+                value={allowlistForm.address}
+                onChange={(event) =>
+                  setAllowlistForm((previous) => ({ ...previous, address: event.currentTarget.value }))
+                }
+              />
+            </Label>
+            <Label>
+              Label
+              <Input
+                value={allowlistForm.label}
+                onChange={(event) =>
+                  setAllowlistForm((previous) => ({ ...previous, label: event.currentTarget.value }))
+                }
+              />
+            </Label>
+          </div>
+          <Button type="button" onClick={handleAddAllowlist} disabled={isPending}>
+            Add allowlist entry
+          </Button>
+
+          {allowlistError ? (
+            <p className="text-sm text-[#8a1f2a]">{allowlistError}</p>
+          ) : allowlistEntries.length === 0 ? (
+            <p className="text-sm text-[rgba(28,28,29,0.68)]">No active allowlist entries.</p>
+          ) : (
+            <div className="space-y-2">
+              {allowlistEntries.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="flex items-center justify-between gap-2 rounded-lg border border-[rgba(28,28,29,0.12)] px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-mono text-xs text-[#1c1c1d]">{entry.address}</p>
+                    <p className="text-xs text-[rgba(28,28,29,0.62)]">{entry.label ?? "No label"}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleRemoveAllowlist(entry.id)}
+                    disabled={isPending}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </ActionCard>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card className="gap-4">
+          <CardHeader>
+            <CardTitle>Transactions</CardTitle>
+            <CardDescription>Recent token operations</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {transactionsError ? (
+              <p className="text-sm text-[#8a1f2a]">{transactionsError}</p>
+            ) : transactions.length === 0 ? (
+              <p className="text-sm text-[rgba(28,28,29,0.68)]">No transactions yet.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Signature</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {transactions.slice(0, 12).map((transaction) => (
+                    <TableRow key={transaction.id}>
+                      <TableCell>{transaction.type}</TableCell>
+                      <TableCell>{transaction.status}</TableCell>
+                      <TableCell className="max-w-[220px] truncate font-mono text-xs">
+                        {transaction.signature ?? "—"}
+                      </TableCell>
+                      <TableCell>{formatDate(transaction.createdAt)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="gap-4">
+          <CardHeader>
+            <CardTitle>Control Lists</CardTitle>
+            <CardDescription>Allowlist and frozen account status</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-xl border border-[rgba(28,28,29,0.12)] p-3">
+              <p className="text-sm font-medium text-[#1c1c1d]">Allowlist Entries</p>
+              {allowlistError ? (
+                <p className="mt-1 text-sm text-[#8a1f2a]">{allowlistError}</p>
+              ) : (
+                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">{allowlistEntries.length} entries</p>
+              )}
+            </div>
+            <div className="rounded-xl border border-[rgba(28,28,29,0.12)] p-3">
+              <p className="text-sm font-medium text-[#1c1c1d]">Frozen Accounts</p>
+              {frozenAccountsError ? (
+                <p className="mt-1 text-sm text-[#8a1f2a]">{frozenAccountsError}</p>
+              ) : (
+                <p className="mt-1 text-sm text-[rgba(28,28,29,0.66)]">{frozenAccounts.length} accounts</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="gap-4">
+        <CardHeader>
+          <CardTitle>Last Action Response</CardTitle>
+          <CardDescription>Most recent API payload for admin action execution.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {lastActionResult ? (
+            <div className="space-y-2">
+              <p className={lastActionResult.ok ? "text-sm text-[#0f9b58]" : "text-sm text-[#8a1f2a]"}>
+                {lastActionResult.message}
+              </p>
+              <pre className="max-h-[320px] overflow-auto rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-3 text-xs text-[#1c1c1d]">
+                {stringifyBody(lastActionResult.body)}
+              </pre>
+            </div>
+          ) : (
+            <p className="text-sm text-[rgba(28,28,29,0.68)]">Select and run an action to inspect response data.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {actionConfirmation ? (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-[rgba(18,18,19,0.44)] p-4">
+          <div className="w-full max-w-md rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white p-5 shadow-[0_20px_40px_rgba(0,0,0,0.16)]">
+            <h4 className="text-[22px] leading-[1.2] font-medium text-[#1c1c1d]">
+              {actionConfirmation.options.confirmationTitle}
+            </h4>
+            <p className="mt-2 text-[15px] leading-[1.45] text-[rgba(28,28,29,0.72)]">
+              {actionConfirmation.options.confirmationDescription}
+            </p>
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setActionConfirmation(null)}
+                disabled={isPending}
+              >
+                Not now
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  const pendingConfirmation = actionConfirmation;
+                  if (!pendingConfirmation) {
+                    return;
+                  }
+                  setActionConfirmation(null);
+                  executeAction(pendingConfirmation.input, pendingConfirmation.options);
+                }}
+                disabled={isPending}
+              >
+                {actionConfirmation.options.confirmButtonLabel}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {isPending ? (
+        <div className="fixed right-4 bottom-4 z-30 inline-flex items-center gap-2 rounded-lg border border-[rgba(28,28,29,0.12)] bg-white px-3 py-2 text-sm shadow-lg">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Running action...
+        </div>
+      ) : null}
+
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
@@ -285,15 +285,37 @@ function TemplateCard({
   );
 }
 
-export function CreateIssuanceTokenModal() {
+interface CreateIssuanceTokenModalProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  hideTrigger?: boolean;
+  triggerLabel?: string;
+  triggerClassName?: string;
+}
+
+export function CreateIssuanceTokenModal({
+  open,
+  onOpenChange,
+  hideTrigger = false,
+  triggerLabel = "Create token",
+  triggerClassName,
+}: CreateIssuanceTokenModalProps = {}) {
   const router = useRouter();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpenInternal, setIsOpenInternal] = useState(false);
   const [flow, setFlow] = useState<FlowState>({ kind: "templateSelection" });
   const [draft, setDraft] = useState<TokenDraft>(createInitialDraft());
   const [submitState, setSubmitState] = useState<CreateIssuanceTokenResult>(
     INITIAL_CREATE_ISSUANCE_TOKEN_RESULT
   );
   const [isPending, startTransition] = useTransition();
+  const isOpen = open ?? isOpenInternal;
+
+  const setIsOpen = (next: boolean) => {
+    if (open === undefined) {
+      setIsOpenInternal(next);
+    }
+    onOpenChange?.(next);
+  };
 
   const template = flow.kind === "creation" ? flow.template : draft.template;
   const decimalOptions = useMemo(
@@ -343,11 +365,6 @@ export function CreateIssuanceTokenModal() {
 
   const close = () => {
     setIsOpen(false);
-    reset();
-  };
-
-  const open = () => {
-    setIsOpen(true);
     reset();
   };
 
@@ -406,9 +423,11 @@ export function CreateIssuanceTokenModal() {
 
   return (
     <>
-      <Button type="button" onClick={open}>
-        Create token
-      </Button>
+      {hideTrigger ? null : (
+        <Button type="button" className={triggerClassName} onClick={() => setIsOpen(true)}>
+          {triggerLabel}
+        </Button>
+      )}
 
       <AnimatePresence>
         {isOpen ? (

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -244,7 +244,8 @@ export function IssuanceWorkspace({
       return (
         token.name.toLowerCase().includes(needle) ||
         token.symbol.toLowerCase().includes(needle) ||
-        token.id.toLowerCase().includes(needle)
+        token.id.toLowerCase().includes(needle) ||
+        (token.mintAddress ? token.mintAddress.toLowerCase().includes(needle) : false)
       );
     });
   }, [tokens, search]);

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -291,7 +291,9 @@ export function IssuanceWorkspace({
             </div>
 
             {tokens.length > 0 && filteredTokens.length === 0 ? (
-              <p className="text-sm text-[rgba(28,28,29,0.64)]">No tokens match your current search.</p>
+              <p className="text-sm text-[rgba(28,28,29,0.64)]">
+                No tokens match your current search.
+              </p>
             ) : null}
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
@@ -326,20 +328,31 @@ export function IssuanceWorkspace({
                   <div className="mt-6 space-y-2 rounded-xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.03)] p-3">
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-[rgba(28,28,29,0.58)]">Type</span>
-                      <span className="font-medium text-[#1c1c1d]">{getTokenTypeLabel(token.template)}</span>
+                      <span className="font-medium text-[#1c1c1d]">
+                        {getTokenTypeLabel(token.template)}
+                      </span>
                     </div>
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-[rgba(28,28,29,0.58)]">Supply</span>
-                      <span className="font-medium text-[#1c1c1d]">{formatSupply(token.totalSupply)}</span>
+                      <span className="font-medium text-[#1c1c1d]">
+                        {formatSupply(token.totalSupply)}
+                      </span>
                     </div>
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-[rgba(28,28,29,0.58)]">Created</span>
-                      <span className="font-medium text-[#1c1c1d]">{formatDate(token.createdAt)}</span>
+                      <span className="font-medium text-[#1c1c1d]">
+                        {formatDate(token.createdAt)}
+                      </span>
                     </div>
                   </div>
 
                   <div className="mt-auto pt-3">
-                    <Button type="button" variant="outline" className="h-11 w-full rounded-[10px]" asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="h-11 w-full rounded-[10px]"
+                      asChild
+                    >
                       <Link href={`/dashboard/issuance/${token.id}`}>Manage</Link>
                     </Button>
                   </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -4,19 +4,13 @@ import { ApiEndpointPlayground } from "@/components/api-endpoint-playground";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import { AnimatePresence, motion } from "framer-motion";
-import { Search } from "lucide-react";
+import { Plus, Search } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { CreateIssuanceTokenModal } from "./create-token-modal";
 import { type IssuanceTemplateId, getTemplateCatalogEntry } from "./template-catalog";
 
 interface IssuanceTokenView {
@@ -25,6 +19,7 @@ interface IssuanceTokenView {
   symbol: string;
   status: string;
   template: IssuanceTemplateId | "rwa" | string;
+  imageUrl: string | null;
   mintAddress: string | null;
   totalSupply: string;
   createdAt: string;
@@ -162,25 +157,47 @@ function formatDate(value: string | null | undefined): string {
   if (!value) {
     return "—";
   }
+
+  const isoDateMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (isoDateMatch) {
+    const [, year, month, day] = isoDateMatch;
+    return `${month}/${day}/${year}`;
+  }
+
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
     return value;
   }
-  return date.toLocaleDateString();
+
+  return date.toLocaleDateString("en-US");
 }
 
-function normalizeStatus(status: string): string {
-  return status.replaceAll("_", " ");
-}
-
-function truncateAddress(value: string | null): string {
-  if (!value) {
-    return "Not deployed";
+function formatSupply(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    return "0";
   }
-  if (value.length <= 12) {
+
+  const parsed = Number.parseFloat(normalized);
+  if (!Number.isFinite(parsed)) {
     return value;
   }
-  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+
+  const formatted = new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: parsed >= 100 ? 0 : 1,
+  }).format(parsed);
+
+  return formatted.replace(/\.0([A-Za-z])$/, "$1");
+}
+
+function getTokenTypeLabel(template: IssuanceTokenView["template"]): string {
+  const templateEntry = getTemplateCatalogEntry(template);
+  if (templateEntry?.name) {
+    return templateEntry.name;
+  }
+
+  return template;
 }
 
 export function IssuanceWorkspace({
@@ -193,6 +210,7 @@ export function IssuanceWorkspace({
   const { issuanceTab, setIssuanceTab, selectedIssuanceApiKeyId, setIssuanceApiKeys } =
     useDashboardWorkspace();
   const [search, setSearch] = useState("");
+  const [isCreateTokenModalOpen, setIsCreateTokenModalOpen] = useState(false);
 
   useEffect(() => {
     setIssuanceApiKeys(apiKeys);
@@ -226,19 +244,10 @@ export function IssuanceWorkspace({
       return (
         token.name.toLowerCase().includes(needle) ||
         token.symbol.toLowerCase().includes(needle) ||
-        token.id.toLowerCase().includes(needle) ||
-        (token.mintAddress ? token.mintAddress.toLowerCase().includes(needle) : false)
+        token.id.toLowerCase().includes(needle)
       );
     });
   }, [tokens, search]);
-
-  const stats = useMemo(() => {
-    const total = tokens.length;
-    const active = tokens.filter((token) => token.status === "active").length;
-    const pending = tokens.filter((token) => token.status === "pending").length;
-    const deployed = tokens.filter((token) => token.mintAddress).length;
-    return { total, active, pending, deployed };
-  }, [tokens]);
 
   return (
     <div className="w-full space-y-6">
@@ -252,118 +261,106 @@ export function IssuanceWorkspace({
             transition={{ duration: 0.2, ease: "easeOut" }}
             className="space-y-6"
           >
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              <Card className="gap-2 py-4">
-                <CardHeader className="px-4">
-                  <CardDescription>Total tokens</CardDescription>
-                  <CardTitle>{stats.total}</CardTitle>
-                </CardHeader>
-              </Card>
-              <Card className="gap-2 py-4">
-                <CardHeader className="px-4">
-                  <CardDescription>Active</CardDescription>
-                  <CardTitle>{stats.active}</CardTitle>
-                </CardHeader>
-              </Card>
-              <Card className="gap-2 py-4">
-                <CardHeader className="px-4">
-                  <CardDescription>Pending</CardDescription>
-                  <CardTitle>{stats.pending}</CardTitle>
-                </CardHeader>
-              </Card>
-              <Card className="gap-2 py-4">
-                <CardHeader className="px-4">
-                  <CardDescription>Deployed mints</CardDescription>
-                  <CardTitle>{stats.deployed}</CardTitle>
-                </CardHeader>
-              </Card>
-            </div>
-
             {tokensError ? (
-              <Card className="border-[#c71f37]/20 bg-[#c71f37]/[0.03]">
-                <CardHeader>
-                  <CardTitle>Unable to load tokens</CardTitle>
-                  <CardDescription>{tokensError}</CardDescription>
-                </CardHeader>
-              </Card>
+              <div className="rounded-xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] px-4 py-3">
+                <p className="text-sm font-medium text-[#8a1f2a]">Unable to load tokens</p>
+                <p className="mt-1 text-sm text-[#8a1f2a]">{tokensError}</p>
+              </div>
             ) : null}
 
-            <Card>
-              <CardHeader className="gap-3">
-                <CardTitle>Token inventory</CardTitle>
-                <CardDescription>
-                  Search and inspect issued tokens tracked in this organization workspace.
-                </CardDescription>
-                <div className="relative w-full sm:max-w-[320px]">
-                  <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-[rgba(28,28,29,0.52)]" />
-                  <Input
-                    value={search}
-                    onChange={(event) => {
-                      const value = event.currentTarget.value;
-                      setSearch(value);
-                    }}
-                    className="pl-9"
-                    placeholder="Find by token, symbol, mint or id"
-                  />
-                </div>
-              </CardHeader>
-              <CardContent>
-                {filteredTokens.length === 0 ? (
-                  <p className="text-sm text-[rgba(28,28,29,0.72)]">
-                    {tokens.length === 0
-                      ? "No tokens found yet. Use Create token in quick actions to start."
-                      : "No tokens match your current search."}
-                  </p>
-                ) : (
-                  <div className="overflow-x-auto">
-                    <Table>
-                      <TableHeader>
-                        <TableRow>
-                          <TableHead>Token</TableHead>
-                          <TableHead>Template</TableHead>
-                          <TableHead>Status</TableHead>
-                          <TableHead>Total supply</TableHead>
-                          <TableHead>Mint</TableHead>
-                          <TableHead>Created</TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {filteredTokens.map((token) => {
-                          const template = getTemplateCatalogEntry(token.template) ?? null;
-                          return (
-                            <TableRow key={token.id}>
-                              <TableCell>
-                                <div>
-                                  <p className="font-medium text-[#1c1c1d]">{token.name}</p>
-                                  <p className="text-xs text-[rgba(28,28,29,0.62)]">
-                                    {token.symbol}
-                                  </p>
-                                </div>
-                              </TableCell>
-                              <TableCell>{template?.name ?? token.template}</TableCell>
-                              <TableCell>
-                                <span className="rounded-full bg-[rgba(28,28,29,0.08)] px-2 py-0.5 text-xs capitalize">
-                                  {normalizeStatus(token.status)}
-                                </span>
-                              </TableCell>
-                              <TableCell className="font-mono text-xs">
-                                {token.totalSupply}
-                              </TableCell>
-                              <TableCell className="font-mono text-xs">
-                                {truncateAddress(token.mintAddress)}
-                              </TableCell>
-                              <TableCell className="text-xs text-[rgba(28,28,29,0.66)]">
-                                {formatDate(token.createdAt)}
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
+            <div className="flex items-center gap-3">
+              <div className="relative flex-1">
+                <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-[rgba(28,28,29,0.52)]" />
+                <Input
+                  value={search}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setSearch(value);
+                  }}
+                  className="h-10 rounded-[10px] border-[rgba(28,28,29,0.16)] bg-white pl-9"
+                  placeholder="Search"
+                />
+              </div>
+              <Button
+                type="button"
+                className="h-10 rounded-[10px] bg-[#1c1c1d] px-4 text-white hover:bg-[rgba(28,28,29,0.92)]"
+                onClick={() => setIsCreateTokenModalOpen(true)}
+              >
+                Create token
+              </Button>
+            </div>
+
+            {tokens.length > 0 && filteredTokens.length === 0 ? (
+              <p className="text-sm text-[rgba(28,28,29,0.64)]">No tokens match your current search.</p>
+            ) : null}
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {filteredTokens.map((token) => (
+                <article
+                  key={token.id}
+                  className="flex min-h-[340px] flex-col rounded-2xl border border-[rgba(28,28,29,0.1)] bg-[#fcfcfa] p-5 shadow-[0_2px_10px_rgba(28,28,29,0.05)]"
+                >
+                  <div className="mb-4 h-14 w-14 overflow-hidden rounded-full border border-[rgba(28,28,29,0.1)] bg-white">
+                    {token.imageUrl ? (
+                      // Token logos are dynamic external assets from API data.
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={token.imageUrl}
+                        alt={`${token.name} logo`}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-lg font-semibold text-[rgba(28,28,29,0.58)]">
+                        {token.symbol.slice(0, 1) || "?"}
+                      </div>
+                    )}
                   </div>
-                )}
-              </CardContent>
-            </Card>
+
+                  <p className="text-sm font-medium tracking-wide text-[rgba(28,28,29,0.58)] uppercase">
+                    {token.symbol}
+                  </p>
+                  <h3 className="mt-1 text-[30px] leading-[1.1] font-medium text-[#1c1c1d]">
+                    {token.name}
+                  </h3>
+
+                  <div className="mt-6 space-y-2 rounded-xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.03)] p-3">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-[rgba(28,28,29,0.58)]">Type</span>
+                      <span className="font-medium text-[#1c1c1d]">{getTokenTypeLabel(token.template)}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-[rgba(28,28,29,0.58)]">Supply</span>
+                      <span className="font-medium text-[#1c1c1d]">{formatSupply(token.totalSupply)}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-[rgba(28,28,29,0.58)]">Created</span>
+                      <span className="font-medium text-[#1c1c1d]">{formatDate(token.createdAt)}</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-auto pt-3">
+                    <Button type="button" variant="outline" className="h-11 w-full rounded-[10px]" asChild>
+                      <Link href={`/dashboard/issuance/${token.id}`}>Manage</Link>
+                    </Button>
+                  </div>
+                </article>
+              ))}
+
+              <button
+                type="button"
+                onClick={() => setIsCreateTokenModalOpen(true)}
+                className="flex min-h-[340px] items-center justify-center rounded-2xl border border-dashed border-[rgba(28,28,29,0.2)] bg-[#fcfcfa] text-[rgba(28,28,29,0.5)] transition-colors hover:border-[rgba(28,28,29,0.35)] hover:text-[rgba(28,28,29,0.75)]"
+                aria-label="Add new token"
+              >
+                <Plus className="h-6 w-6" />
+              </button>
+            </div>
+
+            <CreateIssuanceTokenModal
+              open={isCreateTokenModalOpen}
+              onOpenChange={setIsCreateTokenModalOpen}
+              hideTrigger
+            />
           </motion.div>
         ) : (
           <motion.div

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -15,6 +15,7 @@ interface IssuanceTokenView {
   symbol: string;
   status: string;
   template: string;
+  imageUrl: string | null;
   mintAddress: string | null;
   totalSupply: string;
   createdAt: string;
@@ -112,6 +113,7 @@ async function fetchTokens(
         symbol?: string;
         status?: string;
         template?: string;
+        imageUrl?: string | null;
         mintAddress?: string | null;
         totalSupply?: string;
         createdAt?: string;
@@ -127,6 +129,7 @@ async function fetchTokens(
         symbol: token.symbol ?? "-",
         status: token.status ?? "pending",
         template: token.template ?? "custom",
+        imageUrl: token.imageUrl ?? null,
         mintAddress: token.mintAddress ?? null,
         totalSupply: token.totalSupply ?? "0",
         createdAt: token.createdAt ?? "",

--- a/apps/sdp-web/src/app/dashboard/payments/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/page.tsx
@@ -2,7 +2,7 @@ import { PaymentsWorkspace } from "./payments-workspace";
 
 export default function PaymentsPage() {
   return (
-    <div className="w-full max-w-5xl flex flex-col gap-6">
+    <div className="w-full flex flex-col gap-6">
       <PaymentsWorkspace />
     </div>
   );

--- a/apps/sdp-web/src/app/dashboard/wallets/wallets-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/wallets/wallets-page-skeleton.tsx
@@ -65,7 +65,7 @@ export function WalletsTableSectionSkeleton() {
 
 export function WalletsPageSkeleton() {
   return (
-    <div className="w-full max-w-5xl flex flex-col gap-6">
+    <div className="w-full flex flex-col gap-6">
       <WalletsOnboardingSkeleton />
       <WalletsSigningConfigSkeleton />
       <WalletsTableSectionSkeleton />

--- a/apps/sdp-web/src/components/dashboard-quick-actions.tsx
+++ b/apps/sdp-web/src/components/dashboard-quick-actions.tsx
@@ -5,12 +5,19 @@ import type { ReactNode } from "react";
 export function DashboardQuickActions({
   left,
   right,
+  compact = false,
 }: {
   left?: ReactNode;
   right?: ReactNode;
+  compact?: boolean;
 }) {
   return (
-    <div className="flex min-h-[56px] flex-wrap items-start justify-between gap-3 border-t border-[rgba(28,28,29,0.10)] pt-4">
+    <div
+      className={[
+        "flex flex-wrap justify-between",
+        compact ? "min-h-0 items-start gap-2" : "min-h-[56px] items-end gap-3",
+      ].join(" ")}
+    >
       <div className="flex min-w-0 flex-wrap items-center gap-2">{left}</div>
       <div className="flex shrink-0 flex-wrap items-center gap-2">{right}</div>
     </div>

--- a/apps/sdp-web/src/components/dashboard-quick-actions.tsx
+++ b/apps/sdp-web/src/components/dashboard-quick-actions.tsx
@@ -6,16 +6,22 @@ export function DashboardQuickActions({
   left,
   right,
   compact = false,
+  align = "end",
 }: {
   left?: ReactNode;
   right?: ReactNode;
   compact?: boolean;
+  align?: "start" | "end";
 }) {
   return (
     <div
       className={[
         "flex flex-wrap justify-between",
-        compact ? "min-h-0 items-start gap-2" : "min-h-[56px] items-end gap-3",
+        compact
+          ? "min-h-0 items-start gap-2"
+          : align === "start"
+            ? "min-h-[56px] items-start gap-3"
+            : "min-h-[56px] items-end gap-3",
       ].join(" ")}
     >
       <div className="flex min-w-0 flex-wrap items-center gap-2">{left}</div>

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -289,7 +289,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
           transition={{ duration: 0.22, ease: "easeInOut" }}
           style={{ pointerEvents: isSidebarOpen ? "auto" : "none" }}
           className={[
-            "hidden overflow-hidden border border-[rgba(28,28,29,0.10)] border-r-0 bg-[#e9e7de] lg:flex lg:flex-col lg:justify-between",
+            "hidden overflow-hidden border border-[rgba(28,28,29,0.10)] border-r-0 bg-[#e9e7de] lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col lg:justify-between",
           ].join(" ")}
         >
           <div className="w-[296px] space-y-6 p-3">

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -120,6 +120,8 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard/api-keys") {
     return {
       title: "API keys",
+      showHeaderNavRow: true,
+      contentWidthClass: "max-w-none",
     };
   }
   if (pathname === "/dashboard/issuance") {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -9,7 +9,6 @@ import { motion } from "framer-motion";
 import {
   ArrowLeft,
   ArrowLeftRight,
-  ChevronDown,
   Coins,
   KeyRound,
   LayoutDashboard,
@@ -213,7 +212,7 @@ function SidebarGroup({
 export function DashboardShell({ children }: { children: ReactNode }) {
   const { isLoaded, isSignedIn, orgId } = useAuth();
   const pathname = usePathname();
-  const { isSidebarOpen, selectedProject, setSidebarOpen } = useDashboardWorkspace();
+  const { isSidebarOpen, setSidebarOpen } = useDashboardWorkspace();
   const sidebarWidth = 296;
   const pageConfig = getDashboardPageConfig(pathname);
   const contentWidthClass = pageConfig.contentWidthClass ?? "max-w-5xl";
@@ -374,12 +373,6 @@ export function DashboardShell({ children }: { children: ReactNode }) {
                   <h1 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
                     {pageConfig.title}
                   </h1>
-                  {pageConfig.hideHeaderSelectors ? null : (
-                    <div className="pointer-events-none hidden h-10 items-center gap-2 rounded-[10px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] px-3 py-2 text-sm md:flex">
-                      <span className="text-[rgba(28,28,29,0.72)]">{selectedProject}</span>
-                      <ChevronDown className="h-4 w-4 text-[rgba(28,28,29,0.72)]" />
-                    </div>
-                  )}
                 </div>
 
                 {pageConfig.hideHeaderSelectors ? null : (

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -98,10 +98,24 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
     };
   }
   if (pathname === "/dashboard/wallets/setup" || pathname === "/dashboard/custody/setup") {
-    return { title: "Activate provider", contentWidthClass: "max-w-3xl" };
+    return {
+      title: "Activate provider",
+      contentWidthClass: "max-w-3xl",
+      backAction: {
+        href: "/dashboard/wallets",
+        label: "Back to wallets",
+      },
+    };
   }
   if (pathname === "/dashboard/wallets/switch" || pathname === "/dashboard/custody/switch") {
-    return { title: "Activate provider", contentWidthClass: "max-w-3xl" };
+    return {
+      title: "Activate provider",
+      contentWidthClass: "max-w-3xl",
+      backAction: {
+        href: "/dashboard/wallets",
+        label: "Back to wallets",
+      },
+    };
   }
   if (pathname === "/dashboard/api-keys") {
     return {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -216,7 +216,6 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   const sidebarWidth = 296;
   const pageConfig = getDashboardPageConfig(pathname);
   const contentWidthClass = pageConfig.contentWidthClass ?? "max-w-5xl";
-  const hasCompactTopAction = Boolean(pageConfig.backAction);
   const quickActionsLeft = pageConfig.backAction ? (
     <HeaderBackAction href={pageConfig.backAction.href} label={pageConfig.backAction.label} />
   ) : (
@@ -349,7 +348,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
 
         <section className="relative rounded-[16px] border border-[rgba(28,28,29,0.08)] bg-[rgba(255,255,255,0.8)] px-3 py-5 md:p-6 lg:rounded-tl-[16px]">
           <div className="w-full space-y-6">
-            <div className={hasCompactTopAction ? "space-y-2" : "space-y-4"}>
+            <div className="space-y-4">
               <div className="flex items-start justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
                   {!isSidebarOpen ? (
@@ -387,7 +386,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
                   <DashboardQuickActions
                     left={quickActionsLeft}
                     right={pageConfig.quickActionsRight}
-                    compact={hasCompactTopAction}
+                    compact={false}
                   />
                 </div>
               </div>

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -145,6 +145,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
     return {
       title: "Payments",
       quickActionsLeft: <IssuanceHeaderTabs />,
+      contentWidthClass: "max-w-none",
     };
   }
   if (pathname.startsWith("/dashboard/members")) {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -387,6 +387,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
                     left={quickActionsLeft}
                     right={pageConfig.quickActionsRight}
                     compact={false}
+                    align={pageConfig.backAction ? "start" : "end"}
                   />
                 </div>
               </div>

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -129,6 +129,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
       title: "Issuance",
       quickActionsLeft: <IssuanceHeaderTabs />,
       hideHeaderSelectors: true,
+      contentWidthClass: "max-w-none",
     };
   }
   if (pathname.startsWith("/dashboard/issuance/")) {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -109,6 +109,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
     return {
       title: "Wallets",
       quickActionsRight: <WalletQuickAction />,
+      contentWidthClass: "max-w-none",
     };
   }
   if (pathname === "/dashboard/wallets/setup" || pathname === "/dashboard/custody/setup") {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -65,6 +65,7 @@ const bottomNavItems: NavItem[] = [
 type DashboardPageConfig = {
   title: string;
   headerNav?: ReactNode;
+  showHeaderNavRow?: boolean;
   contentWidthClass?: string;
   hideHeaderSelectors?: boolean;
   backAction?: {
@@ -92,6 +93,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard/wallets" || pathname === "/dashboard/custody") {
     return {
       title: "Wallets",
+      showHeaderNavRow: true,
       contentWidthClass: "max-w-none",
     };
   }
@@ -205,6 +207,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   ) : (
     pageConfig.headerNav
   );
+  const shouldRenderHeaderNavRow = pageConfig.showHeaderNavRow || Boolean(headerNav);
 
   if (!isLoaded) {
     return (
@@ -365,7 +368,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
                 )}
               </div>
 
-              {headerNav ? (
+              {shouldRenderHeaderNavRow ? (
                 <div className="-mx-3 border-b border-[rgba(28,28,29,0.10)] md:-mx-6">
                   <div
                     className={[

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -134,6 +134,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
     return {
       title: "Issuance",
       hideHeaderSelectors: true,
+      contentWidthClass: "max-w-none",
       backAction: {
         href: "/dashboard/issuance",
         label: "Back to overview",

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { CreateApiKeyModal } from "@/app/dashboard/api-keys/create-api-key-modal";
-import { CreateIssuanceTokenModal } from "@/app/dashboard/issuance/create-token-modal";
-import { IssuanceApiKeySelector } from "@/app/dashboard/issuance/issuance-api-key-selector";
 import { DashboardQuickActions } from "@/components/dashboard-quick-actions";
 import { IssuanceHeaderTabs } from "@/components/issuance-header-tabs";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { OrganizationSwitcher, SignInButton, UserButton, useAuth } from "@clerk/nextjs";
 import { motion } from "framer-motion";
 import {
+  ArrowLeft,
   ArrowLeftRight,
   ChevronDown,
   Coins,
@@ -71,6 +70,11 @@ type DashboardPageConfig = {
   quickActionsLeft?: ReactNode;
   quickActionsRight?: ReactNode;
   contentWidthClass?: string;
+  hideHeaderSelectors?: boolean;
+  backAction?: {
+    href: string;
+    label: string;
+  };
 };
 
 function WalletQuickAction() {
@@ -82,6 +86,18 @@ function WalletQuickAction() {
       >
         New wallet
       </button>
+    </Link>
+  );
+}
+
+function HeaderBackAction({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex h-7 items-center gap-1.5 rounded-[8px] text-[rgba(28,28,29,0.72)] transition-colors hover:text-[#1c1c1d]"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="text-[13px] leading-[18px] font-medium">{label}</span>
     </Link>
   );
 }
@@ -108,16 +124,21 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
       quickActionsRight: <CreateApiKeyModal triggerMode="button" triggerLabel="Create API key" />,
     };
   }
-  if (pathname.startsWith("/dashboard/issuance")) {
+  if (pathname === "/dashboard/issuance") {
     return {
       title: "Issuance",
       quickActionsLeft: <IssuanceHeaderTabs />,
-      quickActionsRight: (
-        <>
-          <IssuanceApiKeySelector />
-          <CreateIssuanceTokenModal />
-        </>
-      ),
+      hideHeaderSelectors: true,
+    };
+  }
+  if (pathname.startsWith("/dashboard/issuance/")) {
+    return {
+      title: "Issuance",
+      hideHeaderSelectors: true,
+      backAction: {
+        href: "/dashboard/issuance",
+        label: "Back to overview",
+      },
     };
   }
   if (pathname.startsWith("/dashboard/payments")) {
@@ -195,6 +216,12 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   const sidebarWidth = 296;
   const pageConfig = getDashboardPageConfig(pathname);
   const contentWidthClass = pageConfig.contentWidthClass ?? "max-w-5xl";
+  const hasCompactTopAction = Boolean(pageConfig.backAction);
+  const quickActionsLeft = pageConfig.backAction ? (
+    <HeaderBackAction href={pageConfig.backAction.href} label={pageConfig.backAction.label} />
+  ) : (
+    pageConfig.quickActionsLeft
+  );
 
   if (!isLoaded) {
     return (
@@ -321,8 +348,8 @@ export function DashboardShell({ children }: { children: ReactNode }) {
         </motion.aside>
 
         <section className="relative rounded-[16px] border border-[rgba(28,28,29,0.08)] bg-[rgba(255,255,255,0.8)] px-3 py-5 md:p-6 lg:rounded-tl-[16px]">
-          <div className={["mx-auto w-full", contentWidthClass].join(" ")}>
-            <div className="mb-6 space-y-4">
+          <div className="w-full space-y-6">
+            <div className={hasCompactTopAction ? "space-y-2" : "space-y-4"}>
               <div className="flex items-start justify-between gap-3">
                 <div className="flex min-w-0 items-center gap-3">
                   {!isSidebarOpen ? (
@@ -346,23 +373,32 @@ export function DashboardShell({ children }: { children: ReactNode }) {
                   <h1 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
                     {pageConfig.title}
                   </h1>
-                  <div className="pointer-events-none hidden h-10 items-center gap-2 rounded-[10px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] px-3 py-2 text-sm md:flex">
-                    <span className="text-[rgba(28,28,29,0.72)]">{selectedProject}</span>
-                    <ChevronDown className="h-4 w-4 text-[rgba(28,28,29,0.72)]" />
-                  </div>
+                  {pageConfig.hideHeaderSelectors ? null : (
+                    <div className="pointer-events-none hidden h-10 items-center gap-2 rounded-[10px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] px-3 py-2 text-sm md:flex">
+                      <span className="text-[rgba(28,28,29,0.72)]">{selectedProject}</span>
+                      <ChevronDown className="h-4 w-4 text-[rgba(28,28,29,0.72)]" />
+                    </div>
+                  )}
                 </div>
 
-                <div className="flex items-center gap-2">
-                  <UserButton afterSignOutUrl="/sign-in" />
-                </div>
+                {pageConfig.hideHeaderSelectors ? null : (
+                  <div className="flex items-center gap-2">
+                    <UserButton afterSignOutUrl="/sign-in" />
+                  </div>
+                )}
               </div>
 
-              <DashboardQuickActions
-                left={pageConfig.quickActionsLeft}
-                right={pageConfig.quickActionsRight}
-              />
+              <div className="-mx-3 border-b border-[rgba(28,28,29,0.10)] md:-mx-6">
+                <div className="px-3 md:px-6">
+                  <DashboardQuickActions
+                    left={quickActionsLeft}
+                    right={pageConfig.quickActionsRight}
+                    compact={hasCompactTopAction}
+                  />
+                </div>
+              </div>
             </div>
-            {children}
+            <div className={["mx-auto w-full", contentWidthClass].join(" ")}>{children}</div>
           </div>
         </section>
       </div>

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { CreateApiKeyModal } from "@/app/dashboard/api-keys/create-api-key-modal";
-import { DashboardQuickActions } from "@/components/dashboard-quick-actions";
 import { IssuanceHeaderTabs } from "@/components/issuance-header-tabs";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { OrganizationSwitcher, SignInButton, UserButton, useAuth } from "@clerk/nextjs";
@@ -66,8 +64,7 @@ const bottomNavItems: NavItem[] = [
 
 type DashboardPageConfig = {
   title: string;
-  quickActionsLeft?: ReactNode;
-  quickActionsRight?: ReactNode;
+  headerNav?: ReactNode;
   contentWidthClass?: string;
   hideHeaderSelectors?: boolean;
   backAction?: {
@@ -75,19 +72,6 @@ type DashboardPageConfig = {
     label: string;
   };
 };
-
-function WalletQuickAction() {
-  return (
-    <Link href="/dashboard/wallets/setup">
-      <button
-        type="button"
-        className="inline-flex h-10 items-center justify-center rounded-md bg-[#1c1c1d] px-4 text-sm font-medium text-white hover:bg-[rgba(28,28,29,0.92)]"
-      >
-        New wallet
-      </button>
-    </Link>
-  );
-}
 
 function HeaderBackAction({ href, label }: { href: string; label: string }) {
   return (
@@ -108,7 +92,6 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard/wallets" || pathname === "/dashboard/custody") {
     return {
       title: "Wallets",
-      quickActionsRight: <WalletQuickAction />,
       contentWidthClass: "max-w-none",
     };
   }
@@ -121,13 +104,12 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard/api-keys") {
     return {
       title: "API keys",
-      quickActionsRight: <CreateApiKeyModal triggerMode="button" triggerLabel="Create API key" />,
     };
   }
   if (pathname === "/dashboard/issuance") {
     return {
       title: "Issuance",
-      quickActionsLeft: <IssuanceHeaderTabs />,
+      headerNav: <IssuanceHeaderTabs />,
       hideHeaderSelectors: true,
       contentWidthClass: "max-w-none",
     };
@@ -145,7 +127,7 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname.startsWith("/dashboard/payments")) {
     return {
       title: "Payments",
-      quickActionsLeft: <IssuanceHeaderTabs />,
+      headerNav: <IssuanceHeaderTabs />,
       contentWidthClass: "max-w-none",
     };
   }
@@ -218,10 +200,10 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   const sidebarWidth = 296;
   const pageConfig = getDashboardPageConfig(pathname);
   const contentWidthClass = pageConfig.contentWidthClass ?? "max-w-5xl";
-  const quickActionsLeft = pageConfig.backAction ? (
+  const headerNav = pageConfig.backAction ? (
     <HeaderBackAction href={pageConfig.backAction.href} label={pageConfig.backAction.label} />
   ) : (
-    pageConfig.quickActionsLeft
+    pageConfig.headerNav
   );
 
   if (!isLoaded) {
@@ -383,16 +365,20 @@ export function DashboardShell({ children }: { children: ReactNode }) {
                 )}
               </div>
 
-              <div className="-mx-3 border-b border-[rgba(28,28,29,0.10)] md:-mx-6">
-                <div className="px-3 md:px-6">
-                  <DashboardQuickActions
-                    left={quickActionsLeft}
-                    right={pageConfig.quickActionsRight}
-                    compact={false}
-                    align={pageConfig.backAction ? "start" : "end"}
-                  />
+              {headerNav ? (
+                <div className="-mx-3 border-b border-[rgba(28,28,29,0.10)] md:-mx-6">
+                  <div
+                    className={[
+                      "px-3 md:px-6",
+                      pageConfig.backAction
+                        ? "flex min-h-[56px] items-start pt-1"
+                        : "flex min-h-[56px] items-end",
+                    ].join(" ")}
+                  >
+                    {headerNav}
+                  </div>
                 </div>
-              </div>
+              ) : null}
             </div>
             <div className={["mx-auto w-full", contentWidthClass].join(" ")}>{children}</div>
           </div>

--- a/apps/sdp-web/src/components/issuance-header-tabs.tsx
+++ b/apps/sdp-web/src/components/issuance-header-tabs.tsx
@@ -4,30 +4,35 @@ import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { motion } from "framer-motion";
 
 const tabOptions = [
-  { id: "tokens", label: "Tokens list" },
-  { id: "playground", label: "API playground" },
+  { id: "tokens", label: "Overview" },
+  { id: "playground", label: "API Playground" },
 ] as const;
 
 export function IssuanceHeaderTabs() {
   const { issuanceTab, setIssuanceTab } = useDashboardWorkspace();
 
   return (
-    <div className="inline-flex rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-1">
+    <div className="inline-flex items-end gap-6">
       {tabOptions.map((tab) => (
         <button
           key={tab.id}
           type="button"
           onClick={() => setIssuanceTab(tab.id)}
-          className="relative rounded-lg px-4 py-2 text-sm font-medium text-[#1c1c1d]"
+          className={[
+            "relative pb-3 text-[16px] leading-[24px] font-medium transition-colors",
+            issuanceTab === tab.id
+              ? "text-[#1c1c1d]"
+              : "text-[rgba(28,28,29,0.58)] hover:text-[#1c1c1d]",
+          ].join(" ")}
         >
           {issuanceTab === tab.id ? (
             <motion.span
-              layoutId="issuance-tab-active-pill"
-              className="absolute inset-0 rounded-lg bg-white shadow-[0_4px_14px_rgba(28,28,29,0.08)]"
-              transition={{ type: "spring", stiffness: 500, damping: 36 }}
+              layoutId="issuance-tab-active-underline"
+              className="absolute right-0 bottom-[-1px] left-0 h-[3px] bg-[#1c1c1d]"
+              transition={{ type: "spring", stiffness: 500, damping: 36, mass: 0.6 }}
             />
           ) : null}
-          <span className="relative z-[1]">{tab.label}</span>
+          <span>{tab.label}</span>
         </button>
       ))}
     </div>

--- a/packages/sdp-types/src/tokens.ts
+++ b/packages/sdp-types/src/tokens.ts
@@ -206,6 +206,8 @@ export interface Token {
   mintAddress: string | null;
   /** Mint authority public key */
   mintAuthority: string | null;
+  /** Metadata update authority public key (falls back to mint authority when omitted) */
+  metadataAuthority?: string | null;
   /** Freeze authority public key */
   freezeAuthority: string | null;
   /** On-chain ABL list address (null until deployed) */


### PR DESCRIPTION
## Summary
- redesign Issuance overview page from table to token card grid
- remove deprecated top controls/stats and simplify header/tab layout
- add token management workspace at `/dashboard/issuance/[tokenId]` with admin actions
- wire transaction confirmation modal for execute actions with Sonner loading/success states
- move deploy execution to Admin Actions dropdown and disable it when token is already deployed

## Notes
- token cards and details are driven by existing token data source (no hardcoded token values)
- deploy action card section removed; deploy is now handled via dropdown action

## Validation
- `pnpm --filter sdp-web lint`
- `pnpm --filter sdp-web typecheck`
