### PR TITLE
feat: add persisted dashboard cache layer

### DIFF
--- a/apps/sdp-docs/next.config.mjs
+++ b/apps/sdp-docs/next.config.mjs
@@ -9,6 +9,7 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  assetPrefix: "/docs",
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/apps/sdp-web/next.config.ts
+++ b/apps/sdp-web/next.config.ts
@@ -1,8 +1,27 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
+const docsProxyOrigin = (
+  process.env.SDP_DOCS_PROXY_ORIGIN?.trim() ||
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:3001"
+    : "https://docs.platform.solana.com")
+).replace(/\/$/, "");
+
 const nextConfig: NextConfig = {
   distDir: process.env.PLAYWRIGHT_NEXT_DIST_DIR?.trim() || ".next",
+  async rewrites() {
+    return [
+      {
+        source: "/docs",
+        destination: `${docsProxyOrigin}/docs`,
+      },
+      {
+        source: "/docs/:path*",
+        destination: `${docsProxyOrigin}/docs/:path*`,
+      },
+    ];
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -261,8 +261,8 @@ test.describe
       await expect(page.getByTestId("overview-row-supply")).toContainText("7");
 
       await openTab(page, "Operations");
-      await expect(page.getByRole("cell", { name: "mint" })).toBeVisible();
-      await expect(page.getByRole("cell", { name: "burn" })).toBeVisible();
+      await expect(page.getByTestId("fund-management-row-mint")).toBeVisible();
+      await expect(page.getByTestId("fund-management-row-burn")).toBeVisible();
     });
 
     test("9. user can freeze and unfreeze using a wallet address in the UI", async ({ page }) => {

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
@@ -13,10 +13,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type { PaymentTransferSummary as TransferRecord } from "@sdp/types";
 import { ExternalLink, RefreshCw } from "lucide-react";
-import useSWR from "swr";
 import { formatDisplayAmount } from "../payments/payments-overview.utils";
+
+const WALLET_ACTIVITY_CACHE_TTL_MS = 20_000;
 
 interface WalletActivitySectionProps {
   walletId: string;
@@ -105,11 +107,19 @@ export function WalletActivitySection({
     error: requestError,
     isValidating,
     mutate,
-  } = useSWR(`wallet-activity-${walletId}`, () => fetchTransfers({ walletId }), {
-    fallbackData: initialTransfersError ? undefined : initialTransfers,
-    revalidateOnFocus: true,
-    refreshInterval: 20_000,
-  });
+  } = usePersistedDashboardSWR(
+    `wallet-activity-${walletId}`,
+    () => fetchTransfers({ walletId }),
+    {
+      fallbackData: initialTransfersError ? undefined : initialTransfers,
+      revalidateOnFocus: true,
+      refreshInterval: 20_000,
+    },
+    {
+      key: `wallet-activity.${walletId}`,
+      ttlMs: WALLET_ACTIVITY_CACHE_TTL_MS,
+    }
+  );
   const liveTransfers = swrTransfers ?? initialTransfers;
   const liveTransfersError = requestError
     ? requestError instanceof Error

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-card-balance-value.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-card-balance-value.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type { CustodyWalletTokenBalance } from "@sdp/types";
-import useSWR from "swr";
 import { formatCurrencyAmount, resolveTotalBalance } from "../payments/payments-overview.utils";
 
 const BALANCE_REFRESH_INTERVAL_MS = 30_000;
+const WALLET_BALANCE_CACHE_TTL_MS = 30_000;
 
 interface WalletBalancesEnvelope {
   data?: {
@@ -50,7 +51,7 @@ async function fetchWalletBalances(walletId: string): Promise<CustodyWalletToken
 }
 
 export function WalletCardBalanceValue({ walletId, initialBalances }: WalletCardBalanceValueProps) {
-  const { data, error } = useSWR<CustodyWalletTokenBalance[]>(
+  const { data, error } = usePersistedDashboardSWR<CustodyWalletTokenBalance[]>(
     walletId ? `wallet-card-balance:${walletId}` : null,
     () => fetchWalletBalances(walletId),
     {
@@ -59,6 +60,10 @@ export function WalletCardBalanceValue({ walletId, initialBalances }: WalletCard
       refreshInterval: BALANCE_REFRESH_INTERVAL_MS,
       dedupingInterval: 5_000,
       keepPreviousData: true,
+    },
+    {
+      key: `wallet-card-balance.${walletId}`,
+      ttlMs: WALLET_BALANCE_CACHE_TTL_MS,
     }
   );
 

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -14,9 +14,9 @@ import {
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import Link from "next/link";
-import useSWR from "swr";
 import { fetchHomeActivity } from "./home-workspace.data";
 import { formatCurrencyAmount, formatDisplayAmount } from "./payments/payments-overview.utils";
 
@@ -27,6 +27,7 @@ interface HomeWorkspaceProps {
 }
 
 const HOME_ACTIVITY_KEY = "dashboard-home-activity";
+const HOME_ACTIVITY_CACHE_TTL_MS = 60_000;
 
 function formatRelativeTime(value: string): string {
   const date = new Date(value);
@@ -97,12 +98,16 @@ function MetricCard({
 
 export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: HomeWorkspaceProps) {
   const { dashboardAccess } = useDashboardWorkspace();
-  const { data: activitySnapshot, error: activityRequestError } = useSWR(
+  const { data: activitySnapshot, error: activityRequestError } = usePersistedDashboardSWR(
     HOME_ACTIVITY_KEY,
     () => fetchHomeActivity(),
     {
       revalidateOnFocus: true,
       refreshInterval: 20_000,
+    },
+    {
+      key: "home-activity",
+      ttlMs: HOME_ACTIVITY_CACHE_TTL_MS,
     }
   );
   const isWalletEmptyState = wallets.length === 0;

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.tsx
@@ -2,12 +2,12 @@
 
 import { Button } from "@/components/ui/button";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import { Loader2 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import useSWR from "swr";
 import { TokenActionConfirmationDialog } from "./token-action-confirmation-dialog";
 import { TokenActionForms } from "./token-action-forms";
 import { TokenAuthorityModal } from "./token-authority-modal";
@@ -77,6 +77,8 @@ const managementTabs: Array<{ id: TokenManagementTab; label: string }> = [
   { id: "metadata", label: "Metadata" },
   { id: "fund-management", label: "Operations" },
 ];
+const TOKEN_AUTHORITY_WALLETS_CACHE_TTL_MS = 60_000;
+const TOKEN_SUPPORTING_DATA_CACHE_TTL_MS = 60_000;
 
 function isTokenManagementTab(value: string | null): value is TokenManagementTab {
   return managementTabs.some((tab) => tab.id === value);
@@ -293,7 +295,7 @@ export function TokenManagementWorkspace({
     data: authorityWalletsData,
     error: authorityWalletsRequestError,
     mutate: mutateAuthorityWallets,
-  } = useSWR(
+  } = usePersistedDashboardSWR(
     shouldLoadAuthorityWallets ? ["token-management-authority-wallets", token.id] : null,
     ([, tokenId]: readonly [string, string]) => fetchTokenAuthorityWallets(tokenId),
     {
@@ -307,13 +309,17 @@ export function TokenManagementWorkspace({
       refreshInterval: 60_000,
       revalidateOnFocus: true,
       revalidateIfStale: false,
+    },
+    {
+      key: `token.${token.id}.authority-wallets`,
+      ttlMs: TOKEN_AUTHORITY_WALLETS_CACHE_TTL_MS,
     }
   );
   const {
     data: supportingData,
     error: supportingDataRequestError,
     mutate: mutateSupportingData,
-  } = useSWR(
+  } = usePersistedDashboardSWR(
     shouldLoadSupportingData ? ["token-management-supporting-data", token.id] : null,
     ([, tokenId]: readonly [string, string]) => fetchTokenManagementSupportingData(tokenId),
     {
@@ -321,6 +327,10 @@ export function TokenManagementWorkspace({
       refreshInterval: 60_000,
       revalidateOnFocus: true,
       revalidateIfStale: false,
+    },
+    {
+      key: `token.${token.id}.supporting-data`,
+      ttlMs: TOKEN_SUPPORTING_DATA_CACHE_TTL_MS,
     }
   );
   const supportingDataError = supportingDataRequestError

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/use-token-action-runner.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/use-token-action-runner.ts
@@ -32,9 +32,9 @@ export function useTokenActionRunner() {
 
       if (result.ok) {
         setActionConfirmation(null);
-        toast.success(successToast, { id: toastId });
         await options.onSuccess?.(result);
         router.refresh();
+        toast.success(successToast, { id: toastId });
         return result;
       }
 

--- a/apps/sdp-web/src/app/dashboard/layout.tsx
+++ b/apps/sdp-web/src/app/dashboard/layout.tsx
@@ -5,11 +5,14 @@ import { auth } from "@clerk/nextjs/server";
 import type { ReactNode } from "react";
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
-  const { orgRole } = await auth();
+  const { orgRole, orgId, userId } = await auth();
   const dashboardAccess = resolveDashboardAccess(orgRole);
 
   return (
-    <DashboardWorkspaceProvider dashboardAccess={dashboardAccess}>
+    <DashboardWorkspaceProvider
+      dashboardAccess={dashboardAccess}
+      dashboardCacheScope={{ orgId: orgId ?? null, userId: userId ?? null }}
+    >
       <DashboardShell>{children}</DashboardShell>
     </DashboardWorkspaceProvider>
   );

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
@@ -12,11 +12,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type { CustodyWalletAggregate, PaymentTransferSummary as TransferRecord } from "@sdp/types";
 import { ArrowDownLeft, ArrowUpRight, ExternalLink, RefreshCw } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
-import useSWR from "swr";
 import {
   formatCurrencyAmount,
   formatDirection,
@@ -44,6 +44,8 @@ interface PaymentsOverviewProps {
 
 const PAYMENTS_OVERVIEW_AGGREGATE_KEY = "payments-overview-aggregate";
 const PAYMENTS_OVERVIEW_TRANSFERS_KEY = "payments-overview-transfers";
+const PAYMENTS_OVERVIEW_AGGREGATE_CACHE_TTL_MS = 30_000;
+const PAYMENTS_OVERVIEW_TRANSFERS_CACHE_TTL_MS = 20_000;
 
 function statusClassName(status: string): string {
   switch (status.toLowerCase()) {
@@ -106,13 +108,17 @@ export function PaymentsOverview({
     error: aggregateFetchError,
     isValidating: aggregateRefreshing,
     mutate: mutateAggregate,
-  } = useSWR<CustodyWalletAggregate>(
+  } = usePersistedDashboardSWR<CustodyWalletAggregate>(
     [PAYMENTS_OVERVIEW_AGGREGATE_KEY, refreshSeed],
     () => fetchWalletAggregate(),
     {
       fallbackData: aggregateError || !aggregate ? undefined : aggregate,
       revalidateOnFocus: true,
       refreshInterval: 30_000,
+    },
+    {
+      key: "payments.aggregate",
+      ttlMs: PAYMENTS_OVERVIEW_AGGREGATE_CACHE_TTL_MS,
     }
   );
   const {
@@ -120,13 +126,17 @@ export function PaymentsOverview({
     error: transfersFetchError,
     isValidating: transfersRefreshing,
     mutate: mutateTransfers,
-  } = useSWR<TransferRecord[]>(
+  } = usePersistedDashboardSWR<TransferRecord[]>(
     [PAYMENTS_OVERVIEW_TRANSFERS_KEY, refreshSeed],
     () => fetchTransfers(),
     {
       fallbackData: transfersError ? undefined : transfers,
       revalidateOnFocus: true,
       refreshInterval: 10_000,
+    },
+    {
+      key: "payments.transfers.recent",
+      ttlMs: PAYMENTS_OVERVIEW_TRANSFERS_CACHE_TTL_MS,
     }
   );
 

--- a/apps/sdp-web/src/app/dashboard/payments/use-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/use-payments-workspace.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type {
   PaymentTransferSummary as TransferRecord,
   PaymentWalletPolicy as WalletPolicy,
@@ -7,7 +8,6 @@ import type {
 } from "@sdp/types";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import useSWR from "swr";
 import {
   createTransfer,
   fetchTransfers,
@@ -21,6 +21,8 @@ import type { ComplianceSnapshot } from "./payments-workspace.types";
 
 const PAYMENTS_WORKSPACE_WALLETS_KEY = "payments-workspace-wallets";
 const PAYMENTS_WORKSPACE_TRANSFERS_KEY = "payments-workspace-transfers";
+const PAYMENTS_WORKSPACE_WALLETS_CACHE_TTL_MS = 30_000;
+const PAYMENTS_WORKSPACE_TRANSFERS_CACHE_TTL_MS = 20_000;
 
 export interface DestinationAllowlistSectionState {
   walletId: string;
@@ -82,16 +84,30 @@ export function usePaymentsWorkspace(): PaymentsWorkspaceState {
     error: walletsFetchError,
     isLoading: walletsLoading,
     mutate: mutateWallets,
-  } = useSWR<WalletRecord[]>(PAYMENTS_WORKSPACE_WALLETS_KEY, fetchWallets, {
-    revalidateOnFocus: true,
-    refreshInterval: 30_000,
-  });
-  const { data: recentTransfers = [], mutate: mutateTransfers } = useSWR<TransferRecord[]>(
+  } = usePersistedDashboardSWR<WalletRecord[]>(
+    PAYMENTS_WORKSPACE_WALLETS_KEY,
+    fetchWallets,
+    {
+      revalidateOnFocus: true,
+      refreshInterval: 30_000,
+    },
+    {
+      key: "payments.wallets.summary",
+      ttlMs: PAYMENTS_WORKSPACE_WALLETS_CACHE_TTL_MS,
+    }
+  );
+  const { data: recentTransfers = [], mutate: mutateTransfers } = usePersistedDashboardSWR<
+    TransferRecord[]
+  >(
     PAYMENTS_WORKSPACE_TRANSFERS_KEY,
     () => fetchTransfers(),
     {
       revalidateOnFocus: true,
       refreshInterval: 10_000,
+    },
+    {
+      key: "payments.transfers.recent",
+      ttlMs: PAYMENTS_WORKSPACE_TRANSFERS_CACHE_TTL_MS,
     }
   );
 

--- a/apps/sdp-web/src/app/dashboard/payments/use-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/use-payments-workspace.tsx
@@ -106,6 +106,7 @@ export function usePaymentsWorkspace(): PaymentsWorkspaceState {
       refreshInterval: 10_000,
     },
     {
+      // Shared with payments-overview because both views read the same recent transfers endpoint.
       key: "payments.transfers.recent",
       ttlMs: PAYMENTS_WORKSPACE_TRANSFERS_CACHE_TTL_MS,
     }

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { DashboardAccess } from "@/lib/dashboard-access";
+import { DASHBOARD_SWR_CONFIG } from "@/lib/dashboard-swr-config";
 import { useDashboardUrlState } from "@/lib/dashboard-url-state";
 import { type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
 import { SWRConfig } from "swr";
@@ -11,15 +12,6 @@ export interface DashboardCacheScope {
   userId: string | null;
   orgId: string | null;
 }
-
-const DASHBOARD_SWR_CONFIG = {
-  dedupingInterval: 10_000,
-  errorRetryCount: 2,
-  focusThrottleInterval: 15_000,
-  keepPreviousData: true,
-  revalidateIfStale: true,
-  revalidateOnFocus: true,
-};
 
 export interface DashboardPlaygroundApiKeyOption {
   id: string;

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -3,8 +3,23 @@
 import type { DashboardAccess } from "@/lib/dashboard-access";
 import { useDashboardUrlState } from "@/lib/dashboard-url-state";
 import { type ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
+import { SWRConfig } from "swr";
 
 export type IssuanceWorkspaceTab = "tokens" | "playground";
+
+export interface DashboardCacheScope {
+  userId: string | null;
+  orgId: string | null;
+}
+
+const DASHBOARD_SWR_CONFIG = {
+  dedupingInterval: 10_000,
+  errorRetryCount: 2,
+  focusThrottleInterval: 15_000,
+  keepPreviousData: true,
+  revalidateIfStale: true,
+  revalidateOnFocus: true,
+};
 
 export interface DashboardPlaygroundApiKeyOption {
   id: string;
@@ -16,6 +31,7 @@ export interface DashboardPlaygroundApiKeyOption {
 
 type DashboardWorkspaceContextValue = {
   dashboardAccess: DashboardAccess;
+  dashboardCacheScope: DashboardCacheScope;
   isSidebarOpen: boolean;
   selectedProject: string;
   issuanceTab: IssuanceWorkspaceTab;
@@ -36,6 +52,7 @@ const DashboardWorkspaceContext = createContext<DashboardWorkspaceContextValue |
 type DashboardWorkspaceProviderProps = {
   children: ReactNode;
   dashboardAccess: DashboardAccess;
+  dashboardCacheScope: DashboardCacheScope;
   defaultProject?: string;
   initialSidebarOpen?: boolean;
 };
@@ -43,6 +60,7 @@ type DashboardWorkspaceProviderProps = {
 export function DashboardWorkspaceProvider({
   children,
   dashboardAccess,
+  dashboardCacheScope,
   defaultProject = "Default Project",
   initialSidebarOpen = true,
 }: DashboardWorkspaceProviderProps) {
@@ -92,6 +110,7 @@ export function DashboardWorkspaceProvider({
   const value = useMemo<DashboardWorkspaceContextValue>(
     () => ({
       dashboardAccess,
+      dashboardCacheScope,
       isSidebarOpen,
       selectedProject,
       issuanceTab,
@@ -106,6 +125,7 @@ export function DashboardWorkspaceProvider({
     }),
     [
       dashboardAccess,
+      dashboardCacheScope,
       isSidebarOpen,
       playgroundApiKeys,
       issuanceTab,
@@ -120,7 +140,7 @@ export function DashboardWorkspaceProvider({
 
   return (
     <DashboardWorkspaceContext.Provider value={value}>
-      {children}
+      <SWRConfig value={DASHBOARD_SWR_CONFIG}>{children}</SWRConfig>
     </DashboardWorkspaceContext.Provider>
   );
 }

--- a/apps/sdp-web/src/lib/dashboard-swr-config.ts
+++ b/apps/sdp-web/src/lib/dashboard-swr-config.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import type { SWRConfiguration } from "swr";
+
+export const DASHBOARD_SWR_CONFIG: SWRConfiguration = {
+  dedupingInterval: 10_000,
+  errorRetryCount: 2,
+  focusThrottleInterval: 15_000,
+  keepPreviousData: true,
+  revalidateIfStale: true,
+  revalidateOnFocus: true,
+};

--- a/apps/sdp-web/src/lib/dashboard-swr.tsx
+++ b/apps/sdp-web/src/lib/dashboard-swr.tsx
@@ -21,15 +21,6 @@ interface PersistedDashboardSnapshotEnvelope<Data> {
 const DASHBOARD_CACHE_STORAGE_PREFIX = "sdp.dashboard.cache";
 const DEFAULT_PERSISTED_SNAPSHOT_VERSION = 1;
 
-export const DASHBOARD_SWR_CONFIG: SWRConfiguration = {
-  dedupingInterval: 10_000,
-  errorRetryCount: 2,
-  focusThrottleInterval: 15_000,
-  keepPreviousData: true,
-  revalidateIfStale: true,
-  revalidateOnFocus: true,
-};
-
 function getStorage(storage: "local" | "session" = "local"): Storage | null {
   if (typeof window === "undefined") {
     return null;
@@ -112,14 +103,32 @@ export function usePersistedDashboardSWR<Data, Error = unknown>(
     dashboardCacheScope: { orgId, userId },
   } = useDashboardWorkspace();
   const scopeKey = useMemo(() => `${userId ?? "anonymous"}:${orgId ?? "no-org"}`, [orgId, userId]);
+  const persistedKey = persistedConfig?.key;
+  const persistedTtlMs = persistedConfig?.ttlMs;
+  const persistedVersion = persistedConfig?.version ?? DEFAULT_PERSISTED_SNAPSHOT_VERSION;
+  const persistedStorage = persistedConfig?.storage ?? "local";
+  const persistedShouldPersist = persistedConfig?.shouldPersist;
+  const normalizedPersistedConfig = useMemo<PersistedDashboardSnapshotConfig<Data> | undefined>(
+    () =>
+      persistedKey && typeof persistedTtlMs === "number"
+        ? {
+            key: persistedKey,
+            ttlMs: persistedTtlMs,
+            version: persistedVersion,
+            storage: persistedStorage,
+            shouldPersist: persistedShouldPersist,
+          }
+        : undefined,
+    [persistedKey, persistedShouldPersist, persistedStorage, persistedTtlMs, persistedVersion]
+  );
 
   const persistedFallbackData = useMemo(() => {
-    if (!persistedConfig || config.fallbackData !== undefined) {
+    if (!normalizedPersistedConfig || config.fallbackData !== undefined) {
       return undefined;
     }
 
-    return readPersistedDashboardSnapshot<Data>(scopeKey, persistedConfig);
-  }, [config.fallbackData, persistedConfig, scopeKey]);
+    return readPersistedDashboardSnapshot<Data>(scopeKey, normalizedPersistedConfig);
+  }, [config.fallbackData, normalizedPersistedConfig, scopeKey]);
 
   const response = useSWR<Data, Error>(key, fetcher, {
     ...config,
@@ -127,16 +136,16 @@ export function usePersistedDashboardSWR<Data, Error = unknown>(
   });
 
   useEffect(() => {
-    if (!persistedConfig || response.data === undefined || response.error) {
+    if (!normalizedPersistedConfig || response.data === undefined || response.error) {
       return;
     }
 
-    if (persistedConfig.shouldPersist && !persistedConfig.shouldPersist(response.data)) {
+    if (normalizedPersistedConfig.shouldPersist?.(response.data) === false) {
       return;
     }
 
-    writePersistedDashboardSnapshot(scopeKey, persistedConfig, response.data);
-  }, [persistedConfig, response.data, response.error, scopeKey]);
+    writePersistedDashboardSnapshot(scopeKey, normalizedPersistedConfig, response.data);
+  }, [normalizedPersistedConfig, response.data, response.error, scopeKey]);
 
   return response;
 }

--- a/apps/sdp-web/src/lib/dashboard-swr.tsx
+++ b/apps/sdp-web/src/lib/dashboard-swr.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { useEffect, useMemo } from "react";
+import useSWR, { type BareFetcher, type Key, type SWRConfiguration, type SWRResponse } from "swr";
+
+export interface PersistedDashboardSnapshotConfig<Data> {
+  key: string;
+  ttlMs: number;
+  version?: number;
+  storage?: "local" | "session";
+  shouldPersist?: (value: Data) => boolean;
+}
+
+interface PersistedDashboardSnapshotEnvelope<Data> {
+  expiresAt: number;
+  value: Data;
+  version: number;
+}
+
+const DASHBOARD_CACHE_STORAGE_PREFIX = "sdp.dashboard.cache";
+const DEFAULT_PERSISTED_SNAPSHOT_VERSION = 1;
+
+export const DASHBOARD_SWR_CONFIG: SWRConfiguration = {
+  dedupingInterval: 10_000,
+  errorRetryCount: 2,
+  focusThrottleInterval: 15_000,
+  keepPreviousData: true,
+  revalidateIfStale: true,
+  revalidateOnFocus: true,
+};
+
+function getStorage(storage: "local" | "session" = "local"): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return storage === "session" ? window.sessionStorage : window.localStorage;
+}
+
+function buildScopedSnapshotKey(scopeKey: string, key: string): string {
+  return `${DASHBOARD_CACHE_STORAGE_PREFIX}.${scopeKey}.${key}`;
+}
+
+function readPersistedDashboardSnapshot<Data>(
+  scopeKey: string,
+  config: PersistedDashboardSnapshotConfig<Data>
+): Data | undefined {
+  const storage = getStorage(config.storage);
+  if (!storage) {
+    return undefined;
+  }
+
+  const storageKey = buildScopedSnapshotKey(scopeKey, config.key);
+  const rawValue = storage.getItem(storageKey);
+  if (!rawValue) {
+    return undefined;
+  }
+
+  try {
+    const envelope = JSON.parse(rawValue) as PersistedDashboardSnapshotEnvelope<Data>;
+    const version = config.version ?? DEFAULT_PERSISTED_SNAPSHOT_VERSION;
+
+    if (typeof envelope.expiresAt !== "number" || envelope.expiresAt <= Date.now()) {
+      storage.removeItem(storageKey);
+      return undefined;
+    }
+
+    if (envelope.version !== version) {
+      storage.removeItem(storageKey);
+      return undefined;
+    }
+
+    return envelope.value;
+  } catch {
+    storage.removeItem(storageKey);
+    return undefined;
+  }
+}
+
+function writePersistedDashboardSnapshot<Data>(
+  scopeKey: string,
+  config: PersistedDashboardSnapshotConfig<Data>,
+  value: Data
+) {
+  const storage = getStorage(config.storage);
+  if (!storage) {
+    return;
+  }
+
+  const storageKey = buildScopedSnapshotKey(scopeKey, config.key);
+  const envelope: PersistedDashboardSnapshotEnvelope<Data> = {
+    expiresAt: Date.now() + config.ttlMs,
+    value,
+    version: config.version ?? DEFAULT_PERSISTED_SNAPSHOT_VERSION,
+  };
+
+  try {
+    storage.setItem(storageKey, JSON.stringify(envelope));
+  } catch {
+    // Ignore quota and serialization failures. Cache persistence is opportunistic.
+  }
+}
+
+export function usePersistedDashboardSWR<Data, Error = unknown>(
+  key: Key,
+  fetcher: BareFetcher<Data> | null,
+  config: SWRConfiguration<Data, Error> = {},
+  persistedConfig?: PersistedDashboardSnapshotConfig<Data>
+): SWRResponse<Data, Error> {
+  const {
+    dashboardCacheScope: { orgId, userId },
+  } = useDashboardWorkspace();
+  const scopeKey = useMemo(() => `${userId ?? "anonymous"}:${orgId ?? "no-org"}`, [orgId, userId]);
+
+  const persistedFallbackData = useMemo(() => {
+    if (!persistedConfig || config.fallbackData !== undefined) {
+      return undefined;
+    }
+
+    return readPersistedDashboardSnapshot<Data>(scopeKey, persistedConfig);
+  }, [config.fallbackData, persistedConfig, scopeKey]);
+
+  const response = useSWR<Data, Error>(key, fetcher, {
+    ...config,
+    fallbackData: config.fallbackData !== undefined ? config.fallbackData : persistedFallbackData,
+  });
+
+  useEffect(() => {
+    if (!persistedConfig || response.data === undefined || response.error) {
+      return;
+    }
+
+    if (persistedConfig.shouldPersist && !persistedConfig.shouldPersist(response.data)) {
+      return;
+    }
+
+    writePersistedDashboardSnapshot(scopeKey, persistedConfig, response.data);
+  }, [persistedConfig, response.data, response.error, scopeKey]);
+
+  return response;
+}

--- a/apps/sdp-web/src/proxy.ts
+++ b/apps/sdp-web/src/proxy.ts
@@ -1,7 +1,13 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/", "/dashboard(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/",
+  "/docs(.*)",
+  "/dashboard(.*)",
+]);
 
 export const proxy = clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {


### PR DESCRIPTION
## Summary\n- add a shared dashboard SWR configuration in the dashboard shell\n- add persisted per-user per-org warm snapshots for hot dashboard datasets\n- wire the persisted cache into home, payments, wallet activity/balances, and token supporting data\n\n## Testing\n- pnpm --filter sdp-web typecheck\n- pnpm --filter sdp-web build