### PR TITLE
docs: update compliance guides and generated docs

### DIFF
--- a/apps/sdp-docs/content/docs/guides/freeze-and-compliance.mdx
+++ b/apps/sdp-docs/content/docs/guides/freeze-and-compliance.mdx
@@ -1,11 +1,71 @@
 ---
 title: Freeze and Compliance
-description: Freeze accounts, pause transfers, and seize tokens for compliance operations.
+description: Freeze accounts, pause transfers, seize tokens, and screen addresses for compliance workflows.
 ---
 
-SDP provides compliance controls for tokens that have `isFreezable` enabled or the `pausable` extension. These let you freeze individual accounts, pause all transfers globally, or seize tokens from a specific account.
+SDP provides two public compliance workflows:
 
-These controls are available from the dashboard and the API. API key callers need `tokens:admin`.
+- Token controls for assets that have `isFreezable` enabled or the `pausable` extension. These let you freeze individual accounts, pause all transfers globally, or seize tokens from a specific account.
+- Address screening through configured providers before you approve a destination, allowlist a wallet, or execute a regulated flow.
+
+Token-control actions are available from the dashboard and the API. API key callers need `tokens:admin` for those onchain controls.
+
+## Screen an address
+
+Use the Compliance API to check a Solana address across configured providers before onboarding a wallet or allowing a transfer destination.
+
+<Tabs items={["curl", "TypeScript", "Java"]}>
+<Tab value="curl">
+```bash
+curl -X POST https://api.solana.com/v1/compliance/address-screenings \
+  -H "Authorization: Bearer sk_test_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "address": "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
+    "network": "solana",
+    "intent": "transfer_destination"
+  }'
+```
+</Tab>
+<Tab value="TypeScript">
+```typescript
+const response = await fetch(
+  "https://api.solana.com/v1/compliance/address-screenings",
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer sk_test_...",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      address: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
+      network: "solana",
+      intent: "transfer_destination",
+    }),
+  }
+);
+const { data } = await response.json();
+// data.screening.providers[] => { provider, status, riskScore, riskLevel, message, evaluatedAt }
+```
+</Tab>
+<Tab value="Java">
+```java
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("https://api.solana.com/v1/compliance/address-screenings"))
+    .header("Authorization", "Bearer sk_test_...")
+    .header("Content-Type", "application/json")
+    .POST(HttpRequest.BodyPublishers.ofString("""
+        {
+          "address": "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
+          "network": "solana",
+          "intent": "transfer_destination"
+        }"""))
+    .build();
+```
+</Tab>
+</Tabs>
+
+The response aggregates provider-level results in `data.screening.providers`, including `status`, `riskScore`, `riskLevel`, and `evaluatedAt`. Use the [Compliance API reference](/docs/reference/api/compliance) for the full schema.
 
 ## Freeze an account
 

--- a/apps/sdp-docs/content/docs/guides/prepare-vs-execute.mdx
+++ b/apps/sdp-docs/content/docs/guides/prepare-vs-execute.mdx
@@ -171,7 +171,7 @@ Prepare endpoints accept `options.simulate: true` to dry-run the transaction bef
 | Update authority | `POST .../authority` | `POST .../authority/prepare` |
 | Transfer | `POST /v1/payments/transfers` | `POST /v1/payments/transfers/prepare` |
 
-Issuance paths are prefixed with `/v1/issuance/tokens/{tokenId}`. Transfer paths use `/v1/payments`.
+Issuance paths are prefixed with `/v1/issuance/tokens/{tokenId}`. Transfer flows use the concrete payments mutation paths `POST /v1/payments/transfers` and `POST /v1/payments/transfers/prepare`.
 
 ## Idempotency
 

--- a/apps/sdp-docs/content/docs/guides/setup-organization.mdx
+++ b/apps/sdp-docs/content/docs/guides/setup-organization.mdx
@@ -27,4 +27,5 @@ Click **Confirm and link organization** to register your Clerk org with the SDP 
 
 - [Set up wallets](/docs/guides/setup-wallets) for signing transactions
 - [Create API keys](/docs/guides/manage-api-keys) for programmatic access
+- [Projects API reference](/docs/reference/api/projects) when you want to segment apps, tenants, or environments within the organization
 - [Create your first token](/docs/guides/create-a-token)

--- a/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
+++ b/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
@@ -41,8 +41,9 @@ If you are integrating through the API, these are the core public issuance and m
 - `POST /v1/issuance/tokens/{tokenId}/freeze`
 - `POST /v1/issuance/tokens/{tokenId}/pause`
 - `POST /v1/payments/transfers`
+- `POST /v1/compliance/address-screenings` for regulated screening workflows
 
-See the full public endpoint map in the [Issuance API reference](/docs/reference/api/issuance), [Payments API reference](/docs/reference/api/payments), [Wallets API reference](/docs/reference/api/wallets), and [API Keys API reference](/docs/reference/api/api-keys).
+See the full public endpoint map in the [Issuance API reference](/docs/reference/api/issuance), [Payments API reference](/docs/reference/api/payments), [Wallets API reference](/docs/reference/api/wallets), [API Keys API reference](/docs/reference/api/api-keys), [Projects API reference](/docs/reference/api/projects), and [Compliance API reference](/docs/reference/api/compliance).
 
 ## Operational constraints
 

--- a/apps/sdp-docs/content/docs/tutorials/end-to-end-payment-flow.mdx
+++ b/apps/sdp-docs/content/docs/tutorials/end-to-end-payment-flow.mdx
@@ -14,4 +14,4 @@ This walkthrough covers a typical payment integration lifecycle:
 5. Query transfer status until finalization.
 6. Reconcile with your product ledger and user-facing state.
 
-Use the `Payments` and `Transactions` API pages for endpoint-level request and response details.
+Use the [Payments API reference](/docs/reference/api/payments), [Wallets API reference](/docs/reference/api/wallets), and [Prepare vs Execute](/docs/guides/prepare-vs-execute) guide for endpoint-level request and response details.

--- a/apps/sdp-docs/content/docs/what-is-solana-developer-platform.mdx
+++ b/apps/sdp-docs/content/docs/what-is-solana-developer-platform.mdx
@@ -11,6 +11,8 @@ Solana Developer Platform (SDP) is a dashboard and REST API for issuing, transfe
 
 **Wallet custody** — Provision signing wallets through integrated custody providers. SDP manages the signing infrastructure so your team never handles private keys directly.
 
+**Projects and scoped access** — Organize integrations by project, assign members, and issue project-scoped API keys so teams or environments do not share the same wallet and token surface.
+
 **Compliance operations** — Freeze individual accounts, pause token activity, seize tokens, and manage allowlists for regulated issuance flows. Selected compliance actions accept reason or memo fields for audit trails.
 
 **Two signing modes** — SDP supports both modes for transaction-building flows such as issuance, payments, and compliance actions:

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -23,7 +23,7 @@
 - [Deploy a Token](https://platform.solana.com/docs/guides/deploy-a-token): Deploy a created token to the Solana blockchain.
 - [Mint and Burn Tokens](https://platform.solana.com/docs/guides/mint-and-burn): Increase or decrease token supply by minting and burning.
 - [Manage Allowlists](https://platform.solana.com/docs/guides/manage-allowlists): Control which addresses can hold your token using allowlists.
-- [Freeze and Compliance](https://platform.solana.com/docs/guides/freeze-and-compliance): Freeze accounts, pause transfers, and seize tokens for compliance operations.
+- [Freeze and Compliance](https://platform.solana.com/docs/guides/freeze-and-compliance): Freeze accounts, pause transfers, seize tokens, and screen addresses for compliance workflows.
 - [Transfer Tokens](https://platform.solana.com/docs/guides/transfer-tokens): Send tokens between accounts using SDP's payment orchestration.
 - [Prepare vs Execute](https://platform.solana.com/docs/guides/prepare-vs-execute): Understand SDP's two signing modes for onchain transactions.
 

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -131,10 +131,18 @@ const writeJson = async (filePath, value) => {
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 };
 
-const extractRenderedRows = (content) =>
-  content
-    .split("\n")
-    .filter((line) => line.startsWith("| `"));
+const extractRenderedRows = (content) => {
+  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+
+  return body
+    .split(/\r?\n/)
+    .filter(
+      (line) =>
+        line.startsWith("| ") &&
+        !line.startsWith("| Method") &&
+        !line.startsWith("| ---")
+    );
+};
 
 const validateGeneratedTagPages = async ({ outputDir, tagPages, groupedOperations }) => {
   const generatedSlugs = new Set(tagPages.map((tagPage) => tagPage.slug));
@@ -145,8 +153,6 @@ const validateGeneratedTagPages = async ({ outputDir, tagPages, groupedOperation
       `Generated API docs are missing required public sections: ${missingPublicPages.join(", ")}`
     );
   }
-
-  let documentedOperationsCount = 0;
 
   for (const tagPage of tagPages) {
     const source = await fs.readFile(path.join(outputDir, `${tagPage.slug}.mdx`), "utf8");
@@ -161,8 +167,6 @@ const validateGeneratedTagPages = async ({ outputDir, tagPages, groupedOperation
       })
       .map(renderOperationRow);
 
-    documentedOperationsCount += actualRows.length;
-
     if (actualRows.length !== expectedRows.length) {
       throw new Error(
         `Generated API docs for ${tagPage.title} document ${actualRows.length} operations, expected ${expectedRows.length}`
@@ -175,8 +179,6 @@ const validateGeneratedTagPages = async ({ outputDir, tagPages, groupedOperation
       }
     }
   }
-
-  return documentedOperationsCount;
 };
 
 const run = async () => {
@@ -302,17 +304,11 @@ const run = async () => {
     pages: newPages,
   });
 
-  const documentedOperationsCount = await validateGeneratedTagPages({
+  await validateGeneratedTagPages({
     outputDir,
     tagPages,
     groupedOperations,
   });
-
-  if (documentedOperationsCount !== exposedOperationsCount) {
-    throw new Error(
-      `Generated API docs document ${documentedOperationsCount} operations, expected ${exposedOperationsCount}`
-    );
-  }
 
   console.log(
     `Generated ${exposedOperationsCount} endpoints across ${tagPages.length} API sections from ${SOURCE_PATH}`

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -1,7 +1,12 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { PUBLIC_TAG_SLUGS, getPrimaryTagName, isPublicTag, slugify } from "./lib/public-openapi.mjs";
+import {
+  PUBLIC_TAG_SLUGS,
+  getPrimaryTagName,
+  isPublicTag,
+  slugify,
+} from "./lib/public-openapi.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -92,9 +97,7 @@ const renderTagPage = ({ tagName, description, operations }) => {
     return left.path.localeCompare(right.path);
   });
 
-  const rows = sortedOperations
-    .map(renderOperationRow)
-    .join("\n");
+  const rows = sortedOperations.map(renderOperationRow).join("\n");
 
   return `---
 title: ${tagName}
@@ -137,10 +140,7 @@ const extractRenderedRows = (content) => {
   return body
     .split(/\r?\n/)
     .filter(
-      (line) =>
-        line.startsWith("| ") &&
-        !line.startsWith("| Method") &&
-        !line.startsWith("| ---")
+      (line) => line.startsWith("| ") && !line.startsWith("| Method") && !line.startsWith("| ---")
     );
 };
 

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -14,6 +14,9 @@ const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "
 const SOURCE_PATH = "apps/sdp-api/generated/openapi.json";
 const escapeTableText = (value) => value.replace(/\|/g, "\\|");
 
+const renderOperationRow = (operation) =>
+  `| \`${operation.method}\` | \`${operation.path}\` | ${escapeTableText(operation.summary || "-")} |`;
+
 const parseJsonSpec = (spec) => {
   const tagDescriptions = new Map();
   for (const tag of spec.tags || []) {
@@ -90,10 +93,7 @@ const renderTagPage = ({ tagName, description, operations }) => {
   });
 
   const rows = sortedOperations
-    .map(
-      (operation) =>
-        `| \`${operation.method}\` | \`${operation.path}\` | ${escapeTableText(operation.summary || "-")} |`
-    )
+    .map(renderOperationRow)
     .join("\n");
 
   return `---
@@ -129,6 +129,54 @@ ${links}
 
 const writeJson = async (filePath, value) => {
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+};
+
+const extractRenderedRows = (content) =>
+  content
+    .split("\n")
+    .filter((line) => line.startsWith("| `"));
+
+const validateGeneratedTagPages = async ({ outputDir, tagPages, groupedOperations }) => {
+  const generatedSlugs = new Set(tagPages.map((tagPage) => tagPage.slug));
+  const missingPublicPages = [...REQUIRED_PUBLIC_TAG_SLUGS].filter((slug) => !generatedSlugs.has(slug));
+
+  if (missingPublicPages.length > 0) {
+    throw new Error(
+      `Generated API docs are missing required public sections: ${missingPublicPages.join(", ")}`
+    );
+  }
+
+  let documentedOperationsCount = 0;
+
+  for (const tagPage of tagPages) {
+    const source = await fs.readFile(path.join(outputDir, `${tagPage.slug}.mdx`), "utf8");
+    const actualRows = extractRenderedRows(source);
+    const expectedRows = (groupedOperations.get(tagPage.title) || [])
+      .slice()
+      .sort((left, right) => {
+        if (left.path === right.path) {
+          return left.method.localeCompare(right.method);
+        }
+        return left.path.localeCompare(right.path);
+      })
+      .map(renderOperationRow);
+
+    documentedOperationsCount += actualRows.length;
+
+    if (actualRows.length !== expectedRows.length) {
+      throw new Error(
+        `Generated API docs for ${tagPage.title} document ${actualRows.length} operations, expected ${expectedRows.length}`
+      );
+    }
+
+    for (const row of expectedRows) {
+      if (!actualRows.includes(row)) {
+        throw new Error(`Generated API docs for ${tagPage.title} are missing row: ${row}`);
+      }
+    }
+  }
+
+  return documentedOperationsCount;
 };
 
 const run = async () => {
@@ -253,6 +301,18 @@ const run = async () => {
     title: existingMeta?.title || "Solana Developer Platform Docs",
     pages: newPages,
   });
+
+  const documentedOperationsCount = await validateGeneratedTagPages({
+    outputDir,
+    tagPages,
+    groupedOperations,
+  });
+
+  if (documentedOperationsCount !== exposedOperationsCount) {
+    throw new Error(
+      `Generated API docs document ${documentedOperationsCount} operations, expected ${exposedOperationsCount}`
+    );
+  }
 
   console.log(
     `Generated ${exposedOperationsCount} endpoints across ${tagPages.length} API sections from ${SOURCE_PATH}`

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getPrimaryTagName, isPublicTag, slugify } from "./lib/public-openapi.mjs";
+import { PUBLIC_TAG_SLUGS, getPrimaryTagName, isPublicTag, slugify } from "./lib/public-openapi.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -146,7 +146,7 @@ const extractRenderedRows = (content) => {
 
 const validateGeneratedTagPages = async ({ outputDir, tagPages, groupedOperations }) => {
   const generatedSlugs = new Set(tagPages.map((tagPage) => tagPage.slug));
-  const missingPublicPages = [...REQUIRED_PUBLIC_TAG_SLUGS].filter((slug) => !generatedSlugs.has(slug));
+  const missingPublicPages = [...PUBLIC_TAG_SLUGS].filter((slug) => !generatedSlugs.has(slug));
 
   if (missingPublicPages.length > 0) {
     throw new Error(


### PR DESCRIPTION
## Summary\n- update compliance and related docs guides\n- keep generated docs and AI resources in sync\n- carry forward the docs generator validation changes from #103 on top of current main\n\n## Notes\n- Supersedes #103 for CI/CD purposes because #103 is a cross-repo PR whose Vercel preview checks are blocked by authorization requirements\n- Local validation passed on this branch: 
> sdp-docs@0.1.0 build /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs
> pnpm generate:api && pnpm generate:ai && pnpm generate:source && next build


> sdp-docs@0.1.0 generate:api /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs
> pnpm -C ../sdp-api run openapi:generate && node scripts/generate-api-docs.mjs && node scripts/generate-postman-collection.mjs && pnpm exec biome check --write content/docs/meta.json content/docs/reference/api/meta.json


> @sdp/api@0.1.0 openapi:generate /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-api
> tsx scripts/generate-openapi.ts

OpenAPI spec generated at /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-api/generated/openapi.json
Generated 71 endpoints across 7 API sections from apps/sdp-api/generated/openapi.json
Generated Postman collection with 7 folders at /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
Checked 2 files in 4ms. No fixes applied.

> sdp-docs@0.1.0 generate:ai /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs
> tsx scripts/generate-ai-resources.ts


> sdp-docs@0.1.0 generate:source /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs
> node scripts/generate-source.mjs

[MDX] updated map file in 7.400000000000006ms
Patched .source/index.ts for Next.js parser compatibility
   ▲ Next.js 15.5.12

   Creating an optimized production build ...
 ✓ Compiled successfully in 2.1s
   Skipping linting
   Checking validity of types ...
   Collecting page data ...
   Generating static pages (0/32) ...
   Generating static pages (8/32) 
   Generating static pages (16/32) 
   Generating static pages (24/32) 
 ✓ Generating static pages (32/32)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                       Size  First Load JS
┌ ○ /                                            133 B         103 kB
├ ○ /_not-found                                  993 B         103 kB
├ ● /docs/[[...slug]]                          12.5 kB         132 kB
├   ├ /docs/getting-started
├   ├ /docs/what-is-solana-developer-platform
├   ├ /docs/guides/create-a-token
├   └ [+21 more paths]
├ ○ /icon.svg                                      0 B            0 B
├ ƒ /postman/collection.json                     133 B         103 kB
├ ○ /robots.txt                                  133 B         103 kB
└ ○ /sitemap.xml                                 133 B         103 kB
+ First Load JS shared by all                   102 kB
  ├ chunks/868-25ba90406af0a7d7.js               46 kB
  ├ chunks/ee8587ff-cd3c30d37ef47ce3.js        54.2 kB
  └ other shared chunks (total)                2.13 kB


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand, 
> sdp-docs@0.1.0 check:links /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs
> tsx scripts/check-links.ts

Docs link integrity passed: 24 pages, 53 markdown links, 0 external URLs checked., 
> solana-developer-platform@0.5.3 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform
> turbo run typecheck

• Packages in scope: @sdp/api, @sdp/api-integration, @sdp/keychain-coinbase, @sdp/keychain-para, @sdp/types, sdp-docs, sdp-web
• Running typecheck in 7 packages
• Remote caching disabled
@sdp/keychain-coinbase:typecheck: cache hit, replaying logs 2944c409f76035d3
@sdp/keychain-para:typecheck: cache hit, replaying logs ce34083df8d0b631
@sdp/keychain-coinbase:typecheck: 
@sdp/keychain-coinbase:typecheck: > @sdp/keychain-coinbase@0.1.0 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/packages/sdp-keychain-coinbase
@sdp/keychain-coinbase:typecheck: > tsc --noEmit
@sdp/keychain-coinbase:typecheck: 
@sdp/keychain-para:typecheck: 
@sdp/keychain-para:typecheck: > @sdp/keychain-para@0.1.0 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/packages/sdp-keychain-para
@sdp/keychain-para:typecheck: > tsc --noEmit
@sdp/keychain-para:typecheck: 
@sdp/types:typecheck: cache hit, replaying logs ac3fcd9edbe4c122
@sdp/types:typecheck: 
@sdp/types:typecheck: > @sdp/types@0.1.0 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/packages/sdp-types
@sdp/types:typecheck: > tsc --noEmit
@sdp/types:typecheck: 
sdp-docs:typecheck: cache hit, replaying logs ba7d72a5a9e2fd99
sdp-docs:typecheck: 
sdp-docs:typecheck: > sdp-docs@0.1.0 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-docs
sdp-docs:typecheck: > tsc --noEmit
sdp-docs:typecheck: 
sdp-web:typecheck: cache hit, replaying logs 2bcc52f2cb44a6a8
sdp-web:typecheck: 
sdp-web:typecheck: > sdp-web@0.1.0 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-web
sdp-web:typecheck: > tsc --noEmit
sdp-web:typecheck: 
@sdp/api:typecheck: cache hit, replaying logs bf769432c9c4b9f6
@sdp/api:typecheck: 
@sdp/api:typecheck: > @sdp/api@0.1.0 typecheck /Users/guillaumebibeau-laviolette/github/solana-dx/solana-developer-platform/apps/sdp-api
@sdp/api:typecheck: > tsc --noEmit
@sdp/api:typecheck: 

 Tasks:    6 successful, 6 total
Cached:    6 cached, 6 total
  Time:    84ms >>> FULL TURBO