### PR TITLE
feat(web): gate clerk auth entry with vercel flags

### DIFF
--- a/apps/sdp-web/package.json
+++ b/apps/sdp-web/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "@clerk/nextjs": "6.37.2",
+    "@flags-sdk/vercel": "1.2.1",
     "@sdp/types": "workspace:*",
     "@sentry/nextjs": "^10.42.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "flags": "4.0.5",
     "framer-motion": "^11.18.2",
     "lucide-react": "0.562.0",
     "next": "16.1.6",

--- a/apps/sdp-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/sdp-web/src/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,10 @@
+import * as flags from "@/flags";
+import { getProviderData } from "@flags-sdk/vercel";
+import {
+  createFlagsDiscoveryEndpoint,
+  getProviderData as getFallbackProviderData,
+} from "flags/next";
+
+export const GET = createFlagsDiscoveryEndpoint(async () => {
+  return process.env.FLAGS?.trim() ? getProviderData(flags) : getFallbackProviderData(flags);
+});

--- a/apps/sdp-web/src/app/auth/actions.ts
+++ b/apps/sdp-web/src/app/auth/actions.ts
@@ -5,7 +5,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 
 export async function startSignIn() {
-  if (!isAuthEntryEnabled()) {
+  if (!(await isAuthEntryEnabled())) {
     redirect("/");
   }
 
@@ -14,7 +14,7 @@ export async function startSignIn() {
 }
 
 export async function startSignUp() {
-  if (!isAuthEntryEnabled()) {
+  if (!(await isAuthEntryEnabled())) {
     redirect("/");
   }
 

--- a/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/page.tsx
@@ -25,7 +25,7 @@ export const dynamic = "force-dynamic";
 export default async function ApiKeysPage() {
   const { userId, orgId, orgRole } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
@@ -125,7 +125,7 @@ export default async function WalletDetailPage({
 }) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -133,7 +133,7 @@ async function OnboardingGateSection({ orgId }: { orgId: string }) {
 export default async function CustodyPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/page.tsx
@@ -90,7 +90,7 @@ function mapToken(payload: unknown): Token | null {
 export default async function IssuanceTokenManagementPage({ params }: TokenManagementPageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/issuance/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/page.tsx
@@ -160,7 +160,7 @@ interface IssuancePageProps {
 export default async function IssuancePage({ searchParams }: IssuancePageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { fetchPaymentsAggregate, fetchPaymentsWallets } from "./payments/payment
 export default async function DashboardPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     return null;

--- a/apps/sdp-web/src/app/dashboard/payments/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/page.tsx
@@ -20,7 +20,7 @@ interface PaymentsPageProps {
 export default async function PaymentsPage({ searchParams }: PaymentsPageProps) {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -8,7 +8,7 @@ import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 export default async function PaymentsReceivePage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -8,7 +8,7 @@ import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 export default async function PaymentsSendPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/dashboard/settings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/page.tsx
@@ -33,7 +33,7 @@ type ProjectListResponse = {
 export default async function SettingsPage() {
   const { userId, orgId, orgRole } = await auth();
   if (!userId) {
-    redirect(getAuthEntryPath());
+    redirect(await getAuthEntryPath());
   }
   if (!orgId) {
     redirect("/dashboard");

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const pathname = (await headers()).get("x-sdp-pathname") ?? "/";
-  const shouldLoadClerk = shouldLoadClerkForPath(pathname);
+  const shouldLoadClerk = await shouldLoadClerkForPath(pathname);
   const content = shouldLoadClerk ? (
     <ClerkProvider
       signInUrl="/sign-in"

--- a/apps/sdp-web/src/app/page.tsx
+++ b/apps/sdp-web/src/app/page.tsx
@@ -11,8 +11,8 @@ const docsHref =
   (process.env.NODE_ENV === "development" ? "http://localhost:3001/docs" : DEFAULT_SDP_DOCS_URL);
 const waitlistHref = "https://solanafoundation.typeform.com/to/PLfMTDQs";
 
-export default function Home() {
-  const authEntryEnabled = isAuthEntryEnabled();
+export default async function Home() {
+  const authEntryEnabled = await isAuthEntryEnabled();
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] text-[#1c1c1d]">

--- a/apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -2,8 +2,8 @@ import { isAuthEntryEnabled } from "@/lib/auth-entry";
 import { SignIn } from "@clerk/nextjs";
 import { redirect } from "next/navigation";
 
-export default function SignInPage() {
-  if (!isAuthEntryEnabled()) {
+export default async function SignInPage() {
+  if (!(await isAuthEntryEnabled())) {
     redirect("/");
   }
 

--- a/apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -2,8 +2,8 @@ import { isAuthEntryEnabled } from "@/lib/auth-entry";
 import { SignUp } from "@clerk/nextjs";
 import { redirect } from "next/navigation";
 
-export default function SignUpPage() {
-  if (!isAuthEntryEnabled()) {
+export default async function SignUpPage() {
+  if (!(await isAuthEntryEnabled())) {
     redirect("/");
   }
 

--- a/apps/sdp-web/src/flags.ts
+++ b/apps/sdp-web/src/flags.ts
@@ -1,0 +1,20 @@
+import { createVercelAdapter } from "@flags-sdk/vercel";
+import { flag } from "flags/next";
+import { getDefaultAuthEntryEnabled } from "@/lib/auth-entry-config";
+
+const defaultValue = getDefaultAuthEntryEnabled();
+const flagsSdkKey = process.env.FLAGS?.trim();
+
+export const clerkAuthEntry = flag<boolean>({
+  key: "clerk-auth-entry",
+  ...(flagsSdkKey
+    ? { adapter: createVercelAdapter(flagsSdkKey)() }
+    : { decide: () => defaultValue }),
+  defaultValue,
+  description:
+    "Controls whether Clerk sign-in and sign-up entry points are enabled for unauthenticated users.",
+  options: [
+    { value: false, label: "Disabled" },
+    { value: true, label: "Enabled" },
+  ],
+});

--- a/apps/sdp-web/src/flags.ts
+++ b/apps/sdp-web/src/flags.ts
@@ -1,6 +1,6 @@
+import { getDefaultAuthEntryEnabled } from "@/lib/auth-entry-config";
 import { createVercelAdapter } from "@flags-sdk/vercel";
 import { flag } from "flags/next";
-import { getDefaultAuthEntryEnabled } from "@/lib/auth-entry-config";
 
 const defaultValue = getDefaultAuthEntryEnabled();
 const flagsSdkKey = process.env.FLAGS?.trim();

--- a/apps/sdp-web/src/lib/auth-entry-config.ts
+++ b/apps/sdp-web/src/lib/auth-entry-config.ts
@@ -1,0 +1,32 @@
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+const DISABLED_VALUES = new Set(["0", "false", "no", "off"]);
+
+export function parseBooleanEnv(value: string | undefined): boolean | null {
+  const normalized = value?.trim().toLowerCase();
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (ENABLED_VALUES.has(normalized)) {
+    return true;
+  }
+
+  if (DISABLED_VALUES.has(normalized)) {
+    return false;
+  }
+
+  return null;
+}
+
+export function getDefaultAuthEntryEnabled(): boolean {
+  const configured = parseBooleanEnv(process.env.SDP_AUTH_ENTRY_ENABLED);
+
+  if (configured !== null) {
+    return configured;
+  }
+
+  // Vercel preview deployments stay open by default, but production stays closed
+  // until onboarding is intentionally enabled.
+  return process.env.VERCEL_ENV !== "production";
+}

--- a/apps/sdp-web/src/lib/auth-entry.ts
+++ b/apps/sdp-web/src/lib/auth-entry.ts
@@ -1,42 +1,15 @@
-const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
-const DISABLED_VALUES = new Set(["0", "false", "no", "off"]);
+import { clerkAuthEntry } from "@/flags";
 
-function parseBooleanEnv(value: string | undefined): boolean | null {
-  const normalized = value?.trim().toLowerCase();
-
-  if (!normalized) {
-    return null;
-  }
-
-  if (ENABLED_VALUES.has(normalized)) {
-    return true;
-  }
-
-  if (DISABLED_VALUES.has(normalized)) {
-    return false;
-  }
-
-  return null;
+export async function isAuthEntryEnabled(): Promise<boolean> {
+  return clerkAuthEntry();
 }
 
-export function isAuthEntryEnabled(): boolean {
-  const configured = parseBooleanEnv(process.env.SDP_AUTH_ENTRY_ENABLED);
-
-  if (configured !== null) {
-    return configured;
-  }
-
-  // Vercel preview deployments stay open by default, but production stays closed
-  // until onboarding is intentionally enabled.
-  return process.env.VERCEL_ENV !== "production";
+export async function getAuthEntryPath(): Promise<string> {
+  return (await isAuthEntryEnabled()) ? "/sign-in" : "/";
 }
 
-export function getAuthEntryPath(): string {
-  return isAuthEntryEnabled() ? "/sign-in" : "/";
-}
-
-export function shouldLoadClerkForPath(pathname: string): boolean {
-  if (isAuthEntryEnabled()) {
+export async function shouldLoadClerkForPath(pathname: string): Promise<boolean> {
+  if (await isAuthEntryEnabled()) {
     return true;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       '@clerk/nextjs':
         specifier: 6.37.2
         version: 6.37.2(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@flags-sdk/vercel':
+        specifier: 1.2.1
+        version: 1.2.1(flags@4.0.5(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@sdp/types':
         specifier: workspace:*
         version: link:../../packages/sdp-types
@@ -226,6 +229,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      flags:
+        specifier: 4.0.5
+        version: 4.0.5(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       framer-motion:
         specifier: ^11.18.2
         version: 11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -672,6 +678,10 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -1332,6 +1342,11 @@ packages:
     resolution: {integrity: sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
+
+  '@flags-sdk/vercel@1.2.1':
+    resolution: {integrity: sha512-k/0inU3Ly9PD5BIPICGZNv7kXH0fHs3tIiLB6MISK+PC/s1Y/z9m4ED3ROZiNNJqlSj4mNpwbNRkxWba2Qhisw==}
+    peerDependencies:
+      flags: '*'
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -3954,6 +3969,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/flags-core@1.3.1':
+    resolution: {integrity: sha512-tLFn7O0o5Tq90anusBA2ShR/KSMTcj5rW6lfaYnEB3NArUeVaIb4eZRGVkqFtCi97J4G7hIGNmVtBLKCeWoqDw==}
+    peerDependencies:
+      '@openfeature/server-sdk': 1.18.0
+      next: '*'
+    peerDependenciesMeta:
+      '@openfeature/server-sdk':
+        optional: true
+      next:
+        optional: true
+
+  '@vercel/functions@3.4.3':
+    resolution: {integrity: sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
     peerDependencies:
@@ -4888,6 +4927,26 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  flags@4.0.5:
+    resolution: {integrity: sha512-SRah0wf4wMT9TTqt0ac5HikBKl2fM0W8q8xKL+p91UpItWg2C5SiRkzvCrgYJgKhZIuEnCFb6pxeLv+Fg+jT6A==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      '@sveltejs/kit': '*'
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -5352,6 +5411,12 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jose@5.2.1:
+    resolution: {integrity: sha512-qiaQhtQRw6YrOaOj0v59h3R6hUY9NvxBmmnMfKemkqYmBB0tEc97NbLP7ix44VP5p9/0YHG8Vyhzuo5YBNwviA==}
+
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
@@ -5364,6 +5429,10 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-xxhash@4.0.0:
+    resolution: {integrity: sha512-3Q2eIqG6s1KEBBmkj9tGM9lef8LJbuRyTVBdI3GpTnrvtytunjLPO0wqABp5qhtMzfA32jYn1FlnIV7GH1RAHQ==}
+    engines: {node: '>=18.0.0'}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -7242,6 +7311,8 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@edge-runtime/cookies@5.0.2': {}
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -7623,6 +7694,15 @@ snapshots:
       minimatch: 10.2.2
     transitivePeerDependencies:
       - supports-color
+
+  '@flags-sdk/vercel@1.2.1(flags@4.0.5(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@vercel/flags-core': 1.3.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      flags: 4.0.5(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - '@openfeature/server-sdk'
+      - next
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -10756,6 +10836,22 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/flags-core@1.3.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@vercel/functions': 3.4.3
+      jose: 5.2.1
+      js-xxhash: 4.0.0
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+
+  '@vercel/functions@3.4.3':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+
+  '@vercel/oidc@3.2.0': {}
+
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -11584,7 +11680,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -11607,7 +11703,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11622,14 +11718,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11644,7 +11740,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11887,6 +11983,16 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flags@4.0.5(@opentelemetry/api@1.9.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   flat-cache@4.0.1:
     dependencies:
@@ -12429,6 +12535,10 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@5.10.0: {}
+
+  jose@5.2.1: {}
+
   jose@6.1.3: {}
 
   js-cookie@3.0.5: {}
@@ -12436,6 +12546,8 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  js-xxhash@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add the official Vercel Flags SDK to `sdp-web`
- define a `clerk-auth-entry` flag and expose the Vercel Flags discovery endpoint for Flags Explorer
- route the existing Clerk auth entry checks through the async flag evaluation instead of the old env-only gate
- keep builds working when `FLAGS` is absent by falling back to the existing `SDP_AUTH_ENTRY_ENABLED` / `VERCEL_ENV` default

## Verification
- `corepack pnpm --filter sdp-web typecheck`
- `corepack pnpm --filter sdp-web build`

## Follow-up in Vercel
- create or promote the `clerk-auth-entry` flag in the project dashboard
- ensure both `FLAGS` and `FLAGS_SECRET` are available in the deployed environment
- enable Vercel Toolbar in production, then use Flags Explorer to override the flag in-browser for testing