### PR TITLE
fix: reuse Clerk auth work and move AI docs into /docs

### DIFF
--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -53,6 +53,7 @@
     "@asteasolutions/zod-to-openapi": "7.2.0",
     "@cloudflare/vitest-pool-workers": "^0.12.0",
     "@cloudflare/workers-types": "^4.20250124.0",
+    "@types/react": "^19.2.10",
     "@vitest/coverage-v8": "^3.0.0",
     "drizzle-kit": "^0.31.8",
     "openapi3-ts": "4.5.0",

--- a/apps/sdp-api/src/lib/clerk-token.ts
+++ b/apps/sdp-api/src/lib/clerk-token.ts
@@ -79,3 +79,17 @@ export async function verifyClerkJwt(token: string, env: Env): Promise<ClerkJwtP
 
   return payload as ClerkJwtPayload;
 }
+
+export async function verifyClerkJwtForRequest(
+  c: Context<{ Bindings: Env }>,
+  token: string
+): Promise<ClerkJwtPayload> {
+  const cached = c.get("verifiedClerkJwt");
+  if (cached?.token === token) {
+    return cached.payload;
+  }
+
+  const payload = await verifyClerkJwt(token, c.env);
+  c.set("verifiedClerkJwt", { token, payload });
+  return payload;
+}

--- a/apps/sdp-api/src/middleware/clerk-auth.test.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.test.ts
@@ -1,13 +1,20 @@
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { rateLimitMiddleware } from "@/middleware/rate-limit";
-import { TEST_ORG } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/d1";
 import { clearKVNamespaces } from "@/test/mocks/kv";
 import type { Env } from "@/types/env";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const TEST_ORG = {
+  id: "org_clerk_cache_request_test",
+  name: "Clerk Cache Request Test Org",
+  slug: "clerk-cache-request-test-org",
+  tier: "free" as const,
+  status: "active" as const,
+};
 
 function encodeJwtPart(value: Record<string, unknown>): string {
   return Buffer.from(JSON.stringify(value)).toString("base64url");

--- a/apps/sdp-api/src/middleware/clerk-auth.test.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.test.ts
@@ -1,0 +1,123 @@
+import type { ClerkJwtPayload } from "@/lib/clerk-token";
+import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { rateLimitMiddleware } from "@/middleware/rate-limit";
+import { TEST_ORG } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/d1";
+import { clearKVNamespaces } from "@/test/mocks/kv";
+import type { Env } from "@/types/env";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function encodeJwtPart(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function createJwt(payload: ClerkJwtPayload): string {
+  return `${encodeJwtPart({ alg: "RS256", typ: "JWT" })}.${encodeJwtPart(payload)}.signature`;
+}
+
+describe("Clerk auth request cache", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+
+    await env.DB.batch([
+      env.DB.prepare(
+        `CREATE TABLE IF NOT EXISTS auth_user_identities (
+           id TEXT PRIMARY KEY,
+           provider TEXT NOT NULL,
+           provider_user_id TEXT NOT NULL,
+           user_id TEXT NOT NULL,
+           email TEXT
+         )`
+      ),
+      env.DB.prepare(
+        `CREATE TABLE IF NOT EXISTS auth_organization_identities (
+           id TEXT PRIMARY KEY,
+           provider TEXT NOT NULL,
+           provider_org_id TEXT NOT NULL,
+           organization_id TEXT NOT NULL,
+           slug TEXT
+         )`
+      ),
+    ]);
+
+    await env.DB.batch([
+      env.DB.prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)"
+      ).bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, TEST_ORG.tier, TEST_ORG.status),
+      env.DB.prepare(
+        "INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      ).bind("usr_clerk_cached", "clerk-cache@example.com"),
+      env.DB.prepare(
+        `INSERT INTO auth_user_identities (id, provider, provider_user_id, user_id, email)
+         VALUES (?, 'clerk', ?, ?, ?)`
+      ).bind(
+        "aui_clerk_cached",
+        "clerk_user_cached",
+        "usr_clerk_cached",
+        "clerk-cache@example.com"
+      ),
+      env.DB.prepare(
+        `INSERT INTO auth_organization_identities (id, provider, provider_org_id, organization_id, slug)
+         VALUES (?, 'clerk', ?, ?, ?)`
+      ).bind("aoi_clerk_cached", "clerk_org_cached", TEST_ORG.id, TEST_ORG.slug),
+      env.DB.prepare(
+        `INSERT INTO organization_members (id, organization_id, user_id, role, status)
+         VALUES (?, ?, ?, 'admin', 'active')`
+      ).bind("mem_clerk_cached", TEST_ORG.id, "usr_clerk_cached"),
+    ]);
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+    await clearKVNamespaces(env);
+    env.CLERK_ISSUER = undefined;
+    env.CLERK_JWKS_URL = undefined;
+  });
+
+  it("reuses a cached Clerk JWT across rate limiting and auth in one request", async () => {
+    const payload: ClerkJwtPayload = {
+      sub: "clerk_user_cached",
+      org_id: "clerk_org_cached",
+      org_role: "org:admin",
+      org_slug: TEST_ORG.slug,
+      email: "clerk-cache@example.com",
+      iss: "https://clerk.example.test",
+    };
+    const token = createJwt(payload);
+
+    env.CLERK_ISSUER = payload.iss;
+    env.CLERK_JWKS_URL = undefined;
+
+    const app = new Hono<{ Bindings: Env }>();
+
+    app.use("*", async (c, next) => {
+      c.set("verifiedClerkJwt", { token, payload });
+      await next();
+    });
+    app.use("*", rateLimitMiddleware());
+    app.use("*", unifiedAuthMiddleware({ allowClerk: true }));
+
+    app.get("/protected", requirePermissions("org:read"), (c) => {
+      return c.json({
+        organizationId: c.get("clerk")?.organizationId ?? null,
+      });
+    });
+
+    const res = await app.request(
+      "/protected",
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      organizationId: TEST_ORG.id,
+    });
+  });
+});

--- a/apps/sdp-api/src/middleware/clerk-auth.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.ts
@@ -10,7 +10,7 @@ import {
   type ClerkJwtPayload,
   extractBearerToken,
   resolveClerkEmail,
-  verifyClerkJwt,
+  verifyClerkJwtForRequest,
 } from "@/lib/clerk-token";
 import { AppError, unauthorized } from "@/lib/errors";
 import type { Env } from "@/types/env";
@@ -41,6 +41,50 @@ async function resolveClerkOrganization(db: D1Database, clerkOrgId: string) {
     )
     .bind(clerkOrgId)
     .first<{ organization_id: string; slug: string | null }>();
+}
+
+async function resolveExistingClerkContext(
+  db: D1Database,
+  params: {
+    clerkUserId: string;
+    clerkOrgId: string;
+    fallbackEmail: string;
+    fallbackOrgSlug: string | null;
+  }
+) {
+  return db
+    .prepare(
+      `SELECT
+         aui.user_id,
+         COALESCE(aui.email, u.email, ?) AS email,
+         aoi.organization_id,
+         COALESCE(aoi.slug, ?) AS org_slug,
+         om.role
+       FROM auth_organization_identities aoi
+       LEFT JOIN auth_user_identities aui
+         ON aui.provider = 'clerk' AND aui.provider_user_id = ?
+       LEFT JOIN users u
+         ON u.id = aui.user_id
+       LEFT JOIN organization_members om
+         ON om.user_id = aui.user_id
+        AND om.organization_id = aoi.organization_id
+        AND om.status = 'active'
+       WHERE aoi.provider = 'clerk' AND aoi.provider_org_id = ?
+       LIMIT 1`
+    )
+    .bind(
+      params.fallbackEmail.toLowerCase(),
+      params.fallbackOrgSlug,
+      params.clerkUserId,
+      params.clerkOrgId
+    )
+    .first<{
+      user_id: string | null;
+      email: string | null;
+      organization_id: string;
+      org_slug: string | null;
+      role: string | null;
+    }>();
 }
 
 async function resolveOrgRole(db: D1Database, userId: string, organizationId: string) {
@@ -190,6 +234,39 @@ async function buildClerkContext(c: Context<{ Bindings: Env }>, payload: ClerkJw
     throw new AppError("UNAUTHORIZED", "Clerk token missing email");
   }
 
+  const existingContext = await resolveExistingClerkContext(c.env.DB, {
+    clerkUserId: payload.sub as string,
+    clerkOrgId: payload.org_id as string,
+    fallbackEmail: email,
+    fallbackOrgSlug: payload.org_slug ?? null,
+  });
+
+  if (existingContext?.organization_id && existingContext.user_id && existingContext.role) {
+    const role = normalizeOrganizationRole(existingContext.role);
+
+    if (role !== existingContext.role) {
+      await c.env.DB.prepare(
+        `UPDATE organization_members
+           SET role = ?
+           WHERE user_id = ? AND organization_id = ? AND status = 'active'`
+      )
+        .bind(role, existingContext.user_id, existingContext.organization_id)
+        .run();
+    }
+
+    return {
+      userId: existingContext.user_id,
+      organizationId: existingContext.organization_id,
+      permissions: getPermissionsForOrgRole(role),
+      role,
+      clerkUserId: payload.sub as string,
+      clerkOrgId: payload.org_id as string,
+      email: existingContext.email ?? email,
+      orgSlug: payload.org_slug ?? existingContext.org_slug,
+      orgRole: payload.org_role ?? null,
+    };
+  }
+
   const [userIdentity, orgIdentity] = await Promise.all([
     ensureClerkUser(c.env.DB, payload.sub as string, email),
     resolveClerkOrganization(c.env.DB, payload.org_id as string),
@@ -231,7 +308,7 @@ export function clerkAuthMiddleware() {
 
     let payload: ClerkJwtPayload;
     try {
-      payload = await verifyClerkJwt(token, c.env);
+      payload = await verifyClerkJwtForRequest(c, token);
     } catch (error) {
       throw new AppError("UNAUTHORIZED", "Invalid Clerk token", {
         cause: error instanceof Error ? error.message : String(error),
@@ -263,7 +340,7 @@ export function optionalClerkAuth() {
     }
 
     try {
-      const payload = await verifyClerkJwt(token, c.env);
+      const payload = await verifyClerkJwtForRequest(c, token);
 
       if (payload.sub && payload.org_id) {
         const clerkContext = await buildClerkContext(c, payload);

--- a/apps/sdp-api/src/middleware/clerk-onboarding.ts
+++ b/apps/sdp-api/src/middleware/clerk-onboarding.ts
@@ -2,7 +2,7 @@ import {
   type ClerkJwtPayload,
   extractBearerToken,
   resolveClerkEmail,
-  verifyClerkJwt,
+  verifyClerkJwtForRequest,
 } from "@/lib/clerk-token";
 import { AppError, unauthorized } from "@/lib/errors";
 import type { Env } from "@/types/env";
@@ -18,7 +18,7 @@ export function clerkOnboardingMiddleware() {
 
     let payload: ClerkJwtPayload;
     try {
-      payload = await verifyClerkJwt(token, c.env);
+      payload = await verifyClerkJwtForRequest(c, token);
     } catch (error) {
       throw new AppError("UNAUTHORIZED", "Invalid Clerk token", {
         cause: error instanceof Error ? error.message : String(error),

--- a/apps/sdp-api/src/middleware/rate-limit.ts
+++ b/apps/sdp-api/src/middleware/rate-limit.ts
@@ -5,7 +5,7 @@
  * Different tiers have different limits.
  */
 
-import { verifyClerkJwt } from "@/lib/clerk-token";
+import { verifyClerkJwtForRequest } from "@/lib/clerk-token";
 import { AppError } from "@/lib/errors";
 import type { Env } from "@/types/env";
 import type { Context, Next } from "hono";
@@ -117,7 +117,7 @@ function looksLikeClerkJwt(token: string, env: Env): boolean {
 
 async function isVerifiedClerkJwt(c: Context<{ Bindings: Env }>, token: string): Promise<boolean> {
   try {
-    await verifyClerkJwt(token, c.env);
+    await verifyClerkJwtForRequest(c, token);
     return true;
   } catch {
     return false;

--- a/apps/sdp-api/src/routes/llms.ts
+++ b/apps/sdp-api/src/routes/llms.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SDP_API_URL, DEFAULT_SDP_DOCS_URL, SDP_AGENTS_URL } from "@sdp/types";
+import { DEFAULT_SDP_AI_GUIDE_URL, DEFAULT_SDP_API_URL, DEFAULT_SDP_DOCS_URL } from "@sdp/types";
 import { Hono } from "hono";
 
 import type { Env } from "@/types/env";
@@ -15,7 +15,7 @@ const body = [
   `- OpenAPI: ${DEFAULT_SDP_API_URL}/openapi.json`,
   `- Interactive API docs: ${DEFAULT_SDP_API_URL}/docs`,
   `- Product docs: ${DEFAULT_SDP_DOCS_URL}`,
-  `- Agent guide: ${SDP_AGENTS_URL}`,
+  `- AI guide: ${DEFAULT_SDP_AI_GUIDE_URL}`,
   "",
   "## Authentication",
   "- Use `Authorization: Bearer <api_key>`.",

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -5,6 +5,7 @@
  * configured via wrangler.toml.
  */
 
+import type { ClerkJwtPayload } from "@/lib/clerk-token";
 import type { CachedSession, OrganizationRpcProvider, Permission } from "@sdp/types";
 
 export interface Env {
@@ -198,6 +199,10 @@ declare module "hono" {
       orgSlug: string | null;
       orgRole: string | null;
       email: string;
+    };
+    verifiedClerkJwt?: {
+      token: string;
+      payload: ClerkJwtPayload;
     };
     requestId: string;
     traceId: string;

--- a/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
+++ b/apps/sdp-docs/content/docs/guides/tokenize-an-asset.mdx
@@ -54,8 +54,8 @@ See the full public endpoint map in the [Issuance API reference](/docs/reference
 
 ## For coding agents
 
-If you are driving SDP through an agent workflow, start from the public AI discovery entry point:
+If you are driving SDP through an agent workflow, start from the public AI docs guide:
 
-- [llms.txt](/llms.txt)
+- [AI Consumption](/docs/reference/ai-consumption)
 
-That path leads to the repo agent guide, where the repo-local `sdp-tokenization` skill is indexed and kept grounded in the supported public docs and API surface rather than internal handlers.
+That page links the machine-readable SDP discovery files and keeps AI-facing guidance grounded in the supported public docs and API surface rather than internal handlers.

--- a/apps/sdp-docs/content/docs/meta.json
+++ b/apps/sdp-docs/content/docs/meta.json
@@ -19,6 +19,7 @@
     "tutorials/end-to-end-payment-flow",
     "---Reference---",
     "reference/issuance-token-types",
+    "reference/ai-consumption",
     "reference/postman-collection",
     "reference/api/index",
     "reference/api/health",

--- a/apps/sdp-docs/content/docs/reference/ai-consumption.mdx
+++ b/apps/sdp-docs/content/docs/reference/ai-consumption.mdx
@@ -1,0 +1,37 @@
+---
+title: AI Consumption
+description: Public machine-readable entry points and guidance for agents and AI systems consuming SDP docs and APIs.
+---
+
+Use this page when you need the public AI-facing entry points for Solana Developer Platform.
+
+## Machine-readable resources
+
+- [llms.txt](/docs/ai/llms.txt): Concise discovery file with canonical URLs, supported surfaces, and key starting pages.
+- [llms-full.txt](/docs/ai/llms-full.txt): Expanded docs map generated from the docs navigation and public API reference.
+- [OpenAPI](/docs/reference/api): Human-readable API reference generated from the public contract.
+- [OpenAPI JSON](https://api.solana.com/openapi.json): Machine-readable API contract for the public SDP API.
+- [API llms.txt](https://api.solana.com/llms.txt): API-only discovery entry point for endpoint families and authentication expectations.
+- [Postman Collection](/docs/reference/postman-collection): Downloadable public collection generated from the same OpenAPI source.
+
+## Recommended ingestion order
+
+1. Start with [llms.txt](/docs/ai/llms.txt).
+2. Expand to [llms-full.txt](/docs/ai/llms-full.txt) when you need broader site coverage.
+3. Use the [API reference](/docs/reference/api) and [OpenAPI JSON](https://api.solana.com/openapi.json) for exact request and response schemas.
+4. Use the product guides for workflow sequencing, operational constraints, and supported patterns.
+
+## Scope
+
+- These AI resources are limited to the supported public SDP surface.
+- Hidden or internal-only route families are intentionally excluded.
+- Public docs should be treated as the source of truth ahead of internal implementation details.
+
+## Coverage focus
+
+- Wallets and custody
+- API key management
+- Projects
+- Token issuance and lifecycle operations
+- Payments, transfers, and ramps
+- Compliance screening

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -7,8 +7,7 @@
 - API: https://api.solana.com
 - Interactive API docs: https://api.solana.com/docs
 - OpenAPI: https://api.solana.com/openapi.json
-- Repo: https://github.com/solana-foundation/solana-developer-platform
-- Agent guide: https://github.com/solana-foundation/solana-developer-platform/blob/main/AGENTS.md
+- AI guide: https://platform.solana.com/docs/reference/ai-consumption
 
 ## Docs
 - [What is Solana Developer Platform?](https://platform.solana.com/docs/what-is-solana-developer-platform): A dashboard and API for issuing, transferring, and managing Solana tokens with built-in compliance controls.
@@ -32,6 +31,7 @@
 
 ## Reference
 - [Issuance Token Types](https://platform.solana.com/docs/reference/issuance-token-types): Supported issuance templates and default controls.
+- [AI Consumption](https://platform.solana.com/docs/reference/ai-consumption): Public machine-readable entry points and guidance for agents and AI systems consuming SDP docs and APIs.
 - [Postman Collection](https://platform.solana.com/docs/reference/postman-collection): Download the public SDP API Postman collection generated from the OpenAPI contract.
 - [API Reference](https://platform.solana.com/docs/reference/api): Endpoint index from the repository OpenAPI spec.
 - [Health](https://platform.solana.com/docs/reference/api/health): Service health and readiness endpoints.

--- a/apps/sdp-docs/public/llms.txt
+++ b/apps/sdp-docs/public/llms.txt
@@ -7,8 +7,7 @@
 - API: https://api.solana.com
 - Interactive API docs: https://api.solana.com/docs
 - OpenAPI: https://api.solana.com/openapi.json
-- Repo: https://github.com/solana-foundation/solana-developer-platform
-- Agent guide: https://github.com/solana-foundation/solana-developer-platform/blob/main/AGENTS.md
+- AI guide: https://platform.solana.com/docs/reference/ai-consumption
 
 ## Supported surfaces
 - Wallets and custody
@@ -40,11 +39,12 @@
 - [Payments](https://platform.solana.com/docs/reference/api/payments): Wallet balances, transfer execution, policies, and ramps.
 - [Compliance](https://platform.solana.com/docs/reference/api/compliance): Risk and compliance screening endpoints.
 
-## Skills
-- [Agent guide](https://github.com/solana-foundation/solana-developer-platform/blob/main/AGENTS.md): Canonical repo entry point for coding agents, including the repo-local `sdp-tokenization` skill.
+## AI guide
+- [AI Consumption](https://platform.solana.com/docs/reference/ai-consumption): Human-readable landing page for machine-readable SDP docs resources, usage guidance, and public AI scope.
 
 ## Machine-readable resources
-- [llms-full.txt](https://platform.solana.com/llms-full.txt)
+- [llms.txt](https://platform.solana.com/docs/ai/llms.txt)
+- [llms-full.txt](https://platform.solana.com/docs/ai/llms-full.txt)
 - [OpenAPI](https://api.solana.com/openapi.json)
 - [Swagger UI](https://api.solana.com/docs)
 

--- a/apps/sdp-docs/scripts/check-links.ts
+++ b/apps/sdp-docs/scripts/check-links.ts
@@ -114,6 +114,8 @@ async function loadDocPages(): Promise<Map<string, string>> {
 function createAllowedInternalPaths(docSlugs: Iterable<string>): Set<string> {
   const allowed = new Set<string>([
     "/docs",
+    "/docs/ai/llms.txt",
+    "/docs/ai/llms-full.txt",
     "/llms.txt",
     "/llms-full.txt",
     "/robots.txt",

--- a/apps/sdp-docs/scripts/generate-ai-resources.ts
+++ b/apps/sdp-docs/scripts/generate-ai-resources.ts
@@ -3,14 +3,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  agentsUrl,
+  aiGuideUrl,
+  aiLlmsFullUrl,
+  aiLlmsUrl,
   apiDocsUrl,
   apiOpenApiUrl,
   apiUrl,
-  docsOrigin,
   docsUrl,
   getDocsPageUrl,
-  repositoryUrl,
 } from "../src/lib/site";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -198,8 +198,7 @@ function renderLlms(keyPages: DocsPage[]): string {
     `- API: ${apiUrl}`,
     `- Interactive API docs: ${apiDocsUrl}`,
     `- OpenAPI: ${apiOpenApiUrl}`,
-    `- Repo: ${repositoryUrl}`,
-    `- Agent guide: ${agentsUrl}`,
+    `- AI guide: ${aiGuideUrl}`,
     "",
     "## Supported surfaces",
     ...FEATURE_SUMMARY.map((feature) => `- ${feature}`),
@@ -207,11 +206,12 @@ function renderLlms(keyPages: DocsPage[]): string {
     "## Start here",
     ...keyPages.map(renderLink),
     "",
-    "## Skills",
-    `- [Agent guide](${agentsUrl}): Canonical repo entry point for coding agents, including the repo-local \`sdp-tokenization\` skill.`,
+    "## AI guide",
+    `- [AI Consumption](${aiGuideUrl}): Human-readable landing page for machine-readable SDP docs resources, usage guidance, and public AI scope.`,
     "",
     "## Machine-readable resources",
-    `- [llms-full.txt](${docsOrigin}/llms-full.txt)`,
+    `- [llms.txt](${aiLlmsUrl})`,
+    `- [llms-full.txt](${aiLlmsFullUrl})`,
     `- [OpenAPI](${apiOpenApiUrl})`,
     `- [Swagger UI](${apiDocsUrl})`,
     "",
@@ -232,8 +232,7 @@ function renderLlmsFull(sections: Section[]): string {
     `- API: ${apiUrl}`,
     `- Interactive API docs: ${apiDocsUrl}`,
     `- OpenAPI: ${apiOpenApiUrl}`,
-    `- Repo: ${repositoryUrl}`,
-    `- Agent guide: ${agentsUrl}`,
+    `- AI guide: ${aiGuideUrl}`,
     "",
     sections.map(renderSection).join("\n\n"),
     "",

--- a/apps/sdp-docs/scripts/link-check.config.json
+++ b/apps/sdp-docs/scripts/link-check.config.json
@@ -1,4 +1,4 @@
 {
   "ignoredExternalHosts": [],
-  "ignoredExternalUrls": []
+  "ignoredExternalUrls": ["https://api.solana.com/openapi.json", "https://api.solana.com/llms.txt"]
 }

--- a/apps/sdp-docs/src/app/docs/ai/llms-full.txt/route.ts
+++ b/apps/sdp-docs/src/app/docs/ai/llms-full.txt/route.ts
@@ -1,0 +1,7 @@
+import { readAiResourceResponse } from "@/lib/ai-resources";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return readAiResourceResponse("llmsFull");
+}

--- a/apps/sdp-docs/src/app/docs/ai/llms.txt/route.ts
+++ b/apps/sdp-docs/src/app/docs/ai/llms.txt/route.ts
@@ -1,0 +1,7 @@
+import { readAiResourceResponse } from "@/lib/ai-resources";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return readAiResourceResponse("llms");
+}

--- a/apps/sdp-docs/src/app/llms-full.txt/route.ts
+++ b/apps/sdp-docs/src/app/llms-full.txt/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET(request: Request) {
+  return NextResponse.redirect(new URL("/docs/ai/llms-full.txt", request.url), { status: 308 });
+}

--- a/apps/sdp-docs/src/app/llms.txt/route.ts
+++ b/apps/sdp-docs/src/app/llms.txt/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET(request: Request) {
+  return NextResponse.redirect(new URL("/docs/ai/llms.txt", request.url), { status: 308 });
+}

--- a/apps/sdp-docs/src/app/sitemap.ts
+++ b/apps/sdp-docs/src/app/sitemap.ts
@@ -1,4 +1,4 @@
-import { docsOrigin, getDocsPagePath } from "@/lib/site";
+import { aiLlmsFullUrl, aiLlmsUrl, docsOrigin, getDocsPagePath } from "@/lib/site";
 import { source } from "@/lib/source";
 import type { MetadataRoute } from "next";
 
@@ -20,12 +20,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
-      url: `${docsOrigin}/llms.txt`,
+      url: aiLlmsUrl,
       changeFrequency: "weekly",
       priority: 0.6,
     },
     {
-      url: `${docsOrigin}/llms-full.txt`,
+      url: aiLlmsFullUrl,
       changeFrequency: "weekly",
       priority: 0.5,
     },

--- a/apps/sdp-docs/src/lib/ai-resources.ts
+++ b/apps/sdp-docs/src/lib/ai-resources.ts
@@ -1,0 +1,54 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+type AiResourceName = "llms" | "llmsFull";
+
+const aiResourceMap: Record<
+  AiResourceName,
+  {
+    fileName: string;
+    unavailableCode: string;
+    unavailableMessage: string;
+  }
+> = {
+  llms: {
+    fileName: "llms.txt",
+    unavailableCode: "LLMS_RESOURCE_UNAVAILABLE",
+    unavailableMessage: "The generated llms.txt resource is not available.",
+  },
+  llmsFull: {
+    fileName: "llms-full.txt",
+    unavailableCode: "LLMS_FULL_RESOURCE_UNAVAILABLE",
+    unavailableMessage: "The generated llms-full.txt resource is not available.",
+  },
+};
+
+function getAiResourcePath(resourceName: AiResourceName): string {
+  return path.join(process.cwd(), "public", aiResourceMap[resourceName].fileName);
+}
+
+export async function readAiResourceResponse(resourceName: AiResourceName) {
+  const resource = aiResourceMap[resourceName];
+
+  try {
+    const body = await readFile(getAiResourcePath(resourceName), "utf8");
+
+    return new Response(body, {
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "public, max-age=300",
+        "content-disposition": `inline; filename="${resource.fileName}"`,
+      },
+    });
+  } catch {
+    return Response.json(
+      {
+        error: {
+          code: resource.unavailableCode,
+          message: resource.unavailableMessage,
+        },
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/sdp-docs/src/lib/site.ts
+++ b/apps/sdp-docs/src/lib/site.ts
@@ -1,17 +1,17 @@
-import {
-  DEFAULT_SDP_API_URL,
-  DEFAULT_SDP_DOCS_URL,
-  SDP_AGENTS_URL,
-  SDP_GITHUB_REPO_URL,
-} from "@sdp/types";
+import { DEFAULT_SDP_API_URL, DEFAULT_SDP_DOCS_URL, SDP_GITHUB_REPO_URL } from "@sdp/types";
 
 export const docsUrl = process.env.NEXT_PUBLIC_SDP_DOCS_URL || DEFAULT_SDP_DOCS_URL;
 export const docsOrigin = new URL(docsUrl).origin;
 export const apiUrl = process.env.NEXT_PUBLIC_SDP_API_URL || DEFAULT_SDP_API_URL;
 export const apiOpenApiUrl = `${apiUrl}/openapi.json`;
 export const apiDocsUrl = `${apiUrl}/docs`;
-export const agentsUrl = SDP_AGENTS_URL;
 export const repositoryUrl = SDP_GITHUB_REPO_URL;
+export const aiGuidePath = getDocsPagePath("reference/ai-consumption");
+export const aiGuideUrl = `${docsOrigin}${aiGuidePath}`;
+export const aiLlmsPath = "/docs/ai/llms.txt";
+export const aiLlmsUrl = `${docsOrigin}${aiLlmsPath}`;
+export const aiLlmsFullPath = "/docs/ai/llms-full.txt";
+export const aiLlmsFullUrl = `${docsOrigin}${aiLlmsFullPath}`;
 
 export function normalizeDocsPageSlug(pageSlug: string): string {
   return pageSlug.replace(/\/index$/, "");

--- a/apps/sdp-web/src/components/ui/table.tsx
+++ b/apps/sdp-web/src/components/ui/table.tsx
@@ -59,7 +59,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
       data-slot="table-head"
       className={cn(
         // biome-ignore lint/nursery/noSecrets: Tailwind classnames can trigger false positives in entropy-based checks.
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}
@@ -73,7 +73,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
       data-slot="table-cell"
       className={cn(
         // biome-ignore lint/nursery/noSecrets: Tailwind classnames can trigger false positives in entropy-based checks.
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}

--- a/packages/sdp-types/src/site.ts
+++ b/packages/sdp-types/src/site.ts
@@ -1,10 +1,14 @@
 export const DEFAULT_SDP_DOCS_URL = "https://platform.solana.com/docs";
 export const DEFAULT_SDP_API_URL = "https://api.solana.com";
+export const DEFAULT_SDP_AI_GUIDE_URL = `${DEFAULT_SDP_DOCS_URL}/reference/ai-consumption`;
+export const DEFAULT_SDP_AI_LLMS_URL = `${DEFAULT_SDP_DOCS_URL}/ai/llms.txt`;
+export const DEFAULT_SDP_AI_LLMS_FULL_URL = `${DEFAULT_SDP_DOCS_URL}/ai/llms-full.txt`;
 export const SDP_GITHUB_REPO_URL = "https://github.com/solana-foundation/solana-developer-platform";
 export const SDP_GITHUB_REPO_BLOB_MAIN_URL = `${SDP_GITHUB_REPO_URL}/blob/main`;
 export const SDP_GITHUB_REPO_RAW_MAIN_URL = `${SDP_GITHUB_REPO_URL}/raw/main`;
 export const SDP_AGENTS_URL = `${SDP_GITHUB_REPO_BLOB_MAIN_URL}/AGENTS.md`;
 
 export function getSdpDocsOrigin(url: string = DEFAULT_SDP_DOCS_URL): string {
-  return new URL(url).origin;
+  const match = /^https?:\/\/[^/]+/.exec(url);
+  return match ? match[0] : url;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250124.0
         version: 4.20260123.0
+      '@types/react':
+        specifier: ^19.2.10
+        version: 19.2.10
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -11582,7 +11585,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -11615,7 +11618,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11630,7 +11633,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary
- cache Clerk JWT verification per request and collapse warm Clerk context lookup work in the API auth path
- move AI discovery resources into the docs site under `/docs/ai/*` and add a public AI consumption docs page
- redirect root `llms` entry points to the docs-owned routes and update the generated AI resources to point at the docs page

## Verification
- `pnpm --filter ./apps/sdp-api --filter ./apps/sdp-docs --filter ./packages/sdp-types typecheck`
- `pnpm test`
- `pnpm --filter ./apps/sdp-api build`
- `pnpm --filter sdp-docs build`
- `pnpm --filter sdp-docs check:links`
