### PR TITLE
fix(wallets): remove provider card descriptions

### DIFF
--- a/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
@@ -80,12 +80,7 @@ export function CustodySetupForm({
                 ].join(" ")}
               >
                 <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-semibold text-[#1c1c1d]">{provider.label}</p>
-                    <p className="mt-1 text-xs text-[rgba(28,28,29,0.64)]">
-                      {provider.description}
-                    </p>
-                  </div>
+                  <p className="text-sm font-semibold text-[#1c1c1d]">{provider.label}</p>
                   {isActive ? (
                     <span className="inline-flex items-center gap-1 rounded-full bg-[rgba(28,28,29,0.12)] px-2 py-0.5 text-[11px] font-medium text-[#1c1c1d]">
                       <CheckCircle2 className="h-3.5 w-3.5" />

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
@@ -73,9 +73,6 @@ export function WalletsOverview({
                   <h3 className="text-[30px] leading-[1.1] font-medium tracking-[-0.03em] text-[#1c1c1d]">
                     {provider.label}
                   </h3>
-                  <p className="text-sm leading-6 text-[rgba(28,28,29,0.62)]">
-                    {provider.description}
-                  </p>
                 </div>
 
                 <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- remove the provider description copy from wallet creation cards on the overview and setup screens
- keep the shared provider capability tags intact, with Anchorage continuing to omit Issuance
- keep the change scoped to the wallet creation UI only

## Testing
- PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm exec --yes pnpm -- --filter sdp-web typecheck
- PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm exec --yes pnpm -- --filter sdp-web lint -- src/app/dashboard/custody/setup/setup-form.tsx src/app/dashboard/custody/wallets-overview.tsx