### PR TITLE
fix(ci): align release tags with production deploys

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "include-v-in-tag": true,
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "release-type": "node"
     }
   }

--- a/.github/workflows/deploy-sdp-api.yml
+++ b/.github/workflows/deploy-sdp-api.yml
@@ -8,6 +8,7 @@ on:
       # NOTE: paths filters do not apply to tag pushes; every matching tag
       # intentionally triggers a production deploy for that release version.
       - v*.*.*
+      - solana-developer-platform-v*.*.*
     paths:
       - apps/sdp-api/**
       - packages/**
@@ -39,17 +40,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-sdp-api-${{ github.event_name == 'workflow_dispatch' && inputs.environment || startsWith(github.ref, 'refs/tags/v') && 'production' || 'dev' }}
+  group: deploy-sdp-api-${{ github.event_name == 'workflow_dispatch' && inputs.environment || (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/solana-developer-platform-v')) && 'production' || 'dev' }}
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy (${{ github.event_name == 'workflow_dispatch' && inputs.environment || startsWith(github.ref, 'refs/tags/v') && 'production' || 'dev' }})
+    name: Deploy (${{ github.event_name == 'workflow_dispatch' && inputs.environment || (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/solana-developer-platform-v')) && 'production' || 'dev' }})
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || startsWith(github.ref, 'refs/tags/v') && 'production' || 'dev' }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/solana-developer-platform-v')) && 'production' || 'dev' }}
     env:
-      TARGET_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || startsWith(github.ref, 'refs/tags/v') && 'production' || 'dev' }}
-      DEPLOY_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}
+      TARGET_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/solana-developer-platform-v')) && 'production' || 'dev' }}
+      DEPLOY_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/solana-developer-platform-v')) && github.ref_name || github.sha }}
 
     steps:
       - name: Validate production tag input
@@ -61,12 +62,12 @@ jobs:
           set -euo pipefail
 
           if [[ -z "${INPUT_REF}" ]]; then
-            echo "Manual production deploys require ref=vX.Y.Z." >&2
+            echo "Manual production deploys require a release tag ref." >&2
             exit 1
           fi
 
-          if [[ ! "${INPUT_REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Production ref must be an existing semver tag like v1.2.3." >&2
+          if [[ ! "${INPUT_REF}" =~ ^(v|solana-developer-platform-v)[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Production ref must be an existing release tag like v1.2.3 or solana-developer-platform-v1.2.3." >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo uses a two-environment release model for the API:
 
 - `main` deploys the API to `dev`
 - semver tags `vX.Y.Z` deploy the API to `production`
+- legacy tags in the form `solana-developer-platform-vX.Y.Z` are still accepted for rollback compatibility
 - production rollback is a manual redeploy of a previous semver tag
 
 ### GitHub Setup
@@ -37,6 +38,7 @@ To roll back production:
 2. Run `Deploy SDP API`.
 3. Set `environment=production`.
 4. Set `ref` to the previously released tag, for example `v1.2.2`.
+   Legacy release tags like `solana-developer-platform-v0.2.0` are also accepted.
 5. Leave `run_migrations=false` unless you explicitly need to run migrations.
 
 Important: code rollback is supported, but schema rollback is not automated. Production migrations should remain backward-compatible with the previously deployed application version.


### PR DESCRIPTION
## Summary
- configure Release Please to emit plain `vX.Y.Z` tags instead of component-prefixed tags
- allow the deploy workflow to accept existing legacy `solana-developer-platform-vX.Y.Z` tags for rollback compatibility
- document the legacy tag compatibility in the release runbook

## Testing
- git diff --check
