### PR TITLE
fix: docs postman collection links

### DIFF
--- a/apps/sdp-docs/content/docs/reference/api/index.mdx
+++ b/apps/sdp-docs/content/docs/reference/api/index.mdx
@@ -4,9 +4,9 @@ description: Endpoint index from the repository OpenAPI spec.
 ---
 
 <div>
-  <a href="/postman/collection.json" download>Download Postman collection</a>
+  <a href="/docs/postman/collection.json" download>Download Postman collection</a>
   {" · "}
-  <a href="/postman/collection.json">Open raw JSON</a>
+  <a href="/docs/postman/collection.json">Open raw JSON</a>
 </div>
 
 - [Health](/docs/reference/api/health)

--- a/apps/sdp-docs/content/docs/reference/postman-collection.mdx
+++ b/apps/sdp-docs/content/docs/reference/postman-collection.mdx
@@ -16,9 +16,9 @@ The Postman collection is generated from the same public OpenAPI contract that p
 Internal-only endpoint families such as `rpc`, `admin`, `onboarding`, `auth`, `organizations`, and `members` are intentionally excluded.
 
 <div>
-  <a href="/postman/collection.json" download>Download Postman collection</a>
+  <a href="/docs/postman/collection.json" download>Download Postman collection</a>
   {" · "}
-  <a href="/postman/collection.json">Open raw JSON</a>
+  <a href="/docs/postman/collection.json">Open raw JSON</a>
 </div>
 
 When you import the collection into Postman, set:

--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  POSTMAN_COLLECTION_ROUTE,
   PUBLIC_TAG_SLUGS,
   getPrimaryTagName,
   isPublicTag,
@@ -121,9 +122,9 @@ description: Endpoint index from the repository OpenAPI spec.
 ---
 
 <div>
-  <a href="/postman/collection.json" download>Download Postman collection</a>
+  <a href="${POSTMAN_COLLECTION_ROUTE}" download>Download Postman collection</a>
   {" · "}
-  <a href="/postman/collection.json">Open raw JSON</a>
+  <a href="${POSTMAN_COLLECTION_ROUTE}">Open raw JSON</a>
 </div>
 
 ${links}

--- a/apps/sdp-docs/scripts/lib/public-openapi.mjs
+++ b/apps/sdp-docs/scripts/lib/public-openapi.mjs
@@ -8,7 +8,7 @@ export const PUBLIC_TAG_SLUGS = new Set([
   "compliance",
 ]);
 
-export const POSTMAN_COLLECTION_ROUTE = "/postman/collection.json";
+export const POSTMAN_COLLECTION_ROUTE = "/docs/postman/collection.json";
 export const POSTMAN_COLLECTION_FILENAME =
   "solana-developer-platform-public.postman_collection.json";
 export const POSTMAN_COLLECTION_PUBLIC_PATH = `/postman/${POSTMAN_COLLECTION_FILENAME}`;

--- a/apps/sdp-docs/src/app/docs/postman/collection.json/route.ts
+++ b/apps/sdp-docs/src/app/docs/postman/collection.json/route.ts
@@ -1,4 +1,4 @@
-import { readPostmanCollectionResponse } from "../../../lib/postman-collection";
+import { readPostmanCollectionResponse } from "../../../../lib/postman-collection";
 
 export const runtime = "nodejs";
 

--- a/apps/sdp-docs/src/lib/postman-collection.ts
+++ b/apps/sdp-docs/src/lib/postman-collection.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { POSTMAN_COLLECTION_FILENAME } from "../../scripts/lib/public-openapi.mjs";
+
+const collectionPath = path.join(process.cwd(), "public", "postman", POSTMAN_COLLECTION_FILENAME);
+
+export async function readPostmanCollectionResponse() {
+  try {
+    const body = await readFile(collectionPath, "utf8");
+
+    return new Response(body, {
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "public, max-age=300",
+        "content-disposition": `inline; filename="${POSTMAN_COLLECTION_FILENAME}"`,
+      },
+    });
+  } catch {
+    return Response.json(
+      {
+        error: {
+          code: "POSTMAN_COLLECTION_UNAVAILABLE",
+          message: "The generated Postman collection is not available.",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/sdp-web/next.config.ts
+++ b/apps/sdp-web/next.config.ts
@@ -13,6 +13,10 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
+        source: "/postman/collection.json",
+        destination: `${docsProxyOrigin}/postman/collection.json`,
+      },
+      {
         source: "/docs",
         destination: `${docsProxyOrigin}/docs`,
       },

--- a/apps/sdp-web/next.config.ts
+++ b/apps/sdp-web/next.config.ts
@@ -14,7 +14,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/postman/collection.json",
-        destination: `${docsProxyOrigin}/postman/collection.json`,
+        destination: `${docsProxyOrigin}/docs/postman/collection.json`,
       },
       {
         source: "/docs",


### PR DESCRIPTION
## Summary
- serve the Postman collection JSON at /docs/postman/collection.json for the docs app
- update generated and hand-written docs links to use the /docs-prefixed route
- add a compatibility rewrite so the existing /postman/collection.json URL works on platform.solana.com

## Testing
- pnpm -C apps/sdp-docs generate:api
- pnpm --filter sdp-docs build
- pnpm --filter sdp-web typecheck
- pnpm --filter sdp-web build