### PR TITLE
fix: preserve package formatting in release flow

### DIFF
--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -75,7 +75,9 @@ function updatePackageVersion(filePath, currentVersion, nextVersion) {
   );
 
   if (updated === current) {
-    throw new Error(`Unable to update package.json version from ${currentVersion} to ${nextVersion}`);
+    throw new Error(
+      `Unable to update package.json version from ${currentVersion} to ${nextVersion}`
+    );
   }
 
   fs.writeFileSync(filePath, updated);

--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -67,6 +67,20 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function updatePackageVersion(filePath, currentVersion, nextVersion) {
+  const current = fs.readFileSync(filePath, "utf8");
+  const updated = current.replace(
+    new RegExp(`(\"version\"\\s*:\\s*\")${escapeRegExp(currentVersion)}(\")`),
+    `$1${nextVersion}$2`
+  );
+
+  if (updated === current) {
+    throw new Error(`Unable to update package.json version from ${currentVersion} to ${nextVersion}`);
+  }
+
+  fs.writeFileSync(filePath, updated);
+}
+
 function latestReleaseTag() {
   const output = git(["tag", "--list", "v*.*.*", "--sort=-v:refname"]);
   return (
@@ -141,6 +155,10 @@ function incrementVersion(version, level) {
     default:
       return `${major}.${minor}.${patch + 1}`;
   }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function compareUrl(fromTag, toTag) {
@@ -335,10 +353,9 @@ async function prepareRelease() {
 
   git(["checkout", "-B", releaseBranch], { capture: false });
 
-  packageJson.version = nextVersion;
   manifest["."] = nextVersion;
 
-  writeJson(packageJsonPath, packageJson);
+  updatePackageVersion(packageJsonPath, packageJson.version, nextVersion);
   writeJson(manifestPath, manifest);
   prependChangelog(sectionMarkdown);
 


### PR DESCRIPTION
## Summary
- update the release flow to edit package.json version in place
- keep generated release PRs lint-clean by preserving existing package formatting

## Test plan
- node .github/scripts/release-flow.mjs prepare --dry-run
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml