### PR TITLE
fix: configure git identity before publishing release tag

### DIFF
--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -422,6 +422,10 @@ async function publishRelease() {
     return;
   }
 
+  git(["config", "user.name", "github-actions[bot]"], { capture: false });
+  git(["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], {
+    capture: false,
+  });
   git(["tag", "-a", tagName, "-m", tagName], { capture: false });
   git(["push", `https://x-access-token:${token}@github.com/${repo}.git`, tagName], {
     capture: false,


### PR DESCRIPTION
## Summary
- configure the bot git identity in the publish step before creating annotated tags
- let the REST-based release flow complete tag publication without manual intervention

## Test plan
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml
- git diff --name-only --diff-filter=d origin/main...HEAD -z | xargs -0 --no-run-if-empty pnpm exec biome check --no-errors-on-unmatched