### PR TITLE
feat(payments): move send and receive into full-page flows

### DIFF
--- a/apps/sdp-api/src/routes/compliance.test.ts
+++ b/apps/sdp-api/src/routes/compliance.test.ts
@@ -18,7 +18,6 @@ const TEST_USER = {
 };
 const TEST_API_KEY = {
   id: "key_compliance_test",
-  // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret.
   raw: "sk_test_compliance12345678901234567890",
   prefix: "sk_test_com",
 };
@@ -237,7 +236,6 @@ describe("Compliance routes", () => {
 
   it("returns an Elliptic risk score when Elliptic API is configured", async () => {
     env.ELLIPTIC_API_KEY = "elliptic_test_api_key";
-    // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret.
     env.ELLIPTIC_API_SECRET = "Ynl0ZXNlY3JldA==";
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -368,6 +366,69 @@ describe("Compliance routes", () => {
       Authorization: "Bearer elliptic_access_token",
       "Content-Type": "application/json",
     });
+  });
+
+  it("treats Elliptic NotInBlockchain responses as a passed check", async () => {
+    env.ELLIPTIC_API_KEY = "elliptic_test_api_key";
+    env.ELLIPTIC_API_SECRET = "Ynl0ZXNlY3JldA==";
+    env.ELLIPTIC_API_TOKEN = undefined;
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: "NotInBlockchain",
+          message:
+            "The submitted address with hash 9cjSk5dhJpjxgckZ3q2KJqmXr2cCv7XgSm4e4YMrVJ1s has not yet been processed into the Elliptic tool or does not exist on the blockchain.",
+          status: 404,
+        }),
+        {
+          status: 404,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      )
+    );
+
+    const res = await app.request(
+      "/v1/compliance/address-screenings",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          address: TEST_SOLANA_ADDRESSES.wallet1,
+          network: "solana",
+          intent: "transfer_destination",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        screening: {
+          providers: Array<{
+            provider: string;
+            status: string;
+            riskScore: number | null;
+            riskLevel?: string;
+            message?: string;
+          }>;
+        };
+      };
+    };
+
+    const elliptic = body.data.screening.providers.find((entry) => entry.provider === "elliptic");
+    expect(elliptic).toMatchObject({
+      status: "ok",
+      riskScore: null,
+      riskLevel: "Check passed",
+    });
+    expect(elliptic?.message).toBeUndefined();
   });
 
   it("returns a TRM risk score when TRM API is configured", async () => {

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -560,7 +560,6 @@ describe("Payments routes", () => {
     expect(redirect.searchParams.get("baseCurrencyCode")).toBe("usdc_sol");
     expect(redirect.searchParams.get(MOONPAY_PARAM_BASE_CURRENCY_AMOUNT)).toBe("75.25");
     expect(redirect.searchParams.get(MOONPAY_PARAM_QUOTE_CURRENCY_CODE)).toBe("usd");
-    expect(redirect.searchParams.get("walletAddress")).toBe(TEST_SOLANA_ADDRESSES.wallet1);
     expect(redirect.searchParams.get(MOONPAY_PARAM_REFUND_WALLET_ADDRESS)).toBe(
       TEST_SOLANA_ADDRESSES.wallet1
     );

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -1018,7 +1018,6 @@ const moonPayRampProvider: RampProviderExecutor = {
       baseCurrencyCode: normalizeMoonPayCurrencyCode(input.cryptoToken),
       baseCurrencyAmount: input.cryptoAmount,
       quoteCurrencyCode: "usd",
-      walletAddress: sourceWalletAddress,
       refundWalletAddress: sourceWalletAddress,
       redirectURL: input.redirectUrl,
       externalCustomerId: input.kycReference,

--- a/apps/sdp-api/src/routes/payments/token-accounts.ts
+++ b/apps/sdp-api/src/routes/payments/token-accounts.ts
@@ -6,14 +6,28 @@ import type { Address } from "@solana/kit";
 
 // biome-ignore lint/nursery/noSecrets: Solana native SOL mint address constant, not a secret.
 export const SOL_MINT = "So11111111111111111111111111111111111111112";
+// biome-ignore lint/nursery/noSecrets: Devnet USDC mint address constant, not a secret.
+const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+// biome-ignore lint/nursery/noSecrets: Mainnet USDC mint address constant, not a secret.
+const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 // biome-ignore lint/nursery/noSecrets: Solana SPL Token program ID, not a secret.
 const SPL_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
 // biome-ignore lint/nursery/noSecrets: Solana Token-2022 program ID, not a secret.
 const SPL_TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" as Address;
 const SPL_TOKEN_PROGRAM_IDS = [SPL_TOKEN_PROGRAM_ID, SPL_TOKEN_2022_PROGRAM_ID] as const;
+const KNOWN_TOKEN_LABELS_BY_MINT = new Map<string, string>([
+  [SOL_MINT, "SOL"],
+  [DEVNET_USDC_MINT, "USDC"],
+  [MAINNET_USDC_MINT, "USDC"],
+]);
+
 export function isNativeSolToken(token: string): boolean {
   const normalized = token.trim();
   return normalized.toUpperCase() === "SOL" || normalized === SOL_MINT;
+}
+
+function resolveTokenLabel(mint: string): string {
+  return KNOWN_TOKEN_LABELS_BY_MINT.get(mint) ?? mint;
 }
 
 type JsonParsedTokenAccountEntry = {
@@ -138,7 +152,7 @@ export async function getSplTokenBalances(
   return Array.from(balancesByMint.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([mint, balance]) => ({
-      token: mint,
+      token: resolveTokenLabel(mint),
       mint,
       amount: balance.amount.toString(),
       uiAmount: balance.uiAmount ?? formatDecimalAmount(balance.amount, balance.decimals),

--- a/apps/sdp-api/src/services/compliance/providers/elliptic.ts
+++ b/apps/sdp-api/src/services/compliance/providers/elliptic.ts
@@ -41,6 +41,18 @@ function extractErrorMessage(body: string): string {
   return body;
 }
 
+function isNotInBlockchainResponse(responseStatus: number, body: string): boolean {
+  if (responseStatus !== 404) {
+    return false;
+  }
+
+  return (
+    body.includes("NotInBlockchain") ||
+    body.includes("has not yet been processed into the Elliptic tool") ||
+    body.includes("does not exist on the blockchain")
+  );
+}
+
 function decodeBase64(value: string): Uint8Array {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -216,6 +228,16 @@ export class EllipticComplianceProvider implements ComplianceProvider {
 
       if (!response.ok) {
         const body = extractErrorMessage(await response.text().catch(() => ""));
+        if (isNotInBlockchainResponse(response.status, body)) {
+          return {
+            provider: this.name,
+            status: "ok",
+            riskScore: null,
+            riskLevel: "Check passed",
+            evaluatedAt,
+          };
+        }
+
         return {
           provider: this.name,
           status: "error",

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page-skeleton.tsx
@@ -1,0 +1,32 @@
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
+
+export function PaymentsActionPageSkeleton() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 py-6">
+      <div className="space-y-6">
+        <SkeletonBlock className="h-[2px] w-full rounded-full" />
+        <div className="space-y-3 text-center">
+          <SkeletonBlock className="mx-auto h-12 w-48 rounded-[8px]" />
+          <SkeletonBlock className="mx-auto h-5 w-96 max-w-full rounded-[8px]" />
+        </div>
+      </div>
+
+      <div className="mx-auto w-full max-w-3xl space-y-6">
+        <div className="space-y-3 text-center">
+          <SkeletonBlock className="mx-auto h-10 w-72 rounded-[8px]" />
+          <SkeletonBlock className="mx-auto h-5 w-[28rem] max-w-full rounded-[8px]" />
+        </div>
+
+        <div className="grid gap-4">
+          <SkeletonBlock className="h-28 w-full rounded-[24px]" />
+          <SkeletonBlock className="h-28 w-full rounded-[24px]" />
+        </div>
+      </div>
+
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 sm:flex-row-reverse">
+        <SkeletonBlock className="h-14 flex-1 rounded-full" />
+        <SkeletonBlock className="h-14 flex-1 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -26,8 +26,10 @@ import { toast } from "sonner";
 import useSWR from "swr";
 import {
   type PaymentRampExecution,
+  type PaymentWalletBalance,
   createTransfer,
   executeRampFlow,
+  fetchWalletBalances,
   fetchWalletPolicy,
   fetchWallets,
   getDevnetExplorerUrl,
@@ -40,11 +42,19 @@ interface PaymentsActionPageProps {
   mode: "send" | "receive";
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
+  issuedTokenSymbolsByMint: Record<string, string>;
 }
 
 const REQUIRED_ACTION_ASSETS = ["SOL", "USDC"] as const;
 const MOONPAY_ONRAMP_MIN_USD = 20;
 const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
+const PAYMENTS_ACTION_WALLET_BALANCES_KEY = "payments-action-wallet-balances";
+// biome-ignore lint/nursery/noSecrets: Solana native mint address constant, not a secret.
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+// biome-ignore lint/nursery/noSecrets: Devnet USDC mint address constant, not a secret.
+const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+// biome-ignore lint/nursery/noSecrets: Mainnet USDC mint address constant, not a secret.
+const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const BVNK_COUNTRY_OPTIONS = [
   { label: "United States", value: "US" },
   { label: "Canada", value: "CA" },
@@ -127,6 +137,19 @@ const OFFRAMP_PROVIDER_OPTIONS: ProviderOption[] = [
   },
 ];
 
+const KNOWN_ASSET_MINTS: Record<string, string[]> = {
+  SOL: [SOL_MINT],
+  USDC: [DEVNET_USDC_MINT, MAINNET_USDC_MINT],
+};
+
+function buildPaymentsReturnUrl(refreshToken?: string | null): string {
+  if (!refreshToken) {
+    return "/dashboard/payments";
+  }
+
+  return `/dashboard/payments?refresh=${encodeURIComponent(refreshToken)}`;
+}
+
 function parseOptionalNumber(value: string): number | null {
   const numericValue = Number.parseFloat(value);
   return Number.isFinite(numericValue) ? numericValue : null;
@@ -147,26 +170,93 @@ function resolvePrimaryWalletBalance(wallet: PaymentsDashboardWallet | null) {
   );
 }
 
-function getWalletActionLabel(wallet: PaymentsDashboardWallet): string {
+function resolveBalanceDisplayToken(
+  balance: PaymentWalletBalance,
+  issuedTokenSymbolsByMint: Record<string, string>
+): string {
+  const normalizedToken = balance.token.trim().toUpperCase();
+  const normalizedMint = balance.mint.trim();
+  const issuedTokenSymbol = issuedTokenSymbolsByMint[normalizedMint]?.trim();
+
+  if (issuedTokenSymbol) {
+    return issuedTokenSymbol.toUpperCase();
+  }
+
+  if (normalizedToken === "SOL" || normalizedMint === SOL_MINT) {
+    return "SOL";
+  }
+
+  if (
+    normalizedToken === "USDC" ||
+    normalizedMint === DEVNET_USDC_MINT ||
+    normalizedMint === MAINNET_USDC_MINT
+  ) {
+    return "USDC";
+  }
+
+  return normalizedToken || normalizedMint;
+}
+
+function balanceMatchesAsset(
+  balance: PaymentWalletBalance,
+  asset: string,
+  issuedTokenSymbolsByMint: Record<string, string>
+): boolean {
+  const normalizedAsset = asset.trim().toUpperCase();
+  if (!normalizedAsset) {
+    return false;
+  }
+
+  if (resolveBalanceDisplayToken(balance, issuedTokenSymbolsByMint) === normalizedAsset) {
+    return true;
+  }
+
+  return KNOWN_ASSET_MINTS[normalizedAsset]?.includes(balance.mint.trim()) ?? false;
+}
+
+function getWalletActionLabel(
+  wallet: PaymentsDashboardWallet,
+  issuedTokenSymbolsByMint: Record<string, string>
+): string {
   const balance = resolvePrimaryWalletBalance(wallet);
   if (!balance) {
     return wallet.label ?? wallet.walletId;
   }
 
-  return `${wallet.label ?? wallet.walletId} · ${balance.uiAmount} ${balance.token}`;
+  return `${wallet.label ?? wallet.walletId} · ${balance.uiAmount} ${resolveBalanceDisplayToken(balance, issuedTokenSymbolsByMint)}`;
 }
 
-function resolveWalletActionAssets(wallet: PaymentsDashboardWallet | null): string[] {
+function resolveWalletActionAssets(
+  wallet: PaymentsDashboardWallet | null,
+  issuedTokenSymbolsByMint: Record<string, string>
+): string[] {
   const assetSet = new Set<string>(REQUIRED_ACTION_ASSETS);
 
   for (const balance of wallet?.balances ?? []) {
-    const token = balance.token.trim().toUpperCase();
+    const token = resolveBalanceDisplayToken(balance, issuedTokenSymbolsByMint);
     if (token) {
       assetSet.add(token);
     }
   }
 
   return [...assetSet];
+}
+
+function resolveWalletAssetBalance(
+  wallet: PaymentsDashboardWallet | null,
+  asset: string,
+  issuedTokenSymbolsByMint: Record<string, string>
+): NonNullable<PaymentsDashboardWallet["balances"]>[number] | null {
+  const normalizedAsset = asset.trim().toUpperCase();
+  if (!wallet || !normalizedAsset) {
+    return null;
+  }
+
+  return (
+    wallet.balances?.find((balance) =>
+      balanceMatchesAsset(balance, normalizedAsset, issuedTokenSymbolsByMint)
+    ) ?? null
+  );
 }
 
 function appendMoonpayReviewRows(
@@ -490,6 +580,21 @@ function WalletAddressQrCode({ address }: { address: string }) {
           </p>
           <div className="rounded-[18px] border border-[rgba(28,28,29,0.08)] bg-white px-4 py-3">
             <p className="break-all font-mono text-xs text-[rgba(28,28,29,0.78)]">{address}</p>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                void navigator.clipboard.writeText(address);
+                toast.success("Address copied.", {
+                  position: "bottom-right",
+                });
+              }}
+            >
+              <Copy className="size-4" />
+              Copy address
+            </Button>
           </div>
         </div>
       </div>
@@ -831,7 +936,13 @@ function RampProviderFields({
   );
 }
 
-export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActionPageProps) {
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this component intentionally coordinates the full multi-step payments flow in one place.
+export function PaymentsActionPage({
+  mode,
+  wallets,
+  walletsError,
+  issuedTokenSymbolsByMint,
+}: PaymentsActionPageProps) {
   const router = useRouter();
 
   const [branch, setBranch] = useState<ActionBranch | null>(null);
@@ -840,6 +951,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
   const [selectedWalletId, setSelectedWalletId] = useState("");
   const [selectedAsset, setSelectedAsset] = useState("USDC");
   const [amount, setAmount] = useState("");
+  const [amountTouched, setAmountTouched] = useState(false);
   const [destination, setDestination] = useState("");
   const [memo, setMemo] = useState("");
   const [reference, setReference] = useState("");
@@ -901,7 +1013,41 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
     () => liveWallets.find((wallet) => wallet.walletId === selectedWalletId) ?? null,
     [liveWallets, selectedWalletId]
   );
-  const assetOptions = useMemo(() => resolveWalletActionAssets(selectedWallet), [selectedWallet]);
+  const { data: selectedWalletBalancesSnapshot } = useSWR(
+    selectedWalletId ? [PAYMENTS_ACTION_WALLET_BALANCES_KEY, selectedWalletId] : null,
+    ([, walletId]: readonly [string, string]) => fetchWalletBalances(walletId),
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const selectedWalletWithBalances = useMemo(() => {
+    if (!selectedWallet) {
+      return null;
+    }
+
+    if (selectedWalletBalancesSnapshot?.walletId !== selectedWallet.walletId) {
+      return selectedWallet;
+    }
+
+    return {
+      ...selectedWallet,
+      balances: selectedWalletBalancesSnapshot.balances,
+    };
+  }, [selectedWallet, selectedWalletBalancesSnapshot]);
+  const assetOptions = useMemo(
+    () => resolveWalletActionAssets(selectedWalletWithBalances, issuedTokenSymbolsByMint),
+    [issuedTokenSymbolsByMint, selectedWalletWithBalances]
+  );
+  const selectedAssetBalance = useMemo(
+    () =>
+      resolveWalletAssetBalance(
+        selectedWalletWithBalances,
+        selectedAsset,
+        issuedTokenSymbolsByMint
+      ),
+    [issuedTokenSymbolsByMint, selectedAsset, selectedWalletWithBalances]
+  );
 
   useEffect(() => {
     if (assetOptions.length === 0) {
@@ -944,6 +1090,25 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
     provider === "moonpay" &&
     amount.trim().length > 0 &&
     (numericAmount === null || numericAmount < MOONPAY_ONRAMP_MIN_USD);
+  const availableSelectedAssetAmount = useMemo(() => {
+    if (!selectedAsset) {
+      return null;
+    }
+
+    if (!selectedAssetBalance) {
+      return 0;
+    }
+
+    const numericValue = Number(selectedAssetBalance.uiAmount);
+    return Number.isFinite(numericValue) ? numericValue : 0;
+  }, [selectedAsset, selectedAssetBalance]);
+  const exceedsSelectedAssetBalance =
+    isTransferBranch &&
+    !!selectedAsset &&
+    amount.trim().length > 0 &&
+    numericAmount !== null &&
+    availableSelectedAssetAmount !== null &&
+    numericAmount > availableSelectedAssetAmount;
 
   useEffect(() => {
     if (!isTransferBranch || !selectedWalletId) {
@@ -990,6 +1155,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
 
   const resetFlowFields = () => {
     setAmount("");
+    setAmountTouched(false);
     setDestination("");
     setMemo("");
     setReference("");
@@ -1047,6 +1213,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
         !!selectedAsset &&
         !!destinationTrimmed &&
         !!amount.trim() &&
+        !exceedsSelectedAssetBalance &&
         (hasTransferComplianceForDestination || destinationIsAllowlisted)
       );
     }
@@ -1100,6 +1267,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
     customerId,
     destinationIsAllowlisted,
     destinationTrimmed,
+    exceedsSelectedAssetBalance,
     hasTransferComplianceForDestination,
     isBelowMoonPayOnrampMinimum,
     isDepositBranch,
@@ -1212,7 +1380,10 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
       const transfer = await createTransfer({
         source: selectedWalletId,
         destination: destinationTrimmed,
-        token: selectedAsset.trim() || "SOL",
+        token:
+          selectedAssetBalance?.mint?.trim() ||
+          (selectedAsset.trim().toUpperCase() === "SOL" ? "SOL" : selectedAsset.trim()) ||
+          "SOL",
         amount: amount.trim(),
         ...(memo.trim() ? { memo: memo.trim() } : {}),
       });
@@ -1367,7 +1538,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
 
     if (currentStep.id === "review") {
       if (executionState === "success") {
-        router.push("/dashboard/payments");
+        router.push(buildPaymentsReturnUrl(transferResult?.id ?? rampExecution?.id ?? null));
         return;
       }
 
@@ -1419,7 +1590,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
 
   const secondaryLabel = useMemo(() => {
     if (currentStep.id === "branch") {
-      return "Back to payments";
+      return "Back";
     }
 
     if (currentStep.id === "review" && executionState === "success") {
@@ -1513,7 +1684,8 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
         <Select value={value} onValueChange={onChange} disabled={!hasWallets}>
           <SelectTrigger
             id={`${mode}-wallet`}
-            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+            size="lg"
+            className="h-12 w-full rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
           >
             <SelectValue placeholder="Select wallet" />
           </SelectTrigger>
@@ -1523,7 +1695,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
           >
             {liveWallets.map((wallet) => (
               <SelectItem key={wallet.walletId} value={wallet.walletId}>
-                {getWalletActionLabel(wallet)}
+                {getWalletActionLabel(wallet, issuedTokenSymbolsByMint)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -1533,52 +1705,70 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
   };
 
   const renderAssetAndAmount = (amountLabel: string) => (
-    <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_160px]">
-      <div className="space-y-2">
-        <Label htmlFor={`${mode}-amount`}>{amountLabel}</Label>
-        <Input
-          id={`${mode}-amount`}
-          type="number"
-          inputMode="decimal"
-          min="0.000001"
-          step="any"
-          value={amount}
-          onChange={(event) => {
-            setAmount(event.currentTarget.value);
-            resetExecution();
-          }}
-          placeholder="1.00"
-          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor={`${mode}-asset`}>Asset</Label>
-        <Select
-          value={selectedAsset}
-          onValueChange={(value) => {
-            setSelectedAsset(value);
-            resetExecution();
-          }}
-          disabled={walletsLoading || assetOptions.length === 0}
-        >
-          <SelectTrigger
-            id={`${mode}-asset`}
+    <div className="space-y-1">
+      <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_160px]">
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-amount`}>{amountLabel}</Label>
+          <Input
+            id={`${mode}-amount`}
+            type="number"
+            inputMode="decimal"
+            min="0.000001"
+            step="any"
+            value={amount}
+            onChange={(event) => {
+              setAmount(event.currentTarget.value);
+              if (event.currentTarget.value.trim().length > 0) {
+                setAmountTouched(true);
+              }
+              resetExecution();
+            }}
+            onBlur={() => setAmountTouched(true)}
+            placeholder="1.00"
             className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-asset`}>Asset</Label>
+          <Select
+            value={selectedAsset}
+            onValueChange={(value) => {
+              setSelectedAsset(value);
+              resetExecution();
+            }}
+            disabled={walletsLoading || assetOptions.length === 0}
           >
-            <SelectValue placeholder="Select asset" />
-          </SelectTrigger>
-          <SelectContent
-            position="popper"
-            className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
-          >
-            {assetOptions.map((asset) => (
-              <SelectItem key={asset} value={asset}>
-                {asset}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+            <SelectTrigger
+              id={`${mode}-asset`}
+              size="lg"
+              className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+            >
+              <SelectValue placeholder="Select asset" />
+            </SelectTrigger>
+            <SelectContent
+              position="popper"
+              className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
+            >
+              {assetOptions.map((asset) => (
+                <SelectItem key={asset} value={asset}>
+                  {asset}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
+      <p
+        className={[
+          "h-5 text-sm leading-5",
+          amountTouched && exceedsSelectedAssetBalance
+            ? "text-[#9e2b38]"
+            : "invisible text-transparent",
+        ].join(" ")}
+      >
+        Insufficient {selectedAsset}. Available balance: {selectedAssetBalance?.uiAmount ?? "0"}{" "}
+        {selectedAsset}.
+      </p>
     </div>
   );
 
@@ -1627,15 +1817,8 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
               policyLoading || transferComplianceLoading || !selectedWalletId || !destinationTrimmed
             }
           >
-            {policyLoading
-              ? "Loading wallet policy..."
-              : transferComplianceLoading
-                ? "Checking..."
-                : "Check risk score"}
+            Run a risk check
           </Button>
-          <p className="text-sm text-[rgba(28,28,29,0.56)]">
-            Risk check is required unless the destination is already on the wallet allowlist.
-          </p>
         </div>
       )}
       {policyError ? <p className="text-sm text-[#9e2b38]">{policyError}</p> : null}
@@ -1692,6 +1875,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
           >
             <SelectTrigger
               id={`${mode}-deposit-asset`}
+              size="lg"
               className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
             >
               <SelectValue placeholder="Select asset" />
@@ -1786,7 +1970,7 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
             <p className="text-[20px] font-medium text-[#115e3d]">Transfer submitted</p>
             <p className="mt-2 text-sm text-[#115e3d]">
               {transferResult.signature
-                ? "The transfer was signed and broadcast successfully."
+                ? "The transfer was signed and broadcast successfully. It will appear in the transaction list when you return to Payments."
                 : `Current status: ${transferResult.status}`}
             </p>
           </div>
@@ -1925,23 +2109,6 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
         ]}
       />
       <WalletAddressQrCode address={selectedWallet?.publicKey ?? ""} />
-      {selectedWallet?.publicKey ? (
-        <div className="flex justify-end">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={() => {
-              void navigator.clipboard.writeText(selectedWallet.publicKey);
-              toast.success("Address copied.", {
-                position: "bottom-right",
-              });
-            }}
-          >
-            <Copy className="size-4" />
-            Copy address
-          </Button>
-        </div>
-      ) : null}
     </div>
   );
 
@@ -2025,31 +2192,37 @@ export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActi
         {renderCurrentStep()}
       </div>
 
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 sm:flex-row-reverse">
-        {showPrimaryAction ? (
+      {currentStep.id !== "branch" ? (
+        <div
+          className={`mx-auto flex w-full max-w-3xl flex-col gap-3 ${
+            showPrimaryAction ? "sm:flex-row sm:justify-between" : "sm:flex-row sm:justify-start"
+          }`}
+        >
           <Button
             type="button"
+            variant="secondary"
             className="h-14 rounded-full text-base"
-            disabled={primaryDisabled}
+            disabled={executionState === "submitting"}
             onClick={() => {
-              void handlePrimaryAction();
+              void handleSecondaryAction();
             }}
           >
-            {primaryLabel}
+            {secondaryLabel}
           </Button>
-        ) : null}
-        <Button
-          type="button"
-          variant="secondary"
-          className="h-14 rounded-full text-base"
-          disabled={executionState === "submitting"}
-          onClick={() => {
-            void handleSecondaryAction();
-          }}
-        >
-          {secondaryLabel}
-        </Button>
-      </div>
+          {showPrimaryAction ? (
+            <Button
+              type="button"
+              className="h-14 rounded-full text-base"
+              disabled={primaryDisabled}
+              onClick={() => {
+                void handlePrimaryAction();
+              }}
+            >
+              {primaryLabel}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -1,0 +1,2055 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { PaymentTransferSummary, PaymentsDashboardWallet } from "@sdp/types";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  RefreshCw,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import QRCode from "qrcode";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import useSWR from "swr";
+import {
+  type PaymentRampExecution,
+  createTransfer,
+  executeRampFlow,
+  fetchWalletPolicy,
+  fetchWallets,
+  getDevnetExplorerUrl,
+  runComplianceCheck,
+} from "./payments-workspace.data";
+import type { ComplianceSnapshot } from "./payments-workspace.types";
+import { ProviderRiskTable } from "./provider-risk-table";
+
+interface PaymentsActionPageProps {
+  mode: "send" | "receive";
+  wallets: PaymentsDashboardWallet[];
+  walletsError: string | null;
+}
+
+const REQUIRED_ACTION_ASSETS = ["SOL", "USDC"] as const;
+const MOONPAY_ONRAMP_MIN_USD = 20;
+const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
+const BVNK_COUNTRY_OPTIONS = [
+  { label: "United States", value: "US" },
+  { label: "Canada", value: "CA" },
+  { label: "United Kingdom", value: "GB" },
+] as const;
+
+type ActionBranch = "wallet_transfer" | "wallet_deposit" | "onramp" | "offramp";
+type RampProviderId = "moonpay" | "lightspark" | "bvnk";
+type StepId = "branch" | "provider" | "details" | "review" | "deposit";
+type ExecutionState = "idle" | "submitting" | "success";
+
+type ProviderOption = {
+  id: RampProviderId;
+  title: string;
+  description: string;
+};
+
+type StepDefinition = {
+  id: StepId;
+  label: string;
+  title: string;
+  description: string;
+};
+
+type SummaryRow = {
+  label: string;
+  value: ReactNode;
+};
+
+type RampReviewRowsInput = {
+  isOnrampBranch: boolean;
+  isOfframpBranch: boolean;
+  provider: RampProviderId | null;
+  providerLabel: string | null;
+  selectedAsset: string;
+  amount: string;
+  selectedWallet: PaymentsDashboardWallet | null;
+  customerId: string;
+  lightsparkSourceAccountId: string;
+  lightsparkDestinationAccountId: string;
+  bvnkFirstName: string;
+  bvnkLastName: string;
+  bvnkDateOfBirth: string;
+  bvnkCountryCode: string;
+};
+
+const ONRAMP_PROVIDER_OPTIONS: ProviderOption[] = [
+  {
+    id: "moonpay",
+    title: "MoonPay",
+    description: "Hosted fiat-to-crypto checkout into the selected wallet.",
+  },
+  {
+    id: "lightspark",
+    title: "Lightspark",
+    description: "Create a Lightspark quote using the selected wallet as the destination.",
+  },
+  {
+    id: "bvnk",
+    title: "BVNK",
+    description: "Create a BVNK checkout session with a customer reference.",
+  },
+];
+
+const OFFRAMP_PROVIDER_OPTIONS: ProviderOption[] = [
+  {
+    id: "moonpay",
+    title: "MoonPay",
+    description: "Hosted crypto-to-fiat withdrawal using the selected wallet.",
+  },
+  {
+    id: "lightspark",
+    title: "Lightspark",
+    description: "Execute an off-ramp using Lightspark source and destination account IDs.",
+  },
+  {
+    id: "bvnk",
+    title: "BVNK",
+    description: "Create an off-ramp with beneficiary details for compliance.",
+  },
+];
+
+function parseOptionalNumber(value: string): number | null {
+  const numericValue = Number.parseFloat(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function resolvePrimaryWalletBalance(wallet: PaymentsDashboardWallet | null) {
+  if (!wallet?.balances || wallet.balances.length === 0) {
+    return null;
+  }
+
+  return (
+    wallet.balances.find((balance) => {
+      const numericValue = Number(balance.uiAmount);
+      return Number.isFinite(numericValue) && numericValue > 0;
+    }) ??
+    wallet.balances[0] ??
+    null
+  );
+}
+
+function getWalletActionLabel(wallet: PaymentsDashboardWallet): string {
+  const balance = resolvePrimaryWalletBalance(wallet);
+  if (!balance) {
+    return wallet.label ?? wallet.walletId;
+  }
+
+  return `${wallet.label ?? wallet.walletId} · ${balance.uiAmount} ${balance.token}`;
+}
+
+function resolveWalletActionAssets(wallet: PaymentsDashboardWallet | null): string[] {
+  const assetSet = new Set<string>(REQUIRED_ACTION_ASSETS);
+
+  for (const balance of wallet?.balances ?? []) {
+    const token = balance.token.trim().toUpperCase();
+    if (token) {
+      assetSet.add(token);
+    }
+  }
+
+  return [...assetSet];
+}
+
+function appendMoonpayReviewRows(
+  rows: SummaryRow[],
+  selectedWallet: PaymentsDashboardWallet | null
+) {
+  rows.push({
+    label: "Address",
+    value: <span className="font-mono text-xs">{selectedWallet?.publicKey ?? "—"}</span>,
+  });
+}
+
+function appendLightsparkReviewRows(rows: SummaryRow[], input: RampReviewRowsInput) {
+  if (input.isOnrampBranch) {
+    rows.push({
+      label: "Customer ID",
+      value: input.customerId.trim() || "—",
+    });
+    rows.push({
+      label: "Destination address",
+      value: <span className="font-mono text-xs">{input.selectedWallet?.publicKey ?? "—"}</span>,
+    });
+    return;
+  }
+
+  rows.push({
+    label: "Source account ID",
+    value: input.lightsparkSourceAccountId.trim() || "—",
+  });
+  rows.push({
+    label: "Destination account ID",
+    value: input.lightsparkDestinationAccountId.trim() || "—",
+  });
+}
+
+function appendBvnkReviewRows(rows: SummaryRow[], input: RampReviewRowsInput) {
+  rows.push({
+    label: "Customer ID",
+    value: input.customerId.trim() || "—",
+  });
+  rows.push({
+    label: input.isOnrampBranch ? "Destination address" : "Source address",
+    value: <span className="font-mono text-xs">{input.selectedWallet?.publicKey ?? "—"}</span>,
+  });
+
+  if (!input.isOfframpBranch) {
+    return;
+  }
+
+  rows.push({
+    label: "Beneficiary",
+    value: `${input.bvnkFirstName.trim()} ${input.bvnkLastName.trim()}`.trim() || "—",
+  });
+  rows.push({
+    label: "Date of birth",
+    value: input.bvnkDateOfBirth || "—",
+  });
+  rows.push({
+    label: "Country",
+    value:
+      BVNK_COUNTRY_OPTIONS.find((country) => country.value === input.bvnkCountryCode)?.label ?? "—",
+  });
+}
+
+function buildRampReviewRows(input: RampReviewRowsInput): SummaryRow[] {
+  const rows: SummaryRow[] = [
+    {
+      label: "Flow",
+      value: input.isOnrampBranch ? "On-ramp" : "Off-ramp",
+    },
+    {
+      label: "Provider",
+      value: input.providerLabel ?? "—",
+    },
+    {
+      label: "Asset",
+      value: input.selectedAsset || "—",
+    },
+    {
+      label: input.isOnrampBranch ? "Fiat amount (USD)" : "Crypto amount",
+      value: input.amount || "—",
+    },
+  ];
+
+  if (input.isOnrampBranch || input.provider !== "lightspark") {
+    rows.push({
+      label: "Wallet",
+      value: input.selectedWallet?.label ?? input.selectedWallet?.walletId ?? "—",
+    });
+  }
+
+  if (input.provider === "moonpay") {
+    appendMoonpayReviewRows(rows, input.selectedWallet);
+    return rows;
+  }
+
+  if (input.provider === "lightspark") {
+    appendLightsparkReviewRows(rows, input);
+    return rows;
+  }
+
+  if (input.provider === "bvnk") {
+    appendBvnkReviewRows(rows, input);
+  }
+
+  return rows;
+}
+
+function resolveStepSequence(
+  mode: "send" | "receive",
+  branch: ActionBranch | null
+): StepDefinition[] {
+  if (!branch) {
+    return [
+      {
+        id: "branch",
+        label: "Flow",
+        title: `Choose a ${mode} flow`,
+        description:
+          mode === "send"
+            ? "Choose whether you are sending to another wallet or starting an off-ramp."
+            : "Choose whether you want wallet deposit details or an on-ramp flow.",
+      },
+    ];
+  }
+
+  if (branch === "wallet_transfer") {
+    return [
+      {
+        id: "branch",
+        label: "Flow",
+        title: "Choose a send flow",
+        description: "Wallet transfer keeps the flow inside SDP wallets and Solana addresses.",
+      },
+      {
+        id: "details",
+        label: "Details",
+        title: "Enter transfer details",
+        description: "Choose the source wallet, destination, and amount before review.",
+      },
+      {
+        id: "review",
+        label: "Review",
+        title: "Review transfer",
+        description: "Confirm the transfer details before submission.",
+      },
+    ];
+  }
+
+  if (branch === "wallet_deposit") {
+    return [
+      {
+        id: "branch",
+        label: "Flow",
+        title: "Choose a receive flow",
+        description: "Wallet deposit shows the wallet details needed to receive funds directly.",
+      },
+      {
+        id: "details",
+        label: "Details",
+        title: "Choose wallet and asset",
+        description: "Select the wallet and token context you want to use for this deposit.",
+      },
+      {
+        id: "deposit",
+        label: "Receive",
+        title: "Receive funds",
+        description: "Use this address or QR code to deposit into the selected wallet.",
+      },
+    ];
+  }
+
+  return [
+    {
+      id: "branch",
+      label: "Flow",
+      title: `Choose a ${mode} flow`,
+      description:
+        branch === "onramp"
+          ? "On-ramp flows move fiat into the selected wallet through a provider."
+          : "Off-ramp flows move funds out through a provider-specific withdrawal flow.",
+    },
+    {
+      id: "provider",
+      label: "Provider",
+      title: `Choose a ${branch === "onramp" ? "provider" : "provider"}`,
+      description:
+        branch === "onramp"
+          ? "Choose the on-ramp provider you want to use."
+          : "Choose the off-ramp provider you want to use.",
+    },
+    {
+      id: "details",
+      label: "Details",
+      title: branch === "onramp" ? "Enter on-ramp details" : "Enter off-ramp details",
+      description:
+        branch === "onramp"
+          ? "Fill in the wallet, amount, and provider-specific information."
+          : "Fill in the amount and provider-specific payout information.",
+    },
+    {
+      id: "review",
+      label: "Review",
+      title: branch === "onramp" ? "Review on-ramp" : "Review off-ramp",
+      description: "Confirm the provider request before it is submitted.",
+    },
+  ];
+}
+
+function ActionChoiceCard({
+  active,
+  title,
+  description,
+  icon,
+  onClick,
+}: {
+  active: boolean;
+  title: string;
+  description: string;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        "w-full rounded-[24px] border px-5 py-5 text-left transition-colors",
+        active
+          ? "border-[#1c1c1d] bg-[rgba(28,28,29,0.04)]"
+          : "border-[rgba(28,28,29,0.12)] bg-white hover:bg-[rgba(28,28,29,0.03)]",
+      ].join(" ")}
+    >
+      <div className="flex items-start gap-4">
+        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[rgba(28,28,29,0.06)] text-[#1c1c1d]">
+          {icon}
+        </div>
+        <div className="space-y-1">
+          <p className="text-[22px] leading-none font-medium text-[#1c1c1d]">{title}</p>
+          <p className="text-sm text-[rgba(28,28,29,0.62)]">{description}</p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function ReviewSummaryCard({
+  rows,
+}: {
+  rows: Array<{ label: string; value: ReactNode }>;
+}) {
+  return (
+    <section className="rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-5">
+      <div className="divide-y divide-[rgba(28,28,29,0.08)]">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center justify-between gap-4 py-4 first:pt-0 last:pb-0"
+          >
+            <p className="text-sm text-[rgba(28,28,29,0.62)]">{row.label}</p>
+            <div className="text-right text-base font-medium text-[#1c1c1d]">{row.value}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function WalletAddressQrCode({ address }: { address: string }) {
+  const [qrCodeUrl, setQrCodeUrl] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!address) {
+      setQrCodeUrl("");
+      return;
+    }
+
+    void QRCode.toDataURL(address, {
+      margin: 1,
+      width: 240,
+      color: {
+        dark: "#1c1c1d",
+        light: "#ffffff",
+      },
+    })
+      .then((url) => {
+        if (!cancelled) {
+          setQrCodeUrl(url);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setQrCodeUrl("");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  if (!address) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-6">
+      <div className="flex flex-col items-center gap-5 sm:flex-row sm:items-start">
+        <div className="flex size-[180px] items-center justify-center rounded-[22px] bg-white p-4 shadow-[inset_0_0_0_1px_rgba(28,28,29,0.08)]">
+          {qrCodeUrl ? (
+            <img src={qrCodeUrl} alt="Wallet address QR code" className="size-full" />
+          ) : (
+            <div className="size-full animate-pulse rounded-[14px] bg-[rgba(28,28,29,0.08)]" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <p className="text-sm text-[rgba(28,28,29,0.62)]">
+            Scan this QR code or copy the address to receive funds into the selected wallet.
+          </p>
+          <div className="rounded-[18px] border border-[rgba(28,28,29,0.08)] bg-white px-4 py-3">
+            <p className="break-all font-mono text-xs text-[rgba(28,28,29,0.78)]">{address}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MoonpayRampFields({
+  isOnrampBranch,
+  isBelowMoonPayOnrampMinimum,
+  selectedWallet,
+}: {
+  isOnrampBranch: boolean;
+  isBelowMoonPayOnrampMinimum: boolean;
+  selectedWallet: PaymentsDashboardWallet | null;
+}) {
+  return (
+    <>
+      {isOnrampBranch ? (
+        <p
+          className={
+            isBelowMoonPayOnrampMinimum
+              ? "text-sm text-[#9e2b38]"
+              : "text-sm text-[rgba(28,28,29,0.56)]"
+          }
+        >
+          Minimum $20 USD for MoonPay on-ramp.
+        </p>
+      ) : null}
+
+      {selectedWallet?.publicKey ? (
+        <div className="space-y-2">
+          <Label>{isOnrampBranch ? "Destination address" : "Source address"}</Label>
+          <Input
+            readOnly
+            value={selectedWallet.publicKey}
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function LightsparkRampFields({
+  mode,
+  isOnrampBranch,
+  selectedWallet,
+  customerId,
+  setCustomerId,
+  lightsparkSourceAccountId,
+  setLightsparkSourceAccountId,
+  lightsparkDestinationAccountId,
+  setLightsparkDestinationAccountId,
+  resetExecution,
+}: {
+  mode: "send" | "receive";
+  isOnrampBranch: boolean;
+  selectedWallet: PaymentsDashboardWallet | null;
+  customerId: string;
+  setCustomerId: (value: string) => void;
+  lightsparkSourceAccountId: string;
+  setLightsparkSourceAccountId: (value: string) => void;
+  lightsparkDestinationAccountId: string;
+  setLightsparkDestinationAccountId: (value: string) => void;
+  resetExecution: () => void;
+}) {
+  if (isOnrampBranch) {
+    return (
+      <>
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-customer-id`}>Customer ID</Label>
+          <Input
+            id={`${mode}-customer-id`}
+            value={customerId}
+            onChange={(event) => {
+              setCustomerId(event.currentTarget.value);
+              resetExecution();
+            }}
+            placeholder="Customer:cus_123"
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Destination address</Label>
+          <Input
+            readOnly
+            value={selectedWallet?.publicKey ?? ""}
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
+          />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-lightspark-source`}>Source account ID</Label>
+        <Input
+          id={`${mode}-lightspark-source`}
+          value={lightsparkSourceAccountId}
+          onChange={(event) => {
+            setLightsparkSourceAccountId(event.currentTarget.value);
+            resetExecution();
+          }}
+          placeholder="InternalAccount:acc_source_123"
+          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-lightspark-destination`}>Destination account ID</Label>
+        <Input
+          id={`${mode}-lightspark-destination`}
+          value={lightsparkDestinationAccountId}
+          onChange={(event) => {
+            setLightsparkDestinationAccountId(event.currentTarget.value);
+            resetExecution();
+          }}
+          placeholder="ExternalAccount:acc_destination_123"
+          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+        />
+      </div>
+    </div>
+  );
+}
+
+function BvnkRampFields({
+  mode,
+  isOnrampBranch,
+  selectedWallet,
+  customerId,
+  setCustomerId,
+  bvnkFirstName,
+  setBvnkFirstName,
+  bvnkLastName,
+  setBvnkLastName,
+  bvnkDateOfBirth,
+  setBvnkDateOfBirth,
+  bvnkCountryCode,
+  setBvnkCountryCode,
+  resetExecution,
+}: {
+  mode: "send" | "receive";
+  isOnrampBranch: boolean;
+  selectedWallet: PaymentsDashboardWallet | null;
+  customerId: string;
+  setCustomerId: (value: string) => void;
+  bvnkFirstName: string;
+  setBvnkFirstName: (value: string) => void;
+  bvnkLastName: string;
+  setBvnkLastName: (value: string) => void;
+  bvnkDateOfBirth: string;
+  setBvnkDateOfBirth: (value: string) => void;
+  bvnkCountryCode: string;
+  setBvnkCountryCode: (value: string) => void;
+  resetExecution: () => void;
+}) {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-bvnk-customer-id`}>Customer ID</Label>
+        <Input
+          id={`${mode}-bvnk-customer-id`}
+          value={customerId}
+          onChange={(event) => {
+            setCustomerId(event.currentTarget.value);
+            resetExecution();
+          }}
+          placeholder="customer_123"
+          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+        />
+      </div>
+
+      {selectedWallet?.publicKey ? (
+        <div className="space-y-2">
+          <Label>{isOnrampBranch ? "Destination address" : "Source address"}</Label>
+          <Input
+            readOnly
+            value={selectedWallet.publicKey}
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
+          />
+        </div>
+      ) : null}
+
+      {isOnrampBranch ? null : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor={`${mode}-bvnk-first-name`}>First name</Label>
+            <Input
+              id={`${mode}-bvnk-first-name`}
+              value={bvnkFirstName}
+              onChange={(event) => {
+                setBvnkFirstName(event.currentTarget.value);
+                resetExecution();
+              }}
+              placeholder="Jane"
+              className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${mode}-bvnk-last-name`}>Last name</Label>
+            <Input
+              id={`${mode}-bvnk-last-name`}
+              value={bvnkLastName}
+              onChange={(event) => {
+                setBvnkLastName(event.currentTarget.value);
+                resetExecution();
+              }}
+              placeholder="Doe"
+              className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${mode}-bvnk-dob`}>Date of birth</Label>
+            <Input
+              id={`${mode}-bvnk-dob`}
+              type="date"
+              value={bvnkDateOfBirth}
+              onChange={(event) => {
+                setBvnkDateOfBirth(event.currentTarget.value);
+                resetExecution();
+              }}
+              className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`${mode}-bvnk-country`}>Country</Label>
+            <select
+              id={`${mode}-bvnk-country`}
+              value={bvnkCountryCode}
+              onChange={(event) => {
+                setBvnkCountryCode(event.currentTarget.value);
+                resetExecution();
+              }}
+              className="h-12 w-full rounded-[16px] border border-[rgba(28,28,29,0.12)] bg-white px-4 text-sm text-[#1c1c1d]"
+            >
+              <option value="">Select country</option>
+              {BVNK_COUNTRY_OPTIONS.map((country) => (
+                <option key={country.value} value={country.value}>
+                  {country.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function RampProviderFields({
+  mode,
+  provider,
+  isOnrampBranch,
+  isBelowMoonPayOnrampMinimum,
+  selectedWallet,
+  customerId,
+  setCustomerId,
+  lightsparkSourceAccountId,
+  setLightsparkSourceAccountId,
+  lightsparkDestinationAccountId,
+  setLightsparkDestinationAccountId,
+  bvnkFirstName,
+  setBvnkFirstName,
+  bvnkLastName,
+  setBvnkLastName,
+  bvnkDateOfBirth,
+  setBvnkDateOfBirth,
+  bvnkCountryCode,
+  setBvnkCountryCode,
+  resetExecution,
+}: {
+  mode: "send" | "receive";
+  provider: RampProviderId;
+  isOnrampBranch: boolean;
+  isBelowMoonPayOnrampMinimum: boolean;
+  selectedWallet: PaymentsDashboardWallet | null;
+  customerId: string;
+  setCustomerId: (value: string) => void;
+  lightsparkSourceAccountId: string;
+  setLightsparkSourceAccountId: (value: string) => void;
+  lightsparkDestinationAccountId: string;
+  setLightsparkDestinationAccountId: (value: string) => void;
+  bvnkFirstName: string;
+  setBvnkFirstName: (value: string) => void;
+  bvnkLastName: string;
+  setBvnkLastName: (value: string) => void;
+  bvnkDateOfBirth: string;
+  setBvnkDateOfBirth: (value: string) => void;
+  bvnkCountryCode: string;
+  setBvnkCountryCode: (value: string) => void;
+  resetExecution: () => void;
+}) {
+  if (provider === "moonpay") {
+    return (
+      <MoonpayRampFields
+        isOnrampBranch={isOnrampBranch}
+        isBelowMoonPayOnrampMinimum={isBelowMoonPayOnrampMinimum}
+        selectedWallet={selectedWallet}
+      />
+    );
+  }
+
+  if (provider === "lightspark") {
+    return (
+      <LightsparkRampFields
+        mode={mode}
+        isOnrampBranch={isOnrampBranch}
+        selectedWallet={selectedWallet}
+        customerId={customerId}
+        setCustomerId={setCustomerId}
+        lightsparkSourceAccountId={lightsparkSourceAccountId}
+        setLightsparkSourceAccountId={setLightsparkSourceAccountId}
+        lightsparkDestinationAccountId={lightsparkDestinationAccountId}
+        setLightsparkDestinationAccountId={setLightsparkDestinationAccountId}
+        resetExecution={resetExecution}
+      />
+    );
+  }
+
+  return (
+    <BvnkRampFields
+      mode={mode}
+      isOnrampBranch={isOnrampBranch}
+      selectedWallet={selectedWallet}
+      customerId={customerId}
+      setCustomerId={setCustomerId}
+      bvnkFirstName={bvnkFirstName}
+      setBvnkFirstName={setBvnkFirstName}
+      bvnkLastName={bvnkLastName}
+      setBvnkLastName={setBvnkLastName}
+      bvnkDateOfBirth={bvnkDateOfBirth}
+      setBvnkDateOfBirth={setBvnkDateOfBirth}
+      bvnkCountryCode={bvnkCountryCode}
+      setBvnkCountryCode={setBvnkCountryCode}
+      resetExecution={resetExecution}
+    />
+  );
+}
+
+export function PaymentsActionPage({ mode, wallets, walletsError }: PaymentsActionPageProps) {
+  const router = useRouter();
+
+  const [branch, setBranch] = useState<ActionBranch | null>(null);
+  const [provider, setProvider] = useState<RampProviderId | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [selectedWalletId, setSelectedWalletId] = useState("");
+  const [selectedAsset, setSelectedAsset] = useState("USDC");
+  const [amount, setAmount] = useState("");
+  const [destination, setDestination] = useState("");
+  const [memo, setMemo] = useState("");
+  const [reference, setReference] = useState("");
+  const [customerId, setCustomerId] = useState("");
+  const [lightsparkSourceAccountId, setLightsparkSourceAccountId] = useState("");
+  const [lightsparkDestinationAccountId, setLightsparkDestinationAccountId] = useState("");
+  const [bvnkFirstName, setBvnkFirstName] = useState("");
+  const [bvnkLastName, setBvnkLastName] = useState("");
+  const [bvnkDateOfBirth, setBvnkDateOfBirth] = useState("");
+  const [bvnkCountryCode, setBvnkCountryCode] = useState("");
+  const [policyAllowlist, setPolicyAllowlist] = useState<string[]>([]);
+  const [policyLoading, setPolicyLoading] = useState(false);
+  const [policyError, setPolicyError] = useState<string | null>(null);
+  const [transferCompliance, setTransferCompliance] = useState<ComplianceSnapshot | null>(null);
+  const [transferComplianceLoading, setTransferComplianceLoading] = useState(false);
+  const [transferComplianceDismissed, setTransferComplianceDismissed] = useState(false);
+  const [executionState, setExecutionState] = useState<ExecutionState>("idle");
+  const [executionError, setExecutionError] = useState<string | null>(null);
+  const [transferResult, setTransferResult] = useState<PaymentTransferSummary | null>(null);
+  const [rampExecution, setRampExecution] = useState<PaymentRampExecution | null>(null);
+  const shouldLoadWallets = branch !== null;
+  const hasServerWalletSnapshot = wallets.length > 0 || walletsError !== null;
+  const {
+    data: swrWallets,
+    error: walletsFetchError,
+    isValidating: walletsRefreshing,
+  } = useSWR<PaymentsDashboardWallet[]>(
+    shouldLoadWallets ? PAYMENTS_ACTION_WALLETS_KEY : null,
+    () => fetchWallets(),
+    {
+      fallbackData: hasServerWalletSnapshot ? wallets : undefined,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const liveWallets = swrWallets ?? wallets;
+  const liveWalletsError = walletsFetchError
+    ? walletsFetchError instanceof Error
+      ? walletsFetchError.message
+      : "Request failed."
+    : swrWallets === undefined
+      ? walletsError
+      : null;
+  const hasWallets = liveWallets.length > 0;
+  const walletsLoading = shouldLoadWallets && walletsRefreshing && swrWallets === undefined;
+
+  useEffect(() => {
+    if (!hasWallets) {
+      setSelectedWalletId("");
+      return;
+    }
+
+    if (!liveWallets.some((wallet) => wallet.walletId === selectedWalletId)) {
+      setSelectedWalletId(liveWallets[0]?.walletId ?? "");
+    }
+  }, [hasWallets, liveWallets, selectedWalletId]);
+
+  const selectedWallet = useMemo(
+    () => liveWallets.find((wallet) => wallet.walletId === selectedWalletId) ?? null,
+    [liveWallets, selectedWalletId]
+  );
+  const assetOptions = useMemo(() => resolveWalletActionAssets(selectedWallet), [selectedWallet]);
+
+  useEffect(() => {
+    if (assetOptions.length === 0) {
+      setSelectedAsset("");
+      return;
+    }
+
+    if (!assetOptions.includes(selectedAsset)) {
+      setSelectedAsset(assetOptions.includes("USDC") ? "USDC" : (assetOptions[0] ?? ""));
+    }
+  }, [assetOptions, selectedAsset]);
+
+  const steps = useMemo(() => resolveStepSequence(mode, branch), [branch, mode]);
+  const safeStepIndex = Math.min(stepIndex, steps.length - 1);
+  const currentStep = steps[safeStepIndex] ?? steps[0];
+
+  useEffect(() => {
+    if (safeStepIndex !== stepIndex) {
+      setStepIndex(safeStepIndex);
+    }
+  }, [safeStepIndex, stepIndex]);
+
+  const isSendAction = mode === "send";
+  const isTransferBranch = branch === "wallet_transfer";
+  const isDepositBranch = branch === "wallet_deposit";
+  const isOnrampBranch = branch === "onramp";
+  const isOfframpBranch = branch === "offramp";
+  const providerOptions = isOnrampBranch ? ONRAMP_PROVIDER_OPTIONS : OFFRAMP_PROVIDER_OPTIONS;
+  const providerLabel = providerOptions.find((option) => option.id === provider)?.title ?? null;
+  const numericAmount = parseOptionalNumber(amount);
+  const destinationTrimmed = destination.trim();
+  const destinationIsAllowlisted =
+    !!destinationTrimmed && policyAllowlist.includes(destinationTrimmed);
+  const hasTransferComplianceForDestination =
+    !!transferCompliance &&
+    transferCompliance.address === destinationTrimmed &&
+    transferCompliance.providers.length > 0;
+  const isBelowMoonPayOnrampMinimum =
+    isOnrampBranch &&
+    provider === "moonpay" &&
+    amount.trim().length > 0 &&
+    (numericAmount === null || numericAmount < MOONPAY_ONRAMP_MIN_USD);
+
+  useEffect(() => {
+    if (!isTransferBranch || !selectedWalletId) {
+      setPolicyAllowlist([]);
+      setPolicyError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setPolicyLoading(true);
+    setPolicyError(null);
+
+    void fetchWalletPolicy(selectedWalletId)
+      .then((policy) => {
+        if (!cancelled) {
+          setPolicyAllowlist(policy.destinationAllowlist);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setPolicyAllowlist([]);
+          setPolicyError(
+            error instanceof Error ? error.message : "Failed to load source wallet allowlist."
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setPolicyLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isTransferBranch, selectedWalletId]);
+
+  const resetExecution = () => {
+    setExecutionState("idle");
+    setExecutionError(null);
+    setTransferResult(null);
+    setRampExecution(null);
+  };
+
+  const resetFlowFields = () => {
+    setAmount("");
+    setDestination("");
+    setMemo("");
+    setReference("");
+    setCustomerId("");
+    setLightsparkSourceAccountId("");
+    setLightsparkDestinationAccountId("");
+    setBvnkFirstName("");
+    setBvnkLastName("");
+    setBvnkDateOfBirth("");
+    setBvnkCountryCode("");
+    setTransferCompliance(null);
+    setTransferComplianceDismissed(false);
+    setPolicyError(null);
+    resetExecution();
+  };
+
+  const selectBranch = (nextBranch: ActionBranch) => {
+    setBranch(nextBranch);
+    setProvider(null);
+    resetFlowFields();
+    setStepIndex(1);
+  };
+
+  const selectProvider = (nextProvider: RampProviderId) => {
+    setProvider(nextProvider);
+    resetExecution();
+    setExecutionError(null);
+    setStepIndex(2);
+  };
+
+  const checkTransferCompliance = async () => {
+    if (!destinationTrimmed) {
+      return;
+    }
+
+    setTransferComplianceLoading(true);
+    setTransferComplianceDismissed(false);
+    try {
+      setTransferCompliance(await runComplianceCheck(destinationTrimmed, "transfer_destination"));
+    } catch (error) {
+      setTransferCompliance(null);
+      toast.error("Compliance check failed.", {
+        description: error instanceof Error ? error.message : "Compliance check failed.",
+        position: "bottom-right",
+      });
+    } finally {
+      setTransferComplianceLoading(false);
+    }
+  };
+
+  const canAdvanceDetailsStep = useMemo(() => {
+    if (isTransferBranch) {
+      return (
+        !!selectedWalletId &&
+        !!selectedAsset &&
+        !!destinationTrimmed &&
+        !!amount.trim() &&
+        (hasTransferComplianceForDestination || destinationIsAllowlisted)
+      );
+    }
+
+    if (isDepositBranch) {
+      return !!selectedWalletId && !!selectedAsset;
+    }
+
+    if (!provider) {
+      return false;
+    }
+
+    if (isOnrampBranch) {
+      if (!selectedWalletId || !selectedAsset || !amount.trim() || !numericAmount) {
+        return false;
+      }
+
+      if (provider === "moonpay") {
+        return !isBelowMoonPayOnrampMinimum;
+      }
+
+      return !!customerId.trim();
+    }
+
+    if (!selectedAsset || !amount.trim() || !numericAmount) {
+      return false;
+    }
+
+    if (provider === "moonpay") {
+      return !!selectedWalletId;
+    }
+
+    if (provider === "lightspark") {
+      return !!lightsparkSourceAccountId.trim() && !!lightsparkDestinationAccountId.trim();
+    }
+
+    return (
+      !!selectedWalletId &&
+      !!customerId.trim() &&
+      !!bvnkFirstName.trim() &&
+      !!bvnkLastName.trim() &&
+      !!bvnkDateOfBirth &&
+      !!bvnkCountryCode
+    );
+  }, [
+    amount,
+    bvnkCountryCode,
+    bvnkDateOfBirth,
+    bvnkFirstName,
+    bvnkLastName,
+    customerId,
+    destinationIsAllowlisted,
+    destinationTrimmed,
+    hasTransferComplianceForDestination,
+    isBelowMoonPayOnrampMinimum,
+    isDepositBranch,
+    isOnrampBranch,
+    isTransferBranch,
+    lightsparkDestinationAccountId,
+    lightsparkSourceAccountId,
+    numericAmount,
+    provider,
+    selectedAsset,
+    selectedWalletId,
+  ]);
+
+  const transferReviewRows = useMemo(
+    () => [
+      {
+        label: "Flow",
+        value: "Wallet transfer",
+      },
+      {
+        label: "Source wallet",
+        value: selectedWallet?.label ?? selectedWallet?.walletId ?? "—",
+      },
+      {
+        label: "Asset",
+        value: selectedAsset || "—",
+      },
+      {
+        label: "Amount",
+        value: amount || "—",
+      },
+      {
+        label: "Destination",
+        value: <span className="font-mono text-xs">{destinationTrimmed || "—"}</span>,
+      },
+      {
+        label: "Risk/compliance",
+        value: destinationIsAllowlisted
+          ? "Source wallet allowlist"
+          : hasTransferComplianceForDestination
+            ? "Risk check completed"
+            : "Required",
+      },
+      ...(memo.trim()
+        ? [
+            {
+              label: "Memo",
+              value: memo.trim(),
+            },
+          ]
+        : []),
+    ],
+    [
+      amount,
+      destinationIsAllowlisted,
+      destinationTrimmed,
+      hasTransferComplianceForDestination,
+      memo,
+      selectedAsset,
+      selectedWallet?.label,
+      selectedWallet?.walletId,
+    ]
+  );
+
+  const rampReviewRows = useMemo(
+    () =>
+      buildRampReviewRows({
+        isOnrampBranch,
+        isOfframpBranch,
+        provider,
+        providerLabel,
+        selectedAsset,
+        amount,
+        selectedWallet,
+        customerId,
+        lightsparkSourceAccountId,
+        lightsparkDestinationAccountId,
+        bvnkFirstName,
+        bvnkLastName,
+        bvnkDateOfBirth,
+        bvnkCountryCode,
+      }),
+    [
+      amount,
+      bvnkCountryCode,
+      bvnkDateOfBirth,
+      bvnkFirstName,
+      bvnkLastName,
+      customerId,
+      isOfframpBranch,
+      isOnrampBranch,
+      lightsparkDestinationAccountId,
+      lightsparkSourceAccountId,
+      provider,
+      providerLabel,
+      selectedAsset,
+      selectedWallet,
+    ]
+  );
+
+  const submitTransferFlow = async () => {
+    if (!selectedWalletId) {
+      return;
+    }
+
+    setExecutionState("submitting");
+    setExecutionError(null);
+
+    try {
+      const transfer = await createTransfer({
+        source: selectedWalletId,
+        destination: destinationTrimmed,
+        token: selectedAsset.trim() || "SOL",
+        amount: amount.trim(),
+        ...(memo.trim() ? { memo: memo.trim() } : {}),
+      });
+      setTransferResult(transfer);
+      setExecutionState("success");
+
+      toast.success("Transfer submitted.", {
+        description: transfer.signature
+          ? "Transaction sent successfully."
+          : `Status: ${transfer.status}`,
+        position: "bottom-right",
+      });
+    } catch (error) {
+      setExecutionState("idle");
+      setExecutionError(error instanceof Error ? error.message : "Transfer failed.");
+      toast.error("Transfer failed.", {
+        description: error instanceof Error ? error.message : "Transfer failed.",
+        position: "bottom-right",
+      });
+    }
+  };
+
+  const buildRampPayload = (): Record<string, unknown> => {
+    if (!provider) {
+      return {};
+    }
+
+    if (provider === "moonpay" && isOnrampBranch) {
+      return {
+        provider: "moonpay",
+        destinationWallet: selectedWalletId,
+        cryptoToken: selectedAsset,
+        fiatAmount: amount.trim(),
+      };
+    }
+
+    if (provider === "moonpay" && isOfframpBranch) {
+      return {
+        provider: "moonpay",
+        sourceWallet: selectedWalletId,
+        cryptoToken: selectedAsset,
+        cryptoAmount: amount.trim(),
+      };
+    }
+
+    if (provider === "lightspark" && isOnrampBranch) {
+      return {
+        provider: "lightspark",
+        destinationWallet: selectedWalletId,
+        cryptoToken: selectedAsset,
+        fiatAmount: amount.trim(),
+        kycReference: customerId.trim(),
+      };
+    }
+
+    if (provider === "lightspark" && isOfframpBranch) {
+      return {
+        provider: "lightspark",
+        sourceWallet: lightsparkSourceAccountId.trim(),
+        cryptoToken: selectedAsset,
+        cryptoAmount: amount.trim(),
+        kycReference: lightsparkDestinationAccountId.trim(),
+      };
+    }
+
+    if (provider === "bvnk" && isOnrampBranch) {
+      return {
+        provider: "bvnk",
+        destinationWallet: selectedWalletId,
+        cryptoToken: selectedAsset,
+        fiatAmount: amount.trim(),
+        kycReference: customerId.trim(),
+      };
+    }
+
+    return {
+      provider: "bvnk",
+      sourceWallet: selectedWalletId,
+      cryptoToken: selectedAsset,
+      cryptoAmount: amount.trim(),
+      kycReference: customerId.trim(),
+      bvnkCompliance: {
+        partyDetails: [
+          {
+            type: "BENEFICIARY",
+            entityType: "INDIVIDUAL",
+            relationshipType: "THIRD_PARTY",
+            firstName: bvnkFirstName.trim(),
+            lastName: bvnkLastName.trim(),
+            dateOfBirth: bvnkDateOfBirth,
+            countryCode: bvnkCountryCode,
+          },
+        ],
+      },
+    };
+  };
+
+  const submitRampRequest = async () => {
+    if (!provider) {
+      return;
+    }
+
+    setExecutionState("submitting");
+    setExecutionError(null);
+
+    try {
+      const execution = await executeRampFlow(
+        isOnrampBranch ? "onramp" : "offramp",
+        buildRampPayload()
+      );
+      setRampExecution(execution);
+      setExecutionState("success");
+      toast.success(`${providerLabel ?? "Provider"} flow ready.`, {
+        position: "bottom-right",
+      });
+    } catch (error) {
+      setExecutionState("idle");
+      setExecutionError(error instanceof Error ? error.message : "Ramp request failed.");
+      toast.error(`${providerLabel ?? "Provider"} flow failed to initialize.`, {
+        description: error instanceof Error ? error.message : "Ramp request failed.",
+        position: "bottom-right",
+      });
+    }
+  };
+
+  const handlePrimaryAction = async () => {
+    if (currentStep.id === "branch") {
+      if (branch) {
+        setStepIndex((current) => current + 1);
+      }
+      return;
+    }
+
+    if (currentStep.id === "provider") {
+      if (provider) {
+        setStepIndex((current) => current + 1);
+      }
+      return;
+    }
+
+    if (currentStep.id === "details") {
+      if (canAdvanceDetailsStep) {
+        setStepIndex((current) => current + 1);
+      }
+      return;
+    }
+
+    if (currentStep.id === "deposit") {
+      router.push("/dashboard/payments");
+      return;
+    }
+
+    if (currentStep.id === "review") {
+      if (executionState === "success") {
+        router.push("/dashboard/payments");
+        return;
+      }
+
+      if (isTransferBranch) {
+        await submitTransferFlow();
+        return;
+      }
+
+      await submitRampRequest();
+    }
+  };
+
+  const handleSecondaryAction = async () => {
+    if (currentStep.id === "branch") {
+      router.push("/dashboard/payments");
+      return;
+    }
+
+    if (currentStep.id === "review" && executionState === "success") {
+      setStepIndex(0);
+      setBranch(null);
+      setProvider(null);
+      resetFlowFields();
+      return;
+    }
+
+    setStepIndex((current) => Math.max(0, current - 1));
+  };
+
+  const primaryLabel = useMemo(() => {
+    if (currentStep.id === "details") {
+      return "Next";
+    }
+
+    if (currentStep.id === "deposit") {
+      return "Done";
+    }
+
+    if (executionState === "submitting") {
+      return isTransferBranch ? "Submitting..." : "Preparing...";
+    }
+
+    if (executionState === "success") {
+      return "Back to payments";
+    }
+
+    return "Confirm";
+  }, [currentStep.id, executionState, isTransferBranch]);
+
+  const secondaryLabel = useMemo(() => {
+    if (currentStep.id === "branch") {
+      return "Back to payments";
+    }
+
+    if (currentStep.id === "review" && executionState === "success") {
+      return "Start over";
+    }
+
+    return "Previous";
+  }, [currentStep.id, executionState]);
+
+  const showPrimaryAction = currentStep.id !== "branch" && currentStep.id !== "provider";
+
+  const primaryDisabled =
+    executionState === "submitting" || (currentStep.id === "details" && !canAdvanceDetailsStep);
+
+  const renderBranchStep = () => (
+    <div className="grid gap-4">
+      {isSendAction ? (
+        <>
+          <ActionChoiceCard
+            active={branch === "wallet_transfer"}
+            title="Wallet transfer"
+            description="Send funds from an SDP wallet to a destination Solana address."
+            icon={<ArrowUpRight className="size-5" />}
+            onClick={() => selectBranch("wallet_transfer")}
+          />
+          <ActionChoiceCard
+            active={branch === "offramp"}
+            title="Off-ramp"
+            description="Move value out through a provider-specific off-ramp flow."
+            icon={<ArrowDownLeft className="size-5" />}
+            onClick={() => selectBranch("offramp")}
+          />
+        </>
+      ) : (
+        <>
+          <ActionChoiceCard
+            active={branch === "wallet_deposit"}
+            title="Wallet deposit"
+            description="Receive funds directly into one of your SDP wallets."
+            icon={<ArrowDownLeft className="size-5" />}
+            onClick={() => selectBranch("wallet_deposit")}
+          />
+          <ActionChoiceCard
+            active={branch === "onramp"}
+            title="On-ramp"
+            description="Start a provider flow to move fiat into the selected wallet."
+            icon={<ArrowUpRight className="size-5" />}
+            onClick={() => selectBranch("onramp")}
+          />
+        </>
+      )}
+    </div>
+  );
+
+  const renderProviderStep = () => (
+    <div className="grid gap-4">
+      {providerOptions.map((option) => (
+        <ActionChoiceCard
+          key={option.id}
+          active={provider === option.id}
+          title={option.title}
+          description={option.description}
+          icon={<CheckCircle2 className="size-5" />}
+          onClick={() => selectProvider(option.id)}
+        />
+      ))}
+    </div>
+  );
+
+  const renderWalletSelect = ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+  }) => {
+    if (walletsLoading) {
+      return (
+        <div className="space-y-2">
+          <Label>{label}</Label>
+          <div className="h-12 animate-pulse rounded-[16px] border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.05)]" />
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-wallet`}>{label}</Label>
+        <Select value={value} onValueChange={onChange} disabled={!hasWallets}>
+          <SelectTrigger
+            id={`${mode}-wallet`}
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+          >
+            <SelectValue placeholder="Select wallet" />
+          </SelectTrigger>
+          <SelectContent
+            position="popper"
+            className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
+          >
+            {liveWallets.map((wallet) => (
+              <SelectItem key={wallet.walletId} value={wallet.walletId}>
+                {getWalletActionLabel(wallet)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  };
+
+  const renderAssetAndAmount = (amountLabel: string) => (
+    <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_160px]">
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-amount`}>{amountLabel}</Label>
+        <Input
+          id={`${mode}-amount`}
+          type="number"
+          inputMode="decimal"
+          min="0.000001"
+          step="any"
+          value={amount}
+          onChange={(event) => {
+            setAmount(event.currentTarget.value);
+            resetExecution();
+          }}
+          placeholder="1.00"
+          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-asset`}>Asset</Label>
+        <Select
+          value={selectedAsset}
+          onValueChange={(value) => {
+            setSelectedAsset(value);
+            resetExecution();
+          }}
+          disabled={walletsLoading || assetOptions.length === 0}
+        >
+          <SelectTrigger
+            id={`${mode}-asset`}
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+          >
+            <SelectValue placeholder="Select asset" />
+          </SelectTrigger>
+          <SelectContent
+            position="popper"
+            className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
+          >
+            {assetOptions.map((asset) => (
+              <SelectItem key={asset} value={asset}>
+                {asset}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+
+  const renderTransferDetailsStep = () => (
+    <div className="space-y-6">
+      {renderWalletSelect({
+        label: "Source wallet",
+        value: selectedWalletId,
+        onChange: (value) => {
+          setSelectedWalletId(value);
+          setTransferCompliance(null);
+          setTransferComplianceDismissed(false);
+          resetExecution();
+        },
+      })}
+      {renderAssetAndAmount("Amount")}
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-destination`}>Destination address</Label>
+        <Input
+          id={`${mode}-destination`}
+          value={destination}
+          onChange={(event) => {
+            setDestination(event.currentTarget.value);
+            setTransferCompliance(null);
+            setTransferComplianceDismissed(false);
+            resetExecution();
+          }}
+          placeholder="Destination Solana address"
+          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+        />
+      </div>
+      {destinationIsAllowlisted ? (
+        <div className="rounded-[18px] border border-[rgba(17,94,61,0.18)] bg-[rgba(16,185,129,0.08)] px-4 py-3 text-sm text-[#115e3d]">
+          This destination is already on the source wallet allowlist. You can continue without a new
+          risk check.
+        </div>
+      ) : (
+        <div className="flex min-h-[44px] flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              void checkTransferCompliance();
+            }}
+            disabled={
+              policyLoading || transferComplianceLoading || !selectedWalletId || !destinationTrimmed
+            }
+          >
+            {policyLoading
+              ? "Loading wallet policy..."
+              : transferComplianceLoading
+                ? "Checking..."
+                : "Check risk score"}
+          </Button>
+          <p className="text-sm text-[rgba(28,28,29,0.56)]">
+            Risk check is required unless the destination is already on the wallet allowlist.
+          </p>
+        </div>
+      )}
+      {policyError ? <p className="text-sm text-[#9e2b38]">{policyError}</p> : null}
+      {transferCompliance && !transferComplianceDismissed ? (
+        <ProviderRiskTable
+          title="Risk score results"
+          snapshot={transferCompliance}
+          onClose={() => setTransferComplianceDismissed(true)}
+        />
+      ) : null}
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-memo`}>Memo (optional)</Label>
+        <Input
+          id={`${mode}-memo`}
+          value={memo}
+          onChange={(event) => {
+            setMemo(event.currentTarget.value);
+            resetExecution();
+          }}
+          placeholder="Invoice #1234"
+          className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+        />
+      </div>
+    </div>
+  );
+
+  const renderDepositDetailsStep = () => (
+    <div className="space-y-6">
+      {renderWalletSelect({
+        label: "Wallet",
+        value: selectedWalletId,
+        onChange: (value) => {
+          setSelectedWalletId(value);
+          resetExecution();
+        },
+      })}
+      <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_160px]">
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-reference`}>Reference label</Label>
+          <Input
+            id={`${mode}-reference`}
+            value={reference}
+            onChange={(event) => setReference(event.currentTarget.value)}
+            placeholder="Treasury top-up"
+            className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-deposit-asset`}>Asset</Label>
+          <Select
+            value={selectedAsset}
+            onValueChange={setSelectedAsset}
+            disabled={assetOptions.length === 0}
+          >
+            <SelectTrigger
+              id={`${mode}-deposit-asset`}
+              className="h-12 rounded-[16px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
+            >
+              <SelectValue placeholder="Select asset" />
+            </SelectTrigger>
+            <SelectContent
+              position="popper"
+              className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
+            >
+              {assetOptions.map((asset) => (
+                <SelectItem key={asset} value={asset}>
+                  {asset}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderRampDetailsStep = () => {
+    if (!provider) {
+      return null;
+    }
+
+    const shouldShowWalletSelect = !(provider === "lightspark" && isOfframpBranch);
+    const walletLabel = isOnrampBranch ? "Destination wallet" : "Source wallet";
+
+    return (
+      <div className="space-y-6">
+        {shouldShowWalletSelect
+          ? renderWalletSelect({
+              label: walletLabel,
+              value: selectedWalletId,
+              onChange: (value) => {
+                setSelectedWalletId(value);
+                resetExecution();
+              },
+            })
+          : null}
+
+        {renderAssetAndAmount(isOnrampBranch ? "Fiat amount (USD)" : "Crypto amount")}
+
+        <RampProviderFields
+          mode={mode}
+          provider={provider}
+          isOnrampBranch={isOnrampBranch}
+          isBelowMoonPayOnrampMinimum={isBelowMoonPayOnrampMinimum}
+          selectedWallet={selectedWallet}
+          customerId={customerId}
+          setCustomerId={setCustomerId}
+          lightsparkSourceAccountId={lightsparkSourceAccountId}
+          setLightsparkSourceAccountId={setLightsparkSourceAccountId}
+          lightsparkDestinationAccountId={lightsparkDestinationAccountId}
+          setLightsparkDestinationAccountId={setLightsparkDestinationAccountId}
+          bvnkFirstName={bvnkFirstName}
+          setBvnkFirstName={setBvnkFirstName}
+          bvnkLastName={bvnkLastName}
+          setBvnkLastName={setBvnkLastName}
+          bvnkDateOfBirth={bvnkDateOfBirth}
+          setBvnkDateOfBirth={setBvnkDateOfBirth}
+          bvnkCountryCode={bvnkCountryCode}
+          setBvnkCountryCode={setBvnkCountryCode}
+          resetExecution={resetExecution}
+        />
+      </div>
+    );
+  };
+
+  const renderTransferReview = () => {
+    if (executionState === "submitting") {
+      return (
+        <div className="space-y-6 text-center">
+          <div className="mx-auto flex size-16 items-center justify-center rounded-full border border-[rgba(28,28,29,0.14)]">
+            <RefreshCw className="size-7 animate-spin text-[rgba(28,28,29,0.68)]" />
+          </div>
+          <div className="space-y-2">
+            <p className="text-[18px] font-medium text-[#1c1c1d]">Transfer in progress…</p>
+            <p className="text-sm text-[rgba(28,28,29,0.62)]">
+              Submitting the transaction through the payments API.
+            </p>
+          </div>
+          <ReviewSummaryCard rows={transferReviewRows} />
+        </div>
+      );
+    }
+
+    if (executionState === "success" && transferResult) {
+      return (
+        <div className="space-y-6">
+          <div className="rounded-[24px] border border-[rgba(17,94,61,0.18)] bg-[rgba(16,185,129,0.08)] p-5">
+            <p className="text-[20px] font-medium text-[#115e3d]">Transfer submitted</p>
+            <p className="mt-2 text-sm text-[#115e3d]">
+              {transferResult.signature
+                ? "The transfer was signed and broadcast successfully."
+                : `Current status: ${transferResult.status}`}
+            </p>
+          </div>
+          <ReviewSummaryCard
+            rows={[
+              ...transferReviewRows,
+              {
+                label: "Status",
+                value: transferResult.status,
+              },
+              {
+                label: "Signature",
+                value: transferResult.signature ? (
+                  <a
+                    href={getDevnetExplorerUrl(transferResult.signature)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 text-[#1c1c1d] underline underline-offset-2"
+                  >
+                    <span className="max-w-[12rem] truncate font-mono text-xs">
+                      {transferResult.signature}
+                    </span>
+                    <ExternalLink className="size-3" />
+                  </a>
+                ) : (
+                  "Pending"
+                ),
+              },
+            ]}
+          />
+        </div>
+      );
+    }
+
+    return <ReviewSummaryCard rows={transferReviewRows} />;
+  };
+
+  const renderRampReview = () => {
+    if (executionState === "submitting") {
+      return (
+        <div className="space-y-6 text-center">
+          <div className="mx-auto flex size-16 items-center justify-center rounded-full border border-[rgba(28,28,29,0.14)]">
+            <RefreshCw className="size-7 animate-spin text-[rgba(28,28,29,0.68)]" />
+          </div>
+          <div className="space-y-2">
+            <p className="text-[18px] font-medium text-[#1c1c1d]">
+              {providerLabel ?? "Provider"} request in progress…
+            </p>
+            <p className="text-sm text-[rgba(28,28,29,0.62)]">
+              Preparing the {isOnrampBranch ? "on-ramp" : "off-ramp"} flow.
+            </p>
+          </div>
+          <ReviewSummaryCard rows={rampReviewRows} />
+        </div>
+      );
+    }
+
+    if (executionState === "success" && rampExecution) {
+      return (
+        <div className="space-y-6">
+          <div className="rounded-[24px] border border-[rgba(17,94,61,0.18)] bg-[rgba(16,185,129,0.08)] p-5">
+            <p className="text-[20px] font-medium text-[#115e3d]">
+              {providerLabel ?? "Provider"} flow ready
+            </p>
+            <p className="mt-2 text-sm text-[#115e3d]">
+              Continue with the provider using the details below.
+            </p>
+          </div>
+          <ReviewSummaryCard
+            rows={[
+              ...rampReviewRows,
+              {
+                label: "Status",
+                value: rampExecution.status,
+              },
+              ...(rampExecution.reference
+                ? [
+                    {
+                      label: "Reference",
+                      value: <span className="font-mono text-xs">{rampExecution.reference}</span>,
+                    },
+                  ]
+                : []),
+            ]}
+          />
+          {rampExecution.redirectUrl ? (
+            <div className="rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-5">
+              <p className="text-sm font-medium text-[#1c1c1d]">Redirect URL</p>
+              <p className="mt-3 break-all font-mono text-xs text-[rgba(28,28,29,0.78)]">
+                {rampExecution.redirectUrl}
+              </p>
+              <div className="mt-4 flex justify-end">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() =>
+                    window.open(rampExecution.redirectUrl, "_blank", "noopener,noreferrer")
+                  }
+                >
+                  Open {providerLabel ?? "provider"}
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      );
+    }
+
+    return <ReviewSummaryCard rows={rampReviewRows} />;
+  };
+
+  const renderDepositStep = () => (
+    <div className="space-y-6">
+      <ReviewSummaryCard
+        rows={[
+          {
+            label: "Wallet",
+            value: selectedWallet?.label ?? selectedWallet?.walletId ?? "—",
+          },
+          {
+            label: "Asset",
+            value: selectedAsset || "—",
+          },
+          ...(reference.trim()
+            ? [
+                {
+                  label: "Reference",
+                  value: reference.trim(),
+                },
+              ]
+            : []),
+          {
+            label: "Address",
+            value: <span className="font-mono text-xs">{selectedWallet?.publicKey ?? "—"}</span>,
+          },
+        ]}
+      />
+      <WalletAddressQrCode address={selectedWallet?.publicKey ?? ""} />
+      {selectedWallet?.publicKey ? (
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              void navigator.clipboard.writeText(selectedWallet.publicKey);
+              toast.success("Address copied.", {
+                position: "bottom-right",
+              });
+            }}
+          >
+            <Copy className="size-4" />
+            Copy address
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  const renderCurrentStep = () => {
+    if (currentStep.id === "branch") {
+      return renderBranchStep();
+    }
+
+    if (currentStep.id === "provider") {
+      return renderProviderStep();
+    }
+
+    if (currentStep.id === "details") {
+      if (isTransferBranch) {
+        return renderTransferDetailsStep();
+      }
+
+      if (isDepositBranch) {
+        return renderDepositDetailsStep();
+      }
+
+      return renderRampDetailsStep();
+    }
+
+    if (currentStep.id === "deposit") {
+      return renderDepositStep();
+    }
+
+    if (isTransferBranch) {
+      return renderTransferReview();
+    }
+
+    return renderRampReview();
+  };
+
+  if (branch && !walletsLoading && !hasWallets) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 py-8">
+        <div className="space-y-3 text-center">
+          <p className="text-[44px] leading-none font-medium tracking-[-0.04em] text-[#1c1c1d]">
+            {isSendAction ? "Send" : "Receive"}
+          </p>
+          <p className="text-base text-[rgba(28,28,29,0.62)]">
+            You need at least one wallet before you can start this flow.
+          </p>
+          {liveWalletsError ? <p className="text-sm text-[#9e2b38]">{liveWalletsError}</p> : null}
+        </div>
+        <div className="mx-auto flex w-full max-w-md flex-col gap-3">
+          <Button type="button" onClick={() => router.push("/dashboard/wallets")}>
+            Go to wallets
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => router.push("/dashboard/payments")}
+          >
+            Back to payments
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 py-6">
+      <div className="mx-auto w-full max-w-3xl space-y-6">
+        {currentStep.id === "branch" ? null : (
+          <div className="text-center">
+            <p className="text-[28px] leading-tight font-medium text-[#1c1c1d]">
+              {currentStep.title}
+            </p>
+          </div>
+        )}
+
+        {executionError ? (
+          <div className="rounded-[18px] border border-[rgba(158,43,56,0.2)] bg-[rgba(158,43,56,0.08)] px-4 py-3 text-sm text-[#9e2b38]">
+            {executionError}
+          </div>
+        ) : null}
+
+        {renderCurrentStep()}
+      </div>
+
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 sm:flex-row-reverse">
+        {showPrimaryAction ? (
+          <Button
+            type="button"
+            className="h-14 rounded-full text-base"
+            disabled={primaryDisabled}
+            onClick={() => {
+              void handlePrimaryAction();
+            }}
+          >
+            {primaryLabel}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="secondary"
+          className="h-14 rounded-full text-base"
+          disabled={executionState === "submitting"}
+          onClick={() => {
+            void handleSecondaryAction();
+          }}
+        >
+          {secondaryLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
@@ -17,7 +17,7 @@ import type {
   PaymentsDashboardWallet as WalletRecord,
 } from "@sdp/types";
 import { ArrowDownLeft, ArrowUpRight, ExternalLink, RefreshCw } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import useSWR from "swr";
 import {
@@ -85,12 +85,14 @@ export function PaymentsOverview({
   transfersError,
 }: PaymentsOverviewProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const refreshSeed = searchParams.get("refresh") ?? "default";
   const {
     data: swrWallets,
     error: walletsFetchError,
     isValidating: walletsRefreshing,
     mutate: mutateWallets,
-  } = useSWR<WalletRecord[]>(PAYMENTS_OVERVIEW_WALLETS_KEY, () => fetchWallets(), {
+  } = useSWR<WalletRecord[]>([PAYMENTS_OVERVIEW_WALLETS_KEY, refreshSeed], () => fetchWallets(), {
     fallbackData: walletsError ? undefined : wallets,
     revalidateOnFocus: true,
     refreshInterval: 30_000,
@@ -101,7 +103,7 @@ export function PaymentsOverview({
     isValidating: aggregateRefreshing,
     mutate: mutateAggregate,
   } = useSWR<CustodyWalletAggregate>(
-    PAYMENTS_OVERVIEW_AGGREGATE_KEY,
+    [PAYMENTS_OVERVIEW_AGGREGATE_KEY, refreshSeed],
     () => fetchWalletAggregate(),
     {
       fallbackData: aggregateError || !aggregate ? undefined : aggregate,
@@ -114,11 +116,15 @@ export function PaymentsOverview({
     error: transfersFetchError,
     isValidating: transfersRefreshing,
     mutate: mutateTransfers,
-  } = useSWR<TransferRecord[]>(PAYMENTS_OVERVIEW_TRANSFERS_KEY, () => fetchTransfers(), {
-    fallbackData: transfersError ? undefined : transfers,
-    revalidateOnFocus: true,
-    refreshInterval: 10_000,
-  });
+  } = useSWR<TransferRecord[]>(
+    [PAYMENTS_OVERVIEW_TRANSFERS_KEY, refreshSeed],
+    () => fetchTransfers(),
+    {
+      fallbackData: transfersError ? undefined : transfers,
+      revalidateOnFocus: true,
+      refreshInterval: 10_000,
+    }
+  );
 
   const liveWallets = swrWallets ?? wallets;
   const liveAggregate = swrAggregate ?? aggregate;
@@ -152,9 +158,9 @@ export function PaymentsOverview({
   };
 
   return (
-    <div className="grid gap-6">
+    <div className="grid min-w-0 gap-6 overflow-x-hidden">
       <SectionEntry>
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-3">
           <Button
             type="button"
             className="rounded-full px-5"
@@ -177,7 +183,7 @@ export function PaymentsOverview({
       </SectionEntry>
 
       <SectionEntry delay={0.04}>
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,1fr)]">
+        <div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,1fr)]">
           <div className="flex min-h-[244px] flex-col justify-center rounded-[4px] bg-[rgba(28,28,29,0.04)] px-8 py-10 sm:px-14">
             <div className="space-y-3">
               <p className="text-[15px] font-medium tracking-[0.01em] text-[#1c1c1d]">
@@ -192,7 +198,7 @@ export function PaymentsOverview({
             </div>
           </div>
 
-          <div className="grid gap-1.5">
+          <div className="grid min-w-0 gap-1.5">
             {aggregateBalances.length > 0 ? (
               aggregateBalances.map((balance) => (
                 <div
@@ -224,7 +230,7 @@ export function PaymentsOverview({
       </SectionEntry>
 
       <SectionEntry delay={0.08}>
-        <Card>
+        <Card className="min-w-0 overflow-hidden">
           <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1">
               <CardTitle>Recent transactions</CardTitle>
@@ -248,7 +254,7 @@ export function PaymentsOverview({
             ) : liveTransfers.length === 0 ? (
               <p className="text-sm text-[rgba(28,28,29,0.72)]">No transactions found yet.</p>
             ) : (
-              <div className="overflow-x-auto">
+              <div className="min-w-0">
                 <Table>
                   <TableHeader>
                     <TableRow>

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
@@ -3,15 +3,6 @@
 import { SectionEntry } from "@/app/dashboard/wallets/section-entry";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -20,17 +11,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useEscapeKey } from "@/lib/use-escape-key";
 import type {
   CustodyWalletAggregate,
-  CustodyWalletTokenBalance,
   PaymentTransferSummary as TransferRecord,
   PaymentsDashboardWallet as WalletRecord,
 } from "@sdp/types";
 import { ArrowDownLeft, ArrowUpRight, ExternalLink, RefreshCw } from "lucide-react";
-import QRCode from "qrcode";
-import { type FormEvent, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import useSWR from "swr";
 import {
   formatCurrencyAmount,
@@ -46,10 +34,7 @@ import {
   fetchWalletAggregate,
   fetchWallets,
   getDevnetExplorerUrl,
-  runComplianceCheck,
 } from "./payments-workspace.data";
-import type { ComplianceSnapshot } from "./payments-workspace.types";
-import { ProviderRiskTable } from "./provider-risk-table";
 
 interface PaymentsOverviewProps {
   wallets: WalletRecord[];
@@ -60,44 +45,9 @@ interface PaymentsOverviewProps {
   transfersError: string | null;
 }
 
-const REQUIRED_ACTION_ASSETS = ["SOL", "USDC"] as const;
-const MOONPAY_ONRAMP_MIN_USD = 20;
 const PAYMENTS_OVERVIEW_WALLETS_KEY = "payments-overview-wallets";
 const PAYMENTS_OVERVIEW_AGGREGATE_KEY = "payments-overview-aggregate";
 const PAYMENTS_OVERVIEW_TRANSFERS_KEY = "payments-overview-transfers";
-const BVNK_COUNTRY_OPTIONS = [
-  { label: "United States", value: "US" },
-  { label: "Canada", value: "CA" },
-  { label: "United Kingdom", value: "GB" },
-] as const;
-
-type QuickActionFlow =
-  | "transfer"
-  | "moonpay_onramp"
-  | "moonpay_offramp"
-  | "lightspark_onramp"
-  | "lightspark_offramp"
-  | "bvnk_onramp"
-  | "bvnk_offramp";
-type RampDirection = "onramp" | "offramp";
-type RampProviderId = "moonpay" | "lightspark" | "bvnk";
-
-interface RampExecution {
-  id: string;
-  provider: string;
-  status: string;
-  redirectUrl?: string;
-  reference?: string;
-}
-
-interface RampExecutionEnvelope {
-  data?: {
-    ramp?: RampExecution;
-  };
-  error?: {
-    message?: string;
-  };
-}
 
 function statusClassName(status: string): string {
   switch (status.toLowerCase()) {
@@ -114,181 +64,6 @@ function statusClassName(status: string): string {
   }
 }
 
-function resolvePrimaryWalletBalance(
-  wallet: WalletRecord | null
-): CustodyWalletTokenBalance | null {
-  if (!wallet?.balances || wallet.balances.length === 0) {
-    return null;
-  }
-
-  return (
-    wallet.balances.find((balance) => {
-      const numericValue = Number(balance.uiAmount);
-      return Number.isFinite(numericValue) && numericValue > 0;
-    }) ??
-    wallet.balances[0] ??
-    null
-  );
-}
-
-function getWalletActionLabel(wallet: WalletRecord): string {
-  const balance = resolvePrimaryWalletBalance(wallet);
-  if (!balance) {
-    return wallet.label ?? wallet.walletId;
-  }
-
-  return `${wallet.label ?? wallet.walletId} · ${formatCurrencyAmount(balance.uiAmount)}`;
-}
-
-function resolveWalletActionAssets(wallet: WalletRecord | null): string[] {
-  const assetSet = new Set<string>(REQUIRED_ACTION_ASSETS);
-
-  for (const balance of wallet?.balances ?? []) {
-    const token = balance.token.trim().toUpperCase();
-    if (token) {
-      assetSet.add(token);
-    }
-  }
-
-  return [...assetSet];
-}
-
-function getQuickActionFlowOptions(
-  mode: "send" | "receive"
-): Array<{ label: string; value: QuickActionFlow }> {
-  return mode === "send"
-    ? [
-        { label: "Wallet transfer", value: "transfer" },
-        { label: "MoonPay off-ramp", value: "moonpay_offramp" },
-        { label: "Lightspark off-ramp", value: "lightspark_offramp" },
-        { label: "BVNK off-ramp", value: "bvnk_offramp" },
-      ]
-    : [
-        { label: "Wallet transfer", value: "transfer" },
-        { label: "MoonPay on-ramp", value: "moonpay_onramp" },
-        { label: "Lightspark on-ramp", value: "lightspark_onramp" },
-        { label: "BVNK on-ramp", value: "bvnk_onramp" },
-      ];
-}
-
-function getQuickActionDirection(flow: QuickActionFlow): RampDirection | null {
-  if (flow === "transfer") {
-    return null;
-  }
-
-  return flow.endsWith("_onramp") ? "onramp" : "offramp";
-}
-
-function getQuickActionProvider(flow: QuickActionFlow): RampProviderId | null {
-  if (flow === "transfer") {
-    return null;
-  }
-
-  if (flow.startsWith("moonpay_")) {
-    return "moonpay";
-  }
-
-  if (flow.startsWith("lightspark_")) {
-    return "lightspark";
-  }
-
-  return "bvnk";
-}
-
-function getQuickActionProviderLabel(flow: QuickActionFlow): string | null {
-  const provider = getQuickActionProvider(flow);
-  if (provider === "moonpay") {
-    return "MoonPay";
-  }
-  if (provider === "lightspark") {
-    return "Lightspark";
-  }
-  if (provider === "bvnk") {
-    return "BVNK";
-  }
-  return null;
-}
-
-function getQuickActionDescription(mode: "send" | "receive", flow: QuickActionFlow): string {
-  if (flow === "moonpay_onramp") {
-    return "Generate the hosted MoonPay on-ramp URL.";
-  }
-
-  if (flow === "moonpay_offramp") {
-    return "Generate the hosted MoonPay off-ramp URL.";
-  }
-
-  if (flow === "lightspark_onramp") {
-    return "Create a Lightspark quote using the selected wallet as the crypto destination.";
-  }
-
-  if (flow === "lightspark_offramp") {
-    return "Create and execute a Lightspark off-ramp quote with Lightspark account IDs.";
-  }
-
-  if (flow === "bvnk_onramp") {
-    return "Create a BVNK on-ramp checkout session for the selected wallet.";
-  }
-
-  if (flow === "bvnk_offramp") {
-    return "Create a BVNK off-ramp estimate and acceptance flow with beneficiary details.";
-  }
-
-  return mode === "send"
-    ? "Draft a wallet transfer using the same field styling as the API playground."
-    : "Choose a wallet and asset for the incoming wallet transfer flow.";
-}
-
-function getQuickActionSubmitLabel(mode: "send" | "receive", flow: QuickActionFlow): string {
-  if (flow !== "transfer") {
-    return "Generate URL";
-  }
-
-  return mode === "send" ? "Prepare send" : "Prepare receive";
-}
-
-function getApiErrorMessage(
-  body: {
-    error?: {
-      message?: string;
-    };
-  },
-  fallback: string
-): string {
-  return typeof body.error?.message === "string" && body.error.message
-    ? body.error.message
-    : fallback;
-}
-
-async function executeRampFlow(
-  direction: RampDirection,
-  payload: Record<string, unknown>
-): Promise<RampExecution> {
-  const response = await fetch(`/api/dashboard/payments/ramps/${direction}/execute`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-  const body = (await response.json().catch(() => ({}))) as RampExecutionEnvelope;
-
-  if (!response.ok) {
-    throw new Error(getApiErrorMessage(body, `Ramp request failed (${response.status}).`));
-  }
-
-  if (!body.data?.ramp) {
-    throw new Error("Ramp response is missing execution details.");
-  }
-
-  return body.data.ramp;
-}
-
-function parseOptionalNumber(value: string): number | null {
-  const numericValue = Number.parseFloat(value);
-  return Number.isFinite(numericValue) ? numericValue : null;
-}
-
 function resolveRequestError(error: unknown, fallback: string | null): string | null {
   if (error instanceof Error) {
     return error.message;
@@ -301,1072 +76,6 @@ function resolveRequestError(error: unknown, fallback: string | null): string | 
   return fallback;
 }
 
-interface QuickActionModalProps {
-  open: boolean;
-  mode: "send" | "receive";
-  wallets: WalletRecord[];
-  initialWalletId: string;
-  onWalletChange: (walletId: string) => void;
-  onClose: () => void;
-}
-
-interface QuickActionRequestFieldsProps {
-  mode: "send" | "receive";
-  wallets: WalletRecord[];
-  selectedWalletId: string;
-  onWalletChange: (walletId: string) => void;
-  flowOptions: Array<{ label: string; value: QuickActionFlow }>;
-  selectedFlow: QuickActionFlow;
-  onFlowChange: (flow: QuickActionFlow) => void;
-  assetOptions: string[];
-  selectedAsset: string;
-  onAssetChange: (asset: string) => void;
-  amount: string;
-  onAmountChange: (value: string) => void;
-  destination: string;
-  onDestinationChange: (value: string) => void;
-  memo: string;
-  onMemoChange: (value: string) => void;
-  reference: string;
-  onReferenceChange: (value: string) => void;
-  customerId: string;
-  onCustomerIdChange: (value: string) => void;
-  lightsparkSourceAccountId: string;
-  onLightsparkSourceAccountIdChange: (value: string) => void;
-  lightsparkDestinationAccountId: string;
-  onLightsparkDestinationAccountIdChange: (value: string) => void;
-  bvnkFirstName: string;
-  onBvnkFirstNameChange: (value: string) => void;
-  bvnkLastName: string;
-  onBvnkLastNameChange: (value: string) => void;
-  bvnkDateOfBirth: string;
-  onBvnkDateOfBirthChange: (value: string) => void;
-  bvnkCountryCode: string;
-  onBvnkCountryCodeChange: (value: string) => void;
-  selectedWallet: WalletRecord | null;
-  transferCompliance: ComplianceSnapshot | null;
-  transferComplianceLoading: boolean;
-  transferComplianceDismissed: boolean;
-  onCheckTransferCompliance: () => void;
-  onDismissTransferCompliance: () => void;
-}
-
-function FormValueBridge({
-  label,
-  name,
-  required = false,
-  value,
-}: {
-  label: string;
-  name: string;
-  required?: boolean;
-  value: string;
-}) {
-  return (
-    <input
-      aria-label={label}
-      name={name}
-      required={required}
-      value={value}
-      onChange={() => {}}
-      tabIndex={-1}
-      className="pointer-events-none absolute h-px w-px opacity-0"
-    />
-  );
-}
-
-function WalletAddressQrCode({ address }: { address: string }) {
-  const [qrCodeUrl, setQrCodeUrl] = useState("");
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!address) {
-      setQrCodeUrl("");
-      return;
-    }
-
-    void QRCode.toDataURL(address, {
-      margin: 1,
-      width: 240,
-      color: {
-        dark: "#1c1c1d",
-        light: "#ffffff",
-      },
-    })
-      .then((url) => {
-        if (!cancelled) {
-          setQrCodeUrl(url);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setQrCodeUrl("");
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [address]);
-
-  if (!address) {
-    return null;
-  }
-
-  return (
-    <section className="rounded-2xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.03)] p-5">
-      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgba(28,28,29,0.52)]">
-        Wallet QR
-      </p>
-      <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
-        <div className="flex size-[140px] items-center justify-center rounded-[20px] bg-white p-3 shadow-[inset_0_0_0_1px_rgba(28,28,29,0.08)]">
-          {qrCodeUrl ? (
-            <img src={qrCodeUrl} alt="Wallet address QR code" className="size-full" />
-          ) : (
-            <div className="size-full animate-pulse rounded-[14px] bg-[rgba(28,28,29,0.08)]" />
-          )}
-        </div>
-        <div className="min-w-0 flex-1 space-y-2">
-          <p className="text-sm text-[rgba(28,28,29,0.62)]">Scan to send to this wallet.</p>
-          <p className="break-all font-mono text-xs text-[rgba(28,28,29,0.78)]">{address}</p>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Provider-specific demo variants are kept explicit in one renderer.
-function QuickActionRequestFields({
-  mode,
-  wallets,
-  selectedWalletId,
-  onWalletChange,
-  flowOptions,
-  selectedFlow,
-  onFlowChange,
-  assetOptions,
-  selectedAsset,
-  onAssetChange,
-  amount,
-  onAmountChange,
-  destination,
-  onDestinationChange,
-  memo,
-  onMemoChange,
-  reference,
-  onReferenceChange,
-  customerId,
-  onCustomerIdChange,
-  lightsparkSourceAccountId,
-  onLightsparkSourceAccountIdChange,
-  lightsparkDestinationAccountId,
-  onLightsparkDestinationAccountIdChange,
-  bvnkFirstName,
-  onBvnkFirstNameChange,
-  bvnkLastName,
-  onBvnkLastNameChange,
-  bvnkDateOfBirth,
-  onBvnkDateOfBirthChange,
-  bvnkCountryCode,
-  onBvnkCountryCodeChange,
-  selectedWallet,
-  transferCompliance,
-  transferComplianceLoading,
-  transferComplianceDismissed,
-  onCheckTransferCompliance,
-  onDismissTransferCompliance,
-}: QuickActionRequestFieldsProps) {
-  const isSendModal = mode === "send";
-  const isTransferFlow = selectedFlow === "transfer";
-  const rampDirection = getQuickActionDirection(selectedFlow);
-  const provider = getQuickActionProvider(selectedFlow);
-  const providerLabel = getQuickActionProviderLabel(selectedFlow);
-  const isOnrampFlow = rampDirection === "onramp";
-  const isMoonPayFlow = provider === "moonpay";
-  const isLightsparkFlow = provider === "lightspark";
-  const isLightsparkOfframpFlow = selectedFlow === "lightspark_offramp";
-  const isBvnkFlow = provider === "bvnk";
-  const isBvnkOfframpFlow = selectedFlow === "bvnk_offramp";
-  const numericAmount = parseOptionalNumber(amount);
-  const isBelowMoonPayOnrampMinimum =
-    selectedFlow === "moonpay_onramp" &&
-    amount.trim().length > 0 &&
-    (numericAmount === null || numericAmount < MOONPAY_ONRAMP_MIN_USD);
-  const destinationTrimmed = destination.trim();
-
-  return (
-    <section className="space-y-3">
-      <h2 className="text-[18px] leading-6 font-medium text-[#1c1c1d]">Request body</h2>
-      <div className="space-y-4">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor={`${mode}-wallet`}>Wallet</Label>
-            <div className="relative">
-              <FormValueBridge
-                label="Selected wallet"
-                name={`${mode}Wallet`}
-                required
-                value={selectedWalletId}
-              />
-              <Select
-                value={selectedWalletId}
-                onValueChange={onWalletChange}
-                disabled={wallets.length === 0}
-              >
-                <SelectTrigger
-                  id={`${mode}-wallet`}
-                  className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                >
-                  <SelectValue placeholder="Select wallet" />
-                </SelectTrigger>
-                <SelectContent
-                  position="popper"
-                  className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
-                >
-                  {wallets.map((wallet) => (
-                    <SelectItem key={wallet.walletId} value={wallet.walletId}>
-                      {getWalletActionLabel(wallet)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor={`${mode}-flow`}>Flow</Label>
-            <div className="relative">
-              <Select
-                value={selectedFlow}
-                onValueChange={(value) => onFlowChange(value as QuickActionFlow)}
-              >
-                <SelectTrigger
-                  id={`${mode}-flow`}
-                  className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                >
-                  <SelectValue placeholder="Select flow" />
-                </SelectTrigger>
-                <SelectContent
-                  position="popper"
-                  className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
-                >
-                  {flowOptions.map((flow) => (
-                    <SelectItem key={flow.value} value={flow.value}>
-                      {flow.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </div>
-
-        {isTransferFlow ? (
-          <>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor={`${mode}-asset`}>Asset</Label>
-                <div className="relative">
-                  <FormValueBridge
-                    label="Selected asset"
-                    name={`${mode}Asset`}
-                    required
-                    value={selectedAsset}
-                  />
-                  <Select
-                    value={selectedAsset}
-                    onValueChange={onAssetChange}
-                    disabled={assetOptions.length === 0}
-                  >
-                    <SelectTrigger
-                      id={`${mode}-asset`}
-                      className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                    >
-                      <SelectValue placeholder="Select asset" />
-                    </SelectTrigger>
-                    <SelectContent
-                      position="popper"
-                      className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
-                    >
-                      {assetOptions.map((asset) => (
-                        <SelectItem key={asset} value={asset}>
-                          {asset}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              {isSendModal ? (
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-amount`}>Amount</Label>
-                  <Input
-                    id={`${mode}-amount`}
-                    type="number"
-                    inputMode="decimal"
-                    min="0.000001"
-                    step="any"
-                    required
-                    value={amount}
-                    onChange={(event) => onAmountChange(event.currentTarget.value)}
-                    placeholder="1.00"
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                  />
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-reference`}>Reference label</Label>
-                  <Input
-                    id={`${mode}-reference`}
-                    value={reference}
-                    onChange={(event) => onReferenceChange(event.currentTarget.value)}
-                    placeholder="Customer top-up"
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                  />
-                </div>
-              )}
-            </div>
-
-            {isSendModal ? (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-destination`}>Destination address</Label>
-                  <Input
-                    id={`${mode}-destination`}
-                    required
-                    minLength={32}
-                    maxLength={44}
-                    value={destination}
-                    onChange={(event) => onDestinationChange(event.currentTarget.value)}
-                    placeholder="Destination Solana address"
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                  />
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={onCheckTransferCompliance}
-                    disabled={transferComplianceLoading || !selectedWalletId || !destinationTrimmed}
-                  >
-                    {transferComplianceLoading ? "Checking..." : "Check risk score"}
-                  </Button>
-                </div>
-                {transferCompliance && !transferComplianceDismissed ? (
-                  <ProviderRiskTable
-                    title="Risk score results"
-                    snapshot={transferCompliance}
-                    onClose={onDismissTransferCompliance}
-                  />
-                ) : null}
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-memo`}>Memo</Label>
-                  <Input
-                    id={`${mode}-memo`}
-                    value={memo}
-                    onChange={(event) => onMemoChange(event.currentTarget.value)}
-                    placeholder="Invoice #1234"
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                  />
-                </div>
-              </>
-            ) : (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-address`}>Receiving address</Label>
-                  <Input
-                    id={`${mode}-address`}
-                    value={selectedWallet?.publicKey ?? ""}
-                    readOnly
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
-                  />
-                </div>
-                <WalletAddressQrCode address={selectedWallet?.publicKey ?? ""} />
-              </>
-            )}
-          </>
-        ) : (
-          <>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor={`${mode}-provider`}>Provider</Label>
-                <Input
-                  id={`${mode}-provider`}
-                  value={providerLabel ?? ""}
-                  readOnly
-                  className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 shadow-none"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor={`${mode}-asset`}>Asset</Label>
-                <div className="relative">
-                  <FormValueBridge
-                    label="Selected asset"
-                    name={`${mode}Asset`}
-                    required
-                    value={selectedAsset}
-                  />
-                  <Select
-                    value={selectedAsset}
-                    onValueChange={onAssetChange}
-                    disabled={assetOptions.length === 0}
-                  >
-                    <SelectTrigger
-                      id={`${mode}-asset`}
-                      className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                    >
-                      <SelectValue placeholder="Select asset" />
-                    </SelectTrigger>
-                    <SelectContent
-                      position="popper"
-                      className="rounded-2xl border-[rgba(28,28,29,0.12)] bg-white"
-                    >
-                      {assetOptions.map((asset) => (
-                        <SelectItem key={asset} value={asset}>
-                          {asset}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor={`${mode}-amount`}>
-                {isOnrampFlow ? "Fiat amount (USD)" : "Crypto amount"}
-              </Label>
-              <Input
-                id={`${mode}-amount`}
-                type="number"
-                inputMode="decimal"
-                min={
-                  selectedFlow === "moonpay_onramp" ? String(MOONPAY_ONRAMP_MIN_USD) : "0.000001"
-                }
-                step="any"
-                required
-                value={amount}
-                onChange={(event) => onAmountChange(event.currentTarget.value)}
-                placeholder="250.00"
-                className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-              />
-              {selectedFlow === "moonpay_onramp" ? (
-                <p
-                  className={
-                    isBelowMoonPayOnrampMinimum
-                      ? "text-xs text-[#9e2b38]"
-                      : "text-xs text-[rgba(28,28,29,0.56)]"
-                  }
-                >
-                  Minimum $20 USD.
-                </p>
-              ) : null}
-            </div>
-
-            {isLightsparkFlow ? (
-              isLightsparkOfframpFlow ? (
-                <>
-                  <p className="text-xs text-[rgba(28,28,29,0.56)]">
-                    Lightspark off-ramp uses Lightspark account IDs instead of an SDP custody
-                    wallet.
-                  </p>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor={`${mode}-lightspark-source`}>Source account ID</Label>
-                      <Input
-                        id={`${mode}-lightspark-source`}
-                        required
-                        value={lightsparkSourceAccountId}
-                        onChange={(event) =>
-                          onLightsparkSourceAccountIdChange(event.currentTarget.value)
-                        }
-                        placeholder="InternalAccount:acc_source_123"
-                        className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`${mode}-lightspark-destination`}>
-                        Destination account ID
-                      </Label>
-                      <Input
-                        id={`${mode}-lightspark-destination`}
-                        required
-                        value={lightsparkDestinationAccountId}
-                        onChange={(event) =>
-                          onLightsparkDestinationAccountIdChange(event.currentTarget.value)
-                        }
-                        placeholder="ExternalAccount:acc_destination_123"
-                        className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                      />
-                    </div>
-                  </div>
-                </>
-              ) : (
-                <>
-                  <div className="space-y-2">
-                    <Label htmlFor={`${mode}-customer-id`}>Customer ID</Label>
-                    <Input
-                      id={`${mode}-customer-id`}
-                      required
-                      value={customerId}
-                      onChange={(event) => onCustomerIdChange(event.currentTarget.value)}
-                      placeholder="Customer:cus_123"
-                      className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor={`${mode}-address`}>Destination address</Label>
-                    <Input
-                      id={`${mode}-address`}
-                      value={selectedWallet?.publicKey ?? ""}
-                      readOnly
-                      className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
-                    />
-                  </div>
-                </>
-              )
-            ) : null}
-
-            {isBvnkFlow ? (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-customer-id`}>Customer ID</Label>
-                  <Input
-                    id={`${mode}-customer-id`}
-                    required
-                    value={customerId}
-                    onChange={(event) => onCustomerIdChange(event.currentTarget.value)}
-                    placeholder="customer_123"
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor={`${mode}-address`}>
-                    {isOnrampFlow ? "Destination address" : "Source address"}
-                  </Label>
-                  <Input
-                    id={`${mode}-address`}
-                    value={selectedWallet?.publicKey ?? ""}
-                    readOnly
-                    className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
-                  />
-                </div>
-                {isBvnkOfframpFlow ? (
-                  <>
-                    <p className="text-xs text-[rgba(28,28,29,0.56)]">
-                      BVNK off-ramp also needs a lightweight beneficiary profile for compliance.
-                    </p>
-                    <div className="grid gap-4 sm:grid-cols-2">
-                      <div className="space-y-2">
-                        <Label htmlFor={`${mode}-bvnk-first-name`}>First name</Label>
-                        <Input
-                          id={`${mode}-bvnk-first-name`}
-                          required
-                          value={bvnkFirstName}
-                          onChange={(event) => onBvnkFirstNameChange(event.currentTarget.value)}
-                          placeholder="Jane"
-                          className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`${mode}-bvnk-last-name`}>Last name</Label>
-                        <Input
-                          id={`${mode}-bvnk-last-name`}
-                          required
-                          value={bvnkLastName}
-                          onChange={(event) => onBvnkLastNameChange(event.currentTarget.value)}
-                          placeholder="Doe"
-                          className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`${mode}-bvnk-dob`}>Date of birth</Label>
-                        <Input
-                          id={`${mode}-bvnk-dob`}
-                          type="date"
-                          required
-                          value={bvnkDateOfBirth}
-                          onChange={(event) => onBvnkDateOfBirthChange(event.currentTarget.value)}
-                          className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor={`${mode}-bvnk-country`}>Country</Label>
-                        <select
-                          id={`${mode}-bvnk-country`}
-                          required
-                          value={bvnkCountryCode}
-                          onChange={(event) => onBvnkCountryCodeChange(event.currentTarget.value)}
-                          className="h-11 w-full rounded-[12px] border border-[rgba(28,28,29,0.12)] bg-white px-4 text-sm text-[#1c1c1d]"
-                        >
-                          <option value="">Select country</option>
-                          {BVNK_COUNTRY_OPTIONS.map((country) => (
-                            <option key={country.value} value={country.value}>
-                              {country.label}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    </div>
-                  </>
-                ) : null}
-              </>
-            ) : null}
-
-            {isMoonPayFlow ? (
-              <div className="space-y-2">
-                <Label htmlFor={`${mode}-address`}>
-                  {isOnrampFlow ? "Destination address" : "Source address"}
-                </Label>
-                <Input
-                  id={`${mode}-address`}
-                  value={selectedWallet?.publicKey ?? ""}
-                  readOnly
-                  className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-4 font-mono text-sm shadow-none"
-                />
-              </div>
-            ) : null}
-          </>
-        )}
-      </div>
-    </section>
-  );
-}
-
-function QuickActionModal({
-  open,
-  mode,
-  wallets,
-  initialWalletId,
-  onWalletChange,
-  onClose,
-}: QuickActionModalProps) {
-  const [selectedWalletId, setSelectedWalletId] = useState(initialWalletId);
-  const [selectedFlow, setSelectedFlow] = useState<QuickActionFlow>("transfer");
-  const [selectedAsset, setSelectedAsset] = useState<string>("USDC");
-  const [destination, setDestination] = useState("");
-  const [amount, setAmount] = useState("");
-  const [memo, setMemo] = useState("");
-  const [reference, setReference] = useState("");
-  const [customerId, setCustomerId] = useState("");
-  const [lightsparkSourceAccountId, setLightsparkSourceAccountId] = useState("");
-  const [lightsparkDestinationAccountId, setLightsparkDestinationAccountId] = useState("");
-  const [bvnkFirstName, setBvnkFirstName] = useState("");
-  const [bvnkLastName, setBvnkLastName] = useState("");
-  const [bvnkDateOfBirth, setBvnkDateOfBirth] = useState("");
-  const [bvnkCountryCode, setBvnkCountryCode] = useState("");
-  const [rampExecution, setRampExecution] = useState<RampExecution | null>(null);
-  const [transferCompliance, setTransferCompliance] = useState<ComplianceSnapshot | null>(null);
-  const [transferComplianceLoading, setTransferComplianceLoading] = useState(false);
-  const [transferComplianceDismissed, setTransferComplianceDismissed] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    const nextWalletId = wallets.some((wallet) => wallet.walletId === initialWalletId)
-      ? initialWalletId
-      : (wallets[0]?.walletId ?? "");
-    setSelectedWalletId(nextWalletId);
-    setRampExecution(null);
-    setCustomerId("");
-    setLightsparkSourceAccountId("");
-    setLightsparkDestinationAccountId("");
-    setBvnkFirstName("");
-    setBvnkLastName("");
-    setBvnkDateOfBirth("");
-    setBvnkCountryCode("");
-    setTransferCompliance(null);
-    setTransferComplianceDismissed(false);
-    if (nextWalletId) {
-      onWalletChange(nextWalletId);
-    }
-  }, [initialWalletId, onWalletChange, open, wallets]);
-
-  const selectedWallet = useMemo(
-    () => wallets.find((wallet) => wallet.walletId === selectedWalletId) ?? null,
-    [selectedWalletId, wallets]
-  );
-  const flowOptions = useMemo(() => getQuickActionFlowOptions(mode), [mode]);
-  const assetOptions = useMemo(() => resolveWalletActionAssets(selectedWallet), [selectedWallet]);
-
-  useEffect(() => {
-    if (!flowOptions.some((option) => option.value === selectedFlow)) {
-      setSelectedFlow(flowOptions[0]?.value ?? "transfer");
-    }
-  }, [flowOptions, selectedFlow]);
-
-  useEffect(() => {
-    if (assetOptions.length === 0) {
-      setSelectedAsset("");
-      return;
-    }
-
-    if (!assetOptions.includes(selectedAsset)) {
-      setSelectedAsset(assetOptions.includes("USDC") ? "USDC" : (assetOptions[0] ?? ""));
-    }
-  }, [assetOptions, selectedAsset]);
-
-  const isSendModal = mode === "send";
-  const isTransferFlow = selectedFlow === "transfer";
-  const rampDirection = getQuickActionDirection(selectedFlow);
-  const providerLabel = getQuickActionProviderLabel(selectedFlow);
-  const isOnrampFlow = rampDirection === "onramp";
-  const transferDestinationTrimmed = destination.trim();
-  const hasTransferComplianceForDestination =
-    !!transferCompliance &&
-    transferCompliance.address === transferDestinationTrimmed &&
-    transferCompliance.providers.length > 0;
-  const title = isSendModal ? "Send" : "Receive";
-  const description = getQuickActionDescription(mode, selectedFlow);
-  const submitLabel = getQuickActionSubmitLabel(mode, selectedFlow);
-
-  const getWalletSelectionDescription = (wallet: WalletRecord) =>
-    `${wallet.label ?? wallet.walletId} · ${selectedAsset}`;
-
-  const submitTransferFlow = async (wallet: WalletRecord) => {
-    const loadingToastId = toast.loading(
-      isSendModal ? "Preparing send transfer..." : "Preparing receive transfer...",
-      {
-        description: getWalletSelectionDescription(wallet),
-        position: "bottom-right",
-      }
-    );
-
-    await new Promise((resolve) => window.setTimeout(resolve, 900));
-
-    toast.success(`${title} transfer flow ready.`, {
-      id: loadingToastId,
-      description: "Transfer submission is still using placeholder wiring for now.",
-      position: "bottom-right",
-    });
-  };
-
-  const checkTransferCompliance = async () => {
-    if (!transferDestinationTrimmed) {
-      return;
-    }
-
-    setTransferComplianceLoading(true);
-    setTransferComplianceDismissed(false);
-    try {
-      setTransferCompliance(
-        await runComplianceCheck(transferDestinationTrimmed, "transfer_destination")
-      );
-    } catch (error) {
-      setTransferCompliance(null);
-      toast.error("Compliance check failed.", {
-        description: error instanceof Error ? error.message : "Compliance check failed.",
-        position: "bottom-right",
-      });
-    } finally {
-      setTransferComplianceLoading(false);
-    }
-  };
-
-  const buildRampPayload = (wallet: WalletRecord): Record<string, unknown> => {
-    if (selectedFlow === "moonpay_onramp") {
-      return {
-        provider: "moonpay",
-        destinationWallet: wallet.walletId,
-        cryptoToken: selectedAsset,
-        fiatAmount: amount.trim(),
-      };
-    }
-
-    if (selectedFlow === "moonpay_offramp") {
-      return {
-        provider: "moonpay",
-        sourceWallet: wallet.walletId,
-        cryptoToken: selectedAsset,
-        cryptoAmount: amount.trim(),
-      };
-    }
-
-    if (selectedFlow === "lightspark_onramp") {
-      return {
-        provider: "lightspark",
-        destinationWallet: wallet.walletId,
-        cryptoToken: selectedAsset,
-        fiatAmount: amount.trim(),
-        kycReference: customerId.trim(),
-      };
-    }
-
-    if (selectedFlow === "lightspark_offramp") {
-      return {
-        provider: "lightspark",
-        sourceWallet: lightsparkSourceAccountId.trim(),
-        cryptoToken: selectedAsset,
-        cryptoAmount: amount.trim(),
-        kycReference: lightsparkDestinationAccountId.trim(),
-      };
-    }
-
-    if (selectedFlow === "bvnk_onramp") {
-      return {
-        provider: "bvnk",
-        destinationWallet: wallet.walletId,
-        cryptoToken: selectedAsset,
-        fiatAmount: amount.trim(),
-        kycReference: customerId.trim(),
-      };
-    }
-
-    return {
-      provider: "bvnk",
-      sourceWallet: wallet.walletId,
-      cryptoToken: selectedAsset,
-      cryptoAmount: amount.trim(),
-      kycReference: customerId.trim(),
-      bvnkCompliance: {
-        partyDetails: [
-          {
-            type: "BENEFICIARY",
-            entityType: "INDIVIDUAL",
-            relationshipType: "THIRD_PARTY",
-            firstName: bvnkFirstName.trim(),
-            lastName: bvnkLastName.trim(),
-            dateOfBirth: bvnkDateOfBirth,
-            countryCode: bvnkCountryCode,
-          },
-        ],
-      },
-    };
-  };
-
-  const submitRampFlow = async (wallet: WalletRecord) => {
-    const direction = rampDirection;
-    if (!direction) {
-      return;
-    }
-    const loadingToastId = toast.loading(
-      isOnrampFlow
-        ? `Starting ${providerLabel} on-ramp...`
-        : `Starting ${providerLabel} off-ramp...`,
-      {
-        description: getWalletSelectionDescription(wallet),
-        position: "bottom-right",
-      }
-    );
-
-    try {
-      const ramp = await executeRampFlow(direction, buildRampPayload(wallet));
-      setRampExecution(ramp);
-
-      toast.success(`${providerLabel} flow ready.`, {
-        id: loadingToastId,
-        position: "bottom-right",
-      });
-    } catch (error) {
-      toast.error(`${title} flow failed to initialize.`, {
-        id: loadingToastId,
-        description:
-          error instanceof Error ? error.message : "Try again. No request was submitted.",
-        position: "bottom-right",
-      });
-      throw error;
-    }
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (!selectedWallet) {
-      return;
-    }
-
-    if (isTransferFlow && isSendModal && !hasTransferComplianceForDestination) {
-      toast.error("Transfer blocked.", {
-        description: "Run risk check before preparing the transfer.",
-        position: "bottom-right",
-      });
-      return;
-    }
-
-    setIsSubmitting(true);
-
-    try {
-      if (isTransferFlow) {
-        await submitTransferFlow(selectedWallet);
-        onClose();
-      } else {
-        await submitRampFlow(selectedWallet);
-      }
-    } catch (error) {
-      if (isTransferFlow) {
-        toast.error(`${title} flow failed to initialize.`, {
-          description:
-            error instanceof Error ? error.message : "Try again. No request was submitted.",
-          position: "bottom-right",
-        });
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  useEscapeKey(open, onClose);
-
-  if (!open) {
-    return null;
-  }
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-8">
-      <button
-        type="button"
-        aria-label={`Close ${title.toLowerCase()} modal`}
-        className="absolute inset-0 bg-black/35"
-        onClick={onClose}
-      />
-
-      <div className="relative z-10 w-full max-w-2xl overflow-hidden rounded-3xl border border-[rgba(28,28,29,0.16)] bg-white text-[#1c1c1d] shadow-[0_24px_64px_rgba(28,28,29,0.28)]">
-        <div className="border-b border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.02)] px-8 py-7">
-          <p className="text-3xl leading-none font-semibold">{title}</p>
-          <p className="mt-2 text-base text-[rgba(28,28,29,0.62)]">{description}</p>
-        </div>
-
-        <form onSubmit={handleSubmit} className="grid gap-6 px-8 py-7">
-          <QuickActionRequestFields
-            mode={mode}
-            wallets={wallets}
-            selectedWalletId={selectedWalletId}
-            onWalletChange={(value) => {
-              setSelectedWalletId(value);
-              setRampExecution(null);
-              setTransferCompliance(null);
-              setTransferComplianceDismissed(false);
-              onWalletChange(value);
-            }}
-            flowOptions={flowOptions}
-            selectedFlow={selectedFlow}
-            onFlowChange={(value) => {
-              setSelectedFlow(value);
-              setRampExecution(null);
-              setCustomerId("");
-              setLightsparkSourceAccountId("");
-              setLightsparkDestinationAccountId("");
-              setBvnkFirstName("");
-              setBvnkLastName("");
-              setBvnkDateOfBirth("");
-              setBvnkCountryCode("");
-              setTransferCompliance(null);
-              setTransferComplianceDismissed(false);
-            }}
-            assetOptions={assetOptions}
-            selectedAsset={selectedAsset}
-            onAssetChange={(value) => {
-              setSelectedAsset(value);
-              setRampExecution(null);
-            }}
-            amount={amount}
-            onAmountChange={(value) => {
-              setAmount(value);
-              setRampExecution(null);
-            }}
-            destination={destination}
-            onDestinationChange={(value) => {
-              setDestination(value);
-              setTransferCompliance(null);
-              setTransferComplianceDismissed(false);
-            }}
-            memo={memo}
-            onMemoChange={setMemo}
-            reference={reference}
-            onReferenceChange={setReference}
-            customerId={customerId}
-            onCustomerIdChange={setCustomerId}
-            lightsparkSourceAccountId={lightsparkSourceAccountId}
-            onLightsparkSourceAccountIdChange={setLightsparkSourceAccountId}
-            lightsparkDestinationAccountId={lightsparkDestinationAccountId}
-            onLightsparkDestinationAccountIdChange={setLightsparkDestinationAccountId}
-            bvnkFirstName={bvnkFirstName}
-            onBvnkFirstNameChange={setBvnkFirstName}
-            bvnkLastName={bvnkLastName}
-            onBvnkLastNameChange={setBvnkLastName}
-            bvnkDateOfBirth={bvnkDateOfBirth}
-            onBvnkDateOfBirthChange={setBvnkDateOfBirth}
-            bvnkCountryCode={bvnkCountryCode}
-            onBvnkCountryCodeChange={setBvnkCountryCode}
-            selectedWallet={selectedWallet}
-            transferCompliance={transferCompliance}
-            transferComplianceLoading={transferComplianceLoading}
-            transferComplianceDismissed={transferComplianceDismissed}
-            onCheckTransferCompliance={() => {
-              void checkTransferCompliance();
-            }}
-            onDismissTransferCompliance={() => setTransferComplianceDismissed(true)}
-          />
-
-          {!isTransferFlow && rampExecution ? (
-            <section className="rounded-2xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.03)] p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgba(28,28,29,0.52)]">
-                Demo result
-              </p>
-              <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1">
-                  <p className="text-xs text-[rgba(28,28,29,0.56)]">Status</p>
-                  <p className="text-sm font-medium text-[#1c1c1d]">{rampExecution.status}</p>
-                </div>
-                {rampExecution.reference ? (
-                  <div className="space-y-1">
-                    <p className="text-xs text-[rgba(28,28,29,0.56)]">Reference</p>
-                    <p className="font-mono text-xs text-[rgba(28,28,29,0.78)]">
-                      {rampExecution.reference}
-                    </p>
-                  </div>
-                ) : null}
-              </div>
-              {rampExecution.redirectUrl ? (
-                <>
-                  <p className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-[rgba(28,28,29,0.52)]">
-                    Redirect URL
-                  </p>
-                  <Input
-                    readOnly
-                    value={rampExecution.redirectUrl}
-                    className="mt-3 h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 font-mono text-sm shadow-none"
-                  />
-                  <div className="mt-3 flex items-center justify-end gap-3">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() =>
-                        window.open(rampExecution.redirectUrl, "_blank", "noopener,noreferrer")
-                      }
-                    >
-                      {providerLabel ? `Open ${providerLabel}` : "Open provider"}
-                    </Button>
-                  </div>
-                </>
-              ) : null}
-            </section>
-          ) : null}
-
-          <div className="flex items-center justify-end gap-3">
-            <Button type="button" variant="secondary" onClick={onClose} disabled={isSubmitting}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={isSubmitting || wallets.length === 0}
-              aria-busy={isSubmitting}
-            >
-              {isSubmitting ? `${submitLabel}...` : submitLabel}
-            </Button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
 export function PaymentsOverview({
   wallets,
   walletsError,
@@ -1375,6 +84,7 @@ export function PaymentsOverview({
   transfers,
   transfersError,
 }: PaymentsOverviewProps) {
+  const router = useRouter();
   const {
     data: swrWallets,
     error: walletsFetchError,
@@ -1429,21 +139,6 @@ export function PaymentsOverview({
       ? transfersError
       : null;
   const isRefreshing = walletsRefreshing || aggregateRefreshing || transfersRefreshing;
-  const [selectedWalletId, setSelectedWalletId] = useState("");
-  const [sendModalOpen, setSendModalOpen] = useState(false);
-  const [receiveModalOpen, setReceiveModalOpen] = useState(false);
-
-  useEffect(() => {
-    if (liveWallets.length === 0) {
-      setSelectedWalletId("");
-      return;
-    }
-
-    if (!liveWallets.some((wallet) => wallet.walletId === selectedWalletId)) {
-      setSelectedWalletId(liveWallets[0]?.walletId ?? "");
-    }
-  }, [liveWallets, selectedWalletId]);
-
   const aggregateBalances = useMemo(
     () => resolveAggregateBalanceRows(liveAggregate, liveWallets),
     [liveAggregate, liveWallets]
@@ -1457,191 +152,172 @@ export function PaymentsOverview({
   };
 
   return (
-    <>
-      <div className="grid gap-6">
-        <SectionEntry>
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              className="rounded-full px-5"
-              onClick={() => setSendModalOpen(true)}
-              disabled={!hasWallets}
-            >
-              <ArrowUpRight className="size-4" />
-              Send
-            </Button>
-            <Button
-              type="button"
-              className="rounded-full px-5"
-              onClick={() => setReceiveModalOpen(true)}
-              disabled={!hasWallets}
-            >
-              <ArrowDownLeft className="size-4" />
-              Receive
-            </Button>
-          </div>
-        </SectionEntry>
+    <div className="grid gap-6">
+      <SectionEntry>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            className="rounded-full px-5"
+            disabled={!hasWallets}
+            onClick={() => router.push("/dashboard/payments/send")}
+          >
+            <ArrowUpRight className="size-4" />
+            Send
+          </Button>
+          <Button
+            type="button"
+            className="rounded-full px-5"
+            disabled={!hasWallets}
+            onClick={() => router.push("/dashboard/payments/receive")}
+          >
+            <ArrowDownLeft className="size-4" />
+            Receive
+          </Button>
+        </div>
+      </SectionEntry>
 
-        <SectionEntry delay={0.04}>
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,1fr)]">
-            <div className="flex min-h-[244px] flex-col justify-center rounded-[4px] bg-[rgba(28,28,29,0.04)] px-8 py-10 sm:px-14">
-              <div className="space-y-3">
-                <p className="text-[15px] font-medium tracking-[0.01em] text-[#1c1c1d]">
-                  Total SDP balance
-                </p>
-                <p className="text-[38px] leading-none font-medium tracking-[-0.05em] text-[#1c1c1d] sm:text-[54px]">
-                  {formatCurrencyAmount(totalBalance)}
-                </p>
-                <p className="text-sm text-[rgba(28,28,29,0.56)]">
-                  Aggregated across {walletCount} {walletCount === 1 ? "wallet" : "wallets"}.
-                </p>
-              </div>
-            </div>
-
-            <div className="grid gap-1.5">
-              {aggregateBalances.length > 0 ? (
-                aggregateBalances.map((balance) => (
-                  <div
-                    key={`${balance.token}-${balance.mint}`}
-                    className="flex min-h-[78px] items-center justify-between gap-4 rounded-[4px] bg-[rgba(28,28,29,0.04)] px-6 py-5"
-                  >
-                    <p className="text-[18px] font-medium tracking-[0.04em] text-[#1c1c1d] uppercase">
-                      {balance.token}
-                    </p>
-                    <p className="text-right text-[18px] font-medium tracking-[0.01em] text-[#1c1c1d] sm:text-[20px]">
-                      {formatCurrencyAmount(balance.uiAmount)}
-                    </p>
-                  </div>
-                ))
-              ) : (
-                <div className="flex min-h-[78px] items-center rounded-[4px] bg-[rgba(28,28,29,0.04)] px-6 py-5 text-sm text-[rgba(28,28,29,0.64)]">
-                  No aggregated balance rows available yet.
-                </div>
-              )}
+      <SectionEntry delay={0.04}>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,1fr)]">
+          <div className="flex min-h-[244px] flex-col justify-center rounded-[4px] bg-[rgba(28,28,29,0.04)] px-8 py-10 sm:px-14">
+            <div className="space-y-3">
+              <p className="text-[15px] font-medium tracking-[0.01em] text-[#1c1c1d]">
+                Total SDP balance
+              </p>
+              <p className="text-[38px] leading-none font-medium tracking-[-0.05em] text-[#1c1c1d] sm:text-[54px]">
+                {formatCurrencyAmount(totalBalance)}
+              </p>
+              <p className="text-sm text-[rgba(28,28,29,0.56)]">
+                Aggregated across {walletCount} {walletCount === 1 ? "wallet" : "wallets"}.
+              </p>
             </div>
           </div>
 
-          {liveWalletsError ? (
-            <p className="mt-4 text-sm text-[#9e2b38]">{liveWalletsError}</p>
-          ) : null}
-          {liveAggregateError ? (
-            <p className="mt-2 text-sm text-[#9e2b38]">{liveAggregateError}</p>
-          ) : null}
-        </SectionEntry>
-
-        <SectionEntry delay={0.08}>
-          <Card>
-            <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div className="space-y-1">
-                <CardTitle>Recent transactions</CardTitle>
-                <CardDescription>
-                  Latest transfer activity across all organization wallets.
-                </CardDescription>
-              </div>
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={handleRefresh}
-                disabled={isRefreshing}
-              >
-                <RefreshCw className={`size-4 ${isRefreshing ? "animate-spin" : ""}`} />
-                {isRefreshing ? "Refreshing..." : "Refresh"}
-              </Button>
-            </CardHeader>
-            <CardContent>
-              {liveTransfersError ? (
-                <p className="text-sm text-[#9e2b38]">{liveTransfersError}</p>
-              ) : liveTransfers.length === 0 ? (
-                <p className="text-sm text-[rgba(28,28,29,0.72)]">No transactions found yet.</p>
-              ) : (
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Direction</TableHead>
-                        <TableHead>Asset</TableHead>
-                        <TableHead>Counterparty</TableHead>
-                        <TableHead>Signature</TableHead>
-                        <TableHead>Created</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {liveTransfers.map((transfer) => {
-                        const counterparty = resolveCounterparty(transfer);
-
-                        return (
-                          <TableRow key={transfer.id}>
-                            <TableCell>
-                              <span
-                                className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${statusClassName(transfer.status)}`}
-                              >
-                                {transfer.status}
-                              </span>
-                            </TableCell>
-                            <TableCell className="text-[rgba(28,28,29,0.72)]">
-                              {formatDirection(transfer.direction)}
-                            </TableCell>
-                            <TableCell className="font-medium">
-                              {formatDisplayAmount(transfer.amount, transfer.token)}
-                            </TableCell>
-                            <TableCell className="font-mono text-xs text-[rgba(28,28,29,0.72)]">
-                              <div
-                                className="max-w-[12rem] truncate sm:max-w-[18rem]"
-                                title={counterparty}
-                              >
-                                {counterparty}
-                              </div>
-                            </TableCell>
-                            <TableCell className="font-mono text-xs">
-                              {transfer.signature ? (
-                                <a
-                                  href={getDevnetExplorerUrl(transfer.signature)}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="inline-flex items-center gap-1 text-[#1c1c1d] underline underline-offset-2"
-                                  title={transfer.signature}
-                                >
-                                  <span className="max-w-[9rem] truncate sm:max-w-[12rem]">
-                                    {transfer.signature}
-                                  </span>
-                                  <ExternalLink className="size-3" />
-                                </a>
-                              ) : (
-                                <span className="text-[rgba(28,28,29,0.52)]">Pending</span>
-                              )}
-                            </TableCell>
-                            <TableCell className="text-[rgba(28,28,29,0.72)]">
-                              {formatTimestamp(transfer.createdAt)}
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
+          <div className="grid gap-1.5">
+            {aggregateBalances.length > 0 ? (
+              aggregateBalances.map((balance) => (
+                <div
+                  key={`${balance.token}-${balance.mint}`}
+                  className="flex min-h-[78px] items-center justify-between gap-4 rounded-[4px] bg-[rgba(28,28,29,0.04)] px-6 py-5"
+                >
+                  <p className="text-[18px] font-medium tracking-[0.04em] text-[#1c1c1d] uppercase">
+                    {balance.token}
+                  </p>
+                  <p className="text-right text-[18px] font-medium tracking-[0.01em] text-[#1c1c1d] sm:text-[20px]">
+                    {formatCurrencyAmount(balance.uiAmount)}
+                  </p>
                 </div>
-              )}
-            </CardContent>
-          </Card>
-        </SectionEntry>
-      </div>
+              ))
+            ) : (
+              <div className="flex min-h-[78px] items-center rounded-[4px] bg-[rgba(28,28,29,0.04)] px-6 py-5 text-sm text-[rgba(28,28,29,0.64)]">
+                No aggregated balance rows available yet.
+              </div>
+            )}
+          </div>
+        </div>
 
-      <QuickActionModal
-        open={sendModalOpen}
-        mode="send"
-        wallets={liveWallets}
-        initialWalletId={selectedWalletId}
-        onWalletChange={setSelectedWalletId}
-        onClose={() => setSendModalOpen(false)}
-      />
-      <QuickActionModal
-        open={receiveModalOpen}
-        mode="receive"
-        wallets={liveWallets}
-        initialWalletId={selectedWalletId}
-        onWalletChange={setSelectedWalletId}
-        onClose={() => setReceiveModalOpen(false)}
-      />
-    </>
+        {liveWalletsError ? (
+          <p className="mt-4 text-sm text-[#9e2b38]">{liveWalletsError}</p>
+        ) : null}
+        {liveAggregateError ? (
+          <p className="mt-2 text-sm text-[#9e2b38]">{liveAggregateError}</p>
+        ) : null}
+      </SectionEntry>
+
+      <SectionEntry delay={0.08}>
+        <Card>
+          <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle>Recent transactions</CardTitle>
+              <CardDescription>
+                Latest transfer activity across all organization wallets.
+              </CardDescription>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              <RefreshCw className={`size-4 ${isRefreshing ? "animate-spin" : ""}`} />
+              {isRefreshing ? "Refreshing..." : "Refresh"}
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {liveTransfersError ? (
+              <p className="text-sm text-[#9e2b38]">{liveTransfersError}</p>
+            ) : liveTransfers.length === 0 ? (
+              <p className="text-sm text-[rgba(28,28,29,0.72)]">No transactions found yet.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Direction</TableHead>
+                      <TableHead>Asset</TableHead>
+                      <TableHead>Counterparty</TableHead>
+                      <TableHead>Signature</TableHead>
+                      <TableHead>Created</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {liveTransfers.map((transfer) => {
+                      const counterparty = resolveCounterparty(transfer);
+
+                      return (
+                        <TableRow key={transfer.id}>
+                          <TableCell>
+                            <span
+                              className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${statusClassName(transfer.status)}`}
+                            >
+                              {transfer.status}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-[rgba(28,28,29,0.72)]">
+                            {formatDirection(transfer.direction)}
+                          </TableCell>
+                          <TableCell className="font-medium">
+                            {formatDisplayAmount(transfer.amount, transfer.token)}
+                          </TableCell>
+                          <TableCell className="font-mono text-xs text-[rgba(28,28,29,0.72)]">
+                            <div
+                              className="max-w-[12rem] truncate sm:max-w-[18rem]"
+                              title={counterparty}
+                            >
+                              {counterparty}
+                            </div>
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">
+                            {transfer.signature ? (
+                              <a
+                                href={getDevnetExplorerUrl(transfer.signature)}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-1 text-[#1c1c1d] underline underline-offset-2"
+                                title={transfer.signature}
+                              >
+                                <span className="max-w-[9rem] truncate sm:max-w-[12rem]">
+                                  {transfer.signature}
+                                </span>
+                                <ExternalLink className="size-3" />
+                              </a>
+                            ) : (
+                              <span className="text-[rgba(28,28,29,0.52)]">Pending</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-[rgba(28,28,29,0.72)]">
+                            {formatTimestamp(transfer.createdAt)}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </SectionEntry>
+    </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
@@ -16,6 +16,11 @@ interface FetchPaymentsWalletsOptions {
   includeBalances?: boolean;
 }
 
+export interface PaymentsIssuedTokenSymbol {
+  mintAddress: string;
+  symbol: string;
+}
+
 function parseErrorMessage(body: string): string {
   try {
     const parsed = JSON.parse(body) as {
@@ -185,6 +190,56 @@ export async function fetchPaymentTransfers(
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Unable to load transfers",
+    };
+  }
+}
+
+export async function fetchPaymentsIssuedTokenSymbols(
+  request: SdpApiClient["request"],
+  pageSize = 100
+): Promise<FetchResult<PaymentsIssuedTokenSymbol[]>> {
+  try {
+    const response = await request(
+      `/v1/issuance/tokens?${new URLSearchParams({
+        page: "1",
+        pageSize: String(pageSize),
+      }).toString()}`
+    );
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        ok: false,
+        status: response.status,
+        error: parseErrorMessage(body),
+      };
+    }
+
+    const json = (await response.json()) as {
+      data?: Array<{
+        mintAddress?: string | null;
+        symbol?: string;
+      }>;
+    };
+
+    const tokens = (json?.data ?? [])
+      .filter(
+        (
+          token
+        ): token is {
+          mintAddress: string;
+          symbol?: string;
+        } => typeof token?.mintAddress === "string" && token.mintAddress.length > 0
+      )
+      .map((token) => ({
+        mintAddress: token.mintAddress,
+        symbol: token.symbol?.trim() || token.mintAddress,
+      }));
+
+    return { ok: true, data: tokens };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unable to load issued token symbols",
     };
   }
 }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -251,6 +251,23 @@ interface WalletBalancesEnvelope {
   };
 }
 
+export interface PaymentRampExecution {
+  id: string;
+  provider: string;
+  status: string;
+  redirectUrl?: string;
+  reference?: string;
+}
+
+interface RampExecutionEnvelope {
+  data?: {
+    ramp?: PaymentRampExecution;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
 function resolveWalletBalancesSnapshot(
   envelope: WalletBalancesEnvelope
 ): PaymentWalletBalancesSnapshot | null {
@@ -404,6 +421,30 @@ export async function createTransfer(input: {
   }
 
   return body.data.transfer;
+}
+
+export async function executeRampFlow(
+  direction: "onramp" | "offramp",
+  payload: Record<string, unknown>
+): Promise<PaymentRampExecution> {
+  const response = await fetch(`/api/dashboard/payments/ramps/${direction}/execute`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = (await response.json().catch(() => ({}))) as RampExecutionEnvelope;
+
+  if (!response.ok) {
+    throw new Error(getApiError(body, `Ramp request failed (${response.status}).`));
+  }
+
+  if (!body.data?.ramp) {
+    throw new Error("Ramp response is missing execution details.");
+  }
+
+  return body.data.ramp;
 }
 
 export async function runComplianceCheck(

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -99,6 +99,18 @@ function resolveRiskTone(result: ComplianceProviderResult): RiskTone {
     return "neutral";
   }
 
+  if (result.provider === "elliptic" && result.riskLevel?.toLowerCase() === "check passed") {
+    return "green";
+  }
+
+  if (
+    result.provider === "trm" &&
+    result.riskScore === null &&
+    (!result.riskLevel || !result.riskLevel.trim())
+  ) {
+    return "green";
+  }
+
   if (typeof result.riskScore === "number") {
     if (result.riskScore >= 7) {
       return "red";

--- a/apps/sdp-web/src/app/dashboard/payments/provider-risk-table.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/provider-risk-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -8,6 +9,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useEscapeKey } from "@/lib/use-escape-key";
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { formatRiskScore, riskToneClassName, toProviderLabel } from "./payments-workspace.data";
 import type { ComplianceSnapshot } from "./payments-workspace.types";
 
@@ -18,6 +23,17 @@ interface ProviderRiskTableProps {
 }
 
 export function ProviderRiskTable({ title, snapshot, onClose }: ProviderRiskTableProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEscapeKey(Boolean(snapshot) && mounted, () => {
+    onClose?.();
+  });
+
   if (!snapshot || snapshot.providers.length === 0) {
     return null;
   }
@@ -26,50 +42,74 @@ export function ProviderRiskTable({ title, snapshot, onClose }: ProviderRiskTabl
     toProviderLabel(left.provider).localeCompare(toProviderLabel(right.provider))
   );
 
-  return (
-    <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-white p-3">
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <p className="text-sm font-semibold text-[#1c1c1d]">{title}</p>
-        <div className="flex items-center gap-2">
-          <p className="text-xs text-[rgba(28,28,29,0.56)]">
-            {new Date(snapshot.checkedAt).toLocaleString()}
-          </p>
+  if (!mounted) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+      <button
+        type="button"
+        className="absolute inset-0 bg-[rgba(18,18,19,0.44)]"
+        aria-label={`Close ${title}`}
+        onClick={() => onClose?.()}
+      />
+      <div className="relative z-10 w-full max-w-2xl rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-white p-6 shadow-lg">
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-[22px] font-medium text-[#1c1c1d]">{title}</p>
+            <p className="text-sm text-[rgba(28,28,29,0.56)]">
+              {new Date(snapshot.checkedAt).toLocaleString()}
+            </p>
+            <p className="text-sm text-[rgba(28,28,29,0.56)]">
+              This screening checks major risk factors such as sanctions exposure and other
+              compliance signals from the connected providers.
+            </p>
+          </div>
           {onClose ? (
             <button
               type="button"
-              onClick={onClose}
+              onClick={() => onClose()}
               aria-label={`Close ${title}`}
-              className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-[rgba(28,28,29,0.12)] text-xs font-semibold text-[rgba(28,28,29,0.66)] transition-colors hover:bg-[rgba(28,28,29,0.06)]"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[rgba(28,28,29,0.12)] text-[rgba(28,28,29,0.66)] transition-colors hover:bg-[rgba(28,28,29,0.06)]"
             >
-              X
+              <X className="size-4" />
             </button>
           ) : null}
         </div>
-      </div>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Provider</TableHead>
-            <TableHead>Risk score</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {providers.map((provider) => (
-            <TableRow key={provider.provider}>
-              <TableCell className="font-medium text-[#1c1c1d]">
-                {toProviderLabel(provider.provider)}
-              </TableCell>
-              <TableCell className="text-[rgba(28,28,29,0.8)]">
-                <span
-                  className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${riskToneClassName(provider)}`}
-                >
-                  {formatRiskScore(provider)}
-                </span>
-              </TableCell>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Provider</TableHead>
+              <TableHead>Analysis</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+          </TableHeader>
+          <TableBody>
+            {providers.map((provider) => (
+              <TableRow key={provider.provider}>
+                <TableCell className="font-medium text-[#1c1c1d]">
+                  {toProviderLabel(provider.provider)}
+                </TableCell>
+                <TableCell className="text-[rgba(28,28,29,0.8)]">
+                  <span
+                    className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${riskToneClassName(provider)}`}
+                  >
+                    {formatRiskScore(provider)}
+                  </span>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        {onClose ? (
+          <div className="mt-6 flex justify-end">
+            <Button type="button" variant="secondary" onClick={() => onClose()}>
+              Dismiss
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>,
+    document.body
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { PaymentsActionPage } from "../payments-action-page";
+
+export default async function PaymentsReceivePage() {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  return <PaymentsActionPage mode="receive" wallets={[]} walletsError={null} />;
+}

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -1,6 +1,8 @@
+import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { PaymentsActionPage } from "../payments-action-page";
+import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 
 export default async function PaymentsReceivePage() {
   const { userId, orgId } = await auth();
@@ -11,5 +13,18 @@ export default async function PaymentsReceivePage() {
     redirect("/dashboard");
   }
 
-  return <PaymentsActionPage mode="receive" wallets={[]} walletsError={null} />;
+  const apiClient = await createSdpApiClient();
+  const issuedTokenSymbolsResult = await fetchPaymentsIssuedTokenSymbols(apiClient.request);
+  const issuedTokenSymbolsByMint = Object.fromEntries(
+    (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
+  );
+
+  return (
+    <PaymentsActionPage
+      mode="receive"
+      wallets={[]}
+      walletsError={null}
+      issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}
+    />
+  );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -1,6 +1,8 @@
+import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { PaymentsActionPage } from "../payments-action-page";
+import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 
 export default async function PaymentsSendPage() {
   const { userId, orgId } = await auth();
@@ -11,5 +13,18 @@ export default async function PaymentsSendPage() {
     redirect("/dashboard");
   }
 
-  return <PaymentsActionPage mode="send" wallets={[]} walletsError={null} />;
+  const apiClient = await createSdpApiClient();
+  const issuedTokenSymbolsResult = await fetchPaymentsIssuedTokenSymbols(apiClient.request);
+  const issuedTokenSymbolsByMint = Object.fromEntries(
+    (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
+  );
+
+  return (
+    <PaymentsActionPage
+      mode="send"
+      wallets={[]}
+      walletsError={null}
+      issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}
+    />
+  );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { PaymentsActionPage } from "../payments-action-page";
+
+export default async function PaymentsSendPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  return <PaymentsActionPage mode="send" wallets={[]} walletsError={null} />;
+}

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -319,6 +319,7 @@ function SidebarGroup({
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this shell intentionally coordinates route-specific dashboard layout behavior in one place.
 export function DashboardShell({ children }: { children: ReactNode }) {
   const { isLoaded, isSignedIn, orgId } = useAuth();
   const pathname = usePathname();
@@ -335,6 +336,8 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   const shouldRenderHeaderNavRow =
     pageConfig.showHeaderNavRow || Boolean(backAction) || Boolean(headerNav);
   const shouldRenderTopBarBorder = Boolean(centeredTitle) && !shouldRenderHeaderNavRow;
+  const shouldClipHorizontalOverflow =
+    pathname === "/dashboard/payments" || pathname.startsWith("/dashboard/payments/");
   const shouldLockViewportScroll =
     issuanceTab === "playground" &&
     (pathname === "/dashboard/issuance" ||
@@ -481,6 +484,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
           <div
             className={[
               "w-full",
+              shouldClipHorizontalOverflow ? "overflow-x-hidden" : "",
               shouldLockViewportScroll ? "flex min-h-0 flex-1 flex-col gap-0" : "space-y-6",
             ].join(" ")}
           >
@@ -536,6 +540,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
               className={[
                 "mx-auto w-full",
                 contentWidthClass,
+                shouldClipHorizontalOverflow ? "overflow-x-hidden" : "",
                 shouldLockViewportScroll
                   ? "min-h-0 flex-1 overflow-hidden -mx-3 md:-mx-6 -mb-5 md:-mb-6"
                   : "",

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -64,12 +64,24 @@ const bottomNavItems: NavItem[] = [
 type DashboardPageConfig = {
   title: string;
   headerNav?: ReactNode;
+  centeredTitle?: string;
+  topBarLeadingContent?: ReactNode;
   showHeaderNavRow?: boolean;
   contentWidthClass?: string;
+  hideTitle?: boolean;
   backAction?: {
     href: string;
     label: string;
   };
+};
+
+type DashboardTopBarProps = {
+  isSidebarOpen: boolean;
+  setSidebarOpen: (value: boolean) => void;
+  hideTitle?: boolean;
+  title: string;
+  centeredTitle?: string;
+  topBarLeadingContent?: ReactNode;
 };
 
 function HeaderBackAction({ href, label }: { href: string; label: string }) {
@@ -81,6 +93,78 @@ function HeaderBackAction({ href, label }: { href: string; label: string }) {
       <ArrowLeft className="h-4 w-4" />
       <span className="text-[13px] leading-[18px] font-medium">{label}</span>
     </Link>
+  );
+}
+
+function SidebarToggle({
+  isSidebarOpen,
+  setSidebarOpen,
+}: {
+  isSidebarOpen: boolean;
+  setSidebarOpen: (value: boolean) => void;
+}) {
+  if (isSidebarOpen) {
+    return null;
+  }
+
+  return (
+    <motion.button
+      type="button"
+      aria-label="Open navigation"
+      onClick={() => setSidebarOpen(true)}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[rgba(28,28,29,0.72)] transition-colors hover:bg-[rgba(28,28,29,0.08)]"
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.93, rotate: 8 }}
+    >
+      <motion.div initial={{ rotate: 10 }} animate={{ rotate: 0 }} transition={{ duration: 0.18 }}>
+        <PanelRight className="h-4 w-4" />
+      </motion.div>
+    </motion.button>
+  );
+}
+
+function DashboardTopBar({
+  isSidebarOpen,
+  setSidebarOpen,
+  hideTitle,
+  title,
+  centeredTitle,
+  topBarLeadingContent,
+}: DashboardTopBarProps) {
+  if (centeredTitle) {
+    return (
+      <div className="grid min-h-[40px] grid-cols-[1fr_auto_1fr] items-start gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <SidebarToggle isSidebarOpen={isSidebarOpen} setSidebarOpen={setSidebarOpen} />
+          {topBarLeadingContent}
+        </div>
+        <div className="flex items-start justify-center">
+          <h1 className="text-center text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
+            {centeredTitle}
+          </h1>
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <UserButton afterSignOutUrl="/sign-in" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <SidebarToggle isSidebarOpen={isSidebarOpen} setSidebarOpen={setSidebarOpen} />
+        {hideTitle ? null : (
+          <h1 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
+            {title}
+          </h1>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <UserButton afterSignOutUrl="/sign-in" />
+      </div>
+    </div>
   );
 }
 
@@ -152,10 +236,24 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
       },
     };
   }
-  if (pathname.startsWith("/dashboard/payments")) {
+  if (pathname === "/dashboard/payments") {
     return {
       title: "Payments",
       headerNav: <IssuanceHeaderTabs />,
+      contentWidthClass: "max-w-none",
+    };
+  }
+  if (pathname.startsWith("/dashboard/payments/")) {
+    const actionTitle = pathname.endsWith("/receive") ? "Receive" : "Send";
+
+    return {
+      title: "",
+      hideTitle: true,
+      showHeaderNavRow: true,
+      centeredTitle: actionTitle,
+      topBarLeadingContent: (
+        <HeaderBackAction href="/dashboard/payments" label="Back to payments" />
+      ),
       contentWidthClass: "max-w-none",
     };
   }
@@ -228,12 +326,15 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   const sidebarWidth = 296;
   const pageConfig = getDashboardPageConfig(pathname);
   const contentWidthClass = pageConfig.contentWidthClass ?? "max-w-5xl";
-  const headerNav = pageConfig.backAction ? (
+  const backAction = pageConfig.backAction ? (
     <HeaderBackAction href={pageConfig.backAction.href} label={pageConfig.backAction.label} />
-  ) : (
-    pageConfig.headerNav
-  );
-  const shouldRenderHeaderNavRow = pageConfig.showHeaderNavRow || Boolean(headerNav);
+  ) : null;
+  const headerNav = pageConfig.headerNav;
+  const centeredTitle = pageConfig.centeredTitle;
+  const topBarLeadingContent = pageConfig.topBarLeadingContent;
+  const shouldRenderHeaderNavRow =
+    pageConfig.showHeaderNavRow || Boolean(backAction) || Boolean(headerNav);
+  const shouldRenderTopBarBorder = Boolean(centeredTitle) && !shouldRenderHeaderNavRow;
   const shouldLockViewportScroll =
     issuanceTab === "playground" &&
     (pathname === "/dashboard/issuance" ||
@@ -384,47 +485,49 @@ export function DashboardShell({ children }: { children: ReactNode }) {
             ].join(" ")}
           >
             <div className="space-y-4">
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-3">
-                  {!isSidebarOpen ? (
-                    <motion.button
-                      type="button"
-                      aria-label="Open navigation"
-                      onClick={() => setSidebarOpen(true)}
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[rgba(28,28,29,0.72)] transition-colors hover:bg-[rgba(28,28,29,0.08)]"
-                      whileHover={{ scale: 1.05 }}
-                      whileTap={{ scale: 0.93, rotate: 8 }}
-                    >
-                      <motion.div
-                        initial={{ rotate: 10 }}
-                        animate={{ rotate: 0 }}
-                        transition={{ duration: 0.18 }}
-                      >
-                        <PanelRight className="h-4 w-4" />
-                      </motion.div>
-                    </motion.button>
-                  ) : null}
-                  <h1 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
-                    {pageConfig.title}
-                  </h1>
+              {shouldRenderTopBarBorder ? (
+                <div className="-mx-3 border-b border-[rgba(28,28,29,0.10)] px-3 pb-4 md:-mx-6 md:px-6">
+                  <DashboardTopBar
+                    isSidebarOpen={isSidebarOpen}
+                    setSidebarOpen={setSidebarOpen}
+                    hideTitle={pageConfig.hideTitle}
+                    title={pageConfig.title}
+                    centeredTitle={centeredTitle}
+                    topBarLeadingContent={topBarLeadingContent}
+                  />
                 </div>
-
-                <div className="flex items-center gap-2">
-                  <UserButton afterSignOutUrl="/sign-in" />
-                </div>
-              </div>
+              ) : (
+                <DashboardTopBar
+                  isSidebarOpen={isSidebarOpen}
+                  setSidebarOpen={setSidebarOpen}
+                  hideTitle={pageConfig.hideTitle}
+                  title={pageConfig.title}
+                  centeredTitle={centeredTitle}
+                  topBarLeadingContent={topBarLeadingContent}
+                />
+              )}
 
               {shouldRenderHeaderNavRow ? (
                 <div className="-mx-3 border-b border-[rgba(28,28,29,0.10)] md:-mx-6">
                   <div
                     className={[
                       "px-3 md:px-6",
-                      pageConfig.backAction
-                        ? "flex min-h-[56px] items-start pt-1"
-                        : "flex min-h-[56px] items-end",
+                      backAction && headerNav
+                        ? "grid min-h-[56px] grid-cols-[1fr_auto_1fr] items-center"
+                        : backAction
+                          ? "flex min-h-[56px] items-start pt-1"
+                          : "flex min-h-[56px] items-end",
                     ].join(" ")}
                   >
-                    {headerNav}
+                    {backAction && headerNav ? (
+                      <>
+                        <div className="flex items-center justify-start">{backAction}</div>
+                        <div className="flex items-center justify-center">{headerNav}</div>
+                        <div />
+                      </>
+                    ) : (
+                      (backAction ?? headerNav)
+                    )}
                   </div>
                 </div>
               ) : null}

--- a/apps/sdp-web/src/components/ui/select.tsx
+++ b/apps/sdp-web/src/components/ui/select.tsx
@@ -24,14 +24,14 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default";
+  size?: "sm" | "default" | "lg";
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 data-[size=lg]:h-12 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- move Payments send/receive into dedicated full-page flows instead of modal actions
- keep wallet transfer/deposit and ramp paths clearly separated within those flows
- tighten payments UX and compliance handling, including token symbol display for issued assets

## Testing
- pnpm lint
- pnpm --filter sdp-web typecheck
- pnpm --filter @sdp/api typecheck
- pnpm -C apps/sdp-api exec vitest run src/routes/compliance.test.ts -t 'treats Elliptic NotInBlockchain responses as a passed check'
