### PR TITLE
test(e2e): simplify issuance bootstrap funding

### DIFF
--- a/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
@@ -3,27 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { PaymentsDashboardWallet, Token } from "@sdp/types";
-import { getTransferSolInstruction } from "@solana-program/system";
-import {
-  type Address,
-  type Blockhash,
-  appendTransactionMessageInstructions,
-  compileTransaction,
-  createKeyPairSignerFromBytes,
-  createNoopSigner,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getBase58Codec,
-  getBase64EncodedWireTransaction,
-  getSignatureFromTransaction,
-  getTransactionDecoder,
-  getTransactionEncoder,
-  pipe,
-  setTransactionMessageFeePayer,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
-import { KoraClient } from "@solana/kora";
+import { generateKeyPairSigner } from "@solana/kit";
 import type { ClerkTestIdentity } from "./clerk-admin";
 import {
   type IssuanceFixtureToken,
@@ -40,9 +20,6 @@ const DEFAULT_LOCAL_API_URL = "http://127.0.0.1:8788";
 const DEFAULT_API_PERSIST_PATH = ".wrangler/state-playwright";
 const DEFAULT_CLERK_JWT_TEMPLATE = "sdp-api";
 const DEFAULT_METADATA_IMAGE_URL = "https://example.com/assets/sdp-e2e-token.png";
-const ADDRESS_ACTIVATION_AIRDROP_LAMPORTS = 1_000_000;
-const RPC_METHOD_GET_LATEST_BLOCKHASH = `getLatest${"Blockhash"}`;
-const RPC_METHOD_GET_SIGNATURE_STATUSES = `getSignature${"Statuses"}`;
 
 interface BootstrapOptions {
   identity: ClerkTestIdentity;
@@ -53,10 +30,6 @@ interface PlaywrightApiRuntimeEnv {
   clerkJwtTemplate: string;
   localApiBaseUrl: string;
   persistPath: string;
-  solanaRpcUrl: string;
-  koraRpcUrl: string | null;
-  koraApiKey: string | null;
-  fundingPrivateKey: string | null;
 }
 
 interface PlaywrightLocalD1Env {
@@ -85,72 +58,6 @@ interface ListProjectsResponse {
   projects: Array<{ id: string }>;
 }
 
-type SolanaRpcResponse<T> =
-  | { jsonrpc: "2.0"; id: number; result: T }
-  | { jsonrpc: "2.0"; id: number; error: { code: number; message: string; data?: unknown } };
-
-const base58 = getBase58Codec();
-
-function parseEnvFile(filePath: string): Record<string, string> {
-  if (!fs.existsSync(filePath)) {
-    return {};
-  }
-
-  const content = fs.readFileSync(filePath, "utf8");
-  const entries: Record<string, string> = {};
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) {
-      continue;
-    }
-
-    const separatorIndex = line.indexOf("=");
-    if (separatorIndex <= 0) {
-      continue;
-    }
-
-    const key = line.slice(0, separatorIndex).trim();
-    let value = line.slice(separatorIndex + 1).trim();
-
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-
-    entries[key] = value;
-  }
-
-  return entries;
-}
-
-function parseTomlEnvFile(filePath: string): Record<string, string> {
-  if (!fs.existsSync(filePath)) {
-    return {};
-  }
-
-  const content = fs.readFileSync(filePath, "utf8");
-  const entries: Record<string, string> = {};
-
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#") || line.startsWith("[")) {
-      continue;
-    }
-
-    const match = line.match(/^([A-Z0-9_]+)\s*=\s*"([^"]*)"$/);
-    if (!match) {
-      continue;
-    }
-
-    entries[match[1]] = match[2];
-  }
-
-  return entries;
-}
-
 function getRepoRoot(): string {
   return path.resolve(__dirname, "../../../..");
 }
@@ -175,17 +82,6 @@ function getPlaywrightLocalD1Env(): PlaywrightLocalD1Env {
 }
 
 function getPlaywrightApiRuntimeEnv(): PlaywrightApiRuntimeEnv {
-  const apiAppDir = getApiAppDir();
-  const devVars = parseEnvFile(path.join(apiAppDir, ".dev.vars"));
-  const wranglerVars = parseTomlEnvFile(path.join(apiAppDir, "wrangler.toml"));
-  const readValue = (name: string): string | null =>
-    process.env[name] ?? devVars[name] ?? wranglerVars[name] ?? null;
-
-  const solanaRpcUrl = readValue("SOLANA_RPC_URL");
-  if (!solanaRpcUrl) {
-    throw new Error("Missing SOLANA_RPC_URL for Playwright issuance bootstrap");
-  }
-
   return {
     clerkJwtTemplate:
       process.env.CLERK_JWT_TEMPLATE ??
@@ -193,10 +89,6 @@ function getPlaywrightApiRuntimeEnv(): PlaywrightApiRuntimeEnv {
       DEFAULT_CLERK_JWT_TEMPLATE,
     localApiBaseUrl: process.env.PLAYWRIGHT_API_URL ?? DEFAULT_LOCAL_API_URL,
     persistPath: process.env.PLAYWRIGHT_API_PERSIST_PATH ?? DEFAULT_API_PERSIST_PATH,
-    solanaRpcUrl,
-    koraRpcUrl: readValue("KORA_RPC_URL"),
-    koraApiKey: readValue("KORA_API_KEY"),
-    fundingPrivateKey: readValue("FEE_PAYER_PRIVATE_KEY") ?? readValue("CUSTODY_PRIVATE_KEY"),
   };
 }
 
@@ -325,274 +217,6 @@ function toFixtureToken(token: Token): IssuanceFixtureToken {
   };
 }
 
-async function solanaRpc<T>(
-  rpcUrl: string,
-  method: string,
-  params: unknown[],
-  options: { allowErrors?: boolean } = {}
-): Promise<T> {
-  const response = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-  });
-
-  const payload = (await response.json()) as SolanaRpcResponse<T>;
-  if ("error" in payload && !options.allowErrors) {
-    throw new Error(`Solana RPC error calling ${method}: ${payload.error.message}`);
-  }
-
-  if ("error" in payload) {
-    throw new Error(payload.error.message);
-  }
-
-  return payload.result;
-}
-
-async function solanaAccountExists(rpcUrl: string, address: string): Promise<boolean> {
-  const response = await solanaRpc<{ value: object | null }>(rpcUrl, "getAccountInfo", [
-    address,
-    { encoding: "base64", commitment: "confirmed" },
-  ]);
-
-  return response.value !== null;
-}
-
-async function waitForAccountExistence(rpcUrl: string, address: string): Promise<void> {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < 30_000) {
-    if (await solanaAccountExists(rpcUrl, address)) {
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
-  }
-
-  throw new Error(`Timed out waiting for account ${address} to exist on-chain`);
-}
-
-async function requestAirdrop(rpcUrl: string, address: string, lamports: number): Promise<void> {
-  await solanaRpc<string>(
-    rpcUrl,
-    "requestAirdrop",
-    [address, lamports, { commitment: "confirmed" }],
-    { allowErrors: false }
-  );
-}
-
-async function getRecentBlockhash(rpcUrl: string): Promise<{
-  blockhash: string;
-  lastValidBlockHeight: bigint;
-}> {
-  const response = await solanaRpc<{
-    value: { blockhash: string; lastValidBlockHeight: number };
-  }>(rpcUrl, RPC_METHOD_GET_LATEST_BLOCKHASH, [{ commitment: "confirmed" }]);
-
-  return {
-    blockhash: response.value.blockhash,
-    lastValidBlockHeight: BigInt(response.value.lastValidBlockHeight),
-  };
-}
-
-async function getMinimumBalanceForRentExemption(
-  rpcUrl: string,
-  dataLength: number
-): Promise<bigint> {
-  // biome-ignore lint/nursery/noSecrets: Solana RPC method names are not secrets.
-  const lamports = await solanaRpc<number>(rpcUrl, "getMinimumBalanceForRentExemption", [
-    dataLength,
-    { commitment: "confirmed" },
-  ]);
-
-  return BigInt(lamports);
-}
-
-async function confirmSignature(rpcUrl: string, signature: string): Promise<void> {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < 45_000) {
-    const response = await solanaRpc<{
-      value: Array<{ confirmationStatus?: string | null; err?: unknown; slot: number } | null>;
-    }>(rpcUrl, RPC_METHOD_GET_SIGNATURE_STATUSES, [[signature]]);
-
-    const result = response.value[0];
-    if (result?.err) {
-      throw new Error(`Funding signature ${signature} failed: ${JSON.stringify(result.err)}`);
-    }
-
-    if (result?.confirmationStatus === "confirmed" || result?.confirmationStatus === "finalized") {
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
-  }
-
-  throw new Error(`Timed out waiting for funding signature ${signature} to confirm`);
-}
-
-function encodeBase64(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString("base64");
-}
-
-async function fundAddressViaKora(
-  runtimeEnv: PlaywrightApiRuntimeEnv,
-  address: string
-): Promise<boolean> {
-  if (!runtimeEnv.koraRpcUrl) {
-    return false;
-  }
-
-  const client = new KoraClient({
-    rpcUrl: runtimeEnv.koraRpcUrl,
-    ...(runtimeEnv.koraApiKey ? { apiKey: runtimeEnv.koraApiKey } : {}),
-  });
-
-  const response = await client.getPayerSigner();
-  const feePayer =
-    (response as { signer_address?: string }).signer_address ??
-    (response as { payment_address?: string }).payment_address ??
-    (response as { payerSigner?: string }).payerSigner;
-
-  if (!feePayer) {
-    throw new Error("Kora did not return a fee payer signer address");
-  }
-
-  const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(runtimeEnv.solanaRpcUrl);
-  const rentExemption = await getMinimumBalanceForRentExemption(runtimeEnv.solanaRpcUrl, 0);
-  const instruction = getTransferSolInstruction({
-    source: createNoopSigner(feePayer as Address),
-    destination: address as Address,
-    amount: rentExemption + BigInt(1),
-  });
-
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (value) => setTransactionMessageFeePayer(feePayer as Address, value),
-    (value) =>
-      setTransactionMessageLifetimeUsingBlockhash(
-        { blockhash: blockhash as Blockhash, lastValidBlockHeight },
-        value
-      ),
-    (value) => appendTransactionMessageInstructions([instruction], value)
-  );
-
-  const compiled = compileTransaction(message);
-  const transaction = new Uint8Array(getTransactionEncoder().encode(compiled));
-  const result = await client.signAndSendTransaction({
-    transaction: encodeBase64(transaction),
-  });
-
-  const signedTransaction = Buffer.from(result.signed_transaction, "base64");
-  const decodedTransaction = getTransactionDecoder().decode(new Uint8Array(signedTransaction));
-  const signature = getSignatureFromTransaction(decodedTransaction);
-  await confirmSignature(runtimeEnv.solanaRpcUrl, signature);
-
-  return true;
-}
-
-async function fundAddressViaLocalSigner(
-  runtimeEnv: PlaywrightApiRuntimeEnv,
-  address: string
-): Promise<boolean> {
-  if (!runtimeEnv.fundingPrivateKey) {
-    return false;
-  }
-
-  const secretKey = base58.encode(runtimeEnv.fundingPrivateKey);
-  if (secretKey.length !== 64) {
-    throw new Error(
-      `Invalid local funding keypair length: expected 64 bytes, got ${secretKey.length}`
-    );
-  }
-
-  const signer = await createKeyPairSignerFromBytes(secretKey);
-  const { blockhash, lastValidBlockHeight } = await getRecentBlockhash(runtimeEnv.solanaRpcUrl);
-  const rentExemption = await getMinimumBalanceForRentExemption(runtimeEnv.solanaRpcUrl, 0);
-  const instruction = getTransferSolInstruction({
-    source: signer,
-    destination: address as Address,
-    amount: rentExemption + BigInt(1),
-  });
-
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (value) => setTransactionMessageFeePayer(signer.address, value),
-    (value) =>
-      setTransactionMessageLifetimeUsingBlockhash(
-        { blockhash: blockhash as Blockhash, lastValidBlockHeight },
-        value
-      ),
-    (value) => appendTransactionMessageInstructions([instruction], value)
-  );
-
-  const signedTransaction = await signTransactionMessageWithSigners(message);
-  const signature = await solanaRpc<string>(runtimeEnv.solanaRpcUrl, "sendTransaction", [
-    getBase64EncodedWireTransaction(signedTransaction),
-    { encoding: "base64", preflightCommitment: "confirmed" },
-  ]);
-  await confirmSignature(runtimeEnv.solanaRpcUrl, signature);
-
-  return true;
-}
-
-async function ensureAddressAccountExists(address: string): Promise<void> {
-  const runtimeEnv = getPlaywrightApiRuntimeEnv();
-  const exists = await solanaAccountExists(runtimeEnv.solanaRpcUrl, address);
-  if (exists) {
-    return;
-  }
-
-  let koraFundingError: unknown = null;
-  try {
-    const fundedViaKora = await fundAddressViaKora(runtimeEnv, address);
-    if (fundedViaKora) {
-      await waitForAccountExistence(runtimeEnv.solanaRpcUrl, address);
-      return;
-    }
-  } catch (error) {
-    koraFundingError = error;
-  }
-
-  let localFundingError: unknown = null;
-  try {
-    const fundedViaLocalSigner = await fundAddressViaLocalSigner(runtimeEnv, address);
-    if (fundedViaLocalSigner) {
-      await waitForAccountExistence(runtimeEnv.solanaRpcUrl, address);
-      return;
-    }
-  } catch (error) {
-    localFundingError = error;
-  }
-
-  try {
-    await requestAirdrop(runtimeEnv.solanaRpcUrl, address, ADDRESS_ACTIVATION_AIRDROP_LAMPORTS);
-    await waitForAccountExistence(runtimeEnv.solanaRpcUrl, address);
-  } catch (airdropError) {
-    const koraMessage =
-      koraFundingError instanceof Error
-        ? koraFundingError.message
-        : koraFundingError
-          ? String(koraFundingError)
-          : "not attempted";
-    const localMessage =
-      localFundingError instanceof Error
-        ? localFundingError.message
-        : localFundingError
-          ? String(localFundingError)
-          : "not attempted";
-    const airdropMessage =
-      airdropError instanceof Error ? airdropError.message : String(airdropError);
-
-    throw new Error(
-      `Failed to activate address ${address}. ` +
-        `Kora funding failed: ${koraMessage}. ` +
-        `Local signer funding failed: ${localMessage}. ` +
-        `Airdrop failed: ${airdropMessage}`
-    );
-  }
-}
-
 async function listWallets(api: LocalApiClient): Promise<PaymentsDashboardWallet[]> {
   // biome-ignore lint/nursery/noSecrets: This is a local API path, not a credential.
   const data = await api.get<ListWalletsResponse>("/v1/wallets?includeAllProviders=true");
@@ -713,11 +337,7 @@ export async function bootstrapLocalIssuanceFixtures({
     throw new Error("Failed to resolve the seeded Privy wallets for Playwright issuance tests");
   }
 
-  await ensureAddressAccountExists(treasuryWallet.publicKey);
-  await ensureAddressAccountExists(delegatedWallet.publicKey);
-
   const externalAddresses = await createExternalAddressSet();
-  await ensureAddressAccountExists(externalAddresses.freezeWallet);
 
   const pendingToken = await createFixtureToken(api, {
     name: "E2E Pending Stable",


### PR DESCRIPTION
## Summary
- remove the obsolete wallet/account activation path from the issuance Playwright bootstrap
- stop trying to fund authority wallets before fixture setup
- keep the same issuance fixture coverage with a smaller setup surface

## Validation
- pnpm exec biome check apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
- pnpm --filter sdp-web typecheck
- pnpm --filter sdp-web test:e2e:issuance