### PR TITLE
feat: refine dashboard permissions, issuance UX, and wallet activity

### DIFF
--- a/apps/sdp-api/src/db/migrations/0012_align_organization_roles.sql
+++ b/apps/sdp-api/src/db/migrations/0012_align_organization_roles.sql
@@ -1,0 +1,15 @@
+UPDATE organization_members
+SET role = CASE
+  WHEN role = 'owner' THEN 'admin'
+  WHEN role IN ('developer', 'viewer') THEN 'member'
+  ELSE role
+END
+WHERE role IN ('owner', 'developer', 'viewer');
+
+UPDATE invitations
+SET role = CASE
+  WHEN role = 'owner' THEN 'admin'
+  WHEN role IN ('developer', 'viewer') THEN 'member'
+  ELSE role
+END
+WHERE role IN ('owner', 'developer', 'viewer');

--- a/apps/sdp-api/src/db/seed.sql
+++ b/apps/sdp-api/src/db/seed.sql
@@ -16,9 +16,9 @@ INSERT INTO users (id, email, email_verified, name, status) VALUES
 INSERT INTO organizations (id, name, slug, tier, status) VALUES
     ('org_test123456789', 'Test Organization', 'test-org', 'free', 'active');
 
--- Link user to organization as owner
+-- Link user to organization as admin
 INSERT INTO organization_members (id, organization_id, user_id, role, status) VALUES
-    ('mem_test123456789', 'org_test123456789', 'usr_test123456789', 'owner', 'active');
+    ('mem_test123456789', 'org_test123456789', 'usr_test123456789', 'admin', 'active');
 
 -- Create a test API key
 -- Note: This is the hash of "sk_test_abcdefghijklmnopqrstuvwxyz123456"

--- a/apps/sdp-api/src/lib/clerk-role.ts
+++ b/apps/sdp-api/src/lib/clerk-role.ts
@@ -1,11 +1,8 @@
-export type OrganizationRole = "owner" | "admin" | "developer" | "viewer";
+import type { OrganizationRole } from "@sdp/types";
 
 export function mapClerkRoleToOrgRole(role: string | null | undefined): OrganizationRole {
-  if (role === "org:owner") {
-    return "owner";
-  }
   if (role === "org:admin") {
     return "admin";
   }
-  return "developer";
+  return "member";
 }

--- a/apps/sdp-api/src/lib/errors.ts
+++ b/apps/sdp-api/src/lib/errors.ts
@@ -25,8 +25,11 @@ export type ErrorCode =
   | "TOKEN_NOT_MINTABLE"
   | "TOKEN_NOT_DEPLOYED"
   | "TOKEN_PAUSED"
+  | "INVALID_TOKEN_AMOUNT"
   | "NOT_ON_TOKEN_ALLOWLIST"
   | "TOKEN_ACCOUNT_NOT_FOUND"
+  | "INVALID_BURN_SOURCE"
+  | "INSUFFICIENT_TOKEN_BALANCE"
   | "ACCOUNT_FROZEN"
   | "ACCOUNT_NOT_FROZEN"
   | "MAX_SUPPLY_EXCEEDED"
@@ -70,8 +73,11 @@ const ERROR_STATUS_CODES: Record<ErrorCode, number> = {
   TOKEN_NOT_MINTABLE: 400,
   TOKEN_NOT_DEPLOYED: 400,
   TOKEN_PAUSED: 400,
+  INVALID_TOKEN_AMOUNT: 400,
   NOT_ON_TOKEN_ALLOWLIST: 403,
   TOKEN_ACCOUNT_NOT_FOUND: 400,
+  INVALID_BURN_SOURCE: 400,
+  INSUFFICIENT_TOKEN_BALANCE: 400,
   ACCOUNT_FROZEN: 400,
   ACCOUNT_NOT_FROZEN: 400,
   MAX_SUPPLY_EXCEEDED: 400,
@@ -106,8 +112,11 @@ const DEFAULT_ERROR_MESSAGES: Record<ErrorCode, string> = {
   TOKEN_NOT_MINTABLE: "Token is not mintable",
   TOKEN_NOT_DEPLOYED: "Token has not been deployed to Solana",
   TOKEN_PAUSED: "Token operations are paused",
+  INVALID_TOKEN_AMOUNT: "Token amount is invalid",
   NOT_ON_TOKEN_ALLOWLIST: "Address is not on the token allowlist",
   TOKEN_ACCOUNT_NOT_FOUND: "Token account not found for this mint",
+  INVALID_BURN_SOURCE: "Burn source is not valid for this signer",
+  INSUFFICIENT_TOKEN_BALANCE: "Token account does not hold enough balance",
   ACCOUNT_FROZEN: "Account is frozen",
   ACCOUNT_NOT_FROZEN: "Account is not frozen",
   MAX_SUPPLY_EXCEEDED: "Operation would exceed maximum supply",

--- a/apps/sdp-api/src/middleware/clerk-auth.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.ts
@@ -5,7 +5,7 @@
  * and sets a Clerk auth context for downstream handlers.
  */
 
-import { type OrganizationRole, mapClerkRoleToOrgRole } from "@/lib/clerk-role";
+import { mapClerkRoleToOrgRole } from "@/lib/clerk-role";
 import {
   type ClerkJwtPayload,
   extractBearerToken,
@@ -14,7 +14,11 @@ import {
 } from "@/lib/clerk-token";
 import { AppError, unauthorized } from "@/lib/errors";
 import type { Env } from "@/types/env";
-import { getPermissionsForOrgRole } from "@sdp/types";
+import {
+  type OrganizationRole,
+  getPermissionsForOrgRole,
+  normalizeOrganizationRole,
+} from "@sdp/types";
 import type { Context, Next } from "hono";
 
 async function resolveClerkUser(db: D1Database, clerkUserId: string) {
@@ -104,7 +108,18 @@ async function ensureMembership(
 ): Promise<OrganizationRole> {
   const existing = await resolveOrgRole(db, params.userId, params.organizationId);
   if (existing?.role) {
-    return existing.role as OrganizationRole;
+    const normalizedRole = normalizeOrganizationRole(existing.role);
+    if (normalizedRole !== existing.role) {
+      await db
+        .prepare(
+          `UPDATE organization_members
+           SET role = ?
+           WHERE user_id = ? AND organization_id = ? AND status = 'active'`
+        )
+        .bind(normalizedRole, params.userId, params.organizationId)
+        .run();
+    }
+    return normalizedRole;
   }
 
   const pendingInvite = await db
@@ -122,7 +137,13 @@ async function ensureMembership(
 
   if (pendingInvite) {
     if (new Date(pendingInvite.expires_at) >= new Date()) {
-      role = pendingInvite.role as OrganizationRole;
+      role = normalizeOrganizationRole(pendingInvite.role);
+      if (role !== pendingInvite.role) {
+        await db
+          .prepare("UPDATE invitations SET role = ? WHERE id = ?")
+          .bind(role, pendingInvite.id)
+          .run();
+      }
     } else {
       await db
         .prepare("UPDATE invitations SET status = 'expired' WHERE id = ?")
@@ -147,11 +168,11 @@ async function ensureMembership(
   } catch {
     const existingAfterInsert = await resolveOrgRole(db, params.userId, params.organizationId);
     if (existingAfterInsert?.role) {
-      return existingAfterInsert.role as OrganizationRole;
+      return normalizeOrganizationRole(existingAfterInsert.role);
     }
   }
 
-  if (pendingInvite && role === (pendingInvite.role as OrganizationRole)) {
+  if (pendingInvite && role === normalizeOrganizationRole(pendingInvite.role)) {
     await db
       .prepare(
         "UPDATE invitations SET status = 'accepted', accepted_at = datetime('now') WHERE id = ?"

--- a/apps/sdp-api/src/middleware/session-auth.ts
+++ b/apps/sdp-api/src/middleware/session-auth.ts
@@ -127,8 +127,7 @@ async function getSessionFromD1(
 
   // Get permissions for role
   const { getPermissionsForOrgRole } = await import("@sdp/types");
-  type OrganizationRole = "owner" | "admin" | "developer" | "viewer";
-  const permissions = getPermissionsForOrgRole(row.role as OrganizationRole);
+  const permissions = getPermissionsForOrgRole(row.role);
 
   const cachedSession: CachedSession = {
     id: row.id,

--- a/apps/sdp-api/src/openapi/schemas/api-keys.ts
+++ b/apps/sdp-api/src/openapi/schemas/api-keys.ts
@@ -242,7 +242,7 @@ export const createApiKeyRequestSchema = apiKeyCreateSchemaBase
       example: "2025-12-31T00:00:00.000Z",
     }),
     permissions: apiKeyCreateSchemaBase.shape.permissions.openapi({
-      description: "Optional explicit permission set. Requires owner-level access.",
+      description: "Optional explicit permission set. Requires admin access.",
       example: ["tokens:read", "tokens:write"],
     }),
     signingWalletId: apiKeyCreateSchemaBase.shape.signingWalletId.openapi({

--- a/apps/sdp-api/src/openapi/schemas/organizations.ts
+++ b/apps/sdp-api/src/openapi/schemas/organizations.ts
@@ -91,8 +91,8 @@ export const organizationMemberSchema = z
   .object({
     id: memberIdParamSchema,
     role: z
-      .enum(["owner", "admin", "developer", "viewer"])
-      .openapi({ description: "Organization member role.", example: "developer" }),
+      .enum(["admin", "member"])
+      .openapi({ description: "Organization member role.", example: "member" }),
     status: z
       .enum(["active", "suspended", "removed"])
       .openapi({ description: "Membership status.", example: "active" }),
@@ -112,8 +112,8 @@ export const invitationSchema = z
       .email()
       .openapi({ description: "Invitee email.", example: "dev@example.com" }),
     role: z
-      .enum(["owner", "admin", "developer", "viewer"])
-      .openapi({ description: "Role offered to the invitee.", example: "developer" }),
+      .enum(["admin", "member"])
+      .openapi({ description: "Role offered to the invitee.", example: "member" }),
     expiresAt: isoDateTimeSchema.openapi({
       description: "Invitation expiration timestamp.",
       example: "2025-02-01T00:00:00.000Z",
@@ -202,7 +202,7 @@ export const inviteMemberRequestSchema = inviteSchemaBase
     }),
     role: inviteSchemaBase.shape.role.openapi({
       description: "Role assigned to the invited member.",
-      example: "developer",
+      example: "member",
     }),
   })
   .openapi({ description: "Invite member request body." });

--- a/apps/sdp-api/src/routes/allowlist/middleware.ts
+++ b/apps/sdp-api/src/routes/allowlist/middleware.ts
@@ -31,7 +31,12 @@ export const adminAuth = async (c: Context<{ Bindings: Env }>, next: Next) => {
       (adminOrgId && clerk.organizationId === adminOrgId) ||
       (adminOrgSlug && clerk.orgSlug === adminOrgSlug);
 
-    if (isOrgMatch && (clerk.role === "owner" || clerk.permissions.includes("*"))) {
+    if (
+      isOrgMatch &&
+      (clerk.role === "admin" ||
+        clerk.permissions.includes("org:admin") ||
+        clerk.permissions.includes("*"))
+    ) {
       await next();
       return;
     }

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -121,8 +121,11 @@ export const createApiKey = async (c: AppContext) => {
     walletPurpose,
   } = parsed.data;
 
-  if (permissions && !actor.permissions.includes("*")) {
-    throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require owner access");
+  const hasOrgAdminAccess =
+    actor.permissions.includes("*") || actor.permissions.includes("org:admin");
+
+  if (permissions && !hasOrgAdminAccess) {
+    throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require admin access");
   }
 
   const walletSelection = resolveCreateWalletScope({
@@ -186,7 +189,7 @@ export const createApiKey = async (c: AppContext) => {
     const orgOwner = await c.env.DB.prepare(
       `SELECT user_id
        FROM organization_members
-       WHERE organization_id = ? AND role IN ('owner', 'admin')
+       WHERE organization_id = ? AND role IN ('admin', 'owner')
        ORDER BY created_at ASC
        LIMIT 1`
     )
@@ -346,8 +349,11 @@ export const updateApiKey = async (c: AppContext) => {
   }
 
   if (parsed.data.permissions !== undefined) {
-    if (parsed.data.permissions && !actor.permissions.includes("*")) {
-      throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require owner access");
+    const hasOrgAdminAccess =
+      actor.permissions.includes("*") || actor.permissions.includes("org:admin");
+
+    if (parsed.data.permissions && !hasOrgAdminAccess) {
+      throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require admin access");
     }
 
     updates.push("permissions = ?");

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -736,6 +736,60 @@ describe("Issuance Routes", () => {
       const body = await res.json();
       expect(body.error.code).toBe("MAX_SUPPLY_EXCEEDED");
     });
+
+    it("returns 400 for paused token", async () => {
+      const db = (env as { DB: D1Database }).DB;
+      await db
+        .prepare("UPDATE issued_tokens SET status = 'paused' WHERE id = ?")
+        .bind(activeTokenId)
+        .run();
+
+      const res = await app.request(
+        `/v1/issuance/tokens/${activeTokenId}/mint/prepare`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            mint: {
+              destination: TEST_SOLANA_ADDRESSES.wallet1,
+              amount: "1",
+            },
+          }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("TOKEN_PAUSED");
+    });
+
+    it("returns 400 for zero mint amount", async () => {
+      const res = await app.request(
+        `/v1/issuance/tokens/${activeTokenId}/mint/prepare`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            mint: {
+              destination: TEST_SOLANA_ADDRESSES.wallet1,
+              amount: "0",
+            },
+          }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("INVALID_TOKEN_AMOUNT");
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1336,7 +1390,7 @@ describe("Issuance Routes", () => {
 
   describe("Templates API", () => {
     describe("GET /v1/issuance/templates", () => {
-      it("lists all templates", async () => {
+      it("lists publicly exposed templates", async () => {
         const res = await app.request(
           "/v1/issuance/templates",
           {
@@ -1348,7 +1402,7 @@ describe("Issuance Routes", () => {
         expect(res.status).toBe(200);
         const body = await res.json();
         expect(body.data.templates).toBeInstanceOf(Array);
-        expect(body.data.templates.length).toBe(4);
+        expect(body.data.templates.length).toBe(3);
 
         // Verify template structure
         const stablecoin = body.data.templates.find((t: { id: string }) => t.id === "stablecoin");
@@ -1360,6 +1414,8 @@ describe("Issuance Routes", () => {
         expect(tokenized).toBeDefined();
         const custom = body.data.templates.find((t: { id: string }) => t.id === "custom");
         expect(custom).toBeDefined();
+        const arcade = body.data.templates.find((t: { id: string }) => t.id === "arcade");
+        expect(arcade).toBeUndefined();
       });
     });
 
@@ -1379,7 +1435,7 @@ describe("Issuance Routes", () => {
         expect(body.data.template.name).toBe("Stablecoin");
       });
 
-      it("returns arcade template", async () => {
+      it("does not return arcade template", async () => {
         const res = await app.request(
           "/v1/issuance/templates/arcade",
           {
@@ -1388,10 +1444,7 @@ describe("Issuance Routes", () => {
           env
         );
 
-        expect(res.status).toBe(200);
-        const body = await res.json();
-        expect(body.data.template.id).toBe("arcade");
-        expect(body.data.template.name).toBe("Arcade");
+        expect(res.status).toBe(404);
       });
 
       it("returns 404 for unknown template", async () => {

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -1,18 +1,121 @@
-import { toMosaicAmount } from "@/lib/amount";
 import { resolveApiKeySigningWalletId } from "@/lib/api-key-wallet-auth";
 import { getAuth } from "@/lib/auth";
 import { AppError, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
-import { assertValidAddress } from "@/lib/solana";
+import { type Address, assertValidAddress } from "@/lib/solana";
 import { AuditService } from "@/services/audit.service";
 import { createOrgSigner, createToken2022Service } from "@/services/solana";
+import { createRpc } from "@/services/solana/rpc";
 import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
+import type { Rpc, SolanaRpcApi } from "@solana/kit";
+import { resolveTokenAccount } from "@solana/mosaic-sdk";
 import type { Context } from "hono";
 import { burnSchema } from "../schemas";
 import { buildIdempotencyMetadata } from "./idempotency";
+import {
+  assertTokenAllowsSupplyOperation,
+  parsePositiveTokenAmount,
+} from "./token-operation-validation";
 
 type AppContext = Context<{ Bindings: Env }>;
+
+function toBurnOperationAppError(error: unknown): AppError | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+
+  if (error.message.startsWith("Burn source must be the authority wallet")) {
+    return new AppError(
+      "INVALID_BURN_SOURCE",
+      "Standard burn only supports the selected signer wallet or its token account. Use force-burn for a different account.",
+      {
+        field: "source",
+        hint: "Choose the signer wallet as the source, or use force-burn for a different account.",
+      }
+    );
+  }
+
+  if (
+    error.message === "Token account not found" ||
+    error.message === "Failed to parse token account data" ||
+    error.message.startsWith("Unable to parse token account data") ||
+    error.message.includes("is not a valid account for mint") ||
+    error.message.includes("is not for mint")
+  ) {
+    return new AppError(
+      "TOKEN_ACCOUNT_NOT_FOUND",
+      "No token holding account was found for this mint. Provide the signer wallet or its token account.",
+      {
+        field: "source",
+        hint: "Use the selected signer wallet address, or provide its token account for this mint.",
+      }
+    );
+  }
+
+  return null;
+}
+
+async function resolveValidatedBurnSource(
+  env: Env,
+  authorityAddress: Address,
+  requestedSource: Address,
+  mintAddress: Address,
+  amountBaseUnits: bigint,
+  tokenSymbol: string
+): Promise<Address> {
+  const rpc = createRpc(env) as Rpc<SolanaRpcApi>;
+
+  let authorityAta: Awaited<ReturnType<typeof resolveTokenAccount>>;
+  try {
+    authorityAta = await resolveTokenAccount(rpc, authorityAddress, mintAddress);
+  } catch (error) {
+    const appError = toBurnOperationAppError(error);
+    if (appError) {
+      throw appError;
+    }
+    throw error;
+  }
+
+  if (!authorityAta.isInitialized) {
+    throw new AppError(
+      "TOKEN_ACCOUNT_NOT_FOUND",
+      "The selected signer wallet does not currently hold this token.",
+      {
+        field: "source",
+        hint: "Burn uses the signer wallet's token account. Mint or receive tokens into that wallet first, or use force-burn for a different account.",
+      }
+    );
+  }
+
+  const normalizedSource =
+    requestedSource === authorityAddress ? authorityAta.tokenAccount : requestedSource;
+
+  if (normalizedSource !== authorityAta.tokenAccount) {
+    throw new AppError(
+      "INVALID_BURN_SOURCE",
+      "Standard burn only supports the selected signer wallet or its token account. Use force-burn for a different account.",
+      {
+        field: "source",
+        hint: "Choose the signer wallet as the source, or use force-burn for another wallet or token account.",
+      }
+    );
+  }
+
+  if (authorityAta.balance < amountBaseUnits) {
+    throw new AppError(
+      "INSUFFICIENT_TOKEN_BALANCE",
+      `The selected signer wallet only holds ${authorityAta.uiBalance} ${tokenSymbol}.`,
+      {
+        field: "amount",
+        available: authorityAta.uiBalance.toString(),
+        hint: "Lower the burn amount, fund this wallet first, or use force-burn for a different account.",
+      }
+    );
+  }
+
+  return normalizedSource;
+}
 
 export const prepareBurn = async (c: AppContext) => {
   const { tokenId } = c.req.param();
@@ -38,9 +141,7 @@ export const prepareBurn = async (c: AppContext) => {
     throw notFound("Token");
   }
 
-  if (token.status !== "active") {
-    throw new AppError("TOKEN_NOT_ACTIVE", "Token must be active to burn");
-  }
+  assertTokenAllowsSupplyOperation(token, "burn");
 
   if (!token.mintAddress) {
     throw new AppError("TOKEN_NOT_DEPLOYED", "Token has not been deployed to Solana");
@@ -56,19 +157,40 @@ export const prepareBurn = async (c: AppContext) => {
   const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(parsed.data.burn.source, "source");
-  const burnAmount = toMosaicAmount(parsed.data.burn.amount, token.decimals);
+  const { amountBaseUnits, mosaicAmount } = parsePositiveTokenAmount(
+    parsed.data.burn.amount,
+    token.decimals
+  );
+  const normalizedSource = await resolveValidatedBurnSource(
+    c.env,
+    signer.address,
+    source,
+    mintAddress,
+    amountBaseUnits,
+    token.symbol
+  );
 
   // Build unsigned transaction
   const token2022 = createToken2022Service(c.env, signer);
-  const prepared = await token2022.prepareBurn(
-    {
-      mint: mintAddress,
-      source,
-      amount: burnAmount,
-      authority: signer.address,
-    },
-    parsed.data.options?.simulate ?? false
-  );
+  const prepared = await (async () => {
+    try {
+      return await token2022.prepareBurn(
+        {
+          mint: mintAddress,
+          source: normalizedSource,
+          amount: mosaicAmount,
+          authority: signer.address,
+        },
+        parsed.data.options?.simulate ?? false
+      );
+    } catch (error) {
+      const appError = toBurnOperationAppError(error);
+      if (appError) {
+        throw appError;
+      }
+      throw error;
+    }
+  })();
 
   // Create transaction record with serialized tx
   const { transaction: tx } = await tokenService.createTransaction({
@@ -133,9 +255,7 @@ export const executeBurn = async (c: AppContext) => {
     throw notFound("Token");
   }
 
-  if (token.status !== "active") {
-    throw new AppError("TOKEN_NOT_ACTIVE", "Token must be active to burn");
-  }
+  assertTokenAllowsSupplyOperation(token, "burn");
 
   if (!token.mintAddress) {
     throw new AppError("TOKEN_NOT_DEPLOYED", "Token has not been deployed to Solana");
@@ -148,7 +268,10 @@ export const executeBurn = async (c: AppContext) => {
   );
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
   const source = assertValidAddress(parsed.data.burn.source, "source");
-  const burnAmount = toMosaicAmount(parsed.data.burn.amount, token.decimals);
+  const { amountBaseUnits, mosaicAmount } = parsePositiveTokenAmount(
+    parsed.data.burn.amount,
+    token.decimals
+  );
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,
@@ -183,14 +306,22 @@ export const executeBurn = async (c: AppContext) => {
       auth.projectId,
       signingWalletId
     );
+    const normalizedSource = await resolveValidatedBurnSource(
+      c.env,
+      signer.address,
+      source,
+      mintAddress,
+      amountBaseUnits,
+      token.symbol
+    );
 
     // Execute burn on Solana
     const token2022 = createToken2022Service(c.env, signer);
 
     const result = await token2022.burn({
       mint: mintAddress,
-      source,
-      amount: burnAmount,
+      source: normalizedSource,
+      amount: mosaicAmount,
       authority: signer,
     });
 
@@ -225,8 +356,16 @@ export const executeBurn = async (c: AppContext) => {
     // Update transaction as failed
     await tokenService.updateTransaction(tx.id, {
       status: "failed",
-      error: error instanceof Error ? error.message : "Unknown error",
+      error:
+        toBurnOperationAppError(error)?.message ??
+        (error instanceof Error ? error.message : "Unknown error"),
     });
+
+    const appError = toBurnOperationAppError(error);
+    if (appError) {
+      throw appError;
+    }
+
     throw error;
   }
 };

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -1,4 +1,4 @@
-import { parseDecimalAmount, toMosaicAmount } from "@/lib/amount";
+import { parseDecimalAmount } from "@/lib/amount";
 import { resolveApiKeySigningWalletId } from "@/lib/api-key-wallet-auth";
 import { getAuth } from "@/lib/auth";
 import { AppError, notFound } from "@/lib/errors";
@@ -13,6 +13,10 @@ import type { Env } from "@/types/env";
 import type { Context } from "hono";
 import { mintSchema } from "../schemas";
 import { buildIdempotencyMetadata } from "./idempotency";
+import {
+  assertTokenAllowsSupplyOperation,
+  parsePositiveTokenAmount,
+} from "./token-operation-validation";
 
 type AppContext = Context<{ Bindings: Env }>;
 
@@ -40,10 +44,7 @@ export const prepareMint = async (c: AppContext) => {
     throw notFound("Token");
   }
 
-  // Validation checks
-  if (token.status !== "active") {
-    throw new AppError("TOKEN_NOT_ACTIVE", "Token must be active to mint");
-  }
+  assertTokenAllowsSupplyOperation(token, "mint");
 
   if (!token.mintAddress) {
     throw new AppError("TOKEN_NOT_DEPLOYED", "Token has not been deployed to Solana");
@@ -52,6 +53,11 @@ export const prepareMint = async (c: AppContext) => {
   if (!token.isMintable) {
     throw new AppError("TOKEN_NOT_MINTABLE", "Token is not mintable");
   }
+
+  const { amountBaseUnits: mintAmount, mosaicAmount } = parsePositiveTokenAmount(
+    parsed.data.mint.amount,
+    token.decimals
+  );
 
   // Check allowlist if required
   if (token.requiresAllowlist) {
@@ -64,7 +70,6 @@ export const prepareMint = async (c: AppContext) => {
   // Check max supply
   if (token.maxSupply) {
     const currentSupply = parseDecimalAmount(token.totalSupply, token.decimals);
-    const mintAmount = parseDecimalAmount(parsed.data.mint.amount, token.decimals);
     const maxSupply = parseDecimalAmount(token.maxSupply, token.decimals);
 
     if (currentSupply + mintAmount > maxSupply) {
@@ -90,7 +95,7 @@ export const prepareMint = async (c: AppContext) => {
   const prepared = await mosaic.prepareMintTo({
     mint: mintAddress,
     destination,
-    amount: toMosaicAmount(parsed.data.mint.amount, token.decimals),
+    amount: mosaicAmount,
     mintAuthority,
     feePayer: signer.address,
   });
@@ -166,10 +171,7 @@ export const executeMint = async (c: AppContext) => {
     throw notFound("Token");
   }
 
-  // Validation checks (same as prepare)
-  if (token.status !== "active") {
-    throw new AppError("TOKEN_NOT_ACTIVE", "Token must be active to mint");
-  }
+  assertTokenAllowsSupplyOperation(token, "mint");
 
   if (!token.mintAddress) {
     throw new AppError("TOKEN_NOT_DEPLOYED", "Token has not been deployed to Solana");
@@ -178,6 +180,11 @@ export const executeMint = async (c: AppContext) => {
   if (!token.isMintable) {
     throw new AppError("TOKEN_NOT_MINTABLE", "Token is not mintable");
   }
+
+  const { amountBaseUnits: mintAmount, mosaicAmount } = parsePositiveTokenAmount(
+    parsed.data.mint.amount,
+    token.decimals
+  );
 
   if (token.requiresAllowlist) {
     const isAllowed = await tokenService.isAddressAllowed(tokenId, parsed.data.mint.destination);
@@ -188,7 +195,6 @@ export const executeMint = async (c: AppContext) => {
 
   if (token.maxSupply) {
     const currentSupply = parseDecimalAmount(token.totalSupply, token.decimals);
-    const mintAmount = parseDecimalAmount(parsed.data.mint.amount, token.decimals);
     const maxSupply = parseDecimalAmount(token.maxSupply, token.decimals);
 
     if (currentSupply + mintAmount > maxSupply) {
@@ -251,7 +257,7 @@ export const executeMint = async (c: AppContext) => {
     const result = await mosaic.mintTo({
       mint: mintAddress,
       destination,
-      amount: toMosaicAmount(parsed.data.mint.amount, token.decimals),
+      amount: mosaicAmount,
       mintAuthority: signer.address,
       feePayer: signer.address,
     });

--- a/apps/sdp-api/src/routes/issuance/handlers/templates.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/templates.ts
@@ -6,7 +6,7 @@
 
 import { notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
-import { getTemplateInfo, listTemplates } from "@/services/issuance/templates";
+import { getPublicTemplateInfo, listTemplates } from "@/services/issuance/templates";
 import type { Env } from "@/types/env";
 import type { ListTemplatesResponse, TokenTemplateResponse } from "@sdp/types";
 import type { Context } from "hono";
@@ -31,7 +31,7 @@ export const listTokenTemplates = async (c: AppContext) => {
 export const getTokenTemplate = async (c: AppContext) => {
   const { templateId } = c.req.param();
 
-  const template = getTemplateInfo(templateId);
+  const template = getPublicTemplateInfo(templateId);
 
   if (!template) {
     throw notFound("Template");

--- a/apps/sdp-api/src/routes/issuance/handlers/token-operation-validation.test.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/token-operation-validation.test.ts
@@ -1,0 +1,63 @@
+import { AppError } from "@/lib/errors";
+import { describe, expect, it } from "vitest";
+import {
+  assertTokenAllowsSupplyOperation,
+  parsePositiveTokenAmount,
+} from "./token-operation-validation";
+
+describe("token-operation-validation", () => {
+  describe("assertTokenAllowsSupplyOperation", () => {
+    it("allows active tokens", () => {
+      expect(() => assertTokenAllowsSupplyOperation({ status: "active" }, "mint")).not.toThrow();
+    });
+
+    it("returns TOKEN_PAUSED for paused tokens", () => {
+      try {
+        assertTokenAllowsSupplyOperation({ status: "paused" }, "burn");
+        throw new Error("Expected burn validation to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("TOKEN_PAUSED");
+      }
+    });
+
+    it("returns TOKEN_NOT_ACTIVE for pending tokens", () => {
+      try {
+        assertTokenAllowsSupplyOperation({ status: "pending" }, "mint");
+        throw new Error("Expected mint validation to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("TOKEN_NOT_ACTIVE");
+      }
+    });
+  });
+
+  describe("parsePositiveTokenAmount", () => {
+    it("parses valid decimal amounts", () => {
+      expect(parsePositiveTokenAmount("1.25", 2)).toEqual({
+        amountBaseUnits: BigInt(125),
+        mosaicAmount: 1.25,
+      });
+    });
+
+    it("returns INVALID_TOKEN_AMOUNT for zero amounts", () => {
+      try {
+        parsePositiveTokenAmount("0", 6);
+        throw new Error("Expected zero amount validation to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("INVALID_TOKEN_AMOUNT");
+      }
+    });
+
+    it("returns INVALID_TOKEN_AMOUNT for amounts that exceed token precision", () => {
+      try {
+        parsePositiveTokenAmount("1.0000001", 6);
+        throw new Error("Expected precision validation to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("INVALID_TOKEN_AMOUNT");
+      }
+    });
+  });
+});

--- a/apps/sdp-api/src/routes/issuance/handlers/token-operation-validation.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/token-operation-validation.ts
@@ -1,0 +1,62 @@
+import { AmountError, parseDecimalAmount, toMosaicAmount } from "@/lib/amount";
+import { AppError } from "@/lib/errors";
+
+type TokenWithStatus = {
+  status: "pending" | "active" | "paused" | "revoked";
+};
+
+export function assertTokenAllowsSupplyOperation(
+  token: TokenWithStatus,
+  action: "mint" | "burn"
+): void {
+  if (token.status === "paused") {
+    throw new AppError("TOKEN_PAUSED", `Token is paused. Unpause it to ${action}.`);
+  }
+
+  if (token.status !== "active") {
+    throw new AppError("TOKEN_NOT_ACTIVE", `Token must be active to ${action}.`);
+  }
+}
+
+function toInvalidTokenAmountError(message: string): AppError {
+  return new AppError("INVALID_TOKEN_AMOUNT", message, {
+    field: "amount",
+    hint: "Provide a positive token amount that matches this token's decimal precision.",
+  });
+}
+
+export function parsePositiveTokenAmount(
+  amount: string,
+  decimals: number
+): {
+  amountBaseUnits: bigint;
+  mosaicAmount: number;
+} {
+  let amountBaseUnits: bigint;
+  try {
+    amountBaseUnits = parseDecimalAmount(amount, decimals);
+  } catch (error) {
+    if (error instanceof AmountError) {
+      throw toInvalidTokenAmountError(error.message);
+    }
+
+    throw error;
+  }
+
+  if (amountBaseUnits <= 0n) {
+    throw toInvalidTokenAmountError("Amount must be greater than zero.");
+  }
+
+  try {
+    return {
+      amountBaseUnits,
+      mosaicAmount: toMosaicAmount(amount, decimals),
+    };
+  } catch (error) {
+    if (error instanceof AmountError) {
+      throw toInvalidTokenAmountError(error.message);
+    }
+
+    throw error;
+  }
+}

--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -4,7 +4,7 @@ import { created, noContent, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { ClerkOrganizationsService } from "@/services/clerk-organizations.service";
 import type { Env } from "@/types/env";
-import type { OrganizationRole } from "@sdp/types";
+import { type OrganizationRole, normalizeOrganizationRole } from "@sdp/types";
 import type { Context } from "hono";
 import { acceptSchema, inviteSchema } from "./schemas";
 
@@ -46,7 +46,7 @@ function resolveActor(c: AppContext): {
 }
 
 function mapRoleToClerkRole(role: OrganizationRole): string {
-  if (role === "owner" || role === "admin") {
+  if (role === "admin") {
     return "org:admin";
   }
   return "org:member";
@@ -115,7 +115,7 @@ export const listMembers = async (c: AppContext) => {
 
   const memberList = results.results.map((row) => ({
     id: row.id as string,
-    role: row.role as OrganizationRole,
+    role: normalizeOrganizationRole(row.role as string),
     status: row.status as string,
     createdAt: row.created_at as string,
     user: {
@@ -141,7 +141,8 @@ export const inviteMember = async (c: AppContext) => {
     });
   }
 
-  const { email, role } = parsed.data;
+  const { email } = parsed.data;
+  const role = normalizeOrganizationRole(parsed.data.role);
   const normalizedEmail = email.toLowerCase().trim();
   const clerkRole = mapRoleToClerkRole(role);
 
@@ -319,7 +320,7 @@ export const acceptInvitation = async (c: AppContext) => {
     `INSERT INTO organization_members (id, organization_id, user_id, role, status)
      VALUES (?, ?, ?, ?, 'active')`
   )
-    .bind(memberId, invitation.organization_id, user.id, invitation.role)
+    .bind(memberId, invitation.organization_id, user.id, normalizeOrganizationRole(invitation.role))
     .run();
 
   // Mark invitation as accepted

--- a/apps/sdp-api/src/routes/members/schemas.ts
+++ b/apps/sdp-api/src/routes/members/schemas.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const inviteSchema = z.object({
   email: z.string().email(),
-  role: z.enum(["admin", "developer", "viewer"]),
+  role: z.enum(["admin", "member"]),
 });
 
 export const acceptSchema = z.object({

--- a/apps/sdp-api/src/routes/onboarding/handlers.ts
+++ b/apps/sdp-api/src/routes/onboarding/handlers.ts
@@ -180,7 +180,7 @@ export const linkOrganization = async (c: AppContext) => {
     ).bind(orgId, orgName, slug, tier),
     c.env.DB.prepare(
       `INSERT INTO organization_members (id, organization_id, user_id, role, status)
-       VALUES (?, ?, ?, 'owner', 'active')`
+       VALUES (?, ?, ?, 'admin', 'active')`
     ).bind(memberId, orgId, userId),
     c.env.DB.prepare(
       `INSERT INTO auth_organization_identities (id, provider, provider_org_id, organization_id, slug)

--- a/apps/sdp-api/src/routes/organizations.test.ts
+++ b/apps/sdp-api/src/routes/organizations.test.ts
@@ -486,7 +486,7 @@ describe("Organizations routes", () => {
 
         env.DB.prepare(
           "INSERT INTO organization_members (id, organization_id, user_id, role, status) VALUES (?, ?, ?, ?, ?)"
-        ).bind(TEST_MEMBER.id, TEST_MEMBER.organizationId, TEST_MEMBER.userId, "owner", "active"),
+        ).bind(TEST_MEMBER.id, TEST_MEMBER.organizationId, TEST_MEMBER.userId, "admin", "active"),
 
         env.DB.prepare(
           "INSERT INTO api_keys (id, organization_id, created_by, name, key_prefix, key_hash, role, environment, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"

--- a/apps/sdp-api/src/routes/organizations/handlers.ts
+++ b/apps/sdp-api/src/routes/organizations/handlers.ts
@@ -193,10 +193,10 @@ export const createOrganization = async (c: AppContext) => {
        VALUES (?, ?, 0, 'active')`
     ).bind(userId, email.toLowerCase()),
 
-    // Organization member (owner)
+    // Organization member (admin)
     c.env.DB.prepare(
       `INSERT INTO organization_members (id, organization_id, user_id, role, status)
-       VALUES (?, ?, ?, 'owner', 'active')`
+       VALUES (?, ?, ?, 'admin', 'active')`
     ).bind(memberId, orgId, userId),
 
     // API key

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1792,6 +1792,148 @@ describe("Payments routes", () => {
       expect(statuses).toEqual(["confirmed", "pending"]);
     });
 
+    it("surfaces observed inbound transfers for wallet history even without a DB record", async () => {
+      const { getSignaturesForAddress } = await import("@/services/solana/rpc");
+      const observedSig =
+        // biome-ignore lint/nursery/noSecrets: Test transaction signature, not a secret.
+        "3o9XWnJ7CyD6be8xXh8hFXRrM9rPzGQhE1mQ4Z8VjYkU7LZtP4R3WnV5uA2sD1fG6hJ7kL8mN9pQ1rS2tU3v";
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            result: {
+              blockTime: 1700000100,
+              slot: 101,
+              meta: {
+                err: null,
+                fee: 5000,
+                preTokenBalances: [
+                  {
+                    accountIndex: 0,
+                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    owner: TEST_SOLANA_ADDRESSES.wallet2,
+                    uiTokenAmount: {
+                      amount: "10000000",
+                      decimals: 6,
+                      uiAmountString: "10",
+                    },
+                  },
+                  {
+                    accountIndex: 1,
+                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    owner: TEST_SOLANA_ADDRESSES.wallet1,
+                    uiTokenAmount: {
+                      amount: "0",
+                      decimals: 6,
+                      uiAmountString: "0",
+                    },
+                  },
+                ],
+                postTokenBalances: [
+                  {
+                    accountIndex: 0,
+                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    owner: TEST_SOLANA_ADDRESSES.wallet2,
+                    uiTokenAmount: {
+                      amount: "0",
+                      decimals: 6,
+                      uiAmountString: "0",
+                    },
+                  },
+                  {
+                    accountIndex: 1,
+                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    owner: TEST_SOLANA_ADDRESSES.wallet1,
+                    uiTokenAmount: {
+                      amount: "10000000",
+                      decimals: 6,
+                      uiAmountString: "10",
+                    },
+                  },
+                ],
+              },
+              transaction: {
+                message: {
+                  accountKeys: [
+                    "SrcTokenAcct111111111111111111111111111111",
+                    "DstTokenAcct111111111111111111111111111111",
+                  ],
+                  instructions: [
+                    {
+                      program: "spl-token",
+                      parsed: {
+                        type: "transferChecked",
+                        info: {
+                          source: "SrcTokenAcct111111111111111111111111111111",
+                          destination: "DstTokenAcct111111111111111111111111111111",
+                          mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                          tokenAmount: {
+                            amount: "10000000",
+                            decimals: 6,
+                            uiAmountString: "10",
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+      );
+
+      vi.mocked(getSignaturesForAddress).mockResolvedValueOnce([
+        {
+          signature: observedSig as unknown as Signature,
+          slot: 101n,
+          blockTime: 1700000100n,
+          err: null,
+        },
+      ]);
+
+      try {
+        const res = await app.request(
+          `/v1/payments/transfers?wallet=${TEST_WALLET_ID}`,
+          {
+            method: "GET",
+            headers: { Authorization: `Bearer ${TEST_API_KEY.raw}` },
+          },
+          env
+        );
+
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          data: Array<{
+            id: string;
+            amount: string;
+            direction: string;
+            signature: string | null;
+            status: string;
+            token: string;
+          }>;
+          meta: { total: number };
+        };
+        expect(body.meta.total).toBe(1);
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0]).toMatchObject({
+          amount: "10",
+          direction: "inbound",
+          signature: observedSig,
+          status: "confirmed",
+          token: "USDC",
+        });
+        expect(body.data[0]?.id).toMatch(/^xfr_observed_/);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     it("returns all transfers via DB-only path when no wallet filter is provided", async () => {
       const { getSignaturesForAddress } = await import("@/services/solana/rpc");
 

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -4,7 +4,7 @@ import type {
   PaymentTransferStatus as TransferStatus,
   PaymentTransferType as TransferType,
 } from "@/db/repositories/payments.repository";
-import { parseDecimalAmount } from "@/lib/amount";
+import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { assertApiKeyWalletAccess, getAllowedApiKeyWalletIds } from "@/lib/api-key-wallet-auth";
 import { getAuth } from "@/lib/auth";
 import { AppError } from "@/lib/errors";
@@ -62,6 +62,74 @@ import {
   resolveSourceTokenAccount,
 } from "../token-accounts";
 import { resolveScope, resolveWallet } from "../wallets";
+
+// biome-ignore lint/nursery/noSecrets: Devnet USDC mint address constant, not a secret.
+const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+// biome-ignore lint/nursery/noSecrets: Mainnet USDC mint address constant, not a secret.
+const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+interface ParsedInstructionPayload {
+  info?: Record<string, unknown>;
+  type?: string;
+}
+
+interface ParsedInstructionRecord {
+  parsed?: ParsedInstructionPayload;
+  program?: string;
+}
+
+interface ParsedInstructionGroup {
+  instructions?: ParsedInstructionRecord[];
+}
+
+interface ParsedAccountKey {
+  pubkey?: string;
+}
+
+interface RpcTokenBalanceAmount {
+  amount?: string;
+  decimals?: number;
+  uiAmountString?: string | null;
+}
+
+interface RpcTokenBalanceRecord {
+  accountIndex?: number;
+  mint?: string;
+  owner?: string;
+  uiTokenAmount?: RpcTokenBalanceAmount;
+}
+
+interface ParsedTransactionResponse {
+  error?: {
+    message?: string;
+  };
+  result?: {
+    blockTime?: number | null;
+    meta?: {
+      err?: unknown;
+      fee?: number;
+      innerInstructions?: ParsedInstructionGroup[];
+      postBalances?: number[];
+      postTokenBalances?: RpcTokenBalanceRecord[];
+      preBalances?: number[];
+      preTokenBalances?: RpcTokenBalanceRecord[];
+    } | null;
+    slot?: number;
+    transaction?: {
+      message?: {
+        accountKeys?: Array<string | ParsedAccountKey>;
+        instructions?: ParsedInstructionRecord[];
+      };
+    };
+  } | null;
+}
+
+interface ObservedTransferContext {
+  organizationId: string;
+  projectId: string | null;
+  tokenSymbolsByMint: Map<string, string>;
+  walletIdsByAddress: Map<string, string>;
+}
 
 export async function resolveWalletFromParams(
   c: AppContext,
@@ -548,6 +616,430 @@ function createSignatureHistoryRpc(env: Env) {
   return createRpc(env, { rpcUrl: url });
 }
 
+function resolveSignatureHistoryRpcUrl(env: Env): string {
+  return env.SOLANA_RPC_HELIUS_URL
+    ? withHeliusApiKey(env.SOLANA_RPC_HELIUS_URL, env.SOLANA_RPC_HELIUS_API_KEY)
+    : getSolanaConfig(env).rpcUrl;
+}
+
+function resolveObservedTokenSymbol(mint: string, tokenSymbolsByMint: Map<string, string>): string {
+  const normalizedMint = mint.trim();
+  const known = tokenSymbolsByMint.get(normalizedMint)?.trim();
+  if (known) {
+    return known;
+  }
+
+  if (normalizedMint === DEVNET_USDC_MINT || normalizedMint === MAINNET_USDC_MINT) {
+    return "USDC";
+  }
+
+  return normalizedMint;
+}
+
+function resolveParsedAccountKey(accountKey: string | ParsedAccountKey | undefined): string | null {
+  if (typeof accountKey === "string" && accountKey.trim()) {
+    return accountKey;
+  }
+
+  if (
+    accountKey &&
+    typeof accountKey === "object" &&
+    typeof accountKey.pubkey === "string" &&
+    accountKey.pubkey.trim()
+  ) {
+    return accountKey.pubkey;
+  }
+
+  return null;
+}
+
+function flattenParsedInstructions(payload: ParsedTransactionResponse): ParsedInstructionRecord[] {
+  const topLevel = payload.result?.transaction?.message?.instructions ?? [];
+  const inner = (payload.result?.meta?.innerInstructions ?? []).flatMap(
+    (group) => group.instructions ?? []
+  );
+  return [...topLevel, ...inner];
+}
+
+function resolveObservedTimestamp(blockTime: bigint | number | null | undefined): string {
+  if (typeof blockTime === "bigint") {
+    return new Date(Number(blockTime) * 1_000).toISOString();
+  }
+
+  if (typeof blockTime === "number" && Number.isFinite(blockTime) && blockTime > 0) {
+    return new Date(blockTime * 1_000).toISOString();
+  }
+
+  return new Date().toISOString();
+}
+
+function readInstructionInfoString(
+  info: Record<string, unknown> | undefined,
+  key: string
+): string | null {
+  const value = info?.[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function readInstructionInfoInteger(
+  info: Record<string, unknown> | undefined,
+  key: string
+): bigint | null {
+  const value = info?.[key];
+
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    return BigInt(value.trim());
+  }
+
+  if (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  ) {
+    return BigInt(value);
+  }
+
+  return null;
+}
+
+function readTokenAmountInfo(
+  info: Record<string, unknown> | undefined
+): { amount: bigint; decimals: number; uiAmount: string | null } | null {
+  const rawTokenAmount = info?.tokenAmount;
+  if (!rawTokenAmount || typeof rawTokenAmount !== "object" || Array.isArray(rawTokenAmount)) {
+    const rawAmount = readInstructionInfoInteger(info, "amount");
+    const decimalsValue = info?.decimals;
+    if (
+      rawAmount === null ||
+      typeof decimalsValue !== "number" ||
+      !Number.isFinite(decimalsValue) ||
+      !Number.isInteger(decimalsValue)
+    ) {
+      return null;
+    }
+
+    return {
+      amount: rawAmount,
+      decimals: decimalsValue,
+      uiAmount: formatDecimalAmount(rawAmount, decimalsValue),
+    };
+  }
+
+  const tokenAmountRecord = rawTokenAmount as RpcTokenBalanceAmount;
+
+  const amountValue =
+    typeof tokenAmountRecord.amount === "string" && /^\d+$/.test(tokenAmountRecord.amount)
+      ? BigInt(tokenAmountRecord.amount)
+      : null;
+  const decimalsValue =
+    typeof tokenAmountRecord.decimals === "number" &&
+    Number.isFinite(tokenAmountRecord.decimals) &&
+    Number.isInteger(tokenAmountRecord.decimals)
+      ? tokenAmountRecord.decimals
+      : null;
+
+  if (amountValue === null || decimalsValue === null) {
+    return null;
+  }
+
+  return {
+    amount: amountValue,
+    decimals: decimalsValue,
+    uiAmount:
+      typeof tokenAmountRecord.uiAmountString === "string" &&
+      tokenAmountRecord.uiAmountString.trim()
+        ? tokenAmountRecord.uiAmountString
+        : formatDecimalAmount(amountValue, decimalsValue),
+  };
+}
+
+async function resolveObservedTokenSymbols(env: Env): Promise<Map<string, string>> {
+  const symbolsByMint = new Map<string, string>([
+    [DEVNET_USDC_MINT, "USDC"],
+    [MAINNET_USDC_MINT, "USDC"],
+  ]);
+
+  try {
+    const result = await env.DB.prepare(
+      `SELECT mint_address, symbol
+         FROM issued_tokens
+        WHERE mint_address IS NOT NULL
+          AND deployed_at IS NOT NULL`
+    ).all<{
+      mint_address?: string | null;
+      symbol?: string | null;
+    }>();
+
+    for (const row of result.results ?? []) {
+      const mint = row.mint_address?.trim();
+      if (!mint) {
+        continue;
+      }
+
+      symbolsByMint.set(mint, row.symbol?.trim() || mint);
+    }
+  } catch {
+    // Ignore symbol resolution failures and fall back to mint addresses.
+  }
+
+  return symbolsByMint;
+}
+
+async function fetchParsedTransaction(
+  env: Env,
+  signature: string
+): Promise<ParsedTransactionResponse["result"]> {
+  const rpcResponse = await fetch(resolveSignatureHistoryRpcUrl(env), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: crypto.randomUUID(),
+      method: "getTransaction",
+      params: [
+        signature,
+        { encoding: "jsonParsed", commitment: "confirmed", maxSupportedTransactionVersion: 0 },
+      ],
+    }),
+  });
+
+  if (!rpcResponse.ok) {
+    throw new Error(`RPC request failed with status ${rpcResponse.status}`);
+  }
+
+  const payload = (await rpcResponse.json()) as ParsedTransactionResponse;
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "RPC returned an error");
+  }
+
+  return payload.result ?? null;
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Parsed transaction synthesis intentionally handles both SOL and SPL transfers in one pass.
+function buildObservedTransferRows(
+  parsedTransaction: ParsedTransactionResponse["result"],
+  signature: string,
+  fallbackBlockTime: bigint | number | null,
+  context: ObservedTransferContext
+): TransferRow[] {
+  if (!parsedTransaction) {
+    return [];
+  }
+
+  const accountKeys = (parsedTransaction.transaction?.message?.accountKeys ?? [])
+    .map((accountKey) => resolveParsedAccountKey(accountKey))
+    .filter((accountKey): accountKey is string => Boolean(accountKey));
+  const tokenAccountMetadata = new Map<
+    string,
+    { decimals: number | null; mint: string | null; owner: string | null }
+  >();
+  const observedRows = new Map<string, TransferRow>();
+  const preTokenBalances = parsedTransaction.meta?.preTokenBalances ?? [];
+  const postTokenBalances = parsedTransaction.meta?.postTokenBalances ?? [];
+
+  for (const balance of [...preTokenBalances, ...postTokenBalances]) {
+    if (typeof balance.accountIndex !== "number") {
+      continue;
+    }
+
+    const accountAddress = accountKeys[balance.accountIndex];
+    if (!accountAddress) {
+      continue;
+    }
+
+    const current = tokenAccountMetadata.get(accountAddress) ?? {
+      owner: null,
+      mint: null,
+      decimals: null,
+    };
+
+    tokenAccountMetadata.set(accountAddress, {
+      owner:
+        typeof balance.owner === "string" && balance.owner.trim() ? balance.owner : current.owner,
+      mint: typeof balance.mint === "string" && balance.mint.trim() ? balance.mint : current.mint,
+      decimals:
+        typeof balance.uiTokenAmount?.decimals === "number" &&
+        Number.isFinite(balance.uiTokenAmount.decimals) &&
+        Number.isInteger(balance.uiTokenAmount.decimals)
+          ? balance.uiTokenAmount.decimals
+          : current.decimals,
+    });
+  }
+
+  const timestamp = resolveObservedTimestamp(parsedTransaction.blockTime ?? fallbackBlockTime);
+  const status: TransferStatus = parsedTransaction.meta?.err ? "failed" : "confirmed";
+
+  for (const instruction of flattenParsedInstructions({ result: parsedTransaction })) {
+    const parsedType = instruction.parsed?.type;
+    const info = instruction.parsed?.info;
+
+    if (!parsedType || !info) {
+      continue;
+    }
+
+    if ((instruction.program ?? "").startsWith("system") && parsedType === "transfer") {
+      const sourceAddress = readInstructionInfoString(info, "source");
+      const destinationAddress = readInstructionInfoString(info, "destination");
+      const lamports = readInstructionInfoInteger(info, "lamports");
+
+      if (!sourceAddress || !destinationAddress || lamports === null) {
+        continue;
+      }
+
+      const sourceWalletId = context.walletIdsByAddress.get(sourceAddress) ?? null;
+      const destinationWalletId = context.walletIdsByAddress.get(destinationAddress) ?? null;
+      const walletId = sourceWalletId ?? destinationWalletId;
+
+      if (!walletId) {
+        continue;
+      }
+
+      const direction: TransferDirection =
+        destinationWalletId && !sourceWalletId ? "inbound" : "outbound";
+      const dedupeKey = `${walletId}:${signature}:SOL:${direction}`;
+
+      if (observedRows.has(dedupeKey)) {
+        continue;
+      }
+
+      observedRows.set(dedupeKey, {
+        id: `xfr_observed_${walletId}_${signature}`,
+        organization_id: context.organizationId,
+        project_id: context.projectId,
+        wallet_id: walletId,
+        source_address: sourceAddress,
+        destination_address: destinationAddress,
+        token: "SOL",
+        amount: formatDecimalAmount(lamports, 9),
+        memo: null,
+        type: "transfer",
+        direction,
+        status,
+        signature,
+        serialized_tx: null,
+        slot: parsedTransaction.slot ?? null,
+        block_time: timestamp,
+        fee: parsedTransaction.meta?.fee ?? null,
+        error: null,
+        initiated_by_key_id: null,
+        created_at: timestamp,
+        updated_at: timestamp,
+      });
+      continue;
+    }
+
+    const normalizedProgram = (instruction.program ?? "").toLowerCase();
+    if (
+      !normalizedProgram.includes("token") ||
+      (parsedType !== "transfer" && parsedType !== "transferChecked")
+    ) {
+      continue;
+    }
+
+    const sourceTokenAccount = readInstructionInfoString(info, "source");
+    const destinationTokenAccount = readInstructionInfoString(info, "destination");
+    if (!sourceTokenAccount || !destinationTokenAccount) {
+      continue;
+    }
+
+    const sourceTokenMetadata = tokenAccountMetadata.get(sourceTokenAccount);
+    const destinationTokenMetadata = tokenAccountMetadata.get(destinationTokenAccount);
+    const sourceOwner = sourceTokenMetadata?.owner ?? null;
+    const destinationOwner = destinationTokenMetadata?.owner ?? null;
+    const sourceWalletId = sourceOwner
+      ? (context.walletIdsByAddress.get(sourceOwner) ?? null)
+      : null;
+    const destinationWalletId = destinationOwner
+      ? (context.walletIdsByAddress.get(destinationOwner) ?? null)
+      : null;
+    const walletId = sourceWalletId ?? destinationWalletId;
+
+    if (!walletId) {
+      continue;
+    }
+
+    const tokenAmount = readTokenAmountInfo(info);
+    const decimals =
+      tokenAmount?.decimals ?? sourceTokenMetadata?.decimals ?? destinationTokenMetadata?.decimals;
+    const rawAmount = tokenAmount?.amount ?? readInstructionInfoInteger(info, "amount");
+    const mint =
+      readInstructionInfoString(info, "mint") ??
+      sourceTokenMetadata?.mint ??
+      destinationTokenMetadata?.mint;
+    const resolvedDecimals =
+      typeof decimals === "number" && Number.isFinite(decimals) && Number.isInteger(decimals)
+        ? decimals
+        : null;
+
+    if (resolvedDecimals === null || rawAmount === null || !mint) {
+      continue;
+    }
+
+    const direction: TransferDirection =
+      destinationWalletId && !sourceWalletId ? "inbound" : "outbound";
+    const resolvedUiAmount =
+      tokenAmount?.uiAmount ?? formatDecimalAmount(rawAmount, resolvedDecimals);
+    const dedupeKey = `${walletId}:${signature}:${mint}:${direction}:${rawAmount.toString()}`;
+
+    if (observedRows.has(dedupeKey)) {
+      continue;
+    }
+
+    observedRows.set(dedupeKey, {
+      id: `xfr_observed_${walletId}_${signature}_${mint}`,
+      organization_id: context.organizationId,
+      project_id: context.projectId,
+      wallet_id: walletId,
+      source_address: sourceOwner ?? sourceTokenAccount,
+      destination_address: destinationOwner ?? destinationTokenAccount,
+      token: resolveObservedTokenSymbol(mint, context.tokenSymbolsByMint),
+      amount: resolvedUiAmount,
+      memo: null,
+      type: "transfer",
+      direction,
+      status,
+      signature,
+      serialized_tx: null,
+      slot: parsedTransaction.slot ?? null,
+      block_time: timestamp,
+      fee: parsedTransaction.meta?.fee ?? null,
+      error: null,
+      initiated_by_key_id: null,
+      created_at: timestamp,
+      updated_at: timestamp,
+    });
+  }
+
+  return [...observedRows.values()];
+}
+
+async function buildObservedTransfersForSignatures(
+  env: Env,
+  signatures: Array<Awaited<ReturnType<typeof getSignaturesForAddress>>[number]>,
+  context: ObservedTransferContext
+): Promise<TransferRow[]> {
+  if (signatures.length === 0 || context.walletIdsByAddress.size === 0) {
+    return [];
+  }
+
+  const settled = await Promise.allSettled(
+    signatures.map(async (signatureInfo) => {
+      const parsedTransaction = await fetchParsedTransaction(env, String(signatureInfo.signature));
+      return buildObservedTransferRows(
+        parsedTransaction,
+        String(signatureInfo.signature),
+        signatureInfo.blockTime,
+        context
+      );
+    })
+  );
+
+  return settled.flatMap((result) => (result.status === "fulfilled" ? result.value : []));
+}
+
 export async function createTransfer(c: AppContext) {
   const body = await c.req.json();
   const parsed = createTransferSchema.safeParse(body);
@@ -640,6 +1132,7 @@ export async function createTransfer(c: AppContext) {
   }
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Wallet-scoped transfer listing merges DB rows with observed on-chain history.
 export async function listTransfers(c: AppContext) {
   const auth = getAuth(c);
   const query = listTransfersQuerySchema.safeParse(c.req.query());
@@ -671,31 +1164,39 @@ export async function listTransfers(c: AppContext) {
 
     let sourceAddress: string | undefined;
     let resolvedWalletId: string | undefined;
+    let walletIdsByAddress = new Map<string, string>();
+    const scope = await resolveScope(c);
 
     if (walletId) {
       if (allowedWalletIds && !allowedWalletIds.includes(walletId)) {
         throw new AppError("FORBIDDEN", "API key is not authorized for the requested wallet");
       }
 
-      const scope = await resolveScope(c);
       const wallet = resolveWallet(scope.wallets, walletId);
       assertApiKeyWalletAccess(scope.auth, wallet.walletId, ["payments:read"]);
       sourceAddress = wallet.publicKey;
       resolvedWalletId = walletId;
+      walletIdsByAddress = new Map([[wallet.publicKey, wallet.walletId]]);
     } else {
       sourceAddress = walletAddress;
+      const matchedWallet = scope.wallets.find((wallet) => wallet.publicKey === walletAddress);
+      if (matchedWallet) {
+        resolvedWalletId = matchedWallet.walletId;
+        walletIdsByAddress = new Map([[matchedWallet.publicKey, matchedWallet.walletId]]);
+      }
+
       if (allowedWalletIds) {
-        const scope = await resolveScope(c);
-        const matchedWallet = scope.wallets.find(
+        const authorizedWallet = scope.wallets.find(
           (wallet) =>
             wallet.publicKey === walletAddress && allowedWalletIds.includes(wallet.walletId)
         );
-        if (!matchedWallet) {
+        if (!authorizedWallet) {
           throw new AppError("FORBIDDEN", "API key is not authorized for the requested wallet");
         }
 
-        sourceAddress = matchedWallet.publicKey;
-        resolvedWalletId = matchedWallet.walletId;
+        sourceAddress = authorizedWallet.publicKey;
+        resolvedWalletId = authorizedWallet.walletId;
+        walletIdsByAddress = new Map([[authorizedWallet.publicKey, authorizedWallet.walletId]]);
       }
     }
 
@@ -741,9 +1242,29 @@ export async function listTransfers(c: AppContext) {
       pendingRows.push(...pendingResult.rows);
     }
 
+    const confirmedSignatures = new Set(
+      scopedConfirmedRows
+        .map((row) => row.signature)
+        .filter((rowSignature): rowSignature is string => Boolean(rowSignature))
+    );
+    const missingObservedSignatures = onChainSigs.filter(
+      (signatureInfo) => !confirmedSignatures.has(String(signatureInfo.signature))
+    );
+    const tokenSymbolsByMint = await resolveObservedTokenSymbols(c.env);
+    const observedRows = await buildObservedTransfersForSignatures(
+      c.env,
+      missingObservedSignatures,
+      {
+        organizationId: auth.organizationId,
+        projectId: auth.projectId,
+        tokenSymbolsByMint,
+        walletIdsByAddress,
+      }
+    );
+
     // 4. Merge: confirmed (Helius-backed) + non-confirmed (DB), deduplicated
     const seen = new Set<string>();
-    const merged = [...scopedConfirmedRows, ...pendingRows].filter((row) => {
+    const merged = [...scopedConfirmedRows, ...observedRows, ...pendingRows].filter((row) => {
       if (seen.has(row.id)) return false;
       seen.add(row.id);
       return true;

--- a/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
@@ -88,8 +88,11 @@ export const createProjectApiKey = async (c: AppContext) => {
     walletPurpose,
   } = parsed.data;
 
-  if (permissions && !auth.permissions.includes("*")) {
-    throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require owner access");
+  const hasOrgAdminAccess =
+    auth.permissions.includes("*") || auth.permissions.includes("org:admin");
+
+  if (permissions && !hasOrgAdminAccess) {
+    throw new AppError("INSUFFICIENT_PERMISSIONS", "Custom permission sets require admin access");
   }
 
   const walletSelection = resolveCreateWalletScope({

--- a/apps/sdp-api/src/services/adapters/signing/keychain/keychain-fireblocks.adapter.ts
+++ b/apps/sdp-api/src/services/adapters/signing/keychain/keychain-fireblocks.adapter.ts
@@ -16,6 +16,11 @@ import type { Address } from "@solana/kit";
 import { BaseKeychainAdapter } from "./base-keychain.adapter";
 import type { KeychainFireblocksConfig } from "./types";
 
+type FireblocksSignerDebugHooks = {
+  __sdpDebugPatched__?: boolean;
+  request?: <T>(method: string, uri: string, body?: unknown) => Promise<T>;
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Adapter Implementation
 // ═══════════════════════════════════════════════════════════════════════════
@@ -42,6 +47,7 @@ export class KeychainFireblocksAdapter extends BaseKeychainAdapter {
       // Always use RAW signing - we handle broadcast separately via Kora
       useProgramCall: false,
     });
+    this.attachDebugLogging();
 
     // Cast to SolanaSigner interface
     this.signer = this.fireblocksSigner as unknown as SolanaSigner;
@@ -98,5 +104,56 @@ export class KeychainFireblocksAdapter extends BaseKeychainAdapter {
     if (!this.initialized) {
       await this.init();
     }
+  }
+
+  private attachDebugLogging(): void {
+    const signer = this.fireblocksSigner as unknown as FireblocksSignerDebugHooks;
+
+    if (signer.__sdpDebugPatched__ || typeof signer.request !== "function") {
+      return;
+    }
+
+    const originalRequest = signer.request.bind(this.fireblocksSigner) as <T>(
+      method: string,
+      uri: string,
+      body?: unknown
+    ) => Promise<T>;
+
+    signer.request = (async <T>(method: string, uri: string, body?: unknown): Promise<T> => {
+      try {
+        console.info("sdp_fireblocks_api_request", {
+          method,
+          uri,
+          body,
+        });
+
+        const response = await originalRequest<T>(method, uri, body);
+
+        console.info("sdp_fireblocks_api_response", {
+          method,
+          uri,
+          body,
+          response,
+        });
+
+        return response;
+      } catch (error) {
+        console.error("sdp_fireblocks_api_error", {
+          method,
+          uri,
+          body,
+          error:
+            error instanceof Error
+              ? {
+                  message: error.message,
+                  stack: error.stack,
+                }
+              : String(error),
+        });
+        throw error;
+      }
+    }) as typeof signer.request;
+
+    signer.__sdpDebugPatched__ = true;
   }
 }

--- a/apps/sdp-api/src/services/issuance/templates/index.ts
+++ b/apps/sdp-api/src/services/issuance/templates/index.ts
@@ -7,32 +7,12 @@
 import type { TokenTemplateInfo } from "@sdp/types";
 import { TEMPLATE_DEFINITIONS, normalizeTemplateId, resolveTemplateConfig } from "./definitions";
 
-const TEMPLATE_IDS = Object.keys(TEMPLATE_DEFINITIONS);
+const TEMPLATE_IDS = Object.keys(TEMPLATE_DEFINITIONS) as Array<keyof typeof TEMPLATE_DEFINITIONS>;
+const PUBLIC_TEMPLATE_IDS = TEMPLATE_IDS.filter((id) => id !== "arcade");
+const PUBLIC_TEMPLATE_ID_SET = new Set<string>(PUBLIC_TEMPLATE_IDS);
 
-export function listTemplates(): TokenTemplateInfo[] {
-  return TEMPLATE_IDS.map((id) => {
-    const template = TEMPLATE_DEFINITIONS[id as keyof typeof TEMPLATE_DEFINITIONS];
-    return {
-      id: template.id,
-      name: template.name,
-      description: template.description,
-      decimals: template.decimals,
-      maxDecimals: template.maxDecimals,
-      requiresAllowlist: template.requiresAllowlist,
-      allowlistOverridable: template.allowlistOverridable,
-      requiredExtensions: template.extensions.required,
-      availableExtensions: template.extensions.available,
-      defaultExtensions: template.defaultExtensions,
-    };
-  });
-}
-
-export function getTemplateInfo(id: string): TokenTemplateInfo | undefined {
-  const normalized = normalizeTemplateId(id);
-  const template = TEMPLATE_DEFINITIONS[normalized];
-  if (!template) {
-    return undefined;
-  }
+function buildTemplateInfo(templateId: keyof typeof TEMPLATE_DEFINITIONS): TokenTemplateInfo {
+  const template = TEMPLATE_DEFINITIONS[templateId];
   return {
     id: template.id,
     name: template.name,
@@ -45,6 +25,27 @@ export function getTemplateInfo(id: string): TokenTemplateInfo | undefined {
     availableExtensions: template.extensions.available,
     defaultExtensions: template.defaultExtensions,
   };
+}
+
+export function listTemplates(): TokenTemplateInfo[] {
+  return PUBLIC_TEMPLATE_IDS.map(buildTemplateInfo);
+}
+
+export function getTemplateInfo(id: string): TokenTemplateInfo | undefined {
+  const normalized = normalizeTemplateId(id);
+  const template = TEMPLATE_DEFINITIONS[normalized];
+  if (!template) {
+    return undefined;
+  }
+  return buildTemplateInfo(normalized);
+}
+
+export function getPublicTemplateInfo(id: string): TokenTemplateInfo | undefined {
+  const normalized = normalizeTemplateId(id);
+  if (!PUBLIC_TEMPLATE_ID_SET.has(normalized)) {
+    return undefined;
+  }
+  return buildTemplateInfo(normalized);
 }
 
 export { normalizeTemplateId, resolveTemplateConfig };

--- a/apps/sdp-api/src/services/session.service.ts
+++ b/apps/sdp-api/src/services/session.service.ts
@@ -5,7 +5,7 @@
  * Sessions are stored in D1 and cached in KV for fast lookups.
  */
 
-import type { CachedSession, OrganizationRole, Permission, Session } from "@sdp/types";
+import type { CachedSession, Permission, Session } from "@sdp/types";
 import { getPermissionsForOrgRole } from "@sdp/types";
 
 // Session TTL: 7 days
@@ -128,7 +128,7 @@ export class SessionService {
     }
 
     // Get permissions for the user's role
-    const permissions = getPermissionsForOrgRole(row.role as OrganizationRole);
+    const permissions = getPermissionsForOrgRole(row.role);
 
     const cachedSession: CachedSession = {
       id: row.id,

--- a/apps/sdp-api/src/test/fixtures/organizations.ts
+++ b/apps/sdp-api/src/test/fixtures/organizations.ts
@@ -24,6 +24,6 @@ export const TEST_MEMBER = {
   id: "mem_test123456789",
   organizationId: TEST_ORG.id,
   userId: TEST_USER.id,
-  role: "owner" as const,
+  role: "admin" as const,
   status: "active" as const,
 };

--- a/apps/sdp-docs/content/docs/getting-started.mdx
+++ b/apps/sdp-docs/content/docs/getting-started.mdx
@@ -19,7 +19,7 @@ Click **Get started** on the wallet setup card. Choose **Privy (recommended)** a
 
 ### 4. Create your first token
 
-Navigate to **Issuance** and click **Create token**. Select a template (Stablecoin, Arcade, Tokenized Security, or Custom), configure the token details, and confirm.
+Navigate to **Issuance** and click **Create token**. Select a template (Stablecoin, Tokenized Security, or Custom), configure the token details, and confirm.
 
 ### Next steps
 

--- a/apps/sdp-docs/content/docs/guides/create-a-token.mdx
+++ b/apps/sdp-docs/content/docs/guides/create-a-token.mdx
@@ -12,7 +12,6 @@ SDP provides templates that pre-configure extensions and defaults for common use
 | Template | Decimals | Key extensions | Use case |
 | --- | --- | --- | --- |
 | **Stablecoin** | 6 | Permanent delegate, pausable | USD-backed tokens |
-| **Arcade** | 0 | Permanent delegate, pausable | Gaming tokens, loyalty points |
 | **Tokenized Security** | 8 | Permanent delegate, pausable, scaled UI amount | Regulated assets |
 | **Custom** | 9 | None (you choose) | Full control |
 
@@ -28,7 +27,6 @@ Navigate to **Issuance** in the sidebar. Click **Create token** in the top right
 The first step shows a grid of template cards:
 
 - **Stablecoin** — USD-backed stablecoins with compliance controls
-- **Arcade** — closed-loop gaming tokens with optional allowlists
 - **Tokenized Security** — regulated assets with an allowlist requirement
 - **Custom** — fully customizable Token-2022 configuration
 

--- a/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
+++ b/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
@@ -11,7 +11,7 @@ Use this guide when you want to issue a stablecoin, tokenized security, loyalty 
 | --- | --- | --- |
 | Fiat-backed stablecoin | `stablecoin` | Mint authority, freeze authority, pausable, permanent delegate |
 | Tokenized security | `tokenized-security` | Allowlists, freeze authority, pausable, permanent delegate |
-| Loyalty, rewards, or game token | `arcade` | Mintable supply, optional pause controls |
+| Loyalty, rewards, or non-standard utility token | `custom` | Manually selected metadata and extension set |
 | Non-standard asset model | `custom` | Manually selected metadata and extension set |
 
 Default to SDP-controlled custody wallets for your main authorities when you expect SDP execute flows to work without external signing.

--- a/apps/sdp-docs/content/docs/reference/issuance-token-types.mdx
+++ b/apps/sdp-docs/content/docs/reference/issuance-token-types.mdx
@@ -3,12 +3,11 @@ title: Issuance Token Types
 description: Supported issuance templates and default controls.
 ---
 
-The issuance service currently defines four token templates:
+The public issuance surface currently exposes three token templates:
 
 | Template | Defaults | Notes |
 | --- | --- | --- |
 | `stablecoin` | 6 decimals, permanent delegate + pausable extensions, default account state initialized | Intended for fiat-backed token patterns with compliance controls. |
-| `arcade` | 0 decimals, permanent delegate + pausable extensions, default account state initialized | Closed-loop gaming/points style tokens. |
 | `tokenized-security` | 8 decimals, allowlist required, permanent delegate + pausable + scaled UI amount extensions, default account state frozen | Regulated asset flows with stronger defaults. |
 | `custom` | 9 decimals default (up to 18 max), extension set is fully configurable | Use when your requirements do not match preset templates. |
 

--- a/apps/sdp-docs/content/docs/what-is-solana-developer-platform.mdx
+++ b/apps/sdp-docs/content/docs/what-is-solana-developer-platform.mdx
@@ -7,7 +7,7 @@ Solana Developer Platform (SDP) is a dashboard and REST API for issuing, transfe
 
 ## What you get
 
-**Token lifecycle management** — Create tokens from pre-built templates (stablecoin, arcade, tokenized security) or configure your own using Token-2022 extensions. Deploy, mint, burn, and manage supply through the dashboard or API.
+**Token lifecycle management** — Create tokens from pre-built templates (stablecoin, tokenized security) or configure your own using Token-2022 extensions. Deploy, mint, burn, and manage supply through the dashboard or API.
 
 **Wallet custody** — Provision signing wallets through integrated custody providers. SDP manages the signing infrastructure so your team never handles private keys directly.
 

--- a/apps/sdp-web/package.json
+++ b/apps/sdp-web/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:local": "next dev",
+    "dev": "next dev --webpack",
+    "dev:local": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",

--- a/apps/sdp-web/playwright/tests/auth.global.setup.ts
+++ b/apps/sdp-web/playwright/tests/auth.global.setup.ts
@@ -76,7 +76,7 @@ setup("authenticate admin test user and save auth state", async ({ page }) => {
   });
 
   await page.goto("/dashboard/issuance");
-  await expect(page.getByRole("button", { name: "Create token" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create draft" })).toBeVisible();
   fs.mkdirSync(path.dirname(authFile), { recursive: true });
   await page.context().storageState({ path: authFile });
 });

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -7,7 +7,7 @@ function shortValue(value: string): string {
 
 async function gotoIssuanceDashboard(page: Page): Promise<void> {
   await page.goto("/dashboard/issuance");
-  await expect(page.getByRole("button", { name: "Create token" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create draft" })).toBeVisible();
 }
 
 async function gotoToken(page: Page, tokenId: string): Promise<void> {
@@ -31,7 +31,7 @@ async function confirmAction(page: Page, confirmButtonLabel: string): Promise<vo
 }
 
 async function openFundManagementAction(page: Page, action: string): Promise<void> {
-  await openTab(page, "Fund Management");
+  await openTab(page, "Operations");
   const row = page.getByTestId(`fund-management-row-${action}`);
   await expect(row).toBeVisible();
   await row.getByRole("button").click();
@@ -76,7 +76,7 @@ test.describe
       const draftSymbol = `E2E${draftSuffix}`;
 
       await gotoIssuanceDashboard(page);
-      await page.getByRole("button", { name: "Create token" }).click();
+      await page.getByRole("button", { name: "Create draft" }).click();
       await page
         .getByRole("button", { name: /Stablecoin/i })
         .first()
@@ -94,9 +94,13 @@ test.describe
         .filter({ hasText: "This token will not use an allowlist." })
         .click();
       await page.getByLabel("Main Signer").selectOption(fixtures.wallets.treasury.walletId);
-      await page.getByRole("button", { name: "Create Stablecoin" }).click();
+      await page.getByRole("button", { name: "Create Stablecoin Draft" }).click();
 
-      await waitForToast(page, `Token ${draftName} created successfully.`);
+      await expect
+        .poll(async () => page.getByRole("heading", { name: draftName, exact: true }).count(), {
+          timeout: 120_000,
+        })
+        .toBeGreaterThan(0);
       await expect(page.getByRole("heading", { name: draftName, exact: true })).toBeVisible();
     });
 
@@ -104,15 +108,13 @@ test.describe
       page,
     }) => {
       await gotoToken(page, fixtures.tokens.pending.id);
-      await openTab(page, "Fund Management");
+      await openTab(page, "Operations");
 
       const deployRow = page.getByTestId("fund-management-row-deploy");
       await expect(deployRow.getByRole("button", { name: "Deploy" })).toBeVisible();
       await deployRow.getByRole("button", { name: "Deploy" }).click();
       await expect(
-        page.getByText(
-          "This will deploy the token on-chain so fund management actions can be used."
-        )
+        page.getByText("This will deploy the token on-chain so operations can run.")
       ).toBeVisible();
       await page.getByRole("button", { name: "Deploy now", exact: true }).click();
       await expect(page.getByRole("heading", { name: "Deploy token?" })).toBeVisible();
@@ -258,7 +260,7 @@ test.describe
       await openTab(page, "Overview");
       await expect(page.getByTestId("overview-row-supply")).toContainText("7");
 
-      await openTab(page, "Fund Management");
+      await openTab(page, "Operations");
       await expect(page.getByRole("cell", { name: "mint" })).toBeVisible();
       await expect(page.getByRole("cell", { name: "burn" })).toBeVisible();
     });

--- a/apps/sdp-web/src/app/api/dashboard/home/activity/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/home/activity/route.ts
@@ -4,7 +4,7 @@ import {
   fetchIssuanceTokens,
   fetchOrgIssuanceActivity,
 } from "@/app/dashboard/home-page.data";
-import { fetchPaymentTransfers } from "@/app/dashboard/payments/payments-page.data";
+import { fetchDashboardPaymentTransfers } from "@/app/dashboard/payments/payments-page.data";
 import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
@@ -17,7 +17,9 @@ export async function GET(request: Request) {
       trace.childContext("route.dashboard.home.activity.api")
     );
     const [transfersResult, issuanceTokensResult] = await Promise.all([
-      trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request, 20)),
+      trace.step("fetch_payment_transfers", () =>
+        fetchDashboardPaymentTransfers(apiClient.request, 20)
+      ),
       trace.step("fetch_issuance_tokens", () => fetchIssuanceTokens(apiClient.request, 20)),
     ]);
 

--- a/apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/supporting-data/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/issuance/tokens/[tokenId]/supporting-data/route.ts
@@ -78,7 +78,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ toke
 
     const [walletsResult, transactionsResult, allowlistResult, frozenResult] = await Promise.all([
       trace.step("fetch_authority_wallets", () =>
-        fetchPaymentsWallets(apiClient.request, { view: "summary" })
+        fetchPaymentsWallets(apiClient.request, { view: "summary", includeBalances: true })
       ),
       trace.step("fetch_transactions", () =>
         fetchList<TokenTransaction>(

--- a/apps/sdp-web/src/app/api/dashboard/payments/ramps/[direction]/execute/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/ramps/[direction]/execute/route.ts
@@ -2,7 +2,7 @@ import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 type RouteContext = {
-  params: Promise<{ direction: string }> | { direction: string };
+  params: Promise<{ direction: string }>;
 };
 
 async function readParams(context: RouteContext) {

--- a/apps/sdp-web/src/app/api/dashboard/payments/transfers/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/transfers/route.ts
@@ -1,3 +1,4 @@
+import { fetchDashboardPaymentTransfers } from "@/app/dashboard/payments/payments-page.data";
 import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
@@ -11,6 +12,36 @@ export async function GET(request: Request) {
     );
     const url = new URL(request.url);
     const search = url.searchParams.toString();
+    const hasWalletFilter = url.searchParams.has("wallet") || url.searchParams.has("walletAddress");
+    const pageSize = Number.parseInt(url.searchParams.get("pageSize") ?? "20", 10);
+
+    if (!hasWalletFilter) {
+      const result = await fetchDashboardPaymentTransfers(
+        apiClient.request,
+        Number.isFinite(pageSize) && pageSize > 0 ? pageSize : 20
+      );
+      const status = result.ok ? 200 : (result.status ?? 500);
+      const nextResponse = NextResponse.json(
+        result.ok
+          ? { data: result.data ?? [] }
+          : { error: { message: result.error ?? "Transfer list request failed" } },
+        {
+          status,
+          headers: {
+            "X-SDP-Trace-ID": trace.traceId,
+            "Server-Timing": trace.serverTiming(),
+          },
+        }
+      );
+
+      logRouteResult(trace, status, {
+        query: search,
+        source: "dashboard_aggregate",
+      });
+
+      return nextResponse;
+    }
+
     const response = await apiClient.request(
       `/v1/payments/transfers${search ? `?${search}` : ""}`,
       {

--- a/apps/sdp-web/src/app/api/dashboard/payments/wallets/[walletId]/balances/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/wallets/[walletId]/balances/route.ts
@@ -2,16 +2,13 @@ import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 async function readParams(context: {
-  params: Promise<{ walletId: string }> | { walletId: string };
+  params: Promise<{ walletId: string }>;
 }) {
   const resolved = await context.params;
   return resolved.walletId;
 }
 
-export async function GET(
-  _request: Request,
-  context: { params: Promise<{ walletId: string }> | { walletId: string } }
-) {
+export async function GET(_request: Request, context: { params: Promise<{ walletId: string }> }) {
   try {
     const walletId = await readParams(context);
     const apiClient = await createSdpApiClient();

--- a/apps/sdp-web/src/app/api/dashboard/payments/wallets/[walletId]/policies/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/wallets/[walletId]/policies/route.ts
@@ -2,16 +2,13 @@ import { createSdpApiClient } from "@/lib/sdp-api";
 import { NextResponse } from "next/server";
 
 async function readParams(context: {
-  params: Promise<{ walletId: string }> | { walletId: string };
+  params: Promise<{ walletId: string }>;
 }) {
   const resolved = await context.params;
   return resolved.walletId;
 }
 
-export async function GET(
-  _request: Request,
-  context: { params: Promise<{ walletId: string }> | { walletId: string } }
-) {
+export async function GET(_request: Request, context: { params: Promise<{ walletId: string }> }) {
   try {
     const walletId = await readParams(context);
     const apiClient = await createSdpApiClient();
@@ -38,10 +35,7 @@ export async function GET(
   }
 }
 
-export async function PUT(
-  request: Request,
-  context: { params: Promise<{ walletId: string }> | { walletId: string } }
-) {
+export async function PUT(request: Request, context: { params: Promise<{ walletId: string }> }) {
   try {
     const walletId = await readParams(context);
     const body = await request.text();

--- a/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/api-keys/actions.ts
@@ -14,6 +14,7 @@ interface ApiKeyFlash {
   level: FlashLevel;
   message: string;
   key?: string;
+  apiKeyId?: string;
   keyPrefix?: string;
 }
 
@@ -216,6 +217,7 @@ export async function createApiKeyAction(formData: FormData) {
       level: "success",
       message: `API key "${response.apiKey.name}" created. Save it now; it will not be shown again.`,
       key: response.apiKey.key,
+      apiKeyId: response.apiKey.id,
       keyPrefix: response.apiKey.keyPrefix,
     });
   } catch (error) {
@@ -262,6 +264,7 @@ export async function rotateApiKeyAction(formData: FormData) {
       level: "success",
       message: `API key rotated. Previous key remains valid until ${new Date(response.previousKey.rotationDeadline).toLocaleString()}.`,
       key: response.apiKey.key,
+      apiKeyId: response.apiKey.id,
       keyPrefix: response.apiKey.keyPrefix,
     });
   } catch (error) {

--- a/apps/sdp-web/src/app/dashboard/api-keys/api-keys-table-client.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/api-keys-table-client.tsx
@@ -44,7 +44,13 @@ function formatRole(role: ApiKeyRole): string {
   return "Developer";
 }
 
-export function ApiKeysTableClient({ initialApiKeys }: { initialApiKeys: ApiKeyRecord[] }) {
+export function ApiKeysTableClient({
+  initialApiKeys,
+  canManageApiKeys,
+}: {
+  initialApiKeys: ApiKeyRecord[];
+  canManageApiKeys: boolean;
+}) {
   const [apiKeys, setApiKeys] = useState(initialApiKeys);
 
   useEffect(() => {
@@ -73,7 +79,7 @@ export function ApiKeysTableClient({ initialApiKeys }: { initialApiKeys: ApiKeyR
           <TableHead className="w-[11%]">Last used</TableHead>
           <TableHead className="w-[11%]">Expires</TableHead>
           <TableHead className="w-[11%]">Created</TableHead>
-          <TableHead className="w-[21%] text-right">Actions</TableHead>
+          <TableHead className="w-[21%] text-right">{canManageApiKeys ? "Actions" : ""}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -107,14 +113,16 @@ export function ApiKeysTableClient({ initialApiKeys }: { initialApiKeys: ApiKeyR
                 {formatDate(key.createdAt)}
               </TableCell>
               <TableCell className="text-right">
-                <ApiKeyActionsMenu
-                  keyId={key.id}
-                  keyName={key.name}
-                  canRotate={canRotate}
-                  onDeleted={() => {
-                    setApiKeys((previous) => previous.filter((item) => item.id !== key.id));
-                  }}
-                />
+                {canManageApiKeys ? (
+                  <ApiKeyActionsMenu
+                    keyId={key.id}
+                    keyName={key.name}
+                    canRotate={canRotate}
+                    onDeleted={() => {
+                      setApiKeys((previous) => previous.filter((item) => item.id !== key.id));
+                    }}
+                  />
+                ) : null}
               </TableCell>
             </TableRow>
           );

--- a/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/generated-key-modal.tsx
@@ -11,10 +11,16 @@ import { GeneratedApiKeyInput } from "./generated-key-input";
 interface GeneratedApiKeyModalProps {
   keyValue: string;
   message: string;
+  apiKeyId?: string;
   keyPrefix?: string;
 }
 
-function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyModalProps) {
+function GeneratedApiKeyModal({
+  keyValue,
+  message,
+  apiKeyId,
+  keyPrefix,
+}: GeneratedApiKeyModalProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [copyLabel, setCopyLabel] = useState("Copy");
   const clearedFlash = useRef(false);
@@ -26,9 +32,10 @@ function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyM
 
     storeApiKeySecret({
       value: keyValue,
+      apiKeyId: apiKeyId ?? null,
       keyPrefix: keyPrefix ?? null,
     });
-  }, [keyValue, keyPrefix]);
+  }, [apiKeyId, keyValue, keyPrefix]);
 
   useEffect(() => {
     if (clearedFlash.current) {
@@ -92,6 +99,10 @@ function GeneratedApiKeyModal({ keyValue, message, keyPrefix }: GeneratedApiKeyM
         <div className="mt-4 space-y-2">
           <Label htmlFor="generated-key-value">Your full key (shown once)</Label>
           <GeneratedApiKeyInput value={keyValue} />
+          <p className="text-xs text-[rgba(28,28,29,0.58)]">
+            This browser session can now use this key in the API Playground without pasting it
+            again.
+          </p>
         </div>
 
         <div className="mt-5 flex items-center justify-end gap-2">

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -72,6 +72,7 @@ export default async function ApiKeysPage() {
               <GeneratedApiKeyModal
                 keyValue={flash.key ?? ""}
                 message={flash.message}
+                apiKeyId={flash.apiKeyId}
                 keyPrefix={flash.keyPrefix}
               />
             ) : (

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { resolveDashboardAccess } from "@/lib/dashboard-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -21,7 +22,7 @@ import { GeneratedApiKeyModal } from "./generated-key-modal";
 export const dynamic = "force-dynamic";
 
 export default async function ApiKeysPage() {
-  const { userId, orgId } = await auth();
+  const { userId, orgId, orgRole } = await auth();
   if (!userId) {
     redirect("/sign-in");
   }
@@ -30,6 +31,7 @@ export default async function ApiKeysPage() {
   }
 
   const trace = createTimedTrace("dashboard.api_keys.page");
+  const dashboardAccess = resolveDashboardAccess(orgRole);
 
   try {
     const apiClient = await trace.step("create_sdp_api_client", () =>
@@ -40,9 +42,11 @@ export default async function ApiKeysPage() {
       trace.step("fetch_api_keys", () =>
         apiClient.fetch<{ apiKeys: ApiKeyRecord[] }>("/v1/api-keys")
       ),
-      trace.step("fetch_wallets", () =>
-        fetchPaymentsWallets(apiClient.request, { includeBalances: false })
-      ),
+      dashboardAccess.capabilities.canManageApiKeys
+        ? trace.step("fetch_wallets", () =>
+            fetchPaymentsWallets(apiClient.request, { includeBalances: false })
+          )
+        : Promise.resolve({ ok: true as const, data: [] }),
     ]);
 
     const apiKeys = apiKeysResponse.apiKeys;
@@ -87,18 +91,28 @@ export default async function ApiKeysPage() {
           <CardHeader>
             <CardTitle>Existing API keys</CardTitle>
             <CardDescription>Active and historical keys for this workspace.</CardDescription>
-            <CardAction>
-              <CreateApiKeyModal triggerLabel="New API key" wallets={wallets} />
-            </CardAction>
+            {dashboardAccess.capabilities.canManageApiKeys ? (
+              <CardAction>
+                <CreateApiKeyModal triggerLabel="New API key" wallets={wallets} />
+              </CardAction>
+            ) : null}
           </CardHeader>
           <CardContent>
+            {!dashboardAccess.capabilities.canManageApiKeys ? (
+              <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
+                You can view API keys, but only admins can create, rotate, or delete them.
+              </div>
+            ) : null}
             <div className="mb-4 rounded-[10px] border border-[rgba(28,28,29,0.14)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-xs text-[rgba(28,28,29,0.72)]">
               <p className="text-xs text-[rgba(28,28,29,0.72)]">
                 Rotation hint: rotate active keys only. The dashboard uses a 24-hour grace period;
                 use the API for custom grace values (0-168h). New key secrets are shown once.
               </p>
             </div>
-            <ApiKeysTableClient initialApiKeys={apiKeys} />
+            <ApiKeysTableClient
+              initialApiKeys={apiKeys}
+              canManageApiKeys={dashboardAccess.capabilities.canManageApiKeys}
+            />
           </CardContent>
         </Card>
       </div>

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
@@ -3,12 +3,17 @@ import {
   isKnownCustodyProvider,
 } from "@/app/dashboard/custody/provider-catalog";
 import { WalletActionsMenu } from "@/app/dashboard/custody/wallet-actions-menu";
+import { WalletActivitySection } from "@/app/dashboard/custody/wallet-activity-section";
 import { WalletAddressCopyButton } from "@/app/dashboard/custody/wallet-address-copy-button";
 import { formatPurpose, truncateMiddle } from "@/app/dashboard/custody/wallet-format-utils";
 import { WalletProviderMark } from "@/app/dashboard/custody/wallet-provider-mark";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
-import type { CustodyWalletByIdResponse, CustodyWalletTokenBalance } from "@sdp/types";
+import type {
+  CustodyWalletByIdResponse,
+  CustodyWalletTokenBalance,
+  PaymentTransferSummary,
+} from "@sdp/types";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import type { ReactNode } from "react";
@@ -17,6 +22,7 @@ import {
   formatDisplayAmount,
   resolveTotalBalance,
 } from "../../payments/payments-overview.utils";
+import { fetchPaymentTransfers } from "../../payments/payments-page.data";
 
 interface WalletBalancesResponse {
   walletBalances?: {
@@ -97,6 +103,20 @@ async function getOwnedTokenRoutes(request: SdpApiClient["request"]): Promise<Ma
   }
 }
 
+async function getWalletTransfers(
+  request: SdpApiClient["request"],
+  walletId: string
+): Promise<{
+  transfers: PaymentTransferSummary[];
+  error: string | null;
+}> {
+  const result = await fetchPaymentTransfers(request, 20, { walletId });
+  return {
+    transfers: result.data ?? [],
+    error: result.ok ? null : (result.error ?? "Wallet activity is unavailable right now."),
+  };
+}
+
 export default async function WalletDetailPage({
   params,
 }: {
@@ -113,10 +133,11 @@ export default async function WalletDetailPage({
   const { walletId } = await params;
   const resolvedWalletId = decodeURIComponent(walletId);
   const apiClient = await createSdpApiClient();
-  const [wallet, trackedBalances, ownedTokensByMint] = await Promise.all([
+  const [wallet, trackedBalances, ownedTokensByMint, walletTransfersResult] = await Promise.all([
     getWalletDetail(apiClient.request, resolvedWalletId),
     getWalletTrackedBalances(apiClient.request, resolvedWalletId),
     getOwnedTokenRoutes(apiClient.request),
+    getWalletTransfers(apiClient.request, resolvedWalletId),
   ]);
 
   const provider =
@@ -228,6 +249,12 @@ export default async function WalletDetailPage({
           </div>
         )}
       </section>
+
+      <WalletActivitySection
+        walletId={resolvedWalletId}
+        initialTransfers={walletTransfersResult.transfers}
+        initialTransfersError={walletTransfersResult.error}
+      />
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { useEscapeKey } from "@/lib/use-escape-key";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Droplets, Ellipsis, ShieldCheck } from "lucide-react";
@@ -46,6 +47,7 @@ export function WalletActionsMenu({
   triggerMode = "icon",
   triggerClassName,
 }: WalletActionsMenuProps) {
+  const { dashboardAccess } = useDashboardWorkspace();
   const [isFaucetOpen, setIsFaucetOpen] = useState(false);
   const [isBusy, startTransition] = useTransition();
   const resolvedWalletLabel = formatWalletLabel(walletLabel, walletAddress);
@@ -160,9 +162,16 @@ export function WalletActionsMenu({
             <Droplets className="h-4 w-4" />
             Faucet
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={runSignerCheck} disabled={isBusy}>
+          <DropdownMenuItem
+            onSelect={runSignerCheck}
+            disabled={isBusy || !dashboardAccess.capabilities.canUseWalletSignerCheck}
+          >
             <ShieldCheck className="h-4 w-4" />
-            {isBusy ? "Proving..." : "Prove ownership"}
+            {isBusy
+              ? "Proving..."
+              : dashboardAccess.capabilities.canUseWalletSignerCheck
+                ? "Prove ownership"
+                : "Prove ownership (admin only)"}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { fetchTransfers } from "@/app/dashboard/payments/payments-workspace.data";
+import { getDevnetExplorerUrl } from "@/app/dashboard/payments/payments-workspace.data";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { PaymentTransferSummary as TransferRecord } from "@sdp/types";
+import { ExternalLink, RefreshCw } from "lucide-react";
+import useSWR from "swr";
+import { formatDisplayAmount } from "../payments/payments-overview.utils";
+
+interface WalletActivitySectionProps {
+  walletId: string;
+  initialTransfers: TransferRecord[];
+  initialTransfersError: string | null;
+}
+
+function formatTimestamp(value: string | undefined): string {
+  if (!value) {
+    return "—";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatDirection(value: string | undefined): string {
+  if (value === "inbound") {
+    return "Incoming";
+  }
+  if (value === "outbound") {
+    return "Outgoing";
+  }
+  return "Transfer";
+}
+
+function resolveCounterparty(transfer: TransferRecord): string {
+  if (transfer.direction === "inbound") {
+    return transfer.source ?? "Unknown source";
+  }
+
+  if (transfer.direction === "outbound") {
+    return transfer.destination ?? "Unknown destination";
+  }
+
+  return transfer.destination ?? transfer.source ?? "Unknown";
+}
+
+function statusClassName(status: string): string {
+  if (status === "confirmed") {
+    return "border-[rgba(12,128,76,0.18)] bg-[rgba(12,128,76,0.08)] text-[#0c804c]";
+  }
+
+  if (status === "failed") {
+    return "border-[rgba(199,31,55,0.16)] bg-[rgba(199,31,55,0.08)] text-[#9e2b38]";
+  }
+
+  return "border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.04)] text-[rgba(28,28,29,0.72)]";
+}
+
+function TruncatedText({
+  value,
+  className,
+}: {
+  value: string;
+  className?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={className ?? "truncate"}>{value}</div>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="start" className="max-w-[32rem] break-all text-xs">
+        {value}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function WalletActivitySection({
+  walletId,
+  initialTransfers,
+  initialTransfersError,
+}: WalletActivitySectionProps) {
+  const {
+    data: swrTransfers,
+    error: requestError,
+    isValidating,
+    mutate,
+  } = useSWR(`wallet-activity-${walletId}`, () => fetchTransfers({ walletId }), {
+    fallbackData: initialTransfersError ? undefined : initialTransfers,
+    revalidateOnFocus: true,
+    refreshInterval: 20_000,
+  });
+  const liveTransfers = swrTransfers ?? initialTransfers;
+  const liveTransfersError = requestError
+    ? requestError instanceof Error
+      ? requestError.message
+      : "Unable to load wallet activity."
+    : swrTransfers === undefined
+      ? initialTransfersError
+      : null;
+
+  return (
+    <Card className="min-w-0 overflow-hidden">
+      <CardHeader className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <CardTitle>Recent activity</CardTitle>
+          <CardDescription>
+            Incoming and outgoing transfer activity for this wallet.
+          </CardDescription>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => void mutate()}
+          disabled={isValidating}
+        >
+          <RefreshCw className={`size-4 ${isValidating ? "animate-spin" : ""}`} />
+          {isValidating ? "Refreshing..." : "Refresh"}
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {liveTransfersError ? (
+          <p className="text-sm text-[#9e2b38]">{liveTransfersError}</p>
+        ) : liveTransfers.length === 0 ? (
+          <p className="text-sm text-[rgba(28,28,29,0.72)]">No wallet activity found yet.</p>
+        ) : (
+          <TooltipProvider>
+            <div className="min-w-0">
+              <Table className="table-fixed">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[9rem]">Status</TableHead>
+                    <TableHead className="w-[calc(100%-9rem)] md:w-[22%]">
+                      <span className="md:hidden">Transfer</span>
+                      <span className="hidden md:inline">Asset</span>
+                    </TableHead>
+                    <TableHead className="hidden w-[8rem] md:table-cell">Direction</TableHead>
+                    <TableHead className="hidden w-[26%] md:table-cell">Counterparty</TableHead>
+                    <TableHead className="hidden w-[22%] md:table-cell">Signature</TableHead>
+                    <TableHead className="hidden w-[10rem] md:table-cell">Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {liveTransfers.map((transfer) => {
+                    const counterparty = resolveCounterparty(transfer);
+                    const assetLabel =
+                      transfer.amount && transfer.token
+                        ? formatDisplayAmount(transfer.amount, transfer.token)
+                        : (transfer.token ?? "Unknown asset");
+                    const directionLabel = formatDirection(transfer.direction);
+                    const createdLabel = formatTimestamp(transfer.createdAt);
+
+                    return (
+                      <TableRow key={transfer.id}>
+                        <TableCell>
+                          <span
+                            className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${statusClassName(transfer.status)}`}
+                          >
+                            {transfer.status}
+                          </span>
+                        </TableCell>
+                        <TableCell className="min-w-0 font-medium">
+                          <div className="min-w-0">
+                            <TruncatedText value={assetLabel} className="truncate" />
+                            <div className="mt-1 text-xs font-normal text-[rgba(28,28,29,0.56)] md:hidden">
+                              <span>{directionLabel}</span>
+                              <span className="mx-1.5">·</span>
+                              <span>{createdLabel}</span>
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell className="hidden text-[rgba(28,28,29,0.72)] md:table-cell">
+                          {directionLabel}
+                        </TableCell>
+                        <TableCell className="hidden min-w-0 font-mono text-xs text-[rgba(28,28,29,0.72)] md:table-cell">
+                          <TruncatedText value={counterparty} className="truncate" />
+                        </TableCell>
+                        <TableCell className="hidden min-w-0 font-mono text-xs md:table-cell">
+                          {transfer.signature ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <a
+                                  href={getDevnetExplorerUrl(transfer.signature)}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="flex min-w-0 items-center gap-1 text-[#1c1c1d] underline underline-offset-2"
+                                >
+                                  <span className="block min-w-0 truncate">
+                                    {transfer.signature}
+                                  </span>
+                                  <ExternalLink className="size-3 shrink-0" />
+                                </a>
+                              </TooltipTrigger>
+                              <TooltipContent
+                                side="top"
+                                align="start"
+                                className="max-w-[32rem] break-all text-xs"
+                              >
+                                {transfer.signature}
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <span className="text-[rgba(28,28,29,0.52)]">Pending</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="hidden text-[rgba(28,28,29,0.72)] md:table-cell">
+                          {createdLabel}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          </TooltipProvider>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-label-inline-editor.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-label-inline-editor.tsx
@@ -9,11 +9,16 @@ import { toast } from "sonner";
 import { updateWalletLabelAction } from "./actions";
 
 interface WalletLabelInlineEditorProps {
+  canEdit?: boolean;
   walletId: string;
   label: string | null;
 }
 
-export function WalletLabelInlineEditor({ walletId, label }: WalletLabelInlineEditorProps) {
+export function WalletLabelInlineEditor({
+  canEdit = true,
+  walletId,
+  label,
+}: WalletLabelInlineEditorProps) {
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(label ?? "");
@@ -98,17 +103,19 @@ export function WalletLabelInlineEditor({ walletId, label }: WalletLabelInlineEd
       <div className="min-w-0 truncate" title={label ?? "Untitled"}>
         {label ?? "Untitled"}
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-xs"
-        onClick={() => setIsEditing(true)}
-        aria-label="Edit wallet label"
-        title="Edit wallet label"
-        className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
-      >
-        <Pencil className="h-3 w-3" />
-      </Button>
+      {canEdit ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={() => setIsEditing(true)}
+          aria-label="Edit wallet label"
+          title="Edit wallet label"
+          className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { WalletProviderMark } from "./wallet-provider-mark";
 
 interface WalletsOverviewProps {
+  canManageCustody: boolean;
   connectedProviders: KnownCustodyProvider[];
   configsError: string | null;
   wallets: CustodyWalletSummary[];
@@ -25,6 +26,7 @@ interface WalletsOverviewProps {
 }
 
 export function WalletsOverview({
+  canManageCustody,
   connectedProviders,
   configsError,
   wallets,
@@ -47,65 +49,69 @@ export function WalletsOverview({
       <div className="space-y-6">
         <div className="space-y-2">
           <h2 className="text-[34px] leading-[1.04] font-medium tracking-[-0.03em] text-[#1c1c1d]">
-            Create your first wallet
+            {canManageCustody ? "Create your first wallet" : "No wallets available"}
           </h2>
           <p className="max-w-2xl text-[15px] text-[rgba(28,28,29,0.62)]">
-            Choose a custody provider to connect and create the first wallet for your organization.
+            {canManageCustody
+              ? "Choose a custody provider to connect and create the first wallet for your organization."
+              : "Wallet creation is limited to admins. Once a wallet is created, you can still use it across the dashboard."}
           </p>
           {configsError ? <p className="text-sm text-[#9e2b38]">{configsError}</p> : null}
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          {CUSTODY_PROVIDER_CATALOG.map((provider) => {
-            const isConnected = connectedProviderSet.has(provider.id);
-            const isDisabled = isConnected && !provider.supportsAdditionalWallets;
+        {canManageCustody ? (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {CUSTODY_PROVIDER_CATALOG.map((provider) => {
+              const isConnected = connectedProviderSet.has(provider.id);
+              const isDisabled = isConnected && !provider.supportsAdditionalWallets;
 
-            return (
-              <article
-                key={provider.id}
-                className="flex min-h-[340px] flex-col rounded-2xl border border-[rgba(28,28,29,0.1)] bg-[#fcfcfa] p-5 shadow-[0_2px_10px_rgba(28,28,29,0.05)]"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <WalletProviderMark provider={provider.id} />
-                </div>
+              return (
+                <article
+                  key={provider.id}
+                  className="flex min-h-[340px] flex-col rounded-2xl border border-[rgba(28,28,29,0.1)] bg-[#fcfcfa] p-5 shadow-[0_2px_10px_rgba(28,28,29,0.05)]"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <WalletProviderMark provider={provider.id} />
+                  </div>
 
-                <div className="mt-5 space-y-2">
-                  <h3 className="text-[30px] leading-[1.1] font-medium tracking-[-0.03em] text-[#1c1c1d]">
-                    {provider.label}
-                  </h3>
-                </div>
+                  <div className="mt-5 space-y-2">
+                    <h3 className="text-[30px] leading-[1.1] font-medium tracking-[-0.03em] text-[#1c1c1d]">
+                      {provider.label}
+                    </h3>
+                  </div>
 
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {provider.capabilities.map((feature) => (
-                    <span
-                      key={feature}
-                      className="rounded-full border border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.03)] px-2.5 py-1 text-[11px] font-medium text-[rgba(28,28,29,0.68)]"
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {provider.capabilities.map((feature) => (
+                      <span
+                        key={feature}
+                        className="rounded-full border border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.03)] px-2.5 py-1 text-[11px] font-medium text-[rgba(28,28,29,0.68)]"
+                      >
+                        {feature}
+                      </span>
+                    ))}
+                  </div>
+
+                  <div className="mt-auto pt-6">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => onCreateWallet(provider.id)}
+                      disabled={isDisabled}
+                      title={
+                        isDisabled
+                          ? `${provider.label} is already connected, but additional wallets are not available yet.`
+                          : undefined
+                      }
                     >
-                      {feature}
-                    </span>
-                  ))}
-                </div>
-
-                <div className="mt-auto pt-6">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    className="w-full"
-                    onClick={() => onCreateWallet(provider.id)}
-                    disabled={isDisabled}
-                    title={
-                      isDisabled
-                        ? `${provider.label} is already connected, but additional wallets are not available yet.`
-                        : undefined
-                    }
-                  >
-                    New wallet
-                  </Button>
-                </div>
-              </article>
-            );
-          })}
-        </div>
+                      New wallet
+                    </Button>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -144,7 +150,11 @@ export function WalletsOverview({
               </p>
               <div className="mt-1 min-w-0 text-[30px] leading-[1.1] font-medium tracking-[-0.03em] text-[#1c1c1d]">
                 <div className="min-w-0">
-                  <WalletLabelInlineEditor walletId={wallet.walletId} label={wallet.label} />
+                  <WalletLabelInlineEditor
+                    walletId={wallet.walletId}
+                    label={wallet.label}
+                    canEdit={canManageCustody}
+                  />
                 </div>
               </div>
 
@@ -196,13 +206,15 @@ export function WalletsOverview({
           );
         })}
 
-        <button
-          type="button"
-          onClick={() => onCreateWallet(null)}
-          className="flex min-h-[340px] items-center justify-center rounded-2xl border border-dashed border-[rgba(28,28,29,0.2)] bg-[#fcfcfa] text-[rgba(28,28,29,0.5)] transition-colors hover:border-[rgba(28,28,29,0.35)] hover:text-[rgba(28,28,29,0.75)]"
-        >
-          <Plus className="h-6 w-6" />
-        </button>
+        {canManageCustody ? (
+          <button
+            type="button"
+            onClick={() => onCreateWallet(null)}
+            className="flex min-h-[340px] items-center justify-center rounded-2xl border border-dashed border-[rgba(28,28,29,0.2)] bg-[#fcfcfa] text-[rgba(28,28,29,0.5)] transition-colors hover:border-[rgba(28,28,29,0.35)] hover:text-[rgba(28,28,29,0.75)]"
+          >
+            <Plus className="h-6 w-6" />
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-workspace.tsx
@@ -44,7 +44,8 @@ export function WalletsWorkspace({
   wallets,
   walletsError,
 }: WalletsWorkspaceProps) {
-  const { issuanceTab, selectedPlaygroundApiKeyId, setPlaygroundApiKeys } = useDashboardWorkspace();
+  const { dashboardAccess, issuanceTab, selectedPlaygroundApiKeyId, setPlaygroundApiKeys } =
+    useDashboardWorkspace();
   const [isProvisionModalOpen, setIsProvisionModalOpen] = useState(false);
   const [preferredProvider, setPreferredProvider] = useState<KnownCustodyProvider | null>(null);
   const isPlaygroundTab = issuanceTab === "playground";
@@ -131,7 +132,7 @@ export function WalletsWorkspace({
             transition={{ duration: 0.2, ease: "easeOut" }}
             className="w-full space-y-6"
           >
-            {wallets.length > 0 ? (
+            {wallets.length > 0 && dashboardAccess.capabilities.canManageCustody ? (
               <div className="flex items-center justify-end">
                 <Button type="button" onClick={() => openProvisionModal(null)}>
                   Create Wallet
@@ -144,18 +145,21 @@ export function WalletsWorkspace({
               configsError={configsError}
               wallets={wallets}
               walletsError={walletsError}
+              canManageCustody={dashboardAccess.capabilities.canManageCustody}
               onCreateWallet={openProvisionModal}
             />
           </motion.div>
         )}
       </AnimatePresence>
 
-      <WalletProvisionModal
-        isOpen={isProvisionModalOpen}
-        onClose={() => setIsProvisionModalOpen(false)}
-        connectedProviders={connectedProviders}
-        preferredProvider={preferredProvider}
-      />
+      {dashboardAccess.capabilities.canManageCustody ? (
+        <WalletProvisionModal
+          isOpen={isProvisionModalOpen}
+          onClose={() => setIsProvisionModalOpen(false)}
+          connectedProviders={connectedProviders}
+          preferredProvider={preferredProvider}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -13,7 +13,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import type { DashboardAccess } from "@/lib/dashboard-access";
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import Link from "next/link";
 import useSWR from "swr";
@@ -21,7 +21,6 @@ import { fetchHomeActivity } from "./home-workspace.data";
 import { formatCurrencyAmount, formatDisplayAmount } from "./payments/payments-overview.utils";
 
 interface HomeWorkspaceProps {
-  dashboardAccess: DashboardAccess;
   totalBalance: number | null;
   totalBalanceError: string | null;
   wallets: PaymentsDashboardWallet[];
@@ -96,12 +95,8 @@ function MetricCard({
   );
 }
 
-export function HomeWorkspace({
-  dashboardAccess,
-  totalBalance,
-  totalBalanceError,
-  wallets,
-}: HomeWorkspaceProps) {
+export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: HomeWorkspaceProps) {
+  const { dashboardAccess } = useDashboardWorkspace();
   const { data: activitySnapshot, error: activityRequestError } = useSWR(
     HOME_ACTIVITY_KEY,
     () => fetchHomeActivity(),

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -13,6 +13,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { DashboardAccess } from "@/lib/dashboard-access";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import Link from "next/link";
 import useSWR from "swr";
@@ -20,6 +21,7 @@ import { fetchHomeActivity } from "./home-workspace.data";
 import { formatCurrencyAmount, formatDisplayAmount } from "./payments/payments-overview.utils";
 
 interface HomeWorkspaceProps {
+  dashboardAccess: DashboardAccess;
   totalBalance: number | null;
   totalBalanceError: string | null;
   wallets: PaymentsDashboardWallet[];
@@ -94,7 +96,12 @@ function MetricCard({
   );
 }
 
-export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: HomeWorkspaceProps) {
+export function HomeWorkspace({
+  dashboardAccess,
+  totalBalance,
+  totalBalanceError,
+  wallets,
+}: HomeWorkspaceProps) {
   const { data: activitySnapshot, error: activityRequestError } = useSWR(
     HOME_ACTIVITY_KEY,
     () => fetchHomeActivity(),
@@ -139,14 +146,18 @@ export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: Home
     <div className="w-full space-y-8 py-2">
       <SectionEntry>
         <div className="flex flex-wrap items-center justify-end gap-3">
-          <CreateApiKeyModal
-            triggerLabel="Create API key"
-            triggerVariant="secondary"
-            wallets={wallets}
-          />
-          <Button asChild>
-            <Link href="/dashboard/wallets">Create Wallet</Link>
-          </Button>
+          {dashboardAccess.capabilities.canManageApiKeys ? (
+            <CreateApiKeyModal
+              triggerLabel="Create API key"
+              triggerVariant="secondary"
+              wallets={wallets}
+            />
+          ) : null}
+          {dashboardAccess.capabilities.canManageCustody ? (
+            <Button asChild>
+              <Link href="/dashboard/wallets">Create Wallet</Link>
+            </Button>
+          ) : null}
         </div>
       </SectionEntry>
 

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-admin-forms.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-admin-forms.tsx
@@ -12,11 +12,15 @@ import type {
   AllowlistFormState,
   AuthorityFormState,
   ForceBurnFormState,
+  ForceBurnValidationErrors,
   FreezeFormState,
   SeizeFormState,
+  SeizeValidationErrors,
 } from "./token-management-workspace.types";
 import { NON_WHITESPACE_PATTERN, SOLANA_ADDRESS_PATTERN } from "./token-management-workspace.utils";
 import { TokenSignerSelect } from "./token-signer-select";
+import { TokenValidationMessage } from "./token-validation-message";
+import { TokenWalletAddressField } from "./token-wallet-address-field";
 
 interface TokenActionAdminFormsProps {
   activeAction: AdminAction | null;
@@ -34,7 +38,13 @@ interface TokenActionAdminFormsProps {
   allowlistEntries: TokenAllowlistEntry[];
   allowlistError: string | null;
   signerWallets: PaymentsDashboardWallet[];
+  walletOptions: PaymentsDashboardWallet[];
   signerUnavailableReason: string | null;
+  seizeValidationErrors: SeizeValidationErrors;
+  seizeValidationReason: string | null;
+  forceBurnValidationErrors: ForceBurnValidationErrors;
+  forceBurnValidationReason: string | null;
+  submitAlignment?: "start" | "end";
   tokenStatus: "pending" | "active" | "paused" | "revoked";
   onSignerWalletIdChange: (value: string) => void;
   onSeize: () => void;
@@ -62,7 +72,13 @@ export function TokenActionAdminForms({
   allowlistEntries,
   allowlistError,
   signerWallets,
+  walletOptions,
   signerUnavailableReason,
+  seizeValidationErrors,
+  seizeValidationReason,
+  forceBurnValidationErrors,
+  forceBurnValidationReason,
+  submitAlignment = "start",
   tokenStatus,
   onSignerWalletIdChange,
   onSeize,
@@ -93,12 +109,15 @@ export function TokenActionAdminForms({
               signerUnavailableReason={signerUnavailableReason}
               onSignerWalletIdChange={onSignerWalletIdChange}
             />
-            <ActionField
+            <TokenWalletAddressField
               label="Source"
               value={seizeForm.source}
+              walletOptions={walletOptions}
               required
               pattern={SOLANA_ADDRESS_PATTERN}
               title="Enter a valid Solana address."
+              placeholder="Source wallet or token account"
+              error={seizeValidationErrors.source}
               onChange={(value) =>
                 setSeizeForm((previous) => ({
                   ...previous,
@@ -106,12 +125,15 @@ export function TokenActionAdminForms({
                 }))
               }
             />
-            <ActionField
+            <TokenWalletAddressField
               label="Destination"
               value={seizeForm.destination}
+              walletOptions={walletOptions}
               required
               pattern={SOLANA_ADDRESS_PATTERN}
               title="Enter a valid Solana address."
+              placeholder="Destination wallet or token account"
+              error={seizeValidationErrors.destination}
               onChange={(value) =>
                 setSeizeForm((previous) => ({
                   ...previous,
@@ -127,6 +149,7 @@ export function TokenActionAdminForms({
               step="any"
               value={seizeForm.amount}
               required
+              error={seizeValidationErrors.amount}
               onChange={(value) =>
                 setSeizeForm((previous) => ({
                   ...previous,
@@ -144,9 +167,21 @@ export function TokenActionAdminForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending || Boolean(signerUnavailableReason)}>
-              Force transfer
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button
+                type="submit"
+                disabled={
+                  isPending || Boolean(signerUnavailableReason) || Boolean(seizeValidationReason)
+                }
+              >
+                Force transfer
+              </Button>
+            </div>
           </form>
         </TokenActionCard>
       ) : null}
@@ -169,12 +204,15 @@ export function TokenActionAdminForms({
               signerUnavailableReason={signerUnavailableReason}
               onSignerWalletIdChange={onSignerWalletIdChange}
             />
-            <ActionField
+            <TokenWalletAddressField
               label="Source"
               value={forceBurnForm.source}
+              walletOptions={walletOptions}
               required
               pattern={SOLANA_ADDRESS_PATTERN}
               title="Enter a valid Solana address."
+              placeholder="Source wallet or token account"
+              error={forceBurnValidationErrors.source}
               onChange={(value) =>
                 setForceBurnForm((previous) => ({
                   ...previous,
@@ -190,6 +228,7 @@ export function TokenActionAdminForms({
               step="any"
               value={forceBurnForm.amount}
               required
+              error={forceBurnValidationErrors.amount}
               onChange={(value) =>
                 setForceBurnForm((previous) => ({
                   ...previous,
@@ -207,9 +246,23 @@ export function TokenActionAdminForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending || Boolean(signerUnavailableReason)}>
-              Force burn
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button
+                type="submit"
+                disabled={
+                  isPending ||
+                  Boolean(signerUnavailableReason) ||
+                  Boolean(forceBurnValidationReason)
+                }
+              >
+                Force burn
+              </Button>
+            </div>
           </form>
         </TokenActionCard>
       ) : null}
@@ -263,9 +316,16 @@ export function TokenActionAdminForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending}>
-              Update authority
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button type="submit" disabled={isPending}>
+                Update authority
+              </Button>
+            </div>
           </form>
         </TokenActionCard>
       ) : null}
@@ -342,7 +402,12 @@ export function TokenActionAdminForms({
                 }))
               }
             />
-            <div className="flex flex-wrap gap-2">
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
               <Button type="submit" variant="outline" value="freeze" disabled={isPending}>
                 Freeze account
               </Button>
@@ -391,12 +456,19 @@ export function TokenActionAdminForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending}>
-              Add allowlist entry
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button type="submit" disabled={isPending}>
+                Add allowlist entry
+              </Button>
+            </div>
 
             {allowlistError ? (
-              <p className="text-sm text-[#8a1f2a]">{allowlistError}</p>
+              <TokenValidationMessage message={allowlistError} reserveSpace={false} />
             ) : allowlistEntries.length === 0 ? (
               <p className="text-sm text-[rgba(28,28,29,0.68)]">No allowlist entries yet.</p>
             ) : (
@@ -444,6 +516,7 @@ function ActionField({
   step,
   placeholder,
   inputMode,
+  error,
 }: {
   label: string;
   value: string;
@@ -456,6 +529,7 @@ function ActionField({
   step?: string;
   placeholder?: string;
   inputMode?: ComponentProps<typeof Input>["inputMode"];
+  error?: string | null;
 }) {
   const fieldId = useId();
 
@@ -478,9 +552,11 @@ function ActionField({
         step={step}
         placeholder={placeholder}
         inputMode={inputMode}
+        aria-invalid={Boolean(error)}
         onChange={(event) => onChange(event.currentTarget.value)}
         className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
       />
+      <TokenValidationMessage message={error ?? null} />
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-card.tsx
@@ -12,9 +12,11 @@ interface TokenActionCardProps {
 export function TokenActionCard({ title, description, children }: TokenActionCardProps) {
   return (
     <Card className="gap-4">
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        {description ? <CardDescription>{description}</CardDescription> : null}
+      <CardHeader className="gap-1.5">
+        <CardTitle className="text-[17px] leading-6">{title}</CardTitle>
+        {description ? (
+          <CardDescription className="text-[13px] leading-5">{description}</CardDescription>
+        ) : null}
       </CardHeader>
       <CardContent className="space-y-4">{children}</CardContent>
     </Card>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-forms.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-forms.tsx
@@ -9,11 +9,15 @@ import type {
   AllowlistFormState,
   AuthorityFormState,
   BurnFormState,
+  BurnValidationErrors,
   ForceBurnFormState,
+  ForceBurnValidationErrors,
   FreezeFormState,
   MetadataFormState,
   MintFormState,
+  MintValidationErrors,
   SeizeFormState,
+  SeizeValidationErrors,
 } from "./token-management-workspace.types";
 
 interface TokenActionFormsProps {
@@ -39,10 +43,19 @@ interface TokenActionFormsProps {
   allowlistEntries: TokenAllowlistEntry[];
   allowlistError: string | null;
   signerWallets: PaymentsDashboardWallet[];
+  walletOptions: PaymentsDashboardWallet[];
   signerUnavailableReason: string | null;
+  mintValidationErrors: MintValidationErrors;
+  mintValidationReason: string | null;
+  burnValidationErrors: BurnValidationErrors;
+  burnValidationReason: string | null;
+  seizeValidationErrors: SeizeValidationErrors;
+  seizeValidationReason: string | null;
+  forceBurnValidationErrors: ForceBurnValidationErrors;
+  forceBurnValidationReason: string | null;
+  submitAlignment?: "start" | "end";
   onSignerWalletIdChange: (value: string) => void;
   onUpdateMetadata: () => void;
-  onRefreshSupply: () => void;
   onMint: () => void;
   onBurn: () => void;
   onSeize: () => void;
@@ -67,10 +80,15 @@ export function TokenActionForms(props: TokenActionFormsProps) {
         burnForm={props.burnForm}
         setBurnForm={props.setBurnForm}
         signerWallets={props.signerWallets}
+        walletOptions={props.walletOptions}
         signerUnavailableReason={props.signerUnavailableReason}
+        mintValidationErrors={props.mintValidationErrors}
+        mintValidationReason={props.mintValidationReason}
+        burnValidationErrors={props.burnValidationErrors}
+        burnValidationReason={props.burnValidationReason}
+        submitAlignment={props.submitAlignment}
         onSignerWalletIdChange={props.onSignerWalletIdChange}
         onUpdateMetadata={props.onUpdateMetadata}
-        onRefreshSupply={props.onRefreshSupply}
         onMint={props.onMint}
         onBurn={props.onBurn}
       />
@@ -91,7 +109,13 @@ export function TokenActionForms(props: TokenActionFormsProps) {
         allowlistEntries={props.allowlistEntries}
         allowlistError={props.allowlistError}
         signerWallets={props.signerWallets}
+        walletOptions={props.walletOptions}
         signerUnavailableReason={props.signerUnavailableReason}
+        seizeValidationErrors={props.seizeValidationErrors}
+        seizeValidationReason={props.seizeValidationReason}
+        forceBurnValidationErrors={props.forceBurnValidationErrors}
+        forceBurnValidationReason={props.forceBurnValidationReason}
+        submitAlignment={props.submitAlignment}
         onSignerWalletIdChange={props.onSignerWalletIdChange}
         onSeize={props.onSeize}
         onForceBurn={props.onForceBurn}

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-primary-forms.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-action-primary-forms.tsx
@@ -8,11 +8,15 @@ import { TokenActionCard } from "./token-action-card";
 import type {
   AdminAction,
   BurnFormState,
+  BurnValidationErrors,
   MetadataFormState,
   MintFormState,
+  MintValidationErrors,
 } from "./token-management-workspace.types";
 import { NON_WHITESPACE_PATTERN, SOLANA_ADDRESS_PATTERN } from "./token-management-workspace.utils";
 import { TokenSignerSelect } from "./token-signer-select";
+import { TokenValidationMessage } from "./token-validation-message";
+import { TokenWalletAddressField } from "./token-wallet-address-field";
 
 interface TokenActionPrimaryFormsProps {
   activeAction: AdminAction | null;
@@ -24,10 +28,15 @@ interface TokenActionPrimaryFormsProps {
   burnForm: BurnFormState;
   setBurnForm: Dispatch<SetStateAction<BurnFormState>>;
   signerWallets: PaymentsDashboardWallet[];
+  walletOptions: PaymentsDashboardWallet[];
   signerUnavailableReason: string | null;
+  mintValidationErrors: MintValidationErrors;
+  mintValidationReason: string | null;
+  burnValidationErrors: BurnValidationErrors;
+  burnValidationReason: string | null;
+  submitAlignment?: "start" | "end";
   onSignerWalletIdChange: (value: string) => void;
   onUpdateMetadata: () => void;
-  onRefreshSupply: () => void;
   onMint: () => void;
   onBurn: () => void;
 }
@@ -42,10 +51,15 @@ export function TokenActionPrimaryForms({
   burnForm,
   setBurnForm,
   signerWallets,
+  walletOptions,
   signerUnavailableReason,
+  mintValidationErrors,
+  mintValidationReason,
+  burnValidationErrors,
+  burnValidationReason,
+  submitAlignment = "start",
   onSignerWalletIdChange,
   onUpdateMetadata,
-  onRefreshSupply,
   onMint,
   onBurn,
 }: TokenActionPrimaryFormsProps) {
@@ -107,21 +121,17 @@ export function TokenActionPrimaryForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending}>
-              Save metadata
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button type="submit" disabled={isPending}>
+                Save metadata
+              </Button>
+            </div>
           </form>
-        </TokenActionCard>
-      ) : null}
-
-      {activeAction === "refresh-supply" ? (
-        <TokenActionCard
-          title="Refresh Supply"
-          description="Fetch supply from RPC and update cache."
-        >
-          <Button type="button" variant="secondary" onClick={onRefreshSupply} disabled={isPending}>
-            Refresh supply
-          </Button>
         </TokenActionCard>
       ) : null}
 
@@ -143,12 +153,15 @@ export function TokenActionPrimaryForms({
               signerUnavailableReason={signerUnavailableReason}
               onSignerWalletIdChange={onSignerWalletIdChange}
             />
-            <ActionField
+            <TokenWalletAddressField
               label="Destination"
               value={mintForm.destination}
+              walletOptions={walletOptions}
               required
               pattern={SOLANA_ADDRESS_PATTERN}
               title="Enter a valid Solana address."
+              placeholder="Destination wallet or token account"
+              error={mintValidationErrors.destination}
               onChange={(value) =>
                 setMintForm((previous) => ({
                   ...previous,
@@ -164,6 +177,7 @@ export function TokenActionPrimaryForms({
               step="any"
               value={mintForm.amount}
               required
+              error={mintValidationErrors.amount}
               onChange={(value) =>
                 setMintForm((previous) => ({
                   ...previous,
@@ -181,9 +195,21 @@ export function TokenActionPrimaryForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending || Boolean(signerUnavailableReason)}>
-              Mint tokens
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button
+                type="submit"
+                disabled={
+                  isPending || Boolean(signerUnavailableReason) || Boolean(mintValidationReason)
+                }
+              >
+                Mint tokens
+              </Button>
+            </div>
           </form>
         </TokenActionCard>
       ) : null}
@@ -203,12 +229,15 @@ export function TokenActionPrimaryForms({
               signerUnavailableReason={signerUnavailableReason}
               onSignerWalletIdChange={onSignerWalletIdChange}
             />
-            <ActionField
+            <TokenWalletAddressField
               label="Source"
               value={burnForm.source}
+              walletOptions={walletOptions}
               required
               pattern={SOLANA_ADDRESS_PATTERN}
               title="Enter a valid Solana address."
+              placeholder="Signer wallet or its token account"
+              error={burnValidationErrors.source}
               onChange={(value) =>
                 setBurnForm((previous) => ({
                   ...previous,
@@ -224,6 +253,7 @@ export function TokenActionPrimaryForms({
               step="any"
               value={burnForm.amount}
               required
+              error={burnValidationErrors.amount}
               onChange={(value) =>
                 setBurnForm((previous) => ({
                   ...previous,
@@ -241,9 +271,21 @@ export function TokenActionPrimaryForms({
                 }))
               }
             />
-            <Button type="submit" disabled={isPending || Boolean(signerUnavailableReason)}>
-              Burn tokens
-            </Button>
+            <div
+              className={[
+                "flex flex-wrap gap-2",
+                submitAlignment === "end" ? "justify-end" : "",
+              ].join(" ")}
+            >
+              <Button
+                type="submit"
+                disabled={
+                  isPending || Boolean(signerUnavailableReason) || Boolean(burnValidationReason)
+                }
+              >
+                Burn tokens
+              </Button>
+            </div>
           </form>
         </TokenActionCard>
       ) : null}
@@ -263,6 +305,7 @@ function ActionField({
   step,
   placeholder,
   inputMode,
+  error,
 }: {
   label: string;
   value: string;
@@ -275,6 +318,7 @@ function ActionField({
   step?: string;
   placeholder?: string;
   inputMode?: ComponentProps<typeof Input>["inputMode"];
+  error?: string | null;
 }) {
   const fieldId = useId();
 
@@ -297,9 +341,11 @@ function ActionField({
         step={step}
         placeholder={placeholder}
         inputMode={inputMode}
+        aria-invalid={Boolean(error)}
         onChange={(event) => onChange(event.currentTarget.value)}
         className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none"
       />
+      <TokenValidationMessage message={error ?? null} />
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-fund-management-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-fund-management-section.tsx
@@ -3,13 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { TokenDisabledActionTooltip } from "./token-disabled-action-tooltip";
 
-export type FundManagementModalAction =
-  | "deploy"
-  | "mint"
-  | "burn"
-  | "seize"
-  | "force-burn"
-  | "refresh-supply";
+export type FundManagementModalAction = "deploy" | "mint" | "burn";
 
 export interface FundManagementRow {
   id: FundManagementModalAction;

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-header.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-header.tsx
@@ -13,6 +13,7 @@ interface TokenManagementHeaderProps {
   tokenImageUrl: string | null;
   explorerHref: string | null;
   canDeployToken: boolean;
+  canManageTokenAdmin: boolean;
   isPending: boolean;
   deployDisabledReason?: string | null;
   mintDisabledReason?: string | null;
@@ -33,6 +34,7 @@ export function TokenManagementHeader({
   tokenImageUrl,
   explorerHref,
   canDeployToken,
+  canManageTokenAdmin,
   isPending,
   deployDisabledReason,
   mintDisabledReason,
@@ -109,7 +111,7 @@ export function TokenManagementHeader({
             </TokenDisabledActionTooltip>
           ) : (
             <>
-              {tokenStatus === "paused" ? (
+              {tokenStatus === "paused" && canManageTokenAdmin ? (
                 <TokenDisabledActionTooltip reason={isPending ? null : pauseDisabledReason}>
                   <Button
                     type="button"

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-header.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-header.tsx
@@ -16,12 +16,8 @@ interface TokenManagementHeaderProps {
   canManageTokenAdmin: boolean;
   isPending: boolean;
   deployDisabledReason?: string | null;
-  mintDisabledReason?: string | null;
-  burnDisabledReason?: string | null;
   pauseDisabledReason?: string | null;
   onCopyAddress: () => void;
-  onMintSelect: () => void;
-  onBurnSelect: () => void;
   onDeploy: () => void;
   onUnpause: () => void;
 }
@@ -37,12 +33,8 @@ export function TokenManagementHeader({
   canManageTokenAdmin,
   isPending,
   deployDisabledReason,
-  mintDisabledReason,
-  burnDisabledReason,
   pauseDisabledReason,
   onCopyAddress,
-  onMintSelect,
-  onBurnSelect,
   onDeploy,
   onUnpause,
 }: TokenManagementHeaderProps) {
@@ -122,25 +114,6 @@ export function TokenManagementHeader({
                   </Button>
                 </TokenDisabledActionTooltip>
               ) : null}
-              <TokenDisabledActionTooltip reason={isPending ? null : mintDisabledReason}>
-                <Button
-                  type="button"
-                  onClick={onMintSelect}
-                  disabled={isPending || Boolean(mintDisabledReason)}
-                >
-                  Mint
-                </Button>
-              </TokenDisabledActionTooltip>
-              <TokenDisabledActionTooltip reason={isPending ? null : burnDisabledReason}>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={onBurnSelect}
-                  disabled={isPending || Boolean(burnDisabledReason)}
-                >
-                  Burn
-                </Button>
-              </TokenDisabledActionTooltip>
             </>
           )}
         </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -2,8 +2,10 @@
 
 import { Button } from "@/components/ui/button";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import type { PaymentsDashboardWallet } from "@sdp/types";
 import { Loader2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
 import { TokenActionConfirmationDialog } from "./token-action-confirmation-dialog";
@@ -41,11 +43,20 @@ import {
   createInitialMetadataForm,
   createInitialMintForm,
   createInitialSeizeForm,
+  findWalletByWalletId,
+  getBurnValidationErrors,
+  getBurnValidationReason,
   getDefaultActionForTab,
   getDisplayedAuthorityAddress,
   getExplorerHref,
   getExtensionRows,
+  getForceBurnValidationErrors,
+  getForceBurnValidationReason,
+  getMintValidationErrors,
+  getMintValidationReason,
   getPermissionRows,
+  getSeizeValidationErrors,
+  getSeizeValidationReason,
   getSignerSelectionForAction,
   getTabForAction,
   getTokenActionDisabledReasons,
@@ -64,8 +75,38 @@ const managementTabs: Array<{ id: TokenManagementTab; label: string }> = [
   { id: "extensions", label: "Extensions" },
   { id: "compliance", label: "Compliance" },
   { id: "metadata", label: "Metadata" },
-  { id: "fund-management", label: "Fund Management" },
+  { id: "fund-management", label: "Operations" },
 ];
+
+function isTokenManagementTab(value: string | null): value is TokenManagementTab {
+  return managementTabs.some((tab) => tab.id === value);
+}
+
+function getDefaultActionForActiveTab({
+  tab,
+  canDeployToken,
+  showAllowlistControls,
+  canManageTokenAdmin,
+}: {
+  tab: TokenManagementTab;
+  canDeployToken: boolean;
+  showAllowlistControls: boolean;
+  canManageTokenAdmin: boolean;
+}): AdminAction | null {
+  if (tab === "fund-management" && canDeployToken) {
+    return null;
+  }
+
+  if (tab === "compliance" && !showAllowlistControls && canManageTokenAdmin) {
+    return "freeze";
+  }
+
+  if (tab === "compliance" && (!showAllowlistControls || !canManageTokenAdmin)) {
+    return null;
+  }
+
+  return getDefaultActionForTab(tab);
+}
 
 const liveFundManagementRows: Array<{
   id: FundManagementModalAction;
@@ -85,25 +126,41 @@ const liveFundManagementRows: Array<{
     helper: "Remove supply from a source wallet or token account.",
     actionLabel: "Burn",
   },
-  {
-    id: "seize",
-    title: "Force Transfer",
-    helper: "Move tokens administratively between two accounts.",
-    actionLabel: "Transfer",
-  },
-  {
-    id: "force-burn",
-    title: "Force Burn",
-    helper: "Burn tokens administratively from a source account.",
-    actionLabel: "Burn",
-  },
-  {
-    id: "refresh-supply",
-    title: "Refresh Supply",
-    helper: "Sync the cached supply value from on-chain state.",
-    actionLabel: "Refresh",
-  },
 ];
+
+function mergeWalletsPreferBalances(
+  primaryWallets: PaymentsDashboardWallet[],
+  secondaryWallets: PaymentsDashboardWallet[]
+): PaymentsDashboardWallet[] {
+  if (primaryWallets.length === 0) {
+    return secondaryWallets;
+  }
+
+  if (secondaryWallets.length === 0) {
+    return primaryWallets;
+  }
+
+  const secondaryById = new Map(secondaryWallets.map((wallet) => [wallet.id, wallet]));
+  const merged = primaryWallets.map((wallet) => {
+    const richerWallet = secondaryById.get(wallet.id);
+    if (!richerWallet) {
+      return wallet;
+    }
+
+    return Array.isArray(richerWallet.balances)
+      ? { ...wallet, balances: richerWallet.balances }
+      : wallet;
+  });
+
+  const primaryIds = new Set(primaryWallets.map((wallet) => wallet.id));
+  for (const wallet of secondaryWallets) {
+    if (!primaryIds.has(wallet.id)) {
+      merged.push(wallet);
+    }
+  }
+
+  return merged;
+}
 
 function LoadingSection({ message }: { message: string }) {
   return (
@@ -143,6 +200,9 @@ export function TokenManagementWorkspace({
   frozenAccountsHasMore: initialFrozenAccountsHasMore,
 }: TokenManagementWorkspaceProps) {
   const { dashboardAccess } = useDashboardWorkspace();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const {
     isPending,
     actionConfirmation,
@@ -151,7 +211,6 @@ export function TokenManagementWorkspace({
     dismissActionConfirmation,
     confirmAction,
   } = useTokenActionRunner();
-  const [activeTab, setActiveTab] = useState<TokenManagementTab>("overview");
   const [activeAction, setActiveAction] = useState<AdminAction | null>(null);
   const [authorityModalRow, setAuthorityModalRow] = useState<PermissionRow | null>(null);
   const [authorityModalCurrentAuthority, setAuthorityModalCurrentAuthority] = useState<
@@ -170,6 +229,21 @@ export function TokenManagementWorkspace({
   const [authorityForm, setAuthorityForm] = useState(createInitialAuthorityForm);
   const [freezeForm, setFreezeForm] = useState(createInitialFreezeForm);
   const [allowlistForm, setAllowlistForm] = useState(createInitialAllowlistForm);
+  const canManageTokenAdmin = dashboardAccess.capabilities.canManageTokenAdmin;
+  const showAllowlistControls = token.requiresAllowlist;
+  const visibleManagementTabs = useMemo(
+    () =>
+      managementTabs.filter(
+        (tab) => tab.id !== "compliance" || showAllowlistControls || canManageTokenAdmin
+      ),
+    [canManageTokenAdmin, showAllowlistControls]
+  );
+  const requestedTabParam = searchParams.get("tab");
+  const requestedTab = isTokenManagementTab(requestedTabParam) ? requestedTabParam : null;
+  const activeTab: TokenManagementTab =
+    requestedTab && visibleManagementTabs.some((tab) => tab.id === requestedTab)
+      ? requestedTab
+      : "overview";
   const shouldLoadSupportingData = activeTab !== "overview";
   const shouldLoadAuthorityWallets = canLoadAuthorityWallets(activeTab, token.status);
   const hasInitialSupportingData =
@@ -296,8 +370,10 @@ export function TokenManagementWorkspace({
         await revalidateSupportingDataAfterSuccess();
       },
     });
-  const authorityWallets =
-    authorityWalletsData?.authorityWallets ?? resolvedSupportingData.authorityWallets;
+  const authorityWallets = mergeWalletsPreferBalances(
+    authorityWalletsData?.authorityWallets ?? [],
+    resolvedSupportingData.authorityWallets
+  );
   const authorityWalletsError =
     authorityWalletsFetchError ??
     authorityWalletsData?.authorityWalletsError ??
@@ -318,7 +394,6 @@ export function TokenManagementWorkspace({
 
   const tokenBasePath = `/v1/issuance/tokens/${token.id}`;
   const explorerHref = getExplorerHref(token.mintAddress);
-  const canManageTokenAdmin = dashboardAccess.capabilities.canManageTokenAdmin;
   const canDeployToken = token.status === "pending" && !token.mintAddress;
   const {
     mintDisabledReason,
@@ -414,18 +489,12 @@ export function TokenManagementWorkspace({
     authorityWallets,
   });
   const extensionRows = getExtensionRows(token);
-  const showAllowlistControls = token.requiresAllowlist;
-  const visibleManagementTabs = useMemo(
-    () =>
-      managementTabs.filter(
-        (tab) => tab.id !== "compliance" || showAllowlistControls || canManageTokenAdmin
-      ),
-    [canManageTokenAdmin, showAllowlistControls]
-  );
   const complianceActions: Array<{ id: AdminAction; label: string }> = [
     ...(showAllowlistControls ? [{ id: "allowlist" as const, label: "Allowlist" }] : []),
     ...(canManageTokenAdmin
       ? [
+          { id: "seize" as const, label: "Force transfer" },
+          { id: "force-burn" as const, label: "Force burn" },
           { id: "freeze" as const, label: "Freeze" },
           { id: "pause" as const, label: "Pause" },
         ]
@@ -437,15 +506,73 @@ export function TokenManagementWorkspace({
     seizeDisabledReason ?? seizeSignerSelection.unavailableReason;
   const effectiveForceBurnDisabledReason =
     forceBurnDisabledReason ?? forceBurnSignerSelection.unavailableReason;
+  const selectedBurnSignerWallet =
+    findWalletByWalletId(
+      burnSignerSelection.wallets,
+      burnForm.signingWalletId || burnSignerSelection.defaultWalletId
+    ) ??
+    burnSignerSelection.wallets[0] ??
+    null;
+  const mintValidationReason = getMintValidationReason({
+    token,
+    destination: mintForm.destination,
+    amount: mintForm.amount,
+    allowlistEntries,
+  });
+  const mintValidationErrors = getMintValidationErrors({
+    token,
+    destination: mintForm.destination,
+    amount: mintForm.amount,
+    allowlistEntries,
+  });
+  const burnValidationReason = getBurnValidationReason({
+    token,
+    source: burnForm.source,
+    amount: burnForm.amount,
+    signerWallet: selectedBurnSignerWallet,
+    walletOptions: authorityWallets,
+  });
+  const burnValidationErrors = getBurnValidationErrors({
+    token,
+    source: burnForm.source,
+    amount: burnForm.amount,
+    signerWallet: selectedBurnSignerWallet,
+    walletOptions: authorityWallets,
+  });
+  const seizeValidationReason = getSeizeValidationReason({
+    token,
+    source: seizeForm.source,
+    destination: seizeForm.destination,
+    amount: seizeForm.amount,
+    walletOptions: authorityWallets,
+  });
+  const seizeValidationErrors = getSeizeValidationErrors({
+    token,
+    source: seizeForm.source,
+    destination: seizeForm.destination,
+    amount: seizeForm.amount,
+    walletOptions: authorityWallets,
+  });
+  const forceBurnValidationReason = getForceBurnValidationReason({
+    token,
+    source: forceBurnForm.source,
+    amount: forceBurnForm.amount,
+    walletOptions: authorityWallets,
+  });
+  const forceBurnValidationErrors = getForceBurnValidationErrors({
+    token,
+    source: forceBurnForm.source,
+    amount: forceBurnForm.amount,
+    walletOptions: authorityWallets,
+  });
   const fundManagementDisabledReasons: Record<FundManagementModalAction, string | null> = {
     deploy: deploySignerSelection.unavailableReason,
-    mint: effectiveMintDisabledReason,
-    burn: effectiveBurnDisabledReason,
-    seize: effectiveSeizeDisabledReason,
-    "force-burn": effectiveForceBurnDisabledReason,
-    "refresh-supply": null,
+    mint: effectiveMintDisabledReason ?? mintValidationReason,
+    burn: effectiveBurnDisabledReason ?? burnValidationReason,
   };
   const complianceActionDisabledReasons: Partial<Record<AdminAction, string | null>> = {
+    seize: effectiveSeizeDisabledReason ?? seizeValidationReason,
+    "force-burn": effectiveForceBurnDisabledReason ?? forceBurnValidationReason,
     freeze: freezeDisabledReason,
     pause: pauseDisabledReason,
   };
@@ -460,24 +587,63 @@ export function TokenManagementWorkspace({
           disabledReason: fundManagementDisabledReasons.deploy,
         },
       ]
-    : liveFundManagementRows
-        .filter((row) =>
-          canManageTokenAdmin
-            ? true
-            : row.id === "mint" || row.id === "burn" || row.id === "refresh-supply"
-        )
-        .map((row) => ({
-          ...row,
-          disabled: Boolean(fundManagementDisabledReasons[row.id]),
-          disabledReason: fundManagementDisabledReasons[row.id],
-        }));
+    : liveFundManagementRows.map((row) => ({
+        ...row,
+        disabled: Boolean(fundManagementDisabledReasons[row.id]),
+        disabledReason: fundManagementDisabledReasons[row.id],
+      }));
+
+  const syncActiveTabInUrl = useCallback(
+    (nextTab: TokenManagementTab, mode: "push" | "replace" = "push") => {
+      const nextSearchParams = new URLSearchParams(searchParams.toString());
+      if (nextTab === "overview") {
+        nextSearchParams.delete("tab");
+      } else {
+        nextSearchParams.set("tab", nextTab);
+      }
+
+      const nextQuery = nextSearchParams.toString();
+      const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
+      if (mode === "replace") {
+        router.replace(nextUrl, { scroll: false });
+        return;
+      }
+
+      router.push(nextUrl, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
 
   useEffect(() => {
-    if (!visibleManagementTabs.some((tab) => tab.id === activeTab)) {
-      setActiveTab("overview");
-      setActiveAction(null);
+    if (!requestedTabParam) {
+      return;
     }
-  }, [activeTab, visibleManagementTabs]);
+
+    if (requestedTabParam !== activeTab || activeTab === "overview") {
+      syncActiveTabInUrl(activeTab, "replace");
+    }
+  }, [activeTab, requestedTabParam, syncActiveTabInUrl]);
+
+  useEffect(() => {
+    const nextDefaultAction = getDefaultActionForActiveTab({
+      tab: activeTab,
+      canDeployToken,
+      showAllowlistControls,
+      canManageTokenAdmin,
+    });
+
+    setActiveAction((currentAction) =>
+      currentAction && getTabForAction(currentAction) === activeTab
+        ? currentAction
+        : nextDefaultAction
+    );
+  }, [activeTab, canDeployToken, showAllowlistControls, canManageTokenAdmin]);
+
+  useEffect(() => {
+    if (activeTab !== "fund-management" && fundManagementModalAction) {
+      setFundManagementModalAction(null);
+    }
+  }, [activeTab, fundManagementModalAction]);
 
   const handleCopy = async (value: string | null) => {
     if (!value) {
@@ -554,6 +720,10 @@ export function TokenManagementWorkspace({
       toast.error("Mint destination and amount are required.");
       return;
     }
+    if (mintValidationReason) {
+      toast.error(mintValidationReason);
+      return;
+    }
     if (!isPositiveAmount(amount)) {
       toast.error("Amount must be a positive number.");
       return;
@@ -594,6 +764,10 @@ export function TokenManagementWorkspace({
     const amount = burnForm.amount.trim();
     if (!source || !amount) {
       toast.error("Burn source and amount are required.");
+      return;
+    }
+    if (burnValidationReason) {
+      toast.error(burnValidationReason);
       return;
     }
     if (!isPositiveAmount(amount)) {
@@ -639,6 +813,10 @@ export function TokenManagementWorkspace({
       toast.error("Seize source, destination, and amount are required.");
       return;
     }
+    if (seizeValidationReason) {
+      toast.error(seizeValidationReason);
+      return;
+    }
     if (!isPositiveAmount(amount)) {
       toast.error("Amount must be a positive number.");
       return;
@@ -681,6 +859,10 @@ export function TokenManagementWorkspace({
     const amount = forceBurnForm.amount.trim();
     if (!source || !amount) {
       toast.error("Force-burn source and amount are required.");
+      return;
+    }
+    if (forceBurnValidationReason) {
+      toast.error(forceBurnValidationReason);
       return;
     }
     if (!isPositiveAmount(amount)) {
@@ -932,23 +1114,9 @@ export function TokenManagementWorkspace({
           signingWalletId: burnSignerSelection.defaultWalletId,
         }));
         break;
-      case "seize":
-        setSeizeForm((previous) => ({
-          ...previous,
-          signingWalletId: seizeSignerSelection.defaultWalletId,
-        }));
-        break;
-      case "force-burn":
-        setForceBurnForm((previous) => ({
-          ...previous,
-          signingWalletId: forceBurnSignerSelection.defaultWalletId,
-        }));
-        break;
-      case "refresh-supply":
-        break;
     }
 
-    setActiveTab("fund-management");
+    syncActiveTabInUrl("fund-management");
     setFundManagementModalAction(action);
   };
 
@@ -973,41 +1141,15 @@ export function TokenManagementWorkspace({
       case "burn":
         handleBurn();
         return;
-      case "seize":
-        handleSeize();
-        return;
-      case "force-burn":
-        handleForceBurn();
-        return;
-      case "refresh-supply":
-        handleRefreshSupply();
-        return;
     }
   };
 
   const handleTabChange = (tab: TokenManagementTab) => {
-    setActiveTab(tab);
-
-    const nextDefaultAction =
-      tab === "fund-management" && canDeployToken
-        ? null
-        : tab === "compliance" && !showAllowlistControls && canManageTokenAdmin
-          ? "freeze"
-          : tab === "compliance" && (!showAllowlistControls || !canManageTokenAdmin)
-            ? null
-            : getDefaultActionForTab(tab);
-    if (nextDefaultAction) {
-      setActiveAction(nextDefaultAction);
-      return;
-    }
-
-    setActiveAction((currentAction) =>
-      currentAction && getTabForAction(currentAction) === tab ? currentAction : null
-    );
+    syncActiveTabInUrl(tab);
   };
 
   const selectAction = (action: AdminAction) => {
-    setActiveTab(getTabForAction(action));
+    syncActiveTabInUrl(getTabForAction(action));
     setActiveAction(action);
   };
 
@@ -1093,10 +1235,19 @@ export function TokenManagementWorkspace({
         allowlistEntries={allowlistEntries}
         allowlistError={allowlistError}
         signerWallets={visibleActionSignerProps.signerWallets}
+        walletOptions={authorityWallets}
         signerUnavailableReason={visibleActionSignerProps.signerUnavailableReason}
+        mintValidationErrors={mintValidationErrors}
+        mintValidationReason={mintValidationReason}
+        burnValidationErrors={burnValidationErrors}
+        burnValidationReason={burnValidationReason}
+        seizeValidationErrors={seizeValidationErrors}
+        seizeValidationReason={seizeValidationReason}
+        forceBurnValidationErrors={forceBurnValidationErrors}
+        forceBurnValidationReason={forceBurnValidationReason}
+        submitAlignment="start"
         onSignerWalletIdChange={visibleActionSignerProps.onSignerWalletIdChange}
         onUpdateMetadata={handleUpdateMetadata}
-        onRefreshSupply={handleRefreshSupply}
         onMint={handleMint}
         onBurn={handleBurn}
         onSeize={handleSeize}
@@ -1121,13 +1272,9 @@ export function TokenManagementWorkspace({
         canDeployToken={canDeployToken}
         isPending={isPending}
         deployDisabledReason={deploySignerSelection.unavailableReason}
-        mintDisabledReason={effectiveMintDisabledReason}
-        burnDisabledReason={effectiveBurnDisabledReason}
         pauseDisabledReason={pauseDisabledReason}
         canManageTokenAdmin={canManageTokenAdmin}
         onCopyAddress={() => void handleCopy(token.mintAddress)}
-        onMintSelect={() => openFundManagementModal("mint")}
-        onBurnSelect={() => openFundManagementModal("burn")}
         onDeploy={() => {
           if (!canDeployToken) {
             return;
@@ -1197,6 +1344,8 @@ export function TokenManagementWorkspace({
             token={token}
             showTitle={false}
             mintAuthorityValue={displayedMintAuthority}
+            onRefreshSupply={token.status !== "pending" ? handleRefreshSupply : undefined}
+            refreshDisabled={isPending}
           />
         </div>
       ) : null}
@@ -1274,22 +1423,19 @@ export function TokenManagementWorkspace({
       ) : null}
 
       {activeTab === "fund-management" ? (
-        supportingDataLoading ? (
-          <LoadingSection message="Loading fund management data…" />
-        ) : (
-          <div className="space-y-4">
-            <TokenFundManagementSection
-              rows={fundManagementRows}
-              onOpenAction={openFundManagementModal}
-            />
-            <TokenTransactionsSection
-              transactions={transactions}
-              transactionsError={transactionsError}
-              transactionsTotal={transactionsTotal}
-              transactionsHasMore={transactionsHasMore}
-            />
-          </div>
-        )
+        <div className="space-y-4">
+          <TokenFundManagementSection
+            rows={fundManagementRows}
+            onOpenAction={openFundManagementModal}
+          />
+          <TokenTransactionsSection
+            transactions={transactions}
+            transactionsError={transactionsError}
+            transactionsTotal={transactionsTotal}
+            transactionsHasMore={transactionsHasMore}
+            isLoading={supportingDataLoading}
+          />
+        </div>
       ) : null}
 
       <TokenAuthorityModal
@@ -1312,9 +1458,9 @@ export function TokenManagementWorkspace({
       >
         {fundManagementModalAction === "deploy" ? (
           <div className="rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white p-5 shadow-[0_20px_40px_rgba(0,0,0,0.16)]">
-            <p className="text-[24px] leading-[1.15] font-medium text-[#1c1c1d]">Deploy token</p>
-            <p className="mt-2 text-[15px] leading-[1.45] text-[rgba(28,28,29,0.72)]">
-              This will deploy the token on-chain so fund management actions can be used.
+            <p className="text-[20px] leading-[1.2] font-medium text-[#1c1c1d]">Deploy token</p>
+            <p className="mt-2 text-[14px] leading-[1.45] text-[rgba(28,28,29,0.72)]">
+              This will deploy the token on-chain so operations can run.
             </p>
             <div className="mt-5 space-y-5">
               <TokenSignerSelect
@@ -1367,14 +1513,23 @@ export function TokenManagementWorkspace({
             allowlistEntries={allowlistEntries}
             allowlistError={allowlistError}
             signerWallets={fundManagementActionSignerProps.signerWallets}
+            walletOptions={authorityWallets}
             signerUnavailableReason={fundManagementActionSignerProps.signerUnavailableReason}
+            mintValidationErrors={mintValidationErrors}
+            mintValidationReason={mintValidationReason}
+            burnValidationErrors={burnValidationErrors}
+            burnValidationReason={burnValidationReason}
+            seizeValidationErrors={seizeValidationErrors}
+            seizeValidationReason={seizeValidationReason}
+            forceBurnValidationErrors={forceBurnValidationErrors}
+            forceBurnValidationReason={forceBurnValidationReason}
+            submitAlignment="end"
             onSignerWalletIdChange={fundManagementActionSignerProps.onSignerWalletIdChange}
             onUpdateMetadata={handleUpdateMetadata}
-            onRefreshSupply={() => submitFundManagementAction("refresh-supply")}
             onMint={() => submitFundManagementAction("mint")}
             onBurn={() => submitFundManagementAction("burn")}
-            onSeize={() => submitFundManagementAction("seize")}
-            onForceBurn={() => submitFundManagementAction("force-burn")}
+            onSeize={handleSeize}
+            onForceBurn={handleForceBurn}
             onAuthorityUpdate={handleAuthorityUpdate}
             onPause={handlePause}
             onFreeze={handleFreeze}

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
 import { TokenActionConfirmationDialog } from "./token-action-confirmation-dialog";
@@ -141,6 +142,7 @@ export function TokenManagementWorkspace({
   frozenAccountsTotal: initialFrozenAccountsTotal,
   frozenAccountsHasMore: initialFrozenAccountsHasMore,
 }: TokenManagementWorkspaceProps) {
+  const { dashboardAccess } = useDashboardWorkspace();
   const {
     isPending,
     actionConfirmation,
@@ -316,6 +318,7 @@ export function TokenManagementWorkspace({
 
   const tokenBasePath = `/v1/issuance/tokens/${token.id}`;
   const explorerHref = getExplorerHref(token.mintAddress);
+  const canManageTokenAdmin = dashboardAccess.capabilities.canManageTokenAdmin;
   const canDeployToken = token.status === "pending" && !token.mintAddress;
   const {
     mintDisabledReason,
@@ -391,15 +394,17 @@ export function TokenManagementWorkspace({
 
     return {
       ...rowWithDisplayedValue,
-      editDisabledReason: withWalletLoadError(
-        getSignerSelectionForAction({
-          action: "authority",
-          token,
-          authorityWallets,
-          metadataAuthority,
-          permissionRow: rowWithDisplayedValue,
-        })
-      ).unavailableReason,
+      editDisabledReason: canManageTokenAdmin
+        ? withWalletLoadError(
+            getSignerSelectionForAction({
+              action: "authority",
+              token,
+              authorityWallets,
+              metadataAuthority,
+              permissionRow: rowWithDisplayedValue,
+            })
+          ).unavailableReason
+        : "Only admins can edit token authorities.",
     };
   });
   const displayedMintAuthority = getDisplayedAuthorityAddress({
@@ -410,10 +415,21 @@ export function TokenManagementWorkspace({
   });
   const extensionRows = getExtensionRows(token);
   const showAllowlistControls = token.requiresAllowlist;
+  const visibleManagementTabs = useMemo(
+    () =>
+      managementTabs.filter(
+        (tab) => tab.id !== "compliance" || showAllowlistControls || canManageTokenAdmin
+      ),
+    [canManageTokenAdmin, showAllowlistControls]
+  );
   const complianceActions: Array<{ id: AdminAction; label: string }> = [
     ...(showAllowlistControls ? [{ id: "allowlist" as const, label: "Allowlist" }] : []),
-    { id: "freeze", label: "Freeze" },
-    { id: "pause", label: "Pause" },
+    ...(canManageTokenAdmin
+      ? [
+          { id: "freeze" as const, label: "Freeze" },
+          { id: "pause" as const, label: "Pause" },
+        ]
+      : []),
   ];
   const effectiveMintDisabledReason = mintDisabledReason ?? mintSignerSelection.unavailableReason;
   const effectiveBurnDisabledReason = burnDisabledReason ?? burnSignerSelection.unavailableReason;
@@ -444,11 +460,24 @@ export function TokenManagementWorkspace({
           disabledReason: fundManagementDisabledReasons.deploy,
         },
       ]
-    : liveFundManagementRows.map((row) => ({
-        ...row,
-        disabled: Boolean(fundManagementDisabledReasons[row.id]),
-        disabledReason: fundManagementDisabledReasons[row.id],
-      }));
+    : liveFundManagementRows
+        .filter((row) =>
+          canManageTokenAdmin
+            ? true
+            : row.id === "mint" || row.id === "burn" || row.id === "refresh-supply"
+        )
+        .map((row) => ({
+          ...row,
+          disabled: Boolean(fundManagementDisabledReasons[row.id]),
+          disabledReason: fundManagementDisabledReasons[row.id],
+        }));
+
+  useEffect(() => {
+    if (!visibleManagementTabs.some((tab) => tab.id === activeTab)) {
+      setActiveTab("overview");
+      setActiveAction(null);
+    }
+  }, [activeTab, visibleManagementTabs]);
 
   const handleCopy = async (value: string | null) => {
     if (!value) {
@@ -962,9 +991,11 @@ export function TokenManagementWorkspace({
     const nextDefaultAction =
       tab === "fund-management" && canDeployToken
         ? null
-        : tab === "compliance" && !showAllowlistControls
+        : tab === "compliance" && !showAllowlistControls && canManageTokenAdmin
           ? "freeze"
-          : getDefaultActionForTab(tab);
+          : tab === "compliance" && (!showAllowlistControls || !canManageTokenAdmin)
+            ? null
+            : getDefaultActionForTab(tab);
     if (nextDefaultAction) {
       setActiveAction(nextDefaultAction);
       return;
@@ -1093,6 +1124,7 @@ export function TokenManagementWorkspace({
         mintDisabledReason={effectiveMintDisabledReason}
         burnDisabledReason={effectiveBurnDisabledReason}
         pauseDisabledReason={pauseDisabledReason}
+        canManageTokenAdmin={canManageTokenAdmin}
         onCopyAddress={() => void handleCopy(token.mintAddress)}
         onMintSelect={() => openFundManagementModal("mint")}
         onBurnSelect={() => openFundManagementModal("burn")}
@@ -1107,7 +1139,7 @@ export function TokenManagementWorkspace({
 
       <div className="border-b border-[rgba(28,28,29,0.12)]">
         <div className="flex flex-wrap gap-8">
-          {managementTabs.map((tab) => (
+          {visibleManagementTabs.map((tab) => (
             <button
               key={tab.id}
               type="button"
@@ -1144,16 +1176,18 @@ export function TokenManagementWorkspace({
               unpaused.
             </p>
           </div>
-          <TokenDisabledActionTooltip reason={isPending ? null : pauseDisabledReason}>
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => handlePause(false)}
-              disabled={isPending || Boolean(pauseDisabledReason)}
-            >
-              Unpause token
-            </Button>
-          </TokenDisabledActionTooltip>
+          {canManageTokenAdmin ? (
+            <TokenDisabledActionTooltip reason={isPending ? null : pauseDisabledReason}>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => handlePause(false)}
+                disabled={isPending || Boolean(pauseDisabledReason)}
+              >
+                Unpause token
+              </Button>
+            </TokenDisabledActionTooltip>
+          ) : null}
         </div>
       ) : null}
 
@@ -1177,7 +1211,7 @@ export function TokenManagementWorkspace({
               permissionRows={permissionRows}
               extensionRows={extensionRows}
               showTitle={false}
-              canEditAuthorities={!canDeployToken}
+              canEditAuthorities={!canDeployToken && canManageTokenAdmin}
               onCopy={handleCopy}
               onEditAuthority={handleAuthorityModalOpen}
             />
@@ -1192,7 +1226,7 @@ export function TokenManagementWorkspace({
             permissionRows={permissionRows}
             extensionRows={extensionRows}
             showTitle={false}
-            canEditAuthorities={!canDeployToken}
+            canEditAuthorities={!canDeployToken && canManageTokenAdmin}
             onCopy={handleCopy}
             onEditAuthority={handleAuthorityModalOpen}
           />

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.types.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.types.ts
@@ -16,7 +16,6 @@ export type TokenManagementTab =
   | "fund-management";
 export type AdminAction =
   | "update-metadata"
-  | "refresh-supply"
   | "mint"
   | "burn"
   | "seize"
@@ -127,6 +126,27 @@ export interface ForceBurnFormState {
   delegateAuthority: string;
   memo: string;
   signingWalletId: string;
+}
+
+export interface MintValidationErrors {
+  destination: string | null;
+  amount: string | null;
+}
+
+export interface BurnValidationErrors {
+  source: string | null;
+  amount: string | null;
+}
+
+export interface SeizeValidationErrors {
+  source: string | null;
+  destination: string | null;
+  amount: string | null;
+}
+
+export interface ForceBurnValidationErrors {
+  source: string | null;
+  amount: string | null;
 }
 
 export interface AuthorityFormState {

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.utils.ts
@@ -1,4 +1,4 @@
-import type { PaymentsDashboardWallet, Token } from "@sdp/types";
+import type { PaymentsDashboardWallet, Token, TokenAllowlistEntry } from "@sdp/types";
 import type {
   ActionExecutionInput,
   ActionExecutionResult,
@@ -6,14 +6,18 @@ import type {
   AllowlistFormState,
   AuthorityFormState,
   BurnFormState,
+  BurnValidationErrors,
   ExecuteRouteResponse,
   ExtensionRow,
   ForceBurnFormState,
+  ForceBurnValidationErrors,
   FreezeFormState,
   MetadataFormState,
   MintFormState,
+  MintValidationErrors,
   PermissionRow,
   SeizeFormState,
+  SeizeValidationErrors,
   TokenManagementTab,
 } from "./token-management-workspace.types";
 
@@ -123,6 +127,87 @@ export function asOptionalString(value: string): string | undefined {
 export function isPositiveAmount(value: string): boolean {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0;
+}
+
+function isDecimalCharacter(char: string): boolean {
+  return (char >= "0" && char <= "9") || char === ".";
+}
+
+function isDecimalAmountString(value: string): boolean {
+  const normalized = value.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  let hasDigit = false;
+  let seenDot = false;
+
+  for (const char of normalized) {
+    if (!isDecimalCharacter(char)) {
+      return false;
+    }
+
+    if (char === ".") {
+      if (seenDot) {
+        return false;
+      }
+      seenDot = true;
+      continue;
+    }
+
+    hasDigit = true;
+  }
+
+  return hasDigit;
+}
+
+function parseTokenAmountToBaseUnits(value: string, decimals: number): bigint | null {
+  const normalized = value.trim();
+  if (!isDecimalAmountString(normalized) || !Number.isInteger(decimals) || decimals < 0) {
+    return null;
+  }
+
+  const [wholeRaw = "", fractionRaw = ""] = normalized.split(".");
+  const whole = wholeRaw.length ? wholeRaw : "0";
+  if (fractionRaw.length > decimals) {
+    return null;
+  }
+
+  const combined = `${whole}${fractionRaw.padEnd(decimals, "0")}`;
+  const sanitized = combined.replace(/^0+(?=\d)/, "");
+  return BigInt(sanitized || "0");
+}
+
+const ZERO_BIGINT = BigInt(0);
+
+function formatBaseUnitsAsTokenAmount(value: bigint, decimals: number): string {
+  const negative = value < ZERO_BIGINT;
+  const absolute = negative ? -value : value;
+  let digits = absolute.toString();
+
+  if (decimals === 0) {
+    return `${negative ? "-" : ""}${digits}`;
+  }
+
+  if (digits.length <= decimals) {
+    digits = digits.padStart(decimals + 1, "0");
+  }
+
+  const whole = digits.slice(0, -decimals);
+  const fraction = digits.slice(-decimals).replace(/0+$/, "");
+  return `${negative ? "-" : ""}${fraction ? `${whole}.${fraction}` : whole}`;
+}
+
+function getTokenDisplaySymbol(token: Token): string {
+  return token.symbol.trim() || token.name.trim() || "token";
+}
+
+function getWalletTokenBalanceRecord(wallet: PaymentsDashboardWallet, mintAddress: string | null) {
+  if (!mintAddress) {
+    return null;
+  }
+
+  return wallet.balances?.find((balance) => balance.mint === mintAddress) ?? null;
 }
 
 export function hasReachedMaxSupply(totalSupply: string, maxSupply: string | null): boolean {
@@ -378,7 +463,7 @@ function getPendingAuthoritySignerWallet(
     return null;
   }
 
-  return findSignerWalletById(availableWallets, token.signingWalletId) ?? availableWallets[0];
+  return findWalletByWalletId(availableWallets, token.signingWalletId) ?? availableWallets[0];
 }
 
 function pendingTokenRequiresPermanentDelegate(token: Token): boolean {
@@ -448,7 +533,7 @@ export function getSignerWalletOptionLabel(wallet: PaymentsDashboardWallet): str
   return `${primaryLabel} · ${formatValue(wallet.walletId)} · ${formatValue(wallet.publicKey)}`;
 }
 
-function findSignerWalletById(
+export function findWalletByWalletId(
   authorityWallets: PaymentsDashboardWallet[],
   walletId: string | null | undefined
 ): PaymentsDashboardWallet | null {
@@ -459,7 +544,7 @@ function findSignerWalletById(
   return authorityWallets.find((wallet) => wallet.walletId === walletId) ?? null;
 }
 
-function findSignerWalletByPublicKey(
+export function findWalletByPublicKey(
   authorityWallets: PaymentsDashboardWallet[],
   publicKey: string | null | undefined
 ): PaymentsDashboardWallet | null {
@@ -512,7 +597,7 @@ export function getSignerSelectionForAction({
 
   if (action === "deploy" || action === "burn") {
     const preferredWallet =
-      findSignerWalletById(availableWallets, token.signingWalletId) ?? availableWallets[0];
+      findWalletByWalletId(availableWallets, token.signingWalletId) ?? availableWallets[0];
 
     return {
       wallets: availableWallets,
@@ -558,7 +643,7 @@ export function getSignerSelectionForAction({
     };
   }
 
-  const matchedWallet = findSignerWalletByPublicKey(availableWallets, requiredAuthority);
+  const matchedWallet = findWalletByPublicKey(availableWallets, requiredAuthority);
   if (!matchedWallet) {
     return {
       wallets: [],
@@ -572,6 +657,314 @@ export function getSignerSelectionForAction({
     defaultWalletId: matchedWallet.walletId,
     unavailableReason: null,
   };
+}
+
+function getFirstValidationError(...messages: Array<string | null | undefined>): string | null {
+  return messages.find((message): message is string => Boolean(message)) ?? null;
+}
+
+export function getMintValidationErrors({
+  token,
+  destination,
+  amount,
+  allowlistEntries,
+}: {
+  token: Token;
+  destination: string;
+  amount: string;
+  allowlistEntries: TokenAllowlistEntry[];
+}): MintValidationErrors {
+  const normalizedAmount = amount.trim();
+  const normalizedDestination = destination.trim();
+  let amountError: string | null = null;
+  let destinationError: string | null = null;
+
+  if (normalizedAmount) {
+    const amountBaseUnits = parseTokenAmountToBaseUnits(normalizedAmount, token.decimals);
+    if (amountBaseUnits === null) {
+      amountError = "Enter a valid mint amount for this token.";
+    } else if (amountBaseUnits <= ZERO_BIGINT) {
+      amountError = "Mint amount must be greater than zero.";
+    } else if (token.maxSupply) {
+      const currentSupply = parseTokenAmountToBaseUnits(token.totalSupply, token.decimals);
+      const maxSupply = parseTokenAmountToBaseUnits(token.maxSupply, token.decimals);
+
+      if (
+        currentSupply !== null &&
+        maxSupply !== null &&
+        currentSupply + amountBaseUnits > maxSupply
+      ) {
+        const remaining = maxSupply > currentSupply ? maxSupply - currentSupply : ZERO_BIGINT;
+        amountError =
+          remaining > ZERO_BIGINT
+            ? `Mint amount exceeds the remaining supply cap of ${formatBaseUnitsAsTokenAmount(
+                remaining,
+                token.decimals
+              )} ${getTokenDisplaySymbol(token)}.`
+            : "Maximum supply has already been reached.";
+      }
+    }
+  }
+
+  if (
+    token.requiresAllowlist &&
+    normalizedDestination &&
+    allowlistEntries.length > 0 &&
+    !allowlistEntries.some((entry) => entry.address === normalizedDestination)
+  ) {
+    destinationError = "Destination is not on this token's allowlist.";
+  }
+
+  return {
+    destination: destinationError,
+    amount: amountError,
+  };
+}
+
+export function getMintValidationReason(args: {
+  token: Token;
+  destination: string;
+  amount: string;
+  allowlistEntries: TokenAllowlistEntry[];
+}): string | null {
+  const errors = getMintValidationErrors(args);
+  return getFirstValidationError(errors.destination, errors.amount);
+}
+
+export function getBurnValidationErrors({
+  token,
+  source,
+  amount,
+  signerWallet,
+  walletOptions,
+}: {
+  token: Token;
+  source: string;
+  amount: string;
+  signerWallet: PaymentsDashboardWallet | null;
+  walletOptions: PaymentsDashboardWallet[];
+}): BurnValidationErrors {
+  const normalizedAmount = amount.trim();
+  const normalizedSource = source.trim();
+  let amountError: string | null = null;
+  let sourceError: string | null = null;
+
+  if (normalizedAmount) {
+    const amountBaseUnits = parseTokenAmountToBaseUnits(normalizedAmount, token.decimals);
+    if (amountBaseUnits === null) {
+      amountError = "Enter a valid burn amount for this token.";
+    } else if (amountBaseUnits <= ZERO_BIGINT) {
+      amountError = "Burn amount must be greater than zero.";
+    } else if (!normalizedSource || !signerWallet) {
+      return {
+        source: sourceError,
+        amount: amountError,
+      };
+    } else {
+      const totalSupply = parseTokenAmountToBaseUnits(token.totalSupply, token.decimals);
+      if (totalSupply !== null && amountBaseUnits > totalSupply) {
+        amountError = `Burn amount exceeds the current supply of ${token.totalSupply} ${getTokenDisplaySymbol(token)}.`;
+      }
+    }
+  }
+
+  if (!normalizedSource || !signerWallet) {
+    return {
+      source: sourceError,
+      amount: amountError,
+    };
+  }
+
+  const sourceWallet = findWalletByPublicKey(walletOptions, normalizedSource);
+  if (sourceWallet && sourceWallet.publicKey !== signerWallet.publicKey) {
+    sourceError =
+      "Standard burn only works from the selected signer wallet. Use Force burn for a different wallet.";
+  }
+
+  const signerBalance = getWalletTokenBalanceRecord(signerWallet, token.mintAddress);
+  if (
+    !sourceError &&
+    normalizedSource === signerWallet.publicKey &&
+    Array.isArray(signerWallet.balances) &&
+    !signerBalance
+  ) {
+    sourceError = "The selected signer wallet does not currently hold this token.";
+    amountError = null;
+  }
+
+  if (normalizedAmount && normalizedSource === signerWallet.publicKey && signerBalance?.amount) {
+    const amountBaseUnits = parseTokenAmountToBaseUnits(normalizedAmount, token.decimals);
+    if (amountBaseUnits !== null && amountBaseUnits > BigInt(signerBalance.amount)) {
+      amountError = `The selected signer wallet only shows ${signerBalance.uiAmount} ${getTokenDisplaySymbol(
+        token
+      )}.`;
+    }
+  }
+
+  return {
+    source: sourceError,
+    amount: amountError,
+  };
+}
+
+export function getBurnValidationReason(args: {
+  token: Token;
+  source: string;
+  amount: string;
+  signerWallet: PaymentsDashboardWallet | null;
+  walletOptions: PaymentsDashboardWallet[];
+}): string | null {
+  const errors = getBurnValidationErrors(args);
+  return getFirstValidationError(errors.source, errors.amount);
+}
+
+export function getSeizeValidationErrors({
+  token,
+  source,
+  destination,
+  amount,
+  walletOptions,
+}: {
+  token: Token;
+  source: string;
+  destination: string;
+  amount: string;
+  walletOptions: PaymentsDashboardWallet[];
+}): SeizeValidationErrors {
+  const normalizedSource = source.trim();
+  const normalizedDestination = destination.trim();
+  const normalizedAmount = amount.trim();
+  let amountError: string | null = null;
+  let sourceError: string | null = null;
+  let destinationError: string | null = null;
+
+  if (normalizedSource && normalizedDestination && normalizedSource === normalizedDestination) {
+    destinationError = "Destination must be different from the source.";
+  }
+
+  if (!normalizedAmount) {
+    return {
+      source: sourceError,
+      destination: destinationError,
+      amount: amountError,
+    };
+  }
+
+  const amountBaseUnits = parseTokenAmountToBaseUnits(normalizedAmount, token.decimals);
+  if (amountBaseUnits === null) {
+    amountError = "Enter a valid transfer amount for this token.";
+  } else if (amountBaseUnits <= ZERO_BIGINT) {
+    amountError = "Transfer amount must be greater than zero.";
+  }
+
+  const sourceWallet = findWalletByPublicKey(walletOptions, normalizedSource);
+  const sourceBalance = sourceWallet
+    ? getWalletTokenBalanceRecord(sourceWallet, token.mintAddress)
+    : null;
+  if (sourceWallet && Array.isArray(sourceWallet.balances) && !sourceBalance) {
+    sourceError = "The selected source wallet does not currently hold this token.";
+    amountError = null;
+  }
+
+  if (
+    !sourceError &&
+    sourceBalance?.amount &&
+    amountBaseUnits !== null &&
+    amountBaseUnits > BigInt(sourceBalance.amount)
+  ) {
+    amountError = `The selected source wallet only shows ${sourceBalance.uiAmount} ${getTokenDisplaySymbol(
+      token
+    )}.`;
+  }
+
+  return {
+    source: sourceError,
+    destination: destinationError,
+    amount: amountError,
+  };
+}
+
+export function getSeizeValidationReason(args: {
+  token: Token;
+  source: string;
+  destination: string;
+  amount: string;
+  walletOptions: PaymentsDashboardWallet[];
+}): string | null {
+  const errors = getSeizeValidationErrors(args);
+  return getFirstValidationError(errors.source, errors.destination, errors.amount);
+}
+
+export function getForceBurnValidationErrors({
+  token,
+  source,
+  amount,
+  walletOptions,
+}: {
+  token: Token;
+  source: string;
+  amount: string;
+  walletOptions: PaymentsDashboardWallet[];
+}): ForceBurnValidationErrors {
+  const normalizedAmount = amount.trim();
+  let amountError: string | null = null;
+  if (!normalizedAmount) {
+    return {
+      source: null,
+      amount: amountError,
+    };
+  }
+
+  const amountBaseUnits = parseTokenAmountToBaseUnits(normalizedAmount, token.decimals);
+  if (amountBaseUnits === null) {
+    amountError = "Enter a valid burn amount for this token.";
+  } else if (amountBaseUnits <= ZERO_BIGINT) {
+    amountError = "Force-burn amount must be greater than zero.";
+  }
+
+  const sourceWallet = findWalletByPublicKey(walletOptions, source.trim());
+  const sourceBalance = sourceWallet
+    ? getWalletTokenBalanceRecord(sourceWallet, token.mintAddress)
+    : null;
+  const sourceError =
+    sourceWallet && Array.isArray(sourceWallet.balances) && !sourceBalance
+      ? "The selected source wallet does not currently hold this token."
+      : null;
+  if (sourceError) {
+    amountError = null;
+  }
+  if (
+    !sourceError &&
+    sourceBalance?.amount &&
+    amountBaseUnits !== null &&
+    amountBaseUnits > BigInt(sourceBalance.amount)
+  ) {
+    amountError = `The selected source wallet only shows ${sourceBalance.uiAmount} ${getTokenDisplaySymbol(
+      token
+    )}.`;
+  }
+
+  const totalSupply = parseTokenAmountToBaseUnits(token.totalSupply, token.decimals);
+  if (totalSupply !== null && amountBaseUnits !== null && amountBaseUnits > totalSupply) {
+    amountError = `Force-burn amount exceeds the current supply of ${token.totalSupply} ${getTokenDisplaySymbol(
+      token
+    )}.`;
+  }
+
+  return {
+    source: sourceError,
+    amount: amountError,
+  };
+}
+
+export function getForceBurnValidationReason(args: {
+  token: Token;
+  source: string;
+  amount: string;
+  walletOptions: PaymentsDashboardWallet[];
+}): string | null {
+  const errors = getForceBurnValidationErrors(args);
+  return getFirstValidationError(errors.source, errors.amount);
 }
 
 export function getExtensionRows(token: Token): ExtensionRow[] {
@@ -650,14 +1043,13 @@ export function getTabForAction(action: AdminAction): TokenManagementTab {
     case "allowlist":
     case "freeze":
     case "pause":
+    case "seize":
+    case "force-burn":
       return "compliance";
     case "update-metadata":
       return "metadata";
-    case "refresh-supply":
     case "mint":
     case "burn":
-    case "seize":
-    case "force-burn":
       return "fund-management";
   }
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-overview-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-overview-section.tsx
@@ -1,25 +1,52 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import type { Token } from "@sdp/types";
+import { TokenDisabledActionTooltip } from "./token-disabled-action-tooltip";
 import { formatDate } from "./token-management-workspace.utils";
 
 interface TokenOverviewSectionProps {
   token: Token;
   showTitle?: boolean;
   mintAuthorityValue?: string | null;
+  onRefreshSupply?: () => void;
+  refreshDisabled?: boolean;
+  refreshDisabledReason?: string | null;
 }
 
 export function TokenOverviewSection({
   token,
   showTitle = true,
   mintAuthorityValue,
+  onRefreshSupply,
+  refreshDisabled = false,
+  refreshDisabledReason = null,
 }: TokenOverviewSectionProps) {
   return (
     <section className="space-y-3">
-      {showTitle ? (
-        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
-          Token Overview
-        </h3>
+      {showTitle || onRefreshSupply ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          {showTitle ? (
+            <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-[#1c1c1d]">
+              Token Overview
+            </h3>
+          ) : (
+            <div />
+          )}
+          {onRefreshSupply ? (
+            <TokenDisabledActionTooltip reason={refreshDisabled ? refreshDisabledReason : null}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onRefreshSupply}
+                disabled={refreshDisabled}
+              >
+                Refresh supply
+              </Button>
+            </TokenDisabledActionTooltip>
+          ) : null}
+        </div>
       ) : null}
       <div className="overflow-hidden rounded-2xl border border-[rgba(28,28,29,0.12)] bg-white">
         <OverviewRow label="Token Address" value={token.mintAddress ?? "Not deployed"} monospace />

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-signer-select.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-signer-select.tsx
@@ -24,8 +24,12 @@ export function TokenSignerSelect({
 }: TokenSignerSelectProps) {
   const fieldId = useId();
   const isUnavailable = Boolean(signerUnavailableReason) || signerWallets.length === 0;
-  const message =
-    signerUnavailableReason ?? "SDP will sign this transaction with the selected wallet.";
+  const isLocked = !isUnavailable && signerWallets.length === 1;
+  const message = signerUnavailableReason
+    ? signerUnavailableReason
+    : isLocked
+      ? "SDP will sign this action with the required authority wallet."
+      : "SDP will sign this transaction with the selected wallet.";
   const selectedWallet =
     signerWallets.find((wallet) => wallet.walletId === signerWalletId) ?? signerWallets[0] ?? null;
 
@@ -37,32 +41,36 @@ export function TokenSignerSelect({
       >
         {label}
       </label>
-      <select
-        id={fieldId}
-        value={signerWalletId}
-        required={!isUnavailable}
-        disabled={isUnavailable}
-        onChange={(event) => onSignerWalletIdChange(event.currentTarget.value)}
-        className="h-11 w-full rounded-[12px] border border-[rgba(28,28,29,0.12)] bg-white px-4 text-sm text-[#1c1c1d] shadow-none outline-none transition-[box-shadow,border-color] focus:border-[rgba(28,28,29,0.28)] focus:ring-2 focus:ring-[rgba(28,28,29,0.12)] disabled:cursor-not-allowed disabled:bg-[rgba(28,28,29,0.04)] disabled:text-[rgba(28,28,29,0.45)]"
-      >
-        <option value="" disabled>
-          Select a signer wallet
-        </option>
-        {signerWallets.map((wallet) => (
-          <option key={wallet.id} value={wallet.walletId}>
-            {getSignerWalletOptionLabel(wallet)}
+      {isLocked && selectedWallet ? (
+        <TokenWalletIdentityCard wallet={selectedWallet} />
+      ) : (
+        <select
+          id={fieldId}
+          value={signerWalletId}
+          required={!isUnavailable}
+          disabled={isUnavailable}
+          onChange={(event) => onSignerWalletIdChange(event.currentTarget.value)}
+          className="h-11 w-full rounded-[12px] border border-[rgba(28,28,29,0.12)] bg-white px-4 text-sm text-[#1c1c1d] shadow-none outline-none transition-[box-shadow,border-color] focus:border-[rgba(28,28,29,0.28)] focus:ring-2 focus:ring-[rgba(28,28,29,0.12)] disabled:cursor-not-allowed disabled:bg-[rgba(28,28,29,0.04)] disabled:text-[rgba(28,28,29,0.45)]"
+        >
+          <option value="" disabled>
+            Select a signer wallet
           </option>
-        ))}
-      </select>
+          {signerWallets.map((wallet) => (
+            <option key={wallet.id} value={wallet.walletId}>
+              {getSignerWalletOptionLabel(wallet)}
+            </option>
+          ))}
+        </select>
+      )}
       <p
         className={[
-          "text-sm",
-          isUnavailable ? "text-[#8a1f2a]" : "text-[rgba(28,28,29,0.68)]",
+          "text-sm leading-5",
+          isUnavailable ? "text-[#9e2b38]" : "text-[rgba(28,28,29,0.68)]",
         ].join(" ")}
       >
         {message}
       </p>
-      {showSelectionSummary && !isUnavailable && selectedWallet ? (
+      {showSelectionSummary && !isUnavailable && selectedWallet && !isLocked ? (
         <TokenWalletIdentityCard wallet={selectedWallet} />
       ) : null}
     </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-transactions-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-transactions-section.tsx
@@ -10,6 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import type { TokenTransaction } from "@sdp/types";
+import { Loader2 } from "lucide-react";
 import { formatDate } from "./token-management-workspace.utils";
 
 interface TokenTransactionsSectionProps {
@@ -17,6 +18,7 @@ interface TokenTransactionsSectionProps {
   transactionsError: string | null;
   transactionsTotal: number | null;
   transactionsHasMore: boolean;
+  isLoading?: boolean;
 }
 
 export function TokenTransactionsSection({
@@ -24,6 +26,7 @@ export function TokenTransactionsSection({
   transactionsError,
   transactionsTotal,
   transactionsHasMore,
+  isLoading = false,
 }: TokenTransactionsSectionProps) {
   return (
     <Card className="gap-4">
@@ -32,7 +35,14 @@ export function TokenTransactionsSection({
         <CardDescription>Recent token operations</CardDescription>
       </CardHeader>
       <CardContent>
-        {transactionsError ? (
+        {isLoading ? (
+          <div className="flex min-h-[180px] items-center justify-center rounded-2xl border border-[rgba(28,28,29,0.08)] bg-[rgba(28,28,29,0.02)] px-6 py-10">
+            <div className="flex items-center gap-3 text-sm text-[rgba(28,28,29,0.64)]">
+              <Loader2 className="size-4 animate-spin" />
+              <span>Loading operations history…</span>
+            </div>
+          </div>
+        ) : transactionsError ? (
           <p className="text-sm text-[#8a1f2a]">{transactionsError}</p>
         ) : transactions.length === 0 ? (
           <p className="text-sm text-[rgba(28,28,29,0.68)]">No transactions yet.</p>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-validation-message.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-validation-message.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+interface TokenValidationMessageProps {
+  message: string | null;
+  reserveSpace?: boolean;
+}
+
+export function TokenValidationMessage({
+  message,
+  reserveSpace = true,
+}: TokenValidationMessageProps) {
+  if (!reserveSpace && !message) {
+    return null;
+  }
+
+  return (
+    <p
+      aria-live={message ? "polite" : undefined}
+      className={[
+        reserveSpace ? "min-h-5" : "",
+        "text-sm leading-5",
+        message ? "text-[#9e2b38]" : "invisible text-transparent",
+      ].join(" ")}
+    >
+      {message ?? "\u00A0"}
+    </p>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-wallet-address-field.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-wallet-address-field.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import type { PaymentsDashboardWallet } from "@sdp/types";
+import { ChevronDown, X } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { TokenValidationMessage } from "./token-validation-message";
+
+interface TokenWalletAddressFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  walletOptions?: PaymentsDashboardWallet[];
+  required?: boolean;
+  pattern?: string;
+  title?: string;
+  placeholder?: string;
+  error?: string | null;
+}
+
+export function TokenWalletAddressField({
+  label,
+  value,
+  onChange,
+  walletOptions = [],
+  required = false,
+  pattern,
+  title,
+  placeholder,
+  error,
+}: TokenWalletAddressFieldProps) {
+  const inputId = useId();
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const availableWallets = walletOptions.filter((wallet) => wallet.publicKey.trim());
+  const normalizedValue = value.trim().toLowerCase();
+  const filteredWallets = useMemo(() => {
+    if (!normalizedValue) {
+      return availableWallets;
+    }
+
+    return availableWallets.filter((wallet) => {
+      const label = wallet.label?.trim().toLowerCase() ?? "";
+      return (
+        label.includes(normalizedValue) || wallet.publicKey.toLowerCase().includes(normalizedValue)
+      );
+    });
+  }, [availableWallets, normalizedValue]);
+  const visibleWallets = isOpen ? filteredWallets : [];
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [isOpen]);
+
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={inputId}
+        className="block text-[12px] leading-5 font-medium tracking-[0.02em] text-[rgba(28,28,29,0.68)]"
+      >
+        {label}
+      </label>
+      <div ref={wrapperRef} className="relative">
+        <Input
+          id={inputId}
+          type="text"
+          value={value}
+          required={required}
+          pattern={pattern}
+          title={title}
+          placeholder={placeholder ?? "Choose a wallet or paste a Solana address"}
+          autoComplete="off"
+          aria-invalid={Boolean(error)}
+          onFocus={() => {
+            if (availableWallets.length > 0) {
+              setIsOpen(true);
+            }
+          }}
+          onChange={(event) => {
+            onChange(event.currentTarget.value);
+            if (availableWallets.length > 0) {
+              setIsOpen(true);
+            }
+          }}
+          className="h-11 rounded-[12px] border-[rgba(28,28,29,0.12)] bg-white pr-20 shadow-none"
+        />
+        {value.trim() ? (
+          <button
+            type="button"
+            aria-label={`Clear ${label.toLowerCase()}`}
+            onClick={() => {
+              onChange("");
+              setIsOpen(false);
+            }}
+            className="absolute top-1/2 right-11 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-[8px] text-[rgba(28,28,29,0.5)] transition-colors hover:bg-[rgba(28,28,29,0.06)] hover:text-[#1c1c1d]"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        ) : null}
+        {availableWallets.length > 0 ? (
+          <button
+            type="button"
+            aria-label="Select an existing wallet"
+            onClick={() => setIsOpen((current) => !current)}
+            className="absolute top-1/2 right-3 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-[8px] text-[rgba(28,28,29,0.62)] transition-colors hover:bg-[rgba(28,28,29,0.06)] hover:text-[#1c1c1d]"
+          >
+            <ChevronDown
+              className={["h-4 w-4 transition-transform", isOpen ? "rotate-180" : ""].join(" ")}
+            />
+          </button>
+        ) : null}
+        {visibleWallets.length > 0 ? (
+          <div className="absolute z-20 mt-2 max-h-64 w-full overflow-auto rounded-[14px] border border-[rgba(28,28,29,0.12)] bg-white py-2 shadow-[0_16px_40px_rgba(28,28,29,0.12)]">
+            {visibleWallets.map((wallet) => (
+              <button
+                key={wallet.id}
+                type="button"
+                onClick={() => {
+                  onChange(wallet.publicKey);
+                  setIsOpen(false);
+                }}
+                className="flex w-full flex-col items-start gap-1 px-4 py-3 text-left transition-colors hover:bg-[rgba(28,28,29,0.04)]"
+              >
+                <span className="text-sm font-medium text-[#1c1c1d]">
+                  {wallet.label?.trim() || wallet.walletId}
+                </span>
+                <span className="font-mono text-xs text-[rgba(28,28,29,0.62)]">
+                  {wallet.publicKey}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {availableWallets.length > 0 ? (
+        <p className="text-sm text-[rgba(28,28,29,0.64)]">
+          Type to filter existing wallets, use the dropdown, or paste any Solana address.
+        </p>
+      ) : null}
+      <TokenValidationMessage message={error ?? null} />
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/issuance/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/actions.ts
@@ -196,7 +196,7 @@ export async function createIssuanceTokenAction(
 
     return {
       state: "success",
-      message: `Token ${tokenName} created successfully.`,
+      message: `Draft ${tokenName} created. Deploy it on-chain from the token page.`,
       tokenId,
       tokenName,
     };

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-identity-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-identity-step.tsx
@@ -134,9 +134,7 @@ export function CreateTokenIdentityStep({
                 ? "Stablecoin defaults to 6 decimals."
                 : template === "custom"
                   ? "Custom tokens default to 9 decimals."
-                  : template === "tokenized-security"
-                    ? "Tokenized Security uses 8 decimals."
-                    : "Arcade tokens commonly use 0 decimals."}
+                  : "Tokenized Security uses 8 decimals."}
             </p>
           </div>
         </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
@@ -43,7 +43,7 @@ export function CreateIssuanceTokenModal({
   open,
   onOpenChange,
   hideTrigger = false,
-  triggerLabel = "Create token",
+  triggerLabel = "Create draft",
   triggerClassName,
 }: CreateIssuanceTokenModalProps = {}) {
   const router = useRouter();
@@ -180,7 +180,7 @@ export function CreateIssuanceTokenModal({
       setSubmitState(response);
 
       if (response.state === "success") {
-        toast.success(response.message ?? "Token created successfully.");
+        toast.success(response.message ?? "Draft created. Deploy it on-chain from the token page.");
         close();
         router.refresh();
       }
@@ -220,10 +220,12 @@ export function CreateIssuanceTokenModal({
               <div className="flex items-start justify-between border-b border-[rgba(28,28,29,0.1)] bg-[rgba(28,28,29,0.02)] px-8 py-7">
                 <div>
                   <p className="text-4xl leading-none font-semibold">
-                    {template ? getTemplateTitle(template) : "Create New Token"}
+                    {template ? getTemplateTitle(template) : "Create New Token Draft"}
                   </p>
                   <p className="mt-2 text-lg text-[rgba(28,28,29,0.62)]">
-                    {template ? "Configure your token parameters" : "Choose how you want to start."}
+                    {template
+                      ? "Configure the draft now, then deploy it on-chain from the token page."
+                      : "Choose a template to create a draft first, then deploy it on-chain."}
                   </p>
                 </div>
                 <button

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.types.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.types.ts
@@ -1,4 +1,4 @@
-export type TemplateSelection = "stablecoin" | "custom" | "tokenized-security" | "arcade";
+export type TemplateSelection = "stablecoin" | "custom" | "tokenized-security";
 export type CreationStep = "identity" | "features";
 export type AccessControlMode = "allowlist" | "blocklist";
 

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
@@ -1,4 +1,4 @@
-import { BadgeDollarSign, CircleHelp, Gamepad2, ShieldCheck } from "lucide-react";
+import { BadgeDollarSign, CircleHelp, ShieldCheck } from "lucide-react";
 import type { CreateIssuanceTokenResult } from "./actions";
 import type {
   AccessControlMode,
@@ -29,15 +29,6 @@ export const templateCards: Array<
     iconClassName: "bg-[#d8f7e4] text-[#0f9b58]",
     enabled: true,
     template: "tokenized-security",
-  },
-  {
-    id: "arcade",
-    name: "Arcade Token",
-    description: "Deploy a gaming or utility token with custom extensions and features.",
-    icon: Gamepad2,
-    iconClassName: "bg-[#f7ead8] text-[#ff6b00]",
-    enabled: true,
-    template: "arcade",
   },
   {
     id: "custom",
@@ -72,30 +63,26 @@ export function createInitialDraft(): TokenDraft {
 export function getTemplateTitle(template: TemplateSelection): string {
   switch (template) {
     case "stablecoin":
-      return "Create a Stablecoin";
+      return "Create Stablecoin Draft";
     case "custom":
-      return "Create Custom Token";
+      return "Create Custom Token Draft";
     case "tokenized-security":
-      return "Create Tokenized Security";
-    case "arcade":
-      return "Create Arcade Token";
+      return "Create Tokenized Security Draft";
     default:
-      return "Create Token";
+      return "Create Token Draft";
   }
 }
 
 export function getCreateButtonLabel(template: TemplateSelection): string {
   switch (template) {
     case "stablecoin":
-      return "Create Stablecoin";
+      return "Create Stablecoin Draft";
     case "custom":
-      return "Create Custom Token";
+      return "Create Custom Token Draft";
     case "tokenized-security":
-      return "Create Tokenized Security";
-    case "arcade":
-      return "Create Arcade Token";
+      return "Create Tokenized Security Draft";
     default:
-      return "Create Token";
+      return "Create Token Draft";
   }
 }
 
@@ -107,8 +94,6 @@ export function getTemplateDefaultDecimals(template: TemplateSelection): TokenDr
       return "9";
     case "tokenized-security":
       return "8";
-    case "arcade":
-      return "0";
     default:
       return "6";
   }
@@ -123,8 +108,6 @@ export function getTemplateDecimalOptions(
       return ["6", "9"];
     case "tokenized-security":
       return ["8"];
-    case "arcade":
-      return ["0", "6"];
     default:
       return ["6", "9"];
   }

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -106,8 +106,8 @@ function getTokenTypeLabel(template: IssuanceTokenView["template"]): string {
   return template;
 }
 
-function getDeploymentStatus(token: IssuanceTokenView): "pending" | "active" {
-  return token.mintAddress || token.deployedAt ? "active" : "pending";
+function getDeploymentStatus(token: IssuanceTokenView): "draft" | "active" {
+  return token.mintAddress || token.deployedAt ? "active" : "draft";
 }
 
 export function IssuanceWorkspace({
@@ -220,7 +220,7 @@ export function IssuanceWorkspace({
                 className="h-10 rounded-[10px] bg-[#1c1c1d] px-4 text-white hover:bg-[rgba(28,28,29,0.92)]"
                 onClick={() => setIsCreateTokenModalOpen(true)}
               >
-                Create token
+                Create draft
               </Button>
             </div>
 

--- a/apps/sdp-web/src/app/dashboard/issuance/template-catalog.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/template-catalog.ts
@@ -1,4 +1,4 @@
-export type IssuanceTemplateId = "stablecoin" | "arcade" | "tokenized-security" | "custom";
+export type IssuanceTemplateId = "stablecoin" | "tokenized-security" | "custom";
 
 export interface IssuanceTemplateCatalogEntry {
   id: IssuanceTemplateId;
@@ -15,13 +15,6 @@ export const issuanceTemplateCatalog: IssuanceTemplateCatalogEntry[] = [
     description: "USD-backed stablecoins with compliance controls.",
     helper: "Best for fiat-pegged assets with transfer controls and admin freeze support.",
     defaultDecimals: 6,
-  },
-  {
-    id: "arcade",
-    name: "Arcade",
-    description: "Closed-loop gaming tokens with optional allowlists.",
-    helper: "Optimized for game economies and loyalty points with simpler defaults.",
-    defaultDecimals: 0,
   },
   {
     id: "tokenized-security",

--- a/apps/sdp-web/src/app/dashboard/layout.tsx
+++ b/apps/sdp-web/src/app/dashboard/layout.tsx
@@ -1,10 +1,15 @@
 import { DashboardShell } from "@/components/dashboard-shell";
 import { DashboardWorkspaceProvider } from "@/contexts/dashboard-workspace-context";
+import { resolveDashboardAccess } from "@/lib/dashboard-access";
+import { auth } from "@clerk/nextjs/server";
 import type { ReactNode } from "react";
 
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const { orgRole } = await auth();
+  const dashboardAccess = resolveDashboardAccess(orgRole);
+
   return (
-    <DashboardWorkspaceProvider>
+    <DashboardWorkspaceProvider dashboardAccess={dashboardAccess}>
       <DashboardShell>{children}</DashboardShell>
     </DashboardWorkspaceProvider>
   );

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { resolveDashboardAccess } from "@/lib/dashboard-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -7,7 +8,7 @@ import { resolveTotalBalance } from "./payments/payments-overview.utils";
 import { fetchPaymentsAggregate, fetchPaymentsWallets } from "./payments/payments-page.data";
 
 export default async function DashboardPage() {
-  const { userId, orgId } = await auth();
+  const { userId, orgId, orgRole } = await auth();
   if (!userId) {
     redirect("/sign-in");
   }
@@ -16,6 +17,7 @@ export default async function DashboardPage() {
   }
 
   const trace = createTimedTrace("dashboard.home.page");
+  const dashboardAccess = resolveDashboardAccess(orgRole);
 
   try {
     const apiClient = await trace.step("create_sdp_api_client", () =>
@@ -43,6 +45,7 @@ export default async function DashboardPage() {
 
     return (
       <HomeWorkspace
+        dashboardAccess={dashboardAccess}
         totalBalance={totalBalance}
         totalBalanceError={aggregateError}
         wallets={wallets}

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import { resolveDashboardAccess } from "@/lib/dashboard-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -8,7 +7,7 @@ import { resolveTotalBalance } from "./payments/payments-overview.utils";
 import { fetchPaymentsAggregate, fetchPaymentsWallets } from "./payments/payments-page.data";
 
 export default async function DashboardPage() {
-  const { userId, orgId, orgRole } = await auth();
+  const { userId, orgId } = await auth();
   if (!userId) {
     redirect("/sign-in");
   }
@@ -17,8 +16,6 @@ export default async function DashboardPage() {
   }
 
   const trace = createTimedTrace("dashboard.home.page");
-  const dashboardAccess = resolveDashboardAccess(orgRole);
-
   try {
     const apiClient = await trace.step("create_sdp_api_client", () =>
       createSdpApiClient(trace.childContext("dashboard.home.api"))
@@ -45,7 +42,6 @@ export default async function DashboardPage() {
 
     return (
       <HomeWorkspace
-        dashboardAccess={dashboardAccess}
         totalBalance={totalBalance}
         totalBalanceError={aggregateError}
         wallets={wallets}

--- a/apps/sdp-web/src/app/dashboard/payments/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/page.tsx
@@ -4,6 +4,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { fetchActiveApiKeys, resolvePlaygroundApiBaseUrl } from "../playground-api-data";
 import {
+  fetchDashboardPaymentTransfers,
   fetchPaymentTransfers,
   fetchPaymentsAggregate,
   fetchPaymentsIssuedTokenSymbols,
@@ -56,7 +57,11 @@ export default async function PaymentsPage({ searchParams }: PaymentsPageProps) 
       isPlaygroundTab
         ? Promise.resolve({ ok: true as const, data: null })
         : trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
-      trace.step("fetch_payment_transfers", () => fetchPaymentTransfers(apiClient.request)),
+      trace.step("fetch_payment_transfers", () =>
+        isPlaygroundTab
+          ? fetchPaymentTransfers(apiClient.request)
+          : fetchDashboardPaymentTransfers(apiClient.request)
+      ),
       isPlaygroundTab
         ? Promise.resolve({ ok: true as const, data: [] })
         : trace.step("fetch_payment_token_symbols", () =>

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
@@ -136,12 +136,16 @@ export async function fetchPaymentsAggregate(
 
 export async function fetchPaymentTransfers(
   request: SdpApiClient["request"],
-  pageSize = 20
+  pageSize = 20,
+  options: {
+    walletId?: string;
+  } = {}
 ): Promise<FetchResult<PaymentTransferSummary[]>> {
   try {
     const query = new URLSearchParams({
       page: "1",
       pageSize: String(pageSize),
+      ...(options.walletId ? { wallet: options.walletId } : {}),
     }).toString();
     const response = await request(`/v1/payments/transfers?${query}`);
     if (!response.ok) {
@@ -194,6 +198,77 @@ export async function fetchPaymentTransfers(
       error: error instanceof Error ? error.message : "Unable to load transfers",
     };
   }
+}
+
+function dedupeTransfers(transfers: PaymentTransferSummary[]): PaymentTransferSummary[] {
+  const seen = new Set<string>();
+
+  return transfers.filter((transfer) => {
+    const key = transfer.signature?.trim() || transfer.id;
+    if (!key || seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export async function fetchDashboardPaymentTransfers(
+  request: SdpApiClient["request"],
+  pageSize = 20
+): Promise<FetchResult<PaymentTransferSummary[]>> {
+  const walletsResult = await fetchPaymentsWallets(request, { view: "summary" });
+
+  if (!walletsResult.ok || (walletsResult.data?.length ?? 0) === 0) {
+    return fetchPaymentTransfers(request, pageSize);
+  }
+
+  const settledTransfers = await Promise.allSettled(
+    (walletsResult.data ?? []).map((wallet) =>
+      fetchPaymentTransfers(request, pageSize, { walletId: wallet.walletId })
+    )
+  );
+
+  const mergedTransfers: PaymentTransferSummary[] = [];
+  let lastError: string | undefined;
+
+  for (const result of settledTransfers) {
+    if (result.status !== "fulfilled") {
+      lastError =
+        result.reason instanceof Error ? result.reason.message : "Unable to load transfers";
+      continue;
+    }
+
+    if (!result.value.ok) {
+      lastError = result.value.error;
+      continue;
+    }
+
+    mergedTransfers.push(...(result.value.data ?? []));
+  }
+
+  if (mergedTransfers.length === 0) {
+    const fallback = await fetchPaymentTransfers(request, pageSize);
+    if (fallback.ok || !lastError) {
+      return fallback;
+    }
+
+    return {
+      ok: false,
+      error: lastError,
+    };
+  }
+
+  return {
+    ok: true,
+    data: dedupeTransfers(mergedTransfers)
+      .sort((left, right) => {
+        const leftTimestamp = left.createdAt ? new Date(left.createdAt).getTime() : 0;
+        const rightTimestamp = right.createdAt ? new Date(right.createdAt).getTime() : 0;
+        return rightTimestamp - leftTimestamp;
+      })
+      .slice(0, pageSize),
+  };
 }
 
 export async function fetchPaymentsIssuedTokenSymbols(

--- a/apps/sdp-web/src/app/dashboard/settings/organization-rpc-settings-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/organization-rpc-settings-form.tsx
@@ -287,7 +287,7 @@ export function OrganizationRpcSettingsForm({
               size="sm"
               variant="secondary"
               className="w-full sm:w-[112px] sm:justify-center"
-              disabled={!canManageSettings || isTesting || isSaving}
+              disabled={isTesting || isSaving}
               onClick={() => {
                 void testProvider();
               }}

--- a/apps/sdp-web/src/app/dashboard/settings/organization-rpc-settings-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/organization-rpc-settings-form.tsx
@@ -166,8 +166,10 @@ const RPC_PROVIDER_LABELS: Record<OrganizationRpcProvider, string> = {
 };
 
 export function OrganizationRpcSettingsForm({
+  canManageSettings,
   organization,
 }: {
+  canManageSettings: boolean;
   organization: SettingsOrganization;
 }) {
   const rpcProvider = organization.settings?.rpcProvider ?? "default";
@@ -253,6 +255,12 @@ export function OrganizationRpcSettingsForm({
           </div>
         </div>
 
+        {!canManageSettings ? (
+          <div className="rounded-xl border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-3 py-2 text-sm text-[rgba(28,28,29,0.72)]">
+            You can view organization RPC settings, but only admins can change them.
+          </div>
+        ) : null}
+
         <div className="grid gap-2">
           <Label htmlFor="rpcProvider">RPC provider</Label>
           <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_112px] sm:items-center">
@@ -261,7 +269,7 @@ export function OrganizationRpcSettingsForm({
               name="rpcProvider"
               className="h-10 w-full min-w-0 rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
               value={selectedProvider}
-              disabled={isSaving || isTesting}
+              disabled={!canManageSettings || isSaving || isTesting}
               onChange={(event) => {
                 const nextProvider = event.currentTarget.value as typeof selectedProvider;
                 setSelectedProvider(nextProvider);
@@ -279,7 +287,7 @@ export function OrganizationRpcSettingsForm({
               size="sm"
               variant="secondary"
               className="w-full sm:w-[112px] sm:justify-center"
-              disabled={isTesting || isSaving}
+              disabled={!canManageSettings || isTesting || isSaving}
               onClick={() => {
                 void testProvider();
               }}

--- a/apps/sdp-web/src/app/dashboard/settings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/page.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { resolveDashboardAccess } from "@/lib/dashboard-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -29,7 +30,7 @@ type ProjectListResponse = {
 };
 
 export default async function SettingsPage() {
-  const { userId, orgId } = await auth();
+  const { userId, orgId, orgRole } = await auth();
   if (!userId) {
     redirect("/sign-in");
   }
@@ -38,6 +39,7 @@ export default async function SettingsPage() {
   }
 
   const trace = createTimedTrace("dashboard.settings.page");
+  const dashboardAccess = resolveDashboardAccess(orgRole);
 
   let organization: Organization | null = null;
   let isLinked = true;
@@ -123,7 +125,10 @@ export default async function SettingsPage() {
             ) : null}
 
             {!loadError && organization ? (
-              <OrganizationRpcSettingsForm organization={organization} />
+              <OrganizationRpcSettingsForm
+                organization={organization}
+                canManageSettings={dashboardAccess.capabilities.canManageOrgSettings}
+              />
             ) : null}
 
             {!loadError && !organization && !isLinked ? (

--- a/apps/sdp-web/src/app/members/actions.ts
+++ b/apps/sdp-web/src/app/members/actions.ts
@@ -22,7 +22,7 @@ export async function listMembers(): Promise<Member[]> {
 
 export async function inviteMember(formData: FormData) {
   const email = String(formData.get("email") ?? "").trim();
-  const role = String(formData.get("role") ?? "viewer").trim();
+  const role = String(formData.get("role") ?? "member").trim();
 
   if (!email) {
     throw new Error("Email is required");

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -56,11 +56,6 @@ const docsHref =
   process.env.NEXT_PUBLIC_SDP_DOCS_URL ||
   (process.env.NODE_ENV === "development" ? "http://localhost:3001/docs" : DEFAULT_SDP_DOCS_URL);
 
-const bottomNavItems: NavItem[] = [
-  { label: "API Docs", href: docsHref, icon: Library, external: true },
-  { label: "Settings", href: "/dashboard/settings", icon: Settings2 },
-];
-
 type DashboardPageConfig = {
   title: string;
   headerNav?: ReactNode;
@@ -382,10 +377,12 @@ function SidebarGroup({
 }
 
 function DashboardSidebarContent({
+  bottomNavItems,
   pathname,
   onNavigate,
   onClose,
 }: {
+  bottomNavItems: NavItem[];
   pathname: string;
   onNavigate?: () => void;
   onClose: () => void;
@@ -454,11 +451,17 @@ function DashboardSidebarContent({
 export function DashboardShell({ children }: { children: ReactNode }) {
   const { isLoaded, isSignedIn, orgId } = useAuth();
   const pathname = usePathname();
-  const { isSidebarOpen, issuanceTab, setSidebarOpen } = useDashboardWorkspace();
+  const { dashboardAccess, isSidebarOpen, issuanceTab, setSidebarOpen } = useDashboardWorkspace();
   const [isMobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const previousPathnameRef = useRef(pathname);
   const sidebarWidth = 296;
   const pageConfig = getDashboardPageConfig(pathname);
+  const bottomNavItems: NavItem[] = [
+    { label: "API Docs", href: docsHref, icon: Library, external: true },
+    ...(dashboardAccess.capabilities.canManageOrgSettings
+      ? [{ label: "Settings", href: "/dashboard/settings", icon: Settings2 }]
+      : []),
+  ];
   const contentWidthClass = pageConfig.contentWidthClass ?? "max-w-5xl";
   const backAction = pageConfig.backAction ? (
     <HeaderBackAction href={pageConfig.backAction.href} label={pageConfig.backAction.label} />
@@ -563,6 +566,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
           ].join(" ")}
         >
           <DashboardSidebarContent
+            bottomNavItems={bottomNavItems}
             pathname={pathname}
             onNavigate={undefined}
             onClose={() => setSidebarOpen(false)}
@@ -579,6 +583,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
             />
             <div className="relative z-10 flex h-full w-[296px] max-w-[85vw] flex-col justify-between border-r border-[rgba(28,28,29,0.10)] bg-[#e9e7de] shadow-[0_12px_40px_rgba(28,28,29,0.16)]">
               <DashboardSidebarContent
+                bottomNavItems={bottomNavItems}
                 pathname={pathname}
                 onNavigate={() => setMobileSidebarOpen(false)}
                 onClose={() => setMobileSidebarOpen(false)}

--- a/apps/sdp-web/src/components/playground-api-key-selector.tsx
+++ b/apps/sdp-web/src/components/playground-api-key-selector.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import { KeyRound } from "lucide-react";
+import Link from "next/link";
 
 function formatKeyIdentifier(keyPrefix: string): string {
   const trimmed = keyPrefix.trim();
@@ -40,44 +42,65 @@ export function PlaygroundApiKeySelector() {
     );
   }
 
+  const selectedApiKeySecret = selectedApiKey
+    ? getStoredApiKeySecret({
+        apiKeyId: selectedApiKey.id,
+        keyPrefix: selectedApiKey.keyPrefix,
+      })
+    : null;
+
   return (
-    <div className="relative w-full min-w-[260px] lg:max-w-[360px]">
-      <div className="pointer-events-none flex h-11 w-full items-center rounded-[14px] border border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none">
-        <span className="flex min-w-0 items-center gap-2 pr-8">
-          <KeyRound className="h-4 w-4 text-[rgba(28,28,29,0.58)]" />
-          <span className="truncate text-left text-sm font-medium text-[#1c1c1d]">
-            {selectedApiKey
-              ? formatApiKeyLabel(selectedApiKey.name, selectedApiKey.keyPrefix)
-              : "Select API key"}
+    <div className="w-full min-w-[260px] lg:max-w-[360px]">
+      <div className="relative">
+        <div className="pointer-events-none flex h-11 w-full items-center rounded-[14px] border border-[rgba(28,28,29,0.12)] bg-white px-4 shadow-none">
+          <span className="flex min-w-0 items-center gap-2 pr-8">
+            <KeyRound className="h-4 w-4 text-[rgba(28,28,29,0.58)]" />
+            <span className="truncate text-left text-sm font-medium text-[#1c1c1d]">
+              {selectedApiKey
+                ? formatApiKeyLabel(selectedApiKey.name, selectedApiKey.keyPrefix)
+                : "Select API key"}
+            </span>
           </span>
-        </span>
+        </div>
+
+        <select
+          aria-label="Select API key"
+          className="absolute inset-0 h-full w-full cursor-pointer appearance-none rounded-[14px] opacity-0"
+          value={selectedPlaygroundApiKeyId ?? playgroundApiKeys[0].id}
+          onChange={(event) => setSelectedPlaygroundApiKeyId(event.currentTarget.value)}
+        >
+          {playgroundApiKeys.map((apiKey) => (
+            <option key={apiKey.id} value={apiKey.id}>
+              {formatApiKeyLabel(apiKey.name, apiKey.keyPrefix)}
+            </option>
+          ))}
+        </select>
+
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          className="pointer-events-none absolute top-1/2 right-4 h-4 w-4 -translate-y-1/2 text-[rgba(28,28,29,0.42)]"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m4 6 4 4 4-4" />
+        </svg>
       </div>
 
-      <select
-        aria-label="Select API key"
-        className="absolute inset-0 h-full w-full cursor-pointer appearance-none rounded-[14px] opacity-0"
-        value={selectedPlaygroundApiKeyId ?? playgroundApiKeys[0].id}
-        onChange={(event) => setSelectedPlaygroundApiKeyId(event.currentTarget.value)}
-      >
-        {playgroundApiKeys.map((apiKey) => (
-          <option key={apiKey.id} value={apiKey.id}>
-            {formatApiKeyLabel(apiKey.name, apiKey.keyPrefix)}
-          </option>
-        ))}
-      </select>
-
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 16 16"
-        className="pointer-events-none absolute top-1/2 right-4 h-4 w-4 -translate-y-1/2 text-[rgba(28,28,29,0.42)]"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.75"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="m4 6 4 4 4-4" />
-      </svg>
+      {!selectedApiKeySecret && selectedApiKey ? (
+        <p className="mt-2 text-xs leading-5 text-[rgba(28,28,29,0.62)]">
+          This browser session does not have the raw secret for this key yet. The playground will
+          fall back to your current dashboard session until you{" "}
+          <Link href="/dashboard/api-keys" className="font-medium text-[#1c1c1d] underline">
+            create or rotate the key
+          </Link>{" "}
+          and copy the full{" "}
+          <code className="rounded bg-[rgba(28,28,29,0.06)] px-1 py-0.5">sk_...</code> value.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { DashboardAccess } from "@/lib/dashboard-access";
 import { useDashboardUrlState } from "@/lib/dashboard-url-state";
 import { type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
 
@@ -14,6 +15,7 @@ export interface DashboardPlaygroundApiKeyOption {
 }
 
 type DashboardWorkspaceContextValue = {
+  dashboardAccess: DashboardAccess;
   isSidebarOpen: boolean;
   selectedProject: string;
   issuanceTab: IssuanceWorkspaceTab;
@@ -33,12 +35,14 @@ const DashboardWorkspaceContext = createContext<DashboardWorkspaceContextValue |
 
 type DashboardWorkspaceProviderProps = {
   children: ReactNode;
+  dashboardAccess: DashboardAccess;
   defaultProject?: string;
   initialSidebarOpen?: boolean;
 };
 
 export function DashboardWorkspaceProvider({
   children,
+  dashboardAccess,
   defaultProject = "Default Project",
   initialSidebarOpen = true,
 }: DashboardWorkspaceProviderProps) {
@@ -87,6 +91,7 @@ export function DashboardWorkspaceProvider({
 
   const value = useMemo<DashboardWorkspaceContextValue>(
     () => ({
+      dashboardAccess,
       isSidebarOpen,
       selectedProject,
       issuanceTab,
@@ -100,6 +105,7 @@ export function DashboardWorkspaceProvider({
       toggleSidebar,
     }),
     [
+      dashboardAccess,
       isSidebarOpen,
       playgroundApiKeys,
       issuanceTab,

--- a/apps/sdp-web/src/lib/dashboard-access.ts
+++ b/apps/sdp-web/src/lib/dashboard-access.ts
@@ -3,6 +3,7 @@ import {
   type Permission,
   getPermissionsForOrgRole,
   hasPermission,
+  normalizeOrganizationRole,
 } from "@sdp/types";
 
 export interface DashboardCapabilities {
@@ -20,13 +21,7 @@ export interface DashboardAccess {
 }
 
 export function mapClerkRoleToDashboardRole(role: string | null | undefined): OrganizationRole {
-  if (role === "org:owner") {
-    return "owner";
-  }
-  if (role === "org:admin") {
-    return "admin";
-  }
-  return "developer";
+  return normalizeOrganizationRole(role);
 }
 
 export function resolveDashboardAccess(role: string | null | undefined): DashboardAccess {

--- a/apps/sdp-web/src/lib/dashboard-access.ts
+++ b/apps/sdp-web/src/lib/dashboard-access.ts
@@ -1,0 +1,49 @@
+import {
+  type OrganizationRole,
+  type Permission,
+  getPermissionsForOrgRole,
+  hasPermission,
+} from "@sdp/types";
+
+export interface DashboardCapabilities {
+  canManageApiKeys: boolean;
+  canManageCustody: boolean;
+  canManageOrgSettings: boolean;
+  canManageTokenAdmin: boolean;
+  canUseWalletSignerCheck: boolean;
+}
+
+export interface DashboardAccess {
+  role: OrganizationRole;
+  permissions: Permission[];
+  capabilities: DashboardCapabilities;
+}
+
+export function mapClerkRoleToDashboardRole(role: string | null | undefined): OrganizationRole {
+  if (role === "org:owner") {
+    return "owner";
+  }
+  if (role === "org:admin") {
+    return "admin";
+  }
+  return "developer";
+}
+
+export function resolveDashboardAccess(role: string | null | undefined): DashboardAccess {
+  const resolvedRole = mapClerkRoleToDashboardRole(role);
+  const permissions = getPermissionsForOrgRole(resolvedRole);
+
+  return {
+    role: resolvedRole,
+    permissions,
+    capabilities: {
+      canManageApiKeys: hasPermission(permissions, "api-keys:write"),
+      canManageCustody: hasPermission(permissions, "custody:admin"),
+      canManageOrgSettings: hasPermission(permissions, "org:write"),
+      canManageTokenAdmin: hasPermission(permissions, "tokens:admin"),
+      // Current dashboard implementation creates a short-lived API key before signer check.
+      canUseWalletSignerCheck:
+        hasPermission(permissions, "wallets:write") && hasPermission(permissions, "api-keys:write"),
+    },
+  };
+}

--- a/packages/sdp-api-integration/src/tests/mosaic-templates.test.ts
+++ b/packages/sdp-api-integration/src/tests/mosaic-templates.test.ts
@@ -203,10 +203,9 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Mosaic Template D
 
     expect(body.data.templates).toBeDefined();
     expect(Array.isArray(body.data.templates)).toBe(true);
-    expect(body.data.templates.length).toBe(4);
+    expect(body.data.templates.length).toBe(3);
     const templateIds = body.data.templates.map((t) => t.id);
     expect(templateIds).toContain("stablecoin");
-    expect(templateIds).toContain("arcade");
     expect(templateIds).toContain("tokenized-security");
     expect(templateIds).toContain("custom");
   });

--- a/packages/sdp-types/src/permissions.ts
+++ b/packages/sdp-types/src/permissions.ts
@@ -69,15 +69,12 @@ export type Permission = (typeof PERMISSIONS)[number];
 
 // Organization roles and their default permissions
 export const ORGANIZATION_ROLES = {
-  owner: {
-    description: "Full control, delete org, transfer ownership",
-    permissions: ["*"] as Permission[],
-  },
   admin: {
-    description: "Manage members, API keys, settings",
+    description: "Full organization control",
     permissions: [
       "org:read",
       "org:write",
+      "org:admin",
       "tokens:read",
       "tokens:write",
       "tokens:admin",
@@ -99,8 +96,8 @@ export const ORGANIZATION_ROLES = {
       "custody:admin",
     ] as Permission[],
   },
-  developer: {
-    description: "Use API, create readonly keys",
+  member: {
+    description: "Standard product access",
     permissions: [
       "org:read",
       "api-keys:read",
@@ -115,20 +112,20 @@ export const ORGANIZATION_ROLES = {
       "projects:read",
     ] as Permission[],
   },
-  viewer: {
-    description: "Read-only dashboard access",
-    permissions: [
-      "org:read",
-      "tokens:read",
-      "payments:read",
-      "wallets:read",
-      "projects:read",
-      "audit:read",
-    ] as Permission[],
-  },
 } as const;
 
 export type OrganizationRole = keyof typeof ORGANIZATION_ROLES;
+export type LegacyOrganizationRole = OrganizationRole | "owner" | "developer" | "viewer";
+
+export function normalizeOrganizationRole(
+  role: LegacyOrganizationRole | string | null | undefined
+): OrganizationRole {
+  if (role === "admin" || role === "owner" || role === "org:admin" || role === "org:owner") {
+    return "admin";
+  }
+
+  return "member";
+}
 
 // API key roles and their default permissions
 export const API_KEY_ROLES = {
@@ -198,8 +195,10 @@ export function hasAllPermissions(userPermissions: Permission[], required: Permi
 /**
  * Get default permissions for an organization role
  */
-export function getPermissionsForOrgRole(role: OrganizationRole): Permission[] {
-  return [...ORGANIZATION_ROLES[role].permissions];
+export function getPermissionsForOrgRole(
+  role: LegacyOrganizationRole | string | null | undefined
+): Permission[] {
+  return [...ORGANIZATION_ROLES[normalizeOrganizationRole(role)].permissions];
 }
 
 /**


### PR DESCRIPTION
## Summary
- gate admin-only dashboard actions and align SDP org roles to Clerk's current `admin` / `member` model
- refine issuance workflows with clearer draft-first token creation, URL-driven tabs, operations/compliance IA cleanup, wallet destination autocomplete, and proactive field-level validation
- improve dashboard usability with wallet activity history, observed inbound payment activity, better API playground key handling, Fireblocks request logging, and removal of the public Arcade template surface

## Testing
- pnpm typecheck
- pnpm --filter sdp-docs build
- pnpm -C apps/sdp-api exec vitest run src/routes/payments.test.ts src/routes/issuance.test.ts src/routes/issuance/handlers/token-operation-validation.test.ts
- pnpm --filter sdp-web test:e2e:issuance
- pnpm exec biome check apps/sdp-web/playwright/tests/auth.global.setup.ts apps/sdp-web/playwright/tests/issuance.e2e.spec.ts

## Notes
- `member` keeps the standard product permissions that previously sat under `developer`
- issuance operations/compliance now validate signer/source wallet assumptions before submit and surface errors on the specific affected fields
- public Arcade docs/templates are removed, but legacy Arcade tokens remain readable for compatibility
