### PR TITLE
feat(docs): add ai discovery resources

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+Use `/AGENTS.md` as the canonical instruction source for this repository.
+
+Additional rule: do not hand-edit generated API docs or generated AI discovery resources. Regenerate them through the documented scripts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,37 @@ jobs:
       - name: Build docs
         run: pnpm --filter sdp-docs build
 
+  docs_integrity:
+    name: Docs Integrity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate public docs artifacts
+        run: |
+          pnpm --filter sdp-docs generate:api
+          pnpm --filter sdp-docs generate:ai
+
+      - name: Check docs links
+        run: pnpm --filter sdp-docs check:links
+
   integration_tests:
     name: Integration Tests (Devnet/Kora)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Solana Developer Platform
+
+This file is the canonical agent guide for this repository.
+
+## Repo layout
+
+- `apps/sdp-api`: Cloudflare Workers API, OpenAPI source, route handlers, D1/KV integrations
+- `apps/sdp-web`: dashboard application
+- `apps/sdp-docs`: public documentation site and generated API reference
+- `packages/sdp-types`: shared runtime types and shared product constants
+
+## Source of truth
+
+- Public API contract: `apps/sdp-api/src/openapi/**`
+- Public docs navigation: `apps/sdp-docs/content/docs/meta.json`
+- Generated API docs: `apps/sdp-docs/content/docs/reference/api/**`
+- AI discovery resources: `apps/sdp-docs/public/llms.txt` and `apps/sdp-docs/public/llms-full.txt`
+
+## Generated files
+
+Do not hand-edit generated artifacts. Regenerate them with the owning script.
+
+- OpenAPI JSON: `pnpm -C apps/sdp-api openapi:generate`
+- API reference docs: `pnpm -C apps/sdp-docs generate:api`
+- AI discovery resources: `pnpm -C apps/sdp-docs generate:ai`
+
+## Public vs internal surfaces
+
+Public docs and AI artifacts should mirror the supported public surface only.
+
+- Public API families: `health`, `api-keys`, `wallets`, `projects`, `issuance`, `payments`, `compliance`
+- Hidden/internal families stay out of public AI resources unless product policy changes: `rpc`, `admin`, `onboarding`, `auth`, `organizations`, `members`
+
+## Preferred checks
+
+- Docs integrity: `pnpm --filter sdp-docs check:links`
+- Docs build: `pnpm --filter sdp-docs build`
+- API typecheck: `pnpm --filter @sdp/api typecheck`
+- API tests: `pnpm --filter @sdp/api test`
+- Full workspace typecheck: `pnpm typecheck`
+
+## Implementation guidance
+
+- Prefer reusing generated docs/OpenAPI metadata instead of duplicating route inventories by hand.
+- Keep public URLs coherent with the shared site constants in `@sdp/types/site`.
+- When changing docs URLs or discovery resources, update both the docs site and any product links that point at it.

--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -26,6 +26,7 @@ import docs from "@/routes/docs";
 // Routes
 import health from "@/routes/health";
 import issuance from "@/routes/issuance";
+import llms from "@/routes/llms";
 import members from "@/routes/members";
 import onboarding from "@/routes/onboarding";
 import openapi from "@/routes/openapi";
@@ -146,7 +147,10 @@ app.use("*", async (c, next) => {
 });
 
 // Rate limiting (skip health check paths)
-app.use("*", skipRateLimitPaths("/health", "/health/ready", "/openapi.json", "/docs", "/webhooks"));
+app.use(
+  "*",
+  skipRateLimitPaths("/health", "/health/ready", "/openapi.json", "/docs", "/llms.txt", "/webhooks")
+);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Routes
@@ -156,6 +160,7 @@ app.use("*", skipRateLimitPaths("/health", "/health/ready", "/openapi.json", "/d
 app.route("/health", health);
 app.route("/openapi.json", openapi);
 app.route("/docs", docs);
+app.route("/llms.txt", llms);
 app.route("/webhooks", webhooks);
 
 // API v1

--- a/apps/sdp-api/src/middleware/cors.ts
+++ b/apps/sdp-api/src/middleware/cors.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Env } from "@/types/env";
+import { getSdpDocsOrigin } from "@sdp/types";
 import { cors } from "hono/cors";
 
 /**
@@ -15,7 +16,7 @@ export function corsMiddleware(env: Env["ENVIRONMENT"]) {
           "https://solana.com",
           "https://www.solana.com",
           "https://developer.solana.com",
-          "https://docs.solana.com",
+          getSdpDocsOrigin(),
         ]
       : [
           "http://localhost:3000",

--- a/apps/sdp-api/src/openapi/spec.ts
+++ b/apps/sdp-api/src/openapi/spec.ts
@@ -1,4 +1,5 @@
 import { OpenAPIRegistry, OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi";
+import { DEFAULT_SDP_API_URL } from "@sdp/types";
 import type { OpenAPIObject } from "openapi3-ts/oas30";
 
 import { registerAdminPaths } from "./paths/admin";
@@ -98,7 +99,7 @@ export function createOpenApiDocument(): OpenAPIObject {
         description: "Local development",
       },
       {
-        url: "https://api.solana.com",
+        url: DEFAULT_SDP_API_URL,
         description: "Production",
       },
     ],

--- a/apps/sdp-api/src/routes/llms.test.ts
+++ b/apps/sdp-api/src/routes/llms.test.ts
@@ -1,0 +1,21 @@
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { describe, expect, it } from "vitest";
+
+describe("GET /llms.txt", () => {
+  it("returns the public API discovery document", async () => {
+    const res = await app.request("/llms.txt", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+
+    const body = await res.text();
+    expect(body).toContain("/openapi.json");
+    expect(body).toContain("/docs");
+    expect(body).toContain("/v1/api-keys");
+    expect(body).toContain("/v1/wallets");
+    expect(body).not.toContain("/admin/allowlist");
+    expect(body).not.toContain("/v1/onboarding");
+    expect(body).not.toContain("/v1/organizations");
+  });
+});

--- a/apps/sdp-api/src/routes/llms.ts
+++ b/apps/sdp-api/src/routes/llms.ts
@@ -1,0 +1,49 @@
+import { DEFAULT_SDP_API_URL, DEFAULT_SDP_DOCS_URL, SDP_AGENTS_URL } from "@sdp/types";
+import { Hono } from "hono";
+
+import type { Env } from "@/types/env";
+
+const llms = new Hono<{ Bindings: Env }>();
+
+const body = [
+  "# Solana Developer Platform API",
+  "",
+  "> Public machine-readable discovery entry point for the SDP API.",
+  "",
+  "## Canonical URLs",
+  `- API base URL: ${DEFAULT_SDP_API_URL}`,
+  `- OpenAPI: ${DEFAULT_SDP_API_URL}/openapi.json`,
+  `- Interactive API docs: ${DEFAULT_SDP_API_URL}/docs`,
+  `- Product docs: ${DEFAULT_SDP_DOCS_URL}`,
+  `- Agent guide: ${SDP_AGENTS_URL}`,
+  "",
+  "## Authentication",
+  "- Use `Authorization: Bearer <api_key>`.",
+  "- API keys are issued by SDP and commonly use `sk_test_...` or `sk_live_...` prefixes.",
+  "- Session-only or internal routes are intentionally excluded from this resource.",
+  "",
+  "## Public endpoint families",
+  `- Health: ${DEFAULT_SDP_API_URL}/health`,
+  `- API keys: ${DEFAULT_SDP_API_URL}/v1/api-keys`,
+  `- Wallets and custody: ${DEFAULT_SDP_API_URL}/v1/wallets`,
+  `- Projects: ${DEFAULT_SDP_API_URL}/v1/projects`,
+  `- Issuance: ${DEFAULT_SDP_API_URL}/v1/issuance`,
+  `- Payments: ${DEFAULT_SDP_API_URL}/v1/payments`,
+  `- Compliance: ${DEFAULT_SDP_API_URL}/v1/compliance`,
+  "",
+  "## Versioning",
+  "- The OpenAPI document is the source of truth for the current public contract.",
+  "- Production releases may lag behind the latest development branch.",
+  "",
+  "## Scope",
+  "- Hidden, internal-only, or session-only route families are intentionally excluded from this resource.",
+  "",
+].join("\n");
+
+llms.get("/", (c) => {
+  c.header("Content-Type", "text/plain; charset=utf-8");
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.body(body);
+});
+
+export default llms;

--- a/apps/sdp-docs/package.json
+++ b/apps/sdp-docs/package.json
@@ -5,16 +5,19 @@
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "dev:local": "node scripts/dev.mjs",
-    "build": "pnpm generate:api && pnpm generate:source && next build",
+    "build": "pnpm generate:api && pnpm generate:ai && pnpm generate:source && next build",
     "start": "next start --port 3001",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "generate:api": "pnpm -C ../sdp-api run openapi:generate && node scripts/generate-api-docs.mjs && pnpm exec biome check --write content/docs/meta.json content/docs/reference/api/meta.json",
+    "generate:ai": "tsx scripts/generate-ai-resources.ts",
     "generate:source": "node scripts/generate-source.mjs",
+    "check:links": "tsx scripts/check-links.ts",
     "watch:source": "node scripts/watch-source.mjs"
   },
   "dependencies": {
+    "@sdp/types": "workspace:*",
     "fumadocs-core": "^15.7.4",
     "fumadocs-mdx": "^11.7.4",
     "fumadocs-ui": "^15.7.4",
@@ -30,6 +33,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
+    "tsx": "4.21.0",
     "typescript": "^5"
   }
 }

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -1,0 +1,45 @@
+# Solana Developer Platform
+
+> Full public docs map for Solana Developer Platform, generated from the docs navigation and public API reference.
+
+## Canonical URLs
+- Docs: https://platform.solana.com/docs
+- API: https://api.solana.com
+- Interactive API docs: https://api.solana.com/docs
+- OpenAPI: https://api.solana.com/openapi.json
+- Repo: https://github.com/solana-foundation/solana-developer-platform
+- Agent guide: https://github.com/solana-foundation/solana-developer-platform/blob/main/AGENTS.md
+
+## Docs
+- [What is Solana Developer Platform?](https://platform.solana.com/docs/what-is-solana-developer-platform): A dashboard and API for issuing, transferring, and managing Solana tokens with built-in compliance controls.
+- [Getting Started](https://platform.solana.com/docs/getting-started): Get up and running with SDP through the dashboard.
+
+## Guides
+- [Set Up Your Organization](https://platform.solana.com/docs/guides/setup-organization): Create and configure your SDP organization through the dashboard.
+- [Set Up Wallets](https://platform.solana.com/docs/guides/setup-wallets): Initialize a custody provider and create wallets for signing transactions.
+- [Manage API Keys](https://platform.solana.com/docs/guides/manage-api-keys): Create, rotate, and revoke API keys with role-based access and environment scoping.
+- [Create a Token](https://platform.solana.com/docs/guides/create-a-token): Define a new token using templates or custom configuration.
+- [Deploy a Token](https://platform.solana.com/docs/guides/deploy-a-token): Deploy a created token to the Solana blockchain.
+- [Mint and Burn Tokens](https://platform.solana.com/docs/guides/mint-and-burn): Increase or decrease token supply by minting and burning.
+- [Manage Allowlists](https://platform.solana.com/docs/guides/manage-allowlists): Control which addresses can hold your token using allowlists.
+- [Freeze and Compliance](https://platform.solana.com/docs/guides/freeze-and-compliance): Freeze accounts, pause transfers, and seize tokens for compliance operations.
+- [Transfer Tokens](https://platform.solana.com/docs/guides/transfer-tokens): Send tokens between accounts using SDP's payment orchestration.
+- [Prepare vs Execute](https://platform.solana.com/docs/guides/prepare-vs-execute): Understand SDP's two signing modes for onchain transactions.
+
+## Tutorials
+- [End-to-end Payment Flow](https://platform.solana.com/docs/tutorials/end-to-end-payment-flow): A high-level payment flow from quote to settlement.
+
+## Reference
+- [Issuance Token Types](https://platform.solana.com/docs/reference/issuance-token-types): Supported issuance templates and default controls.
+- [API Reference](https://platform.solana.com/docs/reference/api): Endpoint index from the repository OpenAPI spec.
+- [Health](https://platform.solana.com/docs/reference/api/health): Service health and readiness endpoints.
+- [API Keys](https://platform.solana.com/docs/reference/api/api-keys): API key management endpoints.
+- [Wallets](https://platform.solana.com/docs/reference/api/wallets): Wallet signing provider configuration and wallet management.
+- [Projects](https://platform.solana.com/docs/reference/api/projects): Project and project member management.
+- [Issuance](https://platform.solana.com/docs/reference/api/issuance): Token issuance, allowlists, and lifecycle operations.
+- [Payments](https://platform.solana.com/docs/reference/api/payments): Wallet balances, transfer execution, policies, and ramps.
+- [Compliance](https://platform.solana.com/docs/reference/api/compliance): Risk and compliance screening endpoints.
+
+## Notes
+- Generated from docs navigation and public API reference pages.
+- Hidden or internal-only APIs are intentionally excluded.

--- a/apps/sdp-docs/public/llms.txt
+++ b/apps/sdp-docs/public/llms.txt
@@ -1,0 +1,48 @@
+# Solana Developer Platform
+
+> Public documentation and API discovery resources for Solana Developer Platform.
+
+## Canonical URLs
+- Docs: https://platform.solana.com/docs
+- API: https://api.solana.com
+- Interactive API docs: https://api.solana.com/docs
+- OpenAPI: https://api.solana.com/openapi.json
+- Repo: https://github.com/solana-foundation/solana-developer-platform
+- Agent guide: https://github.com/solana-foundation/solana-developer-platform/blob/main/AGENTS.md
+
+## Supported surfaces
+- Wallets and custody
+- API key management
+- Projects
+- Token issuance and lifecycle operations
+- Payments, transfers, and ramps
+- Compliance screening
+
+## Start here
+- [What is Solana Developer Platform?](https://platform.solana.com/docs/what-is-solana-developer-platform): A dashboard and API for issuing, transferring, and managing Solana tokens with built-in compliance controls.
+- [Getting Started](https://platform.solana.com/docs/getting-started): Get up and running with SDP through the dashboard.
+- [Set Up Your Organization](https://platform.solana.com/docs/guides/setup-organization): Create and configure your SDP organization through the dashboard.
+- [Set Up Wallets](https://platform.solana.com/docs/guides/setup-wallets): Initialize a custody provider and create wallets for signing transactions.
+- [Manage API Keys](https://platform.solana.com/docs/guides/manage-api-keys): Create, rotate, and revoke API keys with role-based access and environment scoping.
+- [Create a Token](https://platform.solana.com/docs/guides/create-a-token): Define a new token using templates or custom configuration.
+- [Deploy a Token](https://platform.solana.com/docs/guides/deploy-a-token): Deploy a created token to the Solana blockchain.
+- [Mint and Burn Tokens](https://platform.solana.com/docs/guides/mint-and-burn): Increase or decrease token supply by minting and burning.
+- [Transfer Tokens](https://platform.solana.com/docs/guides/transfer-tokens): Send tokens between accounts using SDP's payment orchestration.
+- [End-to-end Payment Flow](https://platform.solana.com/docs/tutorials/end-to-end-payment-flow): A high-level payment flow from quote to settlement.
+- [Issuance Token Types](https://platform.solana.com/docs/reference/issuance-token-types): Supported issuance templates and default controls.
+- [API Reference](https://platform.solana.com/docs/reference/api): Endpoint index from the repository OpenAPI spec.
+- [Health](https://platform.solana.com/docs/reference/api/health): Service health and readiness endpoints.
+- [API Keys](https://platform.solana.com/docs/reference/api/api-keys): API key management endpoints.
+- [Wallets](https://platform.solana.com/docs/reference/api/wallets): Wallet signing provider configuration and wallet management.
+- [Projects](https://platform.solana.com/docs/reference/api/projects): Project and project member management.
+- [Issuance](https://platform.solana.com/docs/reference/api/issuance): Token issuance, allowlists, and lifecycle operations.
+- [Payments](https://platform.solana.com/docs/reference/api/payments): Wallet balances, transfer execution, policies, and ramps.
+- [Compliance](https://platform.solana.com/docs/reference/api/compliance): Risk and compliance screening endpoints.
+
+## Machine-readable resources
+- [llms-full.txt](https://platform.solana.com/llms-full.txt)
+- [OpenAPI](https://api.solana.com/openapi.json)
+- [Swagger UI](https://api.solana.com/docs)
+
+## Scope
+- Public AI artifacts intentionally exclude hidden or internal-only API families.

--- a/apps/sdp-docs/scripts/check-links.ts
+++ b/apps/sdp-docs/scripts/check-links.ts
@@ -1,0 +1,291 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getDocsPagePath } from "../src/lib/site";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const docsContentDir = path.resolve(__dirname, "../content/docs");
+const docsMetaPath = path.resolve(docsContentDir, "meta.json");
+const configPath = path.resolve(__dirname, "link-check.config.json");
+
+type DocsMeta = {
+  pages?: string[];
+};
+
+type LinkCheckConfig = {
+  ignoredExternalHosts: string[];
+  ignoredExternalUrls: string[];
+};
+
+type LinkReference = {
+  sourcePath: string;
+  sourceSlug: string;
+  destination: string;
+  line: number;
+};
+
+const DEFAULT_CONFIG: LinkCheckConfig = {
+  ignoredExternalHosts: [],
+  ignoredExternalUrls: [],
+};
+
+function isDividerEntry(entry: string): boolean {
+  return entry.startsWith("---") && entry.endsWith("---");
+}
+
+function normalizePathname(value: string): string {
+  if (value === "/") {
+    return value;
+  }
+
+  return value.replace(/\/+$/, "");
+}
+
+function stripMarkdownSource(source: string): string {
+  return source
+    .replace(/^---\n[\s\S]*?\n---\n?/m, "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/~~~[\s\S]*?~~~/g, "");
+}
+
+function extractMarkdownLinks(source: string): Array<{ destination: string; line: number }> {
+  const links: Array<{ destination: string; line: number }> = [];
+  const linkPattern = /\[[^\]]+\]\(([^)\s]+(?:\s+"[^"]*")?)\)/g;
+
+  for (const match of source.matchAll(linkPattern)) {
+    const destination = match[1]?.split(/\s+"/)[0]?.trim();
+    if (!destination) {
+      continue;
+    }
+
+    const line = source.slice(0, match.index ?? 0).split("\n").length;
+    links.push({ destination, line });
+  }
+
+  return links;
+}
+
+async function listFiles(dirPath: string): Promise<string[]> {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        return listFiles(fullPath);
+      }
+      return [fullPath];
+    })
+  );
+
+  return nested.flat();
+}
+
+function toPageSlug(filePath: string): string {
+  const relativePath = path.relative(docsContentDir, filePath).replace(/\\/g, "/");
+  return relativePath.replace(/\.mdx$/, "");
+}
+
+async function loadDocsMeta(): Promise<DocsMeta> {
+  const json = await fs.readFile(docsMetaPath, "utf8");
+  return JSON.parse(json) as DocsMeta;
+}
+
+async function loadConfig(): Promise<LinkCheckConfig> {
+  const json = await fs.readFile(configPath, "utf8").catch(() => JSON.stringify(DEFAULT_CONFIG));
+  return { ...DEFAULT_CONFIG, ...(JSON.parse(json) as Partial<LinkCheckConfig>) };
+}
+
+async function loadDocPages(): Promise<Map<string, string>> {
+  const files = await listFiles(docsContentDir);
+  const mdxFiles = files.filter((filePath) => filePath.endsWith(".mdx"));
+  const pages = new Map<string, string>();
+
+  for (const filePath of mdxFiles) {
+    pages.set(toPageSlug(filePath), filePath);
+  }
+
+  return pages;
+}
+
+function createAllowedInternalPaths(docSlugs: Iterable<string>): Set<string> {
+  const allowed = new Set<string>([
+    "/docs",
+    "/llms.txt",
+    "/llms-full.txt",
+    "/robots.txt",
+    "/sitemap.xml",
+  ]);
+
+  for (const slug of docSlugs) {
+    allowed.add(normalizePathname(getDocsPagePath(slug)));
+  }
+
+  return allowed;
+}
+
+function resolveRelativeDocsPath(sourceSlug: string, destination: string): string {
+  const sourceDir =
+    path.posix.basename(sourceSlug) === "index"
+      ? getDocsPagePath(sourceSlug)
+      : path.posix.dirname(getDocsPagePath(sourceSlug));
+  const resolved = path.posix.normalize(path.posix.join(sourceDir, destination));
+  return resolved.startsWith("/") ? resolved : `/${resolved}`;
+}
+
+function stripQueryAndFragment(destination: string): string {
+  return destination.split("#")[0]?.split("?")[0] ?? destination;
+}
+
+function shouldIgnoreExternalUrl(url: URL, config: LinkCheckConfig): boolean {
+  return (
+    config.ignoredExternalUrls.includes(url.toString()) ||
+    config.ignoredExternalHosts.includes(url.host)
+  );
+}
+
+async function probeExternalUrl(
+  url: string
+): Promise<{ ok: boolean; status?: number; error?: string }> {
+  const attempt = async (method: "HEAD" | "GET") => {
+    const response = await fetch(url, {
+      method,
+      redirect: "follow",
+      headers: {
+        "user-agent": "sdp-docs-link-checker/1.0",
+      },
+    });
+
+    return response.status;
+  };
+
+  try {
+    const headStatus = await attempt("HEAD");
+    if ([401, 403, 429].includes(headStatus) || (headStatus >= 200 && headStatus < 400)) {
+      return { ok: true, status: headStatus };
+    }
+    if (headStatus !== 405) {
+      return { ok: false, status: headStatus };
+    }
+  } catch {
+    try {
+      const getStatus = await attempt("GET");
+      if ([401, 403, 429].includes(getStatus) || (getStatus >= 200 && getStatus < 400)) {
+        return { ok: true, status: getStatus };
+      }
+      return { ok: false, status: getStatus };
+    } catch (nestedError) {
+      return {
+        ok: false,
+        error: nestedError instanceof Error ? nestedError.message : String(nestedError),
+      };
+    }
+  }
+
+  try {
+    const getStatus = await attempt("GET");
+    if ([401, 403, 429].includes(getStatus) || (getStatus >= 200 && getStatus < 400)) {
+      return { ok: true, status: getStatus };
+    }
+    return { ok: false, status: getStatus };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function collectLinks(pages: Map<string, string>): Promise<LinkReference[]> {
+  const references: LinkReference[] = [];
+
+  for (const [slug, filePath] of pages) {
+    const raw = await fs.readFile(filePath, "utf8");
+    const source = stripMarkdownSource(raw);
+
+    for (const link of extractMarkdownLinks(source)) {
+      references.push({
+        sourcePath: filePath,
+        sourceSlug: slug,
+        destination: link.destination,
+        line: link.line,
+      });
+    }
+  }
+
+  return references;
+}
+
+async function run(): Promise<void> {
+  const [meta, config, pages] = await Promise.all([loadDocsMeta(), loadConfig(), loadDocPages()]);
+  const allowedInternalPaths = createAllowedInternalPaths(pages.keys());
+  const findings: string[] = [];
+
+  for (const entry of meta.pages ?? []) {
+    if (isDividerEntry(entry)) {
+      continue;
+    }
+    if (!pages.has(entry)) {
+      findings.push(`Missing docs page for navigation entry "${entry}" in ${docsMetaPath}`);
+    }
+  }
+
+  const links = await collectLinks(pages);
+  const externalUrls = new Map<string, LinkReference[]>();
+
+  for (const link of links) {
+    const destination = link.destination.trim();
+    if (!destination || destination.startsWith("#") || destination.startsWith("mailto:")) {
+      continue;
+    }
+    if (destination.startsWith("tel:")) {
+      continue;
+    }
+
+    if (destination.startsWith("http://") || destination.startsWith("https://")) {
+      const url = new URL(destination);
+      if (shouldIgnoreExternalUrl(url, config)) {
+        continue;
+      }
+      const refs = externalUrls.get(url.toString()) ?? [];
+      refs.push(link);
+      externalUrls.set(url.toString(), refs);
+      continue;
+    }
+
+    const normalizedDestination = stripQueryAndFragment(destination);
+    const resolvedInternalPath = normalizedDestination.startsWith("/")
+      ? normalizedDestination
+      : resolveRelativeDocsPath(link.sourceSlug, normalizedDestination);
+    const normalizedInternalPath = normalizePathname(resolvedInternalPath);
+
+    if (!allowedInternalPaths.has(normalizedInternalPath)) {
+      findings.push(
+        `${link.sourcePath}:${link.line} references missing docs path "${destination}" (resolved to "${normalizedInternalPath}")`
+      );
+    }
+  }
+
+  for (const [url, refs] of externalUrls) {
+    const result = await probeExternalUrl(url);
+    if (result.ok) {
+      continue;
+    }
+
+    const locations = refs.map((ref) => `${ref.sourcePath}:${ref.line}`).join(", ");
+    const detail = result.error ? result.error : `HTTP ${result.status}`;
+    findings.push(`External URL check failed for ${url} (${detail}) referenced at ${locations}`);
+  }
+
+  if (findings.length > 0) {
+    throw new Error(`Docs link integrity failed:\n- ${findings.join("\n- ")}`);
+  }
+
+  console.log(
+    `Docs link integrity passed: ${pages.size} pages, ${links.length} markdown links, ${externalUrls.size} external URLs checked.`
+  );
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/apps/sdp-docs/scripts/check-links.ts
+++ b/apps/sdp-docs/scripts/check-links.ts
@@ -10,6 +10,7 @@ const __dirname = path.dirname(__filename);
 const docsContentDir = path.resolve(__dirname, "../content/docs");
 const docsMetaPath = path.resolve(docsContentDir, "meta.json");
 const configPath = path.resolve(__dirname, "link-check.config.json");
+const EXTERNAL_URL_TIMEOUT_MS = 10_000;
 
 type DocsMeta = {
   pages?: string[];
@@ -153,6 +154,7 @@ async function probeExternalUrl(
     const response = await fetch(url, {
       method,
       redirect: "follow",
+      signal: AbortSignal.timeout(EXTERNAL_URL_TIMEOUT_MS),
       headers: {
         "user-agent": "sdp-docs-link-checker/1.0",
       },
@@ -265,8 +267,15 @@ async function run(): Promise<void> {
     }
   }
 
-  for (const [url, refs] of externalUrls) {
-    const result = await probeExternalUrl(url);
+  const externalProbeResults = await Promise.all(
+    [...externalUrls.entries()].map(async ([url, refs]) => ({
+      url,
+      refs,
+      result: await probeExternalUrl(url),
+    }))
+  );
+
+  for (const { url, refs, result } of externalProbeResults) {
     if (result.ok) {
       continue;
     }

--- a/apps/sdp-docs/scripts/dev.mjs
+++ b/apps/sdp-docs/scripts/dev.mjs
@@ -22,6 +22,7 @@ const run = (command, args) =>
 const runDev = async () => {
   await rm(resolve(".next"), { recursive: true, force: true });
   await run("pnpm", ["generate:api"]);
+  await run("pnpm", ["generate:ai"]);
   await run("pnpm", ["generate:source"]);
 
   const sourceWatcher = spawn("node", ["scripts/watch-source.mjs"], {

--- a/apps/sdp-docs/scripts/generate-ai-resources.ts
+++ b/apps/sdp-docs/scripts/generate-ai-resources.ts
@@ -177,9 +177,12 @@ function buildSections(meta: DocsMeta, pages: Map<string, DocsPage>): Section[] 
 }
 
 function buildKeyPages(pages: Map<string, DocsPage>): DocsPage[] {
-  return KEY_PAGE_SLUGS.flatMap((slug) => {
+  return KEY_PAGE_SLUGS.map((slug) => {
     const page = pages.get(slug);
-    return page ? [page] : [];
+    if (!page) {
+      throw new Error(`Missing required key docs page "${slug}" for llms.txt generation`);
+    }
+    return page;
   });
 }
 

--- a/apps/sdp-docs/scripts/generate-ai-resources.ts
+++ b/apps/sdp-docs/scripts/generate-ai-resources.ts
@@ -1,0 +1,265 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  agentsUrl,
+  apiDocsUrl,
+  apiOpenApiUrl,
+  apiUrl,
+  docsOrigin,
+  docsUrl,
+  getDocsPageUrl,
+  repositoryUrl,
+} from "../src/lib/site";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const docsContentDir = path.resolve(__dirname, "../content/docs");
+const docsMetaPath = path.resolve(docsContentDir, "meta.json");
+const publicDir = path.resolve(__dirname, "../public");
+const llmsPath = path.resolve(publicDir, "llms.txt");
+const llmsFullPath = path.resolve(publicDir, "llms-full.txt");
+
+type DocsMeta = {
+  title?: string;
+  pages?: string[];
+};
+
+type DocsPage = {
+  slug: string;
+  title: string;
+  description: string;
+  url: string;
+};
+
+type Section = {
+  title: string;
+  pages: DocsPage[];
+};
+
+const FEATURE_SUMMARY = [
+  "Wallets and custody",
+  "API key management",
+  "Projects",
+  "Token issuance and lifecycle operations",
+  "Payments, transfers, and ramps",
+  "Compliance screening",
+];
+
+const KEY_PAGE_SLUGS = [
+  "what-is-solana-developer-platform",
+  "getting-started",
+  "guides/setup-organization",
+  "guides/setup-wallets",
+  "guides/manage-api-keys",
+  "guides/create-a-token",
+  "guides/deploy-a-token",
+  "guides/mint-and-burn",
+  "guides/transfer-tokens",
+  "tutorials/end-to-end-payment-flow",
+  "reference/issuance-token-types",
+  "reference/api/index",
+  "reference/api/health",
+  "reference/api/api-keys",
+  "reference/api/wallets",
+  "reference/api/projects",
+  "reference/api/issuance",
+  "reference/api/payments",
+  "reference/api/compliance",
+];
+
+function stripMarkdownFormatting(value: string): string {
+  return value.replace(/[`*_]/g, "").trim();
+}
+
+function normalizeLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function parseFrontmatter(source: string): { title: string; description: string } {
+  const match = source.match(/^---\n([\s\S]*?)\n---\n?/);
+  const frontmatter = match?.[1] ?? "";
+
+  const title = stripMarkdownFormatting(frontmatter.match(/^title:\s*(.+)$/m)?.[1] ?? "");
+  const description = stripMarkdownFormatting(
+    frontmatter.match(/^description:\s*(.+)$/m)?.[1] ?? ""
+  );
+
+  return { title, description };
+}
+
+async function listFiles(dirPath: string): Promise<string[]> {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        return listFiles(fullPath);
+      }
+      return [fullPath];
+    })
+  );
+
+  return nested.flat();
+}
+
+function toPageSlug(filePath: string): string {
+  const relativePath = path.relative(docsContentDir, filePath).replace(/\\/g, "/");
+  return relativePath.replace(/\.mdx$/, "");
+}
+
+async function loadPages(): Promise<Map<string, DocsPage>> {
+  const files = await listFiles(docsContentDir);
+  const mdxFiles = files.filter((filePath) => filePath.endsWith(".mdx"));
+  const pages = new Map<string, DocsPage>();
+
+  for (const filePath of mdxFiles) {
+    const slug = toPageSlug(filePath);
+    const source = await fs.readFile(filePath, "utf8");
+    const { title, description } = parseFrontmatter(source);
+
+    pages.set(slug, {
+      slug,
+      title: title || slug.split("/").at(-1)?.replace(/-/g, " ") || slug,
+      description,
+      url: getDocsPageUrl(slug),
+    });
+  }
+
+  return pages;
+}
+
+async function loadMeta(): Promise<DocsMeta> {
+  const json = await fs.readFile(docsMetaPath, "utf8");
+  return JSON.parse(json) as DocsMeta;
+}
+
+function renderLink(page: DocsPage): string {
+  const description = page.description ? `: ${normalizeLine(page.description)}` : "";
+  return `- [${page.title}](${page.url})${description}`;
+}
+
+function renderSection(section: Section): string {
+  const rows = section.pages.map(renderLink).join("\n");
+  return `## ${section.title}\n${rows}`;
+}
+
+function buildSections(meta: DocsMeta, pages: Map<string, DocsPage>): Section[] {
+  const sections: Section[] = [];
+  let currentSection: Section = { title: "Docs", pages: [] };
+
+  for (const entry of meta.pages || []) {
+    if (entry.startsWith("---") && entry.endsWith("---")) {
+      if (currentSection.pages.length > 0) {
+        sections.push(currentSection);
+      }
+      currentSection = {
+        title: entry.replace(/---/g, "").trim(),
+        pages: [],
+      };
+      continue;
+    }
+
+    const page = pages.get(entry);
+    if (!page) {
+      throw new Error(`Missing docs page for meta entry "${entry}"`);
+    }
+    currentSection.pages.push(page);
+  }
+
+  if (currentSection.pages.length > 0) {
+    sections.push(currentSection);
+  }
+
+  return sections;
+}
+
+function buildKeyPages(pages: Map<string, DocsPage>): DocsPage[] {
+  return KEY_PAGE_SLUGS.flatMap((slug) => {
+    const page = pages.get(slug);
+    return page ? [page] : [];
+  });
+}
+
+function renderLlms(keyPages: DocsPage[]): string {
+  return [
+    "# Solana Developer Platform",
+    "",
+    "> Public documentation and API discovery resources for Solana Developer Platform.",
+    "",
+    "## Canonical URLs",
+    `- Docs: ${docsUrl}`,
+    `- API: ${apiUrl}`,
+    `- Interactive API docs: ${apiDocsUrl}`,
+    `- OpenAPI: ${apiOpenApiUrl}`,
+    `- Repo: ${repositoryUrl}`,
+    `- Agent guide: ${agentsUrl}`,
+    "",
+    "## Supported surfaces",
+    ...FEATURE_SUMMARY.map((feature) => `- ${feature}`),
+    "",
+    "## Start here",
+    ...keyPages.map(renderLink),
+    "",
+    "## Machine-readable resources",
+    `- [llms-full.txt](${docsOrigin}/llms-full.txt)`,
+    `- [OpenAPI](${apiOpenApiUrl})`,
+    `- [Swagger UI](${apiDocsUrl})`,
+    "",
+    "## Scope",
+    "- Public AI artifacts intentionally exclude hidden or internal-only API families.",
+    "",
+  ].join("\n");
+}
+
+function renderLlmsFull(sections: Section[]): string {
+  return [
+    "# Solana Developer Platform",
+    "",
+    "> Full public docs map for Solana Developer Platform, generated from the docs navigation and public API reference.",
+    "",
+    "## Canonical URLs",
+    `- Docs: ${docsUrl}`,
+    `- API: ${apiUrl}`,
+    `- Interactive API docs: ${apiDocsUrl}`,
+    `- OpenAPI: ${apiOpenApiUrl}`,
+    `- Repo: ${repositoryUrl}`,
+    `- Agent guide: ${agentsUrl}`,
+    "",
+    sections.map(renderSection).join("\n\n"),
+    "",
+    "## Notes",
+    "- Generated from docs navigation and public API reference pages.",
+    "- Hidden or internal-only APIs are intentionally excluded.",
+    "",
+  ].join("\n");
+}
+
+async function writeFileIfChanged(filePath: string, content: string): Promise<void> {
+  const normalized = `${content.trim()}\n`;
+  const existing = await fs.readFile(filePath, "utf8").catch(() => null);
+  if (existing === normalized) {
+    return;
+  }
+  await fs.writeFile(filePath, normalized, "utf8");
+}
+
+async function run(): Promise<void> {
+  const [meta, pages] = await Promise.all([loadMeta(), loadPages()]);
+  const sections = buildSections(meta, pages);
+  const keyPages = buildKeyPages(pages);
+
+  await fs.mkdir(publicDir, { recursive: true });
+
+  await Promise.all([
+    writeFileIfChanged(llmsPath, renderLlms(keyPages)),
+    writeFileIfChanged(llmsFullPath, renderLlmsFull(sections)),
+  ]);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -122,7 +122,9 @@ ${rows}
 };
 
 const renderIndexPage = ({ tagPages }) => {
-  const links = tagPages.map((tagPage) => `- [${tagPage.title}](./${tagPage.slug})`).join("\n");
+  const links = tagPages
+    .map((tagPage) => `- [${tagPage.title}](/docs/reference/api/${tagPage.slug})`)
+    .join("\n");
 
   return `---
 title: API Reference

--- a/apps/sdp-docs/scripts/link-check.config.json
+++ b/apps/sdp-docs/scripts/link-check.config.json
@@ -1,0 +1,4 @@
+{
+  "ignoredExternalHosts": [],
+  "ignoredExternalUrls": []
+}

--- a/apps/sdp-docs/scripts/watch-source.mjs
+++ b/apps/sdp-docs/scripts/watch-source.mjs
@@ -42,6 +42,7 @@ const flushPatch = async () => {
 
   try {
     await run("node", ["scripts/patch-fumadocs-source.mjs"]);
+    await run("pnpm", ["generate:ai"]);
   } catch (error) {
     console.error("[MDX] failed to patch generated source");
     console.error(error);

--- a/apps/sdp-docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/sdp-docs/src/app/docs/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import { getDocsPagePath } from "@/lib/site";
 import { source } from "@/lib/source";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import defaultMdxComponents from "fumadocs-ui/mdx";
@@ -25,6 +26,30 @@ type DocsPageProps = {
   params: Promise<{ slug?: string[] }>;
 };
 
+type ResolvedPage = {
+  page: NonNullable<ReturnType<typeof source.getPage>>;
+  pageSlug: string[];
+};
+
+function resolvePage(slug?: string[]): ResolvedPage | null {
+  if (!slug || slug.length === 0) {
+    return null;
+  }
+
+  const directPage = source.getPage(slug);
+  if (directPage) {
+    return { page: directPage, pageSlug: slug };
+  }
+
+  const indexSlug = [...slug, "index"];
+  const indexPage = source.getPage(indexSlug);
+  if (indexPage) {
+    return { page: indexPage, pageSlug: indexSlug };
+  }
+
+  return null;
+}
+
 export default async function Page({ params }: DocsPageProps) {
   const { slug } = await params;
 
@@ -32,13 +57,13 @@ export default async function Page({ params }: DocsPageProps) {
     redirect("/docs/what-is-solana-developer-platform");
   }
 
-  const page = source.getPage(slug);
+  const resolvedPage = resolvePage(slug);
 
-  if (!page) {
+  if (!resolvedPage) {
     notFound();
   }
 
-  const data = page.data as DocsData;
+  const data = resolvedPage.page.data as DocsData;
   const MDX = data.body ?? data.content;
 
   if (!MDX) {
@@ -62,16 +87,19 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: DocsPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const page = source.getPage(slug);
+  const resolvedPage = resolvePage(slug);
 
-  if (!page) {
+  if (!resolvedPage) {
     return {};
   }
 
-  const data = page.data as DocsData;
+  const data = resolvedPage.page.data as DocsData;
 
   return {
     title: data.title,
     description: data.description,
+    alternates: {
+      canonical: getDocsPagePath(Array.isArray(slug) ? slug.join("/") : ""),
+    },
   };
 }

--- a/apps/sdp-docs/src/app/layout.tsx
+++ b/apps/sdp-docs/src/app/layout.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
 import "fumadocs-ui/style.css";
+import { docsOrigin, docsUrl } from "@/lib/site";
 import { RootProvider } from "fumadocs-ui/provider";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Solana Developer Platform Docs",
   description: "Documentation for Solana Developer Platform",
+  metadataBase: new URL(docsOrigin),
+  alternates: {
+    canonical: docsUrl,
+  },
 };
 
 export default function RootLayout({

--- a/apps/sdp-docs/src/app/robots.ts
+++ b/apps/sdp-docs/src/app/robots.ts
@@ -1,0 +1,15 @@
+import { docsOrigin } from "@/lib/site";
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${docsOrigin}/sitemap.xml`,
+    host: docsOrigin,
+  };
+}

--- a/apps/sdp-docs/src/app/sitemap.ts
+++ b/apps/sdp-docs/src/app/sitemap.ts
@@ -1,0 +1,34 @@
+import { docsOrigin, getDocsPagePath } from "@/lib/site";
+import { source } from "@/lib/source";
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docEntries = source.generateParams().map(({ slug }) => {
+    const pageSlug = Array.isArray(slug) ? slug.join("/") : "";
+
+    return {
+      url: `${docsOrigin}${getDocsPagePath(pageSlug)}`,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    };
+  });
+
+  return [
+    {
+      url: `${docsOrigin}/docs`,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${docsOrigin}/llms.txt`,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
+      url: `${docsOrigin}/llms-full.txt`,
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+    ...docEntries,
+  ];
+}

--- a/apps/sdp-docs/src/lib/site.ts
+++ b/apps/sdp-docs/src/lib/site.ts
@@ -1,0 +1,27 @@
+import {
+  DEFAULT_SDP_API_URL,
+  DEFAULT_SDP_DOCS_URL,
+  SDP_AGENTS_URL,
+  SDP_GITHUB_REPO_URL,
+} from "@sdp/types";
+
+export const docsUrl = process.env.NEXT_PUBLIC_SDP_DOCS_URL || DEFAULT_SDP_DOCS_URL;
+export const docsOrigin = new URL(docsUrl).origin;
+export const apiUrl = process.env.NEXT_PUBLIC_SDP_API_URL || DEFAULT_SDP_API_URL;
+export const apiOpenApiUrl = `${apiUrl}/openapi.json`;
+export const apiDocsUrl = `${apiUrl}/docs`;
+export const agentsUrl = SDP_AGENTS_URL;
+export const repositoryUrl = SDP_GITHUB_REPO_URL;
+
+export function normalizeDocsPageSlug(pageSlug: string): string {
+  return pageSlug.replace(/\/index$/, "");
+}
+
+export function getDocsPagePath(pageSlug: string): string {
+  const normalized = normalizeDocsPageSlug(pageSlug);
+  return normalized ? `/docs/${normalized}` : "/docs";
+}
+
+export function getDocsPageUrl(pageSlug: string): string {
+  return `${docsOrigin}${getDocsPagePath(pageSlug)}`;
+}

--- a/apps/sdp-web/src/app/page.tsx
+++ b/apps/sdp-web/src/app/page.tsx
@@ -1,7 +1,13 @@
 import { HomeSignedInCard } from "@/components/home-signed-in";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { DEFAULT_SDP_DOCS_URL } from "@sdp/types";
 import Image from "next/image";
+import Link from "next/link";
 import { startSignIn, startSignUp } from "./auth/actions";
+
+const docsHref =
+  process.env.NEXT_PUBLIC_SDP_DOCS_URL ||
+  (process.env.NODE_ENV === "development" ? "http://localhost:3001/docs" : DEFAULT_SDP_DOCS_URL);
 
 export default function Home() {
   return (
@@ -9,7 +15,13 @@ export default function Home() {
       <header className="border-b border-[rgba(28,28,29,0.08)]">
         <div className="mx-auto flex h-[72px] max-w-[1200px] items-center justify-between px-6 xl:px-0">
           <Image src="/landing/solana-logo.svg" alt="Solana" width={20} height={18} />
-          <div className="flex items-center">
+          <div className="flex items-center gap-5">
+            <Link
+              href={docsHref}
+              className="text-sm font-medium text-[rgba(28,28,29,0.72)] transition-colors hover:text-[#1c1c1d]"
+            >
+              Docs
+            </Link>
             <SignedOut>
               <form action={startSignIn}>
                 <button

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -3,6 +3,7 @@
 import { IssuanceHeaderTabs } from "@/components/issuance-header-tabs";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { OrganizationSwitcher, SignInButton, UserButton, useAuth } from "@clerk/nextjs";
+import { DEFAULT_SDP_DOCS_URL } from "@sdp/types";
 import { motion } from "framer-motion";
 import {
   ArrowLeft,
@@ -53,9 +54,7 @@ const navSections: NavSection[] = [
 
 const docsHref =
   process.env.NEXT_PUBLIC_SDP_DOCS_URL ||
-  (process.env.NODE_ENV === "development"
-    ? "http://localhost:3001/docs"
-    : "https://platform.solana.com/docs");
+  (process.env.NODE_ENV === "development" ? "http://localhost:3001/docs" : DEFAULT_SDP_DOCS_URL);
 
 const bottomNavItems: NavItem[] = [
   { label: "API Docs", href: docsHref, icon: Library, external: true },

--- a/packages/sdp-types/package.json
+++ b/packages/sdp-types/package.json
@@ -6,27 +6,38 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./organizations": {
       "types": "./src/organizations.ts",
-      "import": "./src/organizations.ts"
+      "import": "./src/organizations.ts",
+      "default": "./src/organizations.ts"
     },
     "./custody": {
       "types": "./src/custody.ts",
-      "import": "./src/custody.ts"
+      "import": "./src/custody.ts",
+      "default": "./src/custody.ts"
     },
     "./api-keys": {
       "types": "./src/api-keys.ts",
-      "import": "./src/api-keys.ts"
+      "import": "./src/api-keys.ts",
+      "default": "./src/api-keys.ts"
     },
     "./payments": {
       "types": "./src/payments.ts",
-      "import": "./src/payments.ts"
+      "import": "./src/payments.ts",
+      "default": "./src/payments.ts"
+    },
+    "./site": {
+      "types": "./src/site.ts",
+      "import": "./src/site.ts",
+      "default": "./src/site.ts"
     },
     "./permissions": {
       "types": "./src/permissions.ts",
-      "import": "./src/permissions.ts"
+      "import": "./src/permissions.ts",
+      "default": "./src/permissions.ts"
     }
   },
   "scripts": {

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -9,4 +9,5 @@ export * from "./api-keys";
 export * from "./payments";
 export * from "./projects";
 export * from "./sessions";
+export * from "./site";
 export * from "./tokens";

--- a/packages/sdp-types/src/site.ts
+++ b/packages/sdp-types/src/site.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_SDP_DOCS_URL = "https://platform.solana.com/docs";
+export const DEFAULT_SDP_API_URL = "https://api.solana.com";
+export const SDP_GITHUB_REPO_URL = "https://github.com/solana-foundation/solana-developer-platform";
+export const SDP_GITHUB_REPO_BLOB_MAIN_URL = `${SDP_GITHUB_REPO_URL}/blob/main`;
+export const SDP_GITHUB_REPO_RAW_MAIN_URL = `${SDP_GITHUB_REPO_URL}/raw/main`;
+export const SDP_AGENTS_URL = `${SDP_GITHUB_REPO_BLOB_MAIN_URL}/AGENTS.md`;
+
+export function getSdpDocsOrigin(url: string = DEFAULT_SDP_DOCS_URL): string {
+  return new URL(url).origin;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
 
   apps/sdp-docs:
     dependencies:
+      '@sdp/types':
+        specifier: workspace:*
+        version: link:../../packages/sdp-types
       fumadocs-core:
         specifier: ^15.7.4
         version: 15.8.5(@types/react@19.2.10)(lucide-react@0.562.0(react@19.2.3))(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -196,6 +199,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.18
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -11464,7 +11470,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -11497,7 +11503,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11512,7 +11518,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary
- add public AI discovery resources across the docs site, API, and repo root
- generate llms artifacts automatically and add docs link integrity checks to CI
- align docs routing and API reference links with the current public docs surface

## Validation
- pnpm --filter sdp-docs check:links
- pnpm --filter sdp-docs build
- pnpm --filter @sdp/api typecheck
- pnpm --filter sdp-web typecheck