### PR TITLE
feat(docs): add postman api key suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,3 +220,33 @@ jobs:
 
       - name: Integration tests
         run: pnpm test:integration
+
+  postman_api_key_suite:
+    name: Postman API Key Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      POSTMAN_API_BASE_URL: ${{ vars.POSTMAN_API_BASE_URL || secrets.POSTMAN_API_BASE_URL }}
+      POSTMAN_ADMIN_API_KEY: ${{ secrets.POSTMAN_ADMIN_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Postman API key suite
+        run: pnpm test:postman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,15 @@ jobs:
           cache: pnpm
 
       - name: Install
+        if: ${{ env.POSTMAN_API_BASE_URL != '' && env.POSTMAN_ADMIN_API_KEY != '' }}
         run: pnpm install --frozen-lockfile
 
+      - name: Skip Postman API key suite (missing CI secrets)
+        if: ${{ env.POSTMAN_API_BASE_URL == '' || env.POSTMAN_ADMIN_API_KEY == '' }}
+        run: |
+          echo "Skipping Postman API Key Suite."
+          echo "Configure POSTMAN_API_BASE_URL and POSTMAN_ADMIN_API_KEY to enable the required smoke suite."
+
       - name: Run Postman API key suite
+        if: ${{ env.POSTMAN_API_BASE_URL != '' && env.POSTMAN_ADMIN_API_KEY != '' }}
         run: pnpm test:postman

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -2,7 +2,6 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
 import {
-  createConfidentialTransferRequestSchema,
   createTransferRequestSchema,
   errorResponseSchema,
   executeOfframpRequestSchema,
@@ -19,7 +18,6 @@ import {
 } from "../schemas";
 import { errorResponses, jsonContent } from "./helpers";
 import {
-  feeQuoteResponse,
   offrampExecutionResponse,
   onrampExecutionResponse,
   prepareTransferResponse,
@@ -28,10 +26,6 @@ import {
   walletBalancesResponse,
   walletPolicyResponse,
 } from "./responses";
-
-const draftNotice =
-  "DRAFT: This endpoint is not implemented yet. It is provided for discussion and review only.";
-const withDraft = (description: string) => `${draftNotice}\n\n${description}`;
 
 export function registerPaymentsPaths(registry: OpenAPIRegistry) {
   // ═══════════════════════════════════════════════════════════════════════════
@@ -169,9 +163,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     tags: ["Payments"],
     summary: "List transfers",
     operationId: "listPaymentTransfers",
-    description: withDraft(
-      "Lists payment transfers for the authenticated organization or project scope."
-    ),
+    description: "Lists payment transfers for the authenticated organization or project scope.",
     security: [{ apiKeyAuth: [] }],
     request: {
       query: z.object({
@@ -198,35 +190,12 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
   });
 
   registry.registerPath({
-    method: "post",
-    path: "/v1/payments/transfers/confidential",
-    tags: ["Payments"],
-    summary: "Create confidential transfer",
-    operationId: "createConfidentialTransfer",
-    description: withDraft("Creates a confidential transfer using Token-2022."),
-    security: [{ apiKeyAuth: [] }],
-    request: {
-      body: {
-        required: true,
-        content: jsonContent(createConfidentialTransferRequestSchema),
-      },
-    },
-    responses: {
-      200: {
-        description: "Confidential transfer executed",
-        content: jsonContent(transferResponse),
-      },
-      ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
-    },
-  });
-
-  registry.registerPath({
     method: "get",
     path: "/v1/payments/transfers/{transferId}",
     tags: ["Payments"],
     summary: "Get transfer",
     operationId: "getPaymentTransfer",
-    description: withDraft("Retrieves details for a specific transfer."),
+    description: "Retrieves details for a specific transfer.",
     security: [{ apiKeyAuth: [] }],
     request: {
       params: z.object({
@@ -241,36 +210,6 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
       ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
     },
   });
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // Fees
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  registry.registerPath({
-    method: "get",
-    path: "/v1/payments/fees/quote",
-    tags: ["Payments"],
-    summary: "Get fee quote",
-    operationId: "getPaymentFeeQuote",
-    description: withDraft("Retrieves a fee quote for a transfer."),
-    security: [{ apiKeyAuth: [] }],
-    request: {
-      query: z.object({
-        token: z.string().openapi({ description: "Fee token symbol or mint address." }),
-      }),
-    },
-    responses: {
-      200: {
-        description: "Fee quote",
-        content: jsonContent(feeQuoteResponse),
-      },
-      ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
-    },
-  });
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // Ramps
-  // ═══════════════════════════════════════════════════════════════════════════
 
   registry.registerPath({
     method: "post",

--- a/apps/sdp-api/src/openapi/spec.ts
+++ b/apps/sdp-api/src/openapi/spec.ts
@@ -11,6 +11,7 @@ import { registerIssuancePaths } from "./paths/issuance";
 import { registerMemberPaths } from "./paths/members";
 import { registerOnboardingPaths } from "./paths/onboarding";
 import { registerOrganizationPaths } from "./paths/organizations";
+import { registerPaymentsPaths } from "./paths/payments";
 import { registerProjectPaths } from "./paths/projects";
 import { registerRpcPaths } from "./paths/rpc";
 
@@ -55,6 +56,7 @@ export function createOpenApiDocument(): OpenAPIObject {
   registerProjectPaths(registry);
   registerRpcPaths(registry);
   registerIssuancePaths(registry);
+  registerPaymentsPaths(registry);
   registerCompliancePaths(registry);
   registerAdminPaths(registry);
   registerOnboardingPaths(registry);
@@ -82,6 +84,10 @@ export function createOpenApiDocument(): OpenAPIObject {
       { name: "Projects", description: "Project and project member management." },
       { name: "RPC", description: "Managed Solana RPC relay and provider telemetry." },
       { name: "Issuance", description: "Token issuance, allowlists, and lifecycle operations." },
+      {
+        name: "Payments",
+        description: "Wallet balances, transfer execution, policies, and ramps.",
+      },
       { name: "Compliance", description: "Risk and compliance screening endpoints." },
       { name: "Admin", description: "Administrative allowlist management." },
       { name: "Onboarding", description: "Clerk organization onboarding and linking." },

--- a/apps/sdp-docs/content/docs/guides/manage-api-keys.mdx
+++ b/apps/sdp-docs/content/docs/guides/manage-api-keys.mdx
@@ -31,9 +31,18 @@ API keys authenticate every request to the SDP API. Each key is scoped to an env
    - **Name** — a descriptive label (e.g., "CI deploy key")
    - **Role** — Admin, Developer, or Read only
    - **Environment** — Sandbox or Production
+   - **Wallet scope** — All wallets or Selected wallets
    - **Expiration (optional)** — date/time picker
 4. **Step 2 — Review and confirm:** verify the summary and click **Create key**.
 5. The full key appears in a modal titled **API key generated**. Click **Copy** and save it — it will not be shown again.
+
+### Download the Postman collection
+
+- [Download the admin API key Postman collection](/downloads/sdp-api-admin.postman_collection.json)
+- [Download the Postman environment template](/downloads/sdp-api-admin.postman_environment.template.json)
+- [View the generated coverage manifest](/downloads/sdp-api-admin.postman_manifest.json)
+
+The collection is generated from the repository API inventory and is designed for sandbox smoke testing with a dedicated admin key, an active wallet, and a funded sandbox organization.
 
 ### Rotate a key
 
@@ -60,6 +69,7 @@ curl -X POST https://api.solana.com/v1/api-keys \
     "name": "CI deploy key",
     "role": "api_developer",
     "environment": "sandbox",
+    "walletScope": "all",
     "expiresAt": "2026-12-31T23:59:59Z"
   }'
 ```
@@ -76,6 +86,7 @@ const response = await fetch("https://api.solana.com/v1/api-keys", {
     name: "CI deploy key",
     role: "api_developer",
     environment: "sandbox",
+    walletScope: "all",
     expiresAt: "2026-12-31T23:59:59Z",
   }),
 });
@@ -94,6 +105,7 @@ HttpRequest request = HttpRequest.newBuilder()
           "name": "CI deploy key",
           "role": "api_developer",
           "environment": "sandbox",
+          "walletScope": "all",
           "expiresAt": "2026-12-31T23:59:59Z"
         }"""))
     .build();
@@ -103,7 +115,7 @@ HttpRequest request = HttpRequest.newBuilder()
 
 The response includes the full `key` value — **save it, it is only returned once**.
 
-Optional fields: `allowedIps` (CIDR ranges), `permissions` (fine-grained), `signingWalletId`.
+Optional fields: `allowedIps` (CIDR ranges), `permissions` (fine-grained), `signingWalletId`, `walletBindings`.
 
 ### Rotate a key
 

--- a/apps/sdp-docs/content/docs/meta.json
+++ b/apps/sdp-docs/content/docs/meta.json
@@ -24,6 +24,7 @@
     "reference/api/wallets",
     "reference/api/projects",
     "reference/api/issuance",
+    "reference/api/payments",
     "reference/api/compliance"
   ]
 }

--- a/apps/sdp-docs/package.json
+++ b/apps/sdp-docs/package.json
@@ -5,12 +5,13 @@
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "dev:local": "node scripts/dev.mjs",
-    "build": "pnpm generate:api && pnpm generate:source && next build",
+    "build": "pnpm generate:api && pnpm generate:postman && pnpm generate:source && next build",
     "start": "next start --port 3001",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "generate:api": "pnpm -C ../sdp-api run openapi:generate && node scripts/generate-api-docs.mjs && pnpm exec biome check --write content/docs/meta.json content/docs/reference/api/meta.json",
+    "generate:postman": "node scripts/generate-postman-collection.mjs",
     "generate:source": "node scripts/generate-source.mjs",
     "watch:source": "node scripts/watch-source.mjs"
   },

--- a/apps/sdp-docs/package.json
+++ b/apps/sdp-docs/package.json
@@ -11,7 +11,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "generate:api": "pnpm -C ../sdp-api run openapi:generate && node scripts/generate-api-docs.mjs && pnpm exec biome check --write content/docs/meta.json content/docs/reference/api/meta.json",
-    "generate:postman": "node scripts/generate-postman-collection.mjs",
+    "generate:postman": "node scripts/generate-postman-collection.mjs && pnpm exec biome check --write public/downloads/sdp-api-admin.postman_collection.json public/downloads/sdp-api-admin.postman_environment.template.json public/downloads/sdp-api-admin.postman_manifest.json",
     "generate:source": "node scripts/generate-source.mjs",
     "watch:source": "node scripts/watch-source.mjs"
   },

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json
@@ -291,8 +291,12 @@
                 "exec": [
                   "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
                   "const body = pm.response.json();",
+                  "pm.collectionVariables.set(\"previousTemporaryApiKeyId\", pm.collectionVariables.get(\"temporaryApiKeyId\"));",
+                  "pm.collectionVariables.set(\"previousTemporaryApiKeyName\", pm.collectionVariables.get(\"temporaryApiKeyName\"));",
                   "pm.expect(body.data.apiKey.id).to.match(/^key_/);",
-                  "pm.expect(body.data.apiKey.key).to.match(/^sk_test_/);"
+                  "pm.expect(body.data.apiKey.key).to.match(/^sk_test_/);",
+                  "pm.collectionVariables.set(\"temporaryApiKeyId\", body.data.apiKey.id);",
+                  "pm.collectionVariables.set(\"temporaryApiKeyName\", body.data.apiKey.name);"
                 ]
               }
             }
@@ -332,6 +336,56 @@
                 "exec": [
                   "if (!pm.collectionVariables.get(\"temporaryApiKeyId\")) { throw new Error(\"temporaryApiKeyId is required before this request.\"); }",
                   "if (!pm.collectionVariables.get(\"temporaryApiKeyName\")) { throw new Error(\"temporaryApiKeyName is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.success).to.eql(true);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Revoke original temporary API key",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{previousTemporaryApiKeyId}}",
+            "description": "Deactivates (soft deletes) an API key and invalidates it immediately.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"confirmation\": \"{{previousTemporaryApiKeyName}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"previousTemporaryApiKeyId\")) { throw new Error(\"previousTemporaryApiKeyId is required before this request.\"); }",
+                  "if (!pm.collectionVariables.get(\"previousTemporaryApiKeyName\")) { throw new Error(\"previousTemporaryApiKeyName is required before this request.\"); }"
                 ]
               }
             },

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json
@@ -77,33 +77,6 @@
               }
             }
           ]
-        },
-        {
-          "name": "List members",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{apiKey}}"
-              }
-            ],
-            "url": "{{baseUrl}}/v1/members",
-            "description": "Lists members of the authenticated organization."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
-                  "const body = pm.response.json();",
-                  "pm.expect(body.data.members, \"members array\").to.be.an(\"array\");"
-                ]
-              }
-            }
-          ]
         }
       ]
     },
@@ -920,79 +893,6 @@
                 "type": "text/javascript",
                 "exec": [
                   "pm.test(\"Status 204\", function () { pm.response.to.have.status(204); });"
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "RPC",
-      "item": [
-        {
-          "name": "List RPC providers",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{apiKey}}"
-              }
-            ],
-            "url": "{{baseUrl}}/v1/rpc/providers",
-            "description": "Lists managed RPC providers, aggregated telemetry, and the currently selected provider for the caller/project context."
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
-                  "const body = pm.response.json();",
-                  "pm.expect(body.data.providers, \"providers array\").to.be.an(\"array\");"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Proxy getLatestBlockhash",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{apiKey}}"
-              },
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "url": "{{baseUrl}}/v1/rpc/proxy",
-            "description": "Proxies a JSON-RPC request to the resolved provider and records telemetry. Provider selection is controlled via organization/project settings.",
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getLatestBlockhash\",\n  \"params\": []\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            }
-          },
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
-                  "const body = pm.response.json();",
-                  "pm.expect(body.data.provider).to.exist;",
-                  "pm.expect(body.data.response).to.exist;"
                 ]
               }
             }

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json
@@ -1,0 +1,3042 @@
+{
+  "info": {
+    "name": "Solana Developer Platform - Admin API Key Suite",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Generated admin API key smoke suite for SDP. This collection is CI-safe and exercises every supported machine-usable API-key endpoint while documenting explicit exclusions for session-only or destructive operations."
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.solana.com"
+    },
+    {
+      "key": "apiKey",
+      "value": "sk_test_replace_me"
+    },
+    {
+      "key": "externalAddress",
+      "value": "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ"
+    },
+    {
+      "key": "secondaryAddress",
+      "value": "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv"
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "const existingRunId = pm.collectionVariables.get(\"suiteRunId\");",
+          "if (!existingRunId) {",
+          "  pm.collectionVariables.set(\"suiteRunId\", String(Date.now()));",
+          "}",
+          "const runId = pm.collectionVariables.get(\"suiteRunId\");",
+          "pm.collectionVariables.set(\"symbolSuffix\", runId.slice(-4));",
+          "if (!pm.collectionVariables.get(\"externalAddress\")) {",
+          "  pm.collectionVariables.set(\"externalAddress\", \"8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ\");",
+          "}",
+          "if (!pm.collectionVariables.get(\"secondaryAddress\")) {",
+          "  pm.collectionVariables.set(\"secondaryAddress\", \"7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv\");",
+          "}"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Bootstrap",
+      "item": [
+        {
+          "name": "List wallets",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets?includeAllProviders=true",
+            "description": "Lists wallets for the resolved default signing provider by default. Use provider/includeAllProviders to query across active providers."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.wallets.length, \"expected at least one wallet\").to.be.greaterThan(0);",
+                  "const wallet = body.data.wallets[0];",
+                  "pm.collectionVariables.set(\"walletId\", wallet.walletId);",
+                  "pm.collectionVariables.set(\"walletPublicKey\", wallet.publicKey);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List members",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/members",
+            "description": "Lists members of the authenticated organization."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.members, \"members array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "API Keys",
+      "item": [
+        {
+          "name": "List API keys",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys",
+            "description": "Lists API keys for the authenticated organization."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.apiKeys, \"apiKeys array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Create temporary API key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys",
+            "description": "Creates a new API key. The full key is returned once.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Postman temp key {{suiteRunId}}\",\n  \"description\": \"Generated by the Postman admin CI suite\",\n  \"role\": \"api_developer\",\n  \"environment\": \"sandbox\",\n  \"walletScope\": \"selected\",\n  \"signingWalletId\": \"{{walletId}}\",\n  \"walletBindings\": [\n    {\n      \"walletId\": \"{{walletId}}\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                  "const body = pm.response.json();",
+                  "const apiKey = body.data.apiKey;",
+                  "pm.expect(apiKey.id).to.match(/^key_/);",
+                  "pm.expect(apiKey.key).to.match(/^sk_test_/);",
+                  "pm.collectionVariables.set(\"temporaryApiKeyId\", apiKey.id);",
+                  "pm.collectionVariables.set(\"temporaryApiKeyName\", apiKey.name);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get temporary API key",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{temporaryApiKeyId}}",
+            "description": "Gets API key details by id."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"temporaryApiKeyId\")) { throw new Error(\"temporaryApiKeyId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.apiKey.id).to.eql(pm.collectionVariables.get(\"temporaryApiKeyId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update temporary API key",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{temporaryApiKeyId}}",
+            "description": "Updates API key attributes. Use null to clear optional fields.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Updated by the Postman admin CI suite\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"temporaryApiKeyId\")) { throw new Error(\"temporaryApiKeyId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.success).to.eql(true);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Rotate temporary API key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{temporaryApiKeyId}}/rotate",
+            "description": "Rotates an API key and returns the new key plus the old key grace period.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"gracePeriodHours\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"temporaryApiKeyId\")) { throw new Error(\"temporaryApiKeyId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.apiKey.id).to.match(/^key_/);",
+                  "pm.expect(body.data.apiKey.key).to.match(/^sk_test_/);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Revoke temporary API key",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{temporaryApiKeyId}}",
+            "description": "Deactivates (soft deletes) an API key and invalidates it immediately.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"confirmation\": \"{{temporaryApiKeyName}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"temporaryApiKeyId\")) { throw new Error(\"temporaryApiKeyId is required before this request.\"); }",
+                  "if (!pm.collectionVariables.get(\"temporaryApiKeyName\")) { throw new Error(\"temporaryApiKeyName is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.success).to.eql(true);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Wallets",
+      "item": [
+        {
+          "name": "Get wallet by id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/{{walletId}}",
+            "description": "Returns wallet metadata, custody provider, public key, and current SOL balance for a specific wallet ID. This endpoint requires authenticated access."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.wallet.walletId).to.eql(pm.collectionVariables.get(\"walletId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get wallet public key",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/public-key?walletId={{walletId}}",
+            "description": "Returns the resolved wallet public key for transaction construction. Resolution is DB-backed only (no environment fallback)."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.publicKey).to.eql(pm.collectionVariables.get(\"walletPublicKey\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get wallet config",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/config",
+            "description": "Returns the resolved default wallet signing configuration for the organization or project. Resolution is DB-backed only (no environment fallback)."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.config || body.data.walletConfig).to.exist;"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List wallet configs",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/configs",
+            "description": "Returns active wallet signing configurations for the requested scope plus the resolved default configuration ID."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.configs, \"configs array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List switch provider options",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/switch-options",
+            "description": "Returns provider capability metadata, including active/default status for the requested scope."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.options || body.data.providers).to.exist;"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Aggregate wallet balances",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/aggregate?includeAllProviders=true",
+            "description": "Aggregates tracked wallet balances for the requested scope. Defaults to aggregating across all active providers for the organization scope."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.aggregate.walletCount).to.be.greaterThan(0);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Signer check",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/signer-check",
+            "description": "Submits a memo transaction using the wallet bound to the authenticated API key. This endpoint requires API-key authentication.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"walletId\": \"{{walletId}}\",\n  \"memo\": \"postman signer-check {{suiteRunId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.walletId).to.eql(pm.collectionVariables.get(\"walletId\"));",
+                  "pm.expect(body.data.signature).to.be.a(\"string\").and.not.empty;"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Projects",
+      "item": [
+        {
+          "name": "Create temporary project",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects",
+            "description": "Creates a project within the organization.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Postman Project {{suiteRunId}}\",\n  \"slug\": \"postman-{{suiteRunId}}\",\n  \"description\": \"Created by the Postman admin CI suite\",\n  \"environment\": \"sandbox\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                  "const body = pm.response.json();",
+                  "const project = body.data.project;",
+                  "pm.expect(project.id).to.match(/^prj_/);",
+                  "pm.collectionVariables.set(\"projectId\", project.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List projects",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects",
+            "description": "Lists projects in the organization."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.projects, \"projects array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get temporary project",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}",
+            "description": "Gets project details."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"projectId\")) { throw new Error(\"projectId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.project.id).to.eql(pm.collectionVariables.get(\"projectId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update temporary project",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}",
+            "description": "Updates project attributes.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Updated by the Postman admin CI suite\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"projectId\")) { throw new Error(\"projectId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.project.id).to.eql(pm.collectionVariables.get(\"projectId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List project members",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/members",
+            "description": "Lists members assigned to the project."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"projectId\")) { throw new Error(\"projectId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.members, \"members array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Create project API key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/api-keys",
+            "description": "Creates an API key scoped to the project. The full key is returned once.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Project Key {{suiteRunId}}\",\n  \"environment\": \"sandbox\",\n  \"walletScope\": \"all\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"projectId\")) { throw new Error(\"projectId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.apiKey.id).to.match(/^key_/);",
+                  "pm.collectionVariables.set(\"projectApiKeyId\", body.data.apiKey.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List project API keys",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/api-keys",
+            "description": "Lists API keys scoped to the project."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"projectId\")) { throw new Error(\"projectId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.apiKeys, \"apiKeys array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Archive temporary project",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}",
+            "description": "Archives a project and prevents future writes."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"projectId\")) { throw new Error(\"projectId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 204\", function () { pm.response.to.have.status(204); });"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "RPC",
+      "item": [
+        {
+          "name": "List RPC providers",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/rpc/providers",
+            "description": "Lists managed RPC providers, aggregated telemetry, and the currently selected provider for the caller/project context."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.providers, \"providers array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Proxy getLatestBlockhash",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/rpc/proxy",
+            "description": "Proxies a JSON-RPC request to the resolved provider and records telemetry. Provider selection is controlled via organization/project settings.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getLatestBlockhash\",\n  \"params\": []\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.provider).to.exist;",
+                  "pm.expect(body.data.response).to.exist;"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Issuance",
+      "item": [
+        {
+          "name": "CRUD",
+          "item": [
+            {
+              "name": "List token templates",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/templates",
+                "description": "Returns all available token templates with their default configuration and supported extensions."
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.templates, \"templates array\").to.be.an(\"array\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Get stablecoin template",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/templates/stablecoin",
+                "description": "Returns details for a specific token template including default decimals, required extensions, and available overrides."
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.template.id).to.eql(\"stablecoin\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Create CRUD token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens",
+                "description": "Creates a token record that can later be deployed to Solana.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"Postman CRUD {{suiteRunId}}\",\n  \"symbol\": \"PC{{symbolSuffix}}\",\n  \"template\": \"stablecoin\",\n  \"decimals\": 6,\n  \"isMintable\": true,\n  \"isFreezable\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"crudTokenId\", body.data.token.id);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "List tokens",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens?page=1&pageSize=20",
+                "description": "Lists tokens for the current project or organization."
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data, \"token list\").to.be.an(\"array\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Get CRUD token",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{crudTokenId}}",
+                "description": "Gets token details."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"crudTokenId\")) { throw new Error(\"crudTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.token.id).to.eql(pm.collectionVariables.get(\"crudTokenId\"));"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Update CRUD token",
+              "request": {
+                "method": "PATCH",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{crudTokenId}}",
+                "description": "Updates token metadata or status.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"description\": \"Updated by the Postman admin CI suite\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"crudTokenId\")) { throw new Error(\"crudTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.token.id).to.eql(pm.collectionVariables.get(\"crudTokenId\"));"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "List token allowlist",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{crudTokenId}}/allowlist?page=1&pageSize=10",
+                "description": "Lists allowlist entries for a token."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"crudTokenId\")) { throw new Error(\"crudTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data, \"allowlist entries\").to.be.an(\"array\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Add allowlist entry",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{crudTokenId}}/allowlist",
+                "description": "Adds an allowlist entry for a token.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"address\": \"{{externalAddress}}\",\n  \"label\": \"Postman Allowlist {{suiteRunId}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"crudTokenId\")) { throw new Error(\"crudTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"crudAllowlistEntryId\", body.data.entry.id);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "List token allowlist after insert",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{crudTokenId}}/allowlist?page=1&pageSize=10",
+                "description": "Lists allowlist entries for a token."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"crudTokenId\")) { throw new Error(\"crudTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.some((entry) => entry.id === pm.collectionVariables.get(\"crudAllowlistEntryId\"))).to.eql(true);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Remove allowlist entry",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{crudTokenId}}/allowlist/{{crudAllowlistEntryId}}",
+                "description": "Removes an allowlist entry from a token."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"crudTokenId\")) { throw new Error(\"crudTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"crudAllowlistEntryId\")) { throw new Error(\"crudAllowlistEntryId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 204\", function () { pm.response.to.have.status(204); });"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Prepare",
+          "item": [
+            {
+              "name": "Create prepare token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens",
+                "description": "Creates a token record that can later be deployed to Solana.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"Postman Prepare {{suiteRunId}}\",\n  \"symbol\": \"PP{{symbolSuffix}}\",\n  \"template\": \"stablecoin\",\n  \"decimals\": 6,\n  \"isMintable\": true,\n  \"isFreezable\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"prepareTokenId\", body.data.token.id);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Prepare deploy token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/deploy/prepare",
+                "description": "Builds an unsigned deploy transaction for client-side signing."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.serialized).to.be.a(\"string\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Deploy prepare token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/deploy",
+                "description": "Deploys the token to Solana using custody signing."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"prepareMintAddress\", body.data.token.mintAddress);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Prepare mint",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/mint/prepare",
+                "description": "Builds an unsigned mint transaction for client-side signing.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{externalAddress}}\",\n    \"amount\": \"1\"\n  },\n  \"options\": {\n    \"simulate\": true\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.preparedTransaction.serialized).to.be.a(\"string\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Mint to external address",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/mint",
+                "description": "Mints tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{externalAddress}}\",\n    \"amount\": \"3\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"prepareSourceTokenAccount\", body.data.tokenAccount);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Mint to secondary address",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/mint",
+                "description": "Mints tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{secondaryAddress}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"prepareDestinationTokenAccount\", body.data.tokenAccount);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Mint to custody wallet",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/mint",
+                "description": "Mints tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{walletPublicKey}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"walletPublicKey\")) { throw new Error(\"walletPublicKey is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"prepareCustodyTokenAccount\", body.data.tokenAccount);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Prepare burn",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/burn/prepare",
+                "description": "Builds an unsigned burn transaction for client-side signing.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"burn\": {\n    \"source\": \"{{walletPublicKey}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"walletPublicKey\")) { throw new Error(\"walletPublicKey is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.preparedTransaction.serialized).to.be.a(\"string\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Prepare seize",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/seize/prepare",
+                "description": "Builds an unsigned force transfer transaction for client-side signing.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"seize\": {\n    \"source\": \"{{prepareSourceTokenAccount}}\",\n    \"destination\": \"{{prepareDestinationTokenAccount}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"prepareSourceTokenAccount\")) { throw new Error(\"prepareSourceTokenAccount is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"prepareDestinationTokenAccount\")) { throw new Error(\"prepareDestinationTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.preparedTransaction.serialized).to.be.a(\"string\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Prepare force burn",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/force-burn/prepare",
+                "description": "Builds an unsigned force burn transaction for client-side signing.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"forceBurn\": {\n    \"source\": \"{{prepareDestinationTokenAccount}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"prepareDestinationTokenAccount\")) { throw new Error(\"prepareDestinationTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.preparedTransaction.serialized).to.be.a(\"string\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Prepare authority update",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/authority/prepare",
+                "description": "Builds an unsigned authority update transaction for client-side signing.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"authority\": {\n    \"role\": \"mint\",\n    \"newAuthority\": \"{{secondaryAddress}}\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.preparedTransaction.serialized).to.be.a(\"string\").and.not.empty;"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "List pending token transactions",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{prepareTokenId}}/transactions?status=pending&page=1&pageSize=20",
+                "description": "Lists token transactions for an issued token."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"prepareTokenId\")) { throw new Error(\"prepareTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data, \"transactions array\").to.be.an(\"array\");"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Execute",
+          "item": [
+            {
+              "name": "Create execute token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens",
+                "description": "Creates a token record that can later be deployed to Solana.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"Postman Execute {{suiteRunId}}\",\n  \"symbol\": \"PE{{symbolSuffix}}\",\n  \"template\": \"stablecoin\",\n  \"decimals\": 6,\n  \"isMintable\": true,\n  \"isFreezable\": true\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"executeTokenId\", body.data.token.id);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Deploy execute token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/deploy",
+                "description": "Deploys the token to Solana using custody signing."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.token.status).to.eql(\"active\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Mint execute source account",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/mint",
+                "description": "Mints tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{externalAddress}}\",\n    \"amount\": \"4\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"executeSourceTokenAccount\", body.data.tokenAccount);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Mint execute destination account",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/mint",
+                "description": "Mints tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{secondaryAddress}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"executeDestinationTokenAccount\", body.data.tokenAccount);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Mint execute custody account",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/mint",
+                "description": "Mints tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"mint\": {\n    \"destination\": \"{{walletPublicKey}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"walletPublicKey\")) { throw new Error(\"walletPublicKey is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.collectionVariables.set(\"executeCustodyTokenAccount\", body.data.tokenAccount);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Pause token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/pause",
+                "description": "Pauses transfers for a token using the pause authority.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.type).to.eql(\"pause\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Get paused token",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}",
+                "description": "Gets token details."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.token.status).to.eql(\"paused\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Unpause token",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/unpause",
+                "description": "Resumes transfers for a token using the pause authority.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.type).to.eql(\"unpause\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Freeze token account",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/freeze",
+                "description": "Freezes a token account to prevent transfers.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"accountAddress\": \"{{executeSourceTokenAccount}}\",\n  \"reason\": \"Postman freeze {{suiteRunId}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"executeSourceTokenAccount\")) { throw new Error(\"executeSourceTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 201\", function () { pm.response.to.have.status(201); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.frozenAccount.accountAddress).to.eql(pm.collectionVariables.get(\"executeSourceTokenAccount\"));"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "List frozen accounts",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/frozen?page=1&pageSize=10",
+                "description": "Lists frozen accounts for a token."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"executeSourceTokenAccount\")) { throw new Error(\"executeSourceTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.some((entry) => entry.accountAddress === pm.collectionVariables.get(\"executeSourceTokenAccount\"))).to.eql(true);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Unfreeze token account",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/unfreeze",
+                "description": "Unfreezes a token account so it can be used again.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"accountAddress\": \"{{executeSourceTokenAccount}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"executeSourceTokenAccount\")) { throw new Error(\"executeSourceTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.frozenAccount.accountAddress).to.eql(pm.collectionVariables.get(\"executeSourceTokenAccount\"));"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Burn tokens",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/burn",
+                "description": "Burns tokens using custody signing and submission.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"burn\": {\n    \"source\": \"{{walletPublicKey}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"walletPublicKey\")) { throw new Error(\"walletPublicKey is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.type).to.eql(\"burn\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Seize tokens",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/seize",
+                "description": "Forces a transfer using permanent delegate authority.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"seize\": {\n    \"source\": \"{{executeSourceTokenAccount}}\",\n    \"destination\": \"{{executeDestinationTokenAccount}}\",\n    \"amount\": \"2\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"executeSourceTokenAccount\")) { throw new Error(\"executeSourceTokenAccount is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"executeDestinationTokenAccount\")) { throw new Error(\"executeDestinationTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.type).to.eql(\"seize\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Force burn tokens",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/force-burn",
+                "description": "Burns tokens using permanent delegate authority.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"forceBurn\": {\n    \"source\": \"{{executeDestinationTokenAccount}}\",\n    \"amount\": \"1\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"executeDestinationTokenAccount\")) { throw new Error(\"executeDestinationTokenAccount is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.type).to.eql(\"force_burn\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Update mint authority",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/authority",
+                "description": "Updates token authorities using custody signing.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"authority\": {\n    \"role\": \"mint\",\n    \"currentAuthority\": \"{{walletPublicKey}}\",\n    \"newAuthority\": \"{{externalAddress}}\"\n  }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }",
+                      "if (!pm.collectionVariables.get(\"walletPublicKey\")) { throw new Error(\"walletPublicKey is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.transaction.type).to.eql(\"update_authority\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Refresh token supply",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/supply/refresh",
+                "description": "Fetches the current on-chain supply and refreshes the cached totalSupply value."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data.token.totalSupply).to.be.a(\"string\");"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "List confirmed token transactions",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{apiKey}}"
+                  }
+                ],
+                "url": "{{baseUrl}}/v1/issuance/tokens/{{executeTokenId}}/transactions?status=confirmed&page=1&pageSize=50",
+                "description": "Lists token transactions for an issued token."
+              },
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if (!pm.collectionVariables.get(\"executeTokenId\")) { throw new Error(\"executeTokenId is required before this request.\"); }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                      "const body = pm.response.json();",
+                      "pm.expect(body.data, \"transactions array\").to.be.an(\"array\");"
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Compliance",
+      "item": [
+        {
+          "name": "Screen address",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/compliance/address-screenings",
+            "description": "Runs address screening against configured compliance providers and returns provider-level risk scores.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"{{externalAddress}}\",\n  \"network\": \"solana\",\n  \"intent\": \"transfer_destination\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.screening.address).to.eql(pm.collectionVariables.get(\"externalAddress\"));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Payments",
+      "item": [
+        {
+          "name": "Get wallet balances",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/balances",
+            "description": "Retrieves balances for a custody wallet. Wallet lifecycle and provisioning are managed through /v1/custody/wallets."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.walletBalances.walletId).to.eql(pm.collectionVariables.get(\"walletId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get wallet policy",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/policies",
+            "description": "Retrieves payment policy rules for a custody wallet. Policies are payment controls layered on top of custody-managed wallets."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.policy.walletId).to.eql(pm.collectionVariables.get(\"walletId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update wallet policy",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/policies",
+            "description": "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/custody.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"destinationAllowlist\": [\n    \"{{externalAddress}}\"\n  ],\n  \"maxTransferAmount\": \"0.1\",\n  \"maxDailyAmount\": \"1\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.policy.walletId).to.eql(pm.collectionVariables.get(\"walletId\"));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Prepare SOL transfer",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/transfers/prepare",
+            "description": "Builds an unsigned transfer transaction for a custody wallet. The source walletId must reference a wallet from /v1/custody/wallets.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"source\": \"{{walletId}}\",\n  \"destination\": \"{{externalAddress}}\",\n  \"token\": \"SOL\",\n  \"amount\": \"0.000001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.transfer.status).to.eql(\"pending\");",
+                  "pm.expect(body.data.preparedTransaction.serialized).to.be.a(\"string\").and.not.empty;"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Execute SOL transfer",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/transfers",
+            "description": "Executes a transfer using server-side custody signing. The source walletId must reference a wallet from /v1/custody/wallets.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"source\": \"{{walletId}}\",\n  \"destination\": \"{{externalAddress}}\",\n  \"token\": \"SOL\",\n  \"amount\": \"0.000001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.transfer.id).to.match(/^xfr_/);",
+                  "pm.collectionVariables.set(\"paymentTransferId\", body.data.transfer.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List wallet transfers",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/transfers?wallet={{walletId}}",
+            "description": "Lists payment transfers for the authenticated organization or project scope."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"walletId\")) { throw new Error(\"walletId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data, \"transfers array\").to.be.an(\"array\");"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get executed transfer",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiKey}}"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/transfers/{{paymentTransferId}}",
+            "description": "Retrieves details for a specific transfer."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get(\"paymentTransferId\")) { throw new Error(\"paymentTransferId is required before this request.\"); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Status 200\", function () { pm.response.to.have.status(200); });",
+                  "const body = pm.response.json();",
+                  "pm.expect(body.data.transfer.id).to.eql(pm.collectionVariables.get(\"paymentTransferId\"));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json
@@ -16,6 +16,6 @@
     }
   ],
   "_postman_variable_scope": "environment",
-  "_postman_exported_at": "2026-03-11T23:25:28.216Z",
+  "_postman_exported_at": "1970-01-01T00:00:00.000Z",
   "_postman_exported_using": "Codex"
 }

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json
@@ -16,6 +16,6 @@
     }
   ],
   "_postman_variable_scope": "environment",
-  "_postman_exported_at": "2026-03-11T22:55:56.863Z",
+  "_postman_exported_at": "2026-03-11T23:25:28.216Z",
   "_postman_exported_using": "Codex"
 }

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json
@@ -1,0 +1,21 @@
+{
+  "id": "sdp-api-admin-template",
+  "name": "SDP Admin API",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.solana.com",
+      "enabled": true,
+      "type": "default"
+    },
+    {
+      "key": "apiKey",
+      "value": "sk_test_replace_me",
+      "enabled": true,
+      "type": "secret"
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-03-11T22:55:56.863Z",
+  "_postman_exported_using": "Codex"
+}

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_manifest.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_manifest.json
@@ -1,669 +1,499 @@
 {
-  "generatedAt": "2026-03-11T23:25:28.214Z",
+  "generatedAt": "1970-01-01T00:00:00.000Z",
   "sourceOpenApi": "apps/sdp-api/generated/openapi.json",
   "totals": {
     "apiKeyOperations": 68,
     "coveredOperations": 58,
-    "automatedRequests": 69,
+    "automatedRequests": 70,
     "excluded": 10
   },
   "automated": [
     {
       "operationId": "listWallets",
-      "folder": [
-        "Bootstrap"
-      ],
+      "folder": ["Bootstrap"],
       "name": "List wallets",
       "method": "GET",
       "path": "/v1/wallets"
     },
     {
       "operationId": "listApiKeys",
-      "folder": [
-        "API Keys"
-      ],
+      "folder": ["API Keys"],
       "name": "List API keys",
       "method": "GET",
       "path": "/v1/api-keys"
     },
     {
       "operationId": "createApiKey",
-      "folder": [
-        "API Keys"
-      ],
+      "folder": ["API Keys"],
       "name": "Create temporary API key",
       "method": "POST",
       "path": "/v1/api-keys"
     },
     {
       "operationId": "getApiKey",
-      "folder": [
-        "API Keys"
-      ],
+      "folder": ["API Keys"],
       "name": "Get temporary API key",
       "method": "GET",
       "path": "/v1/api-keys/{keyId}"
     },
     {
       "operationId": "updateApiKey",
-      "folder": [
-        "API Keys"
-      ],
+      "folder": ["API Keys"],
       "name": "Update temporary API key",
       "method": "PATCH",
       "path": "/v1/api-keys/{keyId}"
     },
     {
       "operationId": "rotateApiKey",
-      "folder": [
-        "API Keys"
-      ],
+      "folder": ["API Keys"],
       "name": "Rotate temporary API key",
       "method": "POST",
       "path": "/v1/api-keys/{keyId}/rotate"
     },
     {
       "operationId": "revokeApiKey",
-      "folder": [
-        "API Keys"
-      ],
+      "folder": ["API Keys"],
       "name": "Revoke temporary API key",
       "method": "DELETE",
       "path": "/v1/api-keys/{keyId}"
     },
     {
+      "operationId": "revokeApiKey",
+      "folder": ["API Keys"],
+      "name": "Revoke original temporary API key",
+      "method": "DELETE",
+      "path": "/v1/api-keys/{keyId}"
+    },
+    {
       "operationId": "getWalletById",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "Get wallet by id",
       "method": "GET",
       "path": "/v1/wallets/{walletId}"
     },
     {
       "operationId": "getWalletPublicKey",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "Get wallet public key",
       "method": "GET",
       "path": "/v1/wallets/public-key"
     },
     {
       "operationId": "getWalletConfig",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "Get wallet config",
       "method": "GET",
       "path": "/v1/wallets/config"
     },
     {
       "operationId": "listWalletConfigs",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "List wallet configs",
       "method": "GET",
       "path": "/v1/wallets/configs"
     },
     {
       "operationId": "listSwitchProviderOptions",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "List switch provider options",
       "method": "GET",
       "path": "/v1/wallets/switch-options"
     },
     {
       "operationId": "aggregateWalletBalances",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "Aggregate wallet balances",
       "method": "GET",
       "path": "/v1/wallets/aggregate"
     },
     {
       "operationId": "checkWalletSigner",
-      "folder": [
-        "Wallets"
-      ],
+      "folder": ["Wallets"],
       "name": "Signer check",
       "method": "POST",
       "path": "/v1/wallets/signer-check"
     },
     {
       "operationId": "createProject",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "Create temporary project",
       "method": "POST",
       "path": "/v1/projects"
     },
     {
       "operationId": "listProjects",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "List projects",
       "method": "GET",
       "path": "/v1/projects"
     },
     {
       "operationId": "getProject",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "Get temporary project",
       "method": "GET",
       "path": "/v1/projects/{projectId}"
     },
     {
       "operationId": "updateProject",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "Update temporary project",
       "method": "PATCH",
       "path": "/v1/projects/{projectId}"
     },
     {
       "operationId": "listProjectMembers",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "List project members",
       "method": "GET",
       "path": "/v1/projects/{projectId}/members"
     },
     {
       "operationId": "createProjectApiKey",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "Create project API key",
       "method": "POST",
       "path": "/v1/projects/{projectId}/api-keys"
     },
     {
       "operationId": "listProjectApiKeys",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "List project API keys",
       "method": "GET",
       "path": "/v1/projects/{projectId}/api-keys"
     },
     {
       "operationId": "archiveProject",
-      "folder": [
-        "Projects"
-      ],
+      "folder": ["Projects"],
       "name": "Archive temporary project",
       "method": "DELETE",
       "path": "/v1/projects/{projectId}"
     },
     {
       "operationId": "listTokenTemplates",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "List token templates",
       "method": "GET",
       "path": "/v1/issuance/templates"
     },
     {
       "operationId": "getTokenTemplate",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "Get stablecoin template",
       "method": "GET",
       "path": "/v1/issuance/templates/{templateId}"
     },
     {
       "operationId": "createToken",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "Create CRUD token",
       "method": "POST",
       "path": "/v1/issuance/tokens"
     },
     {
       "operationId": "listTokens",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "List tokens",
       "method": "GET",
       "path": "/v1/issuance/tokens"
     },
     {
       "operationId": "getToken",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "Get CRUD token",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}"
     },
     {
       "operationId": "updateToken",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "Update CRUD token",
       "method": "PATCH",
       "path": "/v1/issuance/tokens/{tokenId}"
     },
     {
       "operationId": "listTokenAllowlist",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "List token allowlist",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}/allowlist"
     },
     {
       "operationId": "addTokenAllowlistEntry",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "Add allowlist entry",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/allowlist"
     },
     {
       "operationId": "listTokenAllowlist",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "List token allowlist after insert",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}/allowlist"
     },
     {
       "operationId": "removeTokenAllowlistEntry",
-      "folder": [
-        "Issuance",
-        "CRUD"
-      ],
+      "folder": ["Issuance", "CRUD"],
       "name": "Remove allowlist entry",
       "method": "DELETE",
       "path": "/v1/issuance/tokens/{tokenId}/allowlist/{entryId}"
     },
     {
       "operationId": "createToken",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Create prepare token",
       "method": "POST",
       "path": "/v1/issuance/tokens"
     },
     {
       "operationId": "prepareDeployToken",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Prepare deploy token",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/deploy/prepare"
     },
     {
       "operationId": "deployToken",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Deploy prepare token",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/deploy"
     },
     {
       "operationId": "prepareMint",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Prepare mint",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint/prepare"
     },
     {
       "operationId": "executeMint",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Mint to external address",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint"
     },
     {
       "operationId": "executeMint",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Mint to secondary address",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint"
     },
     {
       "operationId": "executeMint",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Mint to custody wallet",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint"
     },
     {
       "operationId": "prepareBurn",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Prepare burn",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/burn/prepare"
     },
     {
       "operationId": "prepareSeize",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Prepare seize",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/seize/prepare"
     },
     {
       "operationId": "prepareForceBurn",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Prepare force burn",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/force-burn/prepare"
     },
     {
       "operationId": "prepareUpdateAuthority",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "Prepare authority update",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/authority/prepare"
     },
     {
       "operationId": "listTokenTransactions",
-      "folder": [
-        "Issuance",
-        "Prepare"
-      ],
+      "folder": ["Issuance", "Prepare"],
       "name": "List pending token transactions",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}/transactions"
     },
     {
       "operationId": "createToken",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Create execute token",
       "method": "POST",
       "path": "/v1/issuance/tokens"
     },
     {
       "operationId": "deployToken",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Deploy execute token",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/deploy"
     },
     {
       "operationId": "executeMint",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Mint execute source account",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint"
     },
     {
       "operationId": "executeMint",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Mint execute destination account",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint"
     },
     {
       "operationId": "executeMint",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Mint execute custody account",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/mint"
     },
     {
       "operationId": "pauseToken",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Pause token",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/pause"
     },
     {
       "operationId": "getToken",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Get paused token",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}"
     },
     {
       "operationId": "unpauseToken",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Unpause token",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/unpause"
     },
     {
       "operationId": "freezeAccount",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Freeze token account",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/freeze"
     },
     {
       "operationId": "listFrozenAccounts",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "List frozen accounts",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}/frozen"
     },
     {
       "operationId": "unfreezeAccount",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Unfreeze token account",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/unfreeze"
     },
     {
       "operationId": "executeBurn",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Burn tokens",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/burn"
     },
     {
       "operationId": "executeSeize",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Seize tokens",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/seize"
     },
     {
       "operationId": "executeForceBurn",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Force burn tokens",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/force-burn"
     },
     {
       "operationId": "executeUpdateAuthority",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Update mint authority",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/authority"
     },
     {
       "operationId": "refreshTokenSupply",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "Refresh token supply",
       "method": "POST",
       "path": "/v1/issuance/tokens/{tokenId}/supply/refresh"
     },
     {
       "operationId": "listTokenTransactions",
-      "folder": [
-        "Issuance",
-        "Execute"
-      ],
+      "folder": ["Issuance", "Execute"],
       "name": "List confirmed token transactions",
       "method": "GET",
       "path": "/v1/issuance/tokens/{tokenId}/transactions"
     },
     {
       "operationId": "screenComplianceAddress",
-      "folder": [
-        "Compliance"
-      ],
+      "folder": ["Compliance"],
       "name": "Screen address",
       "method": "POST",
       "path": "/v1/compliance/address-screenings"
     },
     {
       "operationId": "getPaymentWalletBalances",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "Get wallet balances",
       "method": "GET",
       "path": "/v1/payments/wallets/{walletId}/balances"
     },
     {
       "operationId": "getPaymentWalletPolicy",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "Get wallet policy",
       "method": "GET",
       "path": "/v1/payments/wallets/{walletId}/policies"
     },
     {
       "operationId": "updatePaymentWalletPolicy",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "Update wallet policy",
       "method": "PUT",
       "path": "/v1/payments/wallets/{walletId}/policies"
     },
     {
       "operationId": "preparePaymentTransfer",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "Prepare SOL transfer",
       "method": "POST",
       "path": "/v1/payments/transfers/prepare"
     },
     {
       "operationId": "createPaymentTransfer",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "Execute SOL transfer",
       "method": "POST",
       "path": "/v1/payments/transfers"
     },
     {
       "operationId": "listPaymentTransfers",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "List wallet transfers",
       "method": "GET",
       "path": "/v1/payments/transfers"
     },
     {
       "operationId": "getPaymentTransfer",
-      "folder": [
-        "Payments"
-      ],
+      "folder": ["Payments"],
       "name": "Get executed transfer",
       "method": "GET",
       "path": "/v1/payments/transfers/{transferId}"

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_manifest.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_manifest.json
@@ -1,0 +1,802 @@
+{
+  "generatedAt": "2026-03-11T22:55:56.855Z",
+  "sourceOpenApi": "apps/sdp-api/generated/openapi.json",
+  "totals": {
+    "apiKeyOperations": 78,
+    "automated": 72,
+    "excluded": 17
+  },
+  "automated": [
+    {
+      "operationId": "listWallets",
+      "folder": [
+        "Bootstrap"
+      ],
+      "name": "List wallets",
+      "method": "GET",
+      "path": "/v1/wallets"
+    },
+    {
+      "operationId": "listMembers",
+      "folder": [
+        "Bootstrap"
+      ],
+      "name": "List members",
+      "method": "GET",
+      "path": "/v1/members"
+    },
+    {
+      "operationId": "listApiKeys",
+      "folder": [
+        "API Keys"
+      ],
+      "name": "List API keys",
+      "method": "GET",
+      "path": "/v1/api-keys"
+    },
+    {
+      "operationId": "createApiKey",
+      "folder": [
+        "API Keys"
+      ],
+      "name": "Create temporary API key",
+      "method": "POST",
+      "path": "/v1/api-keys"
+    },
+    {
+      "operationId": "getApiKey",
+      "folder": [
+        "API Keys"
+      ],
+      "name": "Get temporary API key",
+      "method": "GET",
+      "path": "/v1/api-keys/{keyId}"
+    },
+    {
+      "operationId": "updateApiKey",
+      "folder": [
+        "API Keys"
+      ],
+      "name": "Update temporary API key",
+      "method": "PATCH",
+      "path": "/v1/api-keys/{keyId}"
+    },
+    {
+      "operationId": "rotateApiKey",
+      "folder": [
+        "API Keys"
+      ],
+      "name": "Rotate temporary API key",
+      "method": "POST",
+      "path": "/v1/api-keys/{keyId}/rotate"
+    },
+    {
+      "operationId": "revokeApiKey",
+      "folder": [
+        "API Keys"
+      ],
+      "name": "Revoke temporary API key",
+      "method": "DELETE",
+      "path": "/v1/api-keys/{keyId}"
+    },
+    {
+      "operationId": "getWalletById",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "Get wallet by id",
+      "method": "GET",
+      "path": "/v1/wallets/{walletId}"
+    },
+    {
+      "operationId": "getWalletPublicKey",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "Get wallet public key",
+      "method": "GET",
+      "path": "/v1/wallets/public-key"
+    },
+    {
+      "operationId": "getWalletConfig",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "Get wallet config",
+      "method": "GET",
+      "path": "/v1/wallets/config"
+    },
+    {
+      "operationId": "listWalletConfigs",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "List wallet configs",
+      "method": "GET",
+      "path": "/v1/wallets/configs"
+    },
+    {
+      "operationId": "listSwitchProviderOptions",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "List switch provider options",
+      "method": "GET",
+      "path": "/v1/wallets/switch-options"
+    },
+    {
+      "operationId": "aggregateWalletBalances",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "Aggregate wallet balances",
+      "method": "GET",
+      "path": "/v1/wallets/aggregate"
+    },
+    {
+      "operationId": "checkWalletSigner",
+      "folder": [
+        "Wallets"
+      ],
+      "name": "Signer check",
+      "method": "POST",
+      "path": "/v1/wallets/signer-check"
+    },
+    {
+      "operationId": "createProject",
+      "folder": [
+        "Projects"
+      ],
+      "name": "Create temporary project",
+      "method": "POST",
+      "path": "/v1/projects"
+    },
+    {
+      "operationId": "listProjects",
+      "folder": [
+        "Projects"
+      ],
+      "name": "List projects",
+      "method": "GET",
+      "path": "/v1/projects"
+    },
+    {
+      "operationId": "getProject",
+      "folder": [
+        "Projects"
+      ],
+      "name": "Get temporary project",
+      "method": "GET",
+      "path": "/v1/projects/{projectId}"
+    },
+    {
+      "operationId": "updateProject",
+      "folder": [
+        "Projects"
+      ],
+      "name": "Update temporary project",
+      "method": "PATCH",
+      "path": "/v1/projects/{projectId}"
+    },
+    {
+      "operationId": "listProjectMembers",
+      "folder": [
+        "Projects"
+      ],
+      "name": "List project members",
+      "method": "GET",
+      "path": "/v1/projects/{projectId}/members"
+    },
+    {
+      "operationId": "createProjectApiKey",
+      "folder": [
+        "Projects"
+      ],
+      "name": "Create project API key",
+      "method": "POST",
+      "path": "/v1/projects/{projectId}/api-keys"
+    },
+    {
+      "operationId": "listProjectApiKeys",
+      "folder": [
+        "Projects"
+      ],
+      "name": "List project API keys",
+      "method": "GET",
+      "path": "/v1/projects/{projectId}/api-keys"
+    },
+    {
+      "operationId": "archiveProject",
+      "folder": [
+        "Projects"
+      ],
+      "name": "Archive temporary project",
+      "method": "DELETE",
+      "path": "/v1/projects/{projectId}"
+    },
+    {
+      "operationId": "listRpcProviders",
+      "folder": [
+        "RPC"
+      ],
+      "name": "List RPC providers",
+      "method": "GET",
+      "path": "/v1/rpc/providers"
+    },
+    {
+      "operationId": "proxyRpcRequest",
+      "folder": [
+        "RPC"
+      ],
+      "name": "Proxy getLatestBlockhash",
+      "method": "POST",
+      "path": "/v1/rpc/proxy"
+    },
+    {
+      "operationId": "listTokenTemplates",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "List token templates",
+      "method": "GET",
+      "path": "/v1/issuance/templates"
+    },
+    {
+      "operationId": "getTokenTemplate",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "Get stablecoin template",
+      "method": "GET",
+      "path": "/v1/issuance/templates/{templateId}"
+    },
+    {
+      "operationId": "createToken",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "Create CRUD token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens"
+    },
+    {
+      "operationId": "listTokens",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "List tokens",
+      "method": "GET",
+      "path": "/v1/issuance/tokens"
+    },
+    {
+      "operationId": "getToken",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "Get CRUD token",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}"
+    },
+    {
+      "operationId": "updateToken",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "Update CRUD token",
+      "method": "PATCH",
+      "path": "/v1/issuance/tokens/{tokenId}"
+    },
+    {
+      "operationId": "listTokenAllowlist",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "List token allowlist",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}/allowlist"
+    },
+    {
+      "operationId": "addTokenAllowlistEntry",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "Add allowlist entry",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/allowlist"
+    },
+    {
+      "operationId": "listTokenAllowlist",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "List token allowlist after insert",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}/allowlist"
+    },
+    {
+      "operationId": "removeTokenAllowlistEntry",
+      "folder": [
+        "Issuance",
+        "CRUD"
+      ],
+      "name": "Remove allowlist entry",
+      "method": "DELETE",
+      "path": "/v1/issuance/tokens/{tokenId}/allowlist/{entryId}"
+    },
+    {
+      "operationId": "createToken",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Create prepare token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens"
+    },
+    {
+      "operationId": "prepareDeployToken",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Prepare deploy token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/deploy/prepare"
+    },
+    {
+      "operationId": "deployToken",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Deploy prepare token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/deploy"
+    },
+    {
+      "operationId": "prepareMint",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Prepare mint",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint/prepare"
+    },
+    {
+      "operationId": "executeMint",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Mint to external address",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint"
+    },
+    {
+      "operationId": "executeMint",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Mint to secondary address",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint"
+    },
+    {
+      "operationId": "executeMint",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Mint to custody wallet",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint"
+    },
+    {
+      "operationId": "prepareBurn",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Prepare burn",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/burn/prepare"
+    },
+    {
+      "operationId": "prepareSeize",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Prepare seize",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/seize/prepare"
+    },
+    {
+      "operationId": "prepareForceBurn",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Prepare force burn",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/force-burn/prepare"
+    },
+    {
+      "operationId": "prepareUpdateAuthority",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "Prepare authority update",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/authority/prepare"
+    },
+    {
+      "operationId": "listTokenTransactions",
+      "folder": [
+        "Issuance",
+        "Prepare"
+      ],
+      "name": "List pending token transactions",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}/transactions"
+    },
+    {
+      "operationId": "createToken",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Create execute token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens"
+    },
+    {
+      "operationId": "deployToken",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Deploy execute token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/deploy"
+    },
+    {
+      "operationId": "executeMint",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Mint execute source account",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint"
+    },
+    {
+      "operationId": "executeMint",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Mint execute destination account",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint"
+    },
+    {
+      "operationId": "executeMint",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Mint execute custody account",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/mint"
+    },
+    {
+      "operationId": "pauseToken",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Pause token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/pause"
+    },
+    {
+      "operationId": "getToken",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Get paused token",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}"
+    },
+    {
+      "operationId": "unpauseToken",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Unpause token",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/unpause"
+    },
+    {
+      "operationId": "freezeAccount",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Freeze token account",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/freeze"
+    },
+    {
+      "operationId": "listFrozenAccounts",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "List frozen accounts",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}/frozen"
+    },
+    {
+      "operationId": "unfreezeAccount",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Unfreeze token account",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/unfreeze"
+    },
+    {
+      "operationId": "executeBurn",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Burn tokens",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/burn"
+    },
+    {
+      "operationId": "executeSeize",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Seize tokens",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/seize"
+    },
+    {
+      "operationId": "executeForceBurn",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Force burn tokens",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/force-burn"
+    },
+    {
+      "operationId": "executeUpdateAuthority",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Update mint authority",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/authority"
+    },
+    {
+      "operationId": "refreshTokenSupply",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "Refresh token supply",
+      "method": "POST",
+      "path": "/v1/issuance/tokens/{tokenId}/supply/refresh"
+    },
+    {
+      "operationId": "listTokenTransactions",
+      "folder": [
+        "Issuance",
+        "Execute"
+      ],
+      "name": "List confirmed token transactions",
+      "method": "GET",
+      "path": "/v1/issuance/tokens/{tokenId}/transactions"
+    },
+    {
+      "operationId": "screenComplianceAddress",
+      "folder": [
+        "Compliance"
+      ],
+      "name": "Screen address",
+      "method": "POST",
+      "path": "/v1/compliance/address-screenings"
+    },
+    {
+      "operationId": "getPaymentWalletBalances",
+      "folder": [
+        "Payments"
+      ],
+      "name": "Get wallet balances",
+      "method": "GET",
+      "path": "/v1/payments/wallets/{walletId}/balances"
+    },
+    {
+      "operationId": "getPaymentWalletPolicy",
+      "folder": [
+        "Payments"
+      ],
+      "name": "Get wallet policy",
+      "method": "GET",
+      "path": "/v1/payments/wallets/{walletId}/policies"
+    },
+    {
+      "operationId": "updatePaymentWalletPolicy",
+      "folder": [
+        "Payments"
+      ],
+      "name": "Update wallet policy",
+      "method": "PUT",
+      "path": "/v1/payments/wallets/{walletId}/policies"
+    },
+    {
+      "operationId": "preparePaymentTransfer",
+      "folder": [
+        "Payments"
+      ],
+      "name": "Prepare SOL transfer",
+      "method": "POST",
+      "path": "/v1/payments/transfers/prepare"
+    },
+    {
+      "operationId": "createPaymentTransfer",
+      "folder": [
+        "Payments"
+      ],
+      "name": "Execute SOL transfer",
+      "method": "POST",
+      "path": "/v1/payments/transfers"
+    },
+    {
+      "operationId": "listPaymentTransfers",
+      "folder": [
+        "Payments"
+      ],
+      "name": "List wallet transfers",
+      "method": "GET",
+      "path": "/v1/payments/transfers"
+    },
+    {
+      "operationId": "getPaymentTransfer",
+      "folder": [
+        "Payments"
+      ],
+      "name": "Get executed transfer",
+      "method": "GET",
+      "path": "/v1/payments/transfers/{transferId}"
+    }
+  ],
+  "excluded": [
+    {
+      "operationId": "addProjectMember",
+      "reason": "Requires an additional organization member user id, which is not derivable from a single admin API key bootstrap flow.",
+      "method": "POST",
+      "path": "/v1/projects/{projectId}/members"
+    },
+    {
+      "operationId": "createWallet",
+      "reason": "Wallet provisioning depends on provider capabilities and mutates shared custody state, so it is excluded from the recurring suite.",
+      "method": "POST",
+      "path": "/v1/wallets"
+    },
+    {
+      "operationId": "deleteOrganization",
+      "reason": "Destructive organization deletion is not safe for a recurring required CI suite.",
+      "method": "DELETE",
+      "path": "/v1/organizations/{orgId}"
+    },
+    {
+      "operationId": "deleteWallet",
+      "reason": "Wallet deletion mutates shared custody state and is excluded from the recurring suite.",
+      "method": "DELETE",
+      "path": "/v1/wallets"
+    },
+    {
+      "operationId": "executePaymentOfframp",
+      "reason": "Depends on external provider availability and hosted third-party ramp services, so it is excluded from the required CI suite.",
+      "method": "POST",
+      "path": "/v1/payments/ramps/offramp/execute"
+    },
+    {
+      "operationId": "executePaymentOnramp",
+      "reason": "Depends on external provider availability and hosted third-party ramp services, so it is excluded from the required CI suite.",
+      "method": "POST",
+      "path": "/v1/payments/ramps/onramp/execute"
+    },
+    {
+      "operationId": "getOnboardingStatus",
+      "reason": "Requires a Clerk onboarding session, not an API key.",
+      "method": "GET",
+      "path": "/v1/onboarding/status"
+    },
+    {
+      "operationId": "getOrganization",
+      "reason": "Requires an explicit organization id that cannot be derived from a bare API key in the collection bootstrap flow.",
+      "method": "GET",
+      "path": "/v1/organizations/{orgId}"
+    },
+    {
+      "operationId": "initializeWalletSigning",
+      "reason": "Initializes org-level custody configuration and is excluded from the recurring suite to avoid provider bootstrap side effects.",
+      "method": "POST",
+      "path": "/v1/wallets/initialize"
+    },
+    {
+      "operationId": "inviteMember",
+      "reason": "The handler requires a Clerk-authenticated human user to send invitations, so a machine API key cannot execute it.",
+      "method": "POST",
+      "path": "/v1/members/invite"
+    },
+    {
+      "operationId": "linkOnboardingOrganization",
+      "reason": "Requires a Clerk onboarding session, not an API key.",
+      "method": "POST",
+      "path": "/v1/onboarding/link-org"
+    },
+    {
+      "operationId": "removeMember",
+      "reason": "Organization member removal is excluded from the CI-safe suite because it mutates human membership state.",
+      "method": "DELETE",
+      "path": "/v1/members/{memberId}"
+    },
+    {
+      "operationId": "removeProjectMember",
+      "reason": "Requires a mutable project member target and is excluded from the CI-safe suite.",
+      "method": "DELETE",
+      "path": "/v1/projects/{projectId}/members/{memberId}"
+    },
+    {
+      "operationId": "setDefaultWallet",
+      "reason": "Changing the default wallet mutates shared custody state and is excluded from the recurring suite.",
+      "method": "POST",
+      "path": "/v1/wallets/default-wallet"
+    },
+    {
+      "operationId": "switchWalletSigningProvider",
+      "reason": "Switches the org default signing provider and is excluded from the recurring suite to avoid global side effects.",
+      "method": "POST",
+      "path": "/v1/wallets/switch"
+    },
+    {
+      "operationId": "updateOrganization",
+      "reason": "Requires an explicit organization id and mutates shared organization settings, so it is excluded from the CI-safe admin suite.",
+      "method": "PATCH",
+      "path": "/v1/organizations/{orgId}"
+    },
+    {
+      "operationId": "updateProjectMember",
+      "reason": "Requires a mutable project member target and is excluded from the CI-safe suite.",
+      "method": "PATCH",
+      "path": "/v1/projects/{projectId}/members/{memberId}"
+    }
+  ]
+}

--- a/apps/sdp-docs/public/downloads/sdp-api-admin.postman_manifest.json
+++ b/apps/sdp-docs/public/downloads/sdp-api-admin.postman_manifest.json
@@ -1,10 +1,11 @@
 {
-  "generatedAt": "2026-03-11T22:55:56.855Z",
+  "generatedAt": "2026-03-11T23:25:28.214Z",
   "sourceOpenApi": "apps/sdp-api/generated/openapi.json",
   "totals": {
-    "apiKeyOperations": 78,
-    "automated": 72,
-    "excluded": 17
+    "apiKeyOperations": 68,
+    "coveredOperations": 58,
+    "automatedRequests": 69,
+    "excluded": 10
   },
   "automated": [
     {
@@ -15,15 +16,6 @@
       "name": "List wallets",
       "method": "GET",
       "path": "/v1/wallets"
-    },
-    {
-      "operationId": "listMembers",
-      "folder": [
-        "Bootstrap"
-      ],
-      "name": "List members",
-      "method": "GET",
-      "path": "/v1/members"
     },
     {
       "operationId": "listApiKeys",
@@ -213,24 +205,6 @@
       "name": "Archive temporary project",
       "method": "DELETE",
       "path": "/v1/projects/{projectId}"
-    },
-    {
-      "operationId": "listRpcProviders",
-      "folder": [
-        "RPC"
-      ],
-      "name": "List RPC providers",
-      "method": "GET",
-      "path": "/v1/rpc/providers"
-    },
-    {
-      "operationId": "proxyRpcRequest",
-      "folder": [
-        "RPC"
-      ],
-      "name": "Proxy getLatestBlockhash",
-      "method": "POST",
-      "path": "/v1/rpc/proxy"
     },
     {
       "operationId": "listTokenTemplates",
@@ -709,12 +683,6 @@
       "path": "/v1/wallets"
     },
     {
-      "operationId": "deleteOrganization",
-      "reason": "Destructive organization deletion is not safe for a recurring required CI suite.",
-      "method": "DELETE",
-      "path": "/v1/organizations/{orgId}"
-    },
-    {
       "operationId": "deleteWallet",
       "reason": "Wallet deletion mutates shared custody state and is excluded from the recurring suite.",
       "method": "DELETE",
@@ -733,40 +701,10 @@
       "path": "/v1/payments/ramps/onramp/execute"
     },
     {
-      "operationId": "getOnboardingStatus",
-      "reason": "Requires a Clerk onboarding session, not an API key.",
-      "method": "GET",
-      "path": "/v1/onboarding/status"
-    },
-    {
-      "operationId": "getOrganization",
-      "reason": "Requires an explicit organization id that cannot be derived from a bare API key in the collection bootstrap flow.",
-      "method": "GET",
-      "path": "/v1/organizations/{orgId}"
-    },
-    {
       "operationId": "initializeWalletSigning",
       "reason": "Initializes org-level custody configuration and is excluded from the recurring suite to avoid provider bootstrap side effects.",
       "method": "POST",
       "path": "/v1/wallets/initialize"
-    },
-    {
-      "operationId": "inviteMember",
-      "reason": "The handler requires a Clerk-authenticated human user to send invitations, so a machine API key cannot execute it.",
-      "method": "POST",
-      "path": "/v1/members/invite"
-    },
-    {
-      "operationId": "linkOnboardingOrganization",
-      "reason": "Requires a Clerk onboarding session, not an API key.",
-      "method": "POST",
-      "path": "/v1/onboarding/link-org"
-    },
-    {
-      "operationId": "removeMember",
-      "reason": "Organization member removal is excluded from the CI-safe suite because it mutates human membership state.",
-      "method": "DELETE",
-      "path": "/v1/members/{memberId}"
     },
     {
       "operationId": "removeProjectMember",
@@ -785,12 +723,6 @@
       "reason": "Switches the org default signing provider and is excluded from the recurring suite to avoid global side effects.",
       "method": "POST",
       "path": "/v1/wallets/switch"
-    },
-    {
-      "operationId": "updateOrganization",
-      "reason": "Requires an explicit organization id and mutates shared organization settings, so it is excluded from the CI-safe admin suite.",
-      "method": "PATCH",
-      "path": "/v1/organizations/{orgId}"
     },
     {
       "operationId": "updateProjectMember",

--- a/apps/sdp-docs/scripts/generate-postman-collection.mjs
+++ b/apps/sdp-docs/scripts/generate-postman-collection.mjs
@@ -16,6 +16,8 @@ const environmentTemplatePath = path.join(
 
 const DEFAULT_EXTERNAL_ADDRESS = "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ";
 const DEFAULT_SECONDARY_ADDRESS = "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv";
+// Keep generated artifacts stable across docs builds.
+const DETERMINISTIC_TIMESTAMP = "1970-01-01T00:00:00.000Z";
 const HIDDEN_TAG_SLUGS = new Set([
   "rpc",
   "admin",
@@ -155,7 +157,7 @@ function buildEnvironmentTemplate() {
       },
     ],
     _postman_variable_scope: "environment",
-    _postman_exported_at: new Date().toISOString(),
+    _postman_exported_at: DETERMINISTIC_TIMESTAMP,
     _postman_exported_using: "Codex",
   };
 }
@@ -344,8 +346,12 @@ function automatedRequests(operations) {
       body: JSON.stringify({ gracePeriodHours: 1 }, null, 2),
       tests: jsonStatusTest(
         201,
+        'pm.collectionVariables.set("previousTemporaryApiKeyId", pm.collectionVariables.get("temporaryApiKeyId"));',
+        'pm.collectionVariables.set("previousTemporaryApiKeyName", pm.collectionVariables.get("temporaryApiKeyName"));',
         "pm.expect(body.data.apiKey.id).to.match(/^key_/);",
-        "pm.expect(body.data.apiKey.key).to.match(/^sk_test_/);"
+        "pm.expect(body.data.apiKey.key).to.match(/^sk_test_/);",
+        'pm.collectionVariables.set("temporaryApiKeyId", body.data.apiKey.id);',
+        'pm.collectionVariables.set("temporaryApiKeyName", body.data.apiKey.name);'
       ),
     }),
     request({
@@ -357,6 +363,20 @@ function automatedRequests(operations) {
       description: op("revokeApiKey"),
       prerequest: [requireVar("temporaryApiKeyId"), requireVar("temporaryApiKeyName")],
       body: JSON.stringify({ confirmation: "{{temporaryApiKeyName}}" }, null, 2),
+      tests: jsonStatusTest(200, "pm.expect(body.data.success).to.eql(true);"),
+    }),
+    request({
+      operationId: "revokeApiKey",
+      folder: ["API Keys"],
+      name: "Revoke original temporary API key",
+      method: "DELETE",
+      url: "/v1/api-keys/{{previousTemporaryApiKeyId}}",
+      description: op("revokeApiKey"),
+      prerequest: [
+        requireVar("previousTemporaryApiKeyId"),
+        requireVar("previousTemporaryApiKeyName"),
+      ],
+      body: JSON.stringify({ confirmation: "{{previousTemporaryApiKeyName}}" }, null, 2),
       tests: jsonStatusTest(200, "pm.expect(body.data.success).to.eql(true);"),
     }),
     request({
@@ -1360,7 +1380,7 @@ async function run() {
   };
 
   const manifest = {
-    generatedAt: new Date().toISOString(),
+    generatedAt: DETERMINISTIC_TIMESTAMP,
     sourceOpenApi: "apps/sdp-api/generated/openapi.json",
     totals: {
       apiKeyOperations: operations.size,

--- a/apps/sdp-docs/scripts/generate-postman-collection.mjs
+++ b/apps/sdp-docs/scripts/generate-postman-collection.mjs
@@ -1,0 +1,1423 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const openApiPath = path.resolve(__dirname, "../../sdp-api/generated/openapi.json");
+const downloadsDir = path.resolve(__dirname, "../public/downloads");
+const collectionPath = path.join(downloadsDir, "sdp-api-admin.postman_collection.json");
+const manifestPath = path.join(downloadsDir, "sdp-api-admin.postman_manifest.json");
+const environmentTemplatePath = path.join(
+  downloadsDir,
+  "sdp-api-admin.postman_environment.template.json"
+);
+
+const DEFAULT_EXTERNAL_ADDRESS = "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ";
+const DEFAULT_SECONDARY_ADDRESS = "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv";
+
+const JSON_HEADERS = [{ key: "Content-Type", value: "application/json" }];
+const AUTH_HEADER = { key: "Authorization", value: "Bearer {{apiKey}}" };
+
+function statusTest(status, ...lines) {
+  return [
+    `pm.test("Status ${status}", function () { pm.response.to.have.status(${status}); });`,
+    ...lines,
+  ];
+}
+
+function jsonStatusTest(status, ...lines) {
+  return statusTest(status, "const body = pm.response.json();", ...lines);
+}
+
+function requireVar(name) {
+  return `if (!pm.collectionVariables.get("${name}")) { throw new Error("${name} is required before this request."); }`;
+}
+
+function request({
+  operationId,
+  folder,
+  name,
+  method,
+  url,
+  body,
+  prerequest = [],
+  tests = [],
+  description,
+}) {
+  return {
+    operationId,
+    folder,
+    item: {
+      name,
+      request: {
+        method,
+        header: body ? [AUTH_HEADER, ...JSON_HEADERS] : [AUTH_HEADER],
+        url: `{{baseUrl}}${url}`,
+        ...(description ? { description } : {}),
+        ...(body
+          ? {
+              body: {
+                mode: "raw",
+                raw: body,
+                options: {
+                  raw: {
+                    language: "json",
+                  },
+                },
+              },
+            }
+          : {}),
+      },
+      event: [
+        ...(prerequest.length > 0
+          ? [
+              {
+                listen: "prerequest",
+                script: {
+                  type: "text/javascript",
+                  exec: prerequest,
+                },
+              },
+            ]
+          : []),
+        {
+          listen: "test",
+          script: {
+            type: "text/javascript",
+            exec: tests,
+          },
+        },
+      ],
+    },
+  };
+}
+
+function nestedFolderTree() {
+  return [];
+}
+
+function insertItem(root, folderPath, item) {
+  let cursor = root;
+  for (const segment of folderPath) {
+    let folder = cursor.find(
+      (candidate) => candidate.name === segment && Array.isArray(candidate.item)
+    );
+    if (!folder) {
+      folder = { name: segment, item: [] };
+      cursor.push(folder);
+    }
+    cursor = folder.item;
+  }
+  cursor.push(item);
+}
+
+function slugTitle(value) {
+  return value.replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+
+function operationRequestDescription(operation) {
+  return operation?.description || operation?.summary || slugTitle(operation?.operationId || "");
+}
+
+function buildEnvironmentTemplate() {
+  return {
+    id: "sdp-api-admin-template",
+    name: "SDP Admin API",
+    values: [
+      {
+        key: "baseUrl",
+        value: "https://api.solana.com",
+        enabled: true,
+        type: "default",
+      },
+      {
+        key: "apiKey",
+        value: "sk_test_replace_me",
+        enabled: true,
+        type: "secret",
+      },
+    ],
+    _postman_variable_scope: "environment",
+    _postman_exported_at: new Date().toISOString(),
+    _postman_exported_using: "Codex",
+  };
+}
+
+async function loadOpenApi() {
+  const raw = await fs.readFile(openApiPath, "utf8");
+  return JSON.parse(raw);
+}
+
+function apiKeyOperationsFromSpec(spec) {
+  const operations = new Map();
+
+  for (const [routePath, pathItem] of Object.entries(spec.paths || {})) {
+    for (const [method, operation] of Object.entries(pathItem || {})) {
+      if (!operation || typeof operation !== "object") {
+        continue;
+      }
+
+      const security = operation.security || spec.security || [];
+      const usesApiKey = security.some((entry) =>
+        Object.prototype.hasOwnProperty.call(entry, "apiKeyAuth")
+      );
+
+      if (!usesApiKey || !operation.operationId) {
+        continue;
+      }
+
+      operations.set(operation.operationId, {
+        operationId: operation.operationId,
+        method: method.toUpperCase(),
+        path: routePath,
+        summary: operation.summary || "",
+        description: operation.description || "",
+      });
+    }
+  }
+
+  return operations;
+}
+
+const excludedOperations = {
+  getOrganization:
+    "Requires an explicit organization id that cannot be derived from a bare API key in the collection bootstrap flow.",
+  updateOrganization:
+    "Requires an explicit organization id and mutates shared organization settings, so it is excluded from the CI-safe admin suite.",
+  deleteOrganization:
+    "Destructive organization deletion is not safe for a recurring required CI suite.",
+  inviteMember:
+    "The handler requires a Clerk-authenticated human user to send invitations, so a machine API key cannot execute it.",
+  removeMember:
+    "Organization member removal is excluded from the CI-safe suite because it mutates human membership state.",
+  initializeWalletSigning:
+    "Initializes org-level custody configuration and is excluded from the recurring suite to avoid provider bootstrap side effects.",
+  switchWalletSigningProvider:
+    "Switches the org default signing provider and is excluded from the recurring suite to avoid global side effects.",
+  createWallet:
+    "Wallet provisioning depends on provider capabilities and mutates shared custody state, so it is excluded from the recurring suite.",
+  deleteWallet:
+    "Wallet deletion mutates shared custody state and is excluded from the recurring suite.",
+  setDefaultWallet:
+    "Changing the default wallet mutates shared custody state and is excluded from the recurring suite.",
+  addProjectMember:
+    "Requires an additional organization member user id, which is not derivable from a single admin API key bootstrap flow.",
+  updateProjectMember:
+    "Requires a mutable project member target and is excluded from the CI-safe suite.",
+  removeProjectMember:
+    "Requires a mutable project member target and is excluded from the CI-safe suite.",
+  executePaymentOnramp:
+    "Depends on external provider availability and hosted third-party ramp services, so it is excluded from the required CI suite.",
+  executePaymentOfframp:
+    "Depends on external provider availability and hosted third-party ramp services, so it is excluded from the required CI suite.",
+  getOnboardingStatus: "Requires a Clerk onboarding session, not an API key.",
+  linkOnboardingOrganization: "Requires a Clerk onboarding session, not an API key.",
+};
+
+function automatedRequests(operations) {
+  const op = (operationId) => operationRequestDescription(operations.get(operationId));
+
+  return [
+    request({
+      operationId: "listWallets",
+      folder: ["Bootstrap"],
+      name: "List wallets",
+      method: "GET",
+      url: "/v1/wallets?includeAllProviders=true",
+      description: op("listWallets"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.wallets.length, "expected at least one wallet").to.be.greaterThan(0);',
+        "const wallet = body.data.wallets[0];",
+        'pm.collectionVariables.set("walletId", wallet.walletId);',
+        'pm.collectionVariables.set("walletPublicKey", wallet.publicKey);'
+      ),
+    }),
+    request({
+      operationId: "listMembers",
+      folder: ["Bootstrap"],
+      name: "List members",
+      method: "GET",
+      url: "/v1/members",
+      description: op("listMembers"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.members, "members array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "listApiKeys",
+      folder: ["API Keys"],
+      name: "List API keys",
+      method: "GET",
+      url: "/v1/api-keys",
+      description: op("listApiKeys"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.apiKeys, "apiKeys array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "createApiKey",
+      folder: ["API Keys"],
+      name: "Create temporary API key",
+      method: "POST",
+      url: "/v1/api-keys",
+      description: op("createApiKey"),
+      prerequest: [requireVar("walletId")],
+      body: JSON.stringify(
+        {
+          name: "Postman temp key {{suiteRunId}}",
+          description: "Generated by the Postman admin CI suite",
+          role: "api_developer",
+          environment: "sandbox",
+          walletScope: "selected",
+          signingWalletId: "{{walletId}}",
+          walletBindings: [{ walletId: "{{walletId}}" }],
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        "const apiKey = body.data.apiKey;",
+        "pm.expect(apiKey.id).to.match(/^key_/);",
+        "pm.expect(apiKey.key).to.match(/^sk_test_/);",
+        'pm.collectionVariables.set("temporaryApiKeyId", apiKey.id);',
+        'pm.collectionVariables.set("temporaryApiKeyName", apiKey.name);'
+      ),
+    }),
+    request({
+      operationId: "getApiKey",
+      folder: ["API Keys"],
+      name: "Get temporary API key",
+      method: "GET",
+      url: "/v1/api-keys/{{temporaryApiKeyId}}",
+      description: op("getApiKey"),
+      prerequest: [requireVar("temporaryApiKeyId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.apiKey.id).to.eql(pm.collectionVariables.get("temporaryApiKeyId"));'
+      ),
+    }),
+    request({
+      operationId: "updateApiKey",
+      folder: ["API Keys"],
+      name: "Update temporary API key",
+      method: "PATCH",
+      url: "/v1/api-keys/{{temporaryApiKeyId}}",
+      description: op("updateApiKey"),
+      prerequest: [requireVar("temporaryApiKeyId")],
+      body: JSON.stringify(
+        {
+          description: "Updated by the Postman admin CI suite",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(200, "pm.expect(body.data.success).to.eql(true);"),
+    }),
+    request({
+      operationId: "rotateApiKey",
+      folder: ["API Keys"],
+      name: "Rotate temporary API key",
+      method: "POST",
+      url: "/v1/api-keys/{{temporaryApiKeyId}}/rotate",
+      description: op("rotateApiKey"),
+      prerequest: [requireVar("temporaryApiKeyId")],
+      body: JSON.stringify({ gracePeriodHours: 1 }, null, 2),
+      tests: jsonStatusTest(
+        201,
+        "pm.expect(body.data.apiKey.id).to.match(/^key_/);",
+        "pm.expect(body.data.apiKey.key).to.match(/^sk_test_/);"
+      ),
+    }),
+    request({
+      operationId: "revokeApiKey",
+      folder: ["API Keys"],
+      name: "Revoke temporary API key",
+      method: "DELETE",
+      url: "/v1/api-keys/{{temporaryApiKeyId}}",
+      description: op("revokeApiKey"),
+      prerequest: [requireVar("temporaryApiKeyId"), requireVar("temporaryApiKeyName")],
+      body: JSON.stringify({ confirmation: "{{temporaryApiKeyName}}" }, null, 2),
+      tests: jsonStatusTest(200, "pm.expect(body.data.success).to.eql(true);"),
+    }),
+    request({
+      operationId: "getWalletById",
+      folder: ["Wallets"],
+      name: "Get wallet by id",
+      method: "GET",
+      url: "/v1/wallets/{{walletId}}",
+      description: op("getWalletById"),
+      prerequest: [requireVar("walletId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.wallet.walletId).to.eql(pm.collectionVariables.get("walletId"));'
+      ),
+    }),
+    request({
+      operationId: "getWalletPublicKey",
+      folder: ["Wallets"],
+      name: "Get wallet public key",
+      method: "GET",
+      url: "/v1/wallets/public-key?walletId={{walletId}}",
+      description: op("getWalletPublicKey"),
+      prerequest: [requireVar("walletId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.publicKey).to.eql(pm.collectionVariables.get("walletPublicKey"));'
+      ),
+    }),
+    request({
+      operationId: "getWalletConfig",
+      folder: ["Wallets"],
+      name: "Get wallet config",
+      method: "GET",
+      url: "/v1/wallets/config",
+      description: op("getWalletConfig"),
+      tests: jsonStatusTest(200, "pm.expect(body.data.config || body.data.walletConfig).to.exist;"),
+    }),
+    request({
+      operationId: "listWalletConfigs",
+      folder: ["Wallets"],
+      name: "List wallet configs",
+      method: "GET",
+      url: "/v1/wallets/configs",
+      description: op("listWalletConfigs"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.configs, "configs array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "listSwitchProviderOptions",
+      folder: ["Wallets"],
+      name: "List switch provider options",
+      method: "GET",
+      url: "/v1/wallets/switch-options",
+      description: op("listSwitchProviderOptions"),
+      tests: jsonStatusTest(200, "pm.expect(body.data.options || body.data.providers).to.exist;"),
+    }),
+    request({
+      operationId: "aggregateWalletBalances",
+      folder: ["Wallets"],
+      name: "Aggregate wallet balances",
+      method: "GET",
+      url: "/v1/wallets/aggregate?includeAllProviders=true",
+      description: op("aggregateWalletBalances"),
+      tests: jsonStatusTest(
+        200,
+        "pm.expect(body.data.aggregate.walletCount).to.be.greaterThan(0);"
+      ),
+    }),
+    request({
+      operationId: "checkWalletSigner",
+      folder: ["Wallets"],
+      name: "Signer check",
+      method: "POST",
+      url: "/v1/wallets/signer-check",
+      description: op("checkWalletSigner"),
+      prerequest: [requireVar("walletId")],
+      body: JSON.stringify(
+        { walletId: "{{walletId}}", memo: "postman signer-check {{suiteRunId}}" },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.walletId).to.eql(pm.collectionVariables.get("walletId"));',
+        'pm.expect(body.data.signature).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "createProject",
+      folder: ["Projects"],
+      name: "Create temporary project",
+      method: "POST",
+      url: "/v1/projects",
+      description: op("createProject"),
+      body: JSON.stringify(
+        {
+          name: "Postman Project {{suiteRunId}}",
+          slug: "postman-{{suiteRunId}}",
+          description: "Created by the Postman admin CI suite",
+          environment: "sandbox",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        "const project = body.data.project;",
+        "pm.expect(project.id).to.match(/^prj_/);",
+        'pm.collectionVariables.set("projectId", project.id);'
+      ),
+    }),
+    request({
+      operationId: "listProjects",
+      folder: ["Projects"],
+      name: "List projects",
+      method: "GET",
+      url: "/v1/projects",
+      description: op("listProjects"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.projects, "projects array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "getProject",
+      folder: ["Projects"],
+      name: "Get temporary project",
+      method: "GET",
+      url: "/v1/projects/{{projectId}}",
+      description: op("getProject"),
+      prerequest: [requireVar("projectId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.project.id).to.eql(pm.collectionVariables.get("projectId"));'
+      ),
+    }),
+    request({
+      operationId: "updateProject",
+      folder: ["Projects"],
+      name: "Update temporary project",
+      method: "PATCH",
+      url: "/v1/projects/{{projectId}}",
+      description: op("updateProject"),
+      prerequest: [requireVar("projectId")],
+      body: JSON.stringify(
+        {
+          description: "Updated by the Postman admin CI suite",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.project.id).to.eql(pm.collectionVariables.get("projectId"));'
+      ),
+    }),
+    request({
+      operationId: "listProjectMembers",
+      folder: ["Projects"],
+      name: "List project members",
+      method: "GET",
+      url: "/v1/projects/{{projectId}}/members",
+      description: op("listProjectMembers"),
+      prerequest: [requireVar("projectId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.members, "members array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "createProjectApiKey",
+      folder: ["Projects"],
+      name: "Create project API key",
+      method: "POST",
+      url: "/v1/projects/{{projectId}}/api-keys",
+      description: op("createProjectApiKey"),
+      prerequest: [requireVar("projectId")],
+      body: JSON.stringify(
+        {
+          name: "Project Key {{suiteRunId}}",
+          environment: "sandbox",
+          walletScope: "all",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        "pm.expect(body.data.apiKey.id).to.match(/^key_/);",
+        'pm.collectionVariables.set("projectApiKeyId", body.data.apiKey.id);'
+      ),
+    }),
+    request({
+      operationId: "listProjectApiKeys",
+      folder: ["Projects"],
+      name: "List project API keys",
+      method: "GET",
+      url: "/v1/projects/{{projectId}}/api-keys",
+      description: op("listProjectApiKeys"),
+      prerequest: [requireVar("projectId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.apiKeys, "apiKeys array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "archiveProject",
+      folder: ["Projects"],
+      name: "Archive temporary project",
+      method: "DELETE",
+      url: "/v1/projects/{{projectId}}",
+      description: op("archiveProject"),
+      prerequest: [requireVar("projectId")],
+      tests: statusTest(204),
+    }),
+    request({
+      operationId: "listRpcProviders",
+      folder: ["RPC"],
+      name: "List RPC providers",
+      method: "GET",
+      url: "/v1/rpc/providers",
+      description: op("listRpcProviders"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.providers, "providers array").to.be.an("array");'
+      ),
+    }),
+    request({
+      operationId: "proxyRpcRequest",
+      folder: ["RPC"],
+      name: "Proxy getLatestBlockhash",
+      method: "POST",
+      url: "/v1/rpc/proxy",
+      description: op("proxyRpcRequest"),
+      body: JSON.stringify(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "getLatestBlockhash",
+          params: [],
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        "pm.expect(body.data.provider).to.exist;",
+        "pm.expect(body.data.response).to.exist;"
+      ),
+    }),
+    request({
+      operationId: "listTokenTemplates",
+      folder: ["Issuance", "CRUD"],
+      name: "List token templates",
+      method: "GET",
+      url: "/v1/issuance/templates",
+      description: op("listTokenTemplates"),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.templates, "templates array").to.be.an("array").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "getTokenTemplate",
+      folder: ["Issuance", "CRUD"],
+      name: "Get stablecoin template",
+      method: "GET",
+      url: "/v1/issuance/templates/stablecoin",
+      description: op("getTokenTemplate"),
+      tests: jsonStatusTest(200, 'pm.expect(body.data.template.id).to.eql("stablecoin");'),
+    }),
+    request({
+      operationId: "createToken",
+      folder: ["Issuance", "CRUD"],
+      name: "Create CRUD token",
+      method: "POST",
+      url: "/v1/issuance/tokens",
+      description: op("createToken"),
+      body: JSON.stringify(
+        {
+          name: "Postman CRUD {{suiteRunId}}",
+          symbol: "PC{{symbolSuffix}}",
+          template: "stablecoin",
+          decimals: 6,
+          isMintable: true,
+          isFreezable: true,
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(201, 'pm.collectionVariables.set("crudTokenId", body.data.token.id);'),
+    }),
+    request({
+      operationId: "listTokens",
+      folder: ["Issuance", "CRUD"],
+      name: "List tokens",
+      method: "GET",
+      url: "/v1/issuance/tokens?page=1&pageSize=20",
+      description: op("listTokens"),
+      tests: jsonStatusTest(200, 'pm.expect(body.data, "token list").to.be.an("array");'),
+    }),
+    request({
+      operationId: "getToken",
+      folder: ["Issuance", "CRUD"],
+      name: "Get CRUD token",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{crudTokenId}}",
+      description: op("getToken"),
+      prerequest: [requireVar("crudTokenId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.token.id).to.eql(pm.collectionVariables.get("crudTokenId"));'
+      ),
+    }),
+    request({
+      operationId: "updateToken",
+      folder: ["Issuance", "CRUD"],
+      name: "Update CRUD token",
+      method: "PATCH",
+      url: "/v1/issuance/tokens/{{crudTokenId}}",
+      description: op("updateToken"),
+      prerequest: [requireVar("crudTokenId")],
+      body: JSON.stringify({ description: "Updated by the Postman admin CI suite" }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.token.id).to.eql(pm.collectionVariables.get("crudTokenId"));'
+      ),
+    }),
+    request({
+      operationId: "listTokenAllowlist",
+      folder: ["Issuance", "CRUD"],
+      name: "List token allowlist",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{crudTokenId}}/allowlist?page=1&pageSize=10",
+      description: op("listTokenAllowlist"),
+      prerequest: [requireVar("crudTokenId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data, "allowlist entries").to.be.an("array");'),
+    }),
+    request({
+      operationId: "addTokenAllowlistEntry",
+      folder: ["Issuance", "CRUD"],
+      name: "Add allowlist entry",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{crudTokenId}}/allowlist",
+      description: op("addTokenAllowlistEntry"),
+      prerequest: [requireVar("crudTokenId")],
+      body: JSON.stringify(
+        { address: "{{externalAddress}}", label: "Postman Allowlist {{suiteRunId}}" },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        'pm.collectionVariables.set("crudAllowlistEntryId", body.data.entry.id);'
+      ),
+    }),
+    request({
+      operationId: "listTokenAllowlist",
+      folder: ["Issuance", "CRUD"],
+      name: "List token allowlist after insert",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{crudTokenId}}/allowlist?page=1&pageSize=10",
+      description: op("listTokenAllowlist"),
+      prerequest: [requireVar("crudTokenId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.some((entry) => entry.id === pm.collectionVariables.get("crudAllowlistEntryId"))).to.eql(true);'
+      ),
+    }),
+    request({
+      operationId: "removeTokenAllowlistEntry",
+      folder: ["Issuance", "CRUD"],
+      name: "Remove allowlist entry",
+      method: "DELETE",
+      url: "/v1/issuance/tokens/{{crudTokenId}}/allowlist/{{crudAllowlistEntryId}}",
+      description: op("removeTokenAllowlistEntry"),
+      prerequest: [requireVar("crudTokenId"), requireVar("crudAllowlistEntryId")],
+      tests: statusTest(204),
+    }),
+    request({
+      operationId: "createToken",
+      folder: ["Issuance", "Prepare"],
+      name: "Create prepare token",
+      method: "POST",
+      url: "/v1/issuance/tokens",
+      description: op("createToken"),
+      body: JSON.stringify(
+        {
+          name: "Postman Prepare {{suiteRunId}}",
+          symbol: "PP{{symbolSuffix}}",
+          template: "stablecoin",
+          decimals: 6,
+          isMintable: true,
+          isFreezable: true,
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        'pm.collectionVariables.set("prepareTokenId", body.data.token.id);'
+      ),
+    }),
+    request({
+      operationId: "prepareDeployToken",
+      folder: ["Issuance", "Prepare"],
+      name: "Prepare deploy token",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/deploy/prepare",
+      description: op("prepareDeployToken"),
+      prerequest: [requireVar("prepareTokenId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.transaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "deployToken",
+      folder: ["Issuance", "Prepare"],
+      name: "Deploy prepare token",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/deploy",
+      description: op("deployToken"),
+      prerequest: [requireVar("prepareTokenId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("prepareMintAddress", body.data.token.mintAddress);'
+      ),
+    }),
+    request({
+      operationId: "prepareMint",
+      folder: ["Issuance", "Prepare"],
+      name: "Prepare mint",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/mint/prepare",
+      description: op("prepareMint"),
+      prerequest: [requireVar("prepareTokenId")],
+      body: JSON.stringify(
+        {
+          mint: { destination: "{{externalAddress}}", amount: "1" },
+          options: { simulate: true },
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.preparedTransaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "executeMint",
+      folder: ["Issuance", "Prepare"],
+      name: "Mint to external address",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/mint",
+      description: op("executeMint"),
+      prerequest: [requireVar("prepareTokenId")],
+      body: JSON.stringify({ mint: { destination: "{{externalAddress}}", amount: "3" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("prepareSourceTokenAccount", body.data.tokenAccount);'
+      ),
+    }),
+    request({
+      operationId: "executeMint",
+      folder: ["Issuance", "Prepare"],
+      name: "Mint to secondary address",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/mint",
+      description: op("executeMint"),
+      prerequest: [requireVar("prepareTokenId")],
+      body: JSON.stringify({ mint: { destination: "{{secondaryAddress}}", amount: "1" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("prepareDestinationTokenAccount", body.data.tokenAccount);'
+      ),
+    }),
+    request({
+      operationId: "executeMint",
+      folder: ["Issuance", "Prepare"],
+      name: "Mint to custody wallet",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/mint",
+      description: op("executeMint"),
+      prerequest: [requireVar("prepareTokenId"), requireVar("walletPublicKey")],
+      body: JSON.stringify({ mint: { destination: "{{walletPublicKey}}", amount: "1" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("prepareCustodyTokenAccount", body.data.tokenAccount);'
+      ),
+    }),
+    request({
+      operationId: "prepareBurn",
+      folder: ["Issuance", "Prepare"],
+      name: "Prepare burn",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/burn/prepare",
+      description: op("prepareBurn"),
+      prerequest: [requireVar("prepareTokenId"), requireVar("walletPublicKey")],
+      body: JSON.stringify({ burn: { source: "{{walletPublicKey}}", amount: "1" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.preparedTransaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "prepareSeize",
+      folder: ["Issuance", "Prepare"],
+      name: "Prepare seize",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/seize/prepare",
+      description: op("prepareSeize"),
+      prerequest: [
+        requireVar("prepareTokenId"),
+        requireVar("prepareSourceTokenAccount"),
+        requireVar("prepareDestinationTokenAccount"),
+      ],
+      body: JSON.stringify(
+        {
+          seize: {
+            source: "{{prepareSourceTokenAccount}}",
+            destination: "{{prepareDestinationTokenAccount}}",
+            amount: "1",
+          },
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.preparedTransaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "prepareForceBurn",
+      folder: ["Issuance", "Prepare"],
+      name: "Prepare force burn",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/force-burn/prepare",
+      description: op("prepareForceBurn"),
+      prerequest: [requireVar("prepareTokenId"), requireVar("prepareDestinationTokenAccount")],
+      body: JSON.stringify(
+        { forceBurn: { source: "{{prepareDestinationTokenAccount}}", amount: "1" } },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.preparedTransaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "prepareUpdateAuthority",
+      folder: ["Issuance", "Prepare"],
+      name: "Prepare authority update",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/authority/prepare",
+      description: op("prepareUpdateAuthority"),
+      prerequest: [requireVar("prepareTokenId")],
+      body: JSON.stringify(
+        { authority: { role: "mint", newAuthority: "{{secondaryAddress}}" } },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.preparedTransaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "listTokenTransactions",
+      folder: ["Issuance", "Prepare"],
+      name: "List pending token transactions",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{prepareTokenId}}/transactions?status=pending&page=1&pageSize=20",
+      description: op("listTokenTransactions"),
+      prerequest: [requireVar("prepareTokenId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data, "transactions array").to.be.an("array");'),
+    }),
+    request({
+      operationId: "createToken",
+      folder: ["Issuance", "Execute"],
+      name: "Create execute token",
+      method: "POST",
+      url: "/v1/issuance/tokens",
+      description: op("createToken"),
+      body: JSON.stringify(
+        {
+          name: "Postman Execute {{suiteRunId}}",
+          symbol: "PE{{symbolSuffix}}",
+          template: "stablecoin",
+          decimals: 6,
+          isMintable: true,
+          isFreezable: true,
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        'pm.collectionVariables.set("executeTokenId", body.data.token.id);'
+      ),
+    }),
+    request({
+      operationId: "deployToken",
+      folder: ["Issuance", "Execute"],
+      name: "Deploy execute token",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/deploy",
+      description: op("deployToken"),
+      prerequest: [requireVar("executeTokenId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data.token.status).to.eql("active");'),
+    }),
+    request({
+      operationId: "executeMint",
+      folder: ["Issuance", "Execute"],
+      name: "Mint execute source account",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/mint",
+      description: op("executeMint"),
+      prerequest: [requireVar("executeTokenId")],
+      body: JSON.stringify({ mint: { destination: "{{externalAddress}}", amount: "4" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("executeSourceTokenAccount", body.data.tokenAccount);'
+      ),
+    }),
+    request({
+      operationId: "executeMint",
+      folder: ["Issuance", "Execute"],
+      name: "Mint execute destination account",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/mint",
+      description: op("executeMint"),
+      prerequest: [requireVar("executeTokenId")],
+      body: JSON.stringify({ mint: { destination: "{{secondaryAddress}}", amount: "1" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("executeDestinationTokenAccount", body.data.tokenAccount);'
+      ),
+    }),
+    request({
+      operationId: "executeMint",
+      folder: ["Issuance", "Execute"],
+      name: "Mint execute custody account",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/mint",
+      description: op("executeMint"),
+      prerequest: [requireVar("executeTokenId"), requireVar("walletPublicKey")],
+      body: JSON.stringify({ mint: { destination: "{{walletPublicKey}}", amount: "1" } }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.collectionVariables.set("executeCustodyTokenAccount", body.data.tokenAccount);'
+      ),
+    }),
+    request({
+      operationId: "pauseToken",
+      folder: ["Issuance", "Execute"],
+      name: "Pause token",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/pause",
+      description: op("pauseToken"),
+      prerequest: [requireVar("executeTokenId")],
+      body: JSON.stringify({}, null, 2),
+      tests: jsonStatusTest(200, 'pm.expect(body.data.transaction.type).to.eql("pause");'),
+    }),
+    request({
+      operationId: "getToken",
+      folder: ["Issuance", "Execute"],
+      name: "Get paused token",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{executeTokenId}}",
+      description: op("getToken"),
+      prerequest: [requireVar("executeTokenId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data.token.status).to.eql("paused");'),
+    }),
+    request({
+      operationId: "unpauseToken",
+      folder: ["Issuance", "Execute"],
+      name: "Unpause token",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/unpause",
+      description: op("unpauseToken"),
+      prerequest: [requireVar("executeTokenId")],
+      body: JSON.stringify({}, null, 2),
+      tests: jsonStatusTest(200, 'pm.expect(body.data.transaction.type).to.eql("unpause");'),
+    }),
+    request({
+      operationId: "freezeAccount",
+      folder: ["Issuance", "Execute"],
+      name: "Freeze token account",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/freeze",
+      description: op("freezeAccount"),
+      prerequest: [requireVar("executeTokenId"), requireVar("executeSourceTokenAccount")],
+      body: JSON.stringify(
+        {
+          accountAddress: "{{executeSourceTokenAccount}}",
+          reason: "Postman freeze {{suiteRunId}}",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        201,
+        'pm.expect(body.data.frozenAccount.accountAddress).to.eql(pm.collectionVariables.get("executeSourceTokenAccount"));'
+      ),
+    }),
+    request({
+      operationId: "listFrozenAccounts",
+      folder: ["Issuance", "Execute"],
+      name: "List frozen accounts",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/frozen?page=1&pageSize=10",
+      description: op("listFrozenAccounts"),
+      prerequest: [requireVar("executeTokenId"), requireVar("executeSourceTokenAccount")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.some((entry) => entry.accountAddress === pm.collectionVariables.get("executeSourceTokenAccount"))).to.eql(true);'
+      ),
+    }),
+    request({
+      operationId: "unfreezeAccount",
+      folder: ["Issuance", "Execute"],
+      name: "Unfreeze token account",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/unfreeze",
+      description: op("unfreezeAccount"),
+      prerequest: [requireVar("executeTokenId"), requireVar("executeSourceTokenAccount")],
+      body: JSON.stringify({ accountAddress: "{{executeSourceTokenAccount}}" }, null, 2),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.frozenAccount.accountAddress).to.eql(pm.collectionVariables.get("executeSourceTokenAccount"));'
+      ),
+    }),
+    request({
+      operationId: "executeBurn",
+      folder: ["Issuance", "Execute"],
+      name: "Burn tokens",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/burn",
+      description: op("executeBurn"),
+      prerequest: [requireVar("executeTokenId"), requireVar("walletPublicKey")],
+      body: JSON.stringify({ burn: { source: "{{walletPublicKey}}", amount: "1" } }, null, 2),
+      tests: jsonStatusTest(200, 'pm.expect(body.data.transaction.type).to.eql("burn");'),
+    }),
+    request({
+      operationId: "executeSeize",
+      folder: ["Issuance", "Execute"],
+      name: "Seize tokens",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/seize",
+      description: op("executeSeize"),
+      prerequest: [
+        requireVar("executeTokenId"),
+        requireVar("executeSourceTokenAccount"),
+        requireVar("executeDestinationTokenAccount"),
+      ],
+      body: JSON.stringify(
+        {
+          seize: {
+            source: "{{executeSourceTokenAccount}}",
+            destination: "{{executeDestinationTokenAccount}}",
+            amount: "2",
+          },
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(200, 'pm.expect(body.data.transaction.type).to.eql("seize");'),
+    }),
+    request({
+      operationId: "executeForceBurn",
+      folder: ["Issuance", "Execute"],
+      name: "Force burn tokens",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/force-burn",
+      description: op("executeForceBurn"),
+      prerequest: [requireVar("executeTokenId"), requireVar("executeDestinationTokenAccount")],
+      body: JSON.stringify(
+        { forceBurn: { source: "{{executeDestinationTokenAccount}}", amount: "1" } },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(200, 'pm.expect(body.data.transaction.type).to.eql("force_burn");'),
+    }),
+    request({
+      operationId: "executeUpdateAuthority",
+      folder: ["Issuance", "Execute"],
+      name: "Update mint authority",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/authority",
+      description: op("executeUpdateAuthority"),
+      prerequest: [requireVar("executeTokenId"), requireVar("walletPublicKey")],
+      body: JSON.stringify(
+        {
+          authority: {
+            role: "mint",
+            currentAuthority: "{{walletPublicKey}}",
+            newAuthority: "{{externalAddress}}",
+          },
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.transaction.type).to.eql("update_authority");'
+      ),
+    }),
+    request({
+      operationId: "refreshTokenSupply",
+      folder: ["Issuance", "Execute"],
+      name: "Refresh token supply",
+      method: "POST",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/supply/refresh",
+      description: op("refreshTokenSupply"),
+      prerequest: [requireVar("executeTokenId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data.token.totalSupply).to.be.a("string");'),
+    }),
+    request({
+      operationId: "listTokenTransactions",
+      folder: ["Issuance", "Execute"],
+      name: "List confirmed token transactions",
+      method: "GET",
+      url: "/v1/issuance/tokens/{{executeTokenId}}/transactions?status=confirmed&page=1&pageSize=50",
+      description: op("listTokenTransactions"),
+      prerequest: [requireVar("executeTokenId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data, "transactions array").to.be.an("array");'),
+    }),
+    request({
+      operationId: "screenComplianceAddress",
+      folder: ["Compliance"],
+      name: "Screen address",
+      method: "POST",
+      url: "/v1/compliance/address-screenings",
+      description: op("screenComplianceAddress"),
+      body: JSON.stringify(
+        { address: "{{externalAddress}}", network: "solana", intent: "transfer_destination" },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.screening.address).to.eql(pm.collectionVariables.get("externalAddress"));'
+      ),
+    }),
+    request({
+      operationId: "getPaymentWalletBalances",
+      folder: ["Payments"],
+      name: "Get wallet balances",
+      method: "GET",
+      url: "/v1/payments/wallets/{{walletId}}/balances",
+      description: op("getPaymentWalletBalances"),
+      prerequest: [requireVar("walletId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.walletBalances.walletId).to.eql(pm.collectionVariables.get("walletId"));'
+      ),
+    }),
+    request({
+      operationId: "getPaymentWalletPolicy",
+      folder: ["Payments"],
+      name: "Get wallet policy",
+      method: "GET",
+      url: "/v1/payments/wallets/{{walletId}}/policies",
+      description: op("getPaymentWalletPolicy"),
+      prerequest: [requireVar("walletId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.policy.walletId).to.eql(pm.collectionVariables.get("walletId"));'
+      ),
+    }),
+    request({
+      operationId: "updatePaymentWalletPolicy",
+      folder: ["Payments"],
+      name: "Update wallet policy",
+      method: "PUT",
+      url: "/v1/payments/wallets/{{walletId}}/policies",
+      description: op("updatePaymentWalletPolicy"),
+      prerequest: [requireVar("walletId")],
+      body: JSON.stringify(
+        {
+          destinationAllowlist: ["{{externalAddress}}"],
+          maxTransferAmount: "0.1",
+          maxDailyAmount: "1",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.policy.walletId).to.eql(pm.collectionVariables.get("walletId"));'
+      ),
+    }),
+    request({
+      operationId: "preparePaymentTransfer",
+      folder: ["Payments"],
+      name: "Prepare SOL transfer",
+      method: "POST",
+      url: "/v1/payments/transfers/prepare",
+      description: op("preparePaymentTransfer"),
+      prerequest: [requireVar("walletId")],
+      body: JSON.stringify(
+        {
+          source: "{{walletId}}",
+          destination: "{{externalAddress}}",
+          token: "SOL",
+          amount: "0.000001",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.transfer.status).to.eql("pending");',
+        'pm.expect(body.data.preparedTransaction.serialized).to.be.a("string").and.not.empty;'
+      ),
+    }),
+    request({
+      operationId: "createPaymentTransfer",
+      folder: ["Payments"],
+      name: "Execute SOL transfer",
+      method: "POST",
+      url: "/v1/payments/transfers",
+      description: op("createPaymentTransfer"),
+      prerequest: [requireVar("walletId")],
+      body: JSON.stringify(
+        {
+          source: "{{walletId}}",
+          destination: "{{externalAddress}}",
+          token: "SOL",
+          amount: "0.000001",
+        },
+        null,
+        2
+      ),
+      tests: jsonStatusTest(
+        200,
+        "pm.expect(body.data.transfer.id).to.match(/^xfr_/);",
+        'pm.collectionVariables.set("paymentTransferId", body.data.transfer.id);'
+      ),
+    }),
+    request({
+      operationId: "listPaymentTransfers",
+      folder: ["Payments"],
+      name: "List wallet transfers",
+      method: "GET",
+      url: "/v1/payments/transfers?wallet={{walletId}}",
+      description: op("listPaymentTransfers"),
+      prerequest: [requireVar("walletId")],
+      tests: jsonStatusTest(200, 'pm.expect(body.data, "transfers array").to.be.an("array");'),
+    }),
+    request({
+      operationId: "getPaymentTransfer",
+      folder: ["Payments"],
+      name: "Get executed transfer",
+      method: "GET",
+      url: "/v1/payments/transfers/{{paymentTransferId}}",
+      description: op("getPaymentTransfer"),
+      prerequest: [requireVar("paymentTransferId")],
+      tests: jsonStatusTest(
+        200,
+        'pm.expect(body.data.transfer.id).to.eql(pm.collectionVariables.get("paymentTransferId"));'
+      ),
+    }),
+  ];
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function run() {
+  const spec = await loadOpenApi();
+  const operations = apiKeyOperationsFromSpec(spec);
+  const automated = automatedRequests(operations);
+
+  const automatedIds = new Set(automated.map((entry) => entry.operationId));
+  const excludedIds = new Set(Object.keys(excludedOperations));
+
+  const uncovered = [...operations.keys()].filter(
+    (operationId) => !automatedIds.has(operationId) && !excludedIds.has(operationId)
+  );
+  if (uncovered.length > 0) {
+    throw new Error(`Postman suite is missing API-key operations: ${uncovered.join(", ")}`);
+  }
+
+  await fs.mkdir(downloadsDir, { recursive: true });
+
+  const items = nestedFolderTree();
+  for (const entry of automated) {
+    insertItem(items, entry.folder, entry.item);
+  }
+
+  const collection = {
+    info: {
+      name: "Solana Developer Platform - Admin API Key Suite",
+      schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      description:
+        "Generated admin API key smoke suite for SDP. This collection is CI-safe and exercises every supported machine-usable API-key endpoint while documenting explicit exclusions for session-only or destructive operations.",
+    },
+    variable: [
+      { key: "baseUrl", value: "https://api.solana.com" },
+      { key: "apiKey", value: "sk_test_replace_me" },
+      { key: "externalAddress", value: DEFAULT_EXTERNAL_ADDRESS },
+      { key: "secondaryAddress", value: DEFAULT_SECONDARY_ADDRESS },
+    ],
+    event: [
+      {
+        listen: "prerequest",
+        script: {
+          type: "text/javascript",
+          exec: [
+            'const existingRunId = pm.collectionVariables.get("suiteRunId");',
+            "if (!existingRunId) {",
+            '  pm.collectionVariables.set("suiteRunId", String(Date.now()));',
+            "}",
+            'const runId = pm.collectionVariables.get("suiteRunId");',
+            'pm.collectionVariables.set("symbolSuffix", runId.slice(-4));',
+            'if (!pm.collectionVariables.get("externalAddress")) {',
+            `  pm.collectionVariables.set("externalAddress", "${DEFAULT_EXTERNAL_ADDRESS}");`,
+            "}",
+            'if (!pm.collectionVariables.get("secondaryAddress")) {',
+            `  pm.collectionVariables.set("secondaryAddress", "${DEFAULT_SECONDARY_ADDRESS}");`,
+            "}",
+          ],
+        },
+      },
+    ],
+    item: items,
+  };
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    sourceOpenApi: "apps/sdp-api/generated/openapi.json",
+    totals: {
+      apiKeyOperations: operations.size,
+      automated: automated.length,
+      excluded: excludedIds.size,
+    },
+    automated: automated.map(({ operationId, folder, item }) => {
+      const operation = operations.get(operationId);
+      return {
+        operationId,
+        folder,
+        name: item.name,
+        method: operation?.method ?? null,
+        path: operation?.path ?? null,
+      };
+    }),
+    excluded: [...excludedIds].sort().map((operationId) => {
+      const operation = operations.get(operationId);
+      return {
+        operationId,
+        reason: excludedOperations[operationId],
+        method: operation?.method ?? null,
+        path: operation?.path ?? null,
+      };
+    }),
+  };
+
+  await writeJson(collectionPath, collection);
+  await writeJson(manifestPath, manifest);
+  await writeJson(environmentTemplatePath, buildEnvironmentTemplate());
+
+  console.log(
+    `Generated Postman collection with ${automated.length} automated operations and ${excludedIds.size} exclusions.`
+  );
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/sdp-docs/scripts/generate-postman-collection.mjs
+++ b/apps/sdp-docs/scripts/generate-postman-collection.mjs
@@ -16,6 +16,14 @@ const environmentTemplatePath = path.join(
 
 const DEFAULT_EXTERNAL_ADDRESS = "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ";
 const DEFAULT_SECONDARY_ADDRESS = "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv";
+const HIDDEN_TAG_SLUGS = new Set([
+  "rpc",
+  "admin",
+  "onboarding",
+  "auth",
+  "organizations",
+  "members",
+]);
 
 const JSON_HEADERS = [{ key: "Content-Type", value: "application/json" }];
 const AUTH_HEADER = { key: "Authorization", value: "Bearer {{apiKey}}" };
@@ -117,6 +125,13 @@ function slugTitle(value) {
   return value.replace(/([a-z])([A-Z])/g, "$1 $2");
 }
 
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 function operationRequestDescription(operation) {
   return operation?.description || operation?.summary || slugTitle(operation?.operationId || "");
 }
@@ -168,6 +183,11 @@ function apiKeyOperationsFromSpec(spec) {
         continue;
       }
 
+      const primaryTag = Array.isArray(operation.tags) ? operation.tags[0] : null;
+      if (primaryTag && HIDDEN_TAG_SLUGS.has(slugify(primaryTag))) {
+        continue;
+      }
+
       operations.set(operation.operationId, {
         operationId: operation.operationId,
         method: method.toUpperCase(),
@@ -188,6 +208,8 @@ const excludedOperations = {
     "Requires an explicit organization id and mutates shared organization settings, so it is excluded from the CI-safe admin suite.",
   deleteOrganization:
     "Destructive organization deletion is not safe for a recurring required CI suite.",
+  listMembers:
+    "The Members tag is intentionally hidden from the public docs, so it is excluded from the downloadable Postman suite.",
   inviteMember:
     "The handler requires a Clerk-authenticated human user to send invitations, so a machine API key cannot execute it.",
   removeMember:
@@ -208,6 +230,10 @@ const excludedOperations = {
     "Requires a mutable project member target and is excluded from the CI-safe suite.",
   removeProjectMember:
     "Requires a mutable project member target and is excluded from the CI-safe suite.",
+  listRpcProviders:
+    "The RPC tag is intentionally hidden from the public docs, so it is excluded from the downloadable Postman suite.",
+  proxyRpcRequest:
+    "The RPC tag is intentionally hidden from the public docs, so it is excluded from the downloadable Postman suite.",
   executePaymentOnramp:
     "Depends on external provider availability and hosted third-party ramp services, so it is excluded from the required CI suite.",
   executePaymentOfframp:
@@ -233,18 +259,6 @@ function automatedRequests(operations) {
         "const wallet = body.data.wallets[0];",
         'pm.collectionVariables.set("walletId", wallet.walletId);',
         'pm.collectionVariables.set("walletPublicKey", wallet.publicKey);'
-      ),
-    }),
-    request({
-      operationId: "listMembers",
-      folder: ["Bootstrap"],
-      name: "List members",
-      method: "GET",
-      url: "/v1/members",
-      description: op("listMembers"),
-      tests: jsonStatusTest(
-        200,
-        'pm.expect(body.data.members, "members array").to.be.an("array");'
       ),
     }),
     request({
@@ -559,41 +573,6 @@ function automatedRequests(operations) {
       description: op("archiveProject"),
       prerequest: [requireVar("projectId")],
       tests: statusTest(204),
-    }),
-    request({
-      operationId: "listRpcProviders",
-      folder: ["RPC"],
-      name: "List RPC providers",
-      method: "GET",
-      url: "/v1/rpc/providers",
-      description: op("listRpcProviders"),
-      tests: jsonStatusTest(
-        200,
-        'pm.expect(body.data.providers, "providers array").to.be.an("array");'
-      ),
-    }),
-    request({
-      operationId: "proxyRpcRequest",
-      folder: ["RPC"],
-      name: "Proxy getLatestBlockhash",
-      method: "POST",
-      url: "/v1/rpc/proxy",
-      description: op("proxyRpcRequest"),
-      body: JSON.stringify(
-        {
-          jsonrpc: "2.0",
-          id: 1,
-          method: "getLatestBlockhash",
-          params: [],
-        },
-        null,
-        2
-      ),
-      tests: jsonStatusTest(
-        200,
-        "pm.expect(body.data.provider).to.exist;",
-        "pm.expect(body.data.response).to.exist;"
-      ),
     }),
     request({
       operationId: "listTokenTemplates",
@@ -1326,6 +1305,7 @@ async function run() {
 
   const automatedIds = new Set(automated.map((entry) => entry.operationId));
   const excludedIds = new Set(Object.keys(excludedOperations));
+  const visibleExcludedIds = [...excludedIds].filter((operationId) => operations.has(operationId));
 
   const uncovered = [...operations.keys()].filter(
     (operationId) => !automatedIds.has(operationId) && !excludedIds.has(operationId)
@@ -1384,8 +1364,9 @@ async function run() {
     sourceOpenApi: "apps/sdp-api/generated/openapi.json",
     totals: {
       apiKeyOperations: operations.size,
-      automated: automated.length,
-      excluded: excludedIds.size,
+      coveredOperations: automatedIds.size,
+      automatedRequests: automated.length,
+      excluded: visibleExcludedIds.length,
     },
     automated: automated.map(({ operationId, folder, item }) => {
       const operation = operations.get(operationId);
@@ -1397,7 +1378,7 @@ async function run() {
         path: operation?.path ?? null,
       };
     }),
-    excluded: [...excludedIds].sort().map((operationId) => {
+    excluded: visibleExcludedIds.sort().map((operationId) => {
       const operation = operations.get(operationId);
       return {
         operationId,
@@ -1413,7 +1394,7 @@ async function run() {
   await writeJson(environmentTemplatePath, buildEnvironmentTemplate());
 
   console.log(
-    `Generated Postman collection with ${automated.length} automated operations and ${excludedIds.size} exclusions.`
+    `Generated Postman collection with ${automated.length} automated requests covering ${automatedIds.size} visible API-key operations and ${visibleExcludedIds.length} visible exclusions.`
   );
 }
 

--- a/biome.json
+++ b/biome.json
@@ -71,6 +71,19 @@
       }
     },
     {
+      "include": ["apps/sdp-docs/scripts/generate-postman-collection.mjs"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
+          },
+          "nursery": {
+            "noSecrets": "off"
+          }
+        }
+      }
+    },
+    {
       "include": ["**/issuance/templates/**/*.ts"],
       "linter": {
         "rules": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "format:check": "biome format .",
     "test": "turbo run test --filter=!@sdp/api-integration",
     "test:integration": "turbo run test --filter=@sdp/api-integration",
+    "test:postman": "pnpm -C apps/sdp-api run openapi:generate && pnpm --filter sdp-docs generate:postman && node scripts/run-postman-api-key-suite.mjs",
     "check": "biome check --write . && turbo run typecheck",
     "kora:up": "docker compose -f infra/kora/docker-compose.yml up -d",
     "kora:down": "docker compose -f infra/kora/docker-compose.yml down",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
+    "newman": "6.2.2",
     "turbo": "^2.4.0",
     "typescript": "^5.8.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.0
         version: 1.9.4
+      newman:
+        specifier: 6.2.2
+        version: 6.2.2
       turbo:
         specifier: ^2.4.0
         version: 2.7.5
@@ -610,6 +613,10 @@ packages:
 
   '@cloudflare/workers-types@4.20260123.0':
     resolution: {integrity: sha512-pQccZ8IDLFKkvdKBXZRPkbMtWtS7vVz1giJGkAAZ5cZH2RHK5Bs6p1OoVZA8Z2Sry8Q0tZbZ5Yjud4R7SrG3KQ==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1273,6 +1280,10 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@faker-js/faker@5.5.3':
+    resolution: {integrity: sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==}
+    deprecated: Please update to a newer version.
+
   '@fastify/otel@0.16.0':
     resolution: {integrity: sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==}
     peerDependencies:
@@ -1840,6 +1851,17 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@postman/form-data@3.1.1':
+    resolution: {integrity: sha512-vjh8Q2a8S6UCm/KKs31XFJqEEgmbjBmpPNVV2eVav6905wyFAwaUOBGA1NPBI4ERH9MMZc6w0umFgM6WbEPMdg==}
+    engines: {node: '>= 6'}
+
+  '@postman/tough-cookie@4.1.3-postman.1':
+    resolution: {integrity: sha512-txpgUqZOnWYnUHZpHjkfb0IwVH4qJmyq77pPnJLlfhMtdCLMFTEeQHlzQiK906aaNCe4NEB5fGJHo9uzGbFMeA==}
+    engines: {node: '>=6'}
+
+  '@postman/tunnel-agent@0.6.8':
+    resolution: {integrity: sha512-2U42SmZW5G+suEcS++zB94sBWNO4qD4bvETGFRFDTqSpYl5ksfjcPqzYpgQgXgUmb6dfz+fAGbkcRamounGm0w==}
 
   '@prisma/instrumentation@7.2.0':
     resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
@@ -4010,6 +4032,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -4088,6 +4114,13 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4106,9 +4139,24 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async@3.2.5:
+    resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.12.0:
+    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
@@ -4128,12 +4176,21 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  bluebird@2.11.0:
+    resolution: {integrity: sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -4148,6 +4205,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -4184,6 +4244,9 @@ packages:
   caniuse-lite@1.0.30001767:
     resolution: {integrity: sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==}
 
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -4211,6 +4274,13 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@2.0.0:
+    resolution: {integrity: sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==}
+
+  charset@1.0.1:
+    resolution: {integrity: sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==}
+    engines: {node: '>=4.0.0'}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -4232,6 +4302,14 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -4252,8 +4330,20 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   commander@14.0.1:
     resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
@@ -4265,6 +4355,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -4282,6 +4376,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -4297,8 +4394,15 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  csv-parse@4.16.3:
+    resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -4355,9 +4459,16 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4499,6 +4610,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
@@ -4767,6 +4881,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4809,6 +4927,14 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-type@3.9.0:
+    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
+    engines: {node: '>=0.10.0'}
+
+  filesize@10.1.4:
+    resolution: {integrity: sha512-ryBwPIIeErmxgPnm6cbESAzXjuEFubs+yKYLBZvg3CaiNcmkJChoOGcBSrZ6IwkMwPABwPpVXE6IlNdGJJrvEg==}
+    engines: {node: '>= 10.4.0'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4825,6 +4951,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatted@3.2.6:
+    resolution: {integrity: sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==}
+
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
@@ -4835,6 +4964,9 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
@@ -4972,6 +5104,9 @@ packages:
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -5016,6 +5151,20 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5082,9 +5231,32 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-reasons@0.1.0:
+    resolution: {integrity: sha512-P6kYh0lKZ+y29T2Gqz+RlC9WBLhKe8kDmcJ+A+611jFfxdPsbMRQ5aNmFRM3lENqFkK+HTTL+tlQviAiv0AbLQ==}
+
+  http-signature@1.3.6:
+    resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}
+    engines: {node: '>=0.10'}
+
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
+
+  httpntlm@1.8.13:
+    resolution: {integrity: sha512-2F2FDPiWT4rewPzNMg3uPhNkP3NExENlUGADRUDPQvuftuUTGW98nLZtGemCIW3G40VhWZYgkIDcQFAwZ3mf2Q==}
+    engines: {node: '>=10.4.0'}
+
+  httpreq@1.1.1:
+    resolution: {integrity: sha512-uhSZLPPD2VXXOSN8Cni3kIsoFHaU2pT/nySEU/fHr/ePbqHYr0jeiQRmUKLEirC09SFPsdMoA7LU7UXMd/w0Kw==}
+    engines: {node: '>= 6.15.1'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -5110,12 +5282,19 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -5231,6 +5410,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -5248,6 +5430,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5280,12 +5465,21 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@4.14.4:
+    resolution: {integrity: sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==}
+
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
+
+  js-sha512@0.9.0:
+    resolution: {integrity: sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5296,6 +5490,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5314,8 +5511,14 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -5325,6 +5528,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsprim@2.0.2:
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -5421,6 +5628,10 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  liquid-json@0.3.1:
+    resolution: {integrity: sha512-wUayTU8MS827Dam6MxgD72Ui+KOSF+u/eIqpatOtjnvgJ0+mnDq33uC2M7J0tPK+upe/DpUAuK4JUU89iBoNKQ==}
+    engines: {node: '>=4'}
+
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
@@ -5435,6 +5646,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -5455,6 +5669,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lucide-react@0.562.0:
     resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
@@ -5655,6 +5873,9 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-format@2.0.1:
+    resolution: {integrity: sha512-XxU3ngPbEnrYnNbIX+lYSaYg0M01v6p2ntd2YaFksTu0vayaw5OJvbdRyWs07EYRlLED5qadUZ+xo+XhOvFhwg==}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
@@ -5663,6 +5884,9 @@ packages:
     resolution: {integrity: sha512-XXZyE2pDKMtP5OLuv0LPHEAzIYhov4jrYjcqrhhqtxGGtXneWOHvXIPo+eV8sqwqWd3R7j4DlEKcyb+87BR49Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.2:
     resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
@@ -5685,6 +5909,11 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -5722,6 +5951,11 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  newman@6.2.2:
+    resolution: {integrity: sha512-BmGzMz6f2FLtw/hHAbhEAVqXS+3APJGAWzlxVijSElFaxC37wpHEqsOB09d/2uHMvTyMXGArtbFa+z5m/a68Uw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -5780,6 +6014,13 @@ packages:
       encoding:
         optional: true
 
+  node-forge@1.3.1:
+    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+    engines: {node: '>= 6.13.0'}
+
+  node-oauth1@1.3.0:
+    resolution: {integrity: sha512-0yggixNfrA1KcBwvh/Hy2xAS1Wfs9dcg6TdFf2zN7gilcAigMdrtZ4ybrBSXBgLvGDw9V1p2MRnGBMq7XjTWLg==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -5787,9 +6028,16 @@ packages:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@1.3.1:
+    resolution: {integrity: sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==}
+    engines: {node: '>= 0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -5866,6 +6114,10 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -5903,6 +6155,9 @@ packages:
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -5962,6 +6217,35 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  postman-collection-transformer@4.1.8:
+    resolution: {integrity: sha512-smJ6X7Z7kbg6hp7JZPFixrSN3J3WkQed7DrWCC5tF7IxOMpFLqhtTtGssY8nD1inP8+mJf+N72Pf2ttUAHgBKw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  postman-collection@4.4.0:
+    resolution: {integrity: sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==}
+    engines: {node: '>=10'}
+
+  postman-request@2.88.1-postman.34:
+    resolution: {integrity: sha512-GkolJ4cIzgamcwHRDkeZc/taFWO1u2HuGNML47K9ZAsFH2LdEkS5Yy8QanpzhjydzV3WWthl9v60J8E7SjKodQ==}
+    engines: {node: '>= 6'}
+
+  postman-request@2.88.1-postman.48:
+    resolution: {integrity: sha512-E32FGh8ig2KDvzo4Byi7Ibr+wK2gNKPSqXoNsvjdCHgDBxSK4sCUwv+aa3zOBUwfiibPImHMy0WdlDSSCTqTuw==}
+    engines: {node: '>= 16'}
+
+  postman-runtime@7.39.1:
+    resolution: {integrity: sha512-IRNrBE0l1K3ZqQhQVYgF6MPuqOB9HqYncal+a7RpSS+sysKLhJMkC9SfUn1HVuOpokdPkK92ykvPzj8kCOLYAg==}
+    engines: {node: '>=12'}
+
+  postman-sandbox@4.7.1:
+    resolution: {integrity: sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==}
+    engines: {node: '>=10'}
+
+  postman-url-encoder@3.0.5:
+    resolution: {integrity: sha512-jOrdVvzUXBC7C+9gkIkpDJ3HIxOHTIqjpQ4C1EMt1ZGeMvSEpbFCKq23DEfgsj46vMnDgyQf+1ZLp2Wm+bKSsA==}
+    engines: {node: '>=10'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5970,6 +6254,10 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -5988,6 +6276,9 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5996,6 +6287,17 @@ packages:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
+    engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6132,6 +6434,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -6164,6 +6469,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -6171,6 +6479,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -6189,10 +6500,23 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialised-error@1.1.3:
+    resolution: {integrity: sha512-vybp3GItaR1ZtO2nxZZo8eOo7fnVaNtP3XE2vJKgzkKR2bagCkdJ1EpYYhEMd3qu/80DwQk9KjsNSxE3fXWq0g==}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -6254,6 +6578,18 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -6278,8 +6614,16 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stack-trace@0.0.9:
+    resolution: {integrity: sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -6297,6 +6641,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-length@1.0.2:
+    resolution: {integrity: sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6408,6 +6755,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  teleport-javascript@1.0.0:
+    resolution: {integrity: sha512-j1llvWVFyEn/6XIFDfX5LAU43DXe0GCt3NfXDwJ8XpRRMkS+i50SAkonAONBy+vxwPFBd50MFU8a2uj8R/ccLg==}
 
   terser-webpack-plugin@5.3.17:
     resolution: {integrity: sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==}
@@ -6527,6 +6877,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6563,9 +6916,17 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  underscore@1.12.1:
+    resolution: {integrity: sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -6601,6 +6962,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -6612,6 +6977,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -6645,9 +7013,26 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  uvm@2.1.1:
+    resolution: {integrity: sha512-BZ5w8adTpNNr+zczOBRpaX/hH8UPKAf7fmCnidrcsqt3bn8KT9bDIfuS7hgRU9RXgiN01su2pwysBONY6w8W5w==}
+    engines: {node: '>=10'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -6785,6 +7170,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
   workerd@1.20260120.0:
     resolution: {integrity: sha512-R6X/VQOkwLTBGLp4VRUwLQZZVxZ9T9J8pGiJ6GQUMaRkY7TVWrCSkVfoNMM1/YyFsY5UYhhPoQe5IehnhZ3Pdw==}
     engines: {node: '>=16'}
@@ -6836,6 +7224,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -6845,6 +7237,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -7122,6 +7517,9 @@ snapshots:
     optional: true
 
   '@cloudflare/workers-types@4.20260123.0': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -7500,6 +7898,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@faker-js/faker@5.5.3': {}
 
   '@fastify/otel@0.16.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -8076,6 +8476,23 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@postman/form-data@3.1.1':
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  '@postman/tough-cookie@4.1.3-postman.1':
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  '@postman/tunnel-agent@0.6.8':
+    dependencies:
+      safe-buffer: 5.2.1
 
   '@prisma/instrumentation@7.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -10800,6 +11217,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -10908,6 +11327,12 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -10922,9 +11347,19 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async@3.2.5: {}
+
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.12.0: {}
+
+  aws4@1.13.2: {}
 
   axe-core@4.11.1: {}
 
@@ -10936,9 +11371,17 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   blake3-wasm@2.1.5: {}
+
+  bluebird@2.11.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -10956,6 +11399,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
 
   browserslist@4.28.1:
     dependencies:
@@ -10992,6 +11439,8 @@ snapshots:
 
   caniuse-lite@1.0.30001767: {}
 
+  caseless@0.12.0: {}
+
   ccount@2.0.1: {}
 
   chai@5.3.3:
@@ -11017,6 +11466,10 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@2.0.0: {}
+
+  charset@1.0.1: {}
+
   check-error@2.1.3: {}
 
   chokidar@4.0.3:
@@ -11032,6 +11485,16 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   client-only@0.0.1: {}
 
@@ -11051,13 +11514,23 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colors@1.4.0: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
+
+  commander@11.1.0: {}
 
   commander@14.0.1: {}
 
   commander@14.0.2: {}
 
   commander@2.20.3: {}
+
+  commander@8.3.0: {}
 
   commondir@1.0.1: {}
 
@@ -11068,6 +11541,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  core-util-is@1.0.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11081,7 +11556,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  csv-parse@4.16.3: {}
+
   damerau-levenshtein@1.0.8: {}
+
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -11133,7 +11614,14 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
   dequal@2.0.3: {}
+
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
 
   detect-libc@2.1.2: {}
 
@@ -11193,6 +11681,11 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   electron-to-chromium@1.5.286: {}
 
@@ -11463,7 +11956,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -11486,7 +11979,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11501,14 +11994,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11523,7 +12016,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11713,6 +12206,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extsprintf@1.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -11753,6 +12248,10 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-type@3.9.0: {}
+
+  filesize@10.1.4: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -11772,6 +12271,8 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
 
+  flatted@3.2.6: {}
+
   flatted@3.3.3: {}
 
   for-each@0.3.5:
@@ -11782,6 +12283,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  forever-agent@0.6.1: {}
 
   forwarded-parse@2.1.2: {}
 
@@ -11937,6 +12440,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
+
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -11978,6 +12485,22 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
 
   has-bigints@1.1.0: {}
 
@@ -12091,12 +12614,39 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-reasons@0.1.0: {}
+
+  http-signature@1.3.6:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
+  httpntlm@1.8.13:
+    dependencies:
+      des.js: 1.1.0
+      httpreq: 1.1.1
+      js-md4: 0.3.2
+      underscore: 1.12.1
+
+  httpreq@1.1.1: {}
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -12118,6 +12668,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
 
   internal-slot@1.1.0:
@@ -12125,6 +12677,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip-address@10.1.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -12246,6 +12800,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-typedarray@1.0.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -12260,6 +12816,8 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -12305,9 +12863,15 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@4.14.4: {}
+
   jose@6.1.3: {}
 
   js-cookie@3.0.5: {}
+
+  js-md4@0.3.2: {}
+
+  js-sha512@0.9.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -12316,6 +12880,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsbn@0.1.1: {}
 
   jsesc@3.1.0: {}
 
@@ -12327,13 +12893,24 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -12410,6 +12987,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  liquid-json@0.3.1: {}
+
   loader-runner@4.3.1: {}
 
   locate-path@5.0.0:
@@ -12421,6 +13000,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
 
@@ -12437,6 +13018,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lucide-react@0.562.0(react@19.2.3):
     dependencies:
@@ -12902,6 +13487,10 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-format@2.0.1:
+    dependencies:
+      charset: 1.0.1
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
@@ -12918,6 +13507,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.2:
     dependencies:
@@ -12936,6 +13527,8 @@ snapshots:
   minipass@7.1.2: {}
 
   minipass@7.1.3: {}
+
+  mkdirp@3.0.1: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -12958,6 +13551,32 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  newman@6.2.2:
+    dependencies:
+      '@postman/tough-cookie': 4.1.3-postman.1
+      async: 3.2.5
+      chardet: 2.0.0
+      cli-progress: 3.12.0
+      cli-table3: 0.6.5
+      colors: 1.4.0
+      commander: 11.1.0
+      csv-parse: 4.16.3
+      filesize: 10.1.4
+      liquid-json: 0.3.1
+      lodash: 4.17.21
+      mkdirp: 3.0.1
+      postman-collection: 4.4.0
+      postman-collection-transformer: 4.1.8
+      postman-request: 2.88.1-postman.48
+      postman-runtime: 7.39.1
+      pretty-ms: 7.0.1
+      semver: 7.6.3
+      serialised-error: 1.1.3
+      word-wrap: 1.2.5
+      xmlbuilder: 15.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -13017,11 +13636,19 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-forge@1.3.1: {}
+
+  node-oauth1@1.3.0: {}
+
   node-releases@2.0.27: {}
 
   npm-to-yarn@3.0.1: {}
 
+  oauth-sign@0.9.0: {}
+
   object-assign@4.1.1: {}
+
+  object-hash@1.3.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -13124,6 +13751,8 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-ms@2.1.0: {}
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -13154,6 +13783,8 @@ snapshots:
   pathval@2.0.1: {}
 
   peberminta@0.9.0: {}
+
+  performance-now@2.1.0: {}
 
   pg-int8@1.0.1: {}
 
@@ -13204,9 +13835,118 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  postman-collection-transformer@4.1.8:
+    dependencies:
+      commander: 8.3.0
+      inherits: 2.0.4
+      lodash: 4.17.21
+      semver: 7.5.4
+      strip-json-comments: 3.1.1
+
+  postman-collection@4.4.0:
+    dependencies:
+      '@faker-js/faker': 5.5.3
+      file-type: 3.9.0
+      http-reasons: 0.1.0
+      iconv-lite: 0.6.3
+      liquid-json: 0.3.1
+      lodash: 4.17.21
+      mime-format: 2.0.1
+      mime-types: 2.1.35
+      postman-url-encoder: 3.0.5
+      semver: 7.5.4
+      uuid: 8.3.2
+
+  postman-request@2.88.1-postman.34:
+    dependencies:
+      '@postman/form-data': 3.1.1
+      '@postman/tough-cookie': 4.1.3-postman.1
+      '@postman/tunnel-agent': 0.6.8
+      aws-sign2: 0.7.0
+      aws4: 1.12.0
+      brotli: 1.3.3
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      har-validator: 5.1.5
+      http-signature: 1.3.6
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      stream-length: 1.0.2
+      uuid: 8.3.2
+
+  postman-request@2.88.1-postman.48:
+    dependencies:
+      '@postman/form-data': 3.1.1
+      '@postman/tough-cookie': 4.1.3-postman.1
+      '@postman/tunnel-agent': 0.6.8
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      qs: 6.14.2
+      safe-buffer: 5.2.1
+      socks-proxy-agent: 8.0.5
+      stream-length: 1.0.2
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  postman-runtime@7.39.1:
+    dependencies:
+      '@postman/tough-cookie': 4.1.3-postman.1
+      async: 3.2.5
+      aws4: 1.12.0
+      handlebars: 4.7.8
+      httpntlm: 1.8.13
+      jose: 4.14.4
+      js-sha512: 0.9.0
+      lodash: 4.17.21
+      mime-types: 2.1.35
+      node-forge: 1.3.1
+      node-oauth1: 1.3.0
+      performance-now: 2.1.0
+      postman-collection: 4.4.0
+      postman-request: 2.88.1-postman.34
+      postman-sandbox: 4.7.1
+      postman-url-encoder: 3.0.5
+      serialised-error: 1.1.3
+      strip-json-comments: 3.1.1
+      uuid: 8.3.2
+
+  postman-sandbox@4.7.1:
+    dependencies:
+      lodash: 4.17.21
+      postman-collection: 4.4.0
+      teleport-javascript: 1.0.0
+      uvm: 2.1.1
+
+  postman-url-encoder@3.0.5:
+    dependencies:
+      punycode: 2.3.1
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
+
+  pretty-ms@7.0.1:
+    dependencies:
+      parse-ms: 2.1.0
 
   prismjs@1.30.0: {}
 
@@ -13222,6 +13962,10 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
 
   qrcode@1.5.4:
@@ -13229,6 +13973,14 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.5.5: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -13468,6 +14220,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  requires-port@1.0.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -13529,6 +14283,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -13539,6 +14295,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -13559,7 +14317,19 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
+
+  semver@7.6.3: {}
+
   semver@7.7.3: {}
+
+  serialised-error@1.1.3:
+    dependencies:
+      object-hash: 1.3.1
+      stack-trace: 0.0.9
+      uuid: 3.4.0
 
   server-only@0.0.1: {}
 
@@ -13678,6 +14448,21 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -13696,7 +14481,21 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   stable-hash@0.0.5: {}
+
+  stack-trace@0.0.9: {}
 
   stackback@0.0.2: {}
 
@@ -13715,6 +14514,10 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-length@1.0.2:
+    dependencies:
+      bluebird: 2.11.0
 
   string-width@4.2.3:
     dependencies:
@@ -13849,6 +14652,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  teleport-javascript@1.0.0: {}
+
   terser-webpack-plugin@5.3.17(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -13946,6 +14751,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -13998,12 +14805,17 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  underscore@1.12.1: {}
 
   undici-types@6.21.0: {}
 
@@ -14052,6 +14864,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@0.2.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -14086,6 +14900,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
   use-callback-ref@1.3.3(@types/react@19.2.10)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -14109,7 +14928,21 @@ snapshots:
 
   uuid@10.0.0: {}
 
+  uuid@3.4.0: {}
+
+  uuid@8.3.2: {}
+
   uuid@9.0.1: {}
+
+  uvm@2.1.1:
+    dependencies:
+      flatted: 3.2.6
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   vfile-message@4.0.3:
     dependencies:
@@ -14319,6 +15152,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wordwrap@1.0.0: {}
+
   workerd@1.20260120.0:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20260120.0
@@ -14366,11 +15201,15 @@ snapshots:
 
   ws@8.19.0: {}
 
+  xmlbuilder@15.1.1: {}
+
   xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.2: {}
 

--- a/scripts/run-postman-api-key-suite.mjs
+++ b/scripts/run-postman-api-key-suite.mjs
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +10,10 @@ const repoRoot = path.resolve(__dirname, "..");
 const collectionPath = path.join(
   repoRoot,
   "apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json"
+);
+const environmentTemplatePath = path.join(
+  repoRoot,
+  "apps/sdp-docs/public/downloads/sdp-api-admin.postman_environment.template.json"
 );
 
 const baseUrl = process.env.POSTMAN_API_BASE_URL?.trim();
@@ -27,31 +33,68 @@ if (!apiKey) {
   process.exit(1);
 }
 
-const args = [
-  "exec",
-  "newman",
-  "run",
-  collectionPath,
-  "--bail",
-  "--reporters",
-  "cli",
-  "--env-var",
-  `baseUrl=${baseUrl}`,
-  "--env-var",
-  `apiKey=${apiKey}`,
-];
+async function createEnvironmentFile() {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "sdp-postman-"));
+  const environmentPath = path.join(tmpDir, "environment.json");
+  const template = JSON.parse(await readFile(environmentTemplatePath, "utf8"));
 
-const child = spawn("pnpm", args, {
-  cwd: repoRoot,
-  env: process.env,
-  stdio: "inherit",
-});
+  template.values = template.values.map((entry) => {
+    if (entry.key === "baseUrl") {
+      return { ...entry, value: baseUrl };
+    }
 
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
+    if (entry.key === "apiKey") {
+      return { ...entry, value: apiKey };
+    }
+
+    return entry;
+  });
+
+  await writeFile(environmentPath, `${JSON.stringify(template, null, 2)}\n`, "utf8");
+  return { tmpDir, environmentPath };
+}
+
+async function main() {
+  const { tmpDir, environmentPath } = await createEnvironmentFile();
+
+  try {
+    const args = [
+      "exec",
+      "newman",
+      "run",
+      collectionPath,
+      "--bail",
+      "--reporters",
+      "cli",
+      "--environment",
+      environmentPath,
+    ];
+
+    const exitCode = await new Promise((resolve, reject) => {
+      const child = spawn("pnpm", args, {
+        cwd: repoRoot,
+        env: process.env,
+        stdio: "inherit",
+      });
+
+      child.on("error", reject);
+      child.on("exit", (code, signal) => {
+        if (signal) {
+          process.kill(process.pid, signal);
+          return;
+        }
+
+        resolve(code ?? 1);
+      });
+    });
+
+    process.exit(exitCode);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
   }
+}
 
-  process.exit(code ?? 1);
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/scripts/run-postman-api-key-suite.mjs
+++ b/scripts/run-postman-api-key-suite.mjs
@@ -1,0 +1,57 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const collectionPath = path.join(
+  repoRoot,
+  "apps/sdp-docs/public/downloads/sdp-api-admin.postman_collection.json"
+);
+
+const baseUrl = process.env.POSTMAN_API_BASE_URL?.trim();
+const apiKey = process.env.POSTMAN_ADMIN_API_KEY?.trim();
+
+if (!baseUrl) {
+  console.error(
+    "Missing POSTMAN_API_BASE_URL. Set it to the deployed sandbox API base URL for the dedicated CI admin org."
+  );
+  process.exit(1);
+}
+
+if (!apiKey) {
+  console.error(
+    "Missing POSTMAN_ADMIN_API_KEY. Create a dedicated sandbox admin API key for the CI org and add it to GitHub Actions secrets."
+  );
+  process.exit(1);
+}
+
+const args = [
+  "exec",
+  "newman",
+  "run",
+  collectionPath,
+  "--bail",
+  "--reporters",
+  "cli",
+  "--env-var",
+  `baseUrl=${baseUrl}`,
+  "--env-var",
+  `apiKey=${apiKey}`,
+];
+
+const child = spawn("pnpm", args, {
+  cwd: repoRoot,
+  env: process.env,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- generate a downloadable Postman admin API key collection and environment template from the API inventory
- add a Newman-based CI job for the collection and wire it into the main CI workflow as `Postman API Key Suite`
- expose the collection in the docs and pull payments into the generated OpenAPI reference

## Validation
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter sdp-docs typecheck`
- `pnpm --filter sdp-docs build`
- `pnpm test:postman` (expected setup failure without `POSTMAN_API_BASE_URL` / `POSTMAN_ADMIN_API_KEY`)

## Required CI setup after PR opens
- add `POSTMAN_ADMIN_API_KEY` as a GitHub Actions secret
- add `POSTMAN_API_BASE_URL` as a GitHub Actions repository variable or secret
- use a dedicated sandbox admin key attached to an org with at least one active funded wallet
