### PR TITLE
docs: audit public docs against current product behavior

### DIFF
--- a/apps/sdp-docs/content/docs/guides/create-a-token.mdx
+++ b/apps/sdp-docs/content/docs/guides/create-a-token.mdx
@@ -29,36 +29,34 @@ The first step shows a grid of template cards:
 
 - **Stablecoin** — USD-backed stablecoins with compliance controls
 - **Arcade** — closed-loop gaming tokens with optional allowlists
-- **Tokenized Security** — regulated assets with allowlist defaults
+- **Tokenized Security** — regulated assets with an allowlist requirement
 - **Custom** — fully customizable Token-2022 configuration
 
 Select a template and click **Continue**.
 
 ### 3. Configure token settings (Step 2 of 3)
 
-Fill in the token form:
+Enter the token identity details:
 
+- **Metadata URI** (required) — HTTPS URL for the token metadata JSON
 - **Token name** (required) — e.g., "Acme Dollar"
 - **Symbol** (required) — 1–10 uppercase alphanumeric characters, e.g., "ACME"
-- **Decimals** — pre-filled by the template, adjustable (0–18)
-- **Description (optional)** — e.g., "Asset-backed token for treasury operations"
-- **Max supply (optional)** — leave empty to keep supply uncapped
+- **Decimals** — chosen from the options allowed by the selected template
 
-Checkboxes:
+Click **Continue** when ready.
 
-- **Require allowlist**
-- **Token is mintable** (default: checked)
-- **Token is freezable** (default: checked)
+### 4. Choose operational settings (Step 3 of 3)
 
-Click **Review** when ready.
+Choose the operational settings:
 
-### 4. Review and confirm (Step 3 of 3)
+- **Main signer** — the controlled wallet SDP should use for deploy and later token actions
+- **Allowlist** — enabled or disabled, depending on the template's rules
 
-The review screen shows a read-only summary of all settings. Click **Create token**.
+For `tokenized-security`, allowlist is required and cannot be disabled. Click **Create token** to save the draft.
 
 ### 5. Done
 
-A success screen confirms creation with the token name and ID. The token is now in `pending` status, ready to be [deployed](/docs/guides/deploy-a-token).
+A success toast confirms creation. The token is now in `pending` status, ready to be [deployed](/docs/guides/deploy-a-token).
 
 </Tab>
 <Tab value="API">

--- a/apps/sdp-docs/content/docs/guides/deploy-a-token.mdx
+++ b/apps/sdp-docs/content/docs/guides/deploy-a-token.mdx
@@ -5,7 +5,7 @@ description: Deploy a created token to the Solana blockchain.
 
 After [creating a token](/docs/guides/create-a-token), deploy it onchain. Deployment creates the mint account on Solana and assigns authorities to your configured wallets.
 
-Deployment is currently API-only. Dashboard deployment is coming soon.
+You can deploy from the dashboard or through the API. In the dashboard, open the pending token and use **Deploy** from the token header or fund management panel.
 
 ## Prerequisites
 
@@ -50,7 +50,7 @@ HttpRequest request = HttpRequest.newBuilder()
 </Tab>
 </Tabs>
 
-The token status changes from `pending` to `active`, and `mintAddress` is populated with the onchain address. No request body is needed.
+The token status changes from `pending` to `active`, and `mintAddress` is populated with the onchain address. No request body is required for the public deploy endpoint.
 
 ## Prepare mode (you sign)
 

--- a/apps/sdp-docs/content/docs/guides/freeze-and-compliance.mdx
+++ b/apps/sdp-docs/content/docs/guides/freeze-and-compliance.mdx
@@ -5,11 +5,11 @@ description: Freeze accounts, pause transfers, and seize tokens for compliance o
 
 SDP provides compliance controls for tokens that have `isFreezable` enabled or the `pausable` extension. These let you freeze individual accounts, pause all transfers globally, or seize tokens from a specific account.
 
-These operations are currently API-only. All require the `tokens:admin` permission.
+These controls are available from the dashboard and the API. API key callers need `tokens:admin`.
 
 ## Freeze an account
 
-Prevent a specific account from sending or receiving tokens:
+Prevent a specific holder from sending or receiving tokens:
 
 <Tabs items={["curl", "TypeScript", "Java"]}>
 <Tab value="curl">
@@ -56,6 +56,8 @@ HttpRequest request = HttpRequest.newBuilder()
 ```
 </Tab>
 </Tabs>
+
+The `accountAddress` can be the holder wallet address or the matching token account. SDP derives the associated token account when needed.
 
 ## Unfreeze an account
 
@@ -127,7 +129,7 @@ HttpRequest request = HttpRequest.newBuilder()
 
 ## Pause all transfers
 
-Halt all transfers of a token globally. Requires the `pausable` extension:
+Halt token activity globally. Requires the `pausable` extension:
 
 <Tabs items={["curl", "TypeScript", "Java"]}>
 <Tab value="curl">
@@ -158,7 +160,7 @@ HttpRequest request = HttpRequest.newBuilder()
 </Tab>
 </Tabs>
 
-While paused, no transfers, mints, or burns can occur.
+While paused, transfer-related and supply-management actions should be treated as unavailable until the token is unpaused.
 
 ## Unpause
 

--- a/apps/sdp-docs/content/docs/guides/freeze-and-compliance.mdx
+++ b/apps/sdp-docs/content/docs/guides/freeze-and-compliance.mdx
@@ -127,7 +127,7 @@ HttpRequest request = HttpRequest.newBuilder()
 </Tab>
 </Tabs>
 
-## Pause all transfers
+## Pause token activity
 
 Halt token activity globally. Requires the `pausable` extension:
 

--- a/apps/sdp-docs/content/docs/guides/manage-allowlists.mdx
+++ b/apps/sdp-docs/content/docs/guides/manage-allowlists.mdx
@@ -3,14 +3,14 @@ title: Manage Allowlists
 description: Control which addresses can hold your token using allowlists.
 ---
 
-Tokens created with `requiresAllowlist: true` restrict transfers to approved addresses only. Any transfer to an address not on the allowlist will fail. This is essential for regulated tokens like tokenized securities.
+Tokens created with `requiresAllowlist: true` keep a list of approved destination addresses for controlled token actions. SDP currently enforces that list on allowlist-aware issuance flows such as minting and administrative transfers. This is essential for regulated tokens like tokenized securities.
 
-These operations are currently API-only.
+When a token is created without an allowlist, the dashboard hides allowlist management for that token.
 
 ## Prerequisites
 
 - A token with `requiresAllowlist` enabled
-- The `tokens:write` permission
+- The `tokens:write` permission for API key callers
 
 ## Add an address
 

--- a/apps/sdp-docs/content/docs/guides/manage-allowlists.mdx
+++ b/apps/sdp-docs/content/docs/guides/manage-allowlists.mdx
@@ -3,7 +3,7 @@ title: Manage Allowlists
 description: Control which addresses can hold your token using allowlists.
 ---
 
-Tokens created with `requiresAllowlist: true` keep a list of approved destination addresses for controlled token actions. SDP currently enforces that list on allowlist-aware issuance flows such as minting and administrative transfers. This is essential for regulated tokens like tokenized securities.
+Tokens created with `requiresAllowlist: true` keep a list of approved destination addresses for controlled token actions. SDP enforces that list on allowlist-aware issuance flows such as minting and administrative transfers. Payment transfers use wallet-level destination allowlists instead of this token allowlist. This is essential for regulated tokens like tokenized securities.
 
 When a token is created without an allowlist, the dashboard hides allowlist management for that token.
 

--- a/apps/sdp-docs/content/docs/guides/mint-and-burn.mdx
+++ b/apps/sdp-docs/content/docs/guides/mint-and-burn.mdx
@@ -5,7 +5,7 @@ description: Increase or decrease token supply by minting and burning.
 
 After [deploying a token](/docs/guides/deploy-a-token), you can mint new tokens to any address and burn tokens from accounts you control. Force-burn lets admins burn from any account without the holder's signature.
 
-These operations are currently API-only.
+These operations are available from the dashboard and the API.
 
 ## Prerequisites
 
@@ -204,7 +204,7 @@ HttpRequest request = HttpRequest.newBuilder()
 </Tab>
 </Tabs>
 
-The `source` must be a token account address (not a wallet address).
+The `source` can be the authority wallet or its token account. Use force-burn for other holder accounts.
 
 ## Force-burn (admin)
 

--- a/apps/sdp-docs/content/docs/guides/setup-wallets.mdx
+++ b/apps/sdp-docs/content/docs/guides/setup-wallets.mdx
@@ -14,7 +14,8 @@ Wallets are Solana keypairs managed by a custody provider. SDP uses them to sign
 | **Coinbase CDP** | Coinbase Developer Platform custody | Production |
 | **Para** | MPC wallet infrastructure | Production |
 | **Turnkey** | Non-custodial key management | Production |
-| **Local** | Key stored in the database | Development and testing only |
+| **DFNS** | API-driven MPC wallet orchestration | Production |
+| **Anchorage** | Institutional custody with managed wallet lifecycle | Compliance and treasury operations |
 
 <Tabs items={["Dashboard", "API"]}>
 <Tab value="Dashboard">
@@ -25,24 +26,26 @@ Open the sidebar and click **Wallets**. If you haven't linked your organization 
 
 ### 2. Start wallet setup
 
-Click **Get started** on the "Enable wallets" card. This takes you to the setup page titled **Create your master signing wallet**.
+Click **Get started** on the wallet setup card. This opens the provider setup flow.
 
 ### 3. Configure your provider
 
 Fill in the setup form:
 
-- **Provider** — select **Privy (recommended)** for production or **Local (development only)** for testing
-- **Wallet label** — a descriptive name (placeholder: "Master wallet")
+- **Provider** — choose from the supported custody providers shown in the setup grid
+- **Wallet label** — a descriptive name for the first wallet
+- **Fireblocks credentials** — required only when the selected provider is Fireblocks
 
-Click **Provision wallet** to initialize signing.
+Click **Connect provider & create wallet** to initialize signing and provision the first wallet.
 
 ### 4. View your wallet
 
-After provisioning, the Wallets page shows your signing configuration:
+After provisioning, the Wallets page shows your active provider configuration and wallet cards:
 
 - **Provider** — the active custody provider
-- **Master address** — the public key of your default wallet
-- **Default wallet** — the wallet ID used when no specific wallet is referenced
+- **Address** — the wallet public key
+- **Wallet ID** — the custody wallet identifier used by SDP
+- **Balance** — the latest cached balance for the wallet
 
 A note at the bottom reads: "Changing providers affects new actions only. Existing onchain authorities are not automatically rotated."
 
@@ -50,9 +53,11 @@ A note at the bottom reads: "Changing providers affects new actions only. Existi
 
 Click **New wallet** in the top right. The modal has:
 
-- **Label** — descriptive name (placeholder: "Signing wallet")
-- **Purpose (optional)** — one of: `root`, `mint_authority`, `freeze_authority`, `fee_payer`, `transfer`
-- **Make default** — checkbox to set this as the default signing wallet
+- **Provider** — preselected when only one active provider can create wallets, otherwise selectable
+- **Capabilities** — provider feature chips for issuance, transfers, or compliance
+- **Wallet label** — descriptive name (placeholder: "Signing wallet")
+
+Some providers can be connected but do not yet support provisioning additional wallets from the dashboard.
 
 </Tab>
 <Tab value="API">
@@ -152,7 +157,7 @@ HttpRequest request = HttpRequest.newBuilder()
 </Tab>
 </Tabs>
 
-Available purposes: `root`, `mint_authority`, `freeze_authority`, `fee_payer`, `transfer`.
+The `purpose` field is optional metadata in the API. The current dashboard create-wallet flow does not expose wallet-purpose selection.
 
 ### 3. Check signing configuration
 

--- a/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
+++ b/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
@@ -47,7 +47,7 @@ See the full public endpoint map in the [Issuance API reference](/docs/reference
 ## Operational constraints
 
 - A token must be created before deployment, and deployed before minting or transfer operations.
-- Token actions that target an account often require a token account address, not an owner wallet address.
+- Token actions that target an account may accept either a wallet address or a token account address depending on the endpoint. Freeze and unfreeze flows accept a holder wallet address and derive the associated token account when possible.
 - If the relevant authority is external to SDP custody, prefer prepare flows or rotate the authority to a controlled wallet first.
 - If the token is paused, minting and transfer-related operations should be treated as unavailable until it is unpaused.
 

--- a/apps/sdp-docs/content/docs/guides/transfer-tokens.mdx
+++ b/apps/sdp-docs/content/docs/guides/transfer-tokens.mdx
@@ -5,7 +5,7 @@ description: Send tokens between accounts using SDP's payment orchestration.
 
 SDP handles token transfers through its payments API. Transfers move tokens from a source account to a destination address.
 
-Transfers are currently API-only.
+Transfers are available through the Payments dashboard and the API.
 
 ## Prerequisites
 
@@ -145,5 +145,5 @@ Always include an `Idempotency-Key` header on transfer requests. If a network er
 ## Related guides
 
 - [Mint and Burn](/docs/guides/mint-and-burn) — create or destroy token supply
-- [Manage Allowlists](/docs/guides/manage-allowlists) — restrict who can receive transfers
+- [Manage Allowlists](/docs/guides/manage-allowlists) — define approved destinations for allowlist-enabled issuance flows
 - [Freeze and Compliance](/docs/guides/freeze-and-compliance) — halt transfers for compliance

--- a/apps/sdp-docs/content/docs/what-is-solana-developer-platform.mdx
+++ b/apps/sdp-docs/content/docs/what-is-solana-developer-platform.mdx
@@ -11,9 +11,9 @@ Solana Developer Platform (SDP) is a dashboard and REST API for issuing, transfe
 
 **Wallet custody** — Provision signing wallets through integrated custody providers. SDP manages the signing infrastructure so your team never handles private keys directly.
 
-**Compliance operations** — Freeze individual accounts, pause transfers, seize tokens, and manage allowlists to restrict which addresses can hold a token. All compliance actions accept a reason or memo field for audit trails.
+**Compliance operations** — Freeze individual accounts, pause token activity, seize tokens, and manage allowlists for regulated issuance flows. Selected compliance actions accept reason or memo fields for audit trails.
 
-**Two signing modes** — Every mutation endpoint supports both modes:
+**Two signing modes** — SDP supports both modes for transaction-building flows such as issuance, payments, and compliance actions:
 
 - **Execute** — SDP builds, signs, and submits the transaction in one API call
 - **Prepare** — SDP builds the transaction and returns it unsigned. You sign with your own infrastructure (hardware wallet, multisig, internal HSM) and submit it yourself.


### PR DESCRIPTION
## Summary\n- audit the public docs against the current dashboard and public API behavior\n- correct stale authored guidance around issuance, wallets, allowlists, and compliance\n- confirm generated API docs and AI discovery resources are already up to date\n\n## Testing\n- pnpm --filter @sdp/api typecheck\n- pnpm --filter sdp-docs typecheck\n- pnpm --filter sdp-docs check:links\n- pnpm --filter sdp-docs build