### PR TITLE
fix: gate production auth entry points

### DIFF
--- a/apps/sdp-web/src/app/auth/actions.ts
+++ b/apps/sdp-web/src/app/auth/actions.ts
@@ -1,13 +1,23 @@
 "use server";
 
+import { isAuthEntryEnabled } from "@/lib/auth-entry";
 import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
 export async function startSignIn() {
+  if (!isAuthEntryEnabled()) {
+    redirect("/");
+  }
+
   const { redirectToSignIn } = await auth();
   return redirectToSignIn({ returnBackUrl: "/dashboard" });
 }
 
 export async function startSignUp() {
+  if (!isAuthEntryEnabled()) {
+    redirect("/");
+  }
+
   const { redirectToSignUp } = await auth();
   return redirectToSignUp({ returnBackUrl: "/dashboard" });
 }

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { resolveDashboardAccess } from "@/lib/dashboard-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
@@ -24,7 +25,7 @@ export const dynamic = "force-dynamic";
 export default async function ApiKeysPage() {
   const { userId, orgId, orgRole } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
@@ -7,6 +7,7 @@ import { WalletActivitySection } from "@/app/dashboard/custody/wallet-activity-s
 import { WalletAddressCopyButton } from "@/app/dashboard/custody/wallet-address-copy-button";
 import { formatPurpose, truncateMiddle } from "@/app/dashboard/custody/wallet-format-utils";
 import { WalletProviderMark } from "@/app/dashboard/custody/wallet-provider-mark";
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import type {
@@ -124,7 +125,7 @@ export default async function WalletDetailPage({
 }) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -13,6 +13,7 @@ import {
 import { linkOrganization } from "@/app/onboarding/actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth, clerkClient } from "@clerk/nextjs/server";
@@ -132,7 +133,7 @@ async function OnboardingGateSection({ orgId }: { orgId: string }) {
 export default async function CustodyPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -89,7 +90,7 @@ function mapToken(payload: unknown): Token | null {
 export default async function IssuanceTokenManagementPage({ params }: TokenManagementPageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -159,7 +160,7 @@ interface IssuancePageProps {
 export default async function IssuancePage({ searchParams }: IssuancePageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -9,7 +10,7 @@ import { fetchPaymentsAggregate, fetchPaymentsWallets } from "./payments/payment
 export default async function DashboardPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     return null;

--- a/apps/sdp-web/src/app/dashboard/payments/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -19,7 +20,7 @@ interface PaymentsPageProps {
 export default async function PaymentsPage({ searchParams }: PaymentsPageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
@@ -7,7 +8,7 @@ import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 export default async function PaymentsReceivePage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
@@ -7,7 +8,7 @@ import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 export default async function PaymentsSendPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/settings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/page.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getAuthEntryPath } from "@/lib/auth-entry";
 import { resolveDashboardAccess } from "@/lib/dashboard-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
@@ -32,7 +33,7 @@ type ProjectListResponse = {
 export default async function SettingsPage() {
   const { userId, orgId, orgRole } = await auth();
   if (!userId) {
-    redirect("/sign-in");
+    redirect(getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -17,26 +17,24 @@ export default async function RootLayout({
 }>) {
   const pathname = (await headers()).get("x-sdp-pathname") ?? "/";
   const shouldLoadClerk = shouldLoadClerkForPath(pathname);
+  const content = shouldLoadClerk ? (
+    <ClerkProvider
+      signInUrl="/sign-in"
+      signUpUrl="/sign-up"
+      signInFallbackRedirectUrl="/dashboard"
+      signUpFallbackRedirectUrl="/dashboard"
+    >
+      {children}
+    </ClerkProvider>
+  ) : (
+    children
+  );
 
   return (
     <html lang="en">
       <body>
-        {shouldLoadClerk ? (
-          <ClerkProvider
-            signInUrl="/sign-in"
-            signUpUrl="/sign-up"
-            signInFallbackRedirectUrl="/dashboard"
-            signUpFallbackRedirectUrl="/dashboard"
-          >
-            {children}
-            <Toaster position="top-right" richColors closeButton />
-          </ClerkProvider>
-        ) : (
-          <>
-            {children}
-            <Toaster position="top-right" richColors closeButton />
-          </>
-        )}
+        {content}
+        <Toaster position="top-right" richColors closeButton />
       </body>
     </html>
   );

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -1,5 +1,7 @@
+import { shouldLoadClerkForPath } from "@/lib/auth-entry";
 import { ClerkProvider } from "@clerk/nextjs";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Toaster } from "sonner";
 import "./globals.css";
 
@@ -8,23 +10,33 @@ export const metadata: Metadata = {
   description: "SDP dashboard",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const pathname = (await headers()).get("x-sdp-pathname") ?? "/";
+  const shouldLoadClerk = shouldLoadClerkForPath(pathname);
+
   return (
     <html lang="en">
       <body>
-        <ClerkProvider
-          signInUrl="/sign-in"
-          signUpUrl="/sign-up"
-          signInFallbackRedirectUrl="/dashboard"
-          signUpFallbackRedirectUrl="/dashboard"
-        >
-          {children}
-          <Toaster position="top-right" richColors closeButton />
-        </ClerkProvider>
+        {shouldLoadClerk ? (
+          <ClerkProvider
+            signInUrl="/sign-in"
+            signUpUrl="/sign-up"
+            signInFallbackRedirectUrl="/dashboard"
+            signUpFallbackRedirectUrl="/dashboard"
+          >
+            {children}
+            <Toaster position="top-right" richColors closeButton />
+          </ClerkProvider>
+        ) : (
+          <>
+            {children}
+            <Toaster position="top-right" richColors closeButton />
+          </>
+        )}
       </body>
     </html>
   );

--- a/apps/sdp-web/src/app/page.tsx
+++ b/apps/sdp-web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { HomeSignedInCard } from "@/components/home-signed-in";
+import { isAuthEntryEnabled } from "@/lib/auth-entry";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 import { DEFAULT_SDP_DOCS_URL } from "@sdp/types";
 import Image from "next/image";
@@ -10,6 +11,8 @@ const docsHref =
   (process.env.NODE_ENV === "development" ? "http://localhost:3001/docs" : DEFAULT_SDP_DOCS_URL);
 
 export default function Home() {
+  const authEntryEnabled = isAuthEntryEnabled();
+
   return (
     <main className="min-h-screen bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] text-[#1c1c1d]">
       <header className="border-b border-[rgba(28,28,29,0.08)]">
@@ -22,19 +25,23 @@ export default function Home() {
             >
               Docs
             </Link>
-            <SignedOut>
-              <form action={startSignIn}>
-                <button
-                  type="submit"
-                  className="inline-flex h-9 items-center justify-center rounded-lg bg-[rgba(28,28,29,0.08)] px-3 text-sm font-semibold text-[#1c1c1d] transition-colors hover:bg-[rgba(28,28,29,0.14)]"
-                >
-                  Sign in
-                </button>
-              </form>
-            </SignedOut>
-            <SignedIn>
-              <UserButton />
-            </SignedIn>
+            {authEntryEnabled ? (
+              <>
+                <SignedOut>
+                  <form action={startSignIn}>
+                    <button
+                      type="submit"
+                      className="inline-flex h-9 items-center justify-center rounded-lg bg-[rgba(28,28,29,0.08)] px-3 text-sm font-semibold text-[#1c1c1d] transition-colors hover:bg-[rgba(28,28,29,0.14)]"
+                    >
+                      Sign in
+                    </button>
+                  </form>
+                </SignedOut>
+                <SignedIn>
+                  <UserButton />
+                </SignedIn>
+              </>
+            ) : null}
           </div>
         </div>
       </header>
@@ -53,22 +60,30 @@ export default function Home() {
             team already uses.
           </p>
 
-          <SignedOut>
-            <form action={startSignUp} className="mt-[34px]">
-              <button
-                type="submit"
-                className="inline-flex h-10 items-center justify-center rounded-[10px] bg-[#0f0f10] px-[18px] text-[15px] font-semibold leading-[15px] text-white transition-colors hover:bg-black"
-              >
-                Join Waitlist
-              </button>
-            </form>
-          </SignedOut>
+          {authEntryEnabled ? (
+            <>
+              <SignedOut>
+                <form action={startSignUp} className="mt-[34px]">
+                  <button
+                    type="submit"
+                    className="inline-flex h-10 items-center justify-center rounded-[10px] bg-[#0f0f10] px-[18px] text-[15px] font-semibold leading-[15px] text-white transition-colors hover:bg-black"
+                  >
+                    Join Waitlist
+                  </button>
+                </form>
+              </SignedOut>
 
-          <SignedIn>
-            <div className="mt-[34px] max-w-[360px]">
-              <HomeSignedInCard />
+              <SignedIn>
+                <div className="mt-[34px] max-w-[360px]">
+                  <HomeSignedInCard />
+                </div>
+              </SignedIn>
+            </>
+          ) : (
+            <div className="mt-[34px] inline-flex h-10 items-center justify-center rounded-[10px] bg-[rgba(28,28,29,0.08)] px-[18px] text-[15px] font-semibold leading-[15px] text-[rgba(28,28,29,0.68)]">
+              Access opening soon
             </div>
-          </SignedIn>
+          )}
         </div>
 
         <div

--- a/apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,12 @@
+import { isAuthEntryEnabled } from "@/lib/auth-entry";
 import { SignIn } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
 
 export default function SignInPage() {
+  if (!isAuthEntryEnabled()) {
+    redirect("/");
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] px-6 py-10">
       <SignIn routing="path" path="/sign-in" />

--- a/apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,6 +1,12 @@
+import { isAuthEntryEnabled } from "@/lib/auth-entry";
 import { SignUp } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
 
 export default function SignUpPage() {
+  if (!isAuthEntryEnabled()) {
+    redirect("/");
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] px-6 py-10">
       <SignUp />

--- a/apps/sdp-web/src/lib/auth-entry.ts
+++ b/apps/sdp-web/src/lib/auth-entry.ts
@@ -1,0 +1,49 @@
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+const DISABLED_VALUES = new Set(["0", "false", "no", "off"]);
+
+function parseBooleanEnv(value: string | undefined): boolean | null {
+  const normalized = value?.trim().toLowerCase();
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (ENABLED_VALUES.has(normalized)) {
+    return true;
+  }
+
+  if (DISABLED_VALUES.has(normalized)) {
+    return false;
+  }
+
+  return null;
+}
+
+export function isAuthEntryEnabled(): boolean {
+  const configured = parseBooleanEnv(process.env.SDP_AUTH_ENTRY_ENABLED);
+
+  if (configured !== null) {
+    return configured;
+  }
+
+  return process.env.VERCEL_ENV !== "production";
+}
+
+export function getAuthEntryPath(): string {
+  return isAuthEntryEnabled() ? "/sign-in" : "/";
+}
+
+export function shouldLoadClerkForPath(pathname: string): boolean {
+  if (isAuthEntryEnabled()) {
+    return true;
+  }
+
+  return (
+    pathname === "/dashboard" ||
+    pathname.startsWith("/dashboard/") ||
+    pathname === "/allowlist" ||
+    pathname.startsWith("/allowlist/") ||
+    pathname === "/members" ||
+    pathname.startsWith("/members/")
+  );
+}

--- a/apps/sdp-web/src/lib/auth-entry.ts
+++ b/apps/sdp-web/src/lib/auth-entry.ts
@@ -26,6 +26,8 @@ export function isAuthEntryEnabled(): boolean {
     return configured;
   }
 
+  // Vercel preview deployments stay open by default, but production stays closed
+  // until onboarding is intentionally enabled.
   return process.env.VERCEL_ENV !== "production";
 }
 

--- a/apps/sdp-web/src/proxy.ts
+++ b/apps/sdp-web/src/proxy.ts
@@ -1,11 +1,21 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/", "/dashboard(.*)"]);
 
-export const proxy = clerkMiddleware((auth, req) => {
+export const proxy = clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
-    auth.protect();
+    await auth.protect();
   }
+
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-sdp-pathname", req.nextUrl.pathname);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
- add a shared auth-entry gate with production-default-off behavior for public auth entry
- hide landing-page auth CTAs when auth entry is disabled and replace signup with a neutral launch state
- redirect sign-in/sign-up routes and auth actions back home when public auth entry is disabled
- avoid loading Clerk on public routes when auth entry is disabled while keeping dashboard routes Clerk-enabled
- send unauthenticated dashboard traffic to `/` instead of a dead `/sign-in` route when auth entry is disabled

## Validation
- pnpm --filter sdp-web typecheck
- pnpm --filter sdp-web build
- pnpm exec biome check apps/sdp-web/src/app/layout.tsx apps/sdp-web/src/app/page.tsx apps/sdp-web/src/app/auth/actions.ts 'apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx' 'apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx' apps/sdp-web/src/app/dashboard/page.tsx apps/sdp-web/src/app/dashboard/custody/page.tsx apps/sdp-web/src/app/dashboard/api-keys/page.tsx apps/sdp-web/src/app/dashboard/payments/page.tsx apps/sdp-web/src/app/dashboard/payments/send/page.tsx 'apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx' 'apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx' apps/sdp-web/src/app/dashboard/issuance/page.tsx apps/sdp-web/src/app/dashboard/payments/receive/page.tsx apps/sdp-web/src/app/dashboard/settings/page.tsx apps/sdp-web/src/proxy.ts apps/sdp-web/src/lib/auth-entry.ts