### PR TITLE
feat(observability): trace slow dashboard page loads

### DIFF
--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -15,6 +15,7 @@ import { AppError } from "@/lib/errors";
 import { corsMiddleware } from "@/middleware/cors";
 import { skipRateLimitPaths } from "@/middleware/rate-limit";
 import { requestIdMiddleware } from "@/middleware/request-id";
+import { requestTracingMiddleware } from "@/middleware/request-tracing";
 import type { Env } from "@/types/env";
 
 import allowlist from "@/routes/allowlist";
@@ -79,10 +80,14 @@ function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void
   }
 
   const requestId = c.get("requestId");
+  const traceId = c.get("traceId");
+  const requestSource = c.get("requestSource");
   const path = new URL(c.req.url).pathname;
 
   Sentry.withScope((scope) => {
     scope.setTag("request_id", requestId);
+    scope.setTag("trace_id", traceId);
+    scope.setTag("request_source", requestSource);
     scope.setTag("http_method", c.req.method);
     scope.setTag("http_path", path);
 
@@ -120,6 +125,9 @@ function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void
 
 // Request ID for tracing
 app.use("*", requestIdMiddleware());
+
+// Request trace + duration logging
+app.use("*", requestTracingMiddleware());
 
 // Security headers
 app.use("*", secureHeaders());
@@ -191,8 +199,11 @@ app.get("/", (c) => c.redirect("/health"));
 
 app.onError((err, c) => {
   const requestId = c.get("requestId");
+  const traceId = c.get("traceId");
+  const requestSource = c.get("requestSource");
 
   if (err instanceof AppError) {
+    c.header("X-SDP-Trace-ID", traceId);
     return c.json(
       {
         error: {
@@ -209,11 +220,14 @@ app.onError((err, c) => {
   // Log unexpected errors
   console.error("Unexpected error:", {
     requestId,
+    traceId,
+    source: requestSource,
     error: err.message,
     stack: err.stack,
   });
   captureUnexpectedError(err, c);
 
+  c.header("X-SDP-Trace-ID", traceId);
   return c.json(
     {
       error: {

--- a/apps/sdp-api/src/middleware/index.ts
+++ b/apps/sdp-api/src/middleware/index.ts
@@ -7,3 +7,4 @@ export { clerkAuthMiddleware, optionalClerkAuth } from "./clerk-auth";
 export { corsMiddleware } from "./cors";
 export { rateLimitMiddleware, skipRateLimitPaths } from "./rate-limit";
 export { requestIdMiddleware } from "./request-id";
+export { requestTracingMiddleware } from "./request-tracing";

--- a/apps/sdp-api/src/middleware/request-tracing.ts
+++ b/apps/sdp-api/src/middleware/request-tracing.ts
@@ -1,0 +1,87 @@
+import type { Env } from "@/types/env";
+import type { Context, Next } from "hono";
+
+const TRACE_ID_HEADER = "X-SDP-Trace-ID";
+const TRACE_SOURCE_HEADER = "X-SDP-Trace-Source";
+const MAX_TRACE_ID_LENGTH = 128;
+const MAX_TRACE_SOURCE_LENGTH = 64;
+const TRACE_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const TRACE_SOURCE_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+function roundDuration(durationMs: number): number {
+  return Math.round(durationMs * 10) / 10;
+}
+
+function appendServerTiming(existingValue: string | null, nextEntry: string): string {
+  return existingValue ? `${existingValue}, ${nextEntry}` : nextEntry;
+}
+
+function normalizeHeaderValue(
+  value: string | null | undefined,
+  maxLength: number,
+  pattern: RegExp
+): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidate = trimmed.slice(0, maxLength);
+  if (!pattern.test(candidate)) {
+    return null;
+  }
+
+  return candidate;
+}
+
+export function requestTracingMiddleware() {
+  return async (c: Context<{ Bindings: Env }>, next: Next) => {
+    const startedAt = performance.now();
+    const requestId = c.get("requestId");
+    const traceId =
+      normalizeHeaderValue(c.req.header(TRACE_ID_HEADER), MAX_TRACE_ID_LENGTH, TRACE_ID_PATTERN) ||
+      requestId;
+    const requestSource =
+      normalizeHeaderValue(
+        c.req.header(TRACE_SOURCE_HEADER),
+        MAX_TRACE_SOURCE_LENGTH,
+        TRACE_SOURCE_PATTERN
+      ) || "unknown";
+
+    c.set("traceId", traceId);
+    c.set("requestSource", requestSource);
+
+    try {
+      await next();
+    } finally {
+      if (c.res) {
+        const durationMs = roundDuration(performance.now() - startedAt);
+        const pathname = new URL(c.req.url).pathname;
+
+        c.header(TRACE_ID_HEADER, traceId);
+        c.header(
+          "Server-Timing",
+          appendServerTiming(c.res.headers.get("Server-Timing"), `app;dur=${durationMs}`)
+        );
+
+        console.info(
+          JSON.stringify({
+            event: "sdp_api_request_timing",
+            timestamp: new Date().toISOString(),
+            requestId,
+            traceId,
+            source: requestSource,
+            method: c.req.method,
+            path: pathname,
+            status: c.res.status,
+            durationMs,
+          })
+        );
+      }
+    }
+  };
+}

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -200,5 +200,7 @@ declare module "hono" {
       email: string;
     };
     requestId: string;
+    traceId: string;
+    requestSource: string;
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/compliance/address-screenings/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/compliance/address-screenings/route.ts
@@ -1,10 +1,15 @@
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
+  const trace = createTimedTrace("route.dashboard.compliance.address_screenings", request);
+
   try {
     const body = await request.text();
-    const apiClient = await createSdpApiClient();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.compliance.address_screenings.api")
+    );
     const response = await apiClient.request("/v1/compliance/address-screenings", {
       method: "POST",
       headers: {
@@ -16,18 +21,36 @@ export async function POST(request: Request) {
     const responseBody = await response.text();
     const contentType = response.headers.get("Content-Type") ?? "application/json";
 
-    return new NextResponse(responseBody, {
+    const nextResponse = new NextResponse(responseBody, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
       },
     });
+
+    logRouteResult(trace, response.status, {
+      bodyBytes: body.length,
+    });
+
+    return nextResponse;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Compliance request failed",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Compliance request failed",
+    });
+    return response;
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/payments/transfers/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/transfers/route.ts
@@ -1,9 +1,14 @@
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
+  const trace = createTimedTrace("route.dashboard.payments.transfers.get", request);
+
   try {
-    const apiClient = await createSdpApiClient();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.payments.transfers.api")
+    );
     const url = new URL(request.url);
     const search = url.searchParams.toString();
     const response = await apiClient.request(
@@ -16,26 +21,48 @@ export async function GET(request: Request) {
     const responseBody = await response.text();
     const contentType = response.headers.get("Content-Type") ?? "application/json";
 
-    return new NextResponse(responseBody, {
+    const nextResponse = new NextResponse(responseBody, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
       },
     });
+
+    logRouteResult(trace, response.status, {
+      query: search,
+    });
+
+    return nextResponse;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Transfer list request failed",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Transfer list request failed",
+    });
+    return response;
   }
 }
 
 export async function POST(request: Request) {
+  const trace = createTimedTrace("route.dashboard.payments.transfers.post", request);
+
   try {
     const body = await request.text();
-    const apiClient = await createSdpApiClient();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.payments.transfers.api")
+    );
     const response = await apiClient.request("/v1/payments/transfers", {
       method: "POST",
       headers: {
@@ -47,18 +74,36 @@ export async function POST(request: Request) {
     const responseBody = await response.text();
     const contentType = response.headers.get("Content-Type") ?? "application/json";
 
-    return new NextResponse(responseBody, {
+    const nextResponse = new NextResponse(responseBody, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
       },
     });
+
+    logRouteResult(trace, response.status, {
+      bodyBytes: body.length,
+    });
+
+    return nextResponse;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Transfer request failed",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Transfer request failed",
+    });
+    return response;
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/wallets/aggregate/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/wallets/aggregate/route.ts
@@ -1,9 +1,14 @@
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
+  const trace = createTimedTrace("route.dashboard.wallets.aggregate", request);
+
   try {
-    const apiClient = await createSdpApiClient();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.wallets.aggregate.api")
+    );
     const url = new URL(request.url);
     const query = new URLSearchParams(url.searchParams);
 
@@ -17,18 +22,36 @@ export async function GET(request: Request) {
     const body = await response.text();
     const contentType = response.headers.get("Content-Type") ?? "application/json";
 
-    return new NextResponse(body, {
+    const nextResponse = new NextResponse(body, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
       },
     });
+
+    logRouteResult(trace, response.status, {
+      query: query.toString(),
+    });
+
+    return nextResponse;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Failed to fetch aggregate wallet balances",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to fetch aggregate wallet balances",
+    });
+    return response;
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/wallets/quick-action-status/route.ts
@@ -3,6 +3,7 @@ import {
   type KnownCustodyProvider,
   isKnownCustodyProvider,
 } from "@/app/dashboard/custody/provider-catalog";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
@@ -33,30 +34,54 @@ function formatProviderHint(providerLabels: string[]): string {
   return `${head}, or ${tail}`;
 }
 
-export async function GET() {
+export async function GET(request: Request) {
+  const trace = createTimedTrace("route.dashboard.wallets.quick_action_status", request);
+
   try {
-    const apiClient = await createSdpApiClient();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.wallets.quick_action_status.api")
+    );
     const [onboarding, configsResponse] = await Promise.all([
       apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status"),
       apiClient.request("/v1/wallets/configs"),
     ]);
 
     if (!onboarding.linked) {
-      return NextResponse.json({
-        custodyEnabled: false,
-        walletProvisioningEnabled: false,
-        walletProvisioningReason: "Enable wallets first in the custody providers section.",
-        walletProvisioningProviders: [] as KnownCustodyProvider[],
-      });
+      const response = NextResponse.json(
+        {
+          custodyEnabled: false,
+          walletProvisioningEnabled: false,
+          walletProvisioningReason: "Enable wallets first in the custody providers section.",
+          walletProvisioningProviders: [] as KnownCustodyProvider[],
+        },
+        {
+          headers: {
+            "X-SDP-Trace-ID": trace.traceId,
+            "Server-Timing": trace.serverTiming(),
+          },
+        }
+      );
+      logRouteResult(trace, 200, { linked: false });
+      return response;
     }
 
     if (configsResponse.status === 404) {
-      return NextResponse.json({
-        custodyEnabled: false,
-        walletProvisioningEnabled: false,
-        walletProvisioningReason: "Enable wallets first in the custody providers section.",
-        walletProvisioningProviders: [] as KnownCustodyProvider[],
-      });
+      const response = NextResponse.json(
+        {
+          custodyEnabled: false,
+          walletProvisioningEnabled: false,
+          walletProvisioningReason: "Enable wallets first in the custody providers section.",
+          walletProvisioningProviders: [] as KnownCustodyProvider[],
+        },
+        {
+          headers: {
+            "X-SDP-Trace-ID": trace.traceId,
+            "Server-Timing": trace.serverTiming(),
+          },
+        }
+      );
+      logRouteResult(trace, 200, { configsMissing: true });
+      return response;
     }
 
     if (!configsResponse.ok) {
@@ -86,19 +111,44 @@ export async function GET() {
         ? `Connect ${formatProviderHint(additionalWalletProviderLabels)} to create additional wallets.`
         : "Enable wallets first in the custody providers section.";
 
-    return NextResponse.json({
+    const response = NextResponse.json(
+      {
+        custodyEnabled,
+        walletProvisioningEnabled,
+        walletProvisioningReason,
+        walletProvisioningProviders,
+      },
+      {
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+    logRouteResult(trace, 200, {
       custodyEnabled,
       walletProvisioningEnabled,
-      walletProvisioningReason,
-      walletProvisioningProviders,
+      providerCount: walletProvisioningProviders.length,
     });
+    return response;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error:
           error instanceof Error ? error.message : "Failed to resolve wallet quick action status",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error:
+        error instanceof Error ? error.message : "Failed to resolve wallet quick action status",
+    });
+    return response;
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/wallets/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/wallets/route.ts
@@ -1,9 +1,12 @@
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
+  const trace = createTimedTrace("route.dashboard.wallets", request);
+
   try {
-    const apiClient = await createSdpApiClient();
+    const apiClient = await createSdpApiClient(trace.childContext("route.dashboard.wallets.api"));
     const url = new URL(request.url);
     const query = new URLSearchParams(url.searchParams);
 
@@ -17,18 +20,36 @@ export async function GET(request: Request) {
     const body = await response.text();
     const contentType = response.headers.get("Content-Type") ?? "application/json";
 
-    return new NextResponse(body, {
+    const nextResponse = new NextResponse(body, {
       status: response.status,
       headers: {
         "Content-Type": contentType,
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
       },
     });
+
+    logRouteResult(trace, response.status, {
+      query: query.toString(),
+    });
+
+    return nextResponse;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Failed to fetch wallets",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to fetch wallets",
+    });
+    return response;
   }
 }

--- a/apps/sdp-web/src/app/api/playground/execute/route.ts
+++ b/apps/sdp-web/src/app/api/playground/execute/route.ts
@@ -1,3 +1,4 @@
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { sdpApiRequest } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
@@ -13,20 +14,55 @@ interface PlaygroundExecuteRequestBody {
 const ALLOWED_METHODS = new Set<PlaygroundMethod>(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 
 export async function POST(request: Request) {
+  const trace = createTimedTrace("route.playground.execute", request);
+
   try {
     const payload = (await request.json()) as PlaygroundExecuteRequestBody;
     const method = payload.method;
     const path = payload.path;
 
     if (!method || !ALLOWED_METHODS.has(method)) {
-      return NextResponse.json({ error: "Invalid method" }, { status: 400 });
+      const response = NextResponse.json(
+        { error: "Invalid method" },
+        {
+          status: 400,
+          headers: {
+            "X-SDP-Trace-ID": trace.traceId,
+            "Server-Timing": trace.serverTiming(),
+          },
+        }
+      );
+      logRouteResult(trace, 400, { error: "Invalid method" });
+      return response;
     }
 
     if (!path || typeof path !== "string") {
-      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+      const response = NextResponse.json(
+        { error: "Invalid path" },
+        {
+          status: 400,
+          headers: {
+            "X-SDP-Trace-ID": trace.traceId,
+            "Server-Timing": trace.serverTiming(),
+          },
+        }
+      );
+      logRouteResult(trace, 400, { error: "Invalid path" });
+      return response;
     }
     if (!path.startsWith("/")) {
-      return NextResponse.json({ error: "Path must start with '/'" }, { status: 400 });
+      const response = NextResponse.json(
+        { error: "Path must start with '/'" },
+        {
+          status: 400,
+          headers: {
+            "X-SDP-Trace-ID": trace.traceId,
+            "Server-Timing": trace.serverTiming(),
+          },
+        }
+      );
+      logRouteResult(trace, 400, { error: "Path must start with '/'" });
+      return response;
     }
 
     const normalizedApiKey = typeof payload.apiKey === "string" ? payload.apiKey.trim() : "";
@@ -36,17 +72,21 @@ export async function POST(request: Request) {
       headers.Authorization = `Bearer ${normalizedApiKey}`;
     }
 
-    const response = await sdpApiRequest(path, {
-      method,
-      headers,
-      body:
-        method !== "GET" &&
-        method !== "DELETE" &&
-        payload.body !== null &&
-        payload.body !== undefined
-          ? JSON.stringify(payload.body)
-          : undefined,
-    });
+    const response = await sdpApiRequest(
+      path,
+      {
+        method,
+        headers,
+        body:
+          method !== "GET" &&
+          method !== "DELETE" &&
+          payload.body !== null &&
+          payload.body !== undefined
+            ? JSON.stringify(payload.body)
+            : undefined,
+      },
+      trace.childContext("route.playground.execute.api")
+    );
 
     const text = await response.text();
     const body = text
@@ -59,18 +99,44 @@ export async function POST(request: Request) {
         })()
       : {};
 
-    return NextResponse.json({
+    const nextResponse = NextResponse.json(
+      {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        body,
+      },
+      {
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, response.status, {
+      method,
+      path,
       ok: response.ok,
-      status: response.status,
-      statusText: response.statusText,
-      body,
     });
+
+    return nextResponse;
   } catch (error) {
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Playground execution failed",
       },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
     );
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Playground execution failed",
+    });
+    return response;
   }
 }

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -6,7 +6,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { createSdpApiClient, sdpApiFetch } from "@/lib/sdp-api";
+import { createTimedTrace } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import { redirect } from "next/navigation";
@@ -28,59 +29,85 @@ export default async function ApiKeysPage() {
     redirect("/dashboard");
   }
 
-  const apiClient = await createSdpApiClient();
-  const [flash, apiKeysResponse, walletsResponse] = await Promise.all([
-    consumeApiKeyFlash(),
-    sdpApiFetch<{ apiKeys: ApiKeyRecord[] }>("/v1/api-keys"),
-    fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
-  ]);
+  const trace = createTimedTrace("dashboard.api_keys.page");
 
-  const apiKeys = apiKeysResponse.apiKeys;
-  const hasGeneratedKeyFlash = Boolean(flash?.key);
-  const wallets: PaymentsDashboardWallet[] = walletsResponse.ok ? (walletsResponse.data ?? []) : [];
+  try {
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.api_keys.api"))
+    );
+    const [flash, apiKeysResponse, walletsResponse] = await Promise.all([
+      trace.step("consume_api_key_flash", () => consumeApiKeyFlash()),
+      trace.step("fetch_api_keys", () =>
+        apiClient.fetch<{ apiKeys: ApiKeyRecord[] }>("/v1/api-keys")
+      ),
+      trace.step("fetch_wallets", () =>
+        fetchPaymentsWallets(apiClient.request, { includeBalances: false })
+      ),
+    ]);
 
-  return (
-    <div className="w-full flex flex-col gap-6">
-      {flash ? (
-        <>
-          {!hasGeneratedKeyFlash ? <FlashClearTrigger /> : null}
-          {hasGeneratedKeyFlash ? (
-            <GeneratedApiKeyModal
-              keyValue={flash.key ?? ""}
-              message={flash.message}
-              keyPrefix={flash.keyPrefix}
-            />
-          ) : (
-            <Card
-              className={flash.level === "error" ? "border-[#c71f37]/25" : "border-[#1c1c1d]/12"}
-            >
-              <CardHeader>
-                <CardTitle>{flash.level === "error" ? "Action failed" : "Notice"}</CardTitle>
-                <CardDescription>{flash.message}</CardDescription>
-              </CardHeader>
-            </Card>
-          )}
-        </>
-      ) : null}
+    const apiKeys = apiKeysResponse.apiKeys;
+    const hasGeneratedKeyFlash = Boolean(flash?.key);
+    const wallets: PaymentsDashboardWallet[] = walletsResponse.ok
+      ? (walletsResponse.data ?? [])
+      : [];
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Existing API keys</CardTitle>
-          <CardDescription>Active and historical keys for this workspace.</CardDescription>
-          <CardAction>
-            <CreateApiKeyModal triggerLabel="New API key" wallets={wallets} />
-          </CardAction>
-        </CardHeader>
-        <CardContent>
-          <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
-            <p className="text-xs text-[rgba(28,28,29,0.72)]">
-              Rotation hint: rotate active keys only. The dashboard uses a 24-hour grace period; use
-              the API for custom grace values (0-168h). New key secrets are shown once.
-            </p>
-          </div>
-          <ApiKeysTableClient initialApiKeys={apiKeys} />
-        </CardContent>
-      </Card>
-    </div>
-  );
+    trace.log({
+      ok: true,
+      apiKeyCount: apiKeys.length,
+      walletCount: wallets.length,
+      hasFlash: Boolean(flash),
+      hasGeneratedKeyFlash,
+    });
+
+    return (
+      <div className="w-full flex flex-col gap-6">
+        {flash ? (
+          <>
+            {!hasGeneratedKeyFlash ? <FlashClearTrigger /> : null}
+            {hasGeneratedKeyFlash ? (
+              <GeneratedApiKeyModal
+                keyValue={flash.key ?? ""}
+                message={flash.message}
+                keyPrefix={flash.keyPrefix}
+              />
+            ) : (
+              <Card
+                className={flash.level === "error" ? "border-[#c71f37]/25" : "border-[#1c1c1d]/12"}
+              >
+                <CardHeader>
+                  <CardTitle>{flash.level === "error" ? "Action failed" : "Notice"}</CardTitle>
+                  <CardDescription>{flash.message}</CardDescription>
+                </CardHeader>
+              </Card>
+            )}
+          </>
+        ) : null}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Existing API keys</CardTitle>
+            <CardDescription>Active and historical keys for this workspace.</CardDescription>
+            <CardAction>
+              <CreateApiKeyModal triggerLabel="New API key" wallets={wallets} />
+            </CardAction>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
+              <p className="text-xs text-[rgba(28,28,29,0.72)]">
+                Rotation hint: rotate active keys only. The dashboard uses a 24-hour grace period;
+                use the API for custom grace values (0-168h). New key secrets are shown once.
+              </p>
+            </div>
+            <ApiKeysTableClient initialApiKeys={apiKeys} />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  } catch (error) {
+    trace.log({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
 }

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -13,6 +13,7 @@ import {
 import { linkOrganization } from "@/app/onboarding/actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import type { CustodyConfigSummary, CustodyWalletSummary } from "@sdp/types";
@@ -137,52 +138,79 @@ export default async function CustodyPage() {
     redirect("/dashboard");
   }
 
-  const apiClient = await createSdpApiClient();
-  const onboarding = await apiClient.fetch<{ linked: boolean }>("/v1/onboarding/status");
+  const trace = createTimedTrace("dashboard.custody.page");
 
-  if (!onboarding.linked) {
+  try {
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.custody.api"))
+    );
+    const onboarding = await trace.step("fetch_onboarding_status", () =>
+      apiClient.fetch<{ linked: boolean }>("/v1/onboarding/status")
+    );
+
+    if (!onboarding.linked) {
+      trace.log({
+        ok: true,
+        linked: false,
+      });
+
+      return (
+        <Suspense fallback={<WalletsOnboardingSkeleton />}>
+          <OnboardingGateSection orgId={orgId} />
+        </Suspense>
+      );
+    }
+
+    const [configsResult, walletsResult, apiKeysResult] = await Promise.all([
+      trace.step("fetch_custody_configs", () => settle(getCustodyConfigs(apiClient.request))),
+      trace.step("fetch_custody_wallets", () => settle(getCustodyWallets(apiClient.request))),
+      trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
+    ]);
+
+    const connectedProviders: KnownCustodyProvider[] = configsResult.ok
+      ? configsResult.value.configs
+          .filter((config) => config.status === "active")
+          .map((config) => config.provider)
+          .filter(isKnownCustodyProvider)
+      : [];
+
+    const configsError = configsResult.ok
+      ? null
+      : configsResult.error instanceof Error
+        ? configsResult.error.message
+        : "Unable to load wallet providers";
+    const walletsError = walletsResult.ok
+      ? null
+      : walletsResult.error instanceof Error
+        ? walletsResult.error.message
+        : "Unable to load wallets";
+    const apiKeys = apiKeysResult.ok ? (apiKeysResult.data ?? []) : [];
+
+    trace.log({
+      ok: true,
+      linked: true,
+      connectedProviderCount: connectedProviders.length,
+      walletCount: walletsResult.ok ? walletsResult.value.length : 0,
+      apiKeyCount: apiKeys.length,
+    });
+
     return (
-      <Suspense fallback={<WalletsOnboardingSkeleton />}>
-        <OnboardingGateSection orgId={orgId} />
+      <Suspense fallback={<WalletsPageSkeleton />}>
+        <WalletsWorkspace
+          apiBaseUrl={resolvePlaygroundApiBaseUrl()}
+          apiKeys={apiKeys}
+          connectedProviders={connectedProviders}
+          configsError={configsError}
+          wallets={walletsResult.ok ? walletsResult.value : []}
+          walletsError={walletsError}
+        />
       </Suspense>
     );
+  } catch (error) {
+    trace.log({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
   }
-
-  const [configsResult, walletsResult, apiKeysResult] = await Promise.all([
-    settle(getCustodyConfigs(apiClient.request)),
-    settle(getCustodyWallets(apiClient.request)),
-    fetchActiveApiKeys(apiClient.request),
-  ]);
-
-  const connectedProviders: KnownCustodyProvider[] = configsResult.ok
-    ? configsResult.value.configs
-        .filter((config) => config.status === "active")
-        .map((config) => config.provider)
-        .filter(isKnownCustodyProvider)
-    : [];
-
-  const configsError = configsResult.ok
-    ? null
-    : configsResult.error instanceof Error
-      ? configsResult.error.message
-      : "Unable to load wallet providers";
-  const walletsError = walletsResult.ok
-    ? null
-    : walletsResult.error instanceof Error
-      ? walletsResult.error.message
-      : "Unable to load wallets";
-  const apiKeys = apiKeysResult.ok ? (apiKeysResult.data ?? []) : [];
-
-  return (
-    <Suspense fallback={<WalletsPageSkeleton />}>
-      <WalletsWorkspace
-        apiBaseUrl={resolvePlaygroundApiBaseUrl()}
-        apiKeys={apiKeys}
-        connectedProviders={connectedProviders}
-        configsError={configsError}
-        wallets={walletsResult.ok ? walletsResult.value : []}
-        walletsError={walletsError}
-      />
-    </Suspense>
-  );
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
@@ -1,3 +1,4 @@
+import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import type { FrozenAccount, Token, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
@@ -103,69 +104,106 @@ export default async function IssuanceTokenManagementPage({ params }: TokenManag
   }
 
   const { tokenId } = await params;
-  const apiClient = await createSdpApiClient();
+  const trace = createTimedTrace("dashboard.issuance.token.page");
 
-  const [tokenResult, walletsResult, transactionsResult, allowlistResult, frozenResult] =
-    await Promise.all([
-      fetchData<Token | null>(apiClient.request, `/v1/issuance/tokens/${tokenId}`, mapToken),
-      fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
-      fetchData<TokenTransaction[]>(
-        apiClient.request,
-        `/v1/issuance/tokens/${tokenId}/transactions?page=1&pageSize=100`,
-        (payload) => mapList<TokenTransaction>(payload)
-      ),
-      fetchData<TokenAllowlistEntry[]>(
-        apiClient.request,
-        `/v1/issuance/tokens/${tokenId}/allowlist?page=1&pageSize=100`,
-        (payload) => mapList<TokenAllowlistEntry>(payload)
-      ),
-      fetchData<FrozenAccount[]>(
-        apiClient.request,
-        `/v1/issuance/tokens/${tokenId}/frozen?page=1&pageSize=100`,
-        (payload) => mapList<FrozenAccount>(payload)
-      ),
-    ]);
+  try {
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.issuance.token.api"))
+    );
 
-  if (tokenResult.status === 404 || !tokenResult.data) {
-    notFound();
+    const [tokenResult, walletsResult, transactionsResult, allowlistResult, frozenResult] =
+      await Promise.all([
+        trace.step("fetch_token", () =>
+          fetchData<Token | null>(apiClient.request, `/v1/issuance/tokens/${tokenId}`, mapToken)
+        ),
+        trace.step("fetch_authority_wallets", () =>
+          fetchPaymentsWallets(apiClient.request, { includeBalances: false })
+        ),
+        trace.step("fetch_transactions", () =>
+          fetchData<TokenTransaction[]>(
+            apiClient.request,
+            `/v1/issuance/tokens/${tokenId}/transactions?page=1&pageSize=100`,
+            (payload) => mapList<TokenTransaction>(payload)
+          )
+        ),
+        trace.step("fetch_allowlist", () =>
+          fetchData<TokenAllowlistEntry[]>(
+            apiClient.request,
+            `/v1/issuance/tokens/${tokenId}/allowlist?page=1&pageSize=100`,
+            (payload) => mapList<TokenAllowlistEntry>(payload)
+          )
+        ),
+        trace.step("fetch_frozen_accounts", () =>
+          fetchData<FrozenAccount[]>(
+            apiClient.request,
+            `/v1/issuance/tokens/${tokenId}/frozen?page=1&pageSize=100`,
+            (payload) => mapList<FrozenAccount>(payload)
+          )
+        ),
+      ]);
+
+    if (tokenResult.status === 404 || !tokenResult.data) {
+      trace.log({
+        ok: false,
+        tokenId,
+        notFound: true,
+      });
+      notFound();
+    }
+
+    trace.log({
+      ok: true,
+      tokenId,
+      transactionCount: transactionsResult.data?.length ?? 0,
+      allowlistCount: allowlistResult.data?.length ?? 0,
+      frozenCount: frozenResult.data?.length ?? 0,
+      authorityWalletCount: walletsResult.data?.length ?? 0,
+    });
+
+    return (
+      <TokenManagementWorkspace
+        token={tokenResult.data}
+        tokenError={
+          tokenResult.error
+            ? `Token API ${tokenResult.status ?? "unavailable"}: ${tokenResult.error}`
+            : null
+        }
+        authorityWallets={walletsResult.ok ? (walletsResult.data ?? []) : []}
+        authorityWalletsError={
+          walletsResult.ok ? null : (walletsResult.error ?? "Wallets unavailable")
+        }
+        transactions={transactionsResult.data ?? []}
+        transactionsError={
+          transactionsResult.error
+            ? `Transactions API ${transactionsResult.status ?? "unavailable"}: ${transactionsResult.error}`
+            : null
+        }
+        transactionsTotal={transactionsResult.total}
+        transactionsHasMore={transactionsResult.hasMore}
+        allowlistEntries={allowlistResult.data ?? []}
+        allowlistError={
+          allowlistResult.error
+            ? `Allowlist API ${allowlistResult.status ?? "unavailable"}: ${allowlistResult.error}`
+            : null
+        }
+        allowlistTotal={allowlistResult.total}
+        allowlistHasMore={allowlistResult.hasMore}
+        frozenAccounts={frozenResult.data ?? []}
+        frozenAccountsError={
+          frozenResult.error
+            ? `Frozen API ${frozenResult.status ?? "unavailable"}: ${frozenResult.error}`
+            : null
+        }
+        frozenAccountsTotal={frozenResult.total}
+        frozenAccountsHasMore={frozenResult.hasMore}
+      />
+    );
+  } catch (error) {
+    trace.log({
+      ok: false,
+      tokenId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
   }
-
-  return (
-    <TokenManagementWorkspace
-      token={tokenResult.data}
-      tokenError={
-        tokenResult.error
-          ? `Token API ${tokenResult.status ?? "unavailable"}: ${tokenResult.error}`
-          : null
-      }
-      authorityWallets={walletsResult.ok ? (walletsResult.data ?? []) : []}
-      authorityWalletsError={
-        walletsResult.ok ? null : (walletsResult.error ?? "Wallets unavailable")
-      }
-      transactions={transactionsResult.data ?? []}
-      transactionsError={
-        transactionsResult.error
-          ? `Transactions API ${transactionsResult.status ?? "unavailable"}: ${transactionsResult.error}`
-          : null
-      }
-      transactionsTotal={transactionsResult.total}
-      transactionsHasMore={transactionsResult.hasMore}
-      allowlistEntries={allowlistResult.data ?? []}
-      allowlistError={
-        allowlistResult.error
-          ? `Allowlist API ${allowlistResult.status ?? "unavailable"}: ${allowlistResult.error}`
-          : null
-      }
-      allowlistTotal={allowlistResult.total}
-      allowlistHasMore={allowlistResult.hasMore}
-      frozenAccounts={frozenResult.data ?? []}
-      frozenAccountsError={
-        frozenResult.error
-          ? `Frozen API ${frozenResult.status ?? "unavailable"}: ${frozenResult.error}`
-          : null
-      }
-      frozenAccountsTotal={frozenResult.total}
-      frozenAccountsHasMore={frozenResult.hasMore}
-    />
-  );
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -1,3 +1,4 @@
+import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
@@ -160,35 +161,57 @@ export default async function IssuancePage() {
     redirect("/dashboard");
   }
 
-  const apiBaseUrl = resolvePlaygroundApiBaseUrl();
-  const apiClient = await createSdpApiClient();
-  const [templatesResult, tokensResult, apiKeysResult, signerWalletsResult] = await Promise.all([
-    fetchTemplates(apiClient.request),
-    fetchTokens(apiClient.request),
-    fetchActiveApiKeys(apiClient.request),
-    fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
-  ]);
+  const trace = createTimedTrace("dashboard.issuance.page");
 
-  const tokens = tokensResult.data ?? [];
-  const apiKeys = apiKeysResult.data ?? [];
-  const templatesError = templatesResult.ok
-    ? null
-    : `Template API ${templatesResult.status ?? "unavailable"}: ${templatesResult.error ?? "Unknown error"}`;
+  try {
+    const apiBaseUrl = resolvePlaygroundApiBaseUrl();
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.issuance.api"))
+    );
+    const [templatesResult, tokensResult, apiKeysResult, signerWalletsResult] = await Promise.all([
+      trace.step("fetch_templates", () => fetchTemplates(apiClient.request)),
+      trace.step("fetch_tokens", () => fetchTokens(apiClient.request)),
+      trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
+      trace.step("fetch_signer_wallets", () =>
+        fetchPaymentsWallets(apiClient.request, { includeBalances: false })
+      ),
+    ]);
 
-  return (
-    <IssuanceWorkspace
-      tokens={tokens}
-      templates={templatesResult.data ?? []}
-      apiKeys={apiKeys}
-      signerWallets={signerWalletsResult.data ?? []}
-      apiBaseUrl={apiBaseUrl}
-      templatesError={templatesError}
-      tokensNotice={resolveTokenListNotice(tokensResult)}
-      signerWalletsError={
-        signerWalletsResult.ok
-          ? null
-          : `Wallet API ${signerWalletsResult.status ?? "unavailable"}: ${signerWalletsResult.error ?? "Unknown error"}`
-      }
-    />
-  );
+    const tokens = tokensResult.data ?? [];
+    const apiKeys = apiKeysResult.data ?? [];
+    const templatesError = templatesResult.ok
+      ? null
+      : `Template API ${templatesResult.status ?? "unavailable"}: ${templatesResult.error ?? "Unknown error"}`;
+
+    trace.log({
+      ok: true,
+      tokenCount: tokens.length,
+      templateCount: templatesResult.data?.length ?? 0,
+      apiKeyCount: apiKeys.length,
+      signerWalletCount: signerWalletsResult.data?.length ?? 0,
+    });
+
+    return (
+      <IssuanceWorkspace
+        tokens={tokens}
+        templates={templatesResult.data ?? []}
+        apiKeys={apiKeys}
+        signerWallets={signerWalletsResult.data ?? []}
+        apiBaseUrl={apiBaseUrl}
+        templatesError={templatesError}
+        tokensNotice={resolveTokenListNotice(tokensResult)}
+        signerWalletsError={
+          signerWalletsResult.ok
+            ? null
+            : `Wallet API ${signerWalletsResult.status ?? "unavailable"}: ${signerWalletsResult.error ?? "Unknown error"}`
+        }
+      />
+    );
+  } catch (error) {
+    trace.log({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
 }

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
@@ -27,58 +28,83 @@ export default async function DashboardPage() {
     return null;
   }
 
-  const apiClient = await createSdpApiClient();
-  const [aggregateResult, transfersResult, walletsResult, issuanceTokensResult] = await Promise.all(
-    [
-      fetchPaymentsAggregate(apiClient.request),
-      fetchPaymentTransfers(apiClient.request, 100),
-      fetchPaymentsWallets(apiClient.request, { includeBalances: false }),
-      fetchIssuanceTokens(apiClient.request, 10),
-    ]
-  );
+  const trace = createTimedTrace("dashboard.home.page");
 
-  const issuanceActivityResult =
-    issuanceTokensResult.ok && issuanceTokensResult.data
-      ? await fetchOrgIssuanceActivity(apiClient.request, issuanceTokensResult.data)
-      : { rows: [], error: null };
+  try {
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.home.api"))
+    );
+    const [aggregateResult, transfersResult, walletsResult, issuanceTokensResult] =
+      await Promise.all([
+        trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
+        trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request, 100)),
+        trace.step("fetch_payments_wallets", () =>
+          fetchPaymentsWallets(apiClient.request, { includeBalances: false })
+        ),
+        trace.step("fetch_issuance_tokens", () => fetchIssuanceTokens(apiClient.request, 10)),
+      ]);
+    const issuanceTokens = issuanceTokensResult.data ?? [];
 
-  const wallets = walletsResult.data ?? [];
-  const isWalletEmptyState = walletsResult.ok && wallets.length === 0;
-  const totalBalance = aggregateResult.data?.balances
-    ? resolveTotalBalance(aggregateResult.data.balances)
-    : resolveTotalBalance(aggregateBalancesFromWallets(wallets));
-  const todaysVolume = transfersResult.data ? computeTodaysVolume(transfersResult.data) : null;
-  const activityRows = buildHomeActivityRows(
-    transfersResult.data ?? [],
-    issuanceActivityResult.rows
-  );
+    const issuanceActivityResult =
+      issuanceTokensResult.ok && issuanceTokens.length > 0
+        ? await trace.step("fetch_issuance_activity", () =>
+            fetchOrgIssuanceActivity(apiClient.request, issuanceTokens)
+          )
+        : { rows: [], error: null };
 
-  const aggregateError =
-    aggregateResult.ok || isWalletEmptyState ? null : "Balance data is unavailable right now.";
-  const transfersError =
-    transfersResult.ok || isWalletEmptyState ? null : "Payments activity is unavailable right now.";
-  const issuanceTokensError = issuanceTokensResult.ok
-    ? null
-    : "Issuance activity is unavailable right now.";
+    const wallets = walletsResult.data ?? [];
+    const isWalletEmptyState = walletsResult.ok && wallets.length === 0;
+    const totalBalance = aggregateResult.data?.balances
+      ? resolveTotalBalance(aggregateResult.data.balances)
+      : resolveTotalBalance(aggregateBalancesFromWallets(wallets));
+    const todaysVolume = transfersResult.data ? computeTodaysVolume(transfersResult.data) : null;
+    const activityRows = buildHomeActivityRows(
+      transfersResult.data ?? [],
+      issuanceActivityResult.rows
+    );
 
-  const activityError =
-    activityRows.length === 0
-      ? (transfersError ?? issuanceTokensError ?? issuanceActivityResult.error)
-      : null;
-  const activityNotice = [transfersError, issuanceTokensError, issuanceActivityResult.error]
-    .filter(Boolean)
-    .join(" ");
+    const aggregateError =
+      aggregateResult.ok || isWalletEmptyState ? null : "Balance data is unavailable right now.";
+    const transfersError =
+      transfersResult.ok || isWalletEmptyState
+        ? null
+        : "Payments activity is unavailable right now.";
+    const issuanceTokensError = issuanceTokensResult.ok
+      ? null
+      : "Issuance activity is unavailable right now.";
 
-  return (
-    <HomeWorkspace
-      totalBalance={totalBalance}
-      totalBalanceError={aggregateError}
-      todaysVolume={todaysVolume}
-      todaysVolumeError={transfersError}
-      activityRows={activityRows}
-      activityError={activityError}
-      activityNotice={activityNotice || null}
-      wallets={wallets}
-    />
-  );
+    const activityError =
+      activityRows.length === 0
+        ? (transfersError ?? issuanceTokensError ?? issuanceActivityResult.error)
+        : null;
+    const activityNotice = [transfersError, issuanceTokensError, issuanceActivityResult.error]
+      .filter(Boolean)
+      .join(" ");
+
+    trace.log({
+      ok: true,
+      walletCount: wallets.length,
+      activityRowCount: activityRows.length,
+      hasAggregate: Boolean(aggregateResult.data?.balances),
+    });
+
+    return (
+      <HomeWorkspace
+        totalBalance={totalBalance}
+        totalBalanceError={aggregateError}
+        todaysVolume={todaysVolume}
+        todaysVolumeError={transfersError}
+        activityRows={activityRows}
+        activityError={activityError}
+        activityNotice={activityNotice || null}
+        wallets={wallets}
+      />
+    );
+  } catch (error) {
+    trace.log({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
 }

--- a/apps/sdp-web/src/app/dashboard/payments/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/page.tsx
@@ -1,3 +1,4 @@
+import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
@@ -19,46 +20,75 @@ export default async function PaymentsPage() {
     redirect("/dashboard");
   }
 
-  const apiBaseUrl = resolvePlaygroundApiBaseUrl();
-  const apiClient = await createSdpApiClient();
-  const [apiKeysResult, walletsResult, aggregateResult, transfersResult, issuedTokenSymbolsResult] =
-    await Promise.all([
-      fetchActiveApiKeys(apiClient.request),
-      fetchPaymentsWallets(apiClient.request, { includeBalances: true }),
-      fetchPaymentsAggregate(apiClient.request),
-      fetchPaymentTransfers(apiClient.request),
-      fetchPaymentsIssuedTokenSymbols(apiClient.request),
-    ]);
-  const apiKeys = apiKeysResult.data ?? [];
-  const wallets = walletsResult.data ?? [];
-  const aggregate = aggregateResult.data ?? null;
-  const transfers = transfersResult.data ?? [];
-  const issuedTokenSymbolsByMint = Object.fromEntries(
-    (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
-  );
-  const walletsError = walletsResult.ok
-    ? null
-    : `Wallet API ${walletsResult.status ?? "unavailable"}: ${walletsResult.error ?? "Unknown error"}`;
-  const aggregateError = aggregateResult.ok
-    ? null
-    : `Wallet aggregate API ${aggregateResult.status ?? "unavailable"}: ${aggregateResult.error ?? "Unknown error"}`;
-  const transfersError = transfersResult.ok
-    ? null
-    : `Transfer API ${transfersResult.status ?? "unavailable"}: ${transfersResult.error ?? "Unknown error"}`;
+  const trace = createTimedTrace("dashboard.payments.page");
 
-  return (
-    <div className="flex h-full min-h-0 w-full flex-col">
-      <PaymentsWorkspace
-        apiBaseUrl={apiBaseUrl}
-        apiKeys={apiKeys}
-        wallets={wallets}
-        walletsError={walletsError}
-        aggregate={aggregate}
-        aggregateError={aggregateError}
-        issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}
-        transfers={transfers}
-        transfersError={transfersError}
-      />
-    </div>
-  );
+  try {
+    const apiBaseUrl = resolvePlaygroundApiBaseUrl();
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.payments.api"))
+    );
+    const [
+      apiKeysResult,
+      walletsResult,
+      aggregateResult,
+      transfersResult,
+      issuedTokenSymbolsResult,
+    ] = await Promise.all([
+      trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
+      trace.step("fetch_payments_wallets", () =>
+        fetchPaymentsWallets(apiClient.request, { includeBalances: true })
+      ),
+      trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
+      trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request)),
+      trace.step("fetch_payment_token_symbols", () =>
+        fetchPaymentsIssuedTokenSymbols(apiClient.request)
+      ),
+    ]);
+    const apiKeys = apiKeysResult.data ?? [];
+    const wallets = walletsResult.data ?? [];
+    const aggregate = aggregateResult.data ?? null;
+    const transfers = transfersResult.data ?? [];
+    const issuedTokenSymbolsByMint = Object.fromEntries(
+      (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
+    );
+    const walletsError = walletsResult.ok
+      ? null
+      : `Wallet API ${walletsResult.status ?? "unavailable"}: ${walletsResult.error ?? "Unknown error"}`;
+    const aggregateError = aggregateResult.ok
+      ? null
+      : `Wallet aggregate API ${aggregateResult.status ?? "unavailable"}: ${aggregateResult.error ?? "Unknown error"}`;
+    const transfersError = transfersResult.ok
+      ? null
+      : `Transfer API ${transfersResult.status ?? "unavailable"}: ${transfersResult.error ?? "Unknown error"}`;
+
+    trace.log({
+      ok: true,
+      walletCount: wallets.length,
+      transferCount: transfers.length,
+      apiKeyCount: apiKeys.length,
+      hasAggregate: Boolean(aggregate),
+    });
+
+    return (
+      <div className="flex h-full min-h-0 w-full flex-col">
+        <PaymentsWorkspace
+          apiBaseUrl={apiBaseUrl}
+          apiKeys={apiKeys}
+          wallets={wallets}
+          walletsError={walletsError}
+          aggregate={aggregate}
+          aggregateError={aggregateError}
+          issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}
+          transfers={transfers}
+          transfersError={transfersError}
+        />
+      </div>
+    );
+  } catch (error) {
+    trace.log({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
 }

--- a/apps/sdp-web/src/app/dashboard/settings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/page.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import type { OrganizationRpcProvider } from "@sdp/types";
@@ -36,16 +37,22 @@ export default async function SettingsPage() {
     redirect("/dashboard");
   }
 
+  const trace = createTimedTrace("dashboard.settings.page");
+
   let organization: Organization | null = null;
   let isLinked = true;
   let loadError = false;
 
   try {
-    const apiClient = await createSdpApiClient();
+    const apiClient = await trace.step("create_sdp_api_client", () =>
+      createSdpApiClient(trace.childContext("dashboard.settings.api"))
+    );
     let onboardingFailed = false;
 
     try {
-      const onboarding = await apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status");
+      const onboarding = await trace.step("fetch_onboarding_status", () =>
+        apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status")
+      );
       isLinked = onboarding.linked;
       organization = onboarding.organization;
     } catch {
@@ -54,25 +61,42 @@ export default async function SettingsPage() {
 
     if (!organization && isLinked) {
       try {
-        const projectsPayload = await apiClient.fetch<ProjectListResponse>("/v1/projects");
+        const projectsPayload = await trace.step("fetch_projects", () =>
+          apiClient.fetch<ProjectListResponse>("/v1/projects")
+        );
         const inferredOrgId = projectsPayload.projects[0]?.organizationId;
         if (inferredOrgId) {
-          organization = await apiClient.fetch<Organization>(`/v1/organizations/${inferredOrgId}`);
+          organization = await trace.step("fetch_inferred_organization", () =>
+            apiClient.fetch<Organization>(`/v1/organizations/${inferredOrgId}`)
+          );
         }
       } catch {}
     }
 
     if (!organization && isLinked && orgId) {
       try {
-        organization = await apiClient.fetch<Organization>(`/v1/organizations/${orgId}`);
+        organization = await trace.step("fetch_org_by_active_org_id", () =>
+          apiClient.fetch<Organization>(`/v1/organizations/${orgId}`)
+        );
       } catch {}
     }
 
     if (!organization && isLinked && onboardingFailed) {
       loadError = true;
     }
-  } catch {
+
+    trace.log({
+      ok: !loadError,
+      isLinked,
+      hasOrganization: Boolean(organization),
+      loadError,
+    });
+  } catch (error) {
     loadError = true;
+    trace.log({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
   }
 
   return (

--- a/apps/sdp-web/src/lib/request-tracing.ts
+++ b/apps/sdp-web/src/lib/request-tracing.ts
@@ -1,0 +1,121 @@
+const TRACE_ID_HEADER = "X-SDP-Trace-ID";
+const TRACE_SOURCE_HEADER = "X-SDP-Trace-Source";
+const TRACE_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+export interface TraceContext {
+  traceId: string;
+  source: string;
+}
+
+interface TimedTraceStep {
+  name: string;
+  durationMs: number;
+}
+
+function roundDuration(durationMs: number): number {
+  return Math.round(durationMs * 10) / 10;
+}
+
+function normalizeTraceHeader(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidate = trimmed.slice(0, 128);
+  if (!TRACE_ID_PATTERN.test(candidate)) {
+    return null;
+  }
+
+  return candidate;
+}
+
+function emitTraceLog(event: string, payload: Record<string, unknown>): void {
+  console.info(
+    JSON.stringify({
+      event,
+      timestamp: new Date().toISOString(),
+      ...payload,
+    })
+  );
+}
+
+export function getTraceHeaders(context: TraceContext): Record<string, string> {
+  return {
+    [TRACE_ID_HEADER]: context.traceId,
+    [TRACE_SOURCE_HEADER]: context.source,
+  };
+}
+
+export function resolveTraceContext(source: string, request?: Request): TraceContext {
+  const incomingTraceId = normalizeTraceHeader(request?.headers.get(TRACE_ID_HEADER) ?? null);
+
+  return {
+    traceId: incomingTraceId ?? `web_${crypto.randomUUID().replaceAll("-", "")}`,
+    source,
+  };
+}
+
+export function createTimedTrace(source: string, request?: Request) {
+  const context = resolveTraceContext(source, request);
+  const steps: TimedTraceStep[] = [];
+  const startedAt = performance.now();
+
+  function elapsedMs(): number {
+    return roundDuration(performance.now() - startedAt);
+  }
+
+  return {
+    ...context,
+    childContext(childSource: string): TraceContext {
+      return {
+        traceId: context.traceId,
+        source: childSource,
+      };
+    },
+    async step<T>(name: string, action: () => Promise<T>): Promise<T> {
+      const stepStartedAt = performance.now();
+      try {
+        return await action();
+      } finally {
+        steps.push({
+          name,
+          durationMs: roundDuration(performance.now() - stepStartedAt),
+        });
+      }
+    },
+    elapsedMs,
+    serverTiming(metric = "app"): string {
+      return `${metric};dur=${elapsedMs()}`;
+    },
+    log(extra: Record<string, unknown> = {}): void {
+      emitTraceLog("sdp_web_timed_trace", {
+        traceId: context.traceId,
+        source,
+        durationMs: elapsedMs(),
+        steps,
+        ...extra,
+      });
+    },
+  };
+}
+
+export function logRouteResult(
+  trace: TraceContext & { elapsedMs(): number },
+  status: number,
+  extra: Record<string, unknown> = {}
+): void {
+  emitTraceLog("sdp_web_route_timing", {
+    traceId: trace.traceId,
+    source: trace.source,
+    status,
+    durationMs: trace.elapsedMs(),
+    ...extra,
+  });
+}
+
+export { TRACE_ID_HEADER, TRACE_SOURCE_HEADER };

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -1,4 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
+import { TRACE_ID_HEADER, TRACE_SOURCE_HEADER, type TraceContext } from "./request-tracing";
 
 function getApiBaseUrl(): string {
   const base =
@@ -38,19 +39,58 @@ async function getClerkToken(): Promise<string> {
 
 type SdpApiRequestFn = (path: string, options?: RequestInit) => Promise<Response>;
 
-function createSdpApiRequest(token: string): SdpApiRequestFn {
+function roundDuration(durationMs: number): number {
+  return Math.round(durationMs * 10) / 10;
+}
+
+function createTraceRequestId(traceId: string, sequence: number): string {
+  const suffix = sequence.toString().padStart(2, "0");
+  return `${traceId}:${suffix}`.slice(0, 128);
+}
+
+function createSdpApiRequest(token: string, traceContext?: TraceContext): SdpApiRequestFn {
+  let requestSequence = 0;
+
   return async (path: string, options: RequestInit = {}): Promise<Response> => {
     const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+    requestSequence += 1;
 
-    return fetch(url, {
+    const traceId = traceContext?.traceId ?? `web_${crypto.randomUUID().replaceAll("-", "")}`;
+    const requestId = createTraceRequestId(traceId, requestSequence);
+    const source = traceContext?.source ?? "sdp-web";
+    const headers = new Headers(options.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    headers.set("Content-Type", "application/json");
+    headers.set(TRACE_ID_HEADER, traceId);
+    headers.set(TRACE_SOURCE_HEADER, source);
+    headers.set("X-Request-ID", requestId);
+
+    const startedAt = performance.now();
+    const method = options.method ?? "GET";
+
+    const response = await fetch(url, {
       ...options,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        ...(options.headers || {}),
-      },
+      headers,
       cache: "no-store",
     });
+
+    console.info(
+      JSON.stringify({
+        event: "sdp_web_api_request",
+        timestamp: new Date().toISOString(),
+        traceId,
+        source,
+        requestId,
+        method,
+        path,
+        status: response.status,
+        durationMs: roundDuration(performance.now() - startedAt),
+        upstreamRequestId: response.headers.get("X-Request-ID"),
+        upstreamServerTiming: response.headers.get("Server-Timing"),
+      })
+    );
+
+    return response;
   };
 }
 
@@ -78,9 +118,9 @@ export interface SdpApiClient {
   fetch: <T>(path: string, options?: RequestInit) => Promise<T>;
 }
 
-export async function createSdpApiClient(): Promise<SdpApiClient> {
+export async function createSdpApiClient(traceContext?: TraceContext): Promise<SdpApiClient> {
   const token = await getClerkToken();
-  const request = createSdpApiRequest(token);
+  const request = createSdpApiRequest(token, traceContext);
 
   return {
     request,
@@ -91,13 +131,21 @@ export async function createSdpApiClient(): Promise<SdpApiClient> {
   };
 }
 
-export async function sdpApiRequest(path: string, options: RequestInit = {}): Promise<Response> {
-  const client = await createSdpApiClient();
+export async function sdpApiRequest(
+  path: string,
+  options: RequestInit = {},
+  traceContext?: TraceContext
+): Promise<Response> {
+  const client = await createSdpApiClient(traceContext);
   return client.request(path, options);
 }
 
-export async function sdpApiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const client = await createSdpApiClient();
+export async function sdpApiFetch<T>(
+  path: string,
+  options: RequestInit = {},
+  traceContext?: TraceContext
+): Promise<T> {
+  const client = await createSdpApiClient(traceContext);
   const res = await client.request(path, options);
   return parseSdpApiResponse<T>(res);
 }


### PR DESCRIPTION
## Summary
- add structured timing traces for key dashboard server-rendered pages and internal Next API routes
- propagate `X-SDP-Trace-ID` and request source headers from the web app into the Cloudflare API
- add Cloudflare request timing logs and response headers so smoky/dev investigations can correlate Vercel and Worker latency

## Notes
- no local checks were run for this branch per request
