### PR TITLE
fix: handle release flow git subprocess output correctly

### DIFF
--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -35,10 +35,16 @@ const changelogSections = [
 ];
 
 function git(args, options = {}) {
-  return execFileSync("git", args, {
+  const output = execFileSync("git", args, {
     encoding: "utf8",
     stdio: options.capture === false ? "inherit" : ["ignore", "pipe", "pipe"],
-  }).trim();
+  });
+
+  if (typeof output !== "string") {
+    return "";
+  }
+
+  return output.trim();
 }
 
 function detectRepositoryFromGit() {


### PR DESCRIPTION
## Summary
- make the release flow git helper tolerate non-captured subprocess calls
- unblock branch creation, commit, and push steps in the REST-based release automation

## Test plan
- node .github/scripts/release-flow.mjs prepare --dry-run
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml