### PR TITLE
feat(docs): add generated public Postman collection

### DIFF
--- a/apps/sdp-docs/content/docs/meta.json
+++ b/apps/sdp-docs/content/docs/meta.json
@@ -19,6 +19,7 @@
     "tutorials/end-to-end-payment-flow",
     "---Reference---",
     "reference/issuance-token-types",
+    "reference/postman-collection",
     "reference/api/index",
     "reference/api/health",
     "reference/api/api-keys",

--- a/apps/sdp-docs/content/docs/reference/api/index.mdx
+++ b/apps/sdp-docs/content/docs/reference/api/index.mdx
@@ -1,0 +1,18 @@
+---
+title: API Reference
+description: Endpoint index from the repository OpenAPI spec.
+---
+
+<div>
+  <a href="/postman/collection.json" download>Download Postman collection</a>
+  {" · "}
+  <a href="/postman/collection.json">Open raw JSON</a>
+</div>
+
+- [Health](/docs/reference/api/health)
+- [API Keys](/docs/reference/api/api-keys)
+- [Wallets](/docs/reference/api/wallets)
+- [Projects](/docs/reference/api/projects)
+- [Issuance](/docs/reference/api/issuance)
+- [Payments](/docs/reference/api/payments)
+- [Compliance](/docs/reference/api/compliance)

--- a/apps/sdp-docs/content/docs/reference/api/meta.json
+++ b/apps/sdp-docs/content/docs/reference/api/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "API",
+  "pages": [
+    "index",
+    "health",
+    "api-keys",
+    "wallets",
+    "projects",
+    "issuance",
+    "payments",
+    "compliance"
+  ]
+}

--- a/apps/sdp-docs/content/docs/reference/postman-collection.mdx
+++ b/apps/sdp-docs/content/docs/reference/postman-collection.mdx
@@ -1,0 +1,27 @@
+---
+title: Postman Collection
+description: Download the public SDP API Postman collection generated from the OpenAPI contract.
+---
+
+The Postman collection is generated from the same public OpenAPI contract that powers the API reference. It includes only end-user-facing API families:
+
+- Health
+- API Keys
+- Wallets
+- Projects
+- Issuance
+- Payments
+- Compliance
+
+Internal-only endpoint families such as `rpc`, `admin`, `onboarding`, `auth`, `organizations`, and `members` are intentionally excluded.
+
+<div>
+  <a href="/postman/collection.json" download>Download Postman collection</a>
+  {" · "}
+  <a href="/postman/collection.json">Open raw JSON</a>
+</div>
+
+When you import the collection into Postman, set:
+
+- `baseUrl` to the SDP API environment you want to target
+- `sdpApiKey` to your bearer API key

--- a/apps/sdp-docs/package.json
+++ b/apps/sdp-docs/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "generate:api": "pnpm -C ../sdp-api run openapi:generate && node scripts/generate-api-docs.mjs && pnpm exec biome check --write content/docs/meta.json content/docs/reference/api/meta.json",
+    "generate:api": "pnpm -C ../sdp-api run openapi:generate && node scripts/generate-api-docs.mjs && node scripts/generate-postman-collection.mjs && pnpm exec biome check --write content/docs/meta.json content/docs/reference/api/meta.json",
     "generate:ai": "tsx scripts/generate-ai-resources.ts",
     "generate:source": "node scripts/generate-source.mjs",
     "check:links": "tsx scripts/check-links.ts",

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -32,6 +32,7 @@
 
 ## Reference
 - [Issuance Token Types](https://platform.solana.com/docs/reference/issuance-token-types): Supported issuance templates and default controls.
+- [Postman Collection](https://platform.solana.com/docs/reference/postman-collection): Download the public SDP API Postman collection generated from the OpenAPI contract.
 - [API Reference](https://platform.solana.com/docs/reference/api): Endpoint index from the repository OpenAPI spec.
 - [Health](https://platform.solana.com/docs/reference/api/health): Service health and readiness endpoints.
 - [API Keys](https://platform.solana.com/docs/reference/api/api-keys): API key management endpoints.

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1,0 +1,1290 @@
+{
+  "info": {
+    "name": "Solana Developer Platform Public API",
+    "description": "Public Postman collection generated from the SDP OpenAPI contract. Internal-only endpoint families are excluded.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{sdpApiKey}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://api.solana.com",
+      "type": "string"
+    },
+    {
+      "key": "sdpApiKey",
+      "value": "sk_test_your_api_key",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Health",
+      "item": [
+        {
+          "name": "Health check",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/health",
+            "description": "Returns service health and build metadata."
+          }
+        },
+        {
+          "name": "Readiness check",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/health/ready",
+            "description": "Performs readiness checks for downstream dependencies."
+          }
+        }
+      ]
+    },
+    {
+      "name": "API Keys",
+      "item": [
+        {
+          "name": "List API keys",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/api-keys",
+            "description": "Lists API keys for the authenticated organization."
+          }
+        },
+        {
+          "name": "Create API key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys",
+            "description": "Creates a new API key. The full key is returned once.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Primary Key\",\n  \"description\": \"Used by backend service.\",\n  \"role\": \"api_developer\",\n  \"permissions\": [\n    \"tokens:read\",\n    \"tokens:write\"\n  ],\n  \"environment\": \"sandbox\",\n  \"walletScope\": \"selected\",\n  \"allowedIps\": [\n    \"203.0.113.0/24\"\n  ],\n  \"expiresAt\": \"2025-12-31T00:00:00.000Z\",\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"signingWalletIds\": [\n    \"privy_wallet_123\",\n    \"dfns_wallet_456\"\n  ],\n  \"walletBindings\": [\n    {\n      \"walletId\": \"\",\n      \"permissions\": [\n        \"tokens:read\"\n      ]\n    }\n  ],\n  \"provisionWallet\": false,\n  \"walletLabel\": \"Mint authority wallet\",\n  \"walletPurpose\": \"mint_authority\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Get API key",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/api-keys/{{keyId}}",
+            "description": "Gets API key details by id."
+          }
+        },
+        {
+          "name": "Update API key",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{keyId}}",
+            "description": "Updates API key attributes. Use null to clear optional fields.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Primary Key Updated\",\n  \"description\": \"Rotated key for new service.\",\n  \"walletScope\": \"all\",\n  \"allowedIps\": [\n    \"203.0.113.0/24\"\n  ],\n  \"expiresAt\": \"2026-01-01T00:00:00.000Z\",\n  \"permissions\": [\n    \"tokens:read\",\n    \"tokens:write\"\n  ],\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"signingWalletIds\": [\n    \"privy_wallet_123\",\n    \"dfns_wallet_456\"\n  ],\n  \"walletBindings\": [\n    {\n      \"walletId\": \"\",\n      \"permissions\": [\n        \"tokens:read\"\n      ]\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Deactivate API key",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{keyId}}",
+            "description": "Deactivates (soft deletes) an API key and invalidates it immediately.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"confirmation\": \"Primary Key\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Rotate API key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/api-keys/{{keyId}}/rotate",
+            "description": "Rotates an API key and returns the new key plus the old key grace period.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"gracePeriodHours\": 24\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Wallets",
+      "item": [
+        {
+          "name": "Initialize wallet signing",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/initialize",
+            "description": "Initializes wallet signing for the organization or project by creating an active signing configuration.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"local\",\n  \"projectId\": \"\",\n  \"walletLabel\": \"\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Switch wallet signing provider",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/switch",
+            "description": "Ensures the target provider is active and sets it as the default signing provider for the requested scope. Existing on-chain authorities are not rotated.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"local\",\n  \"projectId\": \"\",\n  \"walletLabel\": \"\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "List wallets",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets",
+            "description": "Lists wallets for the resolved default signing provider by default. Use provider/includeAllProviders to query across active providers."
+          }
+        },
+        {
+          "name": "Create wallet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets",
+            "description": "Provisions a new wallet for the resolved default signing provider configuration, or for an explicitly targeted provider.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"projectId\": \"prj_example\",\n  \"provider\": \"privy\",\n  \"label\": \"Mint authority wallet\",\n  \"purpose\": \"mint_authority\",\n  \"setDefault\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Delete wallet",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets",
+            "description": "Deletes a wallet from the resolved default signing provider configuration, or from an explicitly targeted provider when that provider supports wallet deletion.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"projectId\": \"prj_example\",\n  \"provider\": \"anchorage\",\n  \"walletId\": \"anchorage_wallet_123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Set default wallet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/default-wallet",
+            "description": "Sets the default wallet for the resolved default provider config, or for an explicitly targeted provider.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"projectId\": \"prj_example\",\n  \"provider\": \"privy\",\n  \"walletId\": \"privy_wallet_123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Get wallet signing config",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets/config",
+            "description": "Returns the resolved default wallet signing configuration for the organization or project. Resolution is DB-backed only (no environment fallback)."
+          }
+        },
+        {
+          "name": "List wallet signing configs",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets/configs",
+            "description": "Returns active wallet signing configurations for the requested scope plus the resolved default configuration ID."
+          }
+        },
+        {
+          "name": "Aggregate wallet balances",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets/aggregate",
+            "description": "Aggregates tracked wallet balances for the requested scope. Defaults to aggregating across all active providers for the organization scope."
+          }
+        },
+        {
+          "name": "List switch provider options",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets/switch-options",
+            "description": "Returns provider capability metadata, including active/default status for the requested scope."
+          }
+        },
+        {
+          "name": "Get wallet public key",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets/public-key",
+            "description": "Returns the resolved wallet public key for transaction construction. Resolution is DB-backed only (no environment fallback)."
+          }
+        },
+        {
+          "name": "Check signer via memo transaction",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/signer-check",
+            "description": "Submits a memo transaction using the wallet bound to the authenticated API key. This endpoint requires API-key authentication.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"memo\": \"\",\n  \"walletId\": \"\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Get wallet by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/wallets/{{walletId}}",
+            "description": "Returns wallet metadata, custody provider, public key, and current SOL balance for a specific wallet ID. This endpoint requires authenticated access."
+          }
+        },
+        {
+          "name": "Update wallet",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/wallets/{{walletId}}",
+            "description": "Updates editable wallet metadata such as the display label.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"label\": \"Treasury signer\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Projects",
+      "item": [
+        {
+          "name": "List projects",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/projects",
+            "description": "Lists projects in the organization."
+          }
+        },
+        {
+          "name": "Create project",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects",
+            "description": "Creates a project within the organization.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Payments\",\n  \"slug\": \"payments\",\n  \"description\": \"Project for payments workflows.\",\n  \"environment\": \"sandbox\",\n  \"settings\": {\n    \"rpcProvider\": \"default\",\n    \"webhookUrl\": \"https://example.com/webhook\",\n    \"metadata\": {\n      \"region\": \"us\"\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Get project",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}",
+            "description": "Gets project details."
+          }
+        },
+        {
+          "name": "Update project",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}",
+            "description": "Updates project attributes.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Payments Updated\",\n  \"description\": \"Updated project description.\",\n  \"environment\": \"production\",\n  \"settings\": {\n    \"rpcProvider\": \"custom\",\n    \"rpcEndpoint\": \"https://rpc.example.com\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Archive project",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}",
+            "description": "Archives a project and prevents future writes."
+          }
+        },
+        {
+          "name": "List project members",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/members",
+            "description": "Lists members assigned to the project."
+          }
+        },
+        {
+          "name": "Add project member",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/members",
+            "description": "Adds an organization member to the project.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": \"usr_example\",\n  \"role\": \"developer\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Update project member",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/members/{{memberId}}",
+            "description": "Updates a project member role.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"role\": \"admin\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Remove project member",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/members/{{memberId}}",
+            "description": "Removes a member from the project."
+          }
+        },
+        {
+          "name": "List project API keys",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/api-keys",
+            "description": "Lists API keys scoped to the project."
+          }
+        },
+        {
+          "name": "Create project API key",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/projects/{{projectId}}/api-keys",
+            "description": "Creates an API key scoped to the project. The full key is returned once.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Primary Key\",\n  \"description\": \"Used by backend service.\",\n  \"role\": \"api_developer\",\n  \"permissions\": [\n    \"tokens:read\",\n    \"tokens:write\"\n  ],\n  \"environment\": \"sandbox\",\n  \"walletScope\": \"selected\",\n  \"allowedIps\": [\n    \"203.0.113.0/24\"\n  ],\n  \"expiresAt\": \"2025-12-31T00:00:00.000Z\",\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"signingWalletIds\": [\n    \"privy_wallet_123\",\n    \"dfns_wallet_456\"\n  ],\n  \"walletBindings\": [\n    {\n      \"walletId\": \"\",\n      \"permissions\": [\n        \"tokens:read\"\n      ]\n    }\n  ],\n  \"provisionWallet\": false,\n  \"walletLabel\": \"Mint authority wallet\",\n  \"walletPurpose\": \"mint_authority\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Issuance",
+      "item": [
+        {
+          "name": "List token templates",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/templates",
+            "description": "Returns all available token templates with their default configuration and supported extensions."
+          }
+        },
+        {
+          "name": "Get token template",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/templates/{{templateId}}",
+            "description": "Returns details for a specific token template including default decimals, required extensions, and available overrides."
+          }
+        },
+        {
+          "name": "List tokens",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens",
+            "description": "Lists tokens for the current project or organization."
+          }
+        },
+        {
+          "name": "Create token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens",
+            "description": "Creates a token record that can later be deployed to Solana.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Example Token\",\n  \"symbol\": \"EXM\",\n  \"signingWalletId\": \"wal_example\",\n  \"decimals\": 6,\n  \"description\": \"Example token description.\",\n  \"uri\": \"https://example.com/metadata.json\",\n  \"imageUrl\": \"https://example.com/token.png\",\n  \"maxSupply\": \"1000000\",\n  \"template\": \"stablecoin\",\n  \"overrides\": {\n    \"extensions\": {\n      \"transferFee\": {\n        \"basisPoints\": 50,\n        \"maxFee\": \"0.5\"\n      }\n    }\n  },\n  \"requiresAllowlist\": true,\n  \"isMintable\": true,\n  \"isFreezable\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Get token",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}",
+            "description": "Gets token details."
+          }
+        },
+        {
+          "name": "Update token",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}",
+            "description": "Updates stored token fields. For deployed tokens, metadata fields are also written on-chain through the current metadata authority.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Example Token Updated\",\n  \"description\": \"Updated token description.\",\n  \"uri\": \"https://example.com/metadata.json\",\n  \"imageUrl\": \"https://example.com/token.png\",\n  \"status\": \"active\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Refresh cached token supply",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/supply/refresh",
+            "description": "Fetches the current on-chain supply and refreshes the cached totalSupply value."
+          }
+        },
+        {
+          "name": "List token transactions",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/transactions",
+            "description": "Lists token transactions for an issued token."
+          }
+        },
+        {
+          "name": "Deploy token",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/deploy",
+            "description": "Deploys the token to Solana using custody signing."
+          }
+        },
+        {
+          "name": "Prepare token deploy transaction",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/deploy/prepare",
+            "description": "Builds an unsigned deploy transaction for client-side signing."
+          }
+        },
+        {
+          "name": "Prepare mint transaction",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/mint/prepare",
+            "description": "Builds an unsigned mint transaction for client-side signing.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"mint\": {\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Payout\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Execute mint",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/mint",
+            "description": "Mints tokens using custody signing and submission.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"mint\": {\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Payout\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Prepare burn transaction",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/burn/prepare",
+            "description": "Builds an unsigned burn transaction for client-side signing.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"burn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Correction\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Execute burn",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/burn",
+            "description": "Burns tokens using custody signing and submission.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"burn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Correction\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Prepare seize transaction",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/seize/prepare",
+            "description": "Builds an unsigned force transfer transaction for client-side signing.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"seize\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance seizure\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Execute seize",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/seize",
+            "description": "Forces a transfer using permanent delegate authority.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"seize\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance seizure\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Prepare force burn transaction",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/force-burn/prepare",
+            "description": "Builds an unsigned force burn transaction for client-side signing.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"forceBurn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance burn\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Execute force burn",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/force-burn",
+            "description": "Burns tokens using permanent delegate authority.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"forceBurn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance burn\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Prepare authority update",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/authority/prepare",
+            "description": "Builds an unsigned authority update transaction for client-side signing.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"authority\": {\n    \"role\": \"mint\",\n    \"newAuthority\": \"So11111111111111111111111111111111111111112\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Execute authority update",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/authority",
+            "description": "Updates token authorities using custody signing.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"signingWalletId\": \"wal_example\",\n  \"authority\": {\n    \"role\": \"mint\",\n    \"newAuthority\": \"So11111111111111111111111111111111111111112\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Pause token transfers",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/pause",
+            "description": "Pauses transfers for a token using the pause authority.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Unpause token transfers",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/unpause",
+            "description": "Resumes transfers for a token using the pause authority.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Freeze account",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/freeze",
+            "description": "Freezes a token account to prevent transfers.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountAddress\": \"So11111111111111111111111111111111111111112\",\n  \"reason\": \"Compliance hold\",\n  \"signingWalletId\": \"privy_abcd1234\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Unfreeze account",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/unfreeze",
+            "description": "Unfreezes a token account so it can be used again.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountAddress\": \"So11111111111111111111111111111111111111112\",\n  \"signingWalletId\": \"privy_abcd1234\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "List frozen accounts",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/frozen",
+            "description": "Lists frozen accounts for a token."
+          }
+        },
+        {
+          "name": "List token allowlist",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/allowlist",
+            "description": "Lists allowlist entries for a token."
+          }
+        },
+        {
+          "name": "Add token allowlist entry",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/allowlist",
+            "description": "Adds an allowlist entry for a token.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"So11111111111111111111111111111111111111112\",\n  \"label\": \"Treasury\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Remove token allowlist entry",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": "{{baseUrl}}/v1/issuance/tokens/{{tokenId}}/allowlist/{{entryId}}",
+            "description": "Removes an allowlist entry from a token."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Payments",
+      "item": [
+        {
+          "name": "Get wallet balances",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/balances",
+            "description": "Retrieves balances for a custody wallet. Wallet lifecycle and provisioning are managed through /v1/custody/wallets."
+          }
+        },
+        {
+          "name": "Get wallet policy",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/policies",
+            "description": "Retrieves payment policy rules for a custody wallet. Policies are payment controls layered on top of custody-managed wallets."
+          }
+        },
+        {
+          "name": "Update wallet policy",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/policies",
+            "description": "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/custody.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"destinationAllowlist\": [\n    \"So11111111111111111111111111111111111111112\"\n  ],\n  \"maxTransferAmount\": \"100.00\",\n  \"maxDailyAmount\": \"100.00\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Prepare transfer (unsigned)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/transfers/prepare",
+            "description": "Builds an unsigned transfer transaction for a custody wallet. The source walletId must reference a wallet from /v1/custody/wallets.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"projectId\": \"prj_example\",\n  \"source\": \"wal_example\",\n  \"destination\": \"So11111111111111111111111111111111111111112\",\n  \"token\": \"\",\n  \"amount\": \"100.00\",\n  \"memo\": \"\",\n  \"referenceAddress\": \"So11111111111111111111111111111111111111112\",\n  \"options\": {\n    \"priorityFee\": \"auto\",\n    \"simulate\": true\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "List transfers",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/payments/transfers",
+            "description": "Lists payment transfers for the authenticated organization or project scope."
+          }
+        },
+        {
+          "name": "Execute transfer (custody)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/transfers",
+            "description": "Executes a transfer using server-side custody signing. The source walletId must reference a wallet from /v1/custody/wallets.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"projectId\": \"prj_example\",\n  \"source\": \"wal_example\",\n  \"destination\": \"So11111111111111111111111111111111111111112\",\n  \"token\": \"\",\n  \"amount\": \"100.00\",\n  \"memo\": \"\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Get transfer",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseUrl}}/v1/payments/transfers/{{transferId}}",
+            "description": "Retrieves details for a specific transfer."
+          }
+        },
+        {
+          "name": "Execute on-ramp",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/ramps/onramp/execute",
+            "description": "Creates a fiat-to-crypto on-ramp session through the selected provider.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"moonpay\",\n  \"destinationWallet\": \"\",\n  \"cryptoToken\": \"USDC\",\n  \"fiatCurrency\": \"USD\",\n  \"fiatAmount\": \"100.00\",\n  \"kycReference\": \"\",\n  \"redirectUrl\": \"https://example.com\",\n  \"bvnkCompliance\": {\n    \"partyDetails\": [\n      {}\n    ]\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Execute off-ramp",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/ramps/offramp/execute",
+            "description": "Creates a crypto-to-fiat off-ramp session through the selected provider.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"moonpay\",\n  \"sourceWallet\": \"\",\n  \"cryptoToken\": \"USDC\",\n  \"fiatCurrency\": \"USD\",\n  \"cryptoAmount\": \"50.00\",\n  \"kycReference\": \"\",\n  \"redirectUrl\": \"https://example.com\",\n  \"bvnkCompliance\": {\n    \"partyDetails\": [\n      {}\n    ]\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Compliance",
+      "item": [
+        {
+          "name": "Screen an address across configured compliance providers",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/compliance/address-screenings",
+            "description": "Runs address screening against configured compliance providers and returns provider-level risk scores.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"address\": \"8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ\",\n  \"network\": \"solana\",\n  \"intent\": \"transfer_destination\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getPrimaryTagName, isPublicTag, slugify } from "./lib/public-openapi.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,21 +12,6 @@ const rootMetaPath = path.resolve(__dirname, "../content/docs/meta.json");
 
 const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "options"]);
 const SOURCE_PATH = "apps/sdp-api/generated/openapi.json";
-const HIDDEN_TAG_SLUGS = new Set([
-  "rpc",
-  "admin",
-  "onboarding",
-  "auth",
-  "organizations",
-  "members",
-]);
-
-const slugify = (value) =>
-  value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
 const escapeTableText = (value) => value.replace(/\|/g, "\\|");
 
 const parseJsonSpec = (spec) => {
@@ -131,6 +117,12 @@ title: API Reference
 description: Endpoint index from the repository OpenAPI spec.
 ---
 
+<div>
+  <a href="/postman/collection.json" download>Download Postman collection</a>
+  {" · "}
+  <a href="/postman/collection.json">Open raw JSON</a>
+</div>
+
 ${links}
 `;
 };
@@ -144,8 +136,8 @@ const run = async () => {
 
   const groupedOperations = new Map();
   for (const operation of operations) {
-    const primaryTag = operation.tags[0] || "Other";
-    if (HIDDEN_TAG_SLUGS.has(slugify(primaryTag))) {
+    const primaryTag = getPrimaryTagName(operation);
+    if (!primaryTag || !isPublicTag(primaryTag)) {
       continue;
     }
 

--- a/apps/sdp-docs/scripts/generate-postman-collection.mjs
+++ b/apps/sdp-docs/scripts/generate-postman-collection.mjs
@@ -38,7 +38,21 @@ function resolveSchemaRef(spec, schema) {
   return current;
 }
 
-function buildExampleFromSchema(spec, schema) {
+function getSchemaRef(schema) {
+  return schema && typeof schema === "object" && "$ref" in schema && schema.$ref
+    ? schema.$ref
+    : null;
+}
+
+function buildExampleFromSchema(spec, schema, visitedRefs = new Set()) {
+  const schemaRef = getSchemaRef(schema);
+  if (schemaRef) {
+    if (visitedRefs.has(schemaRef)) {
+      return null;
+    }
+    visitedRefs.add(schemaRef);
+  }
+
   const resolvedSchema = resolveSchemaRef(spec, schema);
   if (!resolvedSchema || typeof resolvedSchema !== "object") {
     return null;
@@ -57,16 +71,16 @@ function buildExampleFromSchema(spec, schema) {
   }
 
   if (Array.isArray(resolvedSchema.oneOf) && resolvedSchema.oneOf.length > 0) {
-    return buildExampleFromSchema(spec, resolvedSchema.oneOf[0]);
+    return buildExampleFromSchema(spec, resolvedSchema.oneOf[0], new Set(visitedRefs));
   }
 
   if (Array.isArray(resolvedSchema.anyOf) && resolvedSchema.anyOf.length > 0) {
-    return buildExampleFromSchema(spec, resolvedSchema.anyOf[0]);
+    return buildExampleFromSchema(spec, resolvedSchema.anyOf[0], new Set(visitedRefs));
   }
 
   if (Array.isArray(resolvedSchema.allOf) && resolvedSchema.allOf.length > 0) {
     return resolvedSchema.allOf.reduce((merged, branch) => {
-      const branchExample = buildExampleFromSchema(spec, branch);
+      const branchExample = buildExampleFromSchema(spec, branch, new Set(visitedRefs));
       if (
         branchExample &&
         typeof branchExample === "object" &&
@@ -91,12 +105,15 @@ function buildExampleFromSchema(spec, schema) {
   if (schemaType === "object") {
     const properties = resolvedSchema.properties ?? {};
     return Object.fromEntries(
-      Object.entries(properties).map(([key, value]) => [key, buildExampleFromSchema(spec, value)])
+      Object.entries(properties).map(([key, value]) => [
+        key,
+        buildExampleFromSchema(spec, value, new Set(visitedRefs)),
+      ])
     );
   }
 
   if (schemaType === "array") {
-    return [buildExampleFromSchema(spec, resolvedSchema.items)];
+    return [buildExampleFromSchema(spec, resolvedSchema.items, new Set(visitedRefs))];
   }
 
   if (schemaType === "string") {
@@ -123,6 +140,25 @@ function buildExampleFromSchema(spec, schema) {
   return null;
 }
 
+function getNamedExampleValue(examples) {
+  if (!examples || typeof examples !== "object") {
+    return undefined;
+  }
+
+  for (const example of Object.values(examples)) {
+    if (
+      example &&
+      typeof example === "object" &&
+      "value" in example &&
+      example.value !== undefined
+    ) {
+      return example.value;
+    }
+  }
+
+  return undefined;
+}
+
 function getRequestHeaders(operation) {
   const headers = [];
 
@@ -145,9 +181,8 @@ function getRequestBody(spec, operation) {
 
   const example =
     jsonBody.example ??
-    (Array.isArray(jsonBody.examples) && jsonBody.examples.length > 0
-      ? jsonBody.examples[0]
-      : buildExampleFromSchema(spec, jsonBody.schema));
+    getNamedExampleValue(jsonBody.examples) ??
+    buildExampleFromSchema(spec, jsonBody.schema);
 
   return {
     mode: "raw",

--- a/apps/sdp-docs/scripts/generate-postman-collection.mjs
+++ b/apps/sdp-docs/scripts/generate-postman-collection.mjs
@@ -75,7 +75,7 @@ function buildExampleFromSchema(spec, schema) {
         typeof merged === "object" &&
         !Array.isArray(merged)
       ) {
-        return { ...merged, ...branchExample };
+        return Object.assign(merged, branchExample);
       }
       return branchExample ?? merged;
     }, {});
@@ -186,7 +186,8 @@ function createRequestItem(spec, baseUrl, routePath, method, operation) {
 function toPostmanCollection(spec) {
   const productionServer =
     spec.servers?.find((server) => server.description === "Production")?.url ||
-    spec.servers?.find((server) => typeof server.url === "string" && server.url.startsWith("https"))?.url ||
+    spec.servers?.find((server) => typeof server.url === "string" && server.url.startsWith("https"))
+      ?.url ||
     "https://api.solana.com";
 
   const folders = new Map();
@@ -211,7 +212,9 @@ function toPostmanCollection(spec) {
         folders.set(tagName, []);
       }
 
-      folders.get(tagName).push(createRequestItem(spec, "{{baseUrl}}", routePath, method, operation));
+      folders
+        .get(tagName)
+        .push(createRequestItem(spec, "{{baseUrl}}", routePath, method, operation));
     }
   }
 
@@ -224,8 +227,7 @@ function toPostmanCollection(spec) {
       name: "Solana Developer Platform Public API",
       description:
         "Public Postman collection generated from the SDP OpenAPI contract. Internal-only endpoint families are excluded.",
-      schema:
-        "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     },
     auth: {
       type: "bearer",
@@ -264,7 +266,9 @@ async function run() {
   await fs.mkdir(outputDir, { recursive: true });
   await fs.writeFile(outputPath, `${JSON.stringify(collection, null, 2)}\n`, "utf8");
 
-  console.log(`Generated Postman collection with ${collection.item.length} folders at ${outputPath}`);
+  console.log(
+    `Generated Postman collection with ${collection.item.length} folders at ${outputPath}`
+  );
 }
 
 run().catch((error) => {

--- a/apps/sdp-docs/scripts/generate-postman-collection.mjs
+++ b/apps/sdp-docs/scripts/generate-postman-collection.mjs
@@ -1,0 +1,273 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  POSTMAN_COLLECTION_FILENAME,
+  getPrimaryTagName,
+  isPublicOperation,
+} from "./lib/public-openapi.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const generatedSpecPath = path.resolve(__dirname, "../../sdp-api/generated/openapi.json");
+const outputDir = path.resolve(__dirname, "../public/postman");
+const outputPath = path.join(outputDir, POSTMAN_COLLECTION_FILENAME);
+
+const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "options"]);
+
+function resolveSchemaRef(spec, schema) {
+  if (!schema || typeof schema !== "object" || !("$ref" in schema) || !schema.$ref) {
+    return schema;
+  }
+
+  const ref = schema.$ref;
+  if (!ref.startsWith("#/")) {
+    return schema;
+  }
+
+  const segments = ref.slice(2).split("/");
+  let current = spec;
+  for (const segment of segments) {
+    if (!current || typeof current !== "object" || !(segment in current)) {
+      return schema;
+    }
+    current = current[segment];
+  }
+
+  return current;
+}
+
+function buildExampleFromSchema(spec, schema) {
+  const resolvedSchema = resolveSchemaRef(spec, schema);
+  if (!resolvedSchema || typeof resolvedSchema !== "object") {
+    return null;
+  }
+
+  if ("example" in resolvedSchema && resolvedSchema.example !== undefined) {
+    return resolvedSchema.example;
+  }
+
+  if ("default" in resolvedSchema && resolvedSchema.default !== undefined) {
+    return resolvedSchema.default;
+  }
+
+  if (Array.isArray(resolvedSchema.enum) && resolvedSchema.enum.length > 0) {
+    return resolvedSchema.enum[0];
+  }
+
+  if (Array.isArray(resolvedSchema.oneOf) && resolvedSchema.oneOf.length > 0) {
+    return buildExampleFromSchema(spec, resolvedSchema.oneOf[0]);
+  }
+
+  if (Array.isArray(resolvedSchema.anyOf) && resolvedSchema.anyOf.length > 0) {
+    return buildExampleFromSchema(spec, resolvedSchema.anyOf[0]);
+  }
+
+  if (Array.isArray(resolvedSchema.allOf) && resolvedSchema.allOf.length > 0) {
+    return resolvedSchema.allOf.reduce((merged, branch) => {
+      const branchExample = buildExampleFromSchema(spec, branch);
+      if (
+        branchExample &&
+        typeof branchExample === "object" &&
+        !Array.isArray(branchExample) &&
+        merged &&
+        typeof merged === "object" &&
+        !Array.isArray(merged)
+      ) {
+        return { ...merged, ...branchExample };
+      }
+      return branchExample ?? merged;
+    }, {});
+  }
+
+  const schemaType =
+    typeof resolvedSchema.type === "string"
+      ? resolvedSchema.type
+      : resolvedSchema.properties
+        ? "object"
+        : null;
+
+  if (schemaType === "object") {
+    const properties = resolvedSchema.properties ?? {};
+    return Object.fromEntries(
+      Object.entries(properties).map(([key, value]) => [key, buildExampleFromSchema(spec, value)])
+    );
+  }
+
+  if (schemaType === "array") {
+    return [buildExampleFromSchema(spec, resolvedSchema.items)];
+  }
+
+  if (schemaType === "string") {
+    if (resolvedSchema.format === "date-time") {
+      return "2026-01-01T00:00:00.000Z";
+    }
+    if (resolvedSchema.format === "uri") {
+      return "https://example.com";
+    }
+    if (resolvedSchema.format === "email") {
+      return "user@example.com";
+    }
+    return "";
+  }
+
+  if (schemaType === "integer" || schemaType === "number") {
+    return 0;
+  }
+
+  if (schemaType === "boolean") {
+    return false;
+  }
+
+  return null;
+}
+
+function getRequestHeaders(operation) {
+  const headers = [];
+
+  if (operation.requestBody?.content?.["application/json"]) {
+    headers.push({
+      key: "Content-Type",
+      value: "application/json",
+      type: "text",
+    });
+  }
+
+  return headers;
+}
+
+function getRequestBody(spec, operation) {
+  const jsonBody = operation.requestBody?.content?.["application/json"];
+  if (!jsonBody) {
+    return undefined;
+  }
+
+  const example =
+    jsonBody.example ??
+    (Array.isArray(jsonBody.examples) && jsonBody.examples.length > 0
+      ? jsonBody.examples[0]
+      : buildExampleFromSchema(spec, jsonBody.schema));
+
+  return {
+    mode: "raw",
+    raw: JSON.stringify(example ?? {}, null, 2),
+    options: {
+      raw: {
+        language: "json",
+      },
+    },
+  };
+}
+
+function buildRequestUrl(baseUrl, routePath) {
+  return `${baseUrl}${routePath.replace(/\{([^}]+)\}/g, "{{$1}}")}`;
+}
+
+function createRequestItem(spec, baseUrl, routePath, method, operation) {
+  const request = {
+    method: method.toUpperCase(),
+    header: getRequestHeaders(operation),
+    url: buildRequestUrl(baseUrl, routePath),
+    description: operation.description || operation.summary || "",
+  };
+
+  const body = getRequestBody(spec, operation);
+  if (body) {
+    request.body = body;
+  }
+
+  return {
+    name: operation.summary || `${method.toUpperCase()} ${routePath}`,
+    request,
+  };
+}
+
+function toPostmanCollection(spec) {
+  const productionServer =
+    spec.servers?.find((server) => server.description === "Production")?.url ||
+    spec.servers?.find((server) => typeof server.url === "string" && server.url.startsWith("https"))?.url ||
+    "https://api.solana.com";
+
+  const folders = new Map();
+
+  for (const [routePath, pathItem] of Object.entries(spec.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== "object") {
+      continue;
+    }
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation || typeof operation !== "object" || !isPublicOperation(operation)) {
+        continue;
+      }
+
+      const tagName = getPrimaryTagName(operation);
+      if (!tagName) {
+        continue;
+      }
+
+      if (!folders.has(tagName)) {
+        folders.set(tagName, []);
+      }
+
+      folders.get(tagName).push(createRequestItem(spec, "{{baseUrl}}", routePath, method, operation));
+    }
+  }
+
+  const orderedTags = (spec.tags ?? [])
+    .map((tag) => tag?.name)
+    .filter((tagName) => tagName && folders.has(tagName));
+
+  return {
+    info: {
+      name: "Solana Developer Platform Public API",
+      description:
+        "Public Postman collection generated from the SDP OpenAPI contract. Internal-only endpoint families are excluded.",
+      schema:
+        "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    },
+    auth: {
+      type: "bearer",
+      bearer: [
+        {
+          key: "token",
+          value: "{{sdpApiKey}}",
+          type: "string",
+        },
+      ],
+    },
+    variable: [
+      {
+        key: "baseUrl",
+        value: productionServer,
+        type: "string",
+      },
+      {
+        key: "sdpApiKey",
+        value: "sk_test_your_api_key",
+        type: "string",
+      },
+    ],
+    item: orderedTags.map((tagName) => ({
+      name: tagName,
+      item: folders.get(tagName) ?? [],
+    })),
+  };
+}
+
+async function run() {
+  const rawSpec = await fs.readFile(generatedSpecPath, "utf8");
+  const spec = JSON.parse(rawSpec);
+  const collection = toPostmanCollection(spec);
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(outputPath, `${JSON.stringify(collection, null, 2)}\n`, "utf8");
+
+  console.log(`Generated Postman collection with ${collection.item.length} folders at ${outputPath}`);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/sdp-docs/scripts/lib/public-openapi.mjs
+++ b/apps/sdp-docs/scripts/lib/public-openapi.mjs
@@ -1,0 +1,30 @@
+export const PUBLIC_TAG_SLUGS = new Set([
+  "health",
+  "api-keys",
+  "wallets",
+  "projects",
+  "issuance",
+  "payments",
+  "compliance",
+]);
+
+export const POSTMAN_COLLECTION_ROUTE = "/postman/collection.json";
+export const POSTMAN_COLLECTION_FILENAME =
+  "solana-developer-platform-public.postman_collection.json";
+export const POSTMAN_COLLECTION_PUBLIC_PATH = `/postman/${POSTMAN_COLLECTION_FILENAME}`;
+
+export const slugify = (value) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const isPublicTag = (tagName) => PUBLIC_TAG_SLUGS.has(slugify(tagName));
+
+export const getPrimaryTagName = (operation) =>
+  Array.isArray(operation?.tags) && operation.tags.length > 0 ? String(operation.tags[0]) : null;
+
+export const isPublicOperation = (operation) => {
+  const primaryTag = getPrimaryTagName(operation);
+  return primaryTag !== null && isPublicTag(primaryTag);
+};

--- a/apps/sdp-docs/src/app/postman/collection.json/route.ts
+++ b/apps/sdp-docs/src/app/postman/collection.json/route.ts
@@ -1,9 +1,9 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { POSTMAN_COLLECTION_FILENAME } from "../../../../scripts/lib/public-openapi.mjs";
 
 export const runtime = "nodejs";
 
-const POSTMAN_COLLECTION_FILENAME = "solana-developer-platform-public.postman_collection.json";
 const collectionPath = path.join(process.cwd(), "public", "postman", POSTMAN_COLLECTION_FILENAME);
 
 export async function GET() {

--- a/apps/sdp-docs/src/app/postman/collection.json/route.ts
+++ b/apps/sdp-docs/src/app/postman/collection.json/route.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export const runtime = "nodejs";
+
+const POSTMAN_COLLECTION_FILENAME = "solana-developer-platform-public.postman_collection.json";
+const collectionPath = path.join(
+  process.cwd(),
+  "public",
+  "postman",
+  POSTMAN_COLLECTION_FILENAME
+);
+
+export async function GET() {
+  try {
+    const body = await readFile(collectionPath, "utf8");
+
+    return new Response(body, {
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "public, max-age=300",
+        "content-disposition": `inline; filename="${POSTMAN_COLLECTION_FILENAME}"`,
+      },
+    });
+  } catch {
+    return Response.json(
+      {
+        error: {
+          code: "POSTMAN_COLLECTION_UNAVAILABLE",
+          message: "The generated Postman collection is not available.",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/sdp-docs/src/app/postman/collection.json/route.ts
+++ b/apps/sdp-docs/src/app/postman/collection.json/route.ts
@@ -4,12 +4,7 @@ import path from "node:path";
 export const runtime = "nodejs";
 
 const POSTMAN_COLLECTION_FILENAME = "solana-developer-platform-public.postman_collection.json";
-const collectionPath = path.join(
-  process.cwd(),
-  "public",
-  "postman",
-  POSTMAN_COLLECTION_FILENAME
-);
+const collectionPath = path.join(process.cwd(), "public", "postman", POSTMAN_COLLECTION_FILENAME);
 
 export async function GET() {
   try {

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -37,6 +37,23 @@ async function openFundManagementAction(page: Page, action: string): Promise<voi
   await row.getByRole("button").click();
 }
 
+async function waitForPermissionRowValue(
+  page: Page,
+  rowTestId: string,
+  expectedText: string
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        await page.reload();
+        await openTab(page, "Permissions");
+        return (await page.getByTestId(rowTestId).textContent()) ?? "";
+      },
+      { timeout: 120_000, intervals: [1_000, 2_000, 5_000] }
+    )
+    .toContain(expectedText);
+}
+
 test.describe
   .serial("issuance e2e", () => {
     let fixtures: IssuanceFixtures;
@@ -143,28 +160,31 @@ test.describe
     test("5. user can update an authority including the None confirmation flow", async ({
       page,
     }) => {
+      const rowTestId = "permission-row-permanent-delegate";
+
       await gotoToken(page, fixtures.tokens.allowlisted.id);
       await openTab(page, "Permissions");
 
-      const row = page.getByTestId("permission-row-permanent-delegate");
+      const row = page.getByTestId(rowTestId);
       await row.getByRole("button", { name: "Edit" }).click();
       await page.getByLabel("New authority").selectOption(fixtures.wallets.delegated.publicKey);
-      let successCount = await page.getByText("Permanent Delegate Authority updated.").count();
       await page.getByRole("button", { name: "Save authority" }).click();
-      await waitForToast(page, "Permanent Delegate Authority updated.", successCount);
-      await expect(row).toContainText(shortValue(fixtures.wallets.delegated.publicKey));
+      await waitForPermissionRowValue(
+        page,
+        rowTestId,
+        shortValue(fixtures.wallets.delegated.publicKey)
+      );
 
-      await row.getByRole("button", { name: "Edit" }).click();
+      const refreshedRow = page.getByTestId(rowTestId);
+      await refreshedRow.getByRole("button", { name: "Edit" }).click();
       await page.getByLabel("New authority").selectOption({ label: "None" });
       await page.getByRole("button", { name: "Save authority" }).click();
 
       await expect(
         page.getByRole("heading", { name: "Set Permanent Delegate Authority to None?" })
       ).toBeVisible();
-      successCount = await page.getByText("Permanent Delegate Authority updated.").count();
       await page.getByRole("button", { name: "Yes, set to None" }).click();
-      await waitForToast(page, "Permanent Delegate Authority updated.", successCount);
-      await expect(row).toContainText("None");
+      await waitForPermissionRowValue(page, rowTestId, "None");
     });
 
     test("6. user can add and remove allowlist entries on the allowlist-enabled token", async ({


### PR DESCRIPTION
## Summary
- generate a public-only Postman collection from the SDP OpenAPI contract
- add a docs reference page and JSON route for downloading the collection
- keep internal endpoint families out of the generated collection and API reference index links

## Testing
- pnpm --filter sdp-docs generate:api
- pnpm --filter sdp-docs typecheck
- pnpm --filter sdp-docs check:links
- pnpm --filter sdp-docs build