### PR TITLE
feat(api): unify wallet-scoped authorization

### DIFF
--- a/apps/sdp-api/src/lib/api-key-wallet-auth.test.ts
+++ b/apps/sdp-api/src/lib/api-key-wallet-auth.test.ts
@@ -3,6 +3,7 @@ import { AppError } from "@/lib/errors";
 import { describe, expect, it } from "vitest";
 import {
   assertApiKeyWalletAccess,
+  filterApiKeyWallets,
   getAllowedApiKeyWalletIds,
   resolveApiKeySigningWalletId,
 } from "./api-key-wallet-auth";
@@ -80,5 +81,22 @@ describe("api-key wallet auth helpers", () => {
     });
 
     expect(getAllowedApiKeyWalletIds(auth)).toEqual(["wal_a", "wal_b"]);
+  });
+
+  it("filters wallet collections to the bound wallet set", () => {
+    const auth = createApiKeyAuth({
+      walletBindings: [{ walletId: "wal_a", permissions: ["wallets:read"] }],
+    });
+
+    expect(
+      filterApiKeyWallets(
+        auth,
+        [
+          { walletId: "wal_a", label: "A" },
+          { walletId: "wal_b", label: "B" },
+        ],
+        ["wallets:read"]
+      )
+    ).toEqual([{ walletId: "wal_a", label: "A" }]);
   });
 });

--- a/apps/sdp-api/src/lib/api-key-wallet-auth.ts
+++ b/apps/sdp-api/src/lib/api-key-wallet-auth.ts
@@ -17,6 +17,15 @@ function normalizeBindings(auth: ApiKeyContext): ApiKeyWalletBinding[] {
   return [];
 }
 
+function getBindingForWallet(auth: ApiKeyContext, walletId: string): ApiKeyWalletBinding | null {
+  const bindings = normalizeBindings(auth);
+  if (bindings.length === 0) {
+    return null;
+  }
+
+  return bindings.find((entry) => entry.walletId === walletId) ?? null;
+}
+
 function hasBindingPermission(
   binding: ApiKeyWalletBinding,
   requiredPermissions: Permission[]
@@ -46,7 +55,7 @@ export function assertApiKeyWalletAccess(
     return;
   }
 
-  const binding = bindings.find((entry) => entry.walletId === walletId);
+  const binding = getBindingForWallet(auth, walletId);
   if (!binding) {
     throw new AppError("FORBIDDEN", "API key is not authorized for the requested wallet");
   }
@@ -101,4 +110,27 @@ export function getAllowedApiKeyWalletIds(auth: ApiKeyContext): string[] | null 
   }
 
   return bindings.map((binding) => binding.walletId);
+}
+
+export function filterApiKeyWallets<T extends { walletId: string }>(
+  auth: ApiKeyContext,
+  wallets: T[],
+  requiredPermissions: Permission[] = []
+): T[] {
+  if (auth.authType !== "api_key") {
+    return wallets;
+  }
+
+  const bindings = normalizeBindings(auth);
+  if (bindings.length === 0) {
+    return wallets;
+  }
+
+  return wallets.filter((wallet) => {
+    const binding = getBindingForWallet(auth, wallet.walletId);
+    if (!binding) {
+      return false;
+    }
+    return hasBindingPermission(binding, requiredPermissions);
+  });
 }

--- a/apps/sdp-api/src/openapi/schemas/api-keys.ts
+++ b/apps/sdp-api/src/openapi/schemas/api-keys.ts
@@ -20,6 +20,11 @@ export const apiKeyEnvironmentSchema = z
   .enum(["sandbox", "production"])
   .openapi({ description: "API key environment.", example: "sandbox" });
 
+export const apiKeyWalletScopeSchema = z.enum(["all", "selected"]).openapi({
+  description: "Whether the key can use all wallets in scope or only explicitly selected wallets.",
+  example: "selected",
+});
+
 export const apiKeyStatusSchema = z
   .enum(["active", "revoked", "expired", "deactivated"])
   .openapi({ description: "API key status.", example: "active" });
@@ -94,6 +99,7 @@ export const apiKeyDetailSchema = z
         description: "CIDR ranges permitted to use the key.",
         example: ["203.0.113.0/24"],
       }),
+    walletScope: apiKeyWalletScopeSchema,
     signingWalletId: z.string().nullable().openapi({
       description: "Default custody wallet bound to this API key for signing.",
       example: "privy_wallet_123",
@@ -222,6 +228,11 @@ export const createApiKeyRequestSchema = apiKeyCreateSchemaBase
       description: "Target environment for the key.",
       example: "sandbox",
     }),
+    walletScope: apiKeyCreateSchemaBase.shape.walletScope.openapi({
+      description:
+        "Explicit wallet access mode. Use 'all' to allow every wallet in scope or 'selected' to bind specific wallets.",
+      example: "selected",
+    }),
     allowedIps: apiKeyCreateSchemaBase.shape.allowedIps.openapi({
       description: "Optional list of CIDR ranges allowed to use the key.",
       example: ["203.0.113.0/24"],
@@ -271,6 +282,11 @@ export const updateApiKeyRequestSchema = apiKeyUpdateSchemaBase
     description: apiKeyUpdateSchemaBase.shape.description.openapi({
       description: "Updated description. Use null to clear.",
       example: "Rotated key for new service.",
+    }),
+    walletScope: apiKeyUpdateSchemaBase.shape.walletScope.openapi({
+      description:
+        "Updated wallet access mode. Provide this when changing wallet bindings, or by itself to reset the key to all wallets.",
+      example: "all",
     }),
     allowedIps: apiKeyUpdateSchemaBase.shape.allowedIps.openapi({
       description: "Updated IP allowlist. Use null to clear.",

--- a/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
@@ -1,0 +1,277 @@
+import app from "@/index";
+import { hashString } from "@/lib/hash";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/d1";
+import { clearKVNamespaces, seedCachedApiKey } from "@/test/mocks/kv";
+import type { CachedApiKey } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const TEST_ORG = {
+  id: "org_api_key_wallet_scope",
+  name: "API Key Wallet Scope Org",
+  slug: "api-key-wallet-scope-org",
+};
+
+const TEST_USER = {
+  id: "usr_api_key_wallet_scope",
+  email: "api-key-wallet-scope@example.com",
+};
+
+const TEST_API_KEY = {
+  id: "key_api_key_wallet_scope",
+  raw: "sk_test_apikeywalletscope12345678901234567890",
+  prefix: "sk_test_aks",
+};
+
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: null,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+
+const TEST_CONFIG_ID = "cust_cfg_api_key_wallet_scope";
+
+async function seedAuthAndWallets(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+
+  await env.DB.batch([
+    env.DB.prepare(
+      "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)"
+    ).bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+    env.DB.prepare(
+      "INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)"
+    ).bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    env.DB.prepare(
+      `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, environment, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      TEST_API_KEY.id,
+      TEST_ORG.id,
+      null,
+      TEST_USER.id,
+      "Admin test key",
+      TEST_API_KEY.prefix,
+      keyHash,
+      "api_admin",
+      JSON.stringify(["*"]),
+      "sandbox",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      TEST_CONFIG_ID,
+      TEST_ORG.id,
+      null,
+      "local",
+      "test-config",
+      "sdp-custody-encryption-v1",
+      "wal_scope_a",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_scope_defaults
+           (id, organization_id, project_id, default_custody_config_id)
+         VALUES (?, ?, ?, ?)`
+    ).bind("csd_api_key_wallet_scope", TEST_ORG.id, null, TEST_CONFIG_ID),
+    env.DB.prepare(
+      `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      "cwlt_scope_a",
+      TEST_CONFIG_ID,
+      "wal_scope_a",
+      "pub_scope_a",
+      "Wallet Scope A",
+      "transfer",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      "cwlt_scope_b",
+      TEST_CONFIG_ID,
+      "wal_scope_b",
+      "pub_scope_b",
+      "Wallet Scope B",
+      "transfer",
+      "active"
+    ),
+  ]);
+}
+
+describe("API key wallet scope routes", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await seedAuthAndWallets();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+    await clearKVNamespaces(env);
+  });
+
+  it("rejects create requests without walletScope", async () => {
+    const res = await app.request(
+      "/v1/api-keys",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          name: "Missing wallet scope",
+          environment: "sandbox",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects wallet bindings when walletScope is all", async () => {
+    const res = await app.request(
+      "/v1/api-keys",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          name: "Conflicting all-wallet key",
+          walletScope: "all",
+          signingWalletId: "wal_scope_a",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("walletScope 'all'");
+  });
+
+  it("creates a selected-wallet key and persists wallet bindings", async () => {
+    const res = await app.request(
+      "/v1/api-keys",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          name: "Scoped key",
+          environment: "sandbox",
+          walletScope: "selected",
+          signingWalletId: "wal_scope_b",
+          signingWalletIds: ["wal_scope_a", "wal_scope_b"],
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      data: {
+        apiKey: {
+          id: string;
+        };
+      };
+    };
+
+    const created = await env.DB.prepare("SELECT signing_wallet_id FROM api_keys WHERE id = ?")
+      .bind(body.data.apiKey.id)
+      .first<{ signing_wallet_id: string | null }>();
+    expect(created?.signing_wallet_id).toBe("wal_scope_b");
+
+    const bindings = await env.DB.prepare(
+      "SELECT wallet_id FROM api_key_wallet_permissions WHERE api_key_id = ? ORDER BY wallet_id"
+    )
+      .bind(body.data.apiKey.id)
+      .all<{ wallet_id: string }>();
+    expect(bindings.results?.map((row) => row.wallet_id)).toEqual(["wal_scope_a", "wal_scope_b"]);
+  });
+
+  it("requires walletScope when updating wallet bindings", async () => {
+    const res = await app.request(
+      `/v1/api-keys/${TEST_API_KEY.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          signingWalletId: "wal_scope_a",
+          signingWalletIds: ["wal_scope_a"],
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("walletScope is required");
+  });
+
+  it("clears wallet bindings when walletScope is updated to all", async () => {
+    await env.DB.batch([
+      env.DB.prepare("UPDATE api_keys SET signing_wallet_id = ? WHERE id = ?").bind(
+        "wal_scope_a",
+        TEST_API_KEY.id
+      ),
+      env.DB.prepare(
+        `INSERT INTO api_key_wallet_permissions (id, api_key_id, wallet_id, permissions)
+         VALUES (?, ?, ?, ?)`
+      ).bind("akw_scope_a", TEST_API_KEY.id, "wal_scope_a", JSON.stringify(["*"])),
+    ]);
+
+    const res = await app.request(
+      `/v1/api-keys/${TEST_API_KEY.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          walletScope: "all",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+
+    const updated = await env.DB.prepare("SELECT signing_wallet_id FROM api_keys WHERE id = ?")
+      .bind(TEST_API_KEY.id)
+      .first<{ signing_wallet_id: string | null }>();
+    expect(updated?.signing_wallet_id).toBeNull();
+
+    const bindings = await env.DB.prepare(
+      "SELECT COUNT(*) as count FROM api_key_wallet_permissions WHERE api_key_id = ?"
+    )
+      .bind(TEST_API_KEY.id)
+      .first<{ count: number }>();
+    expect(bindings?.count).toBe(0);
+  });
+});

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -20,7 +20,11 @@ import type {
 } from "@sdp/types";
 import type { Context } from "hono";
 import { apiKeyCreateSchema, apiKeyRotateSchema, apiKeyUpdateSchema } from "./schemas";
-import { assertWalletBindingsInScope, parseWalletBindingPatch } from "./wallet-bindings";
+import {
+  assertWalletBindingsInScope,
+  resolveCreateWalletScope,
+  resolveUpdateWalletScope,
+} from "./wallet-bindings";
 
 type AppContext = Context<{ Bindings: Env }>;
 
@@ -106,6 +110,7 @@ export const createApiKey = async (c: AppContext) => {
     role = "api_developer",
     environment = "sandbox",
     permissions,
+    walletScope,
     allowedIps,
     expiresAt,
     signingWalletId,
@@ -120,21 +125,16 @@ export const createApiKey = async (c: AppContext) => {
     throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require owner access");
   }
 
-  const walletBindingPatch = parseWalletBindingPatch({
+  const walletSelection = resolveCreateWalletScope({
+    walletScope,
     signingWalletId,
     signingWalletIds,
     walletBindings,
+    provisionWallet,
   });
 
-  if (provisionWallet && walletBindingPatch.bindings.length > 0) {
-    throw new AppError(
-      "BAD_REQUEST",
-      "Provide either wallet bindings (signingWalletId/signingWalletIds/walletBindings) or provisionWallet, not both"
-    );
-  }
-
-  let resolvedSigningWalletId: string | null = walletBindingPatch.defaultSigningWalletId;
-  let resolvedWalletBindings = walletBindingPatch.bindings;
+  let resolvedSigningWalletId: string | null = walletSelection.defaultSigningWalletId;
+  let resolvedWalletBindings = walletSelection.bindings;
 
   if (provisionWallet) {
     if (!(actor.permissions.includes("*") || actor.permissions.includes("custody:admin"))) {
@@ -232,6 +232,7 @@ export const createApiKey = async (c: AppContext) => {
       name,
       role,
       environment,
+      walletScope: resolvedWalletBindings.length > 0 ? "selected" : "all",
       signingWalletId: resolvedSigningWalletId,
       signingWalletIds: resolvedWalletBindings.map((binding) => binding.walletId),
       provisionedWallet: Boolean(provisionWallet),
@@ -278,6 +279,7 @@ export const getApiKey = async (c: AppContext) => {
     status: key.status,
     projectId: key.projectId,
     allowedIps: key.allowedIps,
+    walletScope: walletBindings.length > 0 ? "selected" : "all",
     signingWalletId: key.signingWalletId,
     signingWalletIds: walletBindings.map((binding) => binding.walletId),
     walletBindings,
@@ -313,7 +315,8 @@ export const updateApiKey = async (c: AppContext) => {
     throw notFound("API key");
   }
 
-  const walletBindingPatch = parseWalletBindingPatch({
+  const walletSelection = resolveUpdateWalletScope({
+    walletScope: parsed.data.walletScope,
     signingWalletId: parsed.data.signingWalletId,
     signingWalletIds: parsed.data.signingWalletIds,
     walletBindings: parsed.data.walletBindings,
@@ -351,15 +354,15 @@ export const updateApiKey = async (c: AppContext) => {
     values.push(parsed.data.permissions ? JSON.stringify(parsed.data.permissions) : null);
   }
 
-  if (walletBindingPatch.touched) {
+  if (walletSelection.touched) {
     await assertWalletBindingsInScope(
       c.env.DB,
       actor.organizationId,
       existing.project_id,
-      walletBindingPatch.bindings
+      walletSelection.bindings
     );
     updates.push("signing_wallet_id = ?");
-    values.push(walletBindingPatch.defaultSigningWalletId);
+    values.push(walletSelection.defaultSigningWalletId);
   }
 
   if (updates.length === 0) {
@@ -371,15 +374,15 @@ export const updateApiKey = async (c: AppContext) => {
     .bind(...values)
     .run();
 
-  if (walletBindingPatch.touched) {
-    await replaceApiKeyWalletBindings(c.env.DB, keyId, walletBindingPatch.bindings);
+  if (walletSelection.touched) {
+    await replaceApiKeyWalletBindings(c.env.DB, keyId, walletSelection.bindings);
   }
 
   // Invalidate cache if auth-relevant fields changed
   if (
     parsed.data.allowedIps !== undefined ||
     parsed.data.permissions !== undefined ||
-    walletBindingPatch.touched
+    walletSelection.touched
   ) {
     const kvService = new KVService(c.env.SDP_API_KEYS, c.env.SDP_CACHE);
     await kvService.deleteApiKey(existing.key_hash);

--- a/apps/sdp-api/src/routes/api-keys/schemas.ts
+++ b/apps/sdp-api/src/routes/api-keys/schemas.ts
@@ -12,6 +12,7 @@ export const apiKeyCreateSchema = z.object({
   role: z.enum(["api_admin", "api_developer", "api_readonly"]).optional(),
   permissions: z.array(z.enum(PERMISSIONS)).optional(),
   environment: z.enum(["sandbox", "production"]).optional(),
+  walletScope: z.enum(["all", "selected"]),
   allowedIps: z.array(z.string()).optional(),
   expiresAt: z.string().datetime().optional(),
   signingWalletId: z.string().min(1).optional(),
@@ -27,6 +28,7 @@ export const apiKeyCreateSchema = z.object({
 export const apiKeyUpdateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(500).nullable().optional(),
+  walletScope: z.enum(["all", "selected"]).optional(),
   allowedIps: z.array(z.string()).nullable().optional(),
   expiresAt: z.string().datetime().nullable().optional(),
   permissions: z.array(z.enum(PERMISSIONS)).nullable().optional(),

--- a/apps/sdp-api/src/routes/api-keys/wallet-bindings.test.ts
+++ b/apps/sdp-api/src/routes/api-keys/wallet-bindings.test.ts
@@ -1,6 +1,10 @@
 import { AppError } from "@/lib/errors";
 import { describe, expect, it } from "vitest";
-import { parseWalletBindingPatch } from "./wallet-bindings";
+import {
+  parseWalletBindingPatch,
+  resolveCreateWalletScope,
+  resolveUpdateWalletScope,
+} from "./wallet-bindings";
 
 describe("wallet bindings parser", () => {
   it("supports legacy single signingWalletId payloads", () => {
@@ -43,6 +47,41 @@ describe("wallet bindings parser", () => {
       parseWalletBindingPatch({
         signingWalletIds: null,
         signingWalletId: "wal_conflict",
+      })
+    ).toThrowError(AppError);
+  });
+
+  it("requires wallet bindings when walletScope is selected on create", () => {
+    expect(() =>
+      resolveCreateWalletScope({
+        walletScope: "selected",
+      })
+    ).toThrowError(AppError);
+  });
+
+  it("rejects wallet binding fields when walletScope is all on create", () => {
+    expect(() =>
+      resolveCreateWalletScope({
+        walletScope: "all",
+        signingWalletId: "wal_all_conflict",
+      })
+    ).toThrowError(AppError);
+  });
+
+  it("treats walletScope all as a wallet binding reset on update", () => {
+    const parsed = resolveUpdateWalletScope({
+      walletScope: "all",
+    });
+
+    expect(parsed.touched).toBe(true);
+    expect(parsed.defaultSigningWalletId).toBeNull();
+    expect(parsed.bindings).toEqual([]);
+  });
+
+  it("requires walletScope when updating wallet bindings", () => {
+    expect(() =>
+      resolveUpdateWalletScope({
+        signingWalletId: "wal_missing_scope",
       })
     ).toThrowError(AppError);
   });

--- a/apps/sdp-api/src/routes/api-keys/wallet-bindings.ts
+++ b/apps/sdp-api/src/routes/api-keys/wallet-bindings.ts
@@ -1,6 +1,6 @@
 import { AppError } from "@/lib/errors";
 import { normalizeApiKeyWalletPermissions } from "@/services/api-key-wallets.service";
-import type { ApiKeyWalletBinding, Permission } from "@sdp/types";
+import type { ApiKeyWalletBinding, ApiKeyWalletScope, Permission } from "@sdp/types";
 
 type WalletBindingInput = {
   walletId: string;
@@ -17,6 +17,11 @@ export type ParsedWalletBindingPatch = {
   touched: boolean;
   defaultSigningWalletId: string | null;
   bindings: ApiKeyWalletBinding[];
+};
+
+type WalletScopeInput = WalletBindingPatchInput & {
+  walletScope?: ApiKeyWalletScope;
+  provisionWallet?: boolean;
 };
 
 function trimWalletId(walletId: string): string {
@@ -120,6 +125,119 @@ export function parseWalletBindingPatch(input: WalletBindingPatchInput): ParsedW
     touched,
     defaultSigningWalletId,
     bindings,
+  };
+}
+
+export function resolveCreateWalletScope(input: WalletScopeInput): {
+  walletScope: ApiKeyWalletScope;
+  defaultSigningWalletId: string | null;
+  bindings: ApiKeyWalletBinding[];
+} {
+  const walletScope = input.walletScope;
+  if (!walletScope) {
+    throw new AppError("BAD_REQUEST", "walletScope is required");
+  }
+
+  const walletBindingPatch = parseWalletBindingPatch(input);
+
+  if (walletScope === "all") {
+    if (input.provisionWallet) {
+      throw new AppError(
+        "BAD_REQUEST",
+        "walletScope 'all' cannot be combined with provisionWallet"
+      );
+    }
+    if (walletBindingPatch.touched) {
+      throw new AppError(
+        "BAD_REQUEST",
+        "walletScope 'all' cannot be combined with signingWalletId, signingWalletIds, or walletBindings"
+      );
+    }
+
+    return {
+      walletScope,
+      defaultSigningWalletId: null,
+      bindings: [],
+    };
+  }
+
+  if (!input.provisionWallet && walletBindingPatch.bindings.length === 0) {
+    throw new AppError(
+      "BAD_REQUEST",
+      "walletScope 'selected' requires wallet bindings or provisionWallet"
+    );
+  }
+
+  return {
+    walletScope,
+    defaultSigningWalletId: walletBindingPatch.defaultSigningWalletId,
+    bindings: walletBindingPatch.bindings,
+  };
+}
+
+export function resolveUpdateWalletScope(input: WalletScopeInput): {
+  walletScope: ApiKeyWalletScope | undefined;
+  defaultSigningWalletId: string | null;
+  bindings: ApiKeyWalletBinding[];
+  touched: boolean;
+} {
+  const walletBindingPatch = parseWalletBindingPatch(input);
+  const walletScope = input.walletScope;
+
+  if (walletScope === undefined) {
+    if (walletBindingPatch.touched) {
+      throw new AppError(
+        "BAD_REQUEST",
+        "walletScope is required when updating API key wallet access"
+      );
+    }
+
+    return {
+      walletScope,
+      defaultSigningWalletId: walletBindingPatch.defaultSigningWalletId,
+      bindings: walletBindingPatch.bindings,
+      touched: false,
+    };
+  }
+
+  if (walletScope === "all") {
+    if (input.provisionWallet) {
+      throw new AppError(
+        "BAD_REQUEST",
+        "walletScope 'all' cannot be combined with provisionWallet"
+      );
+    }
+    if (walletBindingPatch.touched) {
+      throw new AppError(
+        "BAD_REQUEST",
+        "walletScope 'all' cannot be combined with signingWalletId, signingWalletIds, or walletBindings"
+      );
+    }
+
+    return {
+      walletScope,
+      defaultSigningWalletId: null,
+      bindings: [],
+      touched: true,
+    };
+  }
+
+  if (input.provisionWallet) {
+    throw new AppError("BAD_REQUEST", "provisionWallet is only supported during API key creation");
+  }
+
+  if (!walletBindingPatch.touched || walletBindingPatch.bindings.length === 0) {
+    throw new AppError(
+      "BAD_REQUEST",
+      "walletScope 'selected' requires signingWalletId, signingWalletIds, or walletBindings"
+    );
+  }
+
+  return {
+    walletScope,
+    defaultSigningWalletId: walletBindingPatch.defaultSigningWalletId,
+    bindings: walletBindingPatch.bindings,
+    touched: true,
   };
 }
 

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -1,0 +1,315 @@
+import app from "@/index";
+import { hashString } from "@/lib/hash";
+import { createSigningService } from "@/services/domain/signing.service";
+import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/d1";
+import { clearKVNamespaces, seedCachedApiKey } from "@/test/mocks/kv";
+import type { CachedApiKey, CustodyWalletTokenBalance } from "@sdp/types";
+import { address } from "@solana/kit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/helius-das.service", async () => {
+  const actual = await vi.importActual<typeof import("@/services/helius-das.service")>(
+    "@/services/helius-das.service"
+  );
+
+  return {
+    ...actual,
+    getTrackedWalletBalancesByOwner: vi.fn(async (_env, owners: string[]) => {
+      return new Map<string, CustodyWalletTokenBalance[]>(
+        owners.map((owner) => [
+          owner,
+          [
+            {
+              token: "USDC",
+              mint: "usdc_mint",
+              amount: "1000000",
+              uiAmount: owner.endsWith("a") ? "1.0" : "2.0",
+              decimals: 6,
+            },
+          ],
+        ])
+      );
+    }),
+  };
+});
+
+vi.mock("@/services/domain/signing.service", async () => {
+  const actual = await vi.importActual<typeof import("@/services/domain/signing.service")>(
+    "@/services/domain/signing.service"
+  );
+
+  return {
+    ...actual,
+    createSigningService: vi.fn((envArg) => {
+      const service = actual.createSigningService(envArg);
+      service.getPublicKey = vi.fn(async (_organizationId, _projectId, walletId) => {
+        if (walletId === "para_wallet_a") {
+          return address(TEST_SOLANA_ADDRESSES.wallet2);
+        }
+        if (walletId === "privy_wallet_a") {
+          return address(TEST_SOLANA_ADDRESSES.wallet1);
+        }
+        return address(TEST_SOLANA_ADDRESSES.wallet1);
+      });
+      return service;
+    }),
+  };
+});
+
+const TEST_ORG = {
+  id: "org_custody_wallet_scope",
+  name: "Custody Wallet Scope Org",
+  slug: "custody-wallet-scope-org",
+};
+
+const TEST_USER = {
+  id: "usr_custody_wallet_scope",
+  email: "custody-wallet-scope@example.com",
+};
+
+const TEST_API_KEY = {
+  id: "key_custody_wallet_scope",
+  raw: "sk_test_custodywalletscope12345678901234567890",
+  prefix: "sk_test_cws",
+};
+
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: null,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+
+const PRIVY_CONFIG_ID = "cust_cfg_scope_privy";
+const PARA_CONFIG_ID = "cust_cfg_scope_para";
+
+async function seedAuthAndConfigs(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+
+  await env.DB.batch([
+    env.DB.prepare(
+      "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)"
+    ).bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+    env.DB.prepare(
+      "INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)"
+    ).bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    env.DB.prepare(
+      `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, environment, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      TEST_API_KEY.id,
+      TEST_ORG.id,
+      null,
+      TEST_USER.id,
+      "Custody scope key",
+      TEST_API_KEY.prefix,
+      keyHash,
+      "api_admin",
+      JSON.stringify(["*"]),
+      "sandbox",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      PRIVY_CONFIG_ID,
+      TEST_ORG.id,
+      null,
+      "privy",
+      "test-config",
+      "sdp-custody-encryption-v1",
+      "privy_wallet_a",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      PARA_CONFIG_ID,
+      TEST_ORG.id,
+      null,
+      "para",
+      "test-config",
+      "sdp-custody-encryption-v1",
+      "para_wallet_a",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_scope_defaults
+           (id, organization_id, project_id, default_custody_config_id)
+         VALUES (?, ?, ?, ?)`
+    ).bind("csd_scope_org_default", TEST_ORG.id, null, PRIVY_CONFIG_ID),
+    env.DB.prepare(
+      `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      "cwlt_scope_privy_a",
+      PRIVY_CONFIG_ID,
+      "privy_wallet_a",
+      "privy_pubkey_a",
+      "A",
+      "root",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      "cwlt_scope_privy_b",
+      PRIVY_CONFIG_ID,
+      "privy_wallet_b",
+      "privy_pubkey_b",
+      "B",
+      "transfer",
+      "active"
+    ),
+    env.DB.prepare(
+      `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).bind(
+      "cwlt_scope_para_a",
+      PARA_CONFIG_ID,
+      "para_wallet_a",
+      "para_pubkey_a",
+      "C",
+      "root",
+      "active"
+    ),
+  ]);
+}
+
+async function seedCachedKey(override: Partial<CachedApiKey>): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, {
+    ...TEST_CACHED_API_KEY,
+    ...override,
+  });
+}
+
+describe("Custody wallet scope routes", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await seedAuthAndConfigs();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+    await clearKVNamespaces(env);
+    vi.mocked(createSigningService).mockClear();
+  });
+
+  it("filters listed wallets to the API key bindings", async () => {
+    await seedCachedKey({
+      walletBindings: [{ walletId: "para_wallet_a", permissions: ["wallets:read"] }],
+    });
+
+    const res = await app.request(
+      "/v1/wallets?includeAllProviders=true",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        wallets: Array<{ walletId: string }>;
+      };
+    };
+    expect(body.data.wallets.map((wallet) => wallet.walletId)).toEqual(["para_wallet_a"]);
+  });
+
+  it("filters aggregate wallets to the API key bindings", async () => {
+    await seedCachedKey({
+      walletBindings: [{ walletId: "privy_wallet_b", permissions: ["wallets:read"] }],
+    });
+
+    const res = await app.request(
+      "/v1/wallets/aggregate?includeAllProviders=true",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        aggregate: {
+          walletCount: number;
+          balances: Array<{ token: string; uiAmount: string }>;
+        };
+      };
+    };
+    expect(body.data.aggregate.walletCount).toBe(1);
+    expect(body.data.aggregate.balances).toHaveLength(1);
+    expect(body.data.aggregate.balances[0]).toMatchObject({
+      token: "USDC",
+      uiAmount: "1",
+    });
+  });
+
+  it("returns the requested public key when the wallet is authorized", async () => {
+    await seedCachedKey({
+      walletBindings: [{ walletId: "para_wallet_a", permissions: ["wallets:read"] }],
+    });
+
+    const res = await app.request(
+      "/v1/wallets/public-key?walletId=para_wallet_a",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { publicKey: string } };
+    expect(body.data.publicKey).toBe(TEST_SOLANA_ADDRESSES.wallet2);
+  });
+
+  it("returns 404 when the requested wallet is outside the API key bindings", async () => {
+    await seedCachedKey({
+      walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:read"] }],
+    });
+
+    const res = await app.request(
+      "/v1/wallets/public-key?walletId=para_wallet_a",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -1,5 +1,9 @@
 import { formatDecimalAmount } from "@/lib/amount";
-import { assertApiKeyWalletAccess } from "@/lib/api-key-wallet-auth";
+import {
+  assertApiKeyWalletAccess,
+  filterApiKeyWallets,
+  resolveApiKeySigningWalletId,
+} from "@/lib/api-key-wallet-auth";
 import { getAuth } from "@/lib/auth";
 import { AppError } from "@/lib/errors";
 import { created, success } from "@/lib/response";
@@ -63,6 +67,7 @@ async function getScopedWallets(
   c: AppContext,
   options: { defaultIncludeAllProviders?: boolean } = {}
 ) {
+  const auth = getAuth(c);
   const actor = resolveActor(c);
   const filters = resolveWalletFilters(c, options);
   const signingService = createSigningService(c.env);
@@ -75,7 +80,10 @@ async function getScopedWallets(
     }
   );
 
-  return { wallets, filters };
+  return {
+    wallets: filterApiKeyWallets(auth, wallets, ["wallets:read"]),
+    filters,
+  };
 }
 
 async function getBalancesByWalletId(
@@ -366,12 +374,14 @@ export const getWalletById = async (c: AppContext) => {
 
 export const getPublicKey = async (c: AppContext) => {
   const actor = resolveActor(c);
+  const auth = getAuth(c);
   const projectId = c.req.query("projectId");
-  const walletId = c.req.query("walletId");
+  const requestedWalletId = c.req.query("walletId");
 
   const signingService = createSigningService(c.env);
 
   try {
+    const walletId = resolveApiKeySigningWalletId(auth, requestedWalletId, ["wallets:read"]);
     const publicKey = await signingService.getPublicKey(
       actor.organizationId,
       projectId ?? undefined,
@@ -380,6 +390,9 @@ export const getPublicKey = async (c: AppContext) => {
 
     return success(c, { publicKey });
   } catch (error) {
+    if (error instanceof AppError && error.code === "FORBIDDEN") {
+      throw new AppError("NOT_FOUND", "Wallet not found");
+    }
     if (error instanceof SigningError) {
       throw new AppError("NOT_FOUND", "No signing key configured for this organization");
     }

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -211,6 +211,14 @@ async function seedAuthAndWallet(): Promise<void> {
   ]);
 }
 
+async function seedCachedKey(override: Partial<CachedApiKey>): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, {
+    ...TEST_CACHED_API_KEY,
+    ...override,
+  });
+}
+
 async function seedWalletPolicy(params: {
   destinationAllowlist: string[];
   maxTransferAmount?: string;
@@ -390,6 +398,91 @@ describe("Payments routes", () => {
     expect(redirect.searchParams.get("redirectURL")).toBe("https://example.com/offramp-done");
     expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("kyc_ref_456");
     assertMoonPaySignature(redirect);
+  });
+
+  it("blocks MoonPay off-ramp when the wallet policy maxTransferAmount is exceeded", async () => {
+    await seedWalletPolicy({
+      destinationAllowlist: [],
+      maxTransferAmount: "50.00",
+    });
+
+    const res = await app.request(
+      "/v1/payments/ramps/offramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          sourceWallet: TEST_WALLET_ID,
+          cryptoToken: "USDC",
+          fiatCurrency: "USD",
+          cryptoAmount: "75.25",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("does not apply outbound wallet policy checks to MoonPay on-ramp", async () => {
+    await seedWalletPolicy({
+      destinationAllowlist: [],
+      maxTransferAmount: "10.00",
+    });
+
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "USDC",
+          fiatCurrency: "USD",
+          fiatAmount: "25.00",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("checks wallet bindings when a custody wallet public key is used for MoonPay off-ramp", async () => {
+    await seedCachedKey({
+      walletBindings: [{ walletId: "wal_other_wallet", permissions: ["payments:write"] }],
+    });
+
+    const res = await app.request(
+      "/v1/payments/ramps/offramp/execute",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          sourceWallet: TEST_SOLANA_ADDRESSES.wallet1,
+          cryptoToken: "USDC",
+          fiatCurrency: "USD",
+          cryptoAmount: "25.00",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(403);
   });
 
   it("returns bad request when MoonPay on-ramp amount is below the minimum", async () => {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -3,6 +3,7 @@ import { AppError } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { isAddress } from "@/lib/solana";
 import type { AppContext } from "../context";
+import { assertWalletPolicyAllowsTransfer } from "../policy";
 import { executeOfframpSchema, executeOnrampSchema } from "../schemas";
 import { type ResolvedScope, resolveScope, resolveWalletAddress } from "../wallets";
 
@@ -1187,6 +1188,20 @@ async function executeRampWithProvider(
 
   if (input.direction === "onramp") {
     return provider.executeOnramp(c, scope, input);
+  }
+
+  const sourceWallet = scope.wallets.find(
+    (wallet) => wallet.walletId === input.sourceWallet || wallet.publicKey === input.sourceWallet
+  );
+  if (sourceWallet) {
+    await assertWalletPolicyAllowsTransfer(c, {
+      organizationId: scope.auth.organizationId,
+      projectId: scope.auth.projectId,
+      wallet: sourceWallet,
+      enforceDestinationAllowlist: false,
+      token: input.cryptoToken,
+      amount: input.cryptoAmount,
+    });
   }
 
   return provider.executeOfframp(c, scope, input);

--- a/apps/sdp-api/src/routes/payments/policy.ts
+++ b/apps/sdp-api/src/routes/payments/policy.ts
@@ -123,7 +123,8 @@ export async function assertWalletPolicyAllowsTransfer(
     organizationId: string;
     projectId: string | null;
     wallet: CustodyWallet;
-    destinationAddress: string;
+    destinationAddress?: string | null;
+    enforceDestinationAllowlist?: boolean;
     token: string;
     amount: string;
   }
@@ -137,9 +138,12 @@ export async function assertWalletPolicyAllowsTransfer(
 
   const policy = buildWalletPolicyPayload(input.wallet.walletId, rows, input.wallet.createdAt);
 
+  const shouldEnforceDestinationAllowlist = input.enforceDestinationAllowlist !== false;
+
   if (
+    shouldEnforceDestinationAllowlist &&
     policy.destinationAllowlist.length > 0 &&
-    !policy.destinationAllowlist.includes(input.destinationAddress)
+    (!input.destinationAddress || !policy.destinationAllowlist.includes(input.destinationAddress))
   ) {
     throw new AppError("FORBIDDEN", "Destination address is not allowed by wallet policy");
   }

--- a/apps/sdp-api/src/routes/payments/wallets.ts
+++ b/apps/sdp-api/src/routes/payments/wallets.ts
@@ -44,7 +44,9 @@ export function resolveWalletAddress(
   auth?: ReturnType<typeof getAuth>,
   requiredWalletPermissions: Permission[] = []
 ): string {
-  const matchingWallet = wallets.find((entry) => entry.walletId === walletIdOrAddress);
+  const matchingWallet = wallets.find(
+    (entry) => entry.walletId === walletIdOrAddress || entry.publicKey === walletIdOrAddress
+  );
   if (matchingWallet) {
     if (auth) {
       assertApiKeyWalletAccess(auth, matchingWallet.walletId, requiredWalletPermissions);

--- a/apps/sdp-api/src/routes/projects.test.ts
+++ b/apps/sdp-api/src/routes/projects.test.ts
@@ -499,6 +499,7 @@ describe("Projects Routes", () => {
           body: JSON.stringify({
             name: "Project Key",
             environment: "sandbox",
+            walletScope: "all",
           }),
         },
         env
@@ -521,7 +522,7 @@ describe("Projects Routes", () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${TEST_API_KEY.raw}`,
           },
-          body: JSON.stringify({ name: "Listed Key" }),
+          body: JSON.stringify({ name: "Listed Key", walletScope: "all" }),
         },
         env
       );

--- a/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
@@ -4,7 +4,7 @@ import { created, success } from "@/lib/response";
 import { apiKeyCreateSchema } from "@/routes/api-keys/schemas";
 import {
   assertWalletBindingsInScope,
-  parseWalletBindingPatch,
+  resolveCreateWalletScope,
 } from "@/routes/api-keys/wallet-bindings";
 import { replaceApiKeyWalletBindings } from "@/services/api-key-wallets.service";
 import { ApiKeyService } from "@/services/api-key.service";
@@ -77,6 +77,7 @@ export const createProjectApiKey = async (c: AppContext) => {
     role = "api_developer",
     environment = "sandbox",
     permissions,
+    walletScope,
     allowedIps,
     expiresAt,
     signingWalletId,
@@ -91,21 +92,16 @@ export const createProjectApiKey = async (c: AppContext) => {
     throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require owner access");
   }
 
-  const walletBindingPatch = parseWalletBindingPatch({
+  const walletSelection = resolveCreateWalletScope({
+    walletScope,
     signingWalletId,
     signingWalletIds,
     walletBindings,
+    provisionWallet,
   });
 
-  if (provisionWallet && walletBindingPatch.bindings.length > 0) {
-    throw new AppError(
-      "BAD_REQUEST",
-      "Provide either wallet bindings (signingWalletId/signingWalletIds/walletBindings) or provisionWallet, not both"
-    );
-  }
-
-  let resolvedSigningWalletId: string | null = walletBindingPatch.defaultSigningWalletId;
-  let resolvedWalletBindings = walletBindingPatch.bindings;
+  let resolvedSigningWalletId: string | null = walletSelection.defaultSigningWalletId;
+  let resolvedWalletBindings = walletSelection.bindings;
 
   if (provisionWallet) {
     if (!(auth.permissions.includes("*") || auth.permissions.includes("custody:admin"))) {
@@ -170,6 +166,7 @@ export const createProjectApiKey = async (c: AppContext) => {
       name,
       role,
       environment,
+      walletScope: resolvedWalletBindings.length > 0 ? "selected" : "all",
       signingWalletId: resolvedSigningWalletId,
       signingWalletIds: resolvedWalletBindings.map((binding) => binding.walletId),
       provisionedWallet: Boolean(provisionWallet),

--- a/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
+++ b/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
@@ -1,0 +1,87 @@
+import custodyRoutes from "@/routes/custody";
+import issuanceRoutes from "@/routes/issuance";
+import paymentsRoutes from "@/routes/payments";
+import { describe, expect, it } from "vitest";
+
+function extractRoutes(router: unknown): string[] {
+  const routes = ((router as { routes?: Array<{ method: string; path: string }> }).routes ?? [])
+    .map((route) => `${route.method.toUpperCase()} ${route.path}`)
+    .filter((route) => route !== "ALL /*");
+
+  return Array.from(new Set(routes)).sort();
+}
+
+describe("wallet-scoped route coverage inventory", () => {
+  it("tracks every wallet-scoped custody route", () => {
+    const allRoutes = extractRoutes(custodyRoutes);
+    const nonWalletScopedRoutes = new Set([
+      "DELETE /",
+      "GET /config",
+      "GET /configs",
+      "GET /switch-options",
+      "POST /",
+      "POST /default-wallet",
+      "POST /initialize",
+      "POST /switch",
+    ]);
+
+    expect(allRoutes.filter((route) => !nonWalletScopedRoutes.has(route))).toEqual([
+      "GET /",
+      "GET /:walletId",
+      "GET /aggregate",
+      "GET /public-key",
+      "POST /signer-check",
+    ]);
+  });
+
+  it("tracks every wallet-scoped payments route", () => {
+    expect(extractRoutes(paymentsRoutes)).toEqual([
+      "GET /transfers",
+      "GET /transfers/:transferId",
+      "GET /wallets/:walletId/balances",
+      "GET /wallets/:walletId/policies",
+      "POST /ramps/offramp/execute",
+      "POST /ramps/onramp/execute",
+      "POST /transfers",
+      "POST /transfers/prepare",
+      "PUT /wallets/:walletId/policies",
+    ]);
+  });
+
+  it("tracks every issuance route that resolves a signing wallet", () => {
+    const allRoutes = extractRoutes(issuanceRoutes);
+    const nonWalletScopedRoutes = new Set([
+      "DELETE /tokens/:tokenId/allowlist/:entryId",
+      "GET /templates",
+      "GET /templates/:templateId",
+      "GET /tokens",
+      "GET /tokens/:tokenId",
+      "GET /tokens/:tokenId/allowlist",
+      "GET /tokens/:tokenId/frozen",
+      "GET /tokens/:tokenId/transactions",
+      "PATCH /tokens/:tokenId",
+      "POST /tokens",
+      "POST /tokens/:tokenId/allowlist",
+      "POST /tokens/:tokenId/supply/refresh",
+    ]);
+
+    expect(allRoutes.filter((route) => !nonWalletScopedRoutes.has(route))).toEqual([
+      "POST /tokens/:tokenId/authority",
+      "POST /tokens/:tokenId/authority/prepare",
+      "POST /tokens/:tokenId/burn",
+      "POST /tokens/:tokenId/burn/prepare",
+      "POST /tokens/:tokenId/deploy",
+      "POST /tokens/:tokenId/deploy/prepare",
+      "POST /tokens/:tokenId/force-burn",
+      "POST /tokens/:tokenId/force-burn/prepare",
+      "POST /tokens/:tokenId/freeze",
+      "POST /tokens/:tokenId/mint",
+      "POST /tokens/:tokenId/mint/prepare",
+      "POST /tokens/:tokenId/pause",
+      "POST /tokens/:tokenId/seize",
+      "POST /tokens/:tokenId/seize/prepare",
+      "POST /tokens/:tokenId/unfreeze",
+      "POST /tokens/:tokenId/unpause",
+    ]);
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
@@ -61,6 +61,12 @@ export async function createApiKeyAction(formData: FormData) {
   const name = String(formData.get("name") ?? "").trim();
   const role = String(formData.get("role") ?? "api_developer");
   const environment = String(formData.get("environment") ?? "sandbox");
+  const walletScope = String(formData.get("walletScope") ?? "").trim();
+  const defaultWalletId = String(formData.get("signingWalletId") ?? "").trim();
+  const signingWalletIds = formData
+    .getAll("signingWalletIds")
+    .map((value) => String(value).trim())
+    .filter(Boolean);
   const expiresAtRaw = String(formData.get("expiresAt") ?? "").trim();
 
   if (!name) {
@@ -71,11 +77,30 @@ export async function createApiKeyAction(formData: FormData) {
     redirect(API_KEYS_PAGE_PATH);
   }
 
+  if (walletScope !== "all" && walletScope !== "selected") {
+    await setFlash({
+      level: "error",
+      message: "Choose whether this key can access all wallets or selected wallets.",
+    });
+    redirect(API_KEYS_PAGE_PATH);
+  }
+
+  if (walletScope === "selected" && signingWalletIds.length === 0) {
+    await setFlash({
+      level: "error",
+      message: "Select at least one wallet for a wallet-scoped API key.",
+    });
+    redirect(API_KEYS_PAGE_PATH);
+  }
+
   const payload: {
     name: string;
     role: "api_admin" | "api_developer" | "api_readonly";
     environment: "sandbox" | "production";
+    walletScope: "all" | "selected";
     expiresAt?: string;
+    signingWalletId?: string;
+    signingWalletIds?: string[];
   } = {
     name,
     role:
@@ -83,7 +108,13 @@ export async function createApiKeyAction(formData: FormData) {
         ? role
         : "api_developer",
     environment: environment === "production" ? "production" : "sandbox",
+    walletScope: walletScope === "selected" ? "selected" : "all",
   };
+
+  if (walletScope === "selected") {
+    payload.signingWalletIds = signingWalletIds;
+    payload.signingWalletId = defaultWalletId || signingWalletIds[0];
+  }
 
   if (expiresAtRaw) {
     const parsedDate = new Date(expiresAtRaw);
@@ -123,7 +154,7 @@ export async function createApiKeyAction(formData: FormData) {
     });
   }
 
-  revalidatePath(API_KEYS_PAGE_PATH);
+  revalidatePath(API_KEYS_PAGE_PATH, "page");
   redirect(API_KEYS_PAGE_PATH);
 }
 
@@ -169,7 +200,7 @@ export async function rotateApiKeyAction(formData: FormData) {
     });
   }
 
-  revalidatePath(API_KEYS_PAGE_PATH);
+  revalidatePath(API_KEYS_PAGE_PATH, "page");
   redirect(API_KEYS_PAGE_PATH);
 }
 
@@ -229,6 +260,6 @@ export async function deactivateApiKeyAction(formData: FormData) {
     });
   }
 
-  revalidatePath(API_KEYS_PAGE_PATH);
+  revalidatePath(API_KEYS_PAGE_PATH, "page");
   redirect(API_KEYS_PAGE_PATH);
 }

--- a/apps/sdp-web/src/app/dashboard/api-keys/create-api-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/create-api-key-modal.tsx
@@ -4,18 +4,23 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useEscapeKey } from "@/lib/use-escape-key";
+import type { PaymentsDashboardWallet } from "@sdp/types";
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import { createApiKeyAction } from "./actions";
 
 type ApiKeyRole = "api_admin" | "api_developer" | "api_readonly";
 type ApiKeyEnvironment = "sandbox" | "production";
+type WalletScope = "all" | "selected";
 
 interface ApiKeyDraft {
   name: string;
   role: ApiKeyRole;
   environment: ApiKeyEnvironment;
   expiresAt: string;
+  walletScope: WalletScope;
+  selectedWalletIds: string[];
+  defaultWalletId: string;
 }
 
 function normalizeDraft(): ApiKeyDraft {
@@ -24,6 +29,9 @@ function normalizeDraft(): ApiKeyDraft {
     role: "api_developer",
     environment: "sandbox",
     expiresAt: "",
+    walletScope: "all",
+    selectedWalletIds: [],
+    defaultWalletId: "",
   };
 }
 
@@ -34,13 +42,345 @@ function formatDisplayDate(value: string): string {
   return date.toLocaleString();
 }
 
+function formatWalletLabel(wallet: PaymentsDashboardWallet): string {
+  return wallet.label?.trim() || wallet.walletId;
+}
+
+function formatRoleLabel(role: ApiKeyRole): string {
+  if (role === "api_admin") return "Admin";
+  if (role === "api_readonly") return "Read only";
+  return "Developer";
+}
+
+function truncateAddress(value: string): string {
+  if (value.length <= 14) return value;
+  return `${value.slice(0, 6)}...${value.slice(-6)}`;
+}
+
 interface CreateApiKeyModalProps {
+  wallets: PaymentsDashboardWallet[];
   triggerMode?: "button" | "icon";
   triggerLabel?: string;
   triggerVariant?: "default" | "secondary";
 }
 
+function resolveDefaultSelectedWallet(
+  selectedWallets: PaymentsDashboardWallet[],
+  defaultWalletId: string
+): PaymentsDashboardWallet | null {
+  return (
+    selectedWallets.find((wallet) => wallet.walletId === defaultWalletId) ??
+    selectedWallets[0] ??
+    null
+  );
+}
+
+function WalletAccessSection({
+  draft,
+  wallets,
+  selectedWallets,
+  setDraft,
+  toggleWallet,
+}: {
+  draft: ApiKeyDraft;
+  wallets: PaymentsDashboardWallet[];
+  selectedWallets: PaymentsDashboardWallet[];
+  setDraft: Dispatch<SetStateAction<ApiKeyDraft>>;
+  toggleWallet: (walletId: string) => void;
+}) {
+  return (
+    <div className="grid gap-3">
+      <div>
+        <Label>Wallet access</Label>
+        <p className="mt-1 text-xs text-[rgba(28,28,29,0.65)]">
+          Choose whether this key can use every wallet in scope or only selected wallets.
+        </p>
+      </div>
+
+      <label className="flex items-start gap-3 rounded-lg border border-[rgba(28,28,29,0.14)] p-3">
+        <input
+          type="radio"
+          name="wallet-access"
+          value="all"
+          checked={draft.walletScope === "all"}
+          onChange={() => setDraft((previous) => ({ ...previous, walletScope: "all" }))}
+          className="mt-1"
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-[#1c1c1d]">All wallets</p>
+          <p className="text-xs text-[rgba(28,28,29,0.65)]">
+            This key can use every wallet available in its org or project scope.
+          </p>
+        </div>
+      </label>
+
+      <label className="flex items-start gap-3 rounded-lg border border-[rgba(28,28,29,0.14)] p-3">
+        <input
+          type="radio"
+          name="wallet-access"
+          value="selected"
+          checked={draft.walletScope === "selected"}
+          onChange={() => setDraft((previous) => ({ ...previous, walletScope: "selected" }))}
+          className="mt-1"
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-[#1c1c1d]">Selected wallets</p>
+          <p className="text-xs text-[rgba(28,28,29,0.65)]">
+            Restrict this key to a specific wallet set and choose its default signing wallet.
+          </p>
+        </div>
+      </label>
+
+      {draft.walletScope === "selected" ? (
+        <div className="rounded-lg border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.02)] p-3">
+          {wallets.length === 0 ? (
+            <p className="text-sm text-[rgba(28,28,29,0.72)]">
+              No active wallets are available for binding yet.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <div className="space-y-2">
+                {wallets.map((wallet) => {
+                  const checked = draft.selectedWalletIds.includes(wallet.walletId);
+
+                  return (
+                    <label
+                      key={wallet.walletId}
+                      className="flex items-start gap-3 rounded-lg border border-[rgba(28,28,29,0.12)] bg-white px-3 py-2"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleWallet(wallet.walletId)}
+                        className="mt-1"
+                      />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-[#1c1c1d]">
+                          {formatWalletLabel(wallet)}
+                        </p>
+                        <p className="text-xs text-[rgba(28,28,29,0.65)]">
+                          {wallet.walletId} · {truncateAddress(wallet.publicKey)}
+                        </p>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+
+              {draft.selectedWalletIds.length > 1 ? (
+                <div className="grid gap-2">
+                  <Label htmlFor="create-key-default-wallet">Default signing wallet</Label>
+                  <select
+                    id="create-key-default-wallet"
+                    value={draft.defaultWalletId}
+                    onChange={(event) => {
+                      const defaultWalletId = event.currentTarget.value;
+                      setDraft((previous) => ({ ...previous, defaultWalletId }));
+                    }}
+                    className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
+                  >
+                    {selectedWallets.map((wallet) => (
+                      <option key={wallet.walletId} value={wallet.walletId}>
+                        {formatWalletLabel(wallet)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CreateApiKeyDetailsStep({
+  draft,
+  wallets,
+  selectedWallets,
+  canContinue,
+  close,
+  nextStep,
+  setDraft,
+  toggleWallet,
+}: {
+  draft: ApiKeyDraft;
+  wallets: PaymentsDashboardWallet[];
+  selectedWallets: PaymentsDashboardWallet[];
+  canContinue: boolean;
+  close: () => void;
+  nextStep: () => void;
+  setDraft: Dispatch<SetStateAction<ApiKeyDraft>>;
+  toggleWallet: (walletId: string) => void;
+}) {
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="grid gap-2">
+        <Label htmlFor="create-key-name">Name</Label>
+        <Input
+          id="create-key-name"
+          value={draft.name}
+          onChange={(event) => {
+            const name = event.currentTarget.value;
+            setDraft((previous) => ({ ...previous, name }));
+          }}
+          placeholder="CI deploy key"
+          required
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="create-key-role">Role</Label>
+        <select
+          id="create-key-role"
+          value={draft.role}
+          onChange={(event) => {
+            const role = event.currentTarget.value as ApiKeyRole;
+            setDraft((previous) => ({ ...previous, role }));
+          }}
+          className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
+        >
+          <option value="api_admin">Admin</option>
+          <option value="api_developer">Developer</option>
+          <option value="api_readonly">Read only</option>
+        </select>
+        <p className="text-xs text-[rgba(28,28,29,0.65)]">
+          Admin includes custody and platform-level privileges. Developer excludes custody actions.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="create-key-environment">Environment</Label>
+        <select
+          id="create-key-environment"
+          value={draft.environment}
+          onChange={(event) => {
+            const environment = event.currentTarget.value as ApiKeyEnvironment;
+            setDraft((previous) => ({ ...previous, environment }));
+          }}
+          className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
+        >
+          <option value="sandbox">Sandbox</option>
+          <option value="production">Production</option>
+        </select>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="create-key-expires-at">Expiration (optional)</Label>
+        <Input
+          id="create-key-expires-at"
+          name="expiresAt"
+          type="datetime-local"
+          value={draft.expiresAt}
+          onChange={(event) => {
+            const expiresAt = event.currentTarget.value;
+            setDraft((previous) => ({ ...previous, expiresAt }));
+          }}
+        />
+      </div>
+
+      <WalletAccessSection
+        draft={draft}
+        wallets={wallets}
+        selectedWallets={selectedWallets}
+        setDraft={setDraft}
+        toggleWallet={toggleWallet}
+      />
+
+      <div className="mt-2 flex items-center justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={close}>
+          Cancel
+        </Button>
+        <Button type="button" disabled={!canContinue} onClick={nextStep}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CreateApiKeyReviewStep({
+  draft,
+  selectedWallets,
+  onBack,
+}: {
+  draft: ApiKeyDraft;
+  selectedWallets: PaymentsDashboardWallet[];
+  onBack: () => void;
+}) {
+  const defaultSelectedWallet = resolveDefaultSelectedWallet(
+    selectedWallets,
+    draft.defaultWalletId
+  );
+
+  return (
+    <form action={createApiKeyAction} className="mt-4 space-y-3">
+      <input type="hidden" name="name" value={draft.name} />
+      <input type="hidden" name="role" value={draft.role} />
+      <input type="hidden" name="environment" value={draft.environment} />
+      <input type="hidden" name="expiresAt" value={draft.expiresAt} />
+      <input type="hidden" name="walletScope" value={draft.walletScope} />
+      {draft.walletScope === "selected"
+        ? selectedWallets.map((wallet) => (
+            <input
+              key={wallet.walletId}
+              type="hidden"
+              name="signingWalletIds"
+              value={wallet.walletId}
+            />
+          ))
+        : null}
+      {draft.walletScope === "selected" && draft.defaultWalletId ? (
+        <input type="hidden" name="signingWalletId" value={draft.defaultWalletId} />
+      ) : null}
+
+      <div className="grid gap-2 rounded-lg border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
+        <div>
+          <span className="font-medium text-[#1c1c1d]">Name:</span> {draft.name}
+        </div>
+        <div>
+          <span className="font-medium text-[#1c1c1d]">Role:</span> {formatRoleLabel(draft.role)}
+        </div>
+        <div>
+          <span className="font-medium text-[#1c1c1d]">Environment:</span> {draft.environment}
+        </div>
+        <div>
+          <span className="font-medium text-[#1c1c1d]">Expires:</span>{" "}
+          {formatDisplayDate(draft.expiresAt)}
+        </div>
+        <div>
+          <span className="font-medium text-[#1c1c1d]">Wallet access:</span>{" "}
+          {draft.walletScope === "all" ? "All wallets" : "Selected wallets"}
+        </div>
+        {draft.walletScope === "selected" ? (
+          <>
+            <div>
+              <span className="font-medium text-[#1c1c1d]">Selected:</span>{" "}
+              {selectedWallets.map(formatWalletLabel).join(", ")}
+            </div>
+            <div>
+              <span className="font-medium text-[#1c1c1d]">Default signing wallet:</span>{" "}
+              {defaultSelectedWallet ? formatWalletLabel(defaultSelectedWallet) : "None"}
+            </div>
+          </>
+        ) : null}
+      </div>
+      <p className="text-xs text-[rgba(28,28,29,0.72)]">
+        After creation, the full key will be shown once in a secure modal.
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onBack}>
+          Back
+        </Button>
+        <Button type="submit">Create key</Button>
+      </div>
+    </form>
+  );
+}
+
 export function CreateApiKeyModal({
+  wallets,
   triggerMode = "button",
   triggerLabel = "Create API key",
   triggerVariant = "default",
@@ -48,6 +388,13 @@ export function CreateApiKeyModal({
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<1 | 2>(1);
   const [draft, setDraft] = useState<ApiKeyDraft>(normalizeDraft());
+
+  const selectedWallets = wallets.filter((wallet) =>
+    draft.selectedWalletIds.includes(wallet.walletId)
+  );
+  const canContinue =
+    draft.name.trim().length > 0 &&
+    (draft.walletScope === "all" || draft.selectedWalletIds.length > 0);
 
   const close = () => {
     setIsOpen(false);
@@ -58,8 +405,26 @@ export function CreateApiKeyModal({
   useEscapeKey(isOpen, close);
 
   const nextStep = () => {
-    if (!draft.name.trim()) return;
+    if (!canContinue) return;
     setStep(2);
+  };
+
+  const toggleWallet = (walletId: string) => {
+    setDraft((previous) => {
+      const alreadySelected = previous.selectedWalletIds.includes(walletId);
+      const selectedWalletIds = alreadySelected
+        ? previous.selectedWalletIds.filter((value) => value !== walletId)
+        : [...previous.selectedWalletIds, walletId];
+      const defaultWalletId = selectedWalletIds.includes(previous.defaultWalletId)
+        ? previous.defaultWalletId
+        : (selectedWalletIds[0] ?? "");
+
+      return {
+        ...previous,
+        selectedWalletIds,
+        defaultWalletId,
+      };
+    });
   };
 
   return (
@@ -89,123 +454,33 @@ export function CreateApiKeyModal({
             className="absolute inset-0 bg-black/35"
             onClick={close}
           />
-          <div className="relative z-10 w-full max-w-lg rounded-2xl border border-[rgba(28,28,29,0.16)] bg-white p-6 shadow-lg">
+          <div className="relative z-10 w-full max-w-2xl rounded-2xl border border-[rgba(28,28,29,0.16)] bg-white p-6 shadow-lg">
             <p className="text-sm font-semibold text-[#1c1c1d]">
               {step === 1 ? "Create API key" : "Review API key"}
             </p>
             <p className="mt-1 text-sm text-[rgba(28,28,29,0.72)]">
-              {step === 1 ? "Define key details, then confirm." : "Review and confirm the request."}
+              {step === 1
+                ? "Define key details and wallet access, then confirm."
+                : "Review and confirm the request."}
             </p>
 
             {step === 1 ? (
-              <div className="mt-4 space-y-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="create-key-name">Name</Label>
-                  <Input
-                    id="create-key-name"
-                    value={draft.name}
-                    onChange={(event) => {
-                      const name = event.currentTarget.value;
-                      setDraft((previous) => ({ ...previous, name }));
-                    }}
-                    placeholder="CI deploy key"
-                    required
-                  />
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="create-key-role">Role</Label>
-                  <select
-                    id="create-key-role"
-                    value={draft.role}
-                    onChange={(event) => {
-                      const role = event.currentTarget.value as ApiKeyRole;
-                      setDraft((previous) => ({ ...previous, role }));
-                    }}
-                    className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
-                  >
-                    <option value="api_admin">Admin</option>
-                    <option value="api_developer">Developer</option>
-                    <option value="api_readonly">Read only</option>
-                  </select>
-                  <p className="text-xs text-[rgba(28,28,29,0.65)]">
-                    Admin includes custody and platform-level privileges. Developer excludes custody
-                    actions.
-                  </p>
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="create-key-environment">Environment</Label>
-                  <select
-                    id="create-key-environment"
-                    value={draft.environment}
-                    onChange={(event) => {
-                      const environment = event.currentTarget.value as ApiKeyEnvironment;
-                      setDraft((previous) => ({ ...previous, environment }));
-                    }}
-                    className="h-10 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
-                  >
-                    <option value="sandbox">Sandbox</option>
-                    <option value="production">Production</option>
-                  </select>
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="create-key-expires-at">Expiration (optional)</Label>
-                  <Input
-                    id="create-key-expires-at"
-                    name="expiresAt"
-                    type="datetime-local"
-                    value={draft.expiresAt}
-                    onChange={(event) => {
-                      const expiresAt = event.currentTarget.value;
-                      setDraft((previous) => ({ ...previous, expiresAt }));
-                    }}
-                  />
-                </div>
-
-                <div className="mt-2 flex items-center justify-end gap-2">
-                  <Button type="button" variant="secondary" onClick={close}>
-                    Cancel
-                  </Button>
-                  <Button type="button" disabled={!draft.name.trim()} onClick={nextStep}>
-                    Continue
-                  </Button>
-                </div>
-              </div>
+              <CreateApiKeyDetailsStep
+                draft={draft}
+                wallets={wallets}
+                selectedWallets={selectedWallets}
+                canContinue={canContinue}
+                close={close}
+                nextStep={nextStep}
+                setDraft={setDraft}
+                toggleWallet={toggleWallet}
+              />
             ) : (
-              <form action={createApiKeyAction} className="mt-4 space-y-3">
-                <input type="hidden" name="name" value={draft.name} />
-                <input type="hidden" name="role" value={draft.role} />
-                <input type="hidden" name="environment" value={draft.environment} />
-                <input type="hidden" name="expiresAt" value={draft.expiresAt} />
-
-                <div className="grid gap-2 rounded-lg border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.02)] p-3 text-sm text-[rgba(28,28,29,0.72)]">
-                  <div>
-                    <span className="font-medium text-[#1c1c1d]">Name:</span> {draft.name}
-                  </div>
-                  <div>
-                    <span className="font-medium text-[#1c1c1d]">Role:</span> {draft.role}
-                  </div>
-                  <div>
-                    <span className="font-medium text-[#1c1c1d]">Environment:</span>{" "}
-                    {draft.environment}
-                  </div>
-                  <div>
-                    <span className="font-medium text-[#1c1c1d]">Expires:</span>{" "}
-                    {formatDisplayDate(draft.expiresAt)}
-                  </div>
-                </div>
-                <p className="text-xs text-[rgba(28,28,29,0.72)]">
-                  After creation, the full key will be shown once in a secure modal.
-                </p>
-                <div className="mt-3 flex items-center justify-end gap-2">
-                  <Button type="button" variant="secondary" onClick={() => setStep(1)}>
-                    Back
-                  </Button>
-                  <Button type="submit">Create key</Button>
-                </div>
-              </form>
+              <CreateApiKeyReviewStep
+                draft={draft}
+                selectedWallets={selectedWallets}
+                onBack={() => setStep(1)}
+              />
             )}
           </div>
         </div>

--- a/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
@@ -30,10 +30,6 @@ function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyM
     });
   }, [keyValue, keyPrefix]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   const close = async () => {
     setIsOpen(false);
     await clearApiKeyFlashAction();
@@ -42,6 +38,10 @@ function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyM
   useEscapeKey(isOpen, () => {
     void close();
   });
+
+  if (!isOpen) {
+    return null;
+  }
 
   const copy = async () => {
     try {

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -14,14 +14,18 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { sdpApiFetch } from "@/lib/sdp-api";
+import { createSdpApiClient, sdpApiFetch } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
+import type { PaymentsDashboardWallet } from "@sdp/types";
 import { redirect } from "next/navigation";
+import { fetchPaymentsWallets } from "../payments/payments-page.data";
 import { consumeApiKeyFlash } from "./actions";
 import { ApiKeyActionsMenu } from "./api-key-actions-menu";
 import { CreateApiKeyModal } from "./create-api-key-modal";
 import { FlashClearTrigger } from "./flash-clear-trigger";
 import { GeneratedApiKeyModal } from "./generated-key-modal";
+
+export const dynamic = "force-dynamic";
 
 type ApiKeyRole = "api_admin" | "api_developer" | "api_readonly";
 type ApiKeyEnvironment = "sandbox" | "production";
@@ -50,6 +54,12 @@ function formatDate(value: string | null): string {
   });
 }
 
+function formatRole(role: ApiKeyRole): string {
+  if (role === "api_admin") return "Admin";
+  if (role === "api_readonly") return "Read only";
+  return "Developer";
+}
+
 export default async function ApiKeysPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
@@ -59,15 +69,18 @@ export default async function ApiKeysPage() {
     redirect("/dashboard");
   }
 
-  const [flash, apiKeysResponse] = await Promise.all([
+  const apiClient = await createSdpApiClient();
+  const [flash, apiKeysResponse, walletsResponse] = await Promise.all([
     consumeApiKeyFlash(),
     sdpApiFetch<{ apiKeys: ApiKeyRecord[] }>("/v1/api-keys"),
+    fetchPaymentsWallets(apiClient.request),
   ]);
 
   const apiKeys = [...apiKeysResponse.apiKeys].sort((a, b) => {
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
   });
   const hasGeneratedKeyFlash = Boolean(flash?.key);
+  const wallets: PaymentsDashboardWallet[] = walletsResponse.ok ? (walletsResponse.data ?? []) : [];
 
   return (
     <div className="w-full flex flex-col gap-6">
@@ -98,7 +111,7 @@ export default async function ApiKeysPage() {
           <CardTitle>Existing API keys</CardTitle>
           <CardDescription>Active and historical keys for this workspace.</CardDescription>
           <CardAction>
-            <CreateApiKeyModal triggerLabel="New API key" />
+            <CreateApiKeyModal triggerLabel="New API key" wallets={wallets} />
           </CardAction>
         </CardHeader>
         <CardContent>
@@ -138,7 +151,7 @@ export default async function ApiKeysPage() {
                         <span className="block truncate">{key.keyPrefix}</span>
                       </TableCell>
                       <TableCell className="text-xs">
-                        <span className="block truncate">{key.role}</span>
+                        <span className="block truncate">{formatRole(key.role)}</span>
                       </TableCell>
                       <TableCell className="text-xs">
                         <span className="block truncate">{key.environment}</span>

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -228,7 +228,9 @@ export async function checkWalletSignerMemoAction(
         name: keyName,
         role: "api_developer",
         environment: "sandbox",
+        walletScope: "selected",
         signingWalletId: resolvedWalletId,
+        signingWalletIds: [resolvedWalletId],
         expiresAt: new Date(now + 10 * 60 * 1000).toISOString(),
       }),
     });

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -12,6 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import type { PaymentsDashboardWallet } from "@sdp/types";
 import Link from "next/link";
 import type { HomeActivityRow } from "./home-page.data";
 import { formatCurrencyAmount, formatDisplayAmount } from "./payments/payments-overview.utils";
@@ -24,6 +25,7 @@ interface HomeWorkspaceProps {
   activityRows: HomeActivityRow[];
   activityError: string | null;
   activityNotice: string | null;
+  wallets: PaymentsDashboardWallet[];
   walletProviders: KnownCustodyProvider[];
   walletDisabledReason: string | null;
 }
@@ -89,6 +91,7 @@ export function HomeWorkspace({
   activityRows,
   activityError,
   activityNotice,
+  wallets,
   walletProviders,
   walletDisabledReason,
 }: HomeWorkspaceProps) {
@@ -96,7 +99,11 @@ export function HomeWorkspace({
     <div className="w-full space-y-8 py-2">
       <SectionEntry>
         <div className="flex flex-wrap items-center justify-end gap-3">
-          <CreateApiKeyModal triggerLabel="Create API key" triggerVariant="secondary" />
+          <CreateApiKeyModal
+            triggerLabel="Create API key"
+            triggerVariant="secondary"
+            wallets={wallets}
+          />
           <CreateWalletModal
             triggerLabel="Create Wallet"
             providers={walletProviders}

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -13,7 +13,11 @@ import {
   normalizeAggregateBalances,
   resolveTotalBalance,
 } from "./payments/payments-overview.utils";
-import { fetchPaymentTransfers, fetchPaymentsAggregate } from "./payments/payments-page.data";
+import {
+  fetchPaymentTransfers,
+  fetchPaymentsAggregate,
+  fetchPaymentsWallets,
+} from "./payments/payments-page.data";
 
 export default async function DashboardPage() {
   const { userId, orgId } = await auth();
@@ -25,13 +29,19 @@ export default async function DashboardPage() {
   }
 
   const apiClient = await createSdpApiClient();
-  const [aggregateResult, transfersResult, walletProvidersResult, issuanceTokensResult] =
-    await Promise.all([
-      fetchPaymentsAggregate(apiClient.request),
-      fetchPaymentTransfers(apiClient.request, 100),
-      fetchCreateWalletProviders(apiClient.request),
-      fetchIssuanceTokens(apiClient.request, 10),
-    ]);
+  const [
+    aggregateResult,
+    transfersResult,
+    walletsResult,
+    walletProvidersResult,
+    issuanceTokensResult,
+  ] = await Promise.all([
+    fetchPaymentsAggregate(apiClient.request),
+    fetchPaymentTransfers(apiClient.request, 100),
+    fetchPaymentsWallets(apiClient.request),
+    fetchCreateWalletProviders(apiClient.request),
+    fetchIssuanceTokens(apiClient.request, 10),
+  ]);
 
   const issuanceActivityResult =
     issuanceTokensResult.ok && issuanceTokensResult.data
@@ -73,6 +83,7 @@ export default async function DashboardPage() {
       activityRows={activityRows}
       activityError={activityError}
       activityNotice={activityNotice || null}
+      wallets={walletsResult.data ?? []}
       walletProviders={walletProvidersResult.data ?? []}
       walletDisabledReason={
         walletProvidersError ??

--- a/packages/sdp-api-integration/src/tests/api-keys-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/api-keys-flow.test.ts
@@ -94,6 +94,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("API Key Integrati
             "payments:write",
             "wallets:read",
           ],
+          walletScope: "selected",
           signingWalletId: sourceWallet.walletId,
         }),
       });

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -225,6 +225,7 @@ describe("Kora Fee Payment (Devnet)", () => {
         body: JSON.stringify({
           name: "Signer check integration key",
           permissions: ["wallets:write"],
+          walletScope: "selected",
           signingWalletId: walletId,
         }),
       });

--- a/packages/sdp-types/src/api-keys.ts
+++ b/packages/sdp-types/src/api-keys.ts
@@ -10,6 +10,8 @@ export type ApiKeyStatus = "active" | "revoked" | "expired" | "deactivated";
 
 export type RateLimitTier = "standard" | "elevated" | "unlimited";
 
+export type ApiKeyWalletScope = "all" | "selected";
+
 export interface ApiKeyWalletBinding {
   walletId: string;
   permissions: Permission[];
@@ -67,6 +69,7 @@ export interface CreateApiKeyRequest {
   role?: ApiKeyRole;
   permissions?: Permission[];
   environment?: ApiKeyEnvironment;
+  walletScope: ApiKeyWalletScope;
   allowedIps?: string[]; // CIDR ranges for IP restriction
   expiresAt?: string; // ISO date string
   signingWalletId?: string;
@@ -83,6 +86,7 @@ export interface CreateApiKeyRequest {
 export interface UpdateApiKeyRequest {
   name?: string;
   description?: string;
+  walletScope?: ApiKeyWalletScope;
   allowedIps?: string[] | null; // null to remove IP restrictions
   expiresAt?: string | null; // null to remove expiration
   permissions?: Permission[] | null; // null to revert to role defaults


### PR DESCRIPTION
## Summary
- unify API key wallet-scope authorization across custody and payments wallet routes
- enforce outbound wallet policy limits on custody-backed off-ramp flows
- require explicit wallet scope in API key creation and mirror it in the dashboard UI
- add auth coverage tests for wallet-scoped routes and API key wallet-scope behavior

## Validation
- pnpm --filter @sdp/api typecheck
- pnpm --filter sdp-web typecheck
- pnpm --filter @sdp/api exec vitest run src/lib/api-key-wallet-auth.test.ts src/routes/api-keys/wallet-bindings.test.ts src/routes/api-keys-wallet-scope.test.ts src/routes/custody-wallet-scope.test.ts src/routes/payments.test.ts src/routes/projects.test.ts src/routes/wallet-scope-route-coverage.test.ts
- pnpm exec biome check --write <touched files>