### PR TITLE
fix(web): route home wallet creation to wallets

### DIFF
--- a/apps/sdp-web/src/app/dashboard/api-keys/create-api-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/create-api-key-modal.tsx
@@ -7,6 +7,7 @@ import { useEscapeKey } from "@/lib/use-escape-key";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import { Plus } from "lucide-react";
 import { type Dispatch, type SetStateAction, useState } from "react";
+import { useFormStatus } from "react-dom";
 import { createApiKeyAction } from "./actions";
 
 type ApiKeyRole = "api_admin" | "api_developer" | "api_readonly";
@@ -369,13 +370,23 @@ function CreateApiKeyReviewStep({
       <p className="text-xs text-[rgba(28,28,29,0.72)]">
         After creation, the full key will be shown once in a secure modal.
       </p>
-      <div className="mt-3 flex items-center justify-end gap-2">
-        <Button type="button" variant="secondary" onClick={onBack}>
-          Back
-        </Button>
-        <Button type="submit">Create key</Button>
-      </div>
+      <CreateApiKeyReviewActions onBack={onBack} />
     </form>
+  );
+}
+
+function CreateApiKeyReviewActions({ onBack }: { onBack: () => void }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="mt-3 flex items-center justify-end gap-2">
+      <Button type="button" variant="secondary" onClick={onBack} disabled={pending}>
+        Back
+      </Button>
+      <Button type="submit" disabled={pending} aria-busy={pending}>
+        {pending ? "Creating..." : "Create key"}
+      </Button>
+    </div>
   );
 }
 

--- a/apps/sdp-web/src/app/dashboard/home-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/home-page.data.ts
@@ -1,16 +1,6 @@
-import {
-  CUSTODY_PROVIDER_CATALOG,
-  type KnownCustodyProvider,
-  isKnownCustodyProvider,
-} from "@/app/dashboard/custody/provider-catalog";
 import type { SdpApiClient } from "@/lib/sdp-api";
 import type { PaymentTransferSummary, TokenTransaction } from "@sdp/types";
 import type { FetchResult } from "./payments/payments-page.data";
-
-interface CustodyConfigSummary {
-  provider?: string;
-  status?: "active" | "inactive";
-}
 
 interface HomeIssuanceToken {
   id: string;
@@ -180,53 +170,6 @@ export function buildHomeActivityRows(
       return new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime();
     })
     .slice(0, 10);
-}
-
-export async function fetchCreateWalletProviders(
-  request: SdpApiClient["request"]
-): Promise<FetchResult<KnownCustodyProvider[]>> {
-  try {
-    const response = await request("/v1/wallets/configs");
-    if (!response.ok) {
-      const body = await response.text();
-      return {
-        ok: false,
-        status: response.status,
-        error: parseErrorMessage(body),
-      };
-    }
-
-    const json = (await response.json()) as {
-      data?: {
-        configs?: CustodyConfigSummary[];
-      };
-    };
-
-    const supportedProviderIds = new Set(
-      CUSTODY_PROVIDER_CATALOG.filter((provider) => provider.supportsAdditionalWallets).map(
-        (provider) => provider.id
-      )
-    );
-
-    const providers = [
-      ...new Set(
-        (json.data?.configs ?? [])
-          .filter((config): config is CustodyConfigSummary & { provider: string } => {
-            return config.status === "active" && typeof config.provider === "string";
-          })
-          .map((config) => config.provider)
-          .filter(isKnownCustodyProvider)
-          .filter((provider) => supportedProviderIds.has(provider))
-      ),
-    ];
-
-    return { ok: true, data: providers };
-  } catch (error) {
-    return {
-      ok: false,
-      error: error instanceof Error ? error.message : "Unable to load wallet providers",
-    };
-  }
 }
 
 export async function fetchIssuanceTokens(

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -1,6 +1,4 @@
 import { CreateApiKeyModal } from "@/app/dashboard/api-keys/create-api-key-modal";
-import { CreateWalletModal } from "@/app/dashboard/custody/create-wallet-modal";
-import type { KnownCustodyProvider } from "@/app/dashboard/custody/provider-catalog";
 import { SectionEntry } from "@/app/dashboard/wallets/section-entry";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,8 +24,6 @@ interface HomeWorkspaceProps {
   activityError: string | null;
   activityNotice: string | null;
   wallets: PaymentsDashboardWallet[];
-  walletProviders: KnownCustodyProvider[];
-  walletDisabledReason: string | null;
 }
 
 function formatRelativeTime(value: string): string {
@@ -92,8 +88,6 @@ export function HomeWorkspace({
   activityError,
   activityNotice,
   wallets,
-  walletProviders,
-  walletDisabledReason,
 }: HomeWorkspaceProps) {
   return (
     <div className="w-full space-y-8 py-2">
@@ -104,12 +98,9 @@ export function HomeWorkspace({
             triggerVariant="secondary"
             wallets={wallets}
           />
-          <CreateWalletModal
-            triggerLabel="Create Wallet"
-            providers={walletProviders}
-            disabled={walletProviders.length === 0}
-            disabledReason={walletDisabledReason ?? undefined}
-          />
+          <Button asChild>
+            <Link href="/dashboard/wallets">Create Wallet</Link>
+          </Button>
         </div>
       </SectionEntry>
 

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 import {
   buildHomeActivityRows,
   computeTodaysVolume,
-  fetchCreateWalletProviders,
   fetchIssuanceTokens,
   fetchOrgIssuanceActivity,
 } from "./home-page.data";
@@ -29,19 +28,14 @@ export default async function DashboardPage() {
   }
 
   const apiClient = await createSdpApiClient();
-  const [
-    aggregateResult,
-    transfersResult,
-    walletsResult,
-    walletProvidersResult,
-    issuanceTokensResult,
-  ] = await Promise.all([
-    fetchPaymentsAggregate(apiClient.request),
-    fetchPaymentTransfers(apiClient.request, 100),
-    fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
-    fetchCreateWalletProviders(apiClient.request),
-    fetchIssuanceTokens(apiClient.request, 10),
-  ]);
+  const [aggregateResult, transfersResult, walletsResult, issuanceTokensResult] = await Promise.all(
+    [
+      fetchPaymentsAggregate(apiClient.request),
+      fetchPaymentTransfers(apiClient.request, 100),
+      fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
+      fetchIssuanceTokens(apiClient.request, 10),
+    ]
+  );
 
   const issuanceActivityResult =
     issuanceTokensResult.ok && issuanceTokensResult.data
@@ -59,9 +53,6 @@ export default async function DashboardPage() {
 
   const aggregateError = aggregateResult.ok ? null : "Balance data is unavailable right now.";
   const transfersError = transfersResult.ok ? null : "Payments activity is unavailable right now.";
-  const walletProvidersError = walletProvidersResult.ok
-    ? null
-    : "Wallet providers are unavailable right now.";
   const issuanceTokensError = issuanceTokensResult.ok
     ? null
     : "Issuance activity is unavailable right now.";
@@ -84,13 +75,6 @@ export default async function DashboardPage() {
       activityError={activityError}
       activityNotice={activityNotice || null}
       wallets={walletsResult.data ?? []}
-      walletProviders={walletProvidersResult.data ?? []}
-      walletDisabledReason={
-        walletProvidersError ??
-        ((walletProvidersResult.data?.length ?? 0) === 0
-          ? "Connect a provider that supports additional wallet provisioning first."
-          : null)
-      }
     />
   );
 }


### PR DESCRIPTION
## Summary\n- replace the disabled home dashboard wallet CTA with a direct link to /dashboard/wallets\n- remove the now-unused home dashboard provider gating fetch\n- show a pending state while API key creation is submitting from the review step\n\n## Testing\n- pnpm --filter sdp-web typecheck\n- pnpm exec biome check apps/sdp-web/src/app/dashboard/page.tsx apps/sdp-web/src/app/dashboard/home-workspace.tsx apps/sdp-web/src/app/dashboard/home-page.data.ts apps/sdp-web/src/app/dashboard/api-keys/create-api-key-modal.tsx