### PR TITLE
chore(api): bump Mosaic SDK to v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "@solana/instructions": "^5.0.0",
       "@solana/keys": "^5.0.0",
       "@solana/kit": "^5.0.0",
-      "@solana/mosaic-sdk": "0.1.0",
+      "@solana/mosaic-sdk": "0.1.1",
       "@solana/programs": "^5.0.0",
       "@solana/rpc": "^5.0.0",
       "@solana/signers": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^5.0.0
       version: 5.0.0
     '@solana/mosaic-sdk':
-      specifier: 0.1.0
-      version: 0.1.0
+      specifier: 0.1.1
+      version: 0.1.1
     '@solana/signers':
       specifier: ^5.0.0
       version: 5.4.0
@@ -97,7 +97,7 @@ importers:
         version: 0.1.2(@solana-program/token@0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)))(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
+        version: 0.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
       '@solana/signers':
         specifier: 'catalog:'
         version: 5.4.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -3362,8 +3362,8 @@ packages:
       '@solana-program/token': ^0.9.0
       '@solana/kit': ^5.0.0
 
-  '@solana/mosaic-sdk@0.1.0':
-    resolution: {integrity: sha512-vH6ATgvboOHKzGAlOVXhZjfMI5htPjaO1rSQVCFqcc9ng216/nsAjWl2A5NwdyeVc82vLmLBzj/Y7zgYqW/G7A==}
+  '@solana/mosaic-sdk@0.1.1':
+    resolution: {integrity: sha512-SsZ9PMMBhFuZo9z+vCTyQ8lC+/FJ2OxiVJXkXOnB0atLDRwk4n64JSmSIykvKzZeWFX3CSxuX54OOv4QU9nuXg==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -10034,7 +10034,7 @@ snapshots:
       '@solana-program/token': 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
       '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)
 
-  '@solana/mosaic-sdk@0.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
+  '@solana/mosaic-sdk@0.1.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0)':
     dependencies:
       '@solana-program/memo': 0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))
       '@solana-program/system': 0.10.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.19.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  # Aligned with @solana/mosaic-sdk v0.1.0 (uses @solana/kit ^5.0.0)
+  # Aligned with @solana/mosaic-sdk v0.1.1 (uses @solana/kit ^5.0.0)
   '@solana-program/system': ^0.10.0
   '@solana-program/token-2022': ^0.6.1
   '@solana/addresses': ^5.0.0
@@ -11,7 +11,7 @@ catalog:
   '@solana/instructions': ^5.0.0
   '@solana/keys': ^5.0.0
   '@solana/kit': ^5.0.0
-  '@solana/mosaic-sdk': 0.1.0
+  '@solana/mosaic-sdk': 0.1.1
   '@solana/programs': ^5.0.0
   '@solana/rpc': ^5.0.0
   '@solana/signers': ^5.0.0


### PR DESCRIPTION
## Summary
- bump `@solana/mosaic-sdk` from `0.1.0` to `0.1.1`
- update the workspace catalog and lockfile to the published npm release
- consume the upstream Mosaic fix for signer freeze authorities without on-chain accounts

## Why
Mosaic `0.1.1` includes the fix for signer-owned freeze authorities that do not have a live on-chain account. That was the root cause of the mint failure we traced for mint `3dJ8Qa5Z4soD37GgxNrAZq3hD4id2R4RZx9pEnVqjA1o`.

## Validation
- `pnpm --filter @sdp/api typecheck`
- direct SDP-side mint preparation against the real failing mint now succeeds with `@solana/mosaic-sdk@0.1.1`