### PR TITLE
feat(custody): streamline Fireblocks platform flow

### DIFF
--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -16,6 +16,7 @@ import { corsMiddleware } from "@/middleware/cors";
 import { skipRateLimitPaths } from "@/middleware/rate-limit";
 import { requestIdMiddleware } from "@/middleware/request-id";
 import { requestTracingMiddleware } from "@/middleware/request-tracing";
+import { SigningError } from "@/services/ports";
 import type { Env } from "@/types/env";
 
 import allowlist from "@/routes/allowlist";
@@ -119,6 +120,46 @@ function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void
   });
 }
 
+function mapSigningError(err: SigningError): {
+  status: 400 | 404 | 409 | 502 | 504;
+  code: string;
+  message: string;
+} {
+  switch (err.code) {
+    case "WALLET_NOT_FOUND":
+    case "NOT_FOUND":
+      return { status: 404, code: err.code, message: err.message };
+    case "ALREADY_INITIALIZED":
+      return { status: 409, code: err.code, message: err.message };
+    case "APPROVAL_TIMEOUT":
+      return { status: 504, code: err.code, message: err.message };
+    case "APPROVAL_REJECTED":
+      return { status: 409, code: err.code, message: err.message };
+    case "NETWORK_ERROR":
+    case "SIGNING_FAILED":
+      return { status: 502, code: err.code, message: err.message };
+    default:
+      return { status: 400, code: err.code, message: err.message };
+  }
+}
+
+function getFireblocksBlockedError(err: Error): {
+  status: 400;
+  code: "SIGNING_BLOCKED";
+  message: string;
+} | null {
+  if (!err.message.includes("Transaction failed with status: BLOCKED")) {
+    return null;
+  }
+
+  return {
+    status: 400,
+    code: "SIGNING_BLOCKED",
+    message:
+      "Fireblocks blocked this signing request. Confirm raw signing is enabled for this workspace and that the raw-signing policy allows this API user and vault.",
+  };
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Global Middleware
 // ═══════════════════════════════════════════════════════════════════════════
@@ -214,6 +255,36 @@ app.onError((err, c) => {
         meta: { requestId },
       },
       err.statusCode as 400
+    );
+  }
+
+  if (err instanceof SigningError) {
+    const mapped = mapSigningError(err);
+    c.header("X-SDP-Trace-ID", traceId);
+    return c.json(
+      {
+        error: {
+          code: mapped.code,
+          message: mapped.message,
+        },
+        meta: { requestId },
+      },
+      mapped.status
+    );
+  }
+
+  const fireblocksBlocked = getFireblocksBlockedError(err);
+  if (fireblocksBlocked) {
+    c.header("X-SDP-Trace-ID", traceId);
+    return c.json(
+      {
+        error: {
+          code: fireblocksBlocked.code,
+          message: fireblocksBlocked.message,
+        },
+        meta: { requestId },
+      },
+      fireblocksBlocked.status
     );
   }
 

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -7,6 +7,10 @@ import type { CustodyProvider } from "@/services/custody/providers";
 import { provisionFireblocksVaultAccount } from "@/services/custody/provisioning";
 import { normalizePem } from "@/services/custody/provisioning.common";
 import { createSigningService } from "@/services/domain/signing.service";
+import {
+  type FireblocksProviderConfig,
+  parseConfigRecord,
+} from "@/services/domain/signing/provider-config";
 import { SigningError } from "@/services/ports";
 import { type AppContext, getPreferredWalletForConfig, resolveActor } from "../context";
 import {
@@ -40,9 +44,11 @@ export const initializeSigning = async (c: AppContext) => {
 
   try {
     const result = await initializeProviderConnection(
+      c,
       signingService,
       c.env,
       actor.organizationId,
+      await resolveOrganizationSlug(c, actor.organizationId),
       parsed.data
     );
 
@@ -121,9 +127,11 @@ export const switchSigning = async (c: AppContext) => {
       });
     } else {
       result = await initializeProviderConnection(
+        c,
         signingService,
         c.env,
         actor.organizationId,
+        await resolveOrganizationSlug(c, actor.organizationId),
         parsed.data
       );
 
@@ -205,9 +213,11 @@ export const getSwitchProviderOptions = async (c: AppContext) => {
 };
 
 async function initializeProviderConnection(
+  c: AppContext,
   signingService: ReturnType<typeof createSigningService>,
   env: AppContext["env"],
   organizationId: string,
+  organizationSlug: string,
   request: InitializeSigningRequest | SwitchSigningRequest
 ): Promise<SigningInitializationResult> {
   switch (request.provider) {
@@ -222,19 +232,31 @@ async function initializeProviderConnection(
 
       const resolvedApiKey = env.FIREBLOCKS_API_KEY;
       const resolvedApiSecretPem = normalizePem(env.FIREBLOCKS_API_SECRET);
+      const existingFireblocksConfig = await findScopeFireblocksConfig(
+        c,
+        organizationId,
+        request.projectId
+      );
 
-      const { vaultAccountId, assetId } = await provisionFireblocksVaultAccount(env, {
-        orgId: organizationId,
-        orgSlug: organizationId,
-        apiKey: resolvedApiKey,
-        apiSecretPem: resolvedApiSecretPem,
-      });
+      const { vaultAccountId, assetId, apiBaseUrl } = existingFireblocksConfig
+        ? {
+            vaultAccountId: existingFireblocksConfig.vaultAccountId,
+            assetId: existingFireblocksConfig.assetId,
+            apiBaseUrl: existingFireblocksConfig.apiBaseUrl,
+          }
+        : await provisionFireblocksVaultAccount(env, {
+            orgId: organizationId,
+            orgSlug: organizationSlug,
+            apiKey: resolvedApiKey,
+            apiSecretPem: env.FIREBLOCKS_API_SECRET,
+          });
 
       return signingService.initializeFireblocksSigning(organizationId, request.projectId, {
         apiKey: resolvedApiKey,
         apiSecretPem: resolvedApiSecretPem,
         vaultAccountId,
         assetId,
+        apiBaseUrl,
         walletLabel: request.walletLabel,
       });
     }
@@ -305,6 +327,86 @@ async function findScopeConfigByProvider(
   )
     .bind(...(projectId ? [organizationId, projectId, provider] : [organizationId, provider]))
     .first<{ id: string; status: "active" | "inactive"; default_wallet_id: string | null }>();
+}
+
+async function findScopeProviderConfigRecord(
+  c: AppContext,
+  organizationId: string,
+  projectId: string | undefined,
+  provider: CustodyProvider
+) {
+  return c.env.DB.prepare(
+    projectId
+      ? `SELECT id,
+                organization_id,
+                project_id,
+                provider,
+                config_encrypted AS config,
+                default_wallet_id,
+                status,
+                created_at,
+                updated_at
+           FROM custody_configs
+           WHERE organization_id = ? AND project_id = ? AND provider = ?
+           LIMIT 1`
+      : `SELECT id,
+                organization_id,
+                project_id,
+                provider,
+                config_encrypted AS config,
+                default_wallet_id,
+                status,
+                created_at,
+                updated_at
+           FROM custody_configs
+           WHERE organization_id = ? AND project_id IS NULL AND provider = ?
+           LIMIT 1`
+  )
+    .bind(...(projectId ? [organizationId, projectId, provider] : [organizationId, provider]))
+    .first<{
+      id: string;
+      organization_id: string;
+      project_id: string | null;
+      provider: CustodyProvider;
+      config: string;
+      default_wallet_id: string | null;
+      status: "active" | "inactive";
+      created_at: string;
+      updated_at: string;
+    }>();
+}
+
+async function findScopeFireblocksConfig(
+  c: AppContext,
+  organizationId: string,
+  projectId: string | undefined
+): Promise<FireblocksProviderConfig | null> {
+  const record = await findScopeProviderConfigRecord(c, organizationId, projectId, "fireblocks");
+  if (!record) {
+    return null;
+  }
+
+  const parsed = await parseConfigRecord(c.env, organizationId, {
+    id: record.id,
+    organizationId: record.organization_id,
+    projectId: record.project_id,
+    provider: record.provider,
+    config: record.config,
+    defaultWalletId: record.default_wallet_id,
+    status: record.status,
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  });
+
+  return parsed.provider === "fireblocks" ? parsed : null;
+}
+
+async function resolveOrganizationSlug(c: AppContext, organizationId: string): Promise<string> {
+  const row = await c.env.DB.prepare("SELECT slug FROM organizations WHERE id = ? LIMIT 1")
+    .bind(organizationId)
+    .first<{ slug: string | null }>();
+
+  return row?.slug?.trim() || organizationId;
 }
 
 async function logDefaultProviderChanged(

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -1,8 +1,11 @@
 import { AppError } from "@/lib/errors";
 import { created, success } from "@/lib/response";
+import { clearWalletCaches } from "@/routes/custody/handlers/wallets";
 import { AuditService } from "@/services/audit.service";
 import { CUSTODY_PROVIDERS } from "@/services/custody/providers";
 import type { CustodyProvider } from "@/services/custody/providers";
+import { provisionFireblocksVaultAccount } from "@/services/custody/provisioning";
+import { normalizePem } from "@/services/custody/provisioning.common";
 import { createSigningService } from "@/services/domain/signing.service";
 import { SigningError } from "@/services/ports";
 import { type AppContext, getPreferredWalletForConfig, resolveActor } from "../context";
@@ -38,6 +41,7 @@ export const initializeSigning = async (c: AppContext) => {
   try {
     const result = await initializeProviderConnection(
       signingService,
+      c.env,
       actor.organizationId,
       parsed.data
     );
@@ -53,6 +57,8 @@ export const initializeSigning = async (c: AppContext) => {
         projectId: parsed.data.projectId ?? null,
       },
     });
+
+    clearWalletCaches();
 
     return created(c, toInitializeSigningResponse(result));
   } catch (error) {
@@ -116,6 +122,7 @@ export const switchSigning = async (c: AppContext) => {
     } else {
       result = await initializeProviderConnection(
         signingService,
+        c.env,
         actor.organizationId,
         parsed.data
       );
@@ -145,6 +152,8 @@ export const switchSigning = async (c: AppContext) => {
         provider: targetProvider,
       });
     }
+
+    clearWalletCaches();
 
     return created(c, toInitializeSigningResponse(result));
   } catch (error) {
@@ -197,6 +206,7 @@ export const getSwitchProviderOptions = async (c: AppContext) => {
 
 async function initializeProviderConnection(
   signingService: ReturnType<typeof createSigningService>,
+  env: AppContext["env"],
   organizationId: string,
   request: InitializeSigningRequest | SwitchSigningRequest
 ): Promise<SigningInitializationResult> {
@@ -205,21 +215,29 @@ async function initializeProviderConnection(
       return signingService.initializeLocalSigning(organizationId, request.projectId, {
         walletLabel: request.walletLabel,
       });
-    case "fireblocks":
-      if (!request.apiKey || !request.apiSecretPem || !request.vaultAccountId) {
-        throw new AppError(
-          "BAD_REQUEST",
-          "Fireblocks requires apiKey, apiSecretPem, and vaultAccountId when connecting a new provider"
-        );
+    case "fireblocks": {
+      if (!env.FIREBLOCKS_API_KEY || !env.FIREBLOCKS_API_SECRET) {
+        throw new AppError("BAD_REQUEST", "Fireblocks backend credentials are not configured");
       }
 
-      return signingService.initializeFireblocksSigning(organizationId, request.projectId, {
-        apiKey: request.apiKey,
-        apiSecretPem: request.apiSecretPem,
-        vaultAccountId: request.vaultAccountId,
-        assetId: request.assetId,
-        apiBaseUrl: request.apiBaseUrl,
+      const resolvedApiKey = env.FIREBLOCKS_API_KEY;
+      const resolvedApiSecretPem = normalizePem(env.FIREBLOCKS_API_SECRET);
+
+      const { vaultAccountId, assetId } = await provisionFireblocksVaultAccount(env, {
+        orgId: organizationId,
+        orgSlug: organizationId,
+        apiKey: resolvedApiKey,
+        apiSecretPem: resolvedApiSecretPem,
       });
+
+      return signingService.initializeFireblocksSigning(organizationId, request.projectId, {
+        apiKey: resolvedApiKey,
+        apiSecretPem: resolvedApiSecretPem,
+        vaultAccountId,
+        assetId,
+        walletLabel: request.walletLabel,
+      });
+    }
     case "privy":
       return signingService.initializePrivySigning(organizationId, request.projectId, {
         apiBaseUrl: request.apiBaseUrl,

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -66,7 +66,7 @@ const walletSummaryCache = new Map<string, CacheEntry<CustodyWalletSummary[]>>()
 const walletAggregateCache = new Map<string, CacheEntry<CustodyWalletAggregate>>();
 const walletBalanceCache = new Map<string, CacheEntry<CustodyWalletTokenBalance[]>>();
 
-function clearWalletCaches() {
+export function clearWalletCaches() {
   walletSummaryCache.clear();
   walletAggregateCache.clear();
   walletBalanceCache.clear();

--- a/apps/sdp-api/src/routes/custody/schemas.ts
+++ b/apps/sdp-api/src/routes/custody/schemas.ts
@@ -32,11 +32,7 @@ export const initializeLocalSchema = z.object({
 export const initializeFireblocksSchema = z.object({
   provider: z.literal("fireblocks"),
   projectId: z.string().optional(),
-  apiKey: z.string().min(1),
-  apiSecretPem: z.string().min(1),
-  vaultAccountId: z.string().min(1),
-  assetId: z.string().default("SOL"),
-  apiBaseUrl: z.string().url().optional(),
+  walletLabel: z.string().max(100).optional(),
 });
 
 export const initializePrivySchema = z.object({
@@ -136,20 +132,9 @@ export type UpdateWalletRequest = z.infer<typeof updateWalletSchema>;
 // Switch Signing Provider
 // ═══════════════════════════════════════════════════════════════════════════
 
-// Switching uses the same provider payload shape as initialize.
-// The handler ensures the target provider is active, then updates the default provider
-// pointer for the requested scope.
-export const switchFireblocksSchema = initializeFireblocksSchema.extend({
-  apiKey: initializeFireblocksSchema.shape.apiKey.optional(),
-  apiSecretPem: initializeFireblocksSchema.shape.apiSecretPem.optional(),
-  vaultAccountId: initializeFireblocksSchema.shape.vaultAccountId.optional(),
-  assetId: initializeFireblocksSchema.shape.assetId.optional(),
-  apiBaseUrl: initializeFireblocksSchema.shape.apiBaseUrl.optional(),
-});
-
 export const switchSigningSchema = z.discriminatedUnion("provider", [
   initializeLocalSchema,
-  switchFireblocksSchema,
+  initializeFireblocksSchema,
   initializePrivySchema,
   initializeCoinbaseCdpSchema,
   initializeParaSchema,

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -146,9 +146,6 @@ export const executeBurn = async (c: AppContext) => {
     parsed.data.signingWalletId ?? token.signingWalletId,
     ["tokens:write"]
   );
-
-  // Get custody signer (via 3-tier resolution)
-  const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(parsed.data.burn.source, "source");
   const burnAmount = toMosaicAmount(parsed.data.burn.amount, token.decimals);
@@ -178,11 +175,18 @@ export const executeBurn = async (c: AppContext) => {
   if (replayed) {
     return success(c, { transaction: tx });
   }
-
-  // Execute burn on Solana
-  const token2022 = createToken2022Service(c.env, signer);
-
   try {
+    // Get custody signer (via 3-tier resolution)
+    const signer = await createOrgSigner(
+      c.env,
+      auth.organizationId,
+      auth.projectId,
+      signingWalletId
+    );
+
+    // Execute burn on Solana
+    const token2022 = createToken2022Service(c.env, signer);
+
     const result = await token2022.burn({
       mint: mintAddress,
       source,

--- a/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
@@ -93,17 +93,22 @@ export const deployToken = async (c: AppContext) => {
     ["tokens:write"]
   );
 
-  // Get custody signer (resolves via 3-tier: project → org → env fallback)
-  const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
-  const custodyAddress = signer.address;
-
-  // Create Mosaic service for template-based token deployment
-  const mosaic = createMosaicService(c.env, signer);
-
   // Deploy using Mosaic templates - handles ABL setup automatically
   const enableAbl = token.requiresAllowlist && c.env.SOLANA_NETWORK === "mainnet-beta";
 
   try {
+    // Get custody signer (resolves via 3-tier: project → org → env fallback)
+    const signer = await createOrgSigner(
+      c.env,
+      auth.organizationId,
+      auth.projectId,
+      signingWalletId
+    );
+    const custodyAddress = signer.address;
+
+    // Create Mosaic service for template-based token deployment
+    const mosaic = createMosaicService(c.env, signer);
+
     const result = await mosaic.createToken({
       template: token.template,
       metadata: {

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -201,9 +201,6 @@ export const executeMint = async (c: AppContext) => {
     parsed.data.signingWalletId ?? token.signingWalletId,
     ["tokens:write"]
   );
-
-  // Get custody signer (via 3-tier resolution)
-  const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const destination = assertValidAddress(parsed.data.mint.destination, "destination");
 
@@ -238,11 +235,19 @@ export const executeMint = async (c: AppContext) => {
     });
   }
 
-  // Execute mint on Solana using Mosaic
-  // Note: amount is decimal (e.g., 100 for 100 tokens), SDK converts to raw
-  const mosaic = createMosaicService(c.env, signer);
-
   try {
+    // Get custody signer (via 3-tier resolution)
+    const signer = await createOrgSigner(
+      c.env,
+      auth.organizationId,
+      auth.projectId,
+      signingWalletId
+    );
+
+    // Execute mint on Solana using Mosaic
+    // Note: amount is decimal (e.g., 100 for 100 tokens), SDK converts to raw
+    const mosaic = createMosaicService(c.env, signer);
+
     const result = await mosaic.mintTo({
       mint: mintAddress,
       destination,

--- a/apps/sdp-api/src/routes/issuance/handlers/pause.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/pause.ts
@@ -63,12 +63,6 @@ export const pauseToken = async (c: AppContext) => {
   const signingWalletId = resolveApiKeySigningWalletId(auth, token.signingWalletId, [
     "tokens:admin",
   ]);
-
-  const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
-  if (pauseAuthorityRaw !== signer.address) {
-    throw new AppError("BAD_REQUEST", "Pause authority is not controlled by custody");
-  }
-
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
@@ -95,9 +89,19 @@ export const pauseToken = async (c: AppContext) => {
     return success(c, { transaction: tx });
   }
 
-  const mosaic = createMosaicService(c.env, signer);
-
   try {
+    const signer = await createOrgSigner(
+      c.env,
+      auth.organizationId,
+      auth.projectId,
+      signingWalletId
+    );
+    if (pauseAuthorityRaw !== signer.address) {
+      throw new AppError("BAD_REQUEST", "Pause authority is not controlled by custody");
+    }
+
+    const mosaic = createMosaicService(c.env, signer);
+
     const result = await mosaic.pauseToken({
       mint: mintAddress,
       pauseAuthority: signer,
@@ -180,12 +184,6 @@ export const unpauseToken = async (c: AppContext) => {
   const signingWalletId = resolveApiKeySigningWalletId(auth, token.signingWalletId, [
     "tokens:admin",
   ]);
-
-  const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
-  if (pauseAuthorityRaw !== signer.address) {
-    throw new AppError("BAD_REQUEST", "Pause authority is not controlled by custody");
-  }
-
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
@@ -212,9 +210,19 @@ export const unpauseToken = async (c: AppContext) => {
     return success(c, { transaction: tx });
   }
 
-  const mosaic = createMosaicService(c.env, signer);
-
   try {
+    const signer = await createOrgSigner(
+      c.env,
+      auth.organizationId,
+      auth.projectId,
+      signingWalletId
+    );
+    if (pauseAuthorityRaw !== signer.address) {
+      throw new AppError("BAD_REQUEST", "Pause authority is not controlled by custody");
+    }
+
+    const mosaic = createMosaicService(c.env, signer);
+
     const result = await mosaic.unpauseToken({
       mint: mintAddress,
       pauseAuthority: signer,

--- a/apps/sdp-api/src/routes/organizations/schemas.ts
+++ b/apps/sdp-api/src/routes/organizations/schemas.ts
@@ -4,9 +4,6 @@ import { z } from "zod";
 const createOrgCustodySchema = z.discriminatedUnion("provider", [
   z.object({
     provider: z.literal("fireblocks"),
-    apiBaseUrl: z.string().url().optional(),
-    assetId: z.string().min(1).optional(),
-    vaultAccountId: z.string().min(1).optional(),
   }),
   z.object({
     provider: z.literal("privy"),

--- a/apps/sdp-api/src/services/adapters/signing/index.ts
+++ b/apps/sdp-api/src/services/adapters/signing/index.ts
@@ -16,6 +16,7 @@
  */
 
 import type { CustodyProvider } from "@/services/custody/providers";
+import { normalizePem } from "@/services/custody/provisioning.common";
 import { createDfnsApiClient, normalizeDfnsWalletId } from "@/services/dfns/client";
 import type { SigningPort } from "@/services/ports";
 import { SigningError } from "@/services/ports";
@@ -222,7 +223,7 @@ interface DfnsConfigJson {
 
 function createFireblocksAdapterFromEnv(env: Env): KeychainFireblocksAdapter {
   const apiKey = env.FIREBLOCKS_API_KEY;
-  const apiSecret = env.FIREBLOCKS_API_SECRET;
+  const apiSecret = env.FIREBLOCKS_API_SECRET ? normalizePem(env.FIREBLOCKS_API_SECRET) : undefined;
   const vaultId = env.FIREBLOCKS_VAULT_ID;
   const assetId = env.FIREBLOCKS_ASSET_ID ?? "SOL";
 

--- a/apps/sdp-api/src/services/custody/provisioning.common.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.common.ts
@@ -117,6 +117,10 @@ export function encodePkcs8Pem(privateKeyDer: Uint8Array): string {
   return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
 }
 
+export function normalizePem(value: string): string {
+  return value.replace(/\\n/g, "\n").trim();
+}
+
 export function encodeBasicAuth(value: string): string {
   if (typeof btoa === "function") {
     return btoa(value);

--- a/apps/sdp-api/src/services/custody/provisioning.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.ts
@@ -18,6 +18,7 @@ import {
 } from "./provisioning.coinbase";
 import {
   encodeBasicAuth,
+  normalizePem,
   parseJsonResponse,
   randomHex,
   readErrorResponseText,
@@ -96,6 +97,8 @@ export interface ProvisionFireblocksOptions {
   assetId?: string;
   apiBaseUrl?: string;
   vaultAccountId?: string;
+  apiKey?: string;
+  apiSecretPem?: string;
 }
 
 export interface ProvisionFireblocksResult {
@@ -158,8 +161,12 @@ export async function provisionFireblocksVaultAccount(
   env: Env,
   options: ProvisionFireblocksOptions
 ): Promise<ProvisionFireblocksResult> {
-  const apiKey = env.FIREBLOCKS_API_KEY;
-  const apiSecretPem = env.FIREBLOCKS_API_SECRET;
+  const apiKey = options.apiKey ?? env.FIREBLOCKS_API_KEY;
+  const apiSecretPem = options.apiSecretPem
+    ? normalizePem(options.apiSecretPem)
+    : env.FIREBLOCKS_API_SECRET
+      ? normalizePem(env.FIREBLOCKS_API_SECRET)
+      : undefined;
 
   if (!apiKey || !apiSecretPem) {
     throw new SigningError(

--- a/apps/sdp-api/src/services/custody/provisioning.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.ts
@@ -104,6 +104,7 @@ export interface ProvisionFireblocksOptions {
 export interface ProvisionFireblocksResult {
   vaultAccountId: string;
   assetId: string;
+  apiBaseUrl: string;
 }
 
 export interface ProvisionPrivyOptions {
@@ -229,7 +230,7 @@ export async function provisionFireblocksVaultAccount(
     );
   }
 
-  return { vaultAccountId, assetId };
+  return { vaultAccountId, assetId, apiBaseUrl };
 }
 
 export async function provisionPrivyWallet(

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -157,6 +157,7 @@ export interface InitFireblocksSigningOptions {
   vaultAccountId: string;
   assetId?: string;
   apiBaseUrl?: string;
+  walletLabel?: string;
 }
 
 /**
@@ -597,7 +598,7 @@ export class SigningService {
     await this.configStore.createWallet(configId, {
       walletId,
       publicKey,
-      label: "Fireblocks Vault",
+      label: options.walletLabel ?? "Fireblocks Vault",
       purpose: "root",
     });
 

--- a/apps/sdp-api/src/services/organization-onboarding.service.ts
+++ b/apps/sdp-api/src/services/organization-onboarding.service.ts
@@ -25,9 +25,6 @@ export class OrganizationOnboardingService {
           const { vaultAccountId, assetId } = await provisionFireblocksVaultAccount(this.env, {
             orgId,
             orgSlug,
-            assetId: custody.assetId,
-            apiBaseUrl: custody.apiBaseUrl,
-            vaultAccountId: custody.vaultAccountId,
           });
 
           if (!this.env.FIREBLOCKS_API_KEY || !this.env.FIREBLOCKS_API_SECRET) {
@@ -42,7 +39,7 @@ export class OrganizationOnboardingService {
             apiSecretPem: this.env.FIREBLOCKS_API_SECRET,
             vaultAccountId,
             assetId,
-            apiBaseUrl: custody.apiBaseUrl ?? this.env.FIREBLOCKS_API_BASE_URL,
+            apiBaseUrl: this.env.FIREBLOCKS_API_BASE_URL,
           });
           return;
         }

--- a/apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/authority-wallets/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/authority-wallets/route.ts
@@ -1,0 +1,62 @@
+import { fetchPaymentsWallets } from "@/app/dashboard/payments/payments-page.data";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request, { params }: { params: Promise<{ tokenId: string }> }) {
+  const trace = createTimedTrace("route.dashboard.issuance.token.authority_wallets", request);
+
+  try {
+    const { tokenId } = await params;
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.issuance.token.authority_wallets.api")
+    );
+
+    const walletsResult = await trace.step("fetch_authority_wallets", () =>
+      fetchPaymentsWallets(apiClient.request, { view: "summary" })
+    );
+
+    const response = NextResponse.json(
+      {
+        data: {
+          authorityWallets: walletsResult.data ?? [],
+          authorityWalletsError: walletsResult.ok
+            ? null
+            : `Wallet API ${walletsResult.status ?? "unavailable"}: ${walletsResult.error ?? "Unknown error"}`,
+        },
+      },
+      {
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, 200, {
+      tokenId,
+      authorityWalletCount: walletsResult.data?.length ?? 0,
+    });
+
+    return response;
+  } catch (error) {
+    const response = NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to load authority wallets",
+      },
+      {
+        status: 500,
+        headers: {
+          "X-SDP-Trace-ID": trace.traceId,
+          "Server-Timing": trace.serverTiming(),
+        },
+      }
+    );
+
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to load authority wallets",
+    });
+
+    return response;
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -118,35 +118,17 @@ export async function initializeCustody(formData: FormData) {
     | "dfns"
     | "anchorage";
   const walletLabel = getOptionalString(formData, "walletLabel");
-  const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
-  const fireblocksApiKey = getOptionalString(formData, "apiKey");
-  const fireblocksApiSecretPem = getOptionalString(formData, "apiSecretPem");
-  const fireblocksVaultAccountId = getOptionalString(formData, "vaultAccountId");
-  const fireblocksAssetId = getOptionalString(formData, "assetId");
   const network = getOptionalString(formData, "network");
   const walletAddress = getOptionalString(formData, "walletAddress");
   const accountPolicy = getOptionalString(formData, "accountPolicy");
+  const apiBaseUrl = getOptionalString(formData, "apiBaseUrl");
 
   const payload: Record<string, unknown> = {
     provider,
     walletLabel,
   };
 
-  if (provider === "fireblocks") {
-    if (!fireblocksApiKey || !fireblocksApiSecretPem || !fireblocksVaultAccountId) {
-      throw new Error("Fireblocks requires apiKey, apiSecretPem, and vaultAccountId");
-    }
-
-    payload.apiKey = fireblocksApiKey;
-    payload.apiSecretPem = fireblocksApiSecretPem;
-    payload.vaultAccountId = fireblocksVaultAccountId;
-    if (fireblocksAssetId) {
-      payload.assetId = fireblocksAssetId;
-    }
-    if (apiBaseUrl) {
-      payload.apiBaseUrl = apiBaseUrl;
-    }
-  } else {
+  if (provider !== "fireblocks") {
     if (apiBaseUrl) {
       payload.apiBaseUrl = apiBaseUrl;
     }

--- a/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx
@@ -110,7 +110,6 @@ export function CustodySetupForm({
     CUSTODY_PROVIDER_CATALOG.find((provider) => provider.id === selectedProvider) ??
     CUSTODY_PROVIDER_CATALOG[0];
   const isConnected = connectedProviderSet.has(selectedProvider);
-  const isFireblocks = selectedProvider === "fireblocks";
   const supportsAdditionalWallets = selectedProviderEntry.supportsAdditionalWallets;
   const canCreateAdditionalWallet = !isConnected || supportsAdditionalWallets;
   const formAction = isConnected ? createWalletAction : initializeAction;
@@ -169,58 +168,6 @@ export function CustodySetupForm({
             <Label htmlFor="walletLabel">Wallet label</Label>
             <Input id="walletLabel" name="walletLabel" placeholder="Primary wallet" />
           </div>
-
-          {isFireblocks ? (
-            <div className="grid gap-4 rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] p-4">
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-[#1c1c1d]">Fireblocks credentials</p>
-                <p className="text-xs text-[rgba(28,28,29,0.64)]">
-                  Required when provider is Fireblocks.
-                </p>
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="apiKey">API key</Label>
-                <Input id="apiKey" name="apiKey" placeholder="Fireblocks API key" required />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="apiSecretPem">API secret PEM</Label>
-                <textarea
-                  id="apiSecretPem"
-                  name="apiSecretPem"
-                  className="min-h-28 w-full rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 py-2 text-sm text-[#1c1c1d]"
-                  placeholder="-----BEGIN PRIVATE KEY-----"
-                  required
-                />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="vaultAccountId">Vault account ID</Label>
-                <Input
-                  id="vaultAccountId"
-                  name="vaultAccountId"
-                  placeholder="Vault account ID"
-                  required
-                />
-              </div>
-
-              <div className="grid gap-2 md:grid-cols-2 md:gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="assetId">Asset ID (optional)</Label>
-                  <Input id="assetId" name="assetId" placeholder="SOL" />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="apiBaseUrl">API base URL (optional)</Label>
-                  <Input
-                    id="apiBaseUrl"
-                    name="apiBaseUrl"
-                    placeholder="https://api.fireblocks.io"
-                  />
-                </div>
-              </div>
-            </div>
-          ) : null}
         </>
       )}
 

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx
@@ -87,7 +87,6 @@ export function WalletProvisionModal({
     [selectedProvider]
   );
   const isConnected = connectedProviderSet.has(selectedProvider);
-  const isFireblocks = selectedProvider === "fireblocks";
   const supportsAdditionalWallets = selectedProviderEntry?.supportsAdditionalWallets ?? false;
   const canProvisionWallet = !isConnected || supportsAdditionalWallets;
   const formAction = isConnected ? createCustodyWallet : initializeCustody;
@@ -175,63 +174,6 @@ export function WalletProvisionModal({
               required
             />
           </div>
-
-          {!isConnected && isFireblocks ? (
-            <div className="grid gap-4 rounded-[18px] border border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.02)] p-4">
-              <div className="space-y-1">
-                <p className="text-sm font-semibold text-[#1c1c1d]">Fireblocks credentials</p>
-                <p className="text-xs text-[rgba(28,28,29,0.62)]">
-                  Fireblocks requires credentials during wallet creation.
-                </p>
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="wallet-fireblocks-api-key">API key</Label>
-                <Input
-                  id="wallet-fireblocks-api-key"
-                  name="apiKey"
-                  placeholder="Fireblocks API key"
-                  required
-                />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="wallet-fireblocks-secret">API secret PEM</Label>
-                <textarea
-                  id="wallet-fireblocks-secret"
-                  name="apiSecretPem"
-                  className="min-h-28 w-full rounded-[14px] border border-[rgba(28,28,29,0.12)] bg-white px-3 py-3 text-sm text-[#1c1c1d]"
-                  placeholder="-----BEGIN PRIVATE KEY-----"
-                  required
-                />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="wallet-fireblocks-vault">Vault account ID</Label>
-                <Input
-                  id="wallet-fireblocks-vault"
-                  name="vaultAccountId"
-                  placeholder="Vault account ID"
-                  required
-                />
-              </div>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="grid gap-2">
-                  <Label htmlFor="wallet-fireblocks-asset">Asset ID</Label>
-                  <Input id="wallet-fireblocks-asset" name="assetId" placeholder="SOL" />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="wallet-fireblocks-base-url">API base URL</Label>
-                  <Input
-                    id="wallet-fireblocks-base-url"
-                    name="apiBaseUrl"
-                    placeholder="https://api.fireblocks.io"
-                  />
-                </div>
-              </div>
-            </div>
-          ) : null}
 
           {!canProvisionWallet ? (
             <div className="rounded-[16px] border border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.03)] px-4 py-3 text-sm text-[rgba(28,28,29,0.68)]">

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.data.ts
@@ -14,6 +14,16 @@ interface SupportingDataEnvelope {
   };
 }
 
+interface AuthorityWalletsEnvelope {
+  data?: {
+    authorityWallets?: PaymentsDashboardWallet[];
+    authorityWalletsError?: string | null;
+  };
+  error?: {
+    message?: string;
+  };
+}
+
 export interface TokenManagementSupportingData {
   authorityWallets: PaymentsDashboardWallet[];
   authorityWalletsError: string | null;
@@ -29,6 +39,11 @@ export interface TokenManagementSupportingData {
   frozenAccountsError: string | null;
   frozenAccountsTotal: number | null;
   frozenAccountsHasMore: boolean;
+}
+
+export interface TokenAuthorityWalletsData {
+  authorityWallets: PaymentsDashboardWallet[];
+  authorityWalletsError: string | null;
 }
 
 function getApiError(body: SupportingDataEnvelope, fallback: string): string {
@@ -66,4 +81,36 @@ export async function fetchTokenManagementSupportingData(
   }
 
   return body.data;
+}
+
+export async function fetchTokenAuthorityWallets(
+  tokenId: string,
+  options: {
+    signal?: AbortSignal;
+  } = {}
+): Promise<TokenAuthorityWalletsData> {
+  const response = await fetch(
+    `/api/dashboard/issuance/tokens/${encodeURIComponent(tokenId)}/authority-wallets`,
+    {
+      method: "GET",
+      cache: "no-store",
+      signal: options.signal,
+    }
+  );
+  const body = (await response.json().catch(() => ({}))) as AuthorityWalletsEnvelope;
+
+  if (!response.ok) {
+    throw new Error(
+      getApiError(
+        body as SupportingDataEnvelope,
+        `Authority wallet request failed (${response.status}).`
+      )
+    );
+  }
+
+  return {
+    authorityWallets: Array.isArray(body.data?.authorityWallets) ? body.data.authorityWallets : [],
+    authorityWalletsError:
+      typeof body.data?.authorityWalletsError === "string" ? body.data.authorityWalletsError : null,
+  };
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -17,7 +17,9 @@ import {
 import { TokenManagementHeader } from "./token-management-header";
 import { TokenManagementModalShell } from "./token-management-modal-shell";
 import {
+  type TokenAuthorityWalletsData,
   type TokenManagementSupportingData,
+  fetchTokenAuthorityWallets,
   fetchTokenManagementSupportingData,
 } from "./token-management-workspace.data";
 import type {
@@ -113,6 +115,13 @@ function LoadingSection({ message }: { message: string }) {
   );
 }
 
+function canLoadAuthorityWallets(
+  activeTab: TokenManagementTab,
+  tokenStatus: TokenManagementWorkspaceProps["token"]["status"]
+): boolean {
+  return activeTab !== "overview" || tokenStatus === "pending";
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: token management intentionally centralizes action orchestration and tab coordination in one workspace.
 export function TokenManagementWorkspace({
   token,
@@ -160,6 +169,7 @@ export function TokenManagementWorkspace({
   const [freezeForm, setFreezeForm] = useState(createInitialFreezeForm);
   const [allowlistForm, setAllowlistForm] = useState(createInitialAllowlistForm);
   const shouldLoadSupportingData = activeTab !== "overview";
+  const shouldLoadAuthorityWallets = canLoadAuthorityWallets(activeTab, token.status);
   const hasInitialSupportingData =
     initialAuthorityWallets.length > 0 ||
     initialTransactions.length > 0 ||
@@ -204,6 +214,26 @@ export function TokenManagementWorkspace({
     ]
   );
   const {
+    data: authorityWalletsData,
+    error: authorityWalletsRequestError,
+    mutate: mutateAuthorityWallets,
+  } = useSWR(
+    shouldLoadAuthorityWallets ? ["token-management-authority-wallets", token.id] : null,
+    ([, tokenId]: readonly [string, string]) => fetchTokenAuthorityWallets(tokenId),
+    {
+      fallbackData:
+        initialAuthorityWallets.length > 0 || initialAuthorityWalletsError !== null
+          ? ({
+              authorityWallets: initialAuthorityWallets,
+              authorityWalletsError: initialAuthorityWalletsError,
+            } satisfies TokenAuthorityWalletsData)
+          : undefined,
+      refreshInterval: 60_000,
+      revalidateOnFocus: true,
+      revalidateIfStale: false,
+    }
+  );
+  const {
     data: supportingData,
     error: supportingDataRequestError,
     mutate: mutateSupportingData,
@@ -225,6 +255,13 @@ export function TokenManagementWorkspace({
   const supportingDataLoading =
     shouldLoadSupportingData && supportingData === undefined && !supportingDataError;
   const resolvedSupportingData = supportingData ?? initialSupportingData;
+  const authorityWalletsFetchError = authorityWalletsRequestError
+    ? authorityWalletsRequestError instanceof Error
+      ? authorityWalletsRequestError.message
+      : "Unable to load signer wallets."
+    : null;
+  const authorityWalletsLoading =
+    shouldLoadAuthorityWallets && authorityWalletsData === undefined && !authorityWalletsFetchError;
   const revalidateSupportingDataAfterSuccess = async () => {
     if (!shouldLoadSupportingData) {
       return;
@@ -232,11 +269,19 @@ export function TokenManagementWorkspace({
 
     await mutateSupportingData();
   };
+  const revalidateAuthorityWalletsAfterSuccess = async () => {
+    if (!shouldLoadAuthorityWallets) {
+      return;
+    }
+
+    await mutateAuthorityWallets();
+  };
   const runAction = (input: ActionExecutionInput, options: RunActionOptions = {}) =>
     runActionBase(input, {
       ...options,
       onSuccess: async (result) => {
         await options.onSuccess?.(result);
+        await revalidateAuthorityWalletsAfterSuccess();
         await revalidateSupportingDataAfterSuccess();
       },
     });
@@ -245,11 +290,17 @@ export function TokenManagementWorkspace({
       ...options,
       onSuccess: async (result) => {
         await options.onSuccess?.(result);
+        await revalidateAuthorityWalletsAfterSuccess();
         await revalidateSupportingDataAfterSuccess();
       },
     });
-  const authorityWallets = resolvedSupportingData.authorityWallets;
-  const authorityWalletsError = supportingDataError ?? resolvedSupportingData.authorityWalletsError;
+  const authorityWallets =
+    authorityWalletsData?.authorityWallets ?? resolvedSupportingData.authorityWallets;
+  const authorityWalletsError =
+    authorityWalletsFetchError ??
+    authorityWalletsData?.authorityWalletsError ??
+    supportingDataError ??
+    resolvedSupportingData.authorityWalletsError;
   const transactions = resolvedSupportingData.transactions;
   const transactionsError = supportingDataError ?? resolvedSupportingData.transactionsError;
   const transactionsTotal = resolvedSupportingData.transactionsTotal;
@@ -276,6 +327,10 @@ export function TokenManagementWorkspace({
   } = getTokenActionDisabledReasons(token);
   const metadataAuthority = token.metadataAuthority ?? token.mintAuthority;
   const withWalletLoadError = <T extends { unavailableReason: string | null }>(selection: T): T => {
+    if (authorityWalletsLoading && selection.unavailableReason) {
+      return { ...selection, unavailableReason: "Loading signer wallets…" };
+    }
+
     if (authorityWalletsError && selection.unavailableReason) {
       return { ...selection, unavailableReason: authorityWalletsError };
     }

--- a/packages/sdp-types/src/custody.ts
+++ b/packages/sdp-types/src/custody.ts
@@ -24,9 +24,6 @@ export type CustodyWalletStatus = "active" | "inactive";
 
 export interface FireblocksCustodyOptions {
   provider: "fireblocks";
-  apiBaseUrl?: string;
-  assetId?: string;
-  vaultAccountId?: string;
 }
 
 export interface PrivyCustodyOptions {
@@ -90,8 +87,6 @@ export interface InitializeLocalSigningRequest {
 
 export interface InitializeFireblocksSigningRequest extends FireblocksCustodyOptions {
   projectId?: string;
-  apiKey: string;
-  apiSecretPem: string;
   walletLabel?: string;
 }
 


### PR DESCRIPTION
## Summary
- align Fireblocks setup and wallet creation with the platform-managed Privy-style flow
- auto-create Fireblocks vaults from backend credentials and remove user-facing Fireblocks credential fields
- improve issuance signer-wallet loading and Fireblocks signing error handling

## Testing
- pnpm --filter @sdp/api typecheck
- pnpm --filter sdp-web typecheck
- pnpm exec biome check apps/sdp-api/src/index.ts apps/sdp-api/src/routes/custody/handlers/provider.ts apps/sdp-api/src/routes/custody/handlers/wallets.ts apps/sdp-api/src/routes/custody/schemas.ts apps/sdp-api/src/routes/issuance/handlers/burn.ts apps/sdp-api/src/routes/issuance/handlers/deploy.ts apps/sdp-api/src/routes/issuance/handlers/mint.ts apps/sdp-api/src/routes/issuance/handlers/pause.ts apps/sdp-api/src/routes/organizations/schemas.ts apps/sdp-api/src/services/adapters/signing/index.ts apps/sdp-api/src/services/custody/provisioning.common.ts apps/sdp-api/src/services/custody/provisioning.ts apps/sdp-api/src/services/domain/signing.service.ts apps/sdp-api/src/services/organization-onboarding.service.ts apps/sdp-web/src/app/dashboard/custody/actions.ts apps/sdp-web/src/app/dashboard/custody/setup/setup-form.tsx apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx 'apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.data.ts' 'apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx' 'apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/authority-wallets/route.ts' packages/sdp-types/src/custody.ts