### PR TITLE
fix: point docs dashboard link to the SDP root

### DIFF
--- a/apps/sdp-docs/src/app/docs/layout.tsx
+++ b/apps/sdp-docs/src/app/docs/layout.tsx
@@ -7,8 +7,10 @@ function resolveDashboardUrl() {
   if (configuredUrl) {
     try {
       const parsed = new URL(configuredUrl);
-      if (parsed.pathname === "/" || parsed.pathname === "") {
-        parsed.pathname = "/dashboard";
+      if (parsed.pathname === "" || parsed.pathname === "/" || parsed.pathname === "/dashboard") {
+        parsed.pathname = "/";
+        parsed.search = "";
+        parsed.hash = "";
       }
       return parsed.toString();
     } catch {
@@ -16,7 +18,7 @@ function resolveDashboardUrl() {
     }
   }
 
-  return process.env.NODE_ENV !== "production" ? "http://localhost:3000/dashboard" : null;
+  return process.env.NODE_ENV !== "production" ? "http://localhost:3000/" : null;
 }
 
 export default function Layout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- keep the docs sidebar copy as `Dashboard`
- point that sidebar link at the SDP root instead of `/dashboard`
- update the local dev fallback to use the app root as well

## Testing
- pnpm --filter sdp-docs check:links
- pnpm --filter sdp-docs build
