### PR TITLE
perf(dashboard): defer heavy wallet and activity loads

### DIFF
--- a/apps/sdp-api/src/lib/api-key-wallet-auth.test.ts
+++ b/apps/sdp-api/src/lib/api-key-wallet-auth.test.ts
@@ -5,6 +5,7 @@ import {
   assertApiKeyWalletAccess,
   filterApiKeyWallets,
   getAllowedApiKeyWalletIds,
+  getAllowedApiKeyWalletIdsForPermissions,
   resolveApiKeySigningWalletId,
 } from "./api-key-wallet-auth";
 
@@ -81,6 +82,17 @@ describe("api-key wallet auth helpers", () => {
     });
 
     expect(getAllowedApiKeyWalletIds(auth)).toEqual(["wal_a", "wal_b"]);
+  });
+
+  it("filters allowed wallet IDs by the required wallet permissions", () => {
+    const auth = createApiKeyAuth({
+      walletBindings: [
+        { walletId: "wal_read", permissions: ["wallets:read"] },
+        { walletId: "wal_write", permissions: ["wallets:write"] },
+      ],
+    });
+
+    expect(getAllowedApiKeyWalletIdsForPermissions(auth, ["wallets:read"])).toEqual(["wal_read"]);
   });
 
   it("filters wallet collections to the bound wallet set", () => {

--- a/apps/sdp-api/src/lib/api-key-wallet-auth.ts
+++ b/apps/sdp-api/src/lib/api-key-wallet-auth.ts
@@ -112,6 +112,24 @@ export function getAllowedApiKeyWalletIds(auth: ApiKeyContext): string[] | null 
   return bindings.map((binding) => binding.walletId);
 }
 
+export function getAllowedApiKeyWalletIdsForPermissions(
+  auth: ApiKeyContext,
+  requiredPermissions: Permission[] = []
+): string[] | null {
+  if (auth.authType !== "api_key") {
+    return null;
+  }
+
+  const bindings = normalizeBindings(auth);
+  if (bindings.length === 0) {
+    return null;
+  }
+
+  return bindings
+    .filter((binding) => hasBindingPermission(binding, requiredPermissions))
+    .map((binding) => binding.walletId);
+}
+
 export function filterApiKeyWallets<T extends { walletId: string }>(
   auth: ApiKeyContext,
   wallets: T[],

--- a/apps/sdp-api/src/openapi/paths/custody.ts
+++ b/apps/sdp-api/src/openapi/paths/custody.ts
@@ -212,6 +212,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
         provider: orgCustodyProviderSchema.optional(),
         includeAllProviders: z.boolean().optional(),
         includeBalances: z.boolean().optional(),
+        view: z.enum(["summary"]).optional(),
       }),
     },
     responses: {

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -263,6 +263,31 @@ describe("Custody wallet scope routes", () => {
     expect(body.data.wallets.map((wallet) => wallet.walletId)).toEqual(["para_wallet_a"]);
   });
 
+  it("returns summary wallets without hydrating balances", async () => {
+    const res = await app.request(
+      "/v1/wallets?includeAllProviders=true&view=summary",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        wallets: Array<{ walletId: string; balances?: unknown[] }>;
+      };
+    };
+
+    expect(body.data.wallets).toHaveLength(3);
+    expect(body.data.wallets.every((wallet) => wallet.balances === undefined)).toBe(true);
+    expect(getAccountInfo).not.toHaveBeenCalled();
+    expect(getSplTokenBalances).not.toHaveBeenCalled();
+  });
+
   it("filters aggregate wallets to the API key bindings", async () => {
     await seedCachedKey({
       walletBindings: [{ walletId: "privy_wallet_b", permissions: ["wallets:read"] }],

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -263,6 +263,31 @@ describe("Custody wallet scope routes", () => {
     expect(body.data.wallets.map((wallet) => wallet.walletId)).toEqual(["para_wallet_a"]);
   });
 
+  it("excludes bound wallets that lack wallets:read from the summary view", async () => {
+    await seedCachedKey({
+      walletBindings: [{ walletId: "para_wallet_a", permissions: ["wallets:write"] }],
+    });
+
+    const res = await app.request(
+      "/v1/wallets?includeAllProviders=true&view=summary",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        wallets: Array<{ walletId: string }>;
+      };
+    };
+    expect(body.data.wallets).toEqual([]);
+  });
+
   it("returns summary wallets without hydrating balances", async () => {
     const res = await app.request(
       "/v1/wallets?includeAllProviders=true&view=summary",

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -1,7 +1,7 @@
 import { formatDecimalAmount } from "@/lib/amount";
 import {
   assertApiKeyWalletAccess,
-  getAllowedApiKeyWalletIds,
+  getAllowedApiKeyWalletIdsForPermissions,
   resolveApiKeySigningWalletId,
 } from "@/lib/api-key-wallet-auth";
 import { getAuth } from "@/lib/auth";
@@ -244,10 +244,13 @@ async function queryWalletSummaries(
     return [];
   }
 
-  const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
+  const allowedWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["wallets:read"]);
+  if (allowedWalletIds !== null && allowedWalletIds.length === 0) {
+    return [];
+  }
   const configPlaceholders = configIds.map(() => "?").join(", ");
   const allowedWalletClause =
-    allowedWalletIds && allowedWalletIds.length > 0
+    allowedWalletIds !== null && allowedWalletIds.length > 0
       ? `AND w.wallet_id IN (${allowedWalletIds.map(() => "?").join(", ")})`
       : "";
 
@@ -294,7 +297,7 @@ function buildWalletCacheKey(
 ): string {
   const auth = getAuth(c);
   const actor = resolveActor(c);
-  const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
+  const allowedWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["wallets:read"]);
 
   return JSON.stringify({
     kind,
@@ -302,7 +305,6 @@ function buildWalletCacheKey(
     projectId: filters.projectId ?? null,
     provider: filters.provider ?? null,
     includeAllProviders: filters.includeAllProviders,
-    view: filters.view,
     authType: auth.authType,
     apiKeyId: auth.apiKeyId,
     allowedWalletIds: allowedWalletIds ? [...allowedWalletIds].sort() : null,

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -1,7 +1,7 @@
 import { formatDecimalAmount } from "@/lib/amount";
 import {
   assertApiKeyWalletAccess,
-  filterApiKeyWallets,
+  getAllowedApiKeyWalletIds,
   resolveApiKeySigningWalletId,
 } from "@/lib/api-key-wallet-auth";
 import { getAuth } from "@/lib/auth";
@@ -18,7 +18,11 @@ import {
 } from "@/services/helius-das.service";
 import { SigningError } from "@/services/ports";
 import { createRpc, getAccountInfo } from "@/services/solana/rpc";
-import type { CustodyWalletTokenBalance } from "@sdp/types";
+import type {
+  CustodyWalletAggregate,
+  CustodyWalletSummary,
+  CustodyWalletTokenBalance,
+} from "@sdp/types";
 import type { Address } from "@solana/kit";
 import { type AppContext, parseBooleanQueryParam, resolveActor } from "../context";
 import {
@@ -33,6 +37,301 @@ import {
   updateWalletSchema,
 } from "../schemas";
 
+const SUMMARY_CACHE_TTL_MS = 15_000;
+const AGGREGATE_CACHE_TTL_MS = 10_000;
+const WALLET_BALANCE_CACHE_TTL_MS = 10_000;
+
+interface CacheEntry<T> {
+  expiresAt: number;
+  value: T;
+}
+
+interface WalletSummaryConfigRow {
+  id: string;
+}
+
+interface WalletSummaryRow {
+  id: string;
+  custody_config_id: string;
+  wallet_id: string;
+  public_key: string;
+  label: string | null;
+  purpose: string | null;
+  status: string;
+  created_at: string;
+  provider: string;
+}
+
+const walletSummaryCache = new Map<string, CacheEntry<CustodyWalletSummary[]>>();
+const walletAggregateCache = new Map<string, CacheEntry<CustodyWalletAggregate>>();
+const walletBalanceCache = new Map<string, CacheEntry<CustodyWalletTokenBalance[]>>();
+
+function clearWalletCaches() {
+  walletSummaryCache.clear();
+  walletAggregateCache.clear();
+  walletBalanceCache.clear();
+}
+
+function readCache<T>(cache: Map<string, CacheEntry<T>>, key: string): T | null {
+  const entry = cache.get(key);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+}
+
+function writeCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T, ttlMs: number): T {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + ttlMs,
+  });
+
+  return value;
+}
+
+function logWalletStep(
+  c: AppContext,
+  route: "list_wallets" | "aggregate_wallets",
+  step: string,
+  startedAt: number,
+  extra: Record<string, unknown> = {}
+) {
+  console.info(
+    JSON.stringify({
+      event: "sdp_api_wallets_step",
+      timestamp: new Date().toISOString(),
+      requestId: c.get("requestId"),
+      traceId: c.get("traceId") ?? null,
+      route,
+      step,
+      durationMs: Number((performance.now() - startedAt).toFixed(1)),
+      ...extra,
+    })
+  );
+}
+
+async function resolveDefaultConfigId(
+  db: D1Database,
+  organizationId: string,
+  projectId?: string
+): Promise<string | null> {
+  if (projectId) {
+    const scopedDefault = await db
+      .prepare(
+        `SELECT default_custody_config_id
+         FROM custody_scope_defaults
+         WHERE organization_id = ? AND project_id = ?
+         LIMIT 1`
+      )
+      .bind(organizationId, projectId)
+      .first<{ default_custody_config_id: string }>();
+
+    if (scopedDefault?.default_custody_config_id) {
+      return scopedDefault.default_custody_config_id;
+    }
+  }
+
+  const orgDefault = await db
+    .prepare(
+      `SELECT default_custody_config_id
+       FROM custody_scope_defaults
+       WHERE organization_id = ? AND project_id IS NULL
+       LIMIT 1`
+    )
+    .bind(organizationId)
+    .first<{ default_custody_config_id: string }>();
+
+  return orgDefault?.default_custody_config_id ?? null;
+}
+
+async function resolveSummaryConfigIds(
+  c: AppContext,
+  filters: ReturnType<typeof resolveWalletFilters>
+): Promise<{ configIds: string[]; defaultConfigId: string | null }> {
+  const actor = resolveActor(c);
+  const defaultConfigId = await resolveDefaultConfigId(
+    c.env.DB,
+    actor.organizationId,
+    filters.projectId
+  );
+
+  if (filters.includeAllProviders) {
+    const includeAllProvidersQuery = filters.projectId
+      ? `SELECT id
+         FROM custody_configs
+         WHERE organization_id = ?
+           AND status = 'active'
+           AND (project_id = ? OR project_id IS NULL)
+           ${filters.provider ? "AND provider = ?" : ""}
+         ORDER BY updated_at DESC, id DESC`
+      : `SELECT id
+         FROM custody_configs
+         WHERE organization_id = ?
+           AND status = 'active'
+           AND project_id IS NULL
+           ${filters.provider ? "AND provider = ?" : ""}
+         ORDER BY updated_at DESC, id DESC`;
+
+    const rows = await c.env.DB.prepare(includeAllProvidersQuery)
+      .bind(
+        ...(filters.projectId
+          ? filters.provider
+            ? [actor.organizationId, filters.projectId, filters.provider]
+            : [actor.organizationId, filters.projectId]
+          : filters.provider
+            ? [actor.organizationId, filters.provider]
+            : [actor.organizationId])
+      )
+      .all<WalletSummaryConfigRow>();
+
+    return {
+      configIds: (rows.results ?? []).map((row) => row.id),
+      defaultConfigId,
+    };
+  }
+
+  if (filters.provider) {
+    const providerRow = filters.projectId
+      ? await c.env.DB.prepare(
+          `SELECT id
+           FROM custody_configs
+           WHERE organization_id = ?
+             AND status = 'active'
+             AND provider = ?
+             AND (project_id = ? OR project_id IS NULL)
+           ORDER BY CASE WHEN project_id = ? THEN 0 ELSE 1 END, updated_at DESC, id DESC
+           LIMIT 1`
+        )
+          .bind(actor.organizationId, filters.provider, filters.projectId, filters.projectId)
+          .first<WalletSummaryConfigRow>()
+      : await c.env.DB.prepare(
+          `SELECT id
+           FROM custody_configs
+           WHERE organization_id = ?
+             AND status = 'active'
+             AND provider = ?
+             AND project_id IS NULL
+           LIMIT 1`
+        )
+          .bind(actor.organizationId, filters.provider)
+          .first<WalletSummaryConfigRow>();
+
+    return {
+      configIds: providerRow?.id ? [providerRow.id] : [],
+      defaultConfigId,
+    };
+  }
+
+  return {
+    configIds: defaultConfigId ? [defaultConfigId] : [],
+    defaultConfigId,
+  };
+}
+
+async function queryWalletSummaries(
+  c: AppContext,
+  filters: ReturnType<typeof resolveWalletFilters>
+): Promise<CustodyWalletSummary[]> {
+  const auth = getAuth(c);
+  const { configIds, defaultConfigId } = await resolveSummaryConfigIds(c, filters);
+  if (configIds.length === 0) {
+    return [];
+  }
+
+  const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
+  const configPlaceholders = configIds.map(() => "?").join(", ");
+  const allowedWalletClause =
+    allowedWalletIds && allowedWalletIds.length > 0
+      ? `AND w.wallet_id IN (${allowedWalletIds.map(() => "?").join(", ")})`
+      : "";
+
+  const rows = await c.env.DB.prepare(
+    `SELECT
+       w.id,
+       w.custody_config_id,
+       w.wallet_id,
+       w.public_key,
+       w.label,
+       w.purpose,
+       w.status,
+       w.created_at,
+       c.provider
+     FROM custody_wallets w
+     JOIN custody_configs c ON c.id = w.custody_config_id
+     WHERE w.status = 'active'
+       AND c.status = 'active'
+       AND c.id IN (${configPlaceholders})
+       ${allowedWalletClause}
+     ORDER BY CASE WHEN c.id = ? THEN 0 ELSE 1 END, c.updated_at DESC, c.id DESC, w.created_at ASC`
+  )
+    .bind(...configIds, ...(allowedWalletIds ?? []), defaultConfigId ?? "")
+    .all<WalletSummaryRow>();
+
+  return (rows.results ?? []).map((row) => ({
+    id: row.id,
+    custodyConfigId: row.custody_config_id,
+    provider: row.provider as CustodyWalletSummary["provider"],
+    isDefaultProvider: row.custody_config_id === defaultConfigId,
+    walletId: row.wallet_id,
+    publicKey: row.public_key,
+    label: row.label,
+    purpose: row.purpose,
+    status: row.status as CustodyWalletSummary["status"],
+    createdAt: row.created_at,
+  }));
+}
+
+function buildWalletCacheKey(
+  c: AppContext,
+  filters: ReturnType<typeof resolveWalletFilters>,
+  kind: "summary" | "aggregate"
+): string {
+  const auth = getAuth(c);
+  const actor = resolveActor(c);
+  const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
+
+  return JSON.stringify({
+    kind,
+    organizationId: actor.organizationId,
+    projectId: filters.projectId ?? null,
+    provider: filters.provider ?? null,
+    includeAllProviders: filters.includeAllProviders,
+    view: filters.view,
+    authType: auth.authType,
+    apiKeyId: auth.apiKeyId,
+    allowedWalletIds: allowedWalletIds ? [...allowedWalletIds].sort() : null,
+  });
+}
+
+async function getCachedWalletSummaries(
+  c: AppContext,
+  filters: ReturnType<typeof resolveWalletFilters>,
+  route: "list_wallets" | "aggregate_wallets"
+): Promise<CustodyWalletSummary[]> {
+  const cacheKey = buildWalletCacheKey(c, filters, "summary");
+  const cached = readCache(walletSummaryCache, cacheKey);
+  if (cached) {
+    logWalletStep(c, route, "wallet_summary_cache_hit", performance.now(), {
+      walletCount: cached.length,
+    });
+    return cached;
+  }
+
+  const startedAt = performance.now();
+  const wallets = await queryWalletSummaries(c, filters);
+  logWalletStep(c, route, "query_wallet_summaries", startedAt, {
+    walletCount: wallets.length,
+  });
+
+  return writeCache(walletSummaryCache, cacheKey, wallets, SUMMARY_CACHE_TTL_MS);
+}
+
 function resolveWalletFilters(
   c: AppContext,
   options: { defaultIncludeAllProviders?: boolean } = {}
@@ -42,6 +341,7 @@ function resolveWalletFilters(
   // biome-ignore lint/nursery/noSecrets: Query parameter name, not a secret.
   const includeAllProviders = c.req.query("includeAllProviders");
   const includeBalances = parseBooleanQueryParam(c.req.query("includeBalances"));
+  const view = c.req.query("view") === "summary" ? "summary" : "default";
 
   const provider =
     providerQuery && CUSTODY_PROVIDERS.includes(providerQuery as CustodyProvider)
@@ -55,34 +355,12 @@ function resolveWalletFilters(
   return {
     projectId,
     provider,
+    view,
     includeBalances,
     includeAllProviders:
       includeAllProviders === undefined
         ? options.defaultIncludeAllProviders === true
         : parseBooleanQueryParam(includeAllProviders),
-  };
-}
-
-async function getScopedWallets(
-  c: AppContext,
-  options: { defaultIncludeAllProviders?: boolean } = {}
-) {
-  const auth = getAuth(c);
-  const actor = resolveActor(c);
-  const filters = resolveWalletFilters(c, options);
-  const signingService = createSigningService(c.env);
-  const wallets = await signingService.getWalletsWithProviders(
-    actor.organizationId,
-    filters.projectId,
-    {
-      provider: filters.provider,
-      includeAllProviders: filters.includeAllProviders,
-    }
-  );
-
-  return {
-    wallets: filterApiKeyWallets(auth, wallets, ["wallets:read"]),
-    filters,
   };
 }
 
@@ -94,44 +372,60 @@ async function getBalancesByWalletId(
   const rpc = createRpc(c.env);
   const balancesByWalletId = await Promise.all(
     walletPublicKeys.map(async (wallet) => {
-      let lamports = 0n;
-      let splBalances: Awaited<ReturnType<typeof getSplTokenBalances>> = [];
+      const cachedBalances = readCache(walletBalanceCache, wallet.publicKey);
+      if (cachedBalances) {
+        return [wallet.walletId, cachedBalances] as const;
+      }
 
-      try {
-        const accountInfo = await getAccountInfo(rpc, wallet.publicKey as Address);
-        lamports = accountInfo?.lamports ?? 0n;
-      } catch (error) {
+      const [solBalanceResult, splBalancesResult] = await Promise.allSettled([
+        getAccountInfo(rpc, wallet.publicKey as Address),
+        getSplTokenBalances(rpc, wallet.publicKey as Address),
+      ]);
+      const lamports =
+        solBalanceResult.status === "fulfilled" ? (solBalanceResult.value?.lamports ?? 0n) : 0n;
+      const splBalances = splBalancesResult.status === "fulfilled" ? splBalancesResult.value : [];
+
+      if (solBalanceResult.status === "rejected") {
         // biome-ignore lint/nursery/noSecrets: Operational log message, not a secret.
         console.error("getBalancesByWalletId: failed to fetch SOL balance", {
           requestId: c.get("requestId"),
           walletId: wallet.walletId,
           publicKey: wallet.publicKey,
-          error: error instanceof Error ? error.message : String(error),
+          error:
+            solBalanceResult.reason instanceof Error
+              ? solBalanceResult.reason.message
+              : String(solBalanceResult.reason),
         });
       }
 
-      try {
-        splBalances = await getSplTokenBalances(rpc, wallet.publicKey as Address);
-      } catch (error) {
+      if (splBalancesResult.status === "rejected") {
         // biome-ignore lint/nursery/noSecrets: Operational log message, not a secret.
         console.error("getBalancesByWalletId: failed to fetch SPL balances", {
           requestId: c.get("requestId"),
           walletId: wallet.walletId,
           publicKey: wallet.publicKey,
-          error: error instanceof Error ? error.message : String(error),
+          error:
+            splBalancesResult.reason instanceof Error
+              ? splBalancesResult.reason.message
+              : String(splBalancesResult.reason),
         });
       }
 
-      const walletBalances: CustodyWalletTokenBalance[] = [
-        {
-          token: "SOL",
-          mint: SOL_MINT,
-          amount: lamports.toString(),
-          uiAmount: formatDecimalAmount(lamports, 9),
-          decimals: 9,
-        },
-        ...splBalances,
-      ];
+      const walletBalances = writeCache(
+        walletBalanceCache,
+        wallet.publicKey,
+        [
+          {
+            token: "SOL",
+            mint: SOL_MINT,
+            amount: lamports.toString(),
+            uiAmount: formatDecimalAmount(lamports, 9),
+            decimals: 9,
+          },
+          ...splBalances,
+        ],
+        WALLET_BALANCE_CACHE_TTL_MS
+      );
 
       return [wallet.walletId, walletBalances] as const;
     })
@@ -179,6 +473,8 @@ export const createWallet = async (c: AppContext) => {
         createdAt: wallet.createdAt,
       },
     };
+
+    clearWalletCaches();
 
     return created(c, response);
   } catch (error) {
@@ -230,6 +526,8 @@ export const deleteWallet = async (c: AppContext) => {
       walletId: parsed.data.walletId,
       deleted: true,
     };
+
+    clearWalletCaches();
 
     return success(c, response);
   } catch (error) {
@@ -302,6 +600,8 @@ export const setDefaultWallet = async (c: AppContext) => {
       projectId: projectId ?? null,
     },
   });
+
+  clearWalletCaches();
 
   return success(c, { defaultWalletId: parsed.data.walletId });
 };
@@ -381,11 +681,15 @@ export const updateWallet = async (c: AppContext) => {
     },
   };
 
+  clearWalletCaches();
+
   return success(c, response);
 };
 
 export const listWallets = async (c: AppContext) => {
-  const { wallets, filters } = await getScopedWallets(c);
+  const filters = resolveWalletFilters(c);
+  const wallets = await getCachedWalletSummaries(c, filters, "list_wallets");
+  const balancesStartedAt = performance.now();
   const balancesByWalletId = filters.includeBalances
     ? await getBalancesByWalletId(
         c,
@@ -395,6 +699,12 @@ export const listWallets = async (c: AppContext) => {
         }))
       )
     : new Map<string, CustodyWalletTokenBalance[]>();
+
+  if (filters.includeBalances) {
+    logWalletStep(c, "list_wallets", "fetch_wallet_balances", balancesStartedAt, {
+      walletCount: wallets.length,
+    });
+  }
 
   const response: CustodyWalletsResponse = {
     wallets: wallets.map((wallet) => ({
@@ -420,7 +730,20 @@ export const listWallets = async (c: AppContext) => {
 };
 
 export const getWalletAggregate = async (c: AppContext) => {
-  const { wallets } = await getScopedWallets(c, { defaultIncludeAllProviders: true });
+  const filters = resolveWalletFilters(c, { defaultIncludeAllProviders: true });
+  const aggregateCacheKey = buildWalletCacheKey(c, filters, "aggregate");
+  const cachedAggregate = readCache(walletAggregateCache, aggregateCacheKey);
+  if (cachedAggregate) {
+    logWalletStep(c, "aggregate_wallets", "aggregate_cache_hit", performance.now(), {
+      walletCount: cachedAggregate.walletCount,
+    });
+    return success(c, {
+      aggregate: cachedAggregate,
+    } satisfies CustodyWalletAggregateResponse);
+  }
+
+  const wallets = await getCachedWalletSummaries(c, filters, "aggregate_wallets");
+  const balancesStartedAt = performance.now();
   const balancesByWalletId = await getBalancesByWalletId(
     c,
     wallets.map((wallet) => ({
@@ -429,18 +752,33 @@ export const getWalletAggregate = async (c: AppContext) => {
     })),
     { includeUsdValues: false }
   );
+  logWalletStep(c, "aggregate_wallets", "fetch_wallet_balances", balancesStartedAt, {
+    walletCount: wallets.length,
+  });
+
+  const aggregateStartedAt = performance.now();
   const aggregatedBalances = await attachUsdValuesToBalances(
     c.env,
     aggregateTrackedWalletBalances(
       wallets.map((wallet) => balancesByWalletId.get(wallet.walletId) ?? [])
     )
   );
+  logWalletStep(c, "aggregate_wallets", "attach_usd_values", aggregateStartedAt, {
+    balanceCount: aggregatedBalances.length,
+  });
 
-  const response: CustodyWalletAggregateResponse = {
-    aggregate: {
+  const aggregate = writeCache(
+    walletAggregateCache,
+    aggregateCacheKey,
+    {
       walletCount: wallets.length,
       balances: aggregatedBalances,
     },
+    AGGREGATE_CACHE_TTL_MS
+  );
+
+  const response: CustodyWalletAggregateResponse = {
+    aggregate,
   };
 
   return success(c, response);

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -89,8 +89,9 @@ test.describe
       await gotoToken(page, fixtures.tokens.pending.id);
       await openTab(page, "Fund Management");
 
-      await expect(page.getByRole("button", { name: "Deploy" })).toBeVisible();
-      await page.getByRole("button", { name: "Deploy" }).click();
+      const deployRow = page.getByTestId("fund-management-row-deploy");
+      await expect(deployRow.getByRole("button", { name: "Deploy" })).toBeVisible();
+      await deployRow.getByRole("button", { name: "Deploy" }).click();
       await expect(
         page.getByText(
           "This will deploy the token on-chain so fund management actions can be used."

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -12,7 +12,7 @@ async function gotoIssuanceDashboard(page: Page): Promise<void> {
 
 async function gotoToken(page: Page, tokenId: string): Promise<void> {
   await page.goto(`/dashboard/issuance/${tokenId}`);
-  await expect(page.getByTestId("permission-row-mint-authority")).toBeVisible();
+  await expect(page.getByTestId("overview-row-token-address")).toBeVisible();
 }
 
 async function openTab(page: Page, name: string): Promise<void> {
@@ -87,6 +87,7 @@ test.describe
       page,
     }) => {
       await gotoToken(page, fixtures.tokens.pending.id);
+      await openTab(page, "Fund Management");
 
       await expect(page.getByRole("button", { name: "Deploy" })).toBeVisible();
       await page.getByRole("button", { name: "Deploy" }).click();
@@ -142,6 +143,7 @@ test.describe
       page,
     }) => {
       await gotoToken(page, fixtures.tokens.allowlisted.id);
+      await openTab(page, "Permissions");
 
       const row = page.getByTestId("permission-row-permanent-delegate");
       await row.getByRole("button", { name: "Edit" }).click();

--- a/apps/sdp-web/src/app/api/dashboard/home/activity/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/home/activity/route.ts
@@ -1,0 +1,95 @@
+import {
+  buildHomeActivityRows,
+  computeTodaysVolume,
+  fetchIssuanceTokens,
+  fetchOrgIssuanceActivity,
+} from "@/app/dashboard/home-page.data";
+import { fetchPaymentTransfers } from "@/app/dashboard/payments/payments-page.data";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const trace = createTimedTrace("route.dashboard.home.activity", request);
+
+  try {
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.home.activity.api")
+    );
+    const [transfersResult, issuanceTokensResult] = await Promise.all([
+      trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request, 20)),
+      trace.step("fetch_issuance_tokens", () => fetchIssuanceTokens(apiClient.request, 20)),
+    ]);
+
+    const issuanceTokens = issuanceTokensResult.data ?? [];
+    const issuanceActivityResult =
+      issuanceTokensResult.ok && issuanceTokens.length > 0
+        ? await trace.step("fetch_issuance_activity", () =>
+            fetchOrgIssuanceActivity(apiClient.request, issuanceTokens)
+          )
+        : { rows: [], error: null };
+
+    const transfersError = transfersResult.ok
+      ? null
+      : "Payments activity is unavailable right now.";
+    const issuanceTokensError = issuanceTokensResult.ok
+      ? null
+      : "Issuance activity is unavailable right now.";
+
+    const activityRows = buildHomeActivityRows(
+      transfersResult.data ?? [],
+      issuanceActivityResult.rows
+    );
+    const activityError =
+      activityRows.length === 0
+        ? (transfersError ?? issuanceTokensError ?? issuanceActivityResult.error)
+        : null;
+    const activityNotice = [transfersError, issuanceTokensError, issuanceActivityResult.error]
+      .filter(Boolean)
+      .join(" ");
+
+    const response = NextResponse.json(
+      {
+        data: {
+          todaysVolume: transfersResult.data ? computeTodaysVolume(transfersResult.data) : null,
+          activityRows,
+          activityError,
+          activityNotice: activityNotice || null,
+        },
+      },
+      {
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, 200, {
+      transferCount: transfersResult.data?.length ?? 0,
+      issuanceTokenCount: issuanceTokens.length,
+      activityRowCount: activityRows.length,
+    });
+
+    return response;
+  } catch (error) {
+    const response = NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to load dashboard activity",
+      },
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to load dashboard activity",
+    });
+
+    return response;
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/supporting-data/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/supporting-data/route.ts
@@ -1,0 +1,167 @@
+import { fetchPaymentsWallets } from "@/app/dashboard/payments/payments-page.data";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+import type { FrozenAccount, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
+import { NextResponse } from "next/server";
+
+interface PaginatedMeta {
+  total?: number;
+  hasMore?: boolean;
+}
+
+function parseErrorMessage(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: string };
+      message?: string;
+    };
+    return parsed?.error?.message ?? parsed?.message ?? body;
+  } catch {
+    return body || "Unknown error";
+  }
+}
+
+async function fetchList<T>(
+  request: Awaited<ReturnType<typeof createSdpApiClient>>["request"],
+  path: string
+): Promise<{
+  status: number | null;
+  data: T[];
+  error: string | null;
+  total: number | null;
+  hasMore: boolean;
+}> {
+  try {
+    const response = await request(path);
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        status: response.status,
+        data: [],
+        error: parseErrorMessage(body),
+        total: null,
+        hasMore: false,
+      };
+    }
+
+    const payload = (await response.json()) as {
+      data?: T[];
+      meta?: PaginatedMeta;
+    };
+
+    return {
+      status: response.status,
+      data: Array.isArray(payload.data) ? payload.data : [],
+      error: null,
+      total: typeof payload.meta?.total === "number" ? payload.meta.total : null,
+      hasMore: payload.meta?.hasMore === true,
+    };
+  } catch (error) {
+    return {
+      status: null,
+      data: [],
+      error: error instanceof Error ? error.message : "Request failed",
+      total: null,
+      hasMore: false,
+    };
+  }
+}
+
+export async function GET(request: Request, { params }: { params: Promise<{ tokenId: string }> }) {
+  const trace = createTimedTrace("route.dashboard.issuance.token.supporting_data", request);
+
+  try {
+    const { tokenId } = await params;
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.issuance.token.supporting_data.api")
+    );
+
+    const [walletsResult, transactionsResult, allowlistResult, frozenResult] = await Promise.all([
+      trace.step("fetch_authority_wallets", () =>
+        fetchPaymentsWallets(apiClient.request, { view: "summary" })
+      ),
+      trace.step("fetch_transactions", () =>
+        fetchList<TokenTransaction>(
+          apiClient.request,
+          `/v1/issuance/tokens/${tokenId}/transactions?page=1&pageSize=100`
+        )
+      ),
+      trace.step("fetch_allowlist", () =>
+        fetchList<TokenAllowlistEntry>(
+          apiClient.request,
+          `/v1/issuance/tokens/${tokenId}/allowlist?page=1&pageSize=100`
+        )
+      ),
+      trace.step("fetch_frozen_accounts", () =>
+        fetchList<FrozenAccount>(
+          apiClient.request,
+          `/v1/issuance/tokens/${tokenId}/frozen?page=1&pageSize=100`
+        )
+      ),
+    ]);
+
+    const response = NextResponse.json(
+      {
+        data: {
+          authorityWallets: walletsResult.data ?? [],
+          authorityWalletsError: walletsResult.ok
+            ? null
+            : `Wallet API ${walletsResult.status ?? "unavailable"}: ${walletsResult.error ?? "Unknown error"}`,
+          transactions: transactionsResult.data,
+          transactionsError: transactionsResult.error
+            ? `Transactions API ${transactionsResult.status ?? "unavailable"}: ${transactionsResult.error}`
+            : null,
+          transactionsTotal: transactionsResult.total,
+          transactionsHasMore: transactionsResult.hasMore,
+          allowlistEntries: allowlistResult.data,
+          allowlistError: allowlistResult.error
+            ? `Allowlist API ${allowlistResult.status ?? "unavailable"}: ${allowlistResult.error}`
+            : null,
+          allowlistTotal: allowlistResult.total,
+          allowlistHasMore: allowlistResult.hasMore,
+          frozenAccounts: frozenResult.data,
+          frozenAccountsError: frozenResult.error
+            ? `Frozen API ${frozenResult.status ?? "unavailable"}: ${frozenResult.error}`
+            : null,
+          frozenAccountsTotal: frozenResult.total,
+          frozenAccountsHasMore: frozenResult.hasMore,
+        },
+      },
+      {
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, 200, {
+      tokenId,
+      transactionCount: transactionsResult.data.length,
+      allowlistCount: allowlistResult.data.length,
+      frozenCount: frozenResult.data.length,
+      authorityWalletCount: walletsResult.data?.length ?? 0,
+    });
+
+    return response;
+  } catch (error) {
+    const response = NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to load token supporting data",
+      },
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to load token supporting data",
+    });
+
+    return response;
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/home-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.data.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import type { HomeActivityRow } from "./home-page.data";
+
+interface HomeActivityResponseEnvelope {
+  data?: {
+    todaysVolume?: number | null;
+    activityRows?: HomeActivityRow[];
+    activityError?: string | null;
+    activityNotice?: string | null;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
+export interface HomeActivitySnapshot {
+  todaysVolume: number | null;
+  activityRows: HomeActivityRow[];
+  activityError: string | null;
+  activityNotice: string | null;
+}
+
+function getApiError(body: HomeActivityResponseEnvelope, fallback: string): string {
+  if (typeof body.error?.message === "string" && body.error.message) {
+    return body.error.message;
+  }
+
+  return fallback;
+}
+
+export async function fetchHomeActivity(
+  options: {
+    signal?: AbortSignal;
+  } = {}
+): Promise<HomeActivitySnapshot> {
+  const response = await fetch("/api/dashboard/home/activity", {
+    method: "GET",
+    cache: "no-store",
+    signal: options.signal,
+  });
+  const body = (await response.json().catch(() => ({}))) as HomeActivityResponseEnvelope;
+
+  if (!response.ok) {
+    throw new Error(getApiError(body, `Home activity request failed (${response.status}).`));
+  }
+
+  return {
+    todaysVolume: body.data?.todaysVolume ?? null,
+    activityRows: body.data?.activityRows ?? [],
+    activityError: body.data?.activityError ?? null,
+    activityNotice: body.data?.activityNotice ?? null,
+  };
+}

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { CreateApiKeyModal } from "@/app/dashboard/api-keys/create-api-key-modal";
 import { SectionEntry } from "@/app/dashboard/wallets/section-entry";
 import { Button } from "@/components/ui/button";
@@ -13,19 +15,17 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import Link from "next/link";
-import type { HomeActivityRow } from "./home-page.data";
+import useSWR from "swr";
+import { fetchHomeActivity } from "./home-workspace.data";
 import { formatCurrencyAmount, formatDisplayAmount } from "./payments/payments-overview.utils";
 
 interface HomeWorkspaceProps {
   totalBalance: number | null;
   totalBalanceError: string | null;
-  todaysVolume: number | null;
-  todaysVolumeError: string | null;
-  activityRows: HomeActivityRow[];
-  activityError: string | null;
-  activityNotice: string | null;
   wallets: PaymentsDashboardWallet[];
 }
+
+const HOME_ACTIVITY_KEY = "dashboard-home-activity";
 
 function formatRelativeTime(value: string): string {
   const date = new Date(value);
@@ -94,30 +94,46 @@ function MetricCard({
   );
 }
 
-export function HomeWorkspace({
-  totalBalance,
-  totalBalanceError,
-  todaysVolume,
-  todaysVolumeError,
-  activityRows,
-  activityError,
-  activityNotice,
-  wallets,
-}: HomeWorkspaceProps) {
+export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: HomeWorkspaceProps) {
+  const { data: activitySnapshot, error: activityRequestError } = useSWR(
+    HOME_ACTIVITY_KEY,
+    () => fetchHomeActivity(),
+    {
+      revalidateOnFocus: true,
+      refreshInterval: 20_000,
+    }
+  );
   const isWalletEmptyState = wallets.length === 0;
   const totalBalanceHint = isWalletEmptyState
     ? "Create your first wallet to start tracking balances."
     : totalBalance === null
       ? "No tracked balances found yet."
       : null;
+  const todaysVolume = activitySnapshot?.todaysVolume ?? null;
+  const todaysVolumeError = activityRequestError
+    ? activityRequestError instanceof Error
+      ? activityRequestError.message
+      : "Activity is unavailable right now."
+    : (activitySnapshot?.activityError ?? null);
+  const activityRows = activitySnapshot?.activityRows ?? [];
+  const activityError = activityRequestError
+    ? activityRequestError instanceof Error
+      ? activityRequestError.message
+      : "Activity is unavailable right now."
+    : (activitySnapshot?.activityError ?? null);
+  const activityNotice = activitySnapshot?.activityNotice ?? null;
   const todaysVolumeHint = isWalletEmptyState
     ? "Payment activity will appear after you create a wallet."
     : todaysVolume === null
-      ? "No payment volume recorded yet."
+      ? activitySnapshot
+        ? "No payment volume recorded yet."
+        : "Loading payment activity..."
       : null;
   const emptyActivityMessage = isWalletEmptyState
     ? "Create your first wallet to start tracking balances and activity."
-    : "No recent activity found yet.";
+    : activitySnapshot
+      ? "No recent activity found yet."
+      : "Loading recent activity...";
 
   return (
     <div className="w-full space-y-8 py-2">

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
@@ -1,9 +1,8 @@
 import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
-import type { FrozenAccount, Token, TokenAllowlistEntry, TokenTransaction } from "@sdp/types";
+import type { Token } from "@sdp/types";
 import { notFound, redirect } from "next/navigation";
-import { fetchPaymentsWallets } from "../../payments/payments-page.data";
 import { TokenManagementWorkspace } from "./token-management-workspace";
 
 interface TokenManagementPageProps {
@@ -87,13 +86,6 @@ function mapToken(payload: unknown): Token | null {
   return token ?? null;
 }
 
-function mapList<T>(payload: unknown): T[] {
-  if (!Array.isArray(payload)) {
-    return [];
-  }
-  return payload as T[];
-}
-
 export default async function IssuanceTokenManagementPage({ params }: TokenManagementPageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
@@ -111,36 +103,9 @@ export default async function IssuanceTokenManagementPage({ params }: TokenManag
       createSdpApiClient(trace.childContext("dashboard.issuance.token.api"))
     );
 
-    const [tokenResult, walletsResult, transactionsResult, allowlistResult, frozenResult] =
-      await Promise.all([
-        trace.step("fetch_token", () =>
-          fetchData<Token | null>(apiClient.request, `/v1/issuance/tokens/${tokenId}`, mapToken)
-        ),
-        trace.step("fetch_authority_wallets", () =>
-          fetchPaymentsWallets(apiClient.request, { includeBalances: false })
-        ),
-        trace.step("fetch_transactions", () =>
-          fetchData<TokenTransaction[]>(
-            apiClient.request,
-            `/v1/issuance/tokens/${tokenId}/transactions?page=1&pageSize=100`,
-            (payload) => mapList<TokenTransaction>(payload)
-          )
-        ),
-        trace.step("fetch_allowlist", () =>
-          fetchData<TokenAllowlistEntry[]>(
-            apiClient.request,
-            `/v1/issuance/tokens/${tokenId}/allowlist?page=1&pageSize=100`,
-            (payload) => mapList<TokenAllowlistEntry>(payload)
-          )
-        ),
-        trace.step("fetch_frozen_accounts", () =>
-          fetchData<FrozenAccount[]>(
-            apiClient.request,
-            `/v1/issuance/tokens/${tokenId}/frozen?page=1&pageSize=100`,
-            (payload) => mapList<FrozenAccount>(payload)
-          )
-        ),
-      ]);
+    const tokenResult = await trace.step("fetch_token", () =>
+      fetchData<Token | null>(apiClient.request, `/v1/issuance/tokens/${tokenId}`, mapToken)
+    );
 
     if (tokenResult.status === 404 || !tokenResult.data) {
       trace.log({
@@ -154,10 +119,6 @@ export default async function IssuanceTokenManagementPage({ params }: TokenManag
     trace.log({
       ok: true,
       tokenId,
-      transactionCount: transactionsResult.data?.length ?? 0,
-      allowlistCount: allowlistResult.data?.length ?? 0,
-      frozenCount: frozenResult.data?.length ?? 0,
-      authorityWalletCount: walletsResult.data?.length ?? 0,
     });
 
     return (
@@ -168,34 +129,20 @@ export default async function IssuanceTokenManagementPage({ params }: TokenManag
             ? `Token API ${tokenResult.status ?? "unavailable"}: ${tokenResult.error}`
             : null
         }
-        authorityWallets={walletsResult.ok ? (walletsResult.data ?? []) : []}
-        authorityWalletsError={
-          walletsResult.ok ? null : (walletsResult.error ?? "Wallets unavailable")
-        }
-        transactions={transactionsResult.data ?? []}
-        transactionsError={
-          transactionsResult.error
-            ? `Transactions API ${transactionsResult.status ?? "unavailable"}: ${transactionsResult.error}`
-            : null
-        }
-        transactionsTotal={transactionsResult.total}
-        transactionsHasMore={transactionsResult.hasMore}
-        allowlistEntries={allowlistResult.data ?? []}
-        allowlistError={
-          allowlistResult.error
-            ? `Allowlist API ${allowlistResult.status ?? "unavailable"}: ${allowlistResult.error}`
-            : null
-        }
-        allowlistTotal={allowlistResult.total}
-        allowlistHasMore={allowlistResult.hasMore}
-        frozenAccounts={frozenResult.data ?? []}
-        frozenAccountsError={
-          frozenResult.error
-            ? `Frozen API ${frozenResult.status ?? "unavailable"}: ${frozenResult.error}`
-            : null
-        }
-        frozenAccountsTotal={frozenResult.total}
-        frozenAccountsHasMore={frozenResult.hasMore}
+        authorityWallets={[]}
+        authorityWalletsError={null}
+        transactions={[]}
+        transactionsError={null}
+        transactionsTotal={null}
+        transactionsHasMore={false}
+        allowlistEntries={[]}
+        allowlistError={null}
+        allowlistTotal={null}
+        allowlistHasMore={false}
+        frozenAccounts={[]}
+        frozenAccountsError={null}
+        frozenAccountsTotal={null}
+        frozenAccountsHasMore={false}
       />
     );
   } catch (error) {

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.data.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import type {
+  FrozenAccount,
+  PaymentsDashboardWallet,
+  TokenAllowlistEntry,
+  TokenTransaction,
+} from "@sdp/types";
+
+interface SupportingDataEnvelope {
+  data?: TokenManagementSupportingData;
+  error?: {
+    message?: string;
+  };
+}
+
+export interface TokenManagementSupportingData {
+  authorityWallets: PaymentsDashboardWallet[];
+  authorityWalletsError: string | null;
+  transactions: TokenTransaction[];
+  transactionsError: string | null;
+  transactionsTotal: number | null;
+  transactionsHasMore: boolean;
+  allowlistEntries: TokenAllowlistEntry[];
+  allowlistError: string | null;
+  allowlistTotal: number | null;
+  allowlistHasMore: boolean;
+  frozenAccounts: FrozenAccount[];
+  frozenAccountsError: string | null;
+  frozenAccountsTotal: number | null;
+  frozenAccountsHasMore: boolean;
+}
+
+function getApiError(body: SupportingDataEnvelope, fallback: string): string {
+  if (typeof body.error?.message === "string" && body.error.message) {
+    return body.error.message;
+  }
+
+  return fallback;
+}
+
+export async function fetchTokenManagementSupportingData(
+  tokenId: string,
+  options: {
+    signal?: AbortSignal;
+  } = {}
+): Promise<TokenManagementSupportingData> {
+  const response = await fetch(
+    `/api/dashboard/issuance/tokens/${encodeURIComponent(tokenId)}/supporting-data`,
+    {
+      method: "GET",
+      cache: "no-store",
+      signal: options.signal,
+    }
+  );
+  const body = (await response.json().catch(() => ({}))) as SupportingDataEnvelope;
+
+  if (!response.ok) {
+    throw new Error(
+      getApiError(body, `Token supporting data request failed (${response.status}).`)
+    );
+  }
+
+  if (!body.data) {
+    throw new Error("Token supporting data response was empty.");
+  }
+
+  return body.data;
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -21,8 +21,10 @@ import {
   fetchTokenManagementSupportingData,
 } from "./token-management-workspace.data";
 import type {
+  ActionExecutionInput,
   AdminAction,
   PermissionRow,
+  RunActionOptions,
   TokenManagementTab,
   TokenManagementWorkspaceProps,
 } from "./token-management-workspace.types";
@@ -133,8 +135,8 @@ export function TokenManagementWorkspace({
   const {
     isPending,
     actionConfirmation,
-    runAction,
-    runActionImmediately,
+    runAction: runActionBase,
+    runActionImmediately: runActionImmediatelyBase,
     dismissActionConfirmation,
     confirmAction,
   } = useTokenActionRunner();
@@ -201,7 +203,11 @@ export function TokenManagementWorkspace({
       initialTransactionsTotal,
     ]
   );
-  const { data: supportingData, error: supportingDataRequestError } = useSWR(
+  const {
+    data: supportingData,
+    error: supportingDataRequestError,
+    mutate: mutateSupportingData,
+  } = useSWR(
     shouldLoadSupportingData ? ["token-management-supporting-data", token.id] : null,
     ([, tokenId]: readonly [string, string]) => fetchTokenManagementSupportingData(tokenId),
     {
@@ -218,6 +224,29 @@ export function TokenManagementWorkspace({
   const supportingDataLoading =
     shouldLoadSupportingData && supportingData === undefined && !supportingDataError;
   const resolvedSupportingData = supportingData ?? initialSupportingData;
+  const revalidateSupportingDataAfterSuccess = async () => {
+    if (!shouldLoadSupportingData) {
+      return;
+    }
+
+    await mutateSupportingData();
+  };
+  const runAction = (input: ActionExecutionInput, options: RunActionOptions = {}) =>
+    runActionBase(input, {
+      ...options,
+      onSuccess: async (result) => {
+        await options.onSuccess?.(result);
+        await revalidateSupportingDataAfterSuccess();
+      },
+    });
+  const runActionImmediately = (input: ActionExecutionInput, options: RunActionOptions = {}) =>
+    runActionImmediatelyBase(input, {
+      ...options,
+      onSuccess: async (result) => {
+        await options.onSuccess?.(result);
+        await revalidateSupportingDataAfterSuccess();
+      },
+    });
   const authorityWallets = resolvedSupportingData.authorityWallets;
   const authorityWalletsError = supportingDataError ?? resolvedSupportingData.authorityWalletsError;
   const transactions = resolvedSupportingData.transactions;

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -2,8 +2,9 @@
 
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import useSWR from "swr";
 import { TokenActionConfirmationDialog } from "./token-action-confirmation-dialog";
 import { TokenActionForms } from "./token-action-forms";
 import { TokenAuthorityModal } from "./token-authority-modal";
@@ -15,6 +16,10 @@ import {
 } from "./token-fund-management-section";
 import { TokenManagementHeader } from "./token-management-header";
 import { TokenManagementModalShell } from "./token-management-modal-shell";
+import {
+  type TokenManagementSupportingData,
+  fetchTokenManagementSupportingData,
+} from "./token-management-workspace.data";
 import type {
   AdminAction,
   PermissionRow,
@@ -95,23 +100,35 @@ const liveFundManagementRows: Array<{
   },
 ];
 
+function LoadingSection({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-[180px] items-center justify-center rounded-2xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.02)] px-6 py-10">
+      <div className="flex items-center gap-3 text-sm text-[rgba(28,28,29,0.64)]">
+        <Loader2 className="size-4 animate-spin" />
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: token management intentionally centralizes action orchestration and tab coordination in one workspace.
 export function TokenManagementWorkspace({
   token,
   tokenError,
-  authorityWallets,
-  authorityWalletsError,
-  transactions,
-  transactionsError,
-  transactionsTotal,
-  transactionsHasMore,
-  allowlistEntries,
-  allowlistError,
-  allowlistTotal,
-  allowlistHasMore,
-  frozenAccounts,
-  frozenAccountsError,
-  frozenAccountsTotal,
-  frozenAccountsHasMore,
+  authorityWallets: initialAuthorityWallets,
+  authorityWalletsError: initialAuthorityWalletsError,
+  transactions: initialTransactions,
+  transactionsError: initialTransactionsError,
+  transactionsTotal: initialTransactionsTotal,
+  transactionsHasMore: initialTransactionsHasMore,
+  allowlistEntries: initialAllowlistEntries,
+  allowlistError: initialAllowlistError,
+  allowlistTotal: initialAllowlistTotal,
+  allowlistHasMore: initialAllowlistHasMore,
+  frozenAccounts: initialFrozenAccounts,
+  frozenAccountsError: initialFrozenAccountsError,
+  frozenAccountsTotal: initialFrozenAccountsTotal,
+  frozenAccountsHasMore: initialFrozenAccountsHasMore,
 }: TokenManagementWorkspaceProps) {
   const {
     isPending,
@@ -121,7 +138,7 @@ export function TokenManagementWorkspace({
     dismissActionConfirmation,
     confirmAction,
   } = useTokenActionRunner();
-  const [activeTab, setActiveTab] = useState<TokenManagementTab>("permissions");
+  const [activeTab, setActiveTab] = useState<TokenManagementTab>("overview");
   const [activeAction, setActiveAction] = useState<AdminAction | null>(null);
   const [authorityModalRow, setAuthorityModalRow] = useState<PermissionRow | null>(null);
   const [authorityModalCurrentAuthority, setAuthorityModalCurrentAuthority] = useState<
@@ -140,6 +157,81 @@ export function TokenManagementWorkspace({
   const [authorityForm, setAuthorityForm] = useState(createInitialAuthorityForm);
   const [freezeForm, setFreezeForm] = useState(createInitialFreezeForm);
   const [allowlistForm, setAllowlistForm] = useState(createInitialAllowlistForm);
+  const shouldLoadSupportingData = activeTab !== "overview";
+  const hasInitialSupportingData =
+    initialAuthorityWallets.length > 0 ||
+    initialTransactions.length > 0 ||
+    initialAllowlistEntries.length > 0 ||
+    initialFrozenAccounts.length > 0 ||
+    initialAuthorityWalletsError !== null ||
+    initialTransactionsError !== null ||
+    initialAllowlistError !== null ||
+    initialFrozenAccountsError !== null;
+  const initialSupportingData = useMemo<TokenManagementSupportingData>(
+    () => ({
+      authorityWallets: initialAuthorityWallets,
+      authorityWalletsError: initialAuthorityWalletsError,
+      transactions: initialTransactions,
+      transactionsError: initialTransactionsError,
+      transactionsTotal: initialTransactionsTotal,
+      transactionsHasMore: initialTransactionsHasMore,
+      allowlistEntries: initialAllowlistEntries,
+      allowlistError: initialAllowlistError,
+      allowlistTotal: initialAllowlistTotal,
+      allowlistHasMore: initialAllowlistHasMore,
+      frozenAccounts: initialFrozenAccounts,
+      frozenAccountsError: initialFrozenAccountsError,
+      frozenAccountsTotal: initialFrozenAccountsTotal,
+      frozenAccountsHasMore: initialFrozenAccountsHasMore,
+    }),
+    [
+      initialAllowlistEntries,
+      initialAllowlistError,
+      initialAllowlistHasMore,
+      initialAllowlistTotal,
+      initialAuthorityWallets,
+      initialAuthorityWalletsError,
+      initialFrozenAccounts,
+      initialFrozenAccountsError,
+      initialFrozenAccountsHasMore,
+      initialFrozenAccountsTotal,
+      initialTransactions,
+      initialTransactionsError,
+      initialTransactionsHasMore,
+      initialTransactionsTotal,
+    ]
+  );
+  const { data: supportingData, error: supportingDataRequestError } = useSWR(
+    shouldLoadSupportingData ? ["token-management-supporting-data", token.id] : null,
+    ([, tokenId]: readonly [string, string]) => fetchTokenManagementSupportingData(tokenId),
+    {
+      fallbackData: hasInitialSupportingData ? initialSupportingData : undefined,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const supportingDataError = supportingDataRequestError
+    ? supportingDataRequestError instanceof Error
+      ? supportingDataRequestError.message
+      : "Unable to load token management data."
+    : null;
+  const supportingDataLoading =
+    shouldLoadSupportingData && supportingData === undefined && !supportingDataError;
+  const resolvedSupportingData = supportingData ?? initialSupportingData;
+  const authorityWallets = resolvedSupportingData.authorityWallets;
+  const authorityWalletsError = supportingDataError ?? resolvedSupportingData.authorityWalletsError;
+  const transactions = resolvedSupportingData.transactions;
+  const transactionsError = supportingDataError ?? resolvedSupportingData.transactionsError;
+  const transactionsTotal = resolvedSupportingData.transactionsTotal;
+  const transactionsHasMore = resolvedSupportingData.transactionsHasMore;
+  const allowlistEntries = resolvedSupportingData.allowlistEntries;
+  const allowlistError = supportingDataError ?? resolvedSupportingData.allowlistError;
+  const allowlistTotal = resolvedSupportingData.allowlistTotal;
+  const allowlistHasMore = resolvedSupportingData.allowlistHasMore;
+  const frozenAccounts = resolvedSupportingData.frozenAccounts;
+  const frozenAccountsError = supportingDataError ?? resolvedSupportingData.frozenAccountsError;
+  const frozenAccountsTotal = resolvedSupportingData.frozenAccountsTotal;
+  const frozenAccountsHasMore = resolvedSupportingData.frozenAccountsHasMore;
 
   const tokenBasePath = `/v1/issuance/tokens/${token.id}`;
   const explorerHref = getExplorerHref(token.mintAddress);
@@ -982,45 +1074,30 @@ export function TokenManagementWorkspace({
 
       {activeTab === "overview" ? (
         <div className="space-y-4">
-          <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
-            <TokenOverviewSection
-              token={token}
-              showTitle={false}
-              mintAuthorityValue={displayedMintAuthority}
-            />
-            <TokenControlListsSection
-              showAllowlist={showAllowlistControls}
-              allowlistEntriesCount={allowlistEntries.length}
-              allowlistError={allowlistError}
-              allowlistTotal={allowlistTotal}
-              allowlistHasMore={allowlistHasMore}
-              frozenAccountsCount={frozenAccounts.length}
-              frozenAccountsError={frozenAccountsError}
-              frozenAccountsTotal={frozenAccountsTotal}
-              frozenAccountsHasMore={frozenAccountsHasMore}
-            />
-          </div>
-          <TokenTransactionsSection
-            transactions={transactions}
-            transactionsError={transactionsError}
-            transactionsTotal={transactionsTotal}
-            transactionsHasMore={transactionsHasMore}
+          <TokenOverviewSection
+            token={token}
+            showTitle={false}
+            mintAuthorityValue={displayedMintAuthority}
           />
         </div>
       ) : null}
 
       {activeTab === "permissions" ? (
-        <div className="space-y-4">
-          <TokenSettingsSection
-            mode="permissions"
-            permissionRows={permissionRows}
-            extensionRows={extensionRows}
-            showTitle={false}
-            canEditAuthorities={!canDeployToken}
-            onCopy={handleCopy}
-            onEditAuthority={handleAuthorityModalOpen}
-          />
-        </div>
+        supportingDataLoading ? (
+          <LoadingSection message="Loading authority wallet access…" />
+        ) : (
+          <div className="space-y-4">
+            <TokenSettingsSection
+              mode="permissions"
+              permissionRows={permissionRows}
+              extensionRows={extensionRows}
+              showTitle={false}
+              canEditAuthorities={!canDeployToken}
+              onCopy={handleCopy}
+              onEditAuthority={handleAuthorityModalOpen}
+            />
+          </div>
+        )
       ) : null}
 
       {activeTab === "extensions" ? (
@@ -1038,28 +1115,32 @@ export function TokenManagementWorkspace({
       ) : null}
 
       {activeTab === "compliance" ? (
-        <div className="space-y-4">
-          <ActionSelector
-            actions={complianceActions}
-            activeAction={activeAction}
-            disabledReasons={complianceActionDisabledReasons}
-            onSelectAction={selectAction}
-          />
-          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
-            <div>{visibleActionForm}</div>
-            <TokenControlListsSection
-              showAllowlist={showAllowlistControls}
-              allowlistEntriesCount={allowlistEntries.length}
-              allowlistError={allowlistError}
-              allowlistTotal={allowlistTotal}
-              allowlistHasMore={allowlistHasMore}
-              frozenAccountsCount={frozenAccounts.length}
-              frozenAccountsError={frozenAccountsError}
-              frozenAccountsTotal={frozenAccountsTotal}
-              frozenAccountsHasMore={frozenAccountsHasMore}
+        supportingDataLoading ? (
+          <LoadingSection message="Loading compliance controls…" />
+        ) : (
+          <div className="space-y-4">
+            <ActionSelector
+              actions={complianceActions}
+              activeAction={activeAction}
+              disabledReasons={complianceActionDisabledReasons}
+              onSelectAction={selectAction}
             />
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+              <div>{visibleActionForm}</div>
+              <TokenControlListsSection
+                showAllowlist={showAllowlistControls}
+                allowlistEntriesCount={allowlistEntries.length}
+                allowlistError={allowlistError}
+                allowlistTotal={allowlistTotal}
+                allowlistHasMore={allowlistHasMore}
+                frozenAccountsCount={frozenAccounts.length}
+                frozenAccountsError={frozenAccountsError}
+                frozenAccountsTotal={frozenAccountsTotal}
+                frozenAccountsHasMore={frozenAccountsHasMore}
+              />
+            </div>
           </div>
-        </div>
+        )
       ) : null}
 
       {activeTab === "metadata" ? (
@@ -1074,18 +1155,22 @@ export function TokenManagementWorkspace({
       ) : null}
 
       {activeTab === "fund-management" ? (
-        <div className="space-y-4">
-          <TokenFundManagementSection
-            rows={fundManagementRows}
-            onOpenAction={openFundManagementModal}
-          />
-          <TokenTransactionsSection
-            transactions={transactions}
-            transactionsError={transactionsError}
-            transactionsTotal={transactionsTotal}
-            transactionsHasMore={transactionsHasMore}
-          />
-        </div>
+        supportingDataLoading ? (
+          <LoadingSection message="Loading fund management data…" />
+        ) : (
+          <div className="space-y-4">
+            <TokenFundManagementSection
+              rows={fundManagementRows}
+              onOpenAction={openFundManagementModal}
+            />
+            <TokenTransactionsSection
+              transactions={transactions}
+              transactionsError={transactionsError}
+              transactionsTotal={transactionsTotal}
+              transactionsHasMore={transactionsHasMore}
+            />
+          </div>
+        )
       ) : null}
 
       <TokenAuthorityModal

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -212,7 +212,8 @@ export function TokenManagementWorkspace({
     ([, tokenId]: readonly [string, string]) => fetchTokenManagementSupportingData(tokenId),
     {
       fallbackData: hasInitialSupportingData ? initialSupportingData : undefined,
-      revalidateOnFocus: false,
+      refreshInterval: 60_000,
+      revalidateOnFocus: true,
       revalidateIfStale: false,
     }
   );

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.types.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.types.ts
@@ -54,6 +54,7 @@ export interface RunActionOptions {
   confirmButtonLabel?: string;
   submitToast?: string;
   successToast?: string;
+  onSuccess?: (result: ActionExecutionResult) => Promise<void> | void;
 }
 
 export interface ActionConfirmationState {
@@ -67,7 +68,8 @@ export interface ActionConfirmationState {
       | "submitToast"
       | "successToast"
     >
-  >;
+  > &
+    Pick<RunActionOptions, "onSuccess">;
 }
 
 export interface TokenManagementWorkspaceProps {

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/use-token-action-runner.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/use-token-action-runner.ts
@@ -33,6 +33,7 @@ export function useTokenActionRunner() {
       if (result.ok) {
         setActionConfirmation(null);
         toast.success(successToast, { id: toastId });
+        await options.onSuccess?.(result);
         router.refresh();
         return result;
       }
@@ -56,6 +57,7 @@ export function useTokenActionRunner() {
           confirmButtonLabel: options.confirmButtonLabel ?? "Go ahead",
           submitToast: options.submitToast ?? `Submitting ${input.label.toLowerCase()}...`,
           successToast: options.successToast ?? "Transaction finalized successfully.",
+          onSuccess: options.onSuccess,
         },
       });
       return;

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-features-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-features-step.tsx
@@ -17,6 +17,7 @@ interface CreateTokenFeaturesStepProps {
   template: TemplateSelection;
   draft: TokenDraft;
   signerWallets: PaymentsDashboardWallet[];
+  signerWalletsLoading: boolean;
   signerWalletsError: string | null;
   submitState: CreateIssuanceTokenResult;
   isPending: boolean;
@@ -31,6 +32,7 @@ export function CreateTokenFeaturesStep({
   template,
   draft,
   signerWallets,
+  signerWalletsLoading,
   signerWalletsError,
   submitState,
   isPending,
@@ -98,6 +100,10 @@ export function CreateTokenFeaturesStep({
                 actions.
               </p>
             </>
+          ) : signerWalletsLoading ? (
+            <p className="rounded-2xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.03)] px-4 py-3 text-base text-[rgba(28,28,29,0.62)]">
+              Loading signer wallets…
+            </p>
           ) : signerWalletsError ? (
             <p className="rounded-2xl border border-[#c71f37]/20 bg-[#c71f37]/[0.03] px-4 py-3 text-base text-[#8a1f2a]">
               {signerWalletsError}

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
@@ -8,6 +8,8 @@ import { X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useState, useTransition } from "react";
 import { toast } from "sonner";
+import useSWR from "swr";
+import { fetchWallets } from "../payments/payments-workspace.data";
 import { type CreateIssuanceTokenResult, createIssuanceTokenAction } from "./actions";
 import { CreateTokenFeaturesStep } from "./create-token-features-step";
 import { CreateTokenIdentityStep } from "./create-token-identity-step";
@@ -34,6 +36,7 @@ interface CreateIssuanceTokenModalProps {
   triggerClassName?: string;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: modal flow intentionally coordinates multi-step issuance creation in one component.
 export function CreateIssuanceTokenModal({
   signerWallets = [],
   signerWalletsError = null,
@@ -67,6 +70,26 @@ export function CreateIssuanceTokenModal({
   };
   const isIdentityStep = flow.kind === "creation" && flow.step === "identity";
   const isFeaturesStep = flow.kind === "creation" && flow.step === "features";
+  const shouldLoadSignerWallets = isOpen && isFeaturesStep;
+  const hasServerWalletSnapshot = signerWallets.length > 0 || signerWalletsError !== null;
+  const { data: liveSignerWalletsData, error: liveSignerWalletsError } = useSWR(
+    shouldLoadSignerWallets ? "issuance-create-token-signer-wallets" : null,
+    () => fetchWallets(),
+    {
+      fallbackData: hasServerWalletSnapshot ? signerWallets : undefined,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const liveSignerWallets = liveSignerWalletsData ?? signerWallets;
+  const signerWalletsLoading = shouldLoadSignerWallets && liveSignerWalletsData === undefined;
+  const resolvedSignerWalletsError = liveSignerWalletsError
+    ? liveSignerWalletsError instanceof Error
+      ? liveSignerWalletsError.message
+      : "Unable to load signer wallets."
+    : liveSignerWalletsData === undefined
+      ? signerWalletsError
+      : null;
   const selectedAccessControlAvailable =
     template && flow.kind === "creation"
       ? getAccessControlAvailability(template, draft.accessControlMode).available
@@ -238,8 +261,9 @@ export function CreateIssuanceTokenModal({
                   <CreateTokenFeaturesStep
                     template={template}
                     draft={draft}
-                    signerWallets={signerWallets}
-                    signerWalletsError={signerWalletsError}
+                    signerWallets={liveSignerWallets}
+                    signerWalletsLoading={signerWalletsLoading}
+                    signerWalletsError={resolvedSignerWalletsError}
                     submitState={submitState}
                     isPending={isPending}
                     canSubmit={canSubmit}

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -152,7 +152,11 @@ async function fetchTokens(
   }
 }
 
-export default async function IssuancePage() {
+interface IssuancePageProps {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function IssuancePage({ searchParams }: IssuancePageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
     redirect("/sign-in");
@@ -164,17 +168,30 @@ export default async function IssuancePage() {
   const trace = createTimedTrace("dashboard.issuance.page");
 
   try {
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const currentTab =
+      resolvedSearchParams?.tab === "playground" ||
+      (Array.isArray(resolvedSearchParams?.tab) && resolvedSearchParams.tab[0] === "playground")
+        ? "playground"
+        : "tokens";
+    const isPlaygroundTab = currentTab === "playground";
     const apiBaseUrl = resolvePlaygroundApiBaseUrl();
     const apiClient = await trace.step("create_sdp_api_client", () =>
       createSdpApiClient(trace.childContext("dashboard.issuance.api"))
     );
     const [templatesResult, tokensResult, apiKeysResult, signerWalletsResult] = await Promise.all([
-      trace.step("fetch_templates", () => fetchTemplates(apiClient.request)),
+      isPlaygroundTab
+        ? trace.step("fetch_templates", () => fetchTemplates(apiClient.request))
+        : Promise.resolve({ ok: true as const, data: [] }),
       trace.step("fetch_tokens", () => fetchTokens(apiClient.request)),
-      trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
-      trace.step("fetch_signer_wallets", () =>
-        fetchPaymentsWallets(apiClient.request, { includeBalances: false })
-      ),
+      isPlaygroundTab
+        ? trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request))
+        : Promise.resolve({ ok: true as const, data: [] }),
+      isPlaygroundTab
+        ? trace.step("fetch_signer_wallets", () =>
+            fetchPaymentsWallets(apiClient.request, { view: "summary" })
+          )
+        : Promise.resolve({ ok: true as const, data: [] }),
     ]);
 
     const tokens = tokensResult.data ?? [];
@@ -185,6 +202,7 @@ export default async function IssuancePage() {
 
     trace.log({
       ok: true,
+      tab: currentTab,
       tokenCount: tokens.length,
       templateCount: templatesResult.data?.length ?? 0,
       apiKeyCount: apiKeys.length,

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -2,22 +2,9 @@ import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import {
-  buildHomeActivityRows,
-  computeTodaysVolume,
-  fetchIssuanceTokens,
-  fetchOrgIssuanceActivity,
-} from "./home-page.data";
 import { HomeWorkspace } from "./home-workspace";
-import {
-  aggregateBalancesFromWallets,
-  resolveTotalBalance,
-} from "./payments/payments-overview.utils";
-import {
-  fetchPaymentTransfers,
-  fetchPaymentsAggregate,
-  fetchPaymentsWallets,
-} from "./payments/payments-page.data";
+import { resolveTotalBalance } from "./payments/payments-overview.utils";
+import { fetchPaymentsAggregate, fetchPaymentsWallets } from "./payments/payments-page.data";
 
 export default async function DashboardPage() {
   const { userId, orgId } = await auth();
@@ -34,57 +21,23 @@ export default async function DashboardPage() {
     const apiClient = await trace.step("create_sdp_api_client", () =>
       createSdpApiClient(trace.childContext("dashboard.home.api"))
     );
-    const [aggregateResult, transfersResult, walletsResult, issuanceTokensResult] =
-      await Promise.all([
-        trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
-        trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request, 100)),
-        trace.step("fetch_payments_wallets", () =>
-          fetchPaymentsWallets(apiClient.request, { includeBalances: false })
-        ),
-        trace.step("fetch_issuance_tokens", () => fetchIssuanceTokens(apiClient.request, 10)),
-      ]);
-    const issuanceTokens = issuanceTokensResult.data ?? [];
-
-    const issuanceActivityResult =
-      issuanceTokensResult.ok && issuanceTokens.length > 0
-        ? await trace.step("fetch_issuance_activity", () =>
-            fetchOrgIssuanceActivity(apiClient.request, issuanceTokens)
-          )
-        : { rows: [], error: null };
+    const [aggregateResult, walletsResult] = await Promise.all([
+      trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
+      trace.step("fetch_wallet_summaries", () =>
+        fetchPaymentsWallets(apiClient.request, { view: "summary" })
+      ),
+    ]);
 
     const wallets = walletsResult.data ?? [];
     const isWalletEmptyState = walletsResult.ok && wallets.length === 0;
-    const totalBalance = aggregateResult.data?.balances
-      ? resolveTotalBalance(aggregateResult.data.balances)
-      : resolveTotalBalance(aggregateBalancesFromWallets(wallets));
-    const todaysVolume = transfersResult.data ? computeTodaysVolume(transfersResult.data) : null;
-    const activityRows = buildHomeActivityRows(
-      transfersResult.data ?? [],
-      issuanceActivityResult.rows
-    );
+    const totalBalance = resolveTotalBalance(aggregateResult.data?.balances ?? []);
 
     const aggregateError =
       aggregateResult.ok || isWalletEmptyState ? null : "Balance data is unavailable right now.";
-    const transfersError =
-      transfersResult.ok || isWalletEmptyState
-        ? null
-        : "Payments activity is unavailable right now.";
-    const issuanceTokensError = issuanceTokensResult.ok
-      ? null
-      : "Issuance activity is unavailable right now.";
-
-    const activityError =
-      activityRows.length === 0
-        ? (transfersError ?? issuanceTokensError ?? issuanceActivityResult.error)
-        : null;
-    const activityNotice = [transfersError, issuanceTokensError, issuanceActivityResult.error]
-      .filter(Boolean)
-      .join(" ");
 
     trace.log({
       ok: true,
       walletCount: wallets.length,
-      activityRowCount: activityRows.length,
       hasAggregate: Boolean(aggregateResult.data?.balances),
     });
 
@@ -92,11 +45,6 @@ export default async function DashboardPage() {
       <HomeWorkspace
         totalBalance={totalBalance}
         totalBalanceError={aggregateError}
-        todaysVolume={todaysVolume}
-        todaysVolumeError={transfersError}
-        activityRows={activityRows}
-        activityError={activityError}
-        activityNotice={activityNotice || null}
         wallets={wallets}
       />
     );

--- a/apps/sdp-web/src/app/dashboard/payments/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/page.tsx
@@ -11,7 +11,11 @@ import {
 } from "./payments-page.data";
 import { PaymentsWorkspace } from "./payments-workspace";
 
-export default async function PaymentsPage() {
+interface PaymentsPageProps {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function PaymentsPage({ searchParams }: PaymentsPageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
     redirect("/sign-in");
@@ -23,6 +27,13 @@ export default async function PaymentsPage() {
   const trace = createTimedTrace("dashboard.payments.page");
 
   try {
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const currentTab =
+      resolvedSearchParams?.tab === "playground" ||
+      (Array.isArray(resolvedSearchParams?.tab) && resolvedSearchParams.tab[0] === "playground")
+        ? "playground"
+        : "overview";
+    const isPlaygroundTab = currentTab === "playground";
     const apiBaseUrl = resolvePlaygroundApiBaseUrl();
     const apiClient = await trace.step("create_sdp_api_client", () =>
       createSdpApiClient(trace.childContext("dashboard.payments.api"))
@@ -34,15 +45,23 @@ export default async function PaymentsPage() {
       transfersResult,
       issuedTokenSymbolsResult,
     ] = await Promise.all([
-      trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
-      trace.step("fetch_payments_wallets", () =>
-        fetchPaymentsWallets(apiClient.request, { includeBalances: true })
-      ),
-      trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
+      isPlaygroundTab
+        ? trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request))
+        : Promise.resolve({ ok: true as const, data: [] }),
+      isPlaygroundTab
+        ? trace.step("fetch_payments_wallet_summaries", () =>
+            fetchPaymentsWallets(apiClient.request, { view: "summary" })
+          )
+        : Promise.resolve({ ok: true as const, data: [] }),
+      isPlaygroundTab
+        ? Promise.resolve({ ok: true as const, data: null })
+        : trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
       trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request)),
-      trace.step("fetch_payment_token_symbols", () =>
-        fetchPaymentsIssuedTokenSymbols(apiClient.request)
-      ),
+      isPlaygroundTab
+        ? Promise.resolve({ ok: true as const, data: [] })
+        : trace.step("fetch_payment_token_symbols", () =>
+            fetchPaymentsIssuedTokenSymbols(apiClient.request)
+          ),
     ]);
     const apiKeys = apiKeysResult.data ?? [];
     const wallets = walletsResult.data ?? [];
@@ -63,6 +82,7 @@ export default async function PaymentsPage() {
 
     trace.log({
       ok: true,
+      tab: currentTab,
       walletCount: wallets.length,
       transferCount: transfers.length,
       apiKeyCount: apiKeys.length,

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
@@ -12,11 +12,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import type {
-  CustodyWalletAggregate,
-  PaymentTransferSummary as TransferRecord,
-  PaymentsDashboardWallet as WalletRecord,
-} from "@sdp/types";
+import type { CustodyWalletAggregate, PaymentTransferSummary as TransferRecord } from "@sdp/types";
 import { ArrowDownLeft, ArrowUpRight, ExternalLink, RefreshCw } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
@@ -27,7 +23,6 @@ import {
   formatDisplayAmount,
   formatTimestamp,
   resolveAggregateBalanceDisplayToken,
-  resolveAggregateBalanceRows,
   resolveCounterparty,
   resolveTotalBalance,
   resolveUsdBalanceValue,
@@ -36,13 +31,10 @@ import {
 import {
   fetchTransfers,
   fetchWalletAggregate,
-  fetchWallets,
   getDevnetExplorerUrl,
 } from "./payments-workspace.data";
 
 interface PaymentsOverviewProps {
-  wallets: WalletRecord[];
-  walletsError: string | null;
   aggregate: CustodyWalletAggregate | null;
   aggregateError: string | null;
   issuedTokenSymbolsByMint: Record<string, string>;
@@ -50,7 +42,6 @@ interface PaymentsOverviewProps {
   transfersError: string | null;
 }
 
-const PAYMENTS_OVERVIEW_WALLETS_KEY = "payments-overview-wallets";
 const PAYMENTS_OVERVIEW_AGGREGATE_KEY = "payments-overview-aggregate";
 const PAYMENTS_OVERVIEW_TRANSFERS_KEY = "payments-overview-transfers";
 
@@ -101,8 +92,6 @@ function TruncatedTableText({
 }
 
 export function PaymentsOverview({
-  wallets,
-  walletsError,
   aggregate,
   aggregateError,
   issuedTokenSymbolsByMint,
@@ -112,16 +101,6 @@ export function PaymentsOverview({
   const router = useRouter();
   const searchParams = useSearchParams();
   const refreshSeed = searchParams.get("refresh") ?? "default";
-  const {
-    data: swrWallets,
-    error: walletsFetchError,
-    isValidating: walletsRefreshing,
-    mutate: mutateWallets,
-  } = useSWR<WalletRecord[]>([PAYMENTS_OVERVIEW_WALLETS_KEY, refreshSeed], () => fetchWallets(), {
-    fallbackData: walletsError ? undefined : wallets,
-    revalidateOnFocus: true,
-    refreshInterval: 30_000,
-  });
   const {
     data: swrAggregate,
     error: aggregateFetchError,
@@ -151,14 +130,8 @@ export function PaymentsOverview({
     }
   );
 
-  const liveWallets = swrWallets ?? wallets;
   const liveAggregate = swrAggregate ?? aggregate;
   const liveTransfers = swrTransfers ?? transfers;
-  const liveWalletsError = walletsFetchError
-    ? resolveRequestError(walletsFetchError, walletsError)
-    : swrWallets === undefined
-      ? walletsError
-      : null;
   const liveAggregateError = aggregateFetchError
     ? resolveRequestError(aggregateFetchError, aggregateError)
     : swrAggregate === undefined
@@ -169,21 +142,18 @@ export function PaymentsOverview({
     : swrTransfers === undefined
       ? transfersError
       : null;
-  const isRefreshing = walletsRefreshing || aggregateRefreshing || transfersRefreshing;
-  const aggregateBalances = useMemo(
-    () => resolveAggregateBalanceRows(liveAggregate, liveWallets),
-    [liveAggregate, liveWallets]
-  );
+  const isRefreshing = aggregateRefreshing || transfersRefreshing;
+  const aggregateBalances = useMemo(() => liveAggregate?.balances ?? [], [liveAggregate]);
   const topAggregateBalances = useMemo(
     () => selectTopAggregateBalanceRows(aggregateBalances, issuedTokenSymbolsByMint),
     [aggregateBalances, issuedTokenSymbolsByMint]
   );
   const totalBalance = resolveTotalBalance(aggregateBalances);
-  const hasWallets = liveWallets.length > 0;
-  const walletCount = liveAggregate?.walletCount ?? liveWallets.length;
+  const walletCount = liveAggregate?.walletCount ?? 0;
+  const hasWallets = walletCount > 0;
 
   const handleRefresh = () => {
-    void Promise.all([mutateWallets(), mutateAggregate(), mutateTransfers()]);
+    void Promise.all([mutateAggregate(), mutateTransfers()]);
   };
 
   return (
@@ -264,11 +234,8 @@ export function PaymentsOverview({
           </div>
         </div>
 
-        {liveWalletsError ? (
-          <p className="mt-4 text-sm text-[#9e2b38]">{liveWalletsError}</p>
-        ) : null}
         {liveAggregateError ? (
-          <p className="mt-2 text-sm text-[#9e2b38]">{liveAggregateError}</p>
+          <p className="mt-4 text-sm text-[#9e2b38]">{liveAggregateError}</p>
         ) : null}
       </SectionEntry>
 

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
@@ -14,6 +14,7 @@ export interface FetchResult<T> {
 
 interface FetchPaymentsWalletsOptions {
   includeBalances?: boolean;
+  view?: "default" | "summary";
 }
 
 export interface PaymentsIssuedTokenSymbol {
@@ -40,6 +41,7 @@ export async function fetchPaymentsWallets(
   try {
     const query = new URLSearchParams({
       includeAllProviders: "true",
+      ...(options.view === "summary" ? { view: "summary" } : {}),
       ...(options.includeBalances ? { includeBalances: "true" } : {}),
     }).toString();
     const response = await request(`/v1/wallets?${query}`);

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -175,7 +175,7 @@ export async function fetchWallets(
   } = {}
 ): Promise<WalletRecord[]> {
   const query = new URLSearchParams({
-    includeBalances: "true",
+    view: "summary",
   }).toString();
   const response = await fetch(`/api/dashboard/wallets?${query}`, {
     method: "GET",

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx
@@ -112,8 +112,6 @@ export function PaymentsWorkspace({
 
   return (
     <PaymentsOverview
-      wallets={wallets}
-      walletsError={walletsError}
       aggregate={aggregate}
       aggregateError={aggregateError}
       issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}


### PR DESCRIPTION
## Summary
- add a lightweight wallet summary path plus short TTL caching/timing in custody wallet handlers
- defer heavy dashboard sections on Payments, Home, Issuance list, and Issuance token detail
- keep first paint focused on core page content while loading supporting data on demand

## Testing
- pnpm --filter sdp-web typecheck
- pnpm --filter @sdp/api typecheck
- pnpm --filter sdp-web build
- pnpm -C apps/sdp-api exec vitest run src/routes/custody-wallet-scope.test.ts
- pnpm exec biome check apps/sdp-api/src/openapi/paths/custody.ts apps/sdp-api/src/routes/custody-wallet-scope.test.ts apps/sdp-api/src/routes/custody/handlers/wallets.ts apps/sdp-web/playwright/tests/issuance.e2e.spec.ts apps/sdp-web/src/app/api/dashboard/home/activity/route.ts apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/supporting-data/route.ts apps/sdp-web/src/app/dashboard/home-workspace.data.ts apps/sdp-web/src/app/dashboard/home-workspace.tsx apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.data.ts apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx apps/sdp-web/src/app/dashboard/issuance/create-token-features-step.tsx apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx apps/sdp-web/src/app/dashboard/issuance/page.tsx apps/sdp-web/src/app/dashboard/page.tsx apps/sdp-web/src/app/dashboard/payments/page.tsx apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts apps/sdp-web/src/app/dashboard/payments/payments-workspace.tsx