### PR TITLE
fix: unblock release flow workflow parsing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   prepare-release-pr:
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(main): release ') }}
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
         run: node .github/scripts/release-flow.mjs prepare
 
   publish-release:
-    if: ${{ startsWith(github.event.head_commit.message, 'chore(main): release ') }}
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- quote the release workflow job conditions so GitHub parses the workflow correctly
- unblock the REST-based release PR and tag flow introduced on main

## Test plan
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml