### PR TITLE
fix(web): improve pending token and API key UX

### DIFF
--- a/apps/sdp-web/src/app/api/dashboard/api-keys/flash/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/api-keys/flash/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+const API_KEY_FLASH_COOKIE = "sdp_api_key_flash";
+const API_KEYS_PAGE_PATH = "/dashboard/api-keys";
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(API_KEY_FLASH_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: API_KEYS_PAGE_PATH,
+    maxAge: 0,
+  });
+  return response;
+}

--- a/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
@@ -40,6 +40,77 @@ function extractErrorMessage(error: unknown): string {
   return "Unknown error";
 }
 
+function normalizeDeactivateApiKeyInput(input: {
+  keyId: string;
+  keyName: string;
+  confirmation: string;
+}): {
+  keyId: string;
+  keyName: string;
+  confirmation: string;
+} {
+  return {
+    keyId: input.keyId.trim(),
+    keyName: input.keyName.trim(),
+    confirmation: input.confirmation.trim(),
+  };
+}
+
+async function deactivateApiKeyRequest(input: {
+  keyId: string;
+  keyName: string;
+  confirmation: string;
+}): Promise<{ ok: true; message: string } | { ok: false; message: string }> {
+  const { keyId, keyName, confirmation } = normalizeDeactivateApiKeyInput(input);
+
+  if (!keyId) {
+    return {
+      ok: false,
+      message: "Missing API key id for deletion.",
+    };
+  }
+
+  if (!keyName) {
+    return {
+      ok: false,
+      message: "Missing API key name for deletion confirmation.",
+    };
+  }
+
+  if (!confirmation) {
+    return {
+      ok: false,
+      message: "Type the key name to confirm API key deletion.",
+    };
+  }
+
+  if (confirmation !== keyName) {
+    return {
+      ok: false,
+      message: "Confirmation did not match the key name.",
+    };
+  }
+
+  try {
+    await sdpApiFetch(`/v1/api-keys/${keyId}`, {
+      method: "DELETE",
+      body: JSON.stringify({
+        confirmation,
+      }),
+    });
+
+    return {
+      ok: true,
+      message: `API key "${keyName}" has been deactivated.`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Delete failed: ${extractErrorMessage(error)}`,
+    };
+  }
+}
+
 export async function consumeApiKeyFlash(): Promise<ApiKeyFlash | null> {
   const jar = await cookies();
   const raw = jar.get(API_KEY_FLASH_COOKIE)?.value;
@@ -205,61 +276,30 @@ export async function rotateApiKeyAction(formData: FormData) {
 }
 
 export async function deactivateApiKeyAction(formData: FormData) {
-  const keyId = String(formData.get("keyId") ?? "").trim();
-  const keyName = String(formData.get("keyName") ?? "").trim();
-  const confirmation = String(formData.get("confirmation") ?? "").trim();
+  const result = await deactivateApiKeyRequest({
+    keyId: String(formData.get("keyId") ?? ""),
+    keyName: String(formData.get("keyName") ?? ""),
+    confirmation: String(formData.get("confirmation") ?? ""),
+  });
 
-  if (!keyId) {
-    await setFlash({
-      level: "error",
-      message: "Missing API key id for deletion.",
-    });
-    redirect(API_KEYS_PAGE_PATH);
-  }
-
-  if (!keyName) {
-    await setFlash({
-      level: "error",
-      message: "Missing API key name for deletion confirmation.",
-    });
-    redirect(API_KEYS_PAGE_PATH);
-  }
-
-  if (!confirmation) {
-    await setFlash({
-      level: "error",
-      message: "Type the key name to confirm API key deletion.",
-    });
-    redirect(API_KEYS_PAGE_PATH);
-  }
-
-  if (confirmation !== keyName) {
-    await setFlash({
-      level: "error",
-      message: "Confirmation did not match the key name.",
-    });
-    redirect(API_KEYS_PAGE_PATH);
-  }
-
-  try {
-    await sdpApiFetch(`/v1/api-keys/${keyId}`, {
-      method: "DELETE",
-      body: JSON.stringify({
-        confirmation,
-      }),
-    });
-
-    await setFlash({
-      level: "success",
-      message: `API key "${keyName}" has been deactivated.`,
-    });
-  } catch (error) {
-    await setFlash({
-      level: "error",
-      message: `Delete failed: ${extractErrorMessage(error)}`,
-    });
-  }
+  await setFlash({
+    level: result.ok ? "success" : "error",
+    message: result.message,
+  });
 
   revalidatePath(API_KEYS_PAGE_PATH, "page");
   redirect(API_KEYS_PAGE_PATH);
+}
+
+export async function deactivateApiKeyInlineAction(input: {
+  keyId: string;
+  keyName: string;
+  confirmation: string;
+}): Promise<{ ok: true; message: string } | { ok: false; message: string }> {
+  const result = await deactivateApiKeyRequest(input);
+  if (result.ok) {
+    revalidatePath(API_KEYS_PAGE_PATH, "page");
+  }
+
+  return result;
 }

--- a/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { rotateApiKeyAction } from "./actions";
 import { DeleteApiKeyModal } from "./delete-api-key-modal";
 
@@ -12,71 +18,60 @@ interface ApiKeyActionsMenuProps {
   keyId: string;
   keyName: string;
   canRotate: boolean;
+  onDeleted?: () => void;
 }
 
-export function ApiKeyActionsMenu({ keyId, keyName, canRotate }: ApiKeyActionsMenuProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+export function ApiKeyActionsMenu({
+  keyId,
+  keyName,
+  canRotate,
+  onDeleted,
+}: ApiKeyActionsMenuProps) {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const rotateFormRef = useRef<HTMLFormElement | null>(null);
 
   return (
-    <div className="relative inline-flex">
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        onClick={() => setIsMenuOpen((open) => !open)}
-      >
-        Actions
-        <ChevronDown className="h-4 w-4" />
-      </Button>
+    <>
+      <form ref={rotateFormRef} action={rotateApiKeyAction} className="hidden">
+        <input type="hidden" name="keyId" value={keyId} />
+        <input type="hidden" name="grace" value={String(DEFAULT_ROTATION_GRACE_HOURS)} />
+      </form>
 
-      {isMenuOpen ? (
-        <>
-          <button
-            type="button"
-            aria-label="Close actions menu"
-            className="fixed inset-0 z-20 cursor-default bg-transparent"
-            onClick={() => setIsMenuOpen(false)}
-          />
-          <div className="absolute top-[42px] right-0 z-30 w-[200px] overflow-hidden rounded-xl border border-[rgba(28,28,29,0.12)] bg-white shadow-[0_14px_28px_rgba(28,28,29,0.16)]">
-            <div className="p-1">
-              {canRotate ? (
-                <form action={rotateApiKeyAction}>
-                  <input type="hidden" name="keyId" value={keyId} />
-                  <input type="hidden" name="grace" value={String(DEFAULT_ROTATION_GRACE_HOURS)} />
-                  <button
-                    type="submit"
-                    onClick={() => setIsMenuOpen(false)}
-                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm hover:bg-[rgba(28,28,29,0.05)]"
-                  >
-                    Rotate key ({DEFAULT_ROTATION_GRACE_HOURS}h grace)
-                  </button>
-                </form>
-              ) : (
-                <span className="flex w-full cursor-not-allowed items-center rounded-lg px-3 py-2 text-left text-sm text-[rgba(28,28,29,0.45)]">
-                  Rotate key ({DEFAULT_ROTATION_GRACE_HOURS}h grace)
-                </span>
-              )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button type="button" variant="secondary" size="sm">
+            Actions
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-[200px]">
+          <DropdownMenuItem
+            onSelect={() => {
+              if (canRotate) {
+                rotateFormRef.current?.requestSubmit();
+              }
+            }}
+            disabled={!canRotate}
+          >
+            Rotate key ({DEFAULT_ROTATION_GRACE_HOURS}h grace)
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-[#c71f37] focus:bg-[#c71f37]/10 focus:text-[#c71f37]"
+            onSelect={() => setIsDeleteModalOpen(true)}
+          >
+            Delete key
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-              <DeleteApiKeyModal
-                keyId={keyId}
-                keyName={keyName}
-                renderTrigger={(open) => (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      open();
-                    }}
-                    className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm text-[#c71f37] hover:bg-[#c71f37]/10"
-                  >
-                    Delete key
-                  </button>
-                )}
-              />
-            </div>
-          </div>
-        </>
-      ) : null}
-    </div>
+      <DeleteApiKeyModal
+        keyId={keyId}
+        keyName={keyName}
+        open={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+        onDeleted={onDeleted}
+        renderTrigger={() => null}
+      />
+    </>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/api-keys/api-keys-table-client.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/api-keys-table-client.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useEffect, useMemo, useState } from "react";
+import { ApiKeyActionsMenu } from "./api-key-actions-menu";
+
+type ApiKeyRole = "api_admin" | "api_developer" | "api_readonly";
+type ApiKeyEnvironment = "sandbox" | "production";
+type ApiKeyStatus = "active" | "revoked" | "expired" | "deactivated";
+
+export interface ApiKeyRecord {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  role: ApiKeyRole;
+  environment: ApiKeyEnvironment;
+  status: ApiKeyStatus;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  });
+}
+
+function formatRole(role: ApiKeyRole): string {
+  if (role === "api_admin") return "Admin";
+  if (role === "api_readonly") return "Read only";
+  return "Developer";
+}
+
+export function ApiKeysTableClient({ initialApiKeys }: { initialApiKeys: ApiKeyRecord[] }) {
+  const [apiKeys, setApiKeys] = useState(initialApiKeys);
+
+  useEffect(() => {
+    setApiKeys(initialApiKeys);
+  }, [initialApiKeys]);
+
+  const sortedApiKeys = useMemo(() => {
+    return [...apiKeys].sort((a, b) => {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+  }, [apiKeys]);
+
+  if (sortedApiKeys.length === 0) {
+    return <p className="text-sm text-[rgba(28,28,29,0.72)]">No API keys found.</p>;
+  }
+
+  return (
+    <Table className="table-fixed">
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[14%]">Name</TableHead>
+          <TableHead className="w-[14%]">Prefix</TableHead>
+          <TableHead className="w-[10%]">Role</TableHead>
+          <TableHead className="w-[8%]">Env</TableHead>
+          <TableHead className="w-[10%]">Status</TableHead>
+          <TableHead className="w-[11%]">Last used</TableHead>
+          <TableHead className="w-[11%]">Expires</TableHead>
+          <TableHead className="w-[11%]">Created</TableHead>
+          <TableHead className="w-[21%] text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {sortedApiKeys.map((key) => {
+          const canRotate = key.status === "active";
+
+          return (
+            <TableRow key={key.id}>
+              <TableCell className="font-medium">
+                <span className="block truncate">{key.name}</span>
+              </TableCell>
+              <TableCell className="font-mono text-xs">
+                <span className="block truncate">{key.keyPrefix}</span>
+              </TableCell>
+              <TableCell className="text-xs">
+                <span className="block truncate">{formatRole(key.role)}</span>
+              </TableCell>
+              <TableCell className="text-xs">
+                <span className="block truncate">{key.environment}</span>
+              </TableCell>
+              <TableCell className="text-xs">
+                <span className="block truncate">{key.status}</span>
+              </TableCell>
+              <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
+                {formatDate(key.lastUsedAt)}
+              </TableCell>
+              <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
+                {formatDate(key.expiresAt)}
+              </TableCell>
+              <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
+                {formatDate(key.createdAt)}
+              </TableCell>
+              <TableCell className="text-right">
+                <ApiKeyActionsMenu
+                  keyId={key.id}
+                  keyName={key.name}
+                  canRotate={canRotate}
+                  onDeleted={() => {
+                    setApiKeys((previous) => previous.filter((item) => item.id !== key.id));
+                  }}
+                />
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/api-keys/delete-api-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/delete-api-key-modal.tsx
@@ -5,43 +5,98 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useEscapeKey } from "@/lib/use-escape-key";
 import type { ReactNode } from "react";
-import { useState } from "react";
-import { deactivateApiKeyAction } from "./actions";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { deactivateApiKeyInlineAction } from "./actions";
 
 interface DeleteApiKeyModalProps {
   keyId: string;
   keyName: string;
   renderTrigger?: (open: () => void) => ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onDeleted?: () => void;
 }
 
-export function DeleteApiKeyModal({ keyId, keyName, renderTrigger }: DeleteApiKeyModalProps) {
-  const [isOpen, setIsOpen] = useState(false);
+export function DeleteApiKeyModal({
+  keyId,
+  keyName,
+  renderTrigger,
+  open: isOpenProp,
+  onOpenChange,
+  onDeleted,
+}: DeleteApiKeyModalProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [confirmation, setConfirmation] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isControlled = isOpenProp !== undefined;
+  const isOpen = isControlled ? isOpenProp : uncontrolledOpen;
 
-  const open = () => {
-    setIsOpen(true);
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirmation("");
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
+
+  const openModal = () => {
+    if (isControlled) {
+      onOpenChange?.(true);
+      return;
+    }
+
+    setUncontrolledOpen(true);
   };
 
   const close = () => {
-    setIsOpen(false);
-    setConfirmation("");
+    if (isControlled) {
+      onOpenChange?.(false);
+      return;
+    }
+
+    setUncontrolledOpen(false);
   };
 
   useEscapeKey(isOpen, close);
 
   const canSubmit = confirmation.trim() === keyName.trim();
 
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const result = await deactivateApiKeyInlineAction({
+      keyId,
+      keyName,
+      confirmation,
+    });
+
+    if (result.ok) {
+      close();
+      toast.success(result.message);
+      onDeleted?.();
+      return;
+    }
+
+    setIsSubmitting(false);
+    toast.error(result.message);
+  };
+
   return (
     <>
       {renderTrigger ? (
-        renderTrigger(open)
+        renderTrigger(openModal)
       ) : (
         <Button
           type="button"
           variant="secondary"
           size="sm"
           className="border-[#c71f37] text-[#c71f37] hover:bg-[#c71f37]/10"
-          onClick={open}
+          onClick={openModal}
         >
           Delete
         </Button>
@@ -55,7 +110,7 @@ export function DeleteApiKeyModal({ keyId, keyName, renderTrigger }: DeleteApiKe
             aria-label="Close confirmation modal"
             onClick={close}
           />
-          <div className="relative z-10 w-full max-w-md rounded-xl border border-[rgba(28,28,29,0.16)] bg-white p-5 shadow-lg">
+          <div className="relative z-10 w-full max-w-md rounded-xl border border-[rgba(28,28,29,0.16)] bg-white p-5 text-left shadow-lg">
             <p className="text-sm font-medium text-[#1c1c1d]">Delete API key</p>
             <p className="mt-2 text-sm text-[rgba(28,28,29,0.72)]">
               This removes the key without deleting the row.
@@ -64,7 +119,7 @@ export function DeleteApiKeyModal({ keyId, keyName, renderTrigger }: DeleteApiKe
               Type <span className="font-mono font-medium">{keyName}</span> to confirm.
             </p>
 
-            <form action={deactivateApiKeyAction} className="mt-4 space-y-3">
+            <form onSubmit={handleSubmit} className="mt-4 space-y-3">
               <input type="hidden" name="keyId" value={keyId} />
               <input type="hidden" name="keyName" value={keyName} />
               <Label htmlFor={`confirm-${keyId}`} className="text-sm">
@@ -78,20 +133,45 @@ export function DeleteApiKeyModal({ keyId, keyName, renderTrigger }: DeleteApiKe
                 placeholder="Paste exact key name"
                 autoFocus
                 autoComplete="off"
+                disabled={isSubmitting}
               />
 
-              <div className="mt-4 flex justify-end gap-2">
-                <Button type="button" variant="secondary" onClick={close}>
-                  Cancel
-                </Button>
-                <Button type="submit" variant="destructive" disabled={!canSubmit}>
-                  Delete key
-                </Button>
-              </div>
+              <DeleteApiKeyFormActions
+                canSubmit={canSubmit}
+                onCancel={close}
+                isSubmitting={isSubmitting}
+              />
             </form>
           </div>
         </div>
       ) : null}
     </>
+  );
+}
+
+function DeleteApiKeyFormActions({
+  canSubmit,
+  onCancel,
+  isSubmitting,
+}: {
+  canSubmit: boolean;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}) {
+  return (
+    <div className="mt-4 flex justify-end gap-2">
+      <Button type="button" variant="secondary" onClick={onCancel} disabled={isSubmitting}>
+        Cancel
+      </Button>
+      <Button
+        type="submit"
+        variant="destructive"
+        disabled={!canSubmit || isSubmitting}
+        aria-busy={isSubmitting}
+        className="min-w-[104px]"
+      >
+        {isSubmitting ? "Deleting..." : "Delete key"}
+      </Button>
+    </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/api-keys/flash-clear-trigger.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/flash-clear-trigger.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { clearApiKeyFlashAction } from "./actions";
 
 export function FlashClearTrigger() {
   const cleared = useRef(false);
@@ -9,7 +8,10 @@ export function FlashClearTrigger() {
   useEffect(() => {
     if (cleared.current) return;
     cleared.current = true;
-    void clearApiKeyFlashAction();
+    void fetch("/api/dashboard/api-keys/flash", {
+      method: "DELETE",
+      credentials: "same-origin",
+    });
   }, []);
 
   return null;

--- a/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
@@ -5,8 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { storeApiKeySecret } from "@/lib/playground-api-keys";
 import { useEscapeKey } from "@/lib/use-escape-key";
-import { useEffect, useState } from "react";
-import { clearApiKeyFlashAction } from "./actions";
+import { useEffect, useRef, useState } from "react";
 import { GeneratedApiKeyInput } from "./generated-key-input";
 
 interface GeneratedApiKeyModalProps {
@@ -18,6 +17,7 @@ interface GeneratedApiKeyModalProps {
 function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyModalProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [copyLabel, setCopyLabel] = useState("Copy");
+  const clearedFlash = useRef(false);
 
   useEffect(() => {
     if (!keyValue) {
@@ -30,9 +30,20 @@ function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyM
     });
   }, [keyValue, keyPrefix]);
 
+  useEffect(() => {
+    if (clearedFlash.current) {
+      return;
+    }
+
+    clearedFlash.current = true;
+    void fetch("/api/dashboard/api-keys/flash", {
+      method: "DELETE",
+      credentials: "same-origin",
+    });
+  }, []);
+
   const close = async () => {
     setIsOpen(false);
-    await clearApiKeyFlashAction();
   };
 
   useEscapeKey(isOpen, () => {
@@ -62,7 +73,7 @@ function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyM
         className="absolute inset-0 bg-black/35"
         onClick={close}
       />
-      <div className="relative z-10 w-full max-w-lg rounded-2xl border border-[rgba(28,28,29,0.16)] bg-white p-6 shadow-lg">
+      <div className="relative z-10 w-full max-w-lg rounded-2xl border border-[rgba(28,28,29,0.16)] bg-white p-6 text-left shadow-lg">
         <p className="text-sm font-semibold text-[#1c1c1d]">API key generated</p>
         <p className="mt-2 text-sm text-[rgba(28,28,29,0.72)]">{message}</p>
 

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -6,59 +6,18 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { createSdpApiClient, sdpApiFetch } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import { redirect } from "next/navigation";
 import { fetchPaymentsWallets } from "../payments/payments-page.data";
 import { consumeApiKeyFlash } from "./actions";
-import { ApiKeyActionsMenu } from "./api-key-actions-menu";
+import { type ApiKeyRecord, ApiKeysTableClient } from "./api-keys-table-client";
 import { CreateApiKeyModal } from "./create-api-key-modal";
 import { FlashClearTrigger } from "./flash-clear-trigger";
 import { GeneratedApiKeyModal } from "./generated-key-modal";
 
 export const dynamic = "force-dynamic";
-
-type ApiKeyRole = "api_admin" | "api_developer" | "api_readonly";
-type ApiKeyEnvironment = "sandbox" | "production";
-type ApiKeyStatus = "active" | "revoked" | "expired" | "deactivated";
-
-interface ApiKeyRecord {
-  id: string;
-  name: string;
-  keyPrefix: string;
-  role: ApiKeyRole;
-  environment: ApiKeyEnvironment;
-  status: ApiKeyStatus;
-  lastUsedAt: string | null;
-  expiresAt: string | null;
-  createdAt: string;
-}
-
-function formatDate(value: string | null): string {
-  if (!value) return "Never";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-  });
-}
-
-function formatRole(role: ApiKeyRole): string {
-  if (role === "api_admin") return "Admin";
-  if (role === "api_readonly") return "Read only";
-  return "Developer";
-}
 
 export default async function ApiKeysPage() {
   const { userId, orgId } = await auth();
@@ -76,9 +35,7 @@ export default async function ApiKeysPage() {
     fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
   ]);
 
-  const apiKeys = [...apiKeysResponse.apiKeys].sort((a, b) => {
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-  });
+  const apiKeys = apiKeysResponse.apiKeys;
   const hasGeneratedKeyFlash = Boolean(flash?.key);
   const wallets: PaymentsDashboardWallet[] = walletsResponse.ok ? (walletsResponse.data ?? []) : [];
 
@@ -121,66 +78,7 @@ export default async function ApiKeysPage() {
               the API for custom grace values (0-168h). New key secrets are shown once.
             </p>
           </div>
-          {apiKeys.length === 0 ? (
-            <p className="text-sm text-[rgba(28,28,29,0.72)]">No API keys found.</p>
-          ) : (
-            <Table className="table-fixed">
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-[14%]">Name</TableHead>
-                  <TableHead className="w-[14%]">Prefix</TableHead>
-                  <TableHead className="w-[10%]">Role</TableHead>
-                  <TableHead className="w-[8%]">Env</TableHead>
-                  <TableHead className="w-[10%]">Status</TableHead>
-                  <TableHead className="w-[11%]">Last used</TableHead>
-                  <TableHead className="w-[11%]">Expires</TableHead>
-                  <TableHead className="w-[11%]">Created</TableHead>
-                  <TableHead className="w-[21%] text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {apiKeys.map((key) => {
-                  const canRotate = key.status === "active";
-
-                  return (
-                    <TableRow key={key.id}>
-                      <TableCell className="font-medium">
-                        <span className="block truncate">{key.name}</span>
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">
-                        <span className="block truncate">{key.keyPrefix}</span>
-                      </TableCell>
-                      <TableCell className="text-xs">
-                        <span className="block truncate">{formatRole(key.role)}</span>
-                      </TableCell>
-                      <TableCell className="text-xs">
-                        <span className="block truncate">{key.environment}</span>
-                      </TableCell>
-                      <TableCell className="text-xs">
-                        <span className="block truncate">{key.status}</span>
-                      </TableCell>
-                      <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
-                        {formatDate(key.lastUsedAt)}
-                      </TableCell>
-                      <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
-                        {formatDate(key.expiresAt)}
-                      </TableCell>
-                      <TableCell className="text-xs text-[rgba(28,28,29,0.72)]">
-                        {formatDate(key.createdAt)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <ApiKeyActionsMenu
-                          keyId={key.id}
-                          keyName={key.name}
-                          canRotate={canRotate}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          )}
+          <ApiKeysTableClient initialApiKeys={apiKeys} />
         </CardContent>
       </Card>
     </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -32,6 +32,7 @@ import {
   createInitialMintForm,
   createInitialSeizeForm,
   getDefaultActionForTab,
+  getDisplayedAuthorityAddress,
   getExplorerHref,
   getExtensionRows,
   getPermissionRows,
@@ -199,18 +200,37 @@ export function TokenManagementWorkspace({
       metadataAuthority,
     })
   );
-  const permissionRows = getPermissionRows(token, metadataAuthority).map((row) => ({
-    ...row,
-    editDisabledReason: withWalletLoadError(
-      getSignerSelectionForAction({
-        action: "authority",
-        token,
-        authorityWallets,
-        metadataAuthority,
-        permissionRow: row,
-      })
-    ).unavailableReason,
-  }));
+  const permissionRows = getPermissionRows(token, metadataAuthority).map((row) => {
+    const displayedAuthorityAddress = getDisplayedAuthorityAddress({
+      token,
+      role: row.authorityRole,
+      metadataAuthority,
+      authorityWallets,
+    });
+    const rowWithDisplayedValue = {
+      ...row,
+      value: displayedAuthorityAddress,
+    };
+
+    return {
+      ...rowWithDisplayedValue,
+      editDisabledReason: withWalletLoadError(
+        getSignerSelectionForAction({
+          action: "authority",
+          token,
+          authorityWallets,
+          metadataAuthority,
+          permissionRow: rowWithDisplayedValue,
+        })
+      ).unavailableReason,
+    };
+  });
+  const displayedMintAuthority = getDisplayedAuthorityAddress({
+    token,
+    role: "mint",
+    metadataAuthority,
+    authorityWallets,
+  });
   const extensionRows = getExtensionRows(token);
   const showAllowlistControls = token.requiresAllowlist;
   const complianceActions: Array<{ id: AdminAction; label: string }> = [
@@ -963,7 +983,11 @@ export function TokenManagementWorkspace({
       {activeTab === "overview" ? (
         <div className="space-y-4">
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
-            <TokenOverviewSection token={token} showTitle={false} />
+            <TokenOverviewSection
+              token={token}
+              showTitle={false}
+              mintAuthorityValue={displayedMintAuthority}
+            />
             <TokenControlListsSection
               showAllowlist={showAllowlistControls}
               allowlistEntriesCount={allowlistEntries.length}
@@ -1041,7 +1065,11 @@ export function TokenManagementWorkspace({
       {activeTab === "metadata" ? (
         <div className="space-y-4">
           {visibleActionForm}
-          <TokenOverviewSection token={token} showTitle={false} />
+          <TokenOverviewSection
+            token={token}
+            showTitle={false}
+            mintAuthorityValue={displayedMintAuthority}
+          />
         </div>
       ) : null}
 

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.utils.ts
@@ -369,6 +369,66 @@ export function getPermissionRows(token: Token, metadataAuthority: string | null
   ];
 }
 
+function getPendingAuthoritySignerWallet(
+  token: Token,
+  authorityWallets: PaymentsDashboardWallet[]
+): PaymentsDashboardWallet | null {
+  const availableWallets = getAvailableSignerWallets(authorityWallets);
+  if (availableWallets.length === 0) {
+    return null;
+  }
+
+  return findSignerWalletById(availableWallets, token.signingWalletId) ?? availableWallets[0];
+}
+
+function pendingTokenRequiresPermanentDelegate(token: Token): boolean {
+  return (
+    token.template === "stablecoin" ||
+    token.template === "arcade" ||
+    token.template === "tokenized-security"
+  );
+}
+
+export function getDisplayedAuthorityAddress({
+  token,
+  role,
+  metadataAuthority,
+  authorityWallets,
+}: {
+  token: Token;
+  role: AuthorityFormState["role"];
+  metadataAuthority: string | null;
+  authorityWallets: PaymentsDashboardWallet[];
+}): string | null {
+  const resolvedAuthority = resolveAuthorityAddressForRole(token, role, metadataAuthority);
+  if (resolvedAuthority) {
+    return resolvedAuthority;
+  }
+
+  if (token.status !== "pending") {
+    return null;
+  }
+
+  const pendingSignerWallet = getPendingAuthoritySignerWallet(token, authorityWallets);
+  if (!pendingSignerWallet) {
+    return null;
+  }
+
+  switch (role) {
+    case "mint":
+    case "metadata":
+      return pendingSignerWallet.publicKey;
+    case "freeze":
+      return token.isFreezable ? pendingSignerWallet.publicKey : null;
+    case "permanentDelegate":
+      if (typeof token.extensions?.permanentDelegate === "string") {
+        return token.extensions.permanentDelegate;
+      }
+
+      return pendingTokenRequiresPermanentDelegate(token) ? pendingSignerWallet.publicKey : null;
+  }
+}
+
 export type SignerAwareAction = "deploy" | "mint" | "burn" | "seize" | "force-burn" | "authority";
 
 export interface SignerSelectionState {

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-overview-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-overview-section.tsx
@@ -6,9 +6,14 @@ import { formatDate } from "./token-management-workspace.utils";
 interface TokenOverviewSectionProps {
   token: Token;
   showTitle?: boolean;
+  mintAuthorityValue?: string | null;
 }
 
-export function TokenOverviewSection({ token, showTitle = true }: TokenOverviewSectionProps) {
+export function TokenOverviewSection({
+  token,
+  showTitle = true,
+  mintAuthorityValue,
+}: TokenOverviewSectionProps) {
   return (
     <section className="space-y-3">
       {showTitle ? (
@@ -18,7 +23,7 @@ export function TokenOverviewSection({ token, showTitle = true }: TokenOverviewS
       ) : null}
       <div className="overflow-hidden rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white">
         <OverviewRow label="Token Address" value={token.mintAddress ?? "Not deployed"} monospace />
-        <OverviewRow label="Mint Authority" value={token.mintAuthority ?? "None"} monospace />
+        <OverviewRow label="Mint Authority" value={mintAuthorityValue ?? "None"} monospace />
         <OverviewRow label="Supply" value={token.totalSupply} />
         <OverviewRow label="Created" value={formatDate(token.createdAt)} />
         <OverviewRow label="Template" value={token.template} />

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -106,6 +106,10 @@ function getTokenTypeLabel(template: IssuanceTokenView["template"]): string {
   return template;
 }
 
+function getDeploymentStatus(token: IssuanceTokenView): "pending" | "active" {
+  return token.mintAddress || token.deployedAt ? "active" : "pending";
+}
+
 export function IssuanceWorkspace({
   tokens,
   templates,
@@ -233,22 +237,41 @@ export function IssuanceWorkspace({
                   data-testid={`token-card-${token.id}`}
                   className="flex min-h-[340px] flex-col rounded-2xl border border-[rgba(28,28,29,0.1)] bg-[#fcfcfa] p-5 shadow-[0_2px_10px_rgba(28,28,29,0.05)]"
                 >
-                  <div className="mb-4 h-14 w-14 overflow-hidden rounded-full border border-[rgba(28,28,29,0.1)] bg-white">
-                    {token.imageUrl ? (
-                      // Token logos are dynamic external assets from API data.
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={token.imageUrl}
-                        alt={`${token.name} logo`}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-lg font-semibold text-[rgba(28,28,29,0.58)]">
-                        {token.symbol.slice(0, 1) || "?"}
-                      </div>
-                    )}
-                  </div>
+                  {(() => {
+                    const deploymentStatus = getDeploymentStatus(token);
 
+                    return (
+                      <div className="mb-4 flex items-start justify-between gap-3">
+                        <div className="h-14 w-14 overflow-hidden rounded-full border border-[rgba(28,28,29,0.1)] bg-white">
+                          {token.imageUrl ? (
+                            // Token logos are dynamic external assets from API data.
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={token.imageUrl}
+                              alt={`${token.name} logo`}
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center text-lg font-semibold text-[rgba(28,28,29,0.58)]">
+                              {token.symbol.slice(0, 1) || "?"}
+                            </div>
+                          )}
+                        </div>
+
+                        <span
+                          data-testid={`token-card-status-${token.id}`}
+                          className={[
+                            "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium tracking-[0.02em] capitalize",
+                            deploymentStatus === "active"
+                              ? "bg-[rgba(12,128,76,0.10)] text-[#0c804c]"
+                              : "bg-[rgba(28,28,29,0.08)] text-[rgba(28,28,29,0.72)]",
+                          ].join(" ")}
+                        >
+                          {deploymentStatus}
+                        </span>
+                      </div>
+                    );
+                  })()}
                   <p className="text-sm font-medium tracking-wide text-[rgba(28,28,29,0.58)] uppercase">
                     {token.symbol}
                   </p>


### PR DESCRIPTION
## Summary
- show expected signer authorities for pending tokens instead of `None`
- add pending/active deployment status chips on issuance cards
- fix local API key rotate/delete actions and remove delete revalidation layout shift
- clean up generated-key flash clearing and actions menu layering

## Validation
- `pnpm --filter sdp-web typecheck`
- targeted biome checks on touched `apps/sdp-web` files