### PR TITLE
Speed up dashboard playground transitions

### DIFF
--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-page-skeleton.tsx
@@ -1,6 +1,4 @@
-function SkeletonBlock({ className }: { className: string }) {
-  return <div className={`animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)] ${className}`} />;
-}
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
 
 function IssuanceTokenCardSkeleton() {
   return (

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-page-skeleton.tsx
@@ -1,0 +1,38 @@
+function SkeletonBlock({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)] ${className}`} />;
+}
+
+function IssuanceTokenCardSkeleton() {
+  return (
+    <article className="flex min-h-[340px] flex-col rounded-2xl border border-[rgba(28,28,29,0.1)] bg-[#fcfcfa] p-5 shadow-[0_2px_10px_rgba(28,28,29,0.05)] animate-pulse">
+      <div className="mb-4 h-14 w-14 rounded-full bg-[rgba(28,28,29,0.08)]" />
+      <SkeletonBlock className="h-4 w-16" />
+      <SkeletonBlock className="mt-3 h-8 w-3/4" />
+      <div className="mt-6 space-y-3 rounded-xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.03)] p-3">
+        <SkeletonBlock className="h-4 w-full" />
+        <SkeletonBlock className="h-4 w-[86%]" />
+        <SkeletonBlock className="h-4 w-[78%]" />
+      </div>
+      <div className="mt-auto pt-3">
+        <SkeletonBlock className="h-11 w-full rounded-[10px]" />
+      </div>
+    </article>
+  );
+}
+
+export function IssuancePageSkeleton() {
+  return (
+    <div className="w-full space-y-6">
+      <div className="flex items-center gap-3">
+        <SkeletonBlock className="h-10 flex-1 rounded-[10px]" />
+        <SkeletonBlock className="h-10 w-32 rounded-[10px]" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }, (_, index) => (
+          <IssuanceTokenCardSkeleton key={`issuance-skeleton-${index + 1}`} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -129,6 +129,7 @@ export function IssuanceWorkspace({
       void import("./issuance-playground");
     };
 
+    // biome-ignore lint/nursery/noSecrets: requestIdleCallback is a browser API, not a secret.
     if (typeof window !== "undefined" && "requestIdleCallback" in window) {
       const idleId = window.requestIdleCallback(preloadPlayground);
       return () => window.cancelIdleCallback(idleId);

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -1,16 +1,24 @@
 "use client";
 
+import { ApiPlaygroundShellSkeleton } from "@/components/api-playground-shell-skeleton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import { AnimatePresence, motion } from "framer-motion";
 import { Plus, Search } from "lucide-react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { CreateIssuanceTokenModal } from "./create-token-modal";
-import { IssuancePlayground } from "./issuance-playground";
 import { type IssuanceTemplateId, getTemplateCatalogEntry } from "./template-catalog";
+
+const IssuancePlayground = dynamic(
+  () => import("./issuance-playground").then((module) => module.IssuancePlayground),
+  {
+    loading: () => <ApiPlaygroundShellSkeleton />,
+  }
+);
 
 interface IssuanceTokenView {
   id: string;
@@ -111,6 +119,24 @@ export function IssuanceWorkspace({
   useEffect(() => {
     setPlaygroundApiKeys(apiKeys);
   }, [apiKeys, setPlaygroundApiKeys]);
+
+  useEffect(() => {
+    if (isPlaygroundTab) {
+      return;
+    }
+
+    const preloadPlayground = () => {
+      void import("./issuance-playground");
+    };
+
+    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(preloadPlayground);
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = globalThis.setTimeout(preloadPlayground, 600);
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [isPlaygroundTab]);
 
   const selectedPlaygroundApiKey = useMemo(
     () => apiKeys.find((key) => key.id === selectedPlaygroundApiKeyId) ?? null,

--- a/apps/sdp-web/src/app/dashboard/issuance/loading.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/loading.tsx
@@ -1,0 +1,5 @@
+import { IssuancePageSkeleton } from "./issuance-page-skeleton";
+
+export default function IssuanceLoading() {
+  return <IssuancePageSkeleton />;
+}

--- a/apps/sdp-web/src/app/dashboard/layout.tsx
+++ b/apps/sdp-web/src/app/dashboard/layout.tsx
@@ -1,17 +1,11 @@
 import { DashboardShell } from "@/components/dashboard-shell";
 import { DashboardWorkspaceProvider } from "@/contexts/dashboard-workspace-context";
-import { type ReactNode, Suspense } from "react";
-
-function DashboardLayoutFallback({ children }: { children: ReactNode }) {
-  return <div className="min-h-screen bg-[#e9e7de]">{children}</div>;
-}
+import type { ReactNode } from "react";
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
-    <Suspense fallback={<DashboardLayoutFallback>{children}</DashboardLayoutFallback>}>
-      <DashboardWorkspaceProvider>
-        <DashboardShell>{children}</DashboardShell>
-      </DashboardWorkspaceProvider>
-    </Suspense>
+    <DashboardWorkspaceProvider>
+      <DashboardShell>{children}</DashboardShell>
+    </DashboardWorkspaceProvider>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/loading.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/loading.tsx
@@ -1,0 +1,5 @@
+import { PaymentsPageSkeleton } from "./payments-page-skeleton";
+
+export default function PaymentsLoading() {
+  return <PaymentsPageSkeleton />;
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page-skeleton.tsx
@@ -1,0 +1,31 @@
+function SkeletonBlock({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)] ${className}`} />;
+}
+
+function PaymentsSectionSkeleton() {
+  return (
+    <section className="rounded-2xl border border-[rgba(28,28,29,0.1)] bg-white/80 p-5 shadow-[0_2px_10px_rgba(28,28,29,0.04)] animate-pulse">
+      <div className="space-y-3">
+        <SkeletonBlock className="h-6 w-36" />
+        <SkeletonBlock className="h-4 w-[54%]" />
+      </div>
+      <div className="mt-6 space-y-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <SkeletonBlock
+            key={`payments-row-skeleton-${index + 1}`}
+            className={index % 2 === 0 ? "h-11 w-full" : "h-11 w-[88%]"}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function PaymentsPageSkeleton() {
+  return (
+    <div className="grid gap-6">
+      <PaymentsSectionSkeleton />
+      <PaymentsSectionSkeleton />
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page-skeleton.tsx
@@ -1,6 +1,4 @@
-function SkeletonBlock({ className }: { className: string }) {
-  return <div className={`animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)] ${className}`} />;
-}
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
 
 function PaymentsSectionSkeleton() {
   return (

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx
@@ -1,12 +1,20 @@
 "use client";
 
+import { ApiPlaygroundShellSkeleton } from "@/components/api-playground-shell-skeleton";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
+import dynamic from "next/dynamic";
 import { useEffect, useMemo } from "react";
 import { PaymentsDestinationAllowlistCard } from "./payments-destination-allowlist-card";
-import { PaymentsPlayground } from "./payments-playground";
 import { PaymentsTransferCard } from "./payments-transfer-card";
 import { usePaymentsWorkspace } from "./use-payments-workspace";
+
+const PaymentsPlayground = dynamic(
+  () => import("./payments-playground").then((module) => module.PaymentsPlayground),
+  {
+    loading: () => <ApiPlaygroundShellSkeleton />,
+  }
+);
 
 interface PaymentsApiKeyOption {
   id: string;
@@ -28,6 +36,24 @@ export function PaymentsWorkspace({ apiBaseUrl, apiKeys }: PaymentsWorkspaceProp
   useEffect(() => {
     setPlaygroundApiKeys(apiKeys);
   }, [apiKeys, setPlaygroundApiKeys]);
+
+  useEffect(() => {
+    if (issuanceTab === "playground") {
+      return;
+    }
+
+    const preloadPlayground = () => {
+      void import("./payments-playground");
+    };
+
+    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(preloadPlayground);
+      return () => window.cancelIdleCallback(idleId);
+    }
+
+    const timeoutId = globalThis.setTimeout(preloadPlayground, 600);
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [issuanceTab]);
 
   const selectedPlaygroundApiKey = useMemo(
     () => apiKeys.find((key) => key.id === selectedPlaygroundApiKeyId) ?? null,

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx
@@ -46,6 +46,7 @@ export function PaymentsWorkspace({ apiBaseUrl, apiKeys }: PaymentsWorkspaceProp
       void import("./payments-playground");
     };
 
+    // biome-ignore lint/nursery/noSecrets: requestIdleCallback is a browser API, not a secret.
     if (typeof window !== "undefined" && "requestIdleCallback" in window) {
       const idleId = window.requestIdleCallback(preloadPlayground);
       return () => window.cancelIdleCallback(idleId);

--- a/apps/sdp-web/src/components/api-playground-shell-skeleton.tsx
+++ b/apps/sdp-web/src/components/api-playground-shell-skeleton.tsx
@@ -1,6 +1,4 @@
-function SkeletonBlock({ className }: { className: string }) {
-  return <div className={`animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)] ${className}`} />;
-}
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
 
 export function ApiPlaygroundShellSkeleton() {
   return (

--- a/apps/sdp-web/src/components/api-playground-shell-skeleton.tsx
+++ b/apps/sdp-web/src/components/api-playground-shell-skeleton.tsx
@@ -1,0 +1,84 @@
+function SkeletonBlock({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)] ${className}`} />;
+}
+
+export function ApiPlaygroundShellSkeleton() {
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
+      <div className="grid shrink-0 border-b border-[rgba(28,28,29,0.1)] lg:grid-cols-2">
+        <div className="px-6 py-5">
+          <SkeletonBlock className="h-11 w-full rounded-[14px]" />
+        </div>
+        <div className="border-t border-[rgba(28,28,29,0.1)] px-6 py-5 lg:border-t-0">
+          <div className="flex justify-stretch lg:justify-end">
+            <SkeletonBlock className="h-11 w-full max-w-[360px] rounded-[14px]" />
+          </div>
+        </div>
+      </div>
+
+      <div className="border-b border-[rgba(28,28,29,0.1)] px-6 py-4 lg:hidden">
+        <SkeletonBlock className="h-11 w-full rounded-full" />
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col border-b border-[rgba(28,28,29,0.1)] lg:grid lg:grid-cols-2">
+        <div className="min-h-0">
+          <div className="flex h-full min-h-0 flex-col px-6 py-6">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <SkeletonBlock className="h-6 w-36" />
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <SkeletonBlock className="h-4 w-20" />
+                    <SkeletonBlock className="h-11 w-full" />
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <SkeletonBlock className="h-6 w-32" />
+                <div className="space-y-4">
+                  {Array.from({ length: 4 }, (_, index) => (
+                    <div key={`playground-field-skeleton-${index + 1}`} className="space-y-2">
+                      <SkeletonBlock className="h-4 w-28" />
+                      <SkeletonBlock className="h-11 w-full" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="min-h-0 border-t border-[rgba(28,28,29,0.1)] lg:border-t-0">
+          <div className="flex h-full min-h-0 flex-col px-6 py-6">
+            <SkeletonBlock className="mb-4 h-11 w-full rounded-full" />
+            <div className="flex min-h-[360px] flex-1 flex-col overflow-hidden rounded-[8px] border border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.03)]">
+              <div className="flex-1 space-y-4 px-4 py-5">
+                {Array.from({ length: 8 }, (_, index) => (
+                  <SkeletonBlock
+                    key={`playground-code-skeleton-${index + 1}`}
+                    className={index % 2 === 0 ? "h-4 w-[92%]" : "h-4 w-[68%]"}
+                  />
+                ))}
+              </div>
+              <div className="border-t border-[rgba(28,28,29,0.1)] px-4 py-3">
+                <SkeletonBlock className="h-6 w-28 rounded-full" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid shrink-0 lg:grid-cols-2">
+        <div className="flex gap-3 px-6 py-5">
+          <SkeletonBlock className="h-10 w-36 rounded-[10px]" />
+          <SkeletonBlock className="h-10 w-20 rounded-[10px]" />
+        </div>
+        <div className="flex gap-3 border-t border-[rgba(28,28,29,0.1)] px-6 py-5 lg:border-t-0">
+          <SkeletonBlock className="h-10 w-32 rounded-[10px]" />
+          <SkeletonBlock className="h-10 w-36 rounded-[10px]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/components/api-playground-shell.tsx
+++ b/apps/sdp-web/src/components/api-playground-shell.tsx
@@ -2,10 +2,10 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useDashboardUrlState } from "@/lib/dashboard-url-state";
 import { normalizeApiKeyInput } from "@/lib/playground-api-keys";
 import { cn } from "@/lib/utils";
 import { Clock3, Copy, Loader2, Play, Sparkles } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { CSSProperties, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -470,9 +470,7 @@ export function ApiPlaygroundShell({
   productName,
   rightMessages = [],
 }: ApiPlaygroundShellProps) {
-  const pathname = usePathname();
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const { replaceSearchParams, searchParams } = useDashboardUrlState();
   const initialEndpoint =
     endpoints.find((endpoint) => endpoint.id === defaultEndpointId) ?? endpoints[0];
   const initialEndpointId = initialEndpoint?.id ?? "";
@@ -504,12 +502,11 @@ export function ApiPlaygroundShell({
 
   const updateEndpointInUrl = useCallback(
     (endpointId: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("endpoint", endpointId);
-      const query = params.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+      replaceSearchParams({
+        endpoint: endpointId,
+      });
     },
-    [pathname, router, searchParams]
+    [replaceSearchParams]
   );
 
   useEffect(() => {

--- a/apps/sdp-web/src/components/ui/skeleton-block.tsx
+++ b/apps/sdp-web/src/components/ui/skeleton-block.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@/lib/utils";
+
+type SkeletonBlockProps = {
+  className?: string;
+};
+
+export function SkeletonBlock({ className }: SkeletonBlockProps) {
+  return <div className={cn("animate-pulse rounded-[12px] bg-[rgba(28,28,29,0.08)]", className)} />;
+}

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useDashboardUrlState } from "@/lib/dashboard-url-state";
 import { type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
 
 export type IssuanceWorkspaceTab = "tokens" | "playground";
@@ -42,9 +42,7 @@ export function DashboardWorkspaceProvider({
   defaultProject = "Default Project",
   initialSidebarOpen = true,
 }: DashboardWorkspaceProviderProps) {
-  const pathname = usePathname();
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const { replaceSearchParams, searchParams } = useDashboardUrlState();
   const [isSidebarOpen, setSidebarOpenState] = useState(initialSidebarOpen);
   const [selectedProject, setSelectedProject] = useState(defaultProject);
   const [playgroundApiKeys, setPlaygroundApiKeysState] = useState<
@@ -80,14 +78,11 @@ export function DashboardWorkspaceProvider({
 
   const setIssuanceTab = useCallback(
     (tab: IssuanceWorkspaceTab) => {
-      const params = new URLSearchParams(searchParams.toString());
-
-      params.set("tab", tab === "playground" ? "playground" : "overview");
-
-      const query = params.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+      replaceSearchParams({
+        tab: tab === "playground" ? "playground" : "overview",
+      });
     },
-    [pathname, router, searchParams]
+    [replaceSearchParams]
   );
 
   const value = useMemo<DashboardWorkspaceContextValue>(

--- a/apps/sdp-web/src/lib/dashboard-url-state.ts
+++ b/apps/sdp-web/src/lib/dashboard-url-state.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+const DASHBOARD_URL_STATE_EVENT = "sdp-dashboard-url-state";
+
+function getSearchSnapshot(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return window.location.search;
+}
+
+function getServerSearchSnapshot(): string {
+  return "";
+}
+
+function subscribe(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handleChange = () => onStoreChange();
+
+  window.addEventListener("popstate", handleChange);
+  window.addEventListener(DASHBOARD_URL_STATE_EVENT, handleChange);
+
+  return () => {
+    window.removeEventListener("popstate", handleChange);
+    window.removeEventListener(DASHBOARD_URL_STATE_EVENT, handleChange);
+  };
+}
+
+function emitUrlStateChange() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new Event(DASHBOARD_URL_STATE_EVENT));
+}
+
+export function useDashboardUrlState() {
+  const search = useSyncExternalStore(subscribe, getSearchSnapshot, getServerSearchSnapshot);
+
+  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
+
+  const replaceSearchParams = useCallback((updates: Record<string, string | null>) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(window.location.search);
+
+    for (const [key, value] of Object.entries(updates)) {
+      if (value && value.trim()) {
+        nextParams.set(key, value);
+      } else {
+        nextParams.delete(key);
+      }
+    }
+
+    const nextQuery = nextParams.toString();
+    const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ""}${window.location.hash}`;
+
+    window.history.replaceState(window.history.state, "", nextUrl);
+    emitUrlStateChange();
+  }, []);
+
+  return {
+    searchParams,
+    replaceSearchParams,
+  };
+}

--- a/apps/sdp-web/src/lib/dashboard-url-state.ts
+++ b/apps/sdp-web/src/lib/dashboard-url-state.ts
@@ -53,7 +53,7 @@ export function useDashboardUrlState() {
     const nextParams = new URLSearchParams(window.location.search);
 
     for (const [key, value] of Object.entries(updates)) {
-      if (value && value.trim()) {
+      if (value?.trim()) {
         nextParams.set(key, value);
       } else {
         nextParams.delete(key);


### PR DESCRIPTION
## Summary
- replace router-driven dashboard tab and endpoint URL syncing with client-side history state to avoid server rerenders on playground switches
- lazy-load the heavy playground surface and preload it during idle time from the overview tabs
- add isolated issuance/payments skeleton loaders so the dashboard frame becomes interactive sooner while data and playground code load

## Validation
- pnpm --filter sdp-web typecheck
- pnpm --filter sdp-web lint src/app/dashboard/layout.tsx src/contexts/dashboard-workspace-context.tsx src/components/api-playground-shell.tsx src/components/api-playground-shell-skeleton.tsx src/lib/dashboard-url-state.ts src/app/dashboard/issuance/issuance-workspace.tsx src/app/dashboard/issuance/issuance-page-skeleton.tsx src/app/dashboard/issuance/loading.tsx src/app/dashboard/payments/payments-workspace.tsx src/app/dashboard/payments/payments-page-skeleton.tsx src/app/dashboard/payments/loading.tsx
- git diff --name-only --diff-filter=d origin/main...HEAD | xargs pnpm exec biome check --no-errors-on-unmatched
