### PR TITLE
feat: keep only the waitlist CTA when auth entry is closed

### DIFF
--- a/apps/sdp-web/src/app/page.tsx
+++ b/apps/sdp-web/src/app/page.tsx
@@ -81,10 +81,7 @@ export default function Home() {
               </SignedIn>
             </>
           ) : (
-            <div className="mt-[34px] flex flex-col items-start gap-3">
-              <div className="inline-flex h-10 items-center justify-center rounded-[10px] bg-[rgba(28,28,29,0.08)] px-[18px] text-[15px] font-semibold leading-[15px] text-[rgba(28,28,29,0.68)]">
-                Access opening soon
-              </div>
+            <div className="mt-[34px]">
               <Link
                 href={waitlistHref}
                 target="_blank"


### PR DESCRIPTION
## Summary\n- remove the extra "Access opening soon" pill from the production-disabled auth state\n- keep the waitlist CTA as the only landing-page action when auth entry is closed\n\n## Testing\n- pnpm --filter sdp-web typecheck\n- pnpm exec biome check apps/sdp-web/src/app/page.tsx