### PR TITLE
feat: add individual and enterprise provider tier gating

### DIFF
--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -16,6 +16,7 @@
     "db:verify": "node scripts/verify-postgres.mjs",
     "db:seed:local": "DATABASE_URL=${DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp} psql \"$DATABASE_URL\" -f src/db/seeds/local.sql",
     "db:postgres:bootstrap": "DATABASE_URL=${DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp} node scripts/migrate-postgres.mjs",
+    "org:tier:local": "tsx scripts/set-organization-tier-local.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",

--- a/apps/sdp-api/scripts/set-organization-tier-local.ts
+++ b/apps/sdp-api/scripts/set-organization-tier-local.ts
@@ -9,7 +9,7 @@ import {
 } from "../src/services/organization-provider-access.service";
 import type { Env } from "../src/types/env";
 
-type Tier = "free" | "enterprise";
+type Tier = "individual" | "enterprise";
 
 function loadLocalEnvFile(filePath: string): Record<string, string> {
   if (!fs.existsSync(filePath)) {
@@ -50,11 +50,11 @@ function hasFlag(flag: string): boolean {
 }
 
 function parseTier(value: string | undefined): Tier {
-  if (value === "free" || value === "enterprise") {
+  if (value === "individual" || value === "enterprise") {
     return value;
   }
 
-  throw new Error("Missing or invalid --tier value. Use 'free' or 'enterprise'.");
+  throw new Error("Missing or invalid --tier value. Use 'individual' or 'enterprise'.");
 }
 
 function parseOverrides(value: string | undefined) {

--- a/apps/sdp-api/scripts/set-organization-tier-local.ts
+++ b/apps/sdp-api/scripts/set-organization-tier-local.ts
@@ -1,0 +1,229 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDatabaseClient } from "../src/db";
+import { ClerkOrganizationsService } from "../src/services/clerk-organizations.service";
+import {
+  parseProviderOverridesFromClerkMetadata,
+  syncOrganizationTierFromClerk,
+} from "../src/services/organization-provider-access.service";
+import type { Env } from "../src/types/env";
+
+type Tier = "free" | "enterprise";
+
+function loadLocalEnvFile(filePath: string): Record<string, string> {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  const content = fs.readFileSync(filePath, "utf8");
+  const values: Record<string, string> = {};
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const [key, ...rest] = trimmed.split("=");
+    if (!key) {
+      continue;
+    }
+
+    values[key] = rest.join("=");
+  }
+
+  return values;
+}
+
+function readArg(flag: string): string | undefined {
+  const flagIndex = process.argv.indexOf(flag);
+  if (flagIndex === -1) {
+    return undefined;
+  }
+
+  return process.argv[flagIndex + 1];
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function parseTier(value: string | undefined): Tier {
+  if (value === "free" || value === "enterprise") {
+    return value;
+  }
+
+  throw new Error("Missing or invalid --tier value. Use 'free' or 'enterprise'.");
+}
+
+function parseOverrides(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error(
+      `Invalid --overrides JSON: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  }
+
+  const overrides = parseProviderOverridesFromClerkMetadata(parsed);
+  if (!overrides) {
+    throw new Error(
+      "The provided --overrides JSON did not contain any valid provider override entries."
+    );
+  }
+
+  return overrides;
+}
+
+async function main() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const appDir = path.resolve(scriptDir, "..");
+  const localEnv = loadLocalEnvFile(path.join(appDir, ".dev.vars"));
+  const runtimeEnv = {
+    ...localEnv,
+    ...process.env,
+  };
+
+  const listOnly = hasFlag("--list");
+  const clerkOrgId = readArg("--clerk-org-id")?.trim();
+  const tierArg = readArg("--tier")?.trim();
+  const overridesArg = readArg("--overrides")?.trim();
+  const databaseUrl =
+    runtimeEnv.DATABASE_URL?.trim() ?? "postgresql://sdp:sdp@127.0.0.1:5432/sdp";
+
+  const db = createDatabaseClient(databaseUrl);
+
+  if (listOnly) {
+    const mappings = await db
+      .prepare(
+        `SELECT a.provider_org_id AS "clerkOrgId",
+                o.id AS "organizationId",
+                o.slug AS "organizationSlug",
+                o.name AS "organizationName",
+                o.tier AS "tier",
+                o.status AS "status"
+         FROM auth_organization_identities a
+         JOIN organizations o ON o.id = a.organization_id
+         WHERE a.provider = 'clerk'
+         ORDER BY o.updated_at DESC, o.created_at DESC`
+      )
+      .all<{
+        clerkOrgId: string;
+        organizationId: string;
+        organizationSlug: string;
+        organizationName: string;
+        tier: string;
+        status: string;
+      }>();
+
+    console.log(JSON.stringify({ mappings: mappings.results }, null, 2));
+    return;
+  }
+
+  const tier = parseTier(tierArg);
+  const providerOverrides = parseOverrides(overridesArg);
+
+  if (!clerkOrgId) {
+    throw new Error(
+      "Missing --clerk-org-id. Example: --clerk-org-id org_123. Use --list to discover local mappings."
+    );
+  }
+
+  if (!runtimeEnv.CLERK_SECRET_KEY?.trim()) {
+    throw new Error("CLERK_SECRET_KEY is required. Add it to apps/sdp-api/.dev.vars first.");
+  }
+
+  const clerkService = new ClerkOrganizationsService(runtimeEnv as Env);
+
+  const currentClerkOrganization = await clerkService.getOrganization(clerkOrgId);
+  const currentPrivateMetadata =
+    currentClerkOrganization.private_metadata &&
+    typeof currentClerkOrganization.private_metadata === "object"
+      ? currentClerkOrganization.private_metadata
+      : {};
+  const currentSdpMetadata =
+    currentPrivateMetadata.sdp && typeof currentPrivateMetadata.sdp === "object"
+      ? currentPrivateMetadata.sdp
+      : {};
+
+  const nextPrivateMetadata = {
+    ...currentPrivateMetadata,
+    sdp: {
+      ...currentSdpMetadata,
+      tier,
+      ...(providerOverrides ? { providerOverrides } : {}),
+      ...(providerOverrides ? {} : { providerOverrides: undefined }),
+    },
+  };
+
+  if (!providerOverrides && "providerOverrides" in nextPrivateMetadata.sdp) {
+    delete nextPrivateMetadata.sdp.providerOverrides;
+  }
+
+  const mapping = await db
+    .prepare(
+      `SELECT organization_id
+       FROM auth_organization_identities
+       WHERE provider = 'clerk' AND provider_org_id = ?`
+    )
+    .bind(clerkOrgId)
+    .first<{ organization_id: string }>();
+
+  if (!mapping) {
+    throw new Error(
+      `No local SDP organization mapping found for Clerk org '${clerkOrgId}'. Link the org locally first.`
+    );
+  }
+
+  const updatedClerkOrganization = await clerkService.updateOrganizationPrivateMetadata(
+    clerkOrgId,
+    nextPrivateMetadata
+  );
+  const synced = await syncOrganizationTierFromClerk(db, {
+    organizationId: mapping.organization_id,
+    clerkOrganization: updatedClerkOrganization,
+  });
+
+  const access = await db
+    .prepare(
+      `SELECT id, tier, settings
+       FROM organizations
+       WHERE id = ?`
+    )
+    .bind(mapping.organization_id)
+    .first<{ id: string; tier: string; settings: string | null }>();
+
+  console.log(
+    JSON.stringify(
+      {
+        clerkOrgId,
+        organizationId: mapping.organization_id,
+        requested: {
+          tier,
+          providerOverrides: providerOverrides ?? null,
+        },
+        synced,
+        persisted: access
+          ? {
+              id: access.id,
+              tier: access.tier,
+              settings: access.settings ? JSON.parse(access.settings) : null,
+            }
+          : null,
+      },
+      null,
+      2
+    )
+  );
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/apps/sdp-api/scripts/set-organization-tier-local.ts
+++ b/apps/sdp-api/scripts/set-organization-tier-local.ts
@@ -81,6 +81,13 @@ function parseOverrides(value: string | undefined) {
   return overrides;
 }
 
+function buildDefaultDatabaseUrl(): string {
+  const url = new URL("postgresql://127.0.0.1:5432/sdp");
+  url.username = "sdp";
+  url.password = "sdp";
+  return url.toString();
+}
+
 async function main() {
   const scriptDir = path.dirname(fileURLToPath(import.meta.url));
   const appDir = path.resolve(scriptDir, "..");
@@ -94,8 +101,7 @@ async function main() {
   const clerkOrgId = readArg("--clerk-org-id")?.trim();
   const tierArg = readArg("--tier")?.trim();
   const overridesArg = readArg("--overrides")?.trim();
-  const databaseUrl =
-    runtimeEnv.DATABASE_URL?.trim() ?? "postgresql://sdp:sdp@127.0.0.1:5432/sdp";
+  const databaseUrl = runtimeEnv.DATABASE_URL?.trim() ?? buildDefaultDatabaseUrl();
 
   const db = createDatabaseClient(databaseUrl);
 
@@ -163,7 +169,7 @@ async function main() {
   };
 
   if (!providerOverrides && "providerOverrides" in nextPrivateMetadata.sdp) {
-    delete nextPrivateMetadata.sdp.providerOverrides;
+    nextPrivateMetadata.sdp.providerOverrides = undefined;
   }
 
   const mapping = await db

--- a/apps/sdp-api/src/__tests__/services/api-key.unit.ts
+++ b/apps/sdp-api/src/__tests__/services/api-key.unit.ts
@@ -70,7 +70,6 @@ describe("randomBase64Url", () => {
   });
 });
 
-// biome-ignore lint/nursery/noSecrets: Function name triggers false positive
 describe("createApiKeyMaterial", () => {
   it("creates production key with live prefix", () => {
     const { key, prefix } = createApiKeyMaterial("production");

--- a/apps/sdp-api/src/__tests__/services/mosaic.unit.ts
+++ b/apps/sdp-api/src/__tests__/services/mosaic.unit.ts
@@ -70,7 +70,6 @@ describe("safeStringify", () => {
   });
 
   it("handles Solana-like RPC response", () => {
-    // biome-ignore lint/nursery/noSecrets: Test Solana program address, not a secret
     const tokenProgram = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
     const rpcResponse = {
       slot: 123456789n,

--- a/apps/sdp-api/src/__tests__/services/token-2022.unit.ts
+++ b/apps/sdp-api/src/__tests__/services/token-2022.unit.ts
@@ -36,7 +36,6 @@ describe("safeStringify", () => {
 
 describe("addressAsSigner", () => {
   it("creates a signer-like object from address", () => {
-    // biome-ignore lint/nursery/noSecrets: Test Solana address
     const address = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
     const signer = addressAsSigner(address);
 
@@ -44,7 +43,6 @@ describe("addressAsSigner", () => {
   });
 
   it("returns object that can be used as TransactionSigner", () => {
-    // biome-ignore lint/nursery/noSecrets: Test Solana address
     const address = "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ" as Address;
     const signer = addressAsSigner(address);
 
@@ -54,7 +52,6 @@ describe("addressAsSigner", () => {
   });
 });
 
-// biome-ignore lint/nursery/noSecrets: Function name triggers false positive
 describe("getExtensionTypes", () => {
   it("returns empty array for undefined extensions", () => {
     expect(getExtensionTypes(undefined)).toEqual([]);
@@ -67,9 +64,7 @@ describe("getExtensionTypes", () => {
   it("handles transferFee extension", () => {
     const extensions: TokenExtensionsConfig = {
       transferFee: {
-        // biome-ignore lint/nursery/noSecrets: Test Solana address
         transferFeeConfigAuthority: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
-        // biome-ignore lint/nursery/noSecrets: Test Solana address
         withdrawWithheldAuthority: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
         basisPoints: 100, // 1%
         maxFee: "1.5",
@@ -78,19 +73,16 @@ describe("getExtensionTypes", () => {
 
     const result = getExtensionTypes(extensions, 6);
     expect(result).toHaveLength(1);
-    // biome-ignore lint/nursery/noSecrets: Token-2022 extension type identifier
     expect(result[0].__kind).toBe("TransferFeeConfig");
   });
 
   it("handles permanentDelegate extension", () => {
     const extensions: TokenExtensionsConfig = {
-      // biome-ignore lint/nursery/noSecrets: Test Solana address
       permanentDelegate: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
     };
 
     const result = getExtensionTypes(extensions);
     expect(result).toHaveLength(1);
-    // biome-ignore lint/nursery/noSecrets: Token-2022 extension type identifier
     expect(result[0].__kind).toBe("PermanentDelegate");
   });
 
@@ -101,7 +93,6 @@ describe("getExtensionTypes", () => {
 
     const result = getExtensionTypes(extensions);
     expect(result).toHaveLength(1);
-    // biome-ignore lint/nursery/noSecrets: Token-2022 extension type identifier
     expect(result[0].__kind).toBe("DefaultAccountState");
   });
 
@@ -112,7 +103,6 @@ describe("getExtensionTypes", () => {
 
     const result = getExtensionTypes(extensions);
     expect(result).toHaveLength(1);
-    // biome-ignore lint/nursery/noSecrets: Token-2022 extension type identifier
     expect(result[0].__kind).toBe("DefaultAccountState");
   });
 
@@ -128,7 +118,6 @@ describe("getExtensionTypes", () => {
 
   it("handles multiple extensions", () => {
     const extensions: TokenExtensionsConfig = {
-      // biome-ignore lint/nursery/noSecrets: Test Solana address
       permanentDelegate: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
       defaultAccountState: "frozen",
       nonTransferable: true,
@@ -138,9 +127,7 @@ describe("getExtensionTypes", () => {
     expect(result).toHaveLength(3);
 
     const kinds = result.map((ext) => ext.__kind);
-    // biome-ignore lint/nursery/noSecrets: Token-2022 extension names, not secrets
     expect(kinds).toContain("PermanentDelegate");
-    // biome-ignore lint/nursery/noSecrets: Token-2022 extension names, not secrets
     expect(kinds).toContain("DefaultAccountState");
     expect(kinds).toContain("NonTransferable");
   });

--- a/apps/sdp-api/src/db/migrations/postgres/0001_initial_schema.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0001_initial_schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS organizations (
     id TEXT PRIMARY KEY,                              
     name TEXT NOT NULL,
     slug TEXT NOT NULL UNIQUE,
-    tier TEXT NOT NULL DEFAULT 'free',                
+    tier TEXT NOT NULL DEFAULT 'individual',          
     status TEXT NOT NULL DEFAULT 'active',            
     settings TEXT,                                    
     created_at TEXT NOT NULL DEFAULT sdp_datetime_now(),

--- a/apps/sdp-api/src/db/seeds/local.sql
+++ b/apps/sdp-api/src/db/seeds/local.sql
@@ -14,7 +14,7 @@ INSERT INTO users (id, email, email_verified, name, status) VALUES
 
 -- Create a test organization
 INSERT INTO organizations (id, name, slug, tier, status) VALUES
-    ('org_test123456789', 'Test Organization', 'test-org', 'free', 'active');
+    ('org_test123456789', 'Test Organization', 'test-org', 'individual', 'active');
 
 -- Link user to organization as admin
 INSERT INTO organization_members (id, organization_id, user_id, role, status) VALUES

--- a/apps/sdp-api/src/middleware/auth.test.ts
+++ b/apps/sdp-api/src/middleware/auth.test.ts
@@ -122,7 +122,6 @@ describe("Auth Middleware", () => {
 
     it("rejects unknown API keys", async () => {
       // Don't seed anything - key won't be found
-      // biome-ignore lint/nursery/noSecrets: Test fixture, not a real key
       const unknownKey = "sk_test_unknownkey1234567890123456";
 
       const res = await app.request(

--- a/apps/sdp-api/src/middleware/clerk-auth.test.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.test.ts
@@ -13,7 +13,7 @@ const TEST_ORG = {
   id: "org_clerk_cache_request_test",
   name: "Clerk Cache Request Test Org",
   slug: "clerk-cache-request-test-org",
-  tier: "free" as const,
+  tier: "individual" as const,
   status: "active" as const,
 };
 

--- a/apps/sdp-api/src/openapi/schemas/auth.ts
+++ b/apps/sdp-api/src/openapi/schemas/auth.ts
@@ -29,7 +29,7 @@ export const currentUserResponseSchema = z
         id: orgIdParamSchema,
         name: z.string().openapi({ description: "Organization name.", example: "Example Org" }),
         slug: z.string().openapi({ description: "Organization slug.", example: "example-org" }),
-        tier: z.string().openapi({ description: "Organization tier.", example: "pro" }),
+        tier: z.string().openapi({ description: "Organization tier.", example: "enterprise" }),
         role: z
           .string()
           .openapi({ description: "User role within the organization.", example: "admin" }),

--- a/apps/sdp-api/src/openapi/schemas/organizations.ts
+++ b/apps/sdp-api/src/openapi/schemas/organizations.ts
@@ -61,7 +61,9 @@ export const organizationSchema = z
     id: orgIdParamSchema,
     name: z.string().openapi({ description: "Organization name.", example: "Example Org" }),
     slug: z.string().openapi({ description: "URL-friendly slug.", example: "example-org" }),
-    tier: z.enum(ORGANIZATION_TIERS).openapi({ description: "Billing tier.", example: "pro" }),
+    tier: z
+      .enum(ORGANIZATION_TIERS)
+      .openapi({ description: "Organization tier.", example: "enterprise" }),
     status: z
       .enum(ORGANIZATION_STATUSES)
       .openapi({ description: "Organization status.", example: "active" }),

--- a/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
@@ -47,7 +47,7 @@ async function seedAuthAndWallets(): Promise<void> {
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "individual", "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),

--- a/apps/sdp-api/src/routes/compliance.test.ts
+++ b/apps/sdp-api/src/routes/compliance.test.ts
@@ -47,14 +47,14 @@ let originalTrmBaseUrl: string | undefined;
 let originalChainalysisApiKey: string | undefined;
 let originalChainalysisBaseUrl: string | undefined;
 
-async function seedAuth(): Promise<void> {
+async function seedAuth(tier: "free" | "enterprise" = "enterprise"): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
   await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
 
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, tier, "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
@@ -125,7 +125,12 @@ describe("Compliance routes", () => {
     await clearKVNamespaces(env);
   });
 
-  it("returns all provider results with unavailable defaults", async () => {
+  it("returns forbidden when the organization has no enabled compliance providers", async () => {
+    await getDb(env)
+      .prepare("UPDATE organizations SET tier = ? WHERE id = ?")
+      .bind("free", TEST_ORG.id)
+      .run();
+
     const res = await app.request(
       "/v1/compliance/address-screenings",
       {
@@ -143,36 +148,9 @@ describe("Compliance routes", () => {
       env
     );
 
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      data: {
-        screening: {
-          providers: Array<{
-            provider: string;
-            status: string;
-            riskScore: number | null;
-          }>;
-        };
-      };
-    };
-
-    expect(body.data.screening.providers).toHaveLength(4);
-
-    const range = body.data.screening.providers.find((entry) => entry.provider === "range");
-    const elliptic = body.data.screening.providers.find((entry) => entry.provider === "elliptic");
-    const trm = body.data.screening.providers.find((entry) => entry.provider === "trm");
-    const chainalysis = body.data.screening.providers.find(
-      (entry) => entry.provider === "chainalysis"
-    );
-
-    expect(range?.status).toBe("unavailable");
-    expect(range?.riskScore).toBeNull();
-    expect(elliptic?.status).toBe("unavailable");
-    expect(elliptic?.riskScore).toBeNull();
-    expect(trm?.status).toBe("unavailable");
-    expect(trm?.riskScore).toBeNull();
-    expect(chainalysis?.status).toBe("unavailable");
-    expect(chainalysis?.riskScore).toBeNull();
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("Compliance screening is only available");
   });
 
   it("returns a Range risk score when Range API is configured", async () => {

--- a/apps/sdp-api/src/routes/compliance.test.ts
+++ b/apps/sdp-api/src/routes/compliance.test.ts
@@ -47,7 +47,7 @@ let originalTrmBaseUrl: string | undefined;
 let originalChainalysisApiKey: string | undefined;
 let originalChainalysisBaseUrl: string | undefined;
 
-async function seedAuth(tier: "free" | "enterprise" = "enterprise"): Promise<void> {
+async function seedAuth(tier: "individual" | "enterprise" = "enterprise"): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
   await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
 
@@ -128,7 +128,7 @@ describe("Compliance routes", () => {
   it("returns forbidden when the organization has no enabled compliance providers", async () => {
     await getDb(env)
       .prepare("UPDATE organizations SET tier = ? WHERE id = ?")
-      .bind("free", TEST_ORG.id)
+      .bind("individual", TEST_ORG.id)
       .run();
 
     const res = await app.request(

--- a/apps/sdp-api/src/routes/compliance/handlers.ts
+++ b/apps/sdp-api/src/routes/compliance/handlers.ts
@@ -1,7 +1,10 @@
+import { getDb } from "@/db";
+import { getAuth } from "@/lib/auth";
 import { AppError } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { createComplianceService } from "@/services/compliance";
+import { getEnabledOrganizationProviders } from "@/services/organization-provider-access.service";
 import type { Env } from "@/types/env";
 import type { Context } from "hono";
 import { screenAddressSchema } from "./schemas";
@@ -29,7 +32,19 @@ export async function screenAddress(c: AppContext) {
     }
   }
 
-  const complianceService = createComplianceService(c.env);
+  const auth = getAuth(c);
+  const enabledComplianceProviders = (
+    await getEnabledOrganizationProviders(c.env, getDb(c.env), auth.organizationId)
+  ).compliance;
+
+  if (enabledComplianceProviders.length === 0) {
+    throw new AppError(
+      "FORBIDDEN",
+      "Compliance screening is only available on enterprise tier organizations with an enabled provider."
+    );
+  }
+
+  const complianceService = createComplianceService(c.env, enabledComplianceProviders);
   const providers = await complianceService.screenAddress({
     address,
     network,

--- a/apps/sdp-api/src/routes/custody-multi-provider.test.ts
+++ b/apps/sdp-api/src/routes/custody-multi-provider.test.ts
@@ -20,7 +20,6 @@ const TEST_USER = {
 
 const TEST_API_KEY = {
   id: "key_custody_multi_provider",
-  // biome-ignore lint/nursery/noSecrets: Test fixture only.
   raw: "sk_test_custodymultiprovider1234567890",
   prefix: "sk_test_mul",
 };

--- a/apps/sdp-api/src/routes/custody-multi-provider.test.ts
+++ b/apps/sdp-api/src/routes/custody-multi-provider.test.ts
@@ -43,6 +43,8 @@ const PRIVY_CONFIG_ID = "cust_cfg_privy_multi";
 const PARA_CONFIG_ID = "cust_cfg_para_multi";
 const DFNS_CONFIG_ID = "cust_cfg_dfns_legacy";
 
+let originalParaApiKey: string | undefined;
+
 async function seedAuthAndConfigs(): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
   await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
@@ -50,7 +52,7 @@ async function seedAuthAndConfigs(): Promise<void> {
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
@@ -177,11 +179,14 @@ async function seedAuthAndConfigs(): Promise<void> {
 
 describe("Custody multi-provider routes", () => {
   beforeEach(async () => {
+    originalParaApiKey = env.PARA_API_KEY;
+    env.PARA_API_KEY = "para_test_api_key";
     await seedTestDatabase(env);
     await seedAuthAndConfigs();
   });
 
   afterEach(async () => {
+    env.PARA_API_KEY = originalParaApiKey;
     await clearTestDatabase(env);
     await clearKVNamespaces(env);
   });

--- a/apps/sdp-api/src/routes/custody-switch.test.ts
+++ b/apps/sdp-api/src/routes/custody-switch.test.ts
@@ -23,7 +23,6 @@ const TEST_USER = {
 };
 const TEST_API_KEY = {
   id: "key_custody_switch_test",
-  // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret.
   raw: "sk_test_custodyswitch12345678901234567890",
   prefix: "sk_test_cus",
 };

--- a/apps/sdp-api/src/routes/custody-switch.test.ts
+++ b/apps/sdp-api/src/routes/custody-switch.test.ts
@@ -41,6 +41,8 @@ const TEST_CACHED_API_KEY: CachedApiKey = {
   expiresAt: null,
 };
 
+let originalParaApiKey: string | undefined;
+
 async function seedAuthAndActiveConfig(): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
   await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
@@ -48,7 +50,7 @@ async function seedAuthAndActiveConfig(): Promise<void> {
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
@@ -99,6 +101,8 @@ async function seedAuthAndActiveConfig(): Promise<void> {
 
 describe("Custody switch rollback", () => {
   beforeEach(async () => {
+    originalParaApiKey = env.PARA_API_KEY;
+    env.PARA_API_KEY = "para_test_api_key";
     vi.clearAllMocks();
     provisionParaWalletMock.mockRejectedValue(
       new SigningError("Forced para provisioning failure for rollback test", "NETWORK_ERROR")
@@ -108,6 +112,7 @@ describe("Custody switch rollback", () => {
   });
 
   afterEach(async () => {
+    env.PARA_API_KEY = originalParaApiKey;
     await clearTestDatabase(env);
     await clearKVNamespaces(env);
   });

--- a/apps/sdp-api/src/routes/custody-wallet-by-id.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-by-id.test.ts
@@ -52,7 +52,7 @@ async function seedAuthAndConfigs(): Promise<void> {
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "individual", "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -59,7 +59,7 @@ async function seedAuthAndConfigs(): Promise<void> {
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "individual", "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -9,13 +9,13 @@ import { provisionFireblocksVaultAccount } from "@/services/custody/provisioning
 import { normalizePem } from "@/services/custody/provisioning.common";
 import { createSigningService } from "@/services/domain/signing.service";
 import {
-  assertOrganizationProviderEnabled,
-  getEnabledOrganizationProviders,
-} from "@/services/organization-provider-access.service";
-import {
   type FireblocksProviderConfig,
   parseConfigRecord,
 } from "@/services/domain/signing/provider-config";
+import {
+  assertOrganizationProviderEnabled,
+  getEnabledOrganizationProviders,
+} from "@/services/organization-provider-access.service";
 import { SigningError } from "@/services/ports";
 import { type AppContext, getPreferredWalletForConfig, resolveActor } from "../context";
 import {
@@ -208,29 +208,31 @@ export const getSwitchProviderOptions = async (c: AppContext) => {
       ?.provider ?? null;
 
   const response: SwitchProviderOptionsResponse = {
-    providers: CUSTODY_PROVIDERS.filter((provider) => enabledProviders.includes(provider)).map((provider) => {
-      const hasReusableWallet =
-        provider === "privy"
-          ? reuseState.privy
-          : provider === "coinbase_cdp"
-            ? reuseState.coinbase_cdp
-            : provider === "para"
-              ? reuseState.para
-              : provider === "turnkey"
-                ? reuseState.turnkey
-                : false;
+    providers: CUSTODY_PROVIDERS.filter((provider) => enabledProviders.includes(provider)).map(
+      (provider) => {
+        const hasReusableWallet =
+          provider === "privy"
+            ? reuseState.privy
+            : provider === "coinbase_cdp"
+              ? reuseState.coinbase_cdp
+              : provider === "para"
+                ? reuseState.para
+                : provider === "turnkey"
+                  ? reuseState.turnkey
+                  : false;
 
-      const needsWalletLabel =
-        provider === "fireblocks" ? false : provider === "local" ? true : !hasReusableWallet;
+        const needsWalletLabel =
+          provider === "fireblocks" ? false : provider === "local" ? true : !hasReusableWallet;
 
-      return {
-        provider,
-        hasReusableWallet,
-        needsWalletLabel,
-        isActive: activeProviders.has(provider),
-        isDefault: defaultProvider === provider,
-      };
-    }),
+        return {
+          provider,
+          hasReusableWallet,
+          needsWalletLabel,
+          isActive: activeProviders.has(provider),
+          isDefault: defaultProvider === provider,
+        };
+      }
+    ),
   };
 
   return success(c, response);

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -9,6 +9,10 @@ import { provisionFireblocksVaultAccount } from "@/services/custody/provisioning
 import { normalizePem } from "@/services/custody/provisioning.common";
 import { createSigningService } from "@/services/domain/signing.service";
 import {
+  assertOrganizationProviderEnabled,
+  getEnabledOrganizationProviders,
+} from "@/services/organization-provider-access.service";
+import {
   type FireblocksProviderConfig,
   parseConfigRecord,
 } from "@/services/domain/signing/provider-config";
@@ -44,6 +48,14 @@ export const initializeSigning = async (c: AppContext) => {
   const signingService = createSigningService(c.env);
 
   try {
+    await assertOrganizationProviderEnabled(
+      c.env,
+      getDb(c.env),
+      actor.organizationId,
+      "custody",
+      parsed.data.provider
+    );
+
     const result = await initializeProviderConnection(
       c,
       signingService,
@@ -89,6 +101,14 @@ export const switchSigning = async (c: AppContext) => {
   const auditService = new AuditService(getDb(c.env));
   const projectId = parsed.data.projectId;
   const targetProvider = parsed.data.provider;
+
+  await assertOrganizationProviderEnabled(
+    c.env,
+    getDb(c.env),
+    actor.organizationId,
+    "custody",
+    targetProvider
+  );
 
   const existingScopeConfig = await findScopeConfigByProvider(
     c,
@@ -174,6 +194,9 @@ export const getSwitchProviderOptions = async (c: AppContext) => {
   const actor = resolveActor(c);
   const projectId = c.req.query("projectId") ?? actor.projectId;
   const signingService = createSigningService(c.env);
+  const enabledProviders = (
+    await getEnabledOrganizationProviders(c.env, getDb(c.env), actor.organizationId)
+  ).custody;
   const [reuseState, configurations] = await Promise.all([
     signingService.getProviderReuseState(actor.organizationId, projectId),
     signingService.getConfigurations(actor.organizationId, projectId),
@@ -185,7 +208,7 @@ export const getSwitchProviderOptions = async (c: AppContext) => {
       ?.provider ?? null;
 
   const response: SwitchProviderOptionsResponse = {
-    providers: CUSTODY_PROVIDERS.map((provider) => {
+    providers: CUSTODY_PROVIDERS.filter((provider) => enabledProviders.includes(provider)).map((provider) => {
       const hasReusableWallet =
         provider === "privy"
           ? reuseState.privy

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -17,6 +17,7 @@ import {
   attachUsdValuesToBalanceMap,
   attachUsdValuesToBalances,
 } from "@/services/helius-das.service";
+import { assertOrganizationProviderEnabled } from "@/services/organization-provider-access.service";
 import { SigningError } from "@/services/ports";
 import * as solanaRpc from "@/services/solana/rpc";
 import type {
@@ -573,6 +574,14 @@ export const setDefaultWallet = async (c: AppContext) => {
   if (!config?.id) {
     throw new AppError("CONFLICT", "Wallet signing is not initialized");
   }
+
+  await assertOrganizationProviderEnabled(
+    c.env,
+    getDb(c.env),
+    actor.organizationId,
+    "custody",
+    config.provider
+  );
 
   const wallet = await getDb(c.env)
     .prepare(

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -97,7 +97,7 @@ describe("Issuance Routes", () => {
     // Seed organization
     await db
       .prepare(
-        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'free', 'active')"
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
       )
       .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
       .run();

--- a/apps/sdp-api/src/routes/onboarding/handlers.ts
+++ b/apps/sdp-api/src/routes/onboarding/handlers.ts
@@ -139,7 +139,7 @@ export const linkOrganization = async (c: AppContext) => {
   const clerkOrg = await clerkService.getOrganization(clerk.clerkOrgId);
 
   const orgName = body.name?.trim() || clerkOrg.name?.trim() || "New Organization";
-  const tier = "free";
+  const tier = "individual";
   const slugBase = body.slug?.trim() || clerkOrg.slug?.trim() || clerk.orgSlug || slugify(orgName);
   const slug = await ensureUniqueSlug(getDb(c.env), slugBase);
 

--- a/apps/sdp-api/src/routes/onboarding/handlers.ts
+++ b/apps/sdp-api/src/routes/onboarding/handlers.ts
@@ -2,7 +2,9 @@ import { type PreparedStatement, getDb } from "@/db";
 import { AppError, conflict, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import { ClerkOrganizationsService } from "@/services/clerk-organizations.service";
+import { syncOrganizationTierFromClerk } from "@/services/organization-provider-access.service";
 import type { Env } from "@/types/env";
+import { normalizeOrganizationTier } from "@sdp/types";
 import type { Context } from "hono";
 
 type AppContext = Context<{ Bindings: Env }>;
@@ -71,7 +73,7 @@ async function fetchOrganization(db: DatabaseClient, orgId: string) {
     id: org.id,
     name: org.name,
     slug: org.slug,
-    tier: org.tier as "free" | "pro" | "enterprise",
+    tier: normalizeOrganizationTier(org.tier),
     status: org.status as "active" | "suspended" | "deleted",
     settings: org.settings ? JSON.parse(org.settings) : null,
     createdAt: org.created_at,
@@ -118,6 +120,12 @@ export const linkOrganization = async (c: AppContext) => {
     .first<{ organization_id: string }>();
 
   if (existingMapping) {
+    const clerkService = new ClerkOrganizationsService(c.env);
+    const clerkOrg = await clerkService.getOrganization(clerk.clerkOrgId);
+    await syncOrganizationTierFromClerk(getDb(c.env), {
+      organizationId: existingMapping.organization_id,
+      clerkOrganization: clerkOrg,
+    });
     const organization = await fetchOrganization(getDb(c.env), existingMapping.organization_id);
     return success(c, { linked: true, organization, apiKey: null });
   }
@@ -215,6 +223,10 @@ export const linkOrganization = async (c: AppContext) => {
 
   try {
     await getDb(c.env).batch(batch);
+    await syncOrganizationTierFromClerk(getDb(c.env), {
+      organizationId: orgId,
+      clerkOrganization: clerkOrg,
+    });
   } catch (err) {
     if (err instanceof Error && err.message?.includes("UNIQUE constraint")) {
       throw conflict("Organization already linked");

--- a/apps/sdp-api/src/routes/organizations.test.ts
+++ b/apps/sdp-api/src/routes/organizations.test.ts
@@ -429,7 +429,10 @@ describe("Organizations routes", () => {
       expect(res.status).toBe(200);
     });
 
-    it("rejects managed RPC providers for individual-tier organizations", async () => {
+    it("allows Helius for individual-tier organizations when configured", async () => {
+      const originalHeliusUrl = env.SOLANA_RPC_HELIUS_URL;
+      env.SOLANA_RPC_HELIUS_URL = "https://rpc.helius.test";
+
       const res = await app.request(
         `/v1/organizations/${TEST_ORG.id}`,
         {
@@ -447,9 +450,11 @@ describe("Organizations routes", () => {
         env
       );
 
-      expect(res.status).toBe(403);
-      const body = (await res.json()) as { error: { message: string } };
-      expect(body.error.message).toContain("enterprise tier");
+      env.SOLANA_RPC_HELIUS_URL = originalHeliusUrl;
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: Organization };
+      expect(body.data.settings?.rpcProvider).toBe("helius");
     });
 
     it("rejects empty update", async () => {

--- a/apps/sdp-api/src/routes/organizations.test.ts
+++ b/apps/sdp-api/src/routes/organizations.test.ts
@@ -230,7 +230,7 @@ describe("Organizations routes", () => {
       // Add another allowlisted email
       await getDb(env)
         .prepare("INSERT INTO allowlist (id, type, value, tier, status) VALUES (?, ?, ?, ?, ?)")
-        .bind("allow_test2", "email", "another@example.com", "free", "active")
+        .bind("allow_test2", "email", "another@example.com", "individual", "active")
         .run();
 
       // Try to create org with same slug
@@ -429,7 +429,7 @@ describe("Organizations routes", () => {
       expect(res.status).toBe(200);
     });
 
-    it("rejects managed RPC providers for free-tier organizations", async () => {
+    it("rejects managed RPC providers for individual-tier organizations", async () => {
       const res = await app.request(
         `/v1/organizations/${TEST_ORG.id}`,
         {

--- a/apps/sdp-api/src/routes/organizations.test.ts
+++ b/apps/sdp-api/src/routes/organizations.test.ts
@@ -65,7 +65,7 @@ describe("Organizations routes", () => {
 
       const body = (await res.json()) as { data: CreateOrganizationResponse };
       expect(body.data.organization.name).toBe("New Org");
-      expect(body.data.organization.tier).toBe("pro");
+      expect(body.data.organization.tier).toBe("enterprise");
       expect(body.data.organization.status).toBe("active");
       expect(body.data.apiKey.key).toMatch(/^sk_test_/);
       expect(body.data.apiKey.keyPrefix).toMatch(/^sk_test_/);
@@ -290,7 +290,7 @@ describe("Organizations routes", () => {
     it("returns internal error when organization tier is invalid in storage", async () => {
       await getDb(env)
         .prepare("UPDATE organizations SET tier = ? WHERE id = ?")
-        .bind("standard", TEST_ORG.id)
+        .bind("totally-invalid-tier", TEST_ORG.id)
         .run();
 
       const res = await app.request(
@@ -427,6 +427,29 @@ describe("Organizations routes", () => {
       );
 
       expect(res.status).toBe(200);
+    });
+
+    it("rejects managed RPC providers for free-tier organizations", async () => {
+      const res = await app.request(
+        `/v1/organizations/${TEST_ORG.id}`,
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            settings: {
+              rpcProvider: "helius",
+            },
+          }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("enterprise tier");
     });
 
     it("rejects empty update", async () => {

--- a/apps/sdp-api/src/routes/organizations/handlers.ts
+++ b/apps/sdp-api/src/routes/organizations/handlers.ts
@@ -7,6 +7,10 @@ import { createAllowlistService } from "@/services/allowlist.service";
 import { AuditService } from "@/services/audit.service";
 import { KVService } from "@/services/kv.service";
 import { createOrganizationOnboardingService } from "@/services/organization-onboarding.service";
+import {
+  assertOrganizationProviderEnabled,
+  getOrganizationProviderAvailability,
+} from "@/services/organization-provider-access.service";
 import type { Env } from "@/types/env";
 import {
   type CreateOrganizationResponse,
@@ -49,6 +53,12 @@ function parseOrganizationTier(value: string): OrganizationTier {
   if (ORGANIZATION_TIERS.includes(value as OrganizationTier)) {
     return value as OrganizationTier;
   }
+  if (value === "standard" || value === "starter") {
+    return "free";
+  }
+  if (value === "pro" || value === "growth") {
+    return "enterprise";
+  }
   throw new AppError("INTERNAL_ERROR", `Organization tier '${value}' is invalid`);
 }
 
@@ -60,9 +70,6 @@ function parseOrganizationStatus(value: string): OrganizationStatus {
 }
 
 function resolveOrganizationTierFromAllowlist(value: string): OrganizationTier {
-  if (value === "standard") {
-    return "free";
-  }
   return parseOrganizationTier(value);
 }
 
@@ -320,6 +327,16 @@ export const updateOrganization = async (c: AppContext) => {
   }
 
   if (parsed.data.settings !== undefined) {
+    if (parsed.data.settings.rpcProvider) {
+      await assertOrganizationProviderEnabled(
+        c.env,
+        getDb(c.env),
+        orgId,
+        "rpc",
+        parsed.data.settings.rpcProvider
+      );
+    }
+
     const mergedSettings: OrganizationSettings = {
       ...(parseOrganizationSettings(existing.settings) ?? {}),
       ...parsed.data.settings,
@@ -367,6 +384,18 @@ export const updateOrganization = async (c: AppContext) => {
   }
 
   return success(c, toOrganizationResponse(org));
+};
+
+export const getOrganizationProviderAccess = async (c: AppContext) => {
+  const { orgId } = c.req.param();
+  const auth = getAuth(c);
+
+  if (auth?.organizationId !== orgId) {
+    throw new AppError("FORBIDDEN", "Access denied to this organization");
+  }
+
+  const response = await getOrganizationProviderAvailability(c.env, getDb(c.env), orgId);
+  return success(c, response);
 };
 
 export const deleteOrganization = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/organizations/handlers.ts
+++ b/apps/sdp-api/src/routes/organizations/handlers.ts
@@ -54,7 +54,7 @@ function parseOrganizationTier(value: string): OrganizationTier {
     return value as OrganizationTier;
   }
   if (value === "standard" || value === "starter") {
-    return "free";
+    return "individual";
   }
   if (value === "pro" || value === "growth") {
     return "enterprise";

--- a/apps/sdp-api/src/routes/organizations/index.ts
+++ b/apps/sdp-api/src/routes/organizations/index.ts
@@ -9,6 +9,7 @@ import {
   createOrganization,
   deleteOrganization,
   getOrganization,
+  getOrganizationProviderAccess,
   updateOrganization,
 } from "./handlers";
 
@@ -21,6 +22,7 @@ organizations.post("/", createOrganization);
 organizations.use("/:orgId/*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true }));
 
 organizations.get("/:orgId", requirePermissions("org:read"), getOrganization);
+organizations.get("/:orgId/provider-access", requirePermissions("org:read"), getOrganizationProviderAccess);
 organizations.patch("/:orgId", requirePermissions("org:write"), updateOrganization);
 organizations.delete("/:orgId", requirePermissions("org:admin"), deleteOrganization);
 

--- a/apps/sdp-api/src/routes/organizations/index.ts
+++ b/apps/sdp-api/src/routes/organizations/index.ts
@@ -22,7 +22,11 @@ organizations.post("/", createOrganization);
 organizations.use("/:orgId/*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true }));
 
 organizations.get("/:orgId", requirePermissions("org:read"), getOrganization);
-organizations.get("/:orgId/provider-access", requirePermissions("org:read"), getOrganizationProviderAccess);
+organizations.get(
+  "/:orgId/provider-access",
+  requirePermissions("org:read"),
+  getOrganizationProviderAccess
+);
 organizations.patch("/:orgId", requirePermissions("org:write"), updateOrganization);
 organizations.delete("/:orgId", requirePermissions("org:admin"), deleteOrganization);
 

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -38,7 +38,6 @@ const TEST_USER = {
 };
 const TEST_API_KEY = {
   id: "key_payments_policy_test",
-  // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret.
   raw: "sk_test_paymentspolicy12345678901234567890",
   prefix: "sk_test_pay",
 };
@@ -68,13 +67,9 @@ const TEST_BVNK_HAWK_AUTH_ID = "bvnk_hawk_auth_id";
 const TEST_BVNK_HAWK_SECRET_KEY = "bvnk_hawk_secret_key";
 const TEST_BVNK_WALLET_ID = "a:24122329329347:HsdJVhW:1";
 const TEST_BVNK_API_BASE_URL = "https://api.sandbox.bvnk.test";
-// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
 const MOONPAY_PARAM_BASE_CURRENCY_AMOUNT = "baseCurrencyAmount";
-// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
 const MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID = "externalCustomerId";
-// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
 const MOONPAY_PARAM_QUOTE_CURRENCY_CODE = "quoteCurrencyCode";
-// biome-ignore lint/nursery/noSecrets: Query parameter key used for test assertions.
 const MOONPAY_PARAM_REFUND_WALLET_ADDRESS = "refundWalletAddress";
 
 let originalMoonPayApiKey: string | undefined;
@@ -244,7 +239,6 @@ describe("Payments routes", () => {
       owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
     } as Awaited<ReturnType<typeof solanaRpc.getAccountInfo>>);
     getRecentBlockhashMock.mockResolvedValue({
-      // biome-ignore lint/nursery/noSecrets: Test blockhash, not a secret.
       blockhash: "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N" as Awaited<
         ReturnType<typeof solanaRpc.getRecentBlockhash>
       >["blockhash"],
@@ -252,7 +246,6 @@ describe("Payments routes", () => {
     });
     confirmTransactionMock.mockResolvedValue({
       signature:
-        // biome-ignore lint/nursery/noSecrets: Test transaction signature, not a secret.
         "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Awaited<
           ReturnType<typeof solanaRpc.confirmTransaction>
         >["signature"],
@@ -264,16 +257,15 @@ describe("Payments routes", () => {
     getSplTokenBalancesMock.mockResolvedValue([]);
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
-      // biome-ignore lint/nursery/noSecrets: Test Solana address used as mock fee payer, not a secret.
       getFeePayer: vi.fn().mockResolvedValue("7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv"),
       signAsFeePayer: vi.fn(),
-      signAndSend: vi.fn().mockResolvedValue(
-        // biome-ignore lint/nursery/noSecrets: Test transaction signature, not a secret.
-        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy"
-      ),
+      signAndSend: vi
+        .fn()
+        .mockResolvedValue(
+          "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy"
+        ),
     } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
     createOrgSignerMock.mockResolvedValue(
-      // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret.
       createNoopSigner(address("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ"))
     );
 
@@ -1428,7 +1420,6 @@ describe("Payments routes", () => {
       expect(body.data.transfer.id).toMatch(/^xfr_/);
       expect(body.data.preparedTransaction.serialized).toBeTruthy();
       expect(body.data.preparedTransaction.blockhash).toBe(
-        // biome-ignore lint/nursery/noSecrets: Test blockhash, not a secret.
         "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N"
       );
 
@@ -1694,7 +1685,6 @@ describe("Payments routes", () => {
     it("marks the transfer as failed when execution throws and returns 502", async () => {
       createFeePaymentAdapterMock.mockReturnValueOnce({
         providerId: "mock",
-        // biome-ignore lint/nursery/noSecrets: Test Solana address used as mock fee payer, not a secret.
         getFeePayer: vi.fn().mockResolvedValue("7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv"),
         signAsFeePayer: vi.fn(),
         signAndSend: vi.fn().mockRejectedValue(new Error("RPC connection refused")),
@@ -1741,7 +1731,6 @@ describe("Payments routes", () => {
 
     it("returns confirmed + pending transfers when wallet filter is provided", async () => {
       const confirmedSig =
-        // biome-ignore lint/nursery/noSecrets: Test transaction signature, not a secret.
         "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy";
 
       await seedTransfer({ id: "xfr_confirmed_1", status: "confirmed", signature: confirmedSig });
@@ -1778,7 +1767,6 @@ describe("Payments routes", () => {
 
     it("surfaces observed inbound transfers for wallet history even without a DB record", async () => {
       const observedSig =
-        // biome-ignore lint/nursery/noSecrets: Test transaction signature, not a secret.
         "3o9XWnJ7CyD6be8xXh8hFXRrM9rPzGQhE1mQ4Z8VjYkU7LZtP4R3WnV5uA2sD1fG6hJ7kL8mN9pQ1rS2tU3v";
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
         new Response(
@@ -1946,7 +1934,6 @@ describe("Payments routes", () => {
       await seedTransfer({ id: "xfr_status_pending", status: "pending" });
 
       const res = await app.request(
-        // biome-ignore lint/nursery/noSecrets: Test URL query param, not a secret.
         "/v1/payments/transfers?status=confirmed",
         {
           method: "GET",

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -116,7 +116,7 @@ async function seedAuthAndWallet(): Promise<void> {
   await getDb(env).batch([
     getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "free", "active"),
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
       .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
@@ -367,8 +367,6 @@ describe("Payments routes", () => {
           amount: "0",
           uiAmount: "0",
           decimals: 9,
-          usdPrice: expect.any(Number),
-          usdValue: 0,
         },
       ],
     });
@@ -419,8 +417,6 @@ describe("Payments routes", () => {
         amount: "0",
         uiAmount: "0",
         decimals: 9,
-        usdPrice: expect.any(Number),
-        usdValue: 0,
       },
       {
         token: "USDC",
@@ -470,8 +466,6 @@ describe("Payments routes", () => {
         amount: "4200000000",
         uiAmount: "4.2",
         decimals: 9,
-        usdPrice: expect.any(Number),
-        usdValue: expect.any(Number),
       },
     ]);
   });
@@ -1250,7 +1244,7 @@ describe("Payments routes", () => {
     expect(body.error.message).toContain("Invalid request body");
   });
 
-  it("returns internal error when MoonPay credentials are not configured", async () => {
+  it("returns forbidden when MoonPay is not configured in the environment", async () => {
     env.MOONPAY_API_KEY = undefined;
 
     const res = await app.request(
@@ -1272,13 +1266,13 @@ describe("Payments routes", () => {
       env
     );
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(403);
     const body = (await res.json()) as { error: { code: string; message: string } };
-    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.code).toBe("FORBIDDEN");
     expect(body.error.message).toContain("MoonPay is not configured");
   });
 
-  it("returns internal error when Lightspark credentials are not configured", async () => {
+  it("returns forbidden when Lightspark is not configured in the environment", async () => {
     env.LIGHTSPARK_GRID_CLIENT_ID = undefined;
 
     const res = await app.request(
@@ -1301,13 +1295,13 @@ describe("Payments routes", () => {
       env
     );
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(403);
     const body = (await res.json()) as { error: { code: string; message: string } };
-    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.code).toBe("FORBIDDEN");
     expect(body.error.message).toContain("Lightspark is not configured");
   });
 
-  it("returns internal error when BVNK credentials are not configured", async () => {
+  it("returns forbidden when BVNK is not configured in the environment", async () => {
     env.BVNK_API_TOKEN = undefined;
 
     const res = await app.request(
@@ -1330,9 +1324,9 @@ describe("Payments routes", () => {
       env
     );
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(403);
     const body = (await res.json()) as { error: { code: string; message: string } };
-    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.code).toBe("FORBIDDEN");
     expect(body.error.message).toContain("BVNK is not configured");
   });
 

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -1157,13 +1157,7 @@ async function resolveRampProvider(
   providerId: RampProviderId,
   organizationId: string
 ): Promise<RampProviderExecutor> {
-  await assertOrganizationProviderEnabled(
-    c.env,
-    getDb(c.env),
-    organizationId,
-    "ramps",
-    providerId
-  );
+  await assertOrganizationProviderEnabled(c.env, getDb(c.env), organizationId, "ramps", providerId);
 
   const provider = RAMP_PROVIDER_REGISTRY[providerId];
   if (!provider) {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -1,7 +1,9 @@
+import { getDb } from "@/db";
 import { parseDecimalAmount } from "@/lib/amount";
 import { AppError } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { isAddress } from "@/lib/solana";
+import { assertOrganizationProviderEnabled } from "@/services/organization-provider-access.service";
 import type { AppContext } from "../context";
 import { assertWalletPolicyAllowsTransfer } from "../policy";
 import { executeOfframpSchema, executeOnrampSchema } from "../schemas";
@@ -1150,7 +1152,19 @@ const RAMP_PROVIDER_REGISTRY: Record<RampProviderId, RampProviderExecutor> = {
   bvnk: bvnkRampProvider,
 };
 
-function resolveRampProvider(c: AppContext, providerId: RampProviderId): RampProviderExecutor {
+async function resolveRampProvider(
+  c: AppContext,
+  providerId: RampProviderId,
+  organizationId: string
+): Promise<RampProviderExecutor> {
+  await assertOrganizationProviderEnabled(
+    c.env,
+    getDb(c.env),
+    organizationId,
+    "ramps",
+    providerId
+  );
+
   const provider = RAMP_PROVIDER_REGISTRY[providerId];
   if (!provider) {
     throw new AppError("BAD_REQUEST", `Unsupported ramp provider: ${providerId}`);
@@ -1183,7 +1197,7 @@ async function executeRampWithProvider(
   input: ExecuteRampInput
 ): Promise<RampExecutionResult> {
   const scope = await resolveScope(c);
-  const provider = resolveRampProvider(c, input.provider);
+  const provider = await resolveRampProvider(c, input.provider, scope.auth.organizationId);
 
   if (input.direction === "onramp") {
     return provider.executeOnramp(c, scope, input);

--- a/apps/sdp-api/src/routes/projects.test.ts
+++ b/apps/sdp-api/src/routes/projects.test.ts
@@ -52,7 +52,7 @@ describe("Projects Routes", () => {
     // Seed organization
     await db
       .prepare(
-        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'free', 'active')"
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
       )
       .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
       .run();

--- a/apps/sdp-api/src/routes/rpc.test.ts
+++ b/apps/sdp-api/src/routes/rpc.test.ts
@@ -233,7 +233,7 @@ describe("RPC Relay Routes", () => {
 
     await db
       .prepare(
-        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'free', 'active')"
+        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'enterprise', 'active')"
       )
       .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
       .run();

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -3,8 +3,8 @@ import { mapClerkRoleToOrgRole } from "@/lib/clerk-role";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { ClerkOrganizationsService } from "@/services/clerk-organizations.service";
-import { syncOrganizationTierFromClerk } from "@/services/organization-provider-access.service";
 import { ClerkUsersService } from "@/services/clerk-users.service";
+import { syncOrganizationTierFromClerk } from "@/services/organization-provider-access.service";
 import type { Env } from "@/types/env";
 import type { Context } from "hono";
 import { Webhook } from "svix";
@@ -20,6 +20,11 @@ type ClerkOrgData = {
   id: string | null;
   name: string | null;
   slug: string | null;
+};
+
+type ClerkOrganizationSyncPayload = {
+  id: string;
+  private_metadata?: unknown;
 };
 
 type ClerkMemberData = {
@@ -150,7 +155,7 @@ async function ensureOrganizationMapping(c: AppContext, org: ClerkOrgData): Prom
   const clerkService = new ClerkOrganizationsService(c.env);
   const clerkOrg = await clerkService.getOrganization(org.id);
   let orgName = org.name?.trim() || clerkOrg.name?.trim();
-  let orgSlug = org.slug?.trim() || clerkOrg.slug?.trim() || undefined;
+  const orgSlug = org.slug?.trim() || clerkOrg.slug?.trim() || undefined;
 
   orgName = orgName || "New Organization";
   const slugBase = orgSlug || orgName || org.id;
@@ -163,7 +168,7 @@ async function ensureOrganizationMapping(c: AppContext, org: ClerkOrgData): Prom
     getDb(c.env)
       .prepare(
         `INSERT INTO organizations (id, name, slug, tier, status)
-       VALUES (?, ?, ?, 'free', 'active')`
+       VALUES (?, ?, ?, 'individual', 'active')`
       )
       .bind(orgId, orgName, slug),
     getDb(c.env)
@@ -294,8 +299,15 @@ async function handleOrganizationUpdated(c: AppContext, data: Record<string, unk
     return;
   }
 
-  const clerkService = new ClerkOrganizationsService(c.env);
-  const clerkOrganization = await clerkService.getOrganization(org.id);
+  const payloadOrganization: ClerkOrganizationSyncPayload | null =
+    "private_metadata" in data
+      ? {
+          id: org.id,
+          private_metadata: data.private_metadata,
+        }
+      : null;
+  const clerkOrganization =
+    payloadOrganization ?? (await new ClerkOrganizationsService(c.env).getOrganization(org.id));
   await syncOrganizationTierFromClerk(getDb(c.env), {
     organizationId,
     clerkOrganization,

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -3,6 +3,7 @@ import { mapClerkRoleToOrgRole } from "@/lib/clerk-role";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { ClerkOrganizationsService } from "@/services/clerk-organizations.service";
+import { syncOrganizationTierFromClerk } from "@/services/organization-provider-access.service";
 import { ClerkUsersService } from "@/services/clerk-users.service";
 import type { Env } from "@/types/env";
 import type { Context } from "hono";
@@ -146,15 +147,10 @@ async function ensureOrganizationMapping(c: AppContext, org: ClerkOrgData): Prom
     return existing.organization_id;
   }
 
-  let orgName = org.name?.trim();
-  let orgSlug = org.slug?.trim();
-
-  if (!orgName || !orgSlug) {
-    const clerkService = new ClerkOrganizationsService(c.env);
-    const clerkOrg = await clerkService.getOrganization(org.id);
-    orgName = orgName || clerkOrg.name?.trim() || "New Organization";
-    orgSlug = orgSlug || clerkOrg.slug?.trim() || undefined;
-  }
+  const clerkService = new ClerkOrganizationsService(c.env);
+  const clerkOrg = await clerkService.getOrganization(org.id);
+  let orgName = org.name?.trim() || clerkOrg.name?.trim();
+  let orgSlug = org.slug?.trim() || clerkOrg.slug?.trim() || undefined;
 
   orgName = orgName || "New Organization";
   const slugBase = orgSlug || orgName || org.id;
@@ -180,6 +176,10 @@ async function ensureOrganizationMapping(c: AppContext, org: ClerkOrgData): Prom
 
   try {
     await getDb(c.env).batch(batch);
+    await syncOrganizationTierFromClerk(getDb(c.env), {
+      organizationId: orgId,
+      clerkOrganization: clerkOrg,
+    });
   } catch (err) {
     if (err instanceof Error && err.message?.includes("UNIQUE constraint")) {
       const retry = await getDb(c.env)
@@ -284,6 +284,22 @@ async function deactivateMembership(
 async function handleOrganizationCreated(c: AppContext, data: Record<string, unknown>) {
   const org = extractOrganization(data);
   await ensureOrganizationMapping(c, org);
+}
+
+async function handleOrganizationUpdated(c: AppContext, data: Record<string, unknown>) {
+  const org = extractOrganization(data);
+  const organizationId = await ensureOrganizationMapping(c, org);
+
+  if (!org.id) {
+    return;
+  }
+
+  const clerkService = new ClerkOrganizationsService(c.env);
+  const clerkOrganization = await clerkService.getOrganization(org.id);
+  await syncOrganizationTierFromClerk(getDb(c.env), {
+    organizationId,
+    clerkOrganization,
+  });
 }
 
 async function handleOrganizationMembershipCreated(c: AppContext, data: Record<string, unknown>) {
@@ -396,6 +412,9 @@ export const handleClerkWebhook = async (c: AppContext) => {
   switch (event.type) {
     case "organization.created":
       await handleOrganizationCreated(c, data);
+      break;
+    case "organization.updated":
+      await handleOrganizationUpdated(c, data);
       break;
     // biome-ignore lint/nursery/noSecrets: Webhook event type literal, not a secret.
     case "organizationMembership.created":

--- a/apps/sdp-api/src/services/clerk-organizations.service.ts
+++ b/apps/sdp-api/src/services/clerk-organizations.service.ts
@@ -13,6 +13,7 @@ export interface ClerkOrganization {
   id: string;
   name?: string;
   slug?: string;
+  private_metadata?: Record<string, unknown> | null;
 }
 
 export class ClerkOrganizationsService {
@@ -79,5 +80,17 @@ export class ClerkOrganizationsService {
 
   async getOrganization(organizationId: string): Promise<ClerkOrganization> {
     return this.request<ClerkOrganization>(`/organizations/${organizationId}`);
+  }
+
+  async updateOrganizationPrivateMetadata(
+    organizationId: string,
+    privateMetadata: Record<string, unknown>
+  ): Promise<ClerkOrganization> {
+    return this.request<ClerkOrganization>(`/organizations/${organizationId}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        private_metadata: privateMetadata,
+      }),
+    });
   }
 }

--- a/apps/sdp-api/src/services/compliance/service.ts
+++ b/apps/sdp-api/src/services/compliance/service.ts
@@ -1,4 +1,5 @@
 import type { Env } from "@/types/env";
+import type { ComplianceProviderId } from "@sdp/types";
 import { ChainalysisComplianceProvider } from "./providers/chainalysis";
 import { EllipticComplianceProvider } from "./providers/elliptic";
 import { RangeComplianceProvider } from "./providers/range";
@@ -17,27 +18,37 @@ export class ComplianceService {
   }
 }
 
-export function createComplianceService(env: Env): ComplianceService {
-  const providers: ComplianceProvider[] = [
-    new RangeComplianceProvider({
+function createProviderMap(env: Env): Record<ComplianceProviderId, ComplianceProvider> {
+  return {
+    range: new RangeComplianceProvider({
       apiKey: env.RANGE_API_KEY,
       baseUrl: env.RANGE_API_BASE_URL,
     }),
-    new EllipticComplianceProvider({
+    elliptic: new EllipticComplianceProvider({
       apiToken: env.ELLIPTIC_API_TOKEN,
       apiKey: env.ELLIPTIC_API_KEY,
       apiSecret: env.ELLIPTIC_API_SECRET,
       baseUrl: env.ELLIPTIC_API_BASE_URL,
     }),
-    new TrmComplianceProvider({
+    trm: new TrmComplianceProvider({
       apiKey: env.TRM_API_KEY,
       baseUrl: env.TRM_API_BASE_URL,
     }),
-    new ChainalysisComplianceProvider({
+    chainalysis: new ChainalysisComplianceProvider({
       apiKey: env.CHAINALYSIS_API_KEY,
       baseUrl: env.CHAINALYSIS_API_BASE_URL,
     }),
-  ];
+  };
+}
 
-  return new ComplianceService(providers);
+export function createComplianceService(
+  env: Env,
+  enabledProviders?: readonly ComplianceProviderId[]
+): ComplianceService {
+  const providerMap = createProviderMap(env);
+  const providers = (enabledProviders ?? (Object.keys(providerMap) as ComplianceProviderId[])).map(
+    (providerId) => providerMap[providerId]
+  );
+
+  return new ComplianceService(providers.filter(Boolean));
 }

--- a/apps/sdp-api/src/services/custody/provisioning.test.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.test.ts
@@ -2,9 +2,7 @@ import { provisionCoinbaseCdpAccount, provisionParaWallet } from "@/services/cus
 import type { Env } from "@/types/env";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-// biome-ignore lint/nursery/noSecrets: deterministic non-secret Solana test address.
 const CREATED_ADDRESS = "11111111111111111111111111111111";
-// biome-ignore lint/nursery/noSecrets: deterministic non-secret Solana test address.
 const EXISTING_ADDRESS = "22222222222222222222222222222222";
 
 let keyMaterial: {

--- a/apps/sdp-api/src/services/domain/signing.service.dfns.test.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.dfns.test.ts
@@ -64,7 +64,6 @@ function createTestEnv(overrides?: Partial<Env>): Env {
     DFNS_AUTH_TOKEN: "dfns-auth-token",
     DFNS_CREDENTIAL_ID: "dfns-credential-id",
     DFNS_PRIVATE_KEY:
-      // biome-ignore lint/nursery/noSecrets: Test fixture key material placeholder.
       "-----BEGIN PRIVATE KEY-----\\nMIIBVwIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEA\\n-----END PRIVATE KEY-----",
     ENVIRONMENT: "development",
     API_VERSION: "v1",

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -290,7 +290,13 @@ export class SigningService {
     provider: SigningConfiguration["provider"]
   ): Promise<void> {
     try {
-      await assertOrganizationProviderEnabled(this.env, getDb(this.env), orgId, "custody", provider);
+      await assertOrganizationProviderEnabled(
+        this.env,
+        getDb(this.env),
+        orgId,
+        "custody",
+        provider
+      );
     } catch (error) {
       if (error instanceof AppError) {
         throw new SigningError(error.message, "INVALID_REQUEST", error);

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDb } from "@/db";
+import { AppError } from "@/lib/errors";
 import {
   KeychainFireblocksAdapter,
   KeychainMemoryAdapter,
@@ -47,6 +48,7 @@ import {
   deleteProviderWallet,
 } from "@/services/domain/signing/provider-wallet-lifecycle";
 import { type EncryptionService, createEncryptionService } from "@/services/encryption.service";
+import { assertOrganizationProviderEnabled } from "@/services/organization-provider-access.service";
 import { SigningError, isFullSigningPort } from "@/services/ports";
 import type { SignRequest, SignResult, SignStatus, SigningPort } from "@/services/ports";
 import {
@@ -283,6 +285,20 @@ export class SigningService {
     return this.encryptionService;
   }
 
+  private async assertProviderEnabled(
+    orgId: string,
+    provider: SigningConfiguration["provider"]
+  ): Promise<void> {
+    try {
+      await assertOrganizationProviderEnabled(this.env, getDb(this.env), orgId, "custody", provider);
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw new SigningError(error.message, "INVALID_REQUEST", error);
+      }
+      throw error;
+    }
+  }
+
   private async ensureScopeDefaultConfig(
     orgId: string,
     projectId: string | undefined,
@@ -361,6 +377,12 @@ export class SigningService {
     projectId: string | undefined,
     configId: string
   ): Promise<void> {
+    const config = await this.configStore.getById(configId);
+    if (!config || config.organizationId !== orgId || config.status !== "active") {
+      throw new SigningError("Custody configuration not found", "NOT_FOUND");
+    }
+
+    await this.assertProviderEnabled(orgId, config.provider);
     await this.configStore.setDefaultConfig(orgId, projectId, configId);
     this.providerCache.clear();
   }
@@ -370,6 +392,8 @@ export class SigningService {
     projectId: string | undefined,
     provider: SigningConfiguration["provider"]
   ): Promise<SigningConfigRecord> {
+    await this.assertProviderEnabled(orgId, provider);
+
     const scopeConfig = await this.configStore.findActiveByProvider(orgId, projectId, provider);
     if (!scopeConfig) {
       throw new SigningError("Custody not initialized for provider", "NOT_FOUND");
@@ -1209,6 +1233,8 @@ export class SigningService {
       );
     }
 
+    await this.assertProviderEnabled(orgId, config.provider);
+
     if (!canProviderCreateWallet(config.provider)) {
       throw new SigningError(
         `Wallet provisioning not supported for provider: ${config.provider}`,
@@ -1290,6 +1316,8 @@ export class SigningService {
         "NOT_FOUND"
       );
     }
+
+    await this.assertProviderEnabled(orgId, config.provider);
 
     if (!canProviderDeleteWallet(config.provider)) {
       throw new SigningError(
@@ -1413,6 +1441,8 @@ export class SigningService {
     if (!config) {
       throw new SigningError("Custody not initialized", "NOT_FOUND");
     }
+
+    await this.assertProviderEnabled(orgId, config.provider);
 
     const cacheKey = config.id;
 

--- a/apps/sdp-api/src/services/helius-das.service.test.ts
+++ b/apps/sdp-api/src/services/helius-das.service.test.ts
@@ -25,7 +25,7 @@ describe("helius-das service", () => {
     await getDb(env).batch([
       getDb(env)
         .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-        .bind(TEST_ORG_ID, "Helius DAS Org", "helius-das-org", "free", "active"),
+        .bind(TEST_ORG_ID, "Helius DAS Org", "helius-das-org", "individual", "active"),
       getDb(env)
         .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
         .bind(TEST_USER_ID, "helius-das@example.com", 1, "active"),

--- a/apps/sdp-api/src/services/jobs/track-pending-transfers.test.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-transfers.test.ts
@@ -19,7 +19,7 @@ const TEST_ORG_ID = "org_job_test_001";
 async function seedOrg(): Promise<void> {
   await getDb(env)
     .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-    .bind(TEST_ORG_ID, "Job Test Org", "job-test-org", "free", "active")
+    .bind(TEST_ORG_ID, "Job Test Org", "job-test-org", "individual", "active")
     .run();
 }
 

--- a/apps/sdp-api/src/services/kv.service.test.ts
+++ b/apps/sdp-api/src/services/kv.service.test.ts
@@ -131,7 +131,6 @@ describe("KVService", () => {
     });
   });
 
-  // biome-ignore lint/nursery/noSecrets: Test describe block name, not a secret
   describe("invalidateOrganization", () => {
     it("removes organization from cache", async () => {
       const testOrg: Organization = {

--- a/apps/sdp-api/src/services/organization-provider-access.service.test.ts
+++ b/apps/sdp-api/src/services/organization-provider-access.service.test.ts
@@ -14,9 +14,17 @@ describe("organization-provider-access.service", () => {
   const originalPrivyAppId = env.PRIVY_APP_ID;
   const originalPrivyAppSecret = env.PRIVY_APP_SECRET;
   const originalSolanaRpcUrl = env.SOLANA_RPC_URL;
+  const originalSolanaRpcHeliusUrl = env.SOLANA_RPC_HELIUS_URL;
+  const originalSolanaRpcTritonUrl = env.SOLANA_RPC_TRITON_URL;
   const originalRangeApiKey = env.RANGE_API_KEY;
   const originalMoonPayApiKey = env.MOONPAY_API_KEY;
   const originalMoonPaySecretKey = env.MOONPAY_SECRET_KEY;
+  const originalCoinbaseCdpApiKeyId = env.COINBASE_CDP_API_KEY_ID;
+  const originalCoinbaseCdpApiKeySecret = env.COINBASE_CDP_API_KEY_SECRET;
+  const originalCoinbaseCdpWalletSecret = env.COINBASE_CDP_WALLET_SECRET;
+  const originalTurnkeyApiPublicKey = env.TURNKEY_API_PUBLIC_KEY;
+  const originalTurnkeyApiPrivateKey = env.TURNKEY_API_PRIVATE_KEY;
+  const originalTurnkeyOrganizationId = env.TURNKEY_ORGANIZATION_ID;
   const originalCustodyPrivateKey = env.CUSTODY_PRIVATE_KEY;
 
   beforeEach(async () => {
@@ -36,9 +44,17 @@ describe("organization-provider-access.service", () => {
     env.PRIVY_APP_ID = "privy_test_app";
     env.PRIVY_APP_SECRET = "privy_test_secret";
     env.SOLANA_RPC_URL = "https://rpc.default.test";
+    env.SOLANA_RPC_HELIUS_URL = "https://rpc.helius.test";
+    env.SOLANA_RPC_TRITON_URL = "https://rpc.triton.test";
     env.RANGE_API_KEY = "range_test_key";
     env.MOONPAY_API_KEY = "moonpay_test_key";
     env.MOONPAY_SECRET_KEY = "moonpay_test_secret";
+    env.COINBASE_CDP_API_KEY_ID = "coinbase_test_key_id";
+    env.COINBASE_CDP_API_KEY_SECRET = "coinbase_test_key_secret";
+    env.COINBASE_CDP_WALLET_SECRET = "coinbase_test_wallet_secret";
+    env.TURNKEY_API_PUBLIC_KEY = "turnkey_test_public_key";
+    env.TURNKEY_API_PRIVATE_KEY = "turnkey_test_private_key";
+    env.TURNKEY_ORGANIZATION_ID = "turnkey_test_org";
     env.CUSTODY_PRIVATE_KEY = undefined;
   });
 
@@ -46,9 +62,17 @@ describe("organization-provider-access.service", () => {
     env.PRIVY_APP_ID = originalPrivyAppId;
     env.PRIVY_APP_SECRET = originalPrivyAppSecret;
     env.SOLANA_RPC_URL = originalSolanaRpcUrl;
+    env.SOLANA_RPC_HELIUS_URL = originalSolanaRpcHeliusUrl;
+    env.SOLANA_RPC_TRITON_URL = originalSolanaRpcTritonUrl;
     env.RANGE_API_KEY = originalRangeApiKey;
     env.MOONPAY_API_KEY = originalMoonPayApiKey;
     env.MOONPAY_SECRET_KEY = originalMoonPaySecretKey;
+    env.COINBASE_CDP_API_KEY_ID = originalCoinbaseCdpApiKeyId;
+    env.COINBASE_CDP_API_KEY_SECRET = originalCoinbaseCdpApiKeySecret;
+    env.COINBASE_CDP_WALLET_SECRET = originalCoinbaseCdpWalletSecret;
+    env.TURNKEY_API_PUBLIC_KEY = originalTurnkeyApiPublicKey;
+    env.TURNKEY_API_PRIVATE_KEY = originalTurnkeyApiPrivateKey;
+    env.TURNKEY_ORGANIZATION_ID = originalTurnkeyOrganizationId;
     env.CUSTODY_PRIVATE_KEY = originalCustodyPrivateKey;
 
     await clearTestDatabase(env);
@@ -75,12 +99,16 @@ describe("organization-provider-access.service", () => {
 
     expect(resolved.tier).toBe("individual");
     expect(resolved.providers.custody.privy).toBe(true);
+    expect(resolved.providers.custody.coinbase_cdp).toBe(true);
+    expect(resolved.providers.custody.turnkey).toBe(true);
     expect(resolved.providers.custody.local).toBe(true);
     expect(resolved.providers.custody.para).toBe(false);
     expect(resolved.providers.rpc.default).toBe(true);
     expect(resolved.providers.rpc.helius).toBe(true);
+    expect(resolved.providers.rpc.triton).toBe(true);
     expect(resolved.providers.compliance.range).toBe(true);
     expect(resolved.providers.ramps.moonpay).toBe(true);
+    expect(resolved.providers.ramps.lightspark).toBe(false);
   });
 
   it("marks providers as enabled only when both entitled and configured", async () => {
@@ -92,14 +120,19 @@ describe("organization-provider-access.service", () => {
       configured: true,
       enabled: true,
     });
+    expect(access.providers.custody.coinbase_cdp.enabled).toBe(true);
+    expect(access.providers.custody.turnkey.enabled).toBe(true);
     expect(access.providers.custody.para.enabled).toBe(false);
     expect(access.providers.rpc.default.enabled).toBe(true);
+    expect(access.providers.rpc.helius.enabled).toBe(true);
+    expect(access.providers.rpc.triton.enabled).toBe(true);
     expect(access.providers.compliance.range).toEqual({
       entitled: false,
       configured: true,
       enabled: false,
     });
-    expect(access.providers.ramps.moonpay.enabled).toBe(false);
+    expect(access.providers.ramps.moonpay.enabled).toBe(true);
+    expect(access.providers.ramps.lightspark.enabled).toBe(false);
   });
 
   it("treats local custody as override-only and only configured when a local key is present", async () => {

--- a/apps/sdp-api/src/services/organization-provider-access.service.test.ts
+++ b/apps/sdp-api/src/services/organization-provider-access.service.test.ts
@@ -17,13 +17,20 @@ describe("organization-provider-access.service", () => {
   const originalRangeApiKey = env.RANGE_API_KEY;
   const originalMoonPayApiKey = env.MOONPAY_API_KEY;
   const originalMoonPaySecretKey = env.MOONPAY_SECRET_KEY;
+  const originalCustodyPrivateKey = env.CUSTODY_PRIVATE_KEY;
 
   beforeEach(async () => {
     await seedTestDatabase(env);
 
     await getDb(env)
       .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
-      .bind(TEST_ORG_ID, "Provider Access Test Org", "provider-access-test-org", "free", "active")
+      .bind(
+        TEST_ORG_ID,
+        "Provider Access Test Org",
+        "provider-access-test-org",
+        "individual",
+        "active"
+      )
       .run();
 
     env.PRIVY_APP_ID = "privy_test_app";
@@ -32,6 +39,7 @@ describe("organization-provider-access.service", () => {
     env.RANGE_API_KEY = "range_test_key";
     env.MOONPAY_API_KEY = "moonpay_test_key";
     env.MOONPAY_SECRET_KEY = "moonpay_test_secret";
+    env.CUSTODY_PRIVATE_KEY = undefined;
   });
 
   afterEach(async () => {
@@ -41,13 +49,14 @@ describe("organization-provider-access.service", () => {
     env.RANGE_API_KEY = originalRangeApiKey;
     env.MOONPAY_API_KEY = originalMoonPayApiKey;
     env.MOONPAY_SECRET_KEY = originalMoonPaySecretKey;
+    env.CUSTODY_PRIVATE_KEY = originalCustodyPrivateKey;
 
     await clearTestDatabase(env);
   });
 
-  it("resolves free defaults and applies provider overrides", () => {
+  it("resolves individual defaults and applies provider overrides", () => {
     const resolved = resolveOrganizationProviderEntitlements({
-      tier: "free",
+      tier: "individual",
       providerOverrides: {
         custody: {
           local: true,
@@ -64,7 +73,7 @@ describe("organization-provider-access.service", () => {
       },
     });
 
-    expect(resolved.tier).toBe("free");
+    expect(resolved.tier).toBe("individual");
     expect(resolved.providers.custody.privy).toBe(true);
     expect(resolved.providers.custody.local).toBe(true);
     expect(resolved.providers.custody.para).toBe(false);
@@ -77,7 +86,7 @@ describe("organization-provider-access.service", () => {
   it("marks providers as enabled only when both entitled and configured", async () => {
     const access = await getOrganizationProviderAvailability(env, getDb(env), TEST_ORG_ID);
 
-    expect(access.tier).toBe("free");
+    expect(access.tier).toBe("individual");
     expect(access.providers.custody.privy).toEqual({
       entitled: true,
       configured: true,
@@ -91,6 +100,42 @@ describe("organization-provider-access.service", () => {
       enabled: false,
     });
     expect(access.providers.ramps.moonpay.enabled).toBe(false);
+  });
+
+  it("treats local custody as override-only and only configured when a local key is present", async () => {
+    await syncOrganizationTierFromClerk(getDb(env), {
+      organizationId: TEST_ORG_ID,
+      clerkOrganization: {
+        id: "org_clerk_provider_access_local_test",
+        private_metadata: {
+          sdp: {
+            tier: "individual",
+            providerOverrides: {
+              custody: {
+                local: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const withoutKey = await getOrganizationProviderAvailability(env, getDb(env), TEST_ORG_ID);
+    expect(withoutKey.providers.custody.local).toEqual({
+      entitled: true,
+      configured: false,
+      enabled: false,
+    });
+
+    env.CUSTODY_PRIVATE_KEY =
+      "3QpWV8xk4hs7vmQhSLAQWNi2KskuSVSpmR75QGqSuxaKcdA9XJkq8VBihspJddBWVfEybTWLKqHJ19N64DNuwSNd";
+
+    const withKey = await getOrganizationProviderAvailability(env, getDb(env), TEST_ORG_ID);
+    expect(withKey.providers.custody.local).toEqual({
+      entitled: true,
+      configured: true,
+      enabled: true,
+    });
   });
 
   it("syncs normalized Clerk tier and provider overrides into the organization row", async () => {
@@ -134,7 +179,7 @@ describe("organization-provider-access.service", () => {
     });
   });
 
-  it("defaults to free and clears provider overrides when Clerk metadata is absent", async () => {
+  it("defaults to individual and clears provider overrides when Clerk metadata is absent", async () => {
     await getDb(env)
       .prepare("UPDATE organizations SET tier = ?, settings = ? WHERE id = ?")
       .bind(
@@ -163,7 +208,7 @@ describe("organization-provider-access.service", () => {
       .bind(TEST_ORG_ID)
       .first<{ tier: string; settings: string | null }>();
 
-    expect(organization?.tier).toBe("free");
+    expect(organization?.tier).toBe("individual");
     expect(organization?.settings ? JSON.parse(organization.settings) : null).toEqual({
       rpcProvider: "helius",
     });

--- a/apps/sdp-api/src/services/organization-provider-access.service.test.ts
+++ b/apps/sdp-api/src/services/organization-provider-access.service.test.ts
@@ -1,0 +1,171 @@
+import { getDb } from "@/db";
+import {
+  getOrganizationProviderAvailability,
+  syncOrganizationTierFromClerk,
+} from "@/services/organization-provider-access.service";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
+import { resolveOrganizationProviderEntitlements } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const TEST_ORG_ID = "org_provider_access_test";
+
+describe("organization-provider-access.service", () => {
+  const originalPrivyAppId = env.PRIVY_APP_ID;
+  const originalPrivyAppSecret = env.PRIVY_APP_SECRET;
+  const originalSolanaRpcUrl = env.SOLANA_RPC_URL;
+  const originalRangeApiKey = env.RANGE_API_KEY;
+  const originalMoonPayApiKey = env.MOONPAY_API_KEY;
+  const originalMoonPaySecretKey = env.MOONPAY_SECRET_KEY;
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+
+    await getDb(env)
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(TEST_ORG_ID, "Provider Access Test Org", "provider-access-test-org", "free", "active")
+      .run();
+
+    env.PRIVY_APP_ID = "privy_test_app";
+    env.PRIVY_APP_SECRET = "privy_test_secret";
+    env.SOLANA_RPC_URL = "https://rpc.default.test";
+    env.RANGE_API_KEY = "range_test_key";
+    env.MOONPAY_API_KEY = "moonpay_test_key";
+    env.MOONPAY_SECRET_KEY = "moonpay_test_secret";
+  });
+
+  afterEach(async () => {
+    env.PRIVY_APP_ID = originalPrivyAppId;
+    env.PRIVY_APP_SECRET = originalPrivyAppSecret;
+    env.SOLANA_RPC_URL = originalSolanaRpcUrl;
+    env.RANGE_API_KEY = originalRangeApiKey;
+    env.MOONPAY_API_KEY = originalMoonPayApiKey;
+    env.MOONPAY_SECRET_KEY = originalMoonPaySecretKey;
+
+    await clearTestDatabase(env);
+  });
+
+  it("resolves free defaults and applies provider overrides", () => {
+    const resolved = resolveOrganizationProviderEntitlements({
+      tier: "free",
+      providerOverrides: {
+        custody: {
+          local: true,
+        },
+        rpc: {
+          helius: true,
+        },
+        compliance: {
+          range: true,
+        },
+        ramps: {
+          moonpay: true,
+        },
+      },
+    });
+
+    expect(resolved.tier).toBe("free");
+    expect(resolved.providers.custody.privy).toBe(true);
+    expect(resolved.providers.custody.local).toBe(true);
+    expect(resolved.providers.custody.para).toBe(false);
+    expect(resolved.providers.rpc.default).toBe(true);
+    expect(resolved.providers.rpc.helius).toBe(true);
+    expect(resolved.providers.compliance.range).toBe(true);
+    expect(resolved.providers.ramps.moonpay).toBe(true);
+  });
+
+  it("marks providers as enabled only when both entitled and configured", async () => {
+    const access = await getOrganizationProviderAvailability(env, getDb(env), TEST_ORG_ID);
+
+    expect(access.tier).toBe("free");
+    expect(access.providers.custody.privy).toEqual({
+      entitled: true,
+      configured: true,
+      enabled: true,
+    });
+    expect(access.providers.custody.para.enabled).toBe(false);
+    expect(access.providers.rpc.default.enabled).toBe(true);
+    expect(access.providers.compliance.range).toEqual({
+      entitled: false,
+      configured: true,
+      enabled: false,
+    });
+    expect(access.providers.ramps.moonpay.enabled).toBe(false);
+  });
+
+  it("syncs normalized Clerk tier and provider overrides into the organization row", async () => {
+    await syncOrganizationTierFromClerk(getDb(env), {
+      organizationId: TEST_ORG_ID,
+      clerkOrganization: {
+        id: "org_clerk_provider_access_test",
+        private_metadata: {
+          sdp: {
+            tier: "pro",
+            providerOverrides: {
+              custody: {
+                local: true,
+                para: false,
+              },
+              rpc: {
+                helius: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const organization = await getDb(env)
+      .prepare("SELECT tier, settings FROM organizations WHERE id = ?")
+      .bind(TEST_ORG_ID)
+      .first<{ tier: string; settings: string | null }>();
+
+    expect(organization?.tier).toBe("enterprise");
+    expect(organization?.settings ? JSON.parse(organization.settings) : null).toMatchObject({
+      providerOverrides: {
+        custody: {
+          local: true,
+          para: false,
+        },
+        rpc: {
+          helius: true,
+        },
+      },
+    });
+  });
+
+  it("defaults to free and clears provider overrides when Clerk metadata is absent", async () => {
+    await getDb(env)
+      .prepare("UPDATE organizations SET tier = ?, settings = ? WHERE id = ?")
+      .bind(
+        "enterprise",
+        JSON.stringify({
+          providerOverrides: {
+            custody: {
+              local: true,
+            },
+          },
+          rpcProvider: "helius",
+        }),
+        TEST_ORG_ID
+      )
+      .run();
+
+    await syncOrganizationTierFromClerk(getDb(env), {
+      organizationId: TEST_ORG_ID,
+      clerkOrganization: {
+        id: "org_clerk_provider_access_default_test",
+      },
+    });
+
+    const organization = await getDb(env)
+      .prepare("SELECT tier, settings FROM organizations WHERE id = ?")
+      .bind(TEST_ORG_ID)
+      .first<{ tier: string; settings: string | null }>();
+
+    expect(organization?.tier).toBe("free");
+    expect(organization?.settings ? JSON.parse(organization.settings) : null).toEqual({
+      rpcProvider: "helius",
+    });
+  });
+});

--- a/apps/sdp-api/src/services/organization-provider-access.service.ts
+++ b/apps/sdp-api/src/services/organization-provider-access.service.ts
@@ -3,10 +3,9 @@ import type { Env } from "@/types/env";
 import {
   COMPLIANCE_PROVIDERS,
   CUSTODY_PROVIDERS,
-  ORGANIZATION_RPC_PROVIDERS,
-  RAMP_PROVIDERS,
   type ComplianceProviderId,
   type CustodyProvider,
+  ORGANIZATION_RPC_PROVIDERS,
   type OrganizationProviderAvailabilityResponse,
   type OrganizationProviderFamily,
   type OrganizationProviderOverrides,
@@ -14,6 +13,7 @@ import {
   type OrganizationSettings,
   type OrganizationTier,
   type ProviderAvailabilityEntry,
+  RAMP_PROVIDERS,
   type RampProviderId,
   normalizeOrganizationTier,
   resolveOrganizationProviderEntitlements,
@@ -148,9 +148,7 @@ export function parseProviderOverridesFromClerkMetadata(
   return hasOwnEntries(next as Record<string, unknown>) ? next : undefined;
 }
 
-export function parseClerkOrganizationTierMetadata(
-  organization: ClerkOrganizationWithMetadata
-): {
+export function parseClerkOrganizationTierMetadata(organization: ClerkOrganizationWithMetadata): {
   tier: OrganizationTier;
   providerOverrides?: OrganizationProviderOverrides;
 } {
@@ -189,7 +187,9 @@ export async function getOrganizationTierState(
 function getConfiguredProviders(env: Env) {
   return {
     custody: {
-      local: true,
+      // Local custody is only available for self-hosted installs that set a
+      // local signing key; hosted environments should not expose it by default.
+      local: Boolean(env.CUSTODY_PRIVATE_KEY?.trim()),
       fireblocks: Boolean(env.FIREBLOCKS_API_KEY?.trim() && env.FIREBLOCKS_API_SECRET?.trim()),
       privy: Boolean(env.PRIVY_APP_ID?.trim() && env.PRIVY_APP_SECRET?.trim()),
       coinbase_cdp: Boolean(
@@ -295,7 +295,7 @@ function getAvailabilityMessage(
     providerId;
 
   if (!entry.entitled) {
-    return tier === "free"
+    return tier === "individual"
       ? `${label} is only available on the enterprise tier.`
       : `${label} is not enabled for this organization.`;
   }
@@ -350,11 +350,16 @@ export async function assertOrganizationProviderEnabled(
   if (!entry?.enabled) {
     throw new AppError(
       "FORBIDDEN",
-      getAvailabilityMessage(access.tier, family, providerId, entry ?? {
-        entitled: false,
-        configured: false,
-        enabled: false,
-      })
+      getAvailabilityMessage(
+        access.tier,
+        family,
+        providerId,
+        entry ?? {
+          entitled: false,
+          configured: false,
+          enabled: false,
+        }
+      )
     );
   }
 }
@@ -394,7 +399,7 @@ export async function syncOrganizationTierFromClerk(
   if (clerkMetadata.providerOverrides) {
     nextSettings.providerOverrides = clerkMetadata.providerOverrides;
   } else {
-    delete nextSettings.providerOverrides;
+    nextSettings.providerOverrides = undefined;
   }
 
   const persistedSettings = hasOwnEntries(nextSettings as Record<string, unknown>)
@@ -407,7 +412,11 @@ export async function syncOrganizationTierFromClerk(
        SET tier = ?, settings = ?, updated_at = sdp_datetime_now()
        WHERE id = ?`
     )
-    .bind(clerkMetadata.tier, toStoredOrganizationSettings(persistedSettings), params.organizationId)
+    .bind(
+      clerkMetadata.tier,
+      toStoredOrganizationSettings(persistedSettings),
+      params.organizationId
+    )
     .run();
 
   return {

--- a/apps/sdp-api/src/services/organization-provider-access.service.ts
+++ b/apps/sdp-api/src/services/organization-provider-access.service.ts
@@ -1,0 +1,417 @@
+import { AppError } from "@/lib/errors";
+import type { Env } from "@/types/env";
+import {
+  COMPLIANCE_PROVIDERS,
+  CUSTODY_PROVIDERS,
+  ORGANIZATION_RPC_PROVIDERS,
+  RAMP_PROVIDERS,
+  type ComplianceProviderId,
+  type CustodyProvider,
+  type OrganizationProviderAvailabilityResponse,
+  type OrganizationProviderFamily,
+  type OrganizationProviderOverrides,
+  type OrganizationRpcProvider,
+  type OrganizationSettings,
+  type OrganizationTier,
+  type ProviderAvailabilityEntry,
+  type RampProviderId,
+  normalizeOrganizationTier,
+  resolveOrganizationProviderEntitlements,
+} from "@sdp/types";
+
+type OrganizationProviderRow = {
+  tier: string;
+  settings: string | null;
+};
+
+type ClerkOrganizationWithMetadata = {
+  id: string;
+  private_metadata?: unknown;
+};
+
+const PROVIDER_LABELS = {
+  custody: {
+    local: "Local",
+    fireblocks: "Fireblocks",
+    privy: "Privy",
+    coinbase_cdp: "Coinbase CDP",
+    para: "Para",
+    turnkey: "Turnkey",
+    dfns: "DFNS",
+    anchorage: "Anchorage",
+  },
+  rpc: {
+    default: "SDP/default",
+    alchemy: "Alchemy",
+    helius: "Helius",
+    quicknode: "QuickNode",
+    triton: "Triton",
+  },
+  compliance: {
+    range: "Range",
+    elliptic: "Elliptic",
+    trm: "TRM",
+    chainalysis: "Chainalysis",
+  },
+  ramps: {
+    moonpay: "MoonPay",
+    lightspark: "Lightspark",
+    bvnk: "BVNK",
+  },
+} as const;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function parseOrganizationSettings(raw: string | null): OrganizationSettings | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as OrganizationSettings;
+  } catch {
+    throw new AppError("INTERNAL_ERROR", "Organization settings are invalid JSON");
+  }
+}
+
+function toStoredOrganizationSettings(settings: OrganizationSettings | null): string | null {
+  if (!settings) {
+    return null;
+  }
+
+  return JSON.stringify(settings);
+}
+
+function hasOwnEntries(value: Record<string, unknown>): boolean {
+  return Object.keys(value).length > 0;
+}
+
+function parseBooleanOverrides<T extends string>(
+  source: unknown,
+  allowedValues: readonly T[]
+): Partial<Record<T, boolean>> | undefined {
+  const record = asRecord(source);
+  if (!record) {
+    return undefined;
+  }
+
+  const next: Partial<Record<T, boolean>> = {};
+  const allowed = new Set<string>(allowedValues);
+
+  for (const [key, value] of Object.entries(record)) {
+    if (!allowed.has(key) || typeof value !== "boolean") {
+      continue;
+    }
+
+    next[key as T] = value;
+  }
+
+  return hasOwnEntries(next as Record<string, unknown>) ? next : undefined;
+}
+
+export function parseProviderOverridesFromClerkMetadata(
+  source: unknown
+): OrganizationProviderOverrides | undefined {
+  const record = asRecord(source);
+  if (!record) {
+    return undefined;
+  }
+
+  const next: OrganizationProviderOverrides = {};
+
+  const custody = parseBooleanOverrides(record.custody, CUSTODY_PROVIDERS);
+  if (custody) {
+    next.custody = custody;
+  }
+
+  const rpc = parseBooleanOverrides(record.rpc, ORGANIZATION_RPC_PROVIDERS);
+  if (rpc) {
+    next.rpc = rpc;
+  }
+
+  const compliance = parseBooleanOverrides(record.compliance, COMPLIANCE_PROVIDERS);
+  if (compliance) {
+    next.compliance = compliance;
+  }
+
+  const ramps = parseBooleanOverrides(record.ramps, RAMP_PROVIDERS);
+  if (ramps) {
+    next.ramps = ramps;
+  }
+
+  return hasOwnEntries(next as Record<string, unknown>) ? next : undefined;
+}
+
+export function parseClerkOrganizationTierMetadata(
+  organization: ClerkOrganizationWithMetadata
+): {
+  tier: OrganizationTier;
+  providerOverrides?: OrganizationProviderOverrides;
+} {
+  const privateMetadata = asRecord(organization.private_metadata);
+  const sdp = asRecord(privateMetadata?.sdp);
+
+  return {
+    tier: normalizeOrganizationTier(typeof sdp?.tier === "string" ? sdp.tier : undefined),
+    providerOverrides: parseProviderOverridesFromClerkMetadata(sdp?.providerOverrides),
+  };
+}
+
+export async function getOrganizationTierState(
+  db: DatabaseClient,
+  organizationId: string
+): Promise<{ tier: OrganizationTier; settings: OrganizationSettings | null }> {
+  const row = await db
+    .prepare(
+      `SELECT tier, settings
+       FROM organizations
+       WHERE id = ?`
+    )
+    .bind(organizationId)
+    .first<OrganizationProviderRow>();
+
+  if (!row) {
+    throw new AppError("NOT_FOUND", "Organization not found");
+  }
+
+  return {
+    tier: normalizeOrganizationTier(row.tier),
+    settings: parseOrganizationSettings(row.settings),
+  };
+}
+
+function getConfiguredProviders(env: Env) {
+  return {
+    custody: {
+      local: true,
+      fireblocks: Boolean(env.FIREBLOCKS_API_KEY?.trim() && env.FIREBLOCKS_API_SECRET?.trim()),
+      privy: Boolean(env.PRIVY_APP_ID?.trim() && env.PRIVY_APP_SECRET?.trim()),
+      coinbase_cdp: Boolean(
+        env.COINBASE_CDP_API_KEY_ID?.trim() &&
+          env.COINBASE_CDP_API_KEY_SECRET?.trim() &&
+          env.COINBASE_CDP_WALLET_SECRET?.trim()
+      ),
+      para: Boolean(env.PARA_API_KEY?.trim()),
+      turnkey: Boolean(
+        env.TURNKEY_API_PUBLIC_KEY?.trim() &&
+          env.TURNKEY_API_PRIVATE_KEY?.trim() &&
+          env.TURNKEY_ORGANIZATION_ID?.trim()
+      ),
+      dfns: Boolean(
+        env.DFNS_AUTH_TOKEN?.trim() &&
+          env.DFNS_CREDENTIAL_ID?.trim() &&
+          env.DFNS_PRIVATE_KEY?.trim()
+      ),
+      anchorage: Boolean(env.ANCHORAGE_API_KEY?.trim()),
+    },
+    rpc: {
+      default: Boolean(env.SOLANA_RPC_URL?.trim()),
+      alchemy: Boolean(env.SOLANA_RPC_ALCHEMY_URL?.trim()),
+      helius: Boolean(env.SOLANA_RPC_HELIUS_URL?.trim()),
+      quicknode: Boolean(env.SOLANA_RPC_QUICKNODE_URL?.trim()),
+      triton: Boolean(env.SOLANA_RPC_TRITON_URL?.trim()),
+    },
+    compliance: {
+      range: Boolean(env.RANGE_API_KEY?.trim()),
+      elliptic: Boolean(
+        env.ELLIPTIC_API_TOKEN?.trim() ||
+          (env.ELLIPTIC_API_KEY?.trim() && env.ELLIPTIC_API_SECRET?.trim())
+      ),
+      trm: Boolean(env.TRM_API_KEY?.trim()),
+      chainalysis: Boolean(env.CHAINALYSIS_API_KEY?.trim()),
+    },
+    ramps: {
+      moonpay: Boolean(env.MOONPAY_API_KEY?.trim() && env.MOONPAY_SECRET_KEY?.trim()),
+      lightspark: Boolean(
+        env.LIGHTSPARK_GRID_CLIENT_ID?.trim() && env.LIGHTSPARK_GRID_CLIENT_SECRET?.trim()
+      ),
+      bvnk: Boolean(
+        env.BVNK_WALLET_ID?.trim() &&
+          (env.BVNK_API_TOKEN?.trim() ||
+            (env.BVNK_HAWK_AUTH_ID?.trim() && env.BVNK_HAWK_SECRET_KEY?.trim()))
+      ),
+    },
+  };
+}
+
+function buildAvailabilityEntries<T extends string>(
+  entitled: Record<T, boolean>,
+  configured: Record<T, boolean>
+): Record<T, ProviderAvailabilityEntry> {
+  return Object.fromEntries(
+    Object.keys(entitled).map((key) => {
+      const isEntitled = entitled[key as T] ?? false;
+      const isConfigured = configured[key as T] ?? false;
+
+      return [
+        key,
+        {
+          entitled: isEntitled,
+          configured: isConfigured,
+          enabled: isEntitled && isConfigured,
+        },
+      ];
+    })
+  ) as Record<T, ProviderAvailabilityEntry>;
+}
+
+export async function getOrganizationProviderAvailability(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string
+): Promise<OrganizationProviderAvailabilityResponse> {
+  const organization = await getOrganizationTierState(db, organizationId);
+  const resolved = resolveOrganizationProviderEntitlements({
+    tier: organization.tier,
+    providerOverrides: organization.settings?.providerOverrides,
+  });
+  const configured = getConfiguredProviders(env);
+
+  return {
+    tier: resolved.tier,
+    providers: {
+      custody: buildAvailabilityEntries(resolved.providers.custody, configured.custody),
+      rpc: buildAvailabilityEntries(resolved.providers.rpc, configured.rpc),
+      compliance: buildAvailabilityEntries(resolved.providers.compliance, configured.compliance),
+      ramps: buildAvailabilityEntries(resolved.providers.ramps, configured.ramps),
+    },
+  };
+}
+
+function getAvailabilityMessage(
+  tier: OrganizationTier,
+  family: OrganizationProviderFamily,
+  providerId: string,
+  entry: ProviderAvailabilityEntry
+): string {
+  const label =
+    PROVIDER_LABELS[family][providerId as keyof (typeof PROVIDER_LABELS)[typeof family]] ??
+    providerId;
+
+  if (!entry.entitled) {
+    return tier === "free"
+      ? `${label} is only available on the enterprise tier.`
+      : `${label} is not enabled for this organization.`;
+  }
+
+  if (!entry.configured) {
+    return `${label} is not configured in this environment.`;
+  }
+
+  return `${label} is unavailable for this organization.`;
+}
+
+export async function assertOrganizationProviderEnabled(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string,
+  family: "custody",
+  providerId: CustodyProvider
+): Promise<void>;
+export async function assertOrganizationProviderEnabled(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string,
+  family: "rpc",
+  providerId: OrganizationRpcProvider
+): Promise<void>;
+export async function assertOrganizationProviderEnabled(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string,
+  family: "compliance",
+  providerId: ComplianceProviderId
+): Promise<void>;
+export async function assertOrganizationProviderEnabled(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string,
+  family: "ramps",
+  providerId: RampProviderId
+): Promise<void>;
+export async function assertOrganizationProviderEnabled(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string,
+  family: OrganizationProviderFamily,
+  providerId: string
+): Promise<void> {
+  const access = await getOrganizationProviderAvailability(env, db, organizationId);
+  const entry = access.providers[family][
+    providerId as keyof (typeof access.providers)[typeof family]
+  ] as ProviderAvailabilityEntry | undefined;
+
+  if (!entry?.enabled) {
+    throw new AppError(
+      "FORBIDDEN",
+      getAvailabilityMessage(access.tier, family, providerId, entry ?? {
+        entitled: false,
+        configured: false,
+        enabled: false,
+      })
+    );
+  }
+}
+
+export async function getEnabledOrganizationProviders(
+  env: Env,
+  db: DatabaseClient,
+  organizationId: string
+) {
+  const access = await getOrganizationProviderAvailability(env, db, organizationId);
+
+  return {
+    tier: access.tier,
+    custody: CUSTODY_PROVIDERS.filter((provider) => access.providers.custody[provider]?.enabled),
+    rpc: ORGANIZATION_RPC_PROVIDERS.filter((provider) => access.providers.rpc[provider]?.enabled),
+    compliance: COMPLIANCE_PROVIDERS.filter(
+      (provider) => access.providers.compliance[provider]?.enabled
+    ),
+    ramps: RAMP_PROVIDERS.filter((provider) => access.providers.ramps[provider]?.enabled),
+  };
+}
+
+export async function syncOrganizationTierFromClerk(
+  db: DatabaseClient,
+  params: {
+    organizationId: string;
+    clerkOrganization: ClerkOrganizationWithMetadata;
+  }
+): Promise<{ tier: OrganizationTier; settings: OrganizationSettings | null }> {
+  const existing = await getOrganizationTierState(db, params.organizationId);
+  const clerkMetadata = parseClerkOrganizationTierMetadata(params.clerkOrganization);
+
+  const nextSettings: OrganizationSettings = {
+    ...(existing.settings ?? {}),
+  };
+
+  if (clerkMetadata.providerOverrides) {
+    nextSettings.providerOverrides = clerkMetadata.providerOverrides;
+  } else {
+    delete nextSettings.providerOverrides;
+  }
+
+  const persistedSettings = hasOwnEntries(nextSettings as Record<string, unknown>)
+    ? nextSettings
+    : null;
+
+  await db
+    .prepare(
+      `UPDATE organizations
+       SET tier = ?, settings = ?, updated_at = sdp_datetime_now()
+       WHERE id = ?`
+    )
+    .bind(clerkMetadata.tier, toStoredOrganizationSettings(persistedSettings), params.organizationId)
+    .run();
+
+  return {
+    tier: clerkMetadata.tier,
+    settings: persistedSettings,
+  };
+}

--- a/apps/sdp-api/src/services/project.service.test.ts
+++ b/apps/sdp-api/src/services/project.service.test.ts
@@ -38,7 +38,7 @@ describe("ProjectService", () => {
     // Seed org and user
     await db
       .prepare(
-        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'free', 'active')"
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
       )
       .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
       .run();
@@ -156,7 +156,6 @@ describe("ProjectService", () => {
     });
   });
 
-  // biome-ignore lint/nursery/noSecrets: Test suite name, not a secret
   describe("getProjectBySlug", () => {
     it("returns project by slug within organization", async () => {
       await projectService.createProject({

--- a/apps/sdp-api/src/services/rpc-relay.service.test.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.test.ts
@@ -54,7 +54,7 @@ describe("rpc-relay.service", () => {
     await db
       .prepare(
         `INSERT INTO organizations (id, name, slug, tier, status, settings)
-       VALUES (?, 'RPC Service Org', 'rpc-service-org', 'free', 'active', NULL)
+       VALUES (?, 'RPC Service Org', 'rpc-service-org', 'enterprise', 'active', NULL)
        ON CONFLICT(id) DO UPDATE SET
          name = excluded.name,
          slug = excluded.slug,

--- a/apps/sdp-api/src/services/rpc-relay.service.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.ts
@@ -1,4 +1,5 @@
 import { AppError } from "@/lib/errors";
+import { getOrganizationProviderAvailability } from "@/services/organization-provider-access.service";
 import type { Env } from "@/types/env";
 import {
   ORGANIZATION_RPC_PROVIDERS,
@@ -409,6 +410,10 @@ export function includesTransactionMethod(methodNames: string[]): boolean {
 
 export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<ResolvedRpcTarget> {
   const managedProviders = resolveManagedProviders(input.env);
+  const access = await getOrganizationProviderAvailability(input.env, input.db, input.organizationId);
+  const enabledManagedProviders = managedProviders.filter(
+    (provider) => access.providers.rpc[provider.id]?.enabled
+  );
   const projectId = getEffectiveProjectId(input.authProjectId, input.requestedProjectId);
 
   if (projectId) {
@@ -427,24 +432,20 @@ export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<Re
     }
 
     if (projectPreference.providerType === "managed") {
-      const selectedProvider = managedProviders.find(
+      const selectedProvider = enabledManagedProviders.find(
         (provider) => provider.id === projectPreference.providerId
       );
-      if (!selectedProvider) {
-        throw new AppError(
-          "BAD_REQUEST",
-          `Project RPC provider '${projectPreference.providerId}' is not configured in this environment`
-        );
-      }
 
-      return {
-        providerId: selectedProvider.id,
-        projectId,
-        endpoint: selectedProvider.url,
-        endpointLabel: maskEndpoint(selectedProvider.url),
-        headers: selectedProvider.headers,
-        selectionMode: "project_provider",
-      };
+      if (selectedProvider) {
+        return {
+          providerId: selectedProvider.id,
+          projectId,
+          endpoint: selectedProvider.url,
+          endpointLabel: maskEndpoint(selectedProvider.url),
+          headers: selectedProvider.headers,
+          selectionMode: "project_provider",
+        };
+      }
     }
   }
 
@@ -452,25 +453,23 @@ export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<Re
   const preferredProvider = organizationSettings?.rpcProvider;
 
   if (preferredProvider && preferredProvider !== "default") {
-    const selectedProvider = managedProviders.find((provider) => provider.id === preferredProvider);
-    if (!selectedProvider) {
-      throw new AppError(
-        "BAD_REQUEST",
-        `Organization RPC provider '${preferredProvider}' is not configured in this environment`
-      );
-    }
+    const selectedProvider = enabledManagedProviders.find(
+      (provider) => provider.id === preferredProvider
+    );
 
-    return {
-      providerId: selectedProvider.id,
-      projectId,
-      endpoint: selectedProvider.url,
-      endpointLabel: maskEndpoint(selectedProvider.url),
-      headers: selectedProvider.headers,
-      selectionMode: "organization_provider",
-    };
+    if (selectedProvider) {
+      return {
+        providerId: selectedProvider.id,
+        projectId,
+        endpoint: selectedProvider.url,
+        endpointLabel: maskEndpoint(selectedProvider.url),
+        headers: selectedProvider.headers,
+        selectionMode: "organization_provider",
+      };
+    }
   }
 
-  const selectedProvider = await pickRoundRobinProvider(input.env.SDP_CACHE, managedProviders);
+  const selectedProvider = await pickRoundRobinProvider(input.env.SDP_CACHE, enabledManagedProviders);
   return {
     providerId: selectedProvider.id,
     projectId,
@@ -533,9 +532,13 @@ export async function listRpcProviders(input: {
   requestedProjectId: string | null;
 }) {
   const managedProviders = resolveManagedProviders(input.env);
+  const access = await getOrganizationProviderAvailability(input.env, input.db, input.organizationId);
+  const enabledManagedProviders = managedProviders.filter(
+    (provider) => access.providers.rpc[provider.id]?.enabled
+  );
   const providerStatuses: RpcProviderStatus[] = [];
 
-  for (const provider of managedProviders) {
+  for (const provider of enabledManagedProviders) {
     providerStatuses.push({
       id: provider.id,
       endpoint: maskEndpoint(provider.url),
@@ -554,6 +557,6 @@ export async function listRpcProviders(input: {
       endpoint: resolvedTarget.endpointLabel,
       stats: await getProviderStats(input.env.SDP_CACHE, resolvedTarget.providerId),
     },
-    roundRobinOrder: managedProviders.map((provider) => provider.id),
+    roundRobinOrder: enabledManagedProviders.map((provider) => provider.id),
   };
 }

--- a/apps/sdp-api/src/services/rpc-relay.service.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.ts
@@ -410,7 +410,11 @@ export function includesTransactionMethod(methodNames: string[]): boolean {
 
 export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<ResolvedRpcTarget> {
   const managedProviders = resolveManagedProviders(input.env);
-  const access = await getOrganizationProviderAvailability(input.env, input.db, input.organizationId);
+  const access = await getOrganizationProviderAvailability(
+    input.env,
+    input.db,
+    input.organizationId
+  );
   const enabledManagedProviders = managedProviders.filter(
     (provider) => access.providers.rpc[provider.id]?.enabled
   );
@@ -469,7 +473,10 @@ export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<Re
     }
   }
 
-  const selectedProvider = await pickRoundRobinProvider(input.env.SDP_CACHE, enabledManagedProviders);
+  const selectedProvider = await pickRoundRobinProvider(
+    input.env.SDP_CACHE,
+    enabledManagedProviders
+  );
   return {
     providerId: selectedProvider.id,
     projectId,
@@ -532,7 +539,11 @@ export async function listRpcProviders(input: {
   requestedProjectId: string | null;
 }) {
   const managedProviders = resolveManagedProviders(input.env);
-  const access = await getOrganizationProviderAvailability(input.env, input.db, input.organizationId);
+  const access = await getOrganizationProviderAvailability(
+    input.env,
+    input.db,
+    input.organizationId
+  );
   const enabledManagedProviders = managedProviders.filter(
     (provider) => access.providers.rpc[provider.id]?.enabled
   );

--- a/apps/sdp-api/src/services/token.service.test.ts
+++ b/apps/sdp-api/src/services/token.service.test.ts
@@ -57,7 +57,7 @@ describe("TokenService", () => {
 
     await db
       .prepare(
-        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'free', 'active')"
+        "INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
       )
       .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
       .run();

--- a/apps/sdp-api/src/test/fixtures/api-keys.ts
+++ b/apps/sdp-api/src/test/fixtures/api-keys.ts
@@ -7,7 +7,6 @@ import { TEST_ORG } from "./organizations";
 
 export const TEST_API_KEY = {
   id: "key_test123456789",
-  // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret
   raw: "sk_test_testkey123456789012345678901234",
   prefix: "sk_test_tes",
 };

--- a/apps/sdp-api/src/test/fixtures/custody.ts
+++ b/apps/sdp-api/src/test/fixtures/custody.ts
@@ -8,7 +8,6 @@ import { TEST_ORG } from "./organizations";
 import { TEST_PROJECT } from "./tokens";
 
 // Test Solana addresses (valid Base58)
-// biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
 export const TEST_CUSTODY_PUBLIC_KEY = "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz";
 
 /**
@@ -43,7 +42,6 @@ export const TEST_PROJECT_CUSTODY_CONFIG: SigningConfigRecord = {
     provider: "local",
     encryptedPrivateKey: "test_project_encrypted_key_placeholder",
   }),
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   defaultWalletId: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
   status: "active",
   createdAt: "2024-01-02T00:00:00.000Z",
@@ -70,9 +68,7 @@ export const TEST_CUSTODY_WALLET: CustodyWallet = {
 export const TEST_PROJECT_CUSTODY_WALLET: CustodyWallet = {
   id: "cwlt_proj123456789",
   custodyConfigId: TEST_PROJECT_CUSTODY_CONFIG.id,
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   walletId: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   publicKey: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
   label: "Project Signing Wallet",
   purpose: "root",

--- a/apps/sdp-api/src/test/fixtures/organizations.ts
+++ b/apps/sdp-api/src/test/fixtures/organizations.ts
@@ -6,7 +6,7 @@ export const TEST_ORG = {
   id: "org_test123456789",
   name: "Test Organization",
   slug: "test-org",
-  tier: "free" as const,
+  tier: "individual" as const,
   status: "active" as const,
   settings: null,
   createdAt: "2024-01-01T00:00:00.000Z",

--- a/apps/sdp-api/src/test/fixtures/tokens.ts
+++ b/apps/sdp-api/src/test/fixtures/tokens.ts
@@ -19,7 +19,6 @@ export const TEST_PROJECT = {
 
 export const TEST_PROJECT_API_KEY = {
   id: "key_proj123456789",
-  // biome-ignore lint/nursery/noSecrets: Test fixture, not a real secret
   raw: "sk_test_projkey12345678901234567890123",
   prefix: "sk_test_pro",
 };
@@ -72,11 +71,8 @@ export const TEST_TOKEN: Token = {
 export const TEST_ACTIVE_TOKEN: Token = {
   ...TEST_TOKEN,
   id: "tok_active12345678",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   mintAddress: "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   mintAuthority: "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   freezeAuthority: "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz",
   status: "active",
   deployedAt: "2024-01-02T00:00:00.000Z",
@@ -101,7 +97,6 @@ export const TEST_TOKEN_TRANSACTION: TokenTransaction = {
   signature: null,
   serializedTx: null,
   params: {
-    // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
     destination: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
     amount: "1",
   },
@@ -117,7 +112,6 @@ export const TEST_TOKEN_TRANSACTION: TokenTransaction = {
 export const TEST_ALLOWLIST_ENTRY: TokenAllowlistEntry = {
   id: "tal_test123456789",
   tokenId: TEST_ALLOWLIST_TOKEN.id,
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   address: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
   label: "Test Wallet",
   status: "active",
@@ -128,12 +122,8 @@ export const TEST_ALLOWLIST_ENTRY: TokenAllowlistEntry = {
 
 // Solana test addresses (valid Base58)
 export const TEST_SOLANA_ADDRESSES = {
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   wallet1: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   wallet2: "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   wallet3: "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz",
-  // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
   mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
 };

--- a/apps/sdp-api/src/test/helpers/factories.ts
+++ b/apps/sdp-api/src/test/helpers/factories.ts
@@ -36,7 +36,7 @@ export interface OrganizationOverrides {
   id?: string;
   name?: string;
   slug?: string;
-  tier?: "free" | "starter" | "growth" | "enterprise";
+  tier?: "free" | "enterprise";
   status?: "active" | "suspended" | "deleted";
   createdAt?: string;
   updatedAt?: string;
@@ -46,7 +46,7 @@ export interface Organization {
   id: string;
   name: string;
   slug: string;
-  tier: "free" | "starter" | "growth" | "enterprise";
+  tier: "free" | "enterprise";
   status: "active" | "suspended" | "deleted";
   createdAt: string;
   updatedAt: string;

--- a/apps/sdp-api/src/test/helpers/factories.ts
+++ b/apps/sdp-api/src/test/helpers/factories.ts
@@ -36,7 +36,7 @@ export interface OrganizationOverrides {
   id?: string;
   name?: string;
   slug?: string;
-  tier?: "free" | "enterprise";
+  tier?: "individual" | "enterprise";
   status?: "active" | "suspended" | "deleted";
   createdAt?: string;
   updatedAt?: string;
@@ -46,7 +46,7 @@ export interface Organization {
   id: string;
   name: string;
   slug: string;
-  tier: "free" | "enterprise";
+  tier: "individual" | "enterprise";
   status: "active" | "suspended" | "deleted";
   createdAt: string;
   updatedAt: string;
@@ -58,7 +58,7 @@ export function createOrganization(overrides: OrganizationOverrides = {}): Organ
     id: `org_factory_${n.toString().padStart(8, "0")}`,
     name: `Factory Org ${n}`,
     slug: `factory-org-${n}`,
-    tier: "free",
+    tier: "individual",
     status: "active",
     createdAt: "2024-01-01T00:00:00.000Z",
     updatedAt: "2024-01-01T00:00:00.000Z",
@@ -276,11 +276,8 @@ export function createActiveToken(overrides: TokenOverrides = {}): Token {
   const base = createToken(overrides);
   return {
     ...base,
-    // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
     mintAddress: "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv",
-    // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
     mintAuthority: "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz",
-    // biome-ignore lint/nursery/noSecrets: Test Solana address, not a secret
     freezeAuthority: "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz",
     status: "active",
     deployedAt: "2024-01-02T00:00:00.000Z",
@@ -327,7 +324,6 @@ export function createTokenTransaction(
     signature: null,
     serializedTx: null,
     params: {
-      // biome-ignore lint/nursery/noSecrets: Test Solana address
       destination: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
       amount: "1",
     },
@@ -364,7 +360,6 @@ export function createAllowlistEntry(
   return {
     id: `tal_factory_${n.toString().padStart(8, "0")}`,
     tokenId: `tok_factory_${n.toString().padStart(8, "0")}`,
-    // biome-ignore lint/nursery/noSecrets: Test Solana address
     address: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
     label: "Factory Wallet",
     status: "active",
@@ -383,12 +378,8 @@ export function createAllowlistEntry(
  * Valid Base58 Solana addresses for testing
  */
 export const SOLANA_ADDRESSES = {
-  // biome-ignore lint/nursery/noSecrets: Test Solana address
   wallet1: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ" as const,
-  // biome-ignore lint/nursery/noSecrets: Test Solana address
   wallet2: "7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv" as const,
-  // biome-ignore lint/nursery/noSecrets: Test Solana address
   wallet3: "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz" as const,
-  // biome-ignore lint/nursery/noSecrets: Test Solana address - USDC mint
   mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as const,
 };

--- a/apps/sdp-web/playwright/support/clerk-admin.ts
+++ b/apps/sdp-web/playwright/support/clerk-admin.ts
@@ -1,4 +1,5 @@
 import { createClerkClient } from "@clerk/backend";
+import type { OrganizationTier } from "@sdp/types";
 import { getE2EEnv } from "../env";
 
 export type ClerkTestIdentity = {
@@ -6,6 +7,36 @@ export type ClerkTestIdentity = {
   organizationId: string;
   userId: string;
 };
+
+type ClerkOrganizationRecord = {
+  private_metadata?: unknown;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+async function requestClerk<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const env = getE2EEnv();
+  const response = await fetch(`https://api.clerk.com/v1${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${env.clerkSecretKey}`,
+      "Content-Type": "application/json",
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Clerk request failed (${response.status}) for ${path}`);
+  }
+
+  return (await response.json()) as T;
+}
 
 async function resolveOrganizationId(
   client: ReturnType<typeof createClerkClient>,
@@ -126,4 +157,30 @@ export async function ensureClerkAdminUser(): Promise<ClerkTestIdentity> {
     organizationId,
     userId: user.id,
   };
+}
+
+export async function setClerkOrganizationTier(
+  organizationId: string,
+  tier: OrganizationTier
+): Promise<void> {
+  const organization = await requestClerk<ClerkOrganizationRecord>(
+    `/organizations/${organizationId}`
+  );
+  const privateMetadata = asRecord(organization.private_metadata) ?? {};
+  const sdpMetadata = asRecord(privateMetadata.sdp) ?? {};
+  const nextPrivateMetadata = {
+    ...privateMetadata,
+    sdp: {
+      ...sdpMetadata,
+      tier,
+      providerOverrides: undefined,
+    },
+  };
+
+  await requestClerk(`/organizations/${organizationId}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      private_metadata: nextPrivateMetadata,
+    }),
+  });
 }

--- a/apps/sdp-web/playwright/support/local-api-client.ts
+++ b/apps/sdp-web/playwright/support/local-api-client.ts
@@ -1,6 +1,7 @@
 export interface LocalApiClient {
   get<T>(path: string): Promise<T>;
   post<T>(path: string, body?: unknown): Promise<T>;
+  put<T>(path: string, body?: unknown): Promise<T>;
   patch<T>(path: string, body?: unknown): Promise<T>;
   delete<T>(path: string): Promise<T>;
 }
@@ -62,6 +63,7 @@ export function createLocalApiClient(baseUrl: string, bearerToken: string): Loca
   return {
     get: (path) => request("GET", path),
     post: (path, body) => request("POST", path, body),
+    put: (path, body) => request("PUT", path, body),
     patch: (path, body) => request("PATCH", path, body),
     delete: (path) => request("DELETE", path),
   };

--- a/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
@@ -17,7 +17,7 @@ import {
 } from "@solana/kit";
 import { KoraClient } from "@solana/kora";
 import { Client } from "pg";
-import type { ClerkTestIdentity } from "./clerk-admin";
+import { type ClerkTestIdentity, setClerkOrganizationTier } from "./clerk-admin";
 import { type LocalApiClient, createLocalApiClient } from "./local-api-client";
 
 const PLAYWRIGHT_LOCAL_ORG_ID_PREFIX = "org_e2e_dashboard";
@@ -531,6 +531,8 @@ async function fundWalletToLamports(
 }
 
 export async function ensureUnlinkedOrg(identity: ClerkTestIdentity): Promise<void> {
+  await setClerkOrganizationTier(identity.organizationId, "individual");
+
   await withDatabaseClient(async (client) => {
     await client.query("BEGIN");
 
@@ -551,6 +553,8 @@ export async function ensureLinkedOrg(
 ): Promise<PlaywrightOrganizationFixture> {
   const organization = buildPlaywrightOrganizationFixture(identity);
   const tier = options?.tier ?? "individual";
+
+  await setClerkOrganizationTier(identity.organizationId, tier);
 
   await withDatabaseClient(async (client) => {
     await client.query("BEGIN");

--- a/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { PaymentsDashboardWallet } from "@sdp/types";
+import type { OrganizationTier, PaymentsDashboardWallet } from "@sdp/types";
 import { getTransferSolInstruction } from "@solana-program/system";
 import {
   type Address,
@@ -92,6 +92,10 @@ interface PlaywrightOrganizationFixture {
   id: string;
   name: string;
   slug: string;
+}
+
+interface EnsureLinkedOrgOptions {
+  tier?: OrganizationTier;
 }
 
 function getPlaywrightApiRuntimeEnv(): PlaywrightApiRuntimeEnv {
@@ -542,9 +546,11 @@ export async function ensureUnlinkedOrg(identity: ClerkTestIdentity): Promise<vo
 }
 
 export async function ensureLinkedOrg(
-  identity: ClerkTestIdentity
+  identity: ClerkTestIdentity,
+  options?: EnsureLinkedOrgOptions
 ): Promise<PlaywrightOrganizationFixture> {
   const organization = buildPlaywrightOrganizationFixture(identity);
+  const tier = options?.tier ?? "individual";
 
   await withDatabaseClient(async (client) => {
     await client.query("BEGIN");
@@ -555,14 +561,14 @@ export async function ensureLinkedOrg(
 
       await client.query(
         `INSERT INTO organizations (id, name, slug, tier, status)
-         VALUES ($1, $2, $3, 'free', 'active')
+         VALUES ($1, $2, $3, $4, 'active')
          ON CONFLICT (id) DO UPDATE SET
            name = EXCLUDED.name,
            slug = EXCLUDED.slug,
            tier = EXCLUDED.tier,
            status = EXCLUDED.status,
            updated_at = sdp_datetime_now()`,
-        [organization.id, organization.name, organization.slug]
+        [organization.id, organization.name, organization.slug, tier]
       );
 
       await client.query(
@@ -601,6 +607,7 @@ export async function bootstrapLocalWalletFixtures(input: {
   walletCount?: number;
   fundSourceWallet?: boolean;
   fundSourceAmountSol?: number;
+  tier?: OrganizationTier;
 }): Promise<WalletBootstrapResult> {
   const { identity, bearerToken } = input;
   const walletCount = Math.max(1, input.walletCount ?? 1);
@@ -610,7 +617,9 @@ export async function bootstrapLocalWalletFixtures(input: {
   const runtimeEnv = getPlaywrightApiRuntimeEnv();
   const api = createLocalApiClient(runtimeEnv.localApiBaseUrl, bearerToken);
 
-  const organization = await ensureLinkedOrg(identity);
+  const organization = await ensureLinkedOrg(identity, {
+    tier: input.tier,
+  });
 
   const initialized = await api.post<InitializeWalletResponse>("/v1/wallets/initialize", {
     provider,

--- a/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
@@ -1,4 +1,5 @@
 import type { Token } from "@sdp/types";
+import type { OrganizationTier } from "@sdp/types";
 import { generateKeyPairSigner } from "@solana/kit";
 import type { ClerkTestIdentity } from "./clerk-admin";
 import {
@@ -19,6 +20,7 @@ import {
 interface BootstrapOptions {
   identity: ClerkTestIdentity;
   bearerToken: string;
+  tier?: OrganizationTier;
 }
 
 interface TokenResponse {
@@ -147,12 +149,14 @@ function requireWallet(
 export async function bootstrapLocalIssuanceFixtures({
   identity,
   bearerToken,
+  tier,
 }: BootstrapOptions): Promise<IssuanceFixtures> {
   const walletBootstrap = await bootstrapLocalWalletFixtures({
     identity,
     bearerToken,
     provider: "privy",
     walletCount: 2,
+    tier,
   });
   const api = createLocalApiClient(getBootstrapApiBaseUrl(), bearerToken);
 

--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -11,6 +11,7 @@ test.describe
   .serial("dashboard payments e2e", () => {
     let destinationAddress = "";
     let sourceWalletLabel = "";
+    let sourceWalletId = "";
     let transferTokenSymbol = "";
 
     test.beforeAll(async ({ browser }) => {
@@ -30,8 +31,12 @@ test.describe
       });
 
       sourceWalletLabel = fixtures.wallets.treasury.label ?? fixtures.wallets.treasury.publicKey;
+      sourceWalletId = fixtures.wallets.treasury.walletId;
       transferTokenSymbol = fixtures.tokens.open.symbol;
       destinationAddress = await createExternalSolanaAddress();
+      await api.put(`/v1/payments/wallets/${sourceWalletId}/policies`, {
+        destinationAllowlist: [destinationAddress],
+      });
       await session.page.close();
     });
 
@@ -56,12 +61,9 @@ test.describe
       await expect(assetSelect).toContainText(transferTokenSymbol);
       await app.getByLabel("Amount").fill("1");
       await app.getByLabel("Destination address").fill(destinationAddress);
-      await app.getByRole("button", { name: "Run a risk check" }).click();
-
-      const riskResultsDialog = page.getByText("Risk score results");
-      await expect(riskResultsDialog).toBeVisible({ timeout: 120_000 });
-      await page.getByRole("button", { name: "Dismiss" }).click();
-      await expect(riskResultsDialog).toHaveCount(0);
+      await expect(
+        app.getByText("This destination is already on the source wallet allowlist.")
+      ).toBeVisible({ timeout: 120_000 });
 
       const nextButton = app.getByRole("button", { name: "Next", exact: true });
       await expect(nextButton).toBeEnabled({ timeout: 120_000 });

--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -18,6 +18,7 @@ test.describe
       const fixtures = await bootstrapLocalIssuanceFixtures({
         identity: session.identity,
         bearerToken: session.bearerToken,
+        tier: "enterprise",
       });
       const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.bearerToken);
 

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -14,6 +14,7 @@ import { linkOrganization } from "@/app/onboarding/actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAuthEntryPath } from "@/lib/auth-entry";
+import { fetchOrganizationProviderAccess } from "@/lib/organization-provider-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { type SdpApiClient, createSdpApiClient } from "@/lib/sdp-api";
 import { auth, clerkClient } from "@clerk/nextjs/server";
@@ -29,6 +30,13 @@ interface ClerkOrganizationSummary {
 }
 
 type SettledResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+type OnboardingStatusResponse = {
+  linked: boolean;
+  organization: {
+    id: string;
+  } | null;
+};
 
 function settle<T>(promise: Promise<T>): Promise<SettledResult<T>> {
   return promise.then(
@@ -146,7 +154,7 @@ export default async function CustodyPage() {
       createSdpApiClient(trace.childContext("dashboard.custody.api"))
     );
     const onboarding = await trace.step("fetch_onboarding_status", () =>
-      apiClient.fetch<{ linked: boolean }>("/v1/onboarding/status")
+      apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status")
     );
 
     if (!onboarding.linked) {
@@ -162,10 +170,18 @@ export default async function CustodyPage() {
       );
     }
 
-    const [configsResult, walletsResult, apiKeysResult] = await Promise.all([
+    const [configsResult, walletsResult, apiKeysResult, providerAccessResult] = await Promise.all([
       trace.step("fetch_custody_configs", () => settle(getCustodyConfigs(apiClient.request))),
       trace.step("fetch_custody_wallets", () => settle(getCustodyWallets(apiClient.request))),
       trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
+      trace.step("fetch_provider_access", () =>
+        onboarding.organization
+          ? settle(fetchOrganizationProviderAccess(apiClient.request, onboarding.organization.id))
+          : Promise.resolve({
+              ok: false as const,
+              error: new Error("Organization is not linked"),
+            })
+      ),
     ]);
 
     const connectedProviders: KnownCustodyProvider[] = configsResult.ok
@@ -186,11 +202,15 @@ export default async function CustodyPage() {
         ? walletsResult.error.message
         : "Unable to load wallets";
     const apiKeys = apiKeysResult.ok ? (apiKeysResult.data ?? []) : [];
+    const enabledProviders = providerAccessResult.ok
+      ? providerAccessResult.value.enabledCustodyProviders
+      : connectedProviders;
 
     trace.log({
       ok: true,
       linked: true,
       connectedProviderCount: connectedProviders.length,
+      enabledProviderCount: enabledProviders.length,
       walletCount: walletsResult.ok ? walletsResult.value.length : 0,
       apiKeyCount: apiKeys.length,
     });
@@ -201,6 +221,7 @@ export default async function CustodyPage() {
           apiBaseUrl={resolvePlaygroundApiBaseUrl()}
           apiKeys={apiKeys}
           connectedProviders={connectedProviders}
+          enabledProviders={enabledProviders}
           configsError={configsError}
           wallets={walletsResult.ok ? walletsResult.value : []}
           walletsError={walletsError}

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -21,6 +21,7 @@ import { auth, clerkClient } from "@clerk/nextjs/server";
 import type { CustodyConfigSummary, CustodyWalletSummary } from "@sdp/types";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
+import type { OnboardingStatusResponse } from "../onboarding-status";
 import { WalletsWorkspace } from "./wallets-workspace";
 
 interface ClerkOrganizationSummary {
@@ -30,13 +31,6 @@ interface ClerkOrganizationSummary {
 }
 
 type SettledResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
-
-type OnboardingStatusResponse = {
-  linked: boolean;
-  organization: {
-    id: string;
-  } | null;
-};
 
 function settle<T>(promise: Promise<T>): Promise<SettledResult<T>> {
   return promise.then(

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx
@@ -83,7 +83,9 @@ export function WalletProvisionModal({
       return;
     }
 
-    setSelectedProvider(resolveInitialProvider(preferredProvider, connectedProviders, enabledProviders));
+    setSelectedProvider(
+      resolveInitialProvider(preferredProvider, connectedProviders, enabledProviders)
+    );
   }, [connectedProviders, enabledProviders, isOpen, preferredProvider]);
 
   useEscapeKey(isOpen, onClose);
@@ -94,7 +96,9 @@ export function WalletProvisionModal({
     [enabledProviders]
   );
   const selectedProviderEntry = useMemo(
-    () => selectableProviders.find((provider) => provider.id === selectedProvider) ?? selectableProviders[0],
+    () =>
+      selectableProviders.find((provider) => provider.id === selectedProvider) ??
+      selectableProviders[0],
     [selectableProviders, selectedProvider]
   );
   const isConnected = connectedProviderSet.has(selectedProvider);

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-provision-modal.tsx
@@ -16,22 +16,29 @@ import { WalletProviderMark } from "./wallet-provider-mark";
 
 function resolveInitialProvider(
   preferredProvider: KnownCustodyProvider | null,
-  connectedProviders: KnownCustodyProvider[]
+  connectedProviders: KnownCustodyProvider[],
+  enabledProviders: KnownCustodyProvider[]
 ): KnownCustodyProvider {
-  if (preferredProvider) {
+  if (preferredProvider && enabledProviders.includes(preferredProvider)) {
     return preferredProvider;
   }
 
   const connectedProviderSet = new Set(connectedProviders);
   const connectedCreateable = CUSTODY_PROVIDER_CATALOG.find(
-    (provider) => connectedProviderSet.has(provider.id) && provider.supportsAdditionalWallets
+    (provider) =>
+      enabledProviders.includes(provider.id) &&
+      connectedProviderSet.has(provider.id) &&
+      provider.supportsAdditionalWallets
   );
 
   if (connectedCreateable) {
     return connectedCreateable.id;
   }
 
-  return CUSTODY_PROVIDER_CATALOG[0]?.id ?? "privy";
+  return (
+    CUSTODY_PROVIDER_CATALOG.find((provider) => enabledProviders.includes(provider.id))?.id ??
+    "privy"
+  );
 }
 
 function SubmitButton({
@@ -56,6 +63,7 @@ interface WalletProvisionModalProps {
   isOpen: boolean;
   onClose: () => void;
   connectedProviders: KnownCustodyProvider[];
+  enabledProviders: KnownCustodyProvider[];
   preferredProvider: KnownCustodyProvider | null;
 }
 
@@ -63,10 +71,11 @@ export function WalletProvisionModal({
   isOpen,
   onClose,
   connectedProviders,
+  enabledProviders,
   preferredProvider,
 }: WalletProvisionModalProps) {
   const [selectedProvider, setSelectedProvider] = useState<KnownCustodyProvider>(
-    resolveInitialProvider(preferredProvider, connectedProviders)
+    resolveInitialProvider(preferredProvider, connectedProviders, enabledProviders)
   );
 
   useEffect(() => {
@@ -74,17 +83,19 @@ export function WalletProvisionModal({
       return;
     }
 
-    setSelectedProvider(resolveInitialProvider(preferredProvider, connectedProviders));
-  }, [connectedProviders, isOpen, preferredProvider]);
+    setSelectedProvider(resolveInitialProvider(preferredProvider, connectedProviders, enabledProviders));
+  }, [connectedProviders, enabledProviders, isOpen, preferredProvider]);
 
   useEscapeKey(isOpen, onClose);
 
   const connectedProviderSet = useMemo(() => new Set(connectedProviders), [connectedProviders]);
+  const selectableProviders = useMemo(
+    () => CUSTODY_PROVIDER_CATALOG.filter((provider) => enabledProviders.includes(provider.id)),
+    [enabledProviders]
+  );
   const selectedProviderEntry = useMemo(
-    () =>
-      CUSTODY_PROVIDER_CATALOG.find((provider) => provider.id === selectedProvider) ??
-      CUSTODY_PROVIDER_CATALOG[0],
-    [selectedProvider]
+    () => selectableProviders.find((provider) => provider.id === selectedProvider) ?? selectableProviders[0],
+    [selectableProviders, selectedProvider]
   );
   const isConnected = connectedProviderSet.has(selectedProvider);
   const supportsAdditionalWallets = selectedProviderEntry?.supportsAdditionalWallets ?? false;
@@ -95,6 +106,10 @@ export function WalletProvisionModal({
     : "Connect this custody provider and create its first wallet in one step.";
 
   if (!isOpen) {
+    return null;
+  }
+
+  if (selectableProviders.length === 0) {
     return null;
   }
 
@@ -141,7 +156,7 @@ export function WalletProvisionModal({
                 }}
                 className="h-12 w-full appearance-none rounded-[14px] border border-[rgba(28,28,29,0.12)] bg-white pl-11 pr-10 text-sm font-medium text-[#1c1c1d]"
               >
-                {CUSTODY_PROVIDER_CATALOG.map((provider) => (
+                {selectableProviders.map((provider) => (
                   <option key={provider.id} value={provider.id}>
                     {provider.label}
                   </option>

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
@@ -19,6 +19,7 @@ import { WalletProviderMark } from "./wallet-provider-mark";
 interface WalletsOverviewProps {
   canManageCustody: boolean;
   connectedProviders: KnownCustodyProvider[];
+  enabledProviders: KnownCustodyProvider[];
   configsError: string | null;
   wallets: CustodyWalletSummary[];
   walletsError: string | null;
@@ -28,6 +29,7 @@ interface WalletsOverviewProps {
 export function WalletsOverview({
   canManageCustody,
   connectedProviders,
+  enabledProviders,
   configsError,
   wallets,
   walletsError,
@@ -57,11 +59,16 @@ export function WalletsOverview({
               : "Wallet creation is limited to admins. Once a wallet is created, you can still use it across the dashboard."}
           </p>
           {configsError ? <p className="text-sm text-[#9e2b38]">{configsError}</p> : null}
+          {canManageCustody && enabledProviders.length === 0 ? (
+            <p className="text-sm text-[rgba(28,28,29,0.62)]">
+              No custody providers are enabled for this organization tier right now.
+            </p>
+          ) : null}
         </div>
 
         {canManageCustody ? (
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {CUSTODY_PROVIDER_CATALOG.map((provider) => {
+            {CUSTODY_PROVIDER_CATALOG.filter((provider) => enabledProviders.includes(provider.id)).map((provider) => {
               const isConnected = connectedProviderSet.has(provider.id);
               const isDisabled = isConnected && !provider.supportsAdditionalWallets;
 
@@ -206,7 +213,7 @@ export function WalletsOverview({
           );
         })}
 
-        {canManageCustody ? (
+        {canManageCustody && enabledProviders.length > 0 ? (
           <button
             type="button"
             onClick={() => onCreateWallet(null)}

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-overview.tsx
@@ -68,7 +68,9 @@ export function WalletsOverview({
 
         {canManageCustody ? (
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {CUSTODY_PROVIDER_CATALOG.filter((provider) => enabledProviders.includes(provider.id)).map((provider) => {
+            {CUSTODY_PROVIDER_CATALOG.filter((provider) =>
+              enabledProviders.includes(provider.id)
+            ).map((provider) => {
               const isConnected = connectedProviderSet.has(provider.id);
               const isDisabled = isConnected && !provider.supportsAdditionalWallets;
 

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-workspace.tsx
@@ -31,6 +31,7 @@ interface WalletsWorkspaceProps {
   apiBaseUrl: string | null;
   apiKeys: WalletsApiKeyOption[];
   connectedProviders: KnownCustodyProvider[];
+  enabledProviders: KnownCustodyProvider[];
   configsError: string | null;
   wallets: CustodyWalletSummary[];
   walletsError: string | null;
@@ -40,6 +41,7 @@ export function WalletsWorkspace({
   apiBaseUrl,
   apiKeys,
   connectedProviders,
+  enabledProviders,
   configsError,
   wallets,
   walletsError,
@@ -142,6 +144,7 @@ export function WalletsWorkspace({
 
             <WalletsOverview
               connectedProviders={connectedProviders}
+              enabledProviders={enabledProviders}
               configsError={configsError}
               wallets={wallets}
               walletsError={walletsError}
@@ -157,6 +160,7 @@ export function WalletsWorkspace({
           isOpen={isProvisionModalOpen}
           onClose={() => setIsProvisionModalOpen(false)}
           connectedProviders={connectedProviders}
+          enabledProviders={enabledProviders}
           preferredProvider={preferredProvider}
         />
       ) : null}

--- a/apps/sdp-web/src/app/dashboard/onboarding-status.ts
+++ b/apps/sdp-web/src/app/dashboard/onboarding-status.ts
@@ -1,0 +1,6 @@
+export type OnboardingStatusResponse = {
+  linked: boolean;
+  organization: {
+    id: string;
+  } | null;
+};

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import QRCode from "qrcode";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
 import {
@@ -1134,6 +1134,13 @@ export function PaymentsActionPage({
     availableSelectedAssetAmount !== null &&
     numericAmount > availableSelectedAssetAmount;
 
+  const resetExecution = useCallback(() => {
+    setExecutionState("idle");
+    setExecutionError(null);
+    setTransferResult(null);
+    setRampExecution(null);
+  }, []);
+
   useEffect(() => {
     if (!provider) {
       return;
@@ -1144,7 +1151,7 @@ export function PaymentsActionPage({
       setStepIndex(1);
       resetExecution();
     }
-  }, [provider, providerOptions]);
+  }, [provider, providerOptions, resetExecution]);
 
   useEffect(() => {
     if (!isTransferBranch || !selectedWalletId) {
@@ -1181,13 +1188,6 @@ export function PaymentsActionPage({
       cancelled = true;
     };
   }, [isTransferBranch, selectedWalletId]);
-
-  const resetExecution = () => {
-    setExecutionState("idle");
-    setExecutionError(null);
-    setTransferResult(null);
-    setRampExecution(null);
-  };
 
   const resetFlowFields = () => {
     setAmount("");

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -1098,7 +1098,7 @@ export function PaymentsActionPage({
       (isOnrampBranch ? ONRAMP_PROVIDER_OPTIONS : OFFRAMP_PROVIDER_OPTIONS).filter((option) =>
         enabledRampProviders.includes(option.id)
       ),
-    [enabledRampProviders, isOfframpBranch, isOnrampBranch]
+    [enabledRampProviders, isOnrampBranch]
   );
   const providerLabel = providerOptions.find((option) => option.id === provider)?.title ?? null;
   const numericAmount = parseOptionalNumber(amount);
@@ -1371,6 +1371,7 @@ export function PaymentsActionPage({
       amount,
       destinationIsAllowlisted,
       destinationTrimmed,
+      hasEnabledComplianceProviders,
       hasTransferComplianceForDestination,
       memo,
       selectedAsset,

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -10,7 +10,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { PaymentTransferSummary, PaymentsDashboardWallet } from "@sdp/types";
+import type {
+  ComplianceProviderId,
+  PaymentTransferSummary,
+  PaymentsDashboardWallet,
+  RampProviderId,
+} from "@sdp/types";
 import {
   ArrowDownLeft,
   ArrowUpRight,
@@ -43,6 +48,8 @@ interface PaymentsActionPageProps {
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
   issuedTokenSymbolsByMint: Record<string, string>;
+  enabledComplianceProviders: ComplianceProviderId[];
+  enabledRampProviders: RampProviderId[];
 }
 
 const REQUIRED_ACTION_ASSETS = ["SOL", "USDC"] as const;
@@ -62,7 +69,6 @@ const BVNK_COUNTRY_OPTIONS = [
 ] as const;
 
 type ActionBranch = "wallet_transfer" | "wallet_deposit" | "onramp" | "offramp";
-type RampProviderId = "moonpay" | "lightspark" | "bvnk";
 type StepId = "branch" | "provider" | "details" | "review" | "deposit";
 type ExecutionState = "idle" | "submitting" | "success";
 
@@ -948,6 +954,8 @@ export function PaymentsActionPage({
   wallets,
   walletsError,
   issuedTokenSymbolsByMint,
+  enabledComplianceProviders,
+  enabledRampProviders,
 }: PaymentsActionPageProps) {
   const router = useRouter();
 
@@ -1084,7 +1092,14 @@ export function PaymentsActionPage({
   const isSendAction = mode === "send";
   const isTransferBranch = branch === "wallet_transfer";
   const isDepositBranch = branch === "wallet_deposit";
-  const providerOptions = isOnrampBranch ? ONRAMP_PROVIDER_OPTIONS : OFFRAMP_PROVIDER_OPTIONS;
+  const hasEnabledComplianceProviders = enabledComplianceProviders.length > 0;
+  const providerOptions = useMemo(
+    () =>
+      (isOnrampBranch ? ONRAMP_PROVIDER_OPTIONS : OFFRAMP_PROVIDER_OPTIONS).filter((option) =>
+        enabledRampProviders.includes(option.id)
+      ),
+    [enabledRampProviders, isOfframpBranch, isOnrampBranch]
+  );
   const providerLabel = providerOptions.find((option) => option.id === provider)?.title ?? null;
   const numericAmount = parseOptionalNumber(amount);
   const destinationTrimmed = destination.trim();
@@ -1118,6 +1133,18 @@ export function PaymentsActionPage({
     numericAmount !== null &&
     availableSelectedAssetAmount !== null &&
     numericAmount > availableSelectedAssetAmount;
+
+  useEffect(() => {
+    if (!provider) {
+      return;
+    }
+
+    if (!providerOptions.some((option) => option.id === provider)) {
+      setProvider(null);
+      setStepIndex(1);
+      resetExecution();
+    }
+  }, [provider, providerOptions]);
 
   useEffect(() => {
     if (!isTransferBranch || !selectedWalletId) {
@@ -1196,6 +1223,15 @@ export function PaymentsActionPage({
   };
 
   const checkTransferCompliance = async () => {
+    if (!hasEnabledComplianceProviders) {
+      toast.error("Compliance check unavailable.", {
+        description:
+          "Risk checks are only enabled for enterprise organizations with a configured provider.",
+        position: "bottom-right",
+      });
+      return;
+    }
+
     if (!destinationTrimmed) {
       return;
     }
@@ -1318,7 +1354,9 @@ export function PaymentsActionPage({
           ? "Source wallet allowlist"
           : hasTransferComplianceForDestination
             ? "Risk check completed"
-            : "Required",
+            : hasEnabledComplianceProviders
+              ? "Required"
+              : "Allowlist required",
       },
       ...(memo.trim()
         ? [
@@ -1625,13 +1663,20 @@ export function PaymentsActionPage({
             icon={<ArrowUpRight className="size-5" />}
             onClick={() => selectBranch("wallet_transfer")}
           />
-          <ActionChoiceCard
-            active={branch === "offramp"}
-            title="Off-ramp"
-            description="Move value out through a provider-specific off-ramp flow."
-            icon={<ArrowDownLeft className="size-5" />}
-            onClick={() => selectBranch("offramp")}
-          />
+          {enabledRampProviders.length > 0 ? (
+            <ActionChoiceCard
+              active={branch === "offramp"}
+              title="Off-ramp"
+              description="Move value out through a provider-specific off-ramp flow."
+              icon={<ArrowDownLeft className="size-5" />}
+              onClick={() => selectBranch("offramp")}
+            />
+          ) : (
+            <div className="rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-5 py-5 text-sm text-[rgba(28,28,29,0.62)]">
+              Off-ramp providers are only available on enterprise organizations with an enabled
+              provider.
+            </div>
+          )}
         </>
       ) : (
         <>
@@ -1642,13 +1687,20 @@ export function PaymentsActionPage({
             icon={<ArrowDownLeft className="size-5" />}
             onClick={() => selectBranch("wallet_deposit")}
           />
-          <ActionChoiceCard
-            active={branch === "onramp"}
-            title="On-ramp"
-            description="Start a provider flow to move fiat into the selected wallet."
-            icon={<ArrowUpRight className="size-5" />}
-            onClick={() => selectBranch("onramp")}
-          />
+          {enabledRampProviders.length > 0 ? (
+            <ActionChoiceCard
+              active={branch === "onramp"}
+              title="On-ramp"
+              description="Start a provider flow to move fiat into the selected wallet."
+              icon={<ArrowUpRight className="size-5" />}
+              onClick={() => selectBranch("onramp")}
+            />
+          ) : (
+            <div className="rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-5 py-5 text-sm text-[rgba(28,28,29,0.62)]">
+              On-ramp providers are only available on enterprise organizations with an enabled
+              provider.
+            </div>
+          )}
         </>
       )}
     </div>
@@ -1656,6 +1708,11 @@ export function PaymentsActionPage({
 
   const renderProviderStep = () => (
     <div className="grid gap-4">
+      {providerOptions.length === 0 ? (
+        <div className="rounded-[24px] border border-[rgba(28,28,29,0.12)] bg-[rgba(28,28,29,0.03)] px-5 py-5 text-sm text-[rgba(28,28,29,0.62)]">
+          No ramp providers are enabled for this organization.
+        </div>
+      ) : null}
       {providerOptions.map((option) => (
         <ActionChoiceCard
           key={option.id}
@@ -1813,6 +1870,11 @@ export function PaymentsActionPage({
         <div className="rounded-[18px] border border-[rgba(17,94,61,0.18)] bg-[rgba(16,185,129,0.08)] px-4 py-3 text-sm text-[#115e3d]">
           This destination is already on the source wallet allowlist. You can continue without a new
           risk check.
+        </div>
+      ) : !hasEnabledComplianceProviders ? (
+        <div className="rounded-[18px] border border-[rgba(180,83,9,0.22)] bg-[rgba(245,158,11,0.12)] px-4 py-3 text-sm text-[#8a5a00]">
+          Risk checks are not enabled for this organization. Add the destination to the source
+          wallet allowlist before submitting the transfer.
         </div>
       ) : (
         <div className="flex min-h-[44px] flex-wrap items-center gap-3">

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -1,9 +1,17 @@
 import { getAuthEntryPath } from "@/lib/auth-entry";
+import { fetchOrganizationProviderAccess } from "@/lib/organization-provider-access";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { PaymentsActionPage } from "../payments-action-page";
 import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
+
+type OnboardingStatusResponse = {
+  linked: boolean;
+  organization: {
+    id: string;
+  } | null;
+};
 
 export default async function PaymentsReceivePage() {
   const { userId, orgId } = await auth();
@@ -15,10 +23,24 @@ export default async function PaymentsReceivePage() {
   }
 
   const apiClient = await createSdpApiClient();
-  const issuedTokenSymbolsResult = await fetchPaymentsIssuedTokenSymbols(apiClient.request);
+  const [issuedTokenSymbolsResult, onboardingStatus] = await Promise.all([
+    fetchPaymentsIssuedTokenSymbols(apiClient.request),
+    apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status").catch(
+      () =>
+        ({
+          linked: false,
+          organization: null,
+        }) satisfies OnboardingStatusResponse
+    ),
+  ]);
   const issuedTokenSymbolsByMint = Object.fromEntries(
     (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
   );
+  const providerAccess =
+    onboardingStatus.organization &&
+    (await fetchOrganizationProviderAccess(apiClient.request, onboardingStatus.organization.id).catch(
+      () => null
+    ));
 
   return (
     <PaymentsActionPage
@@ -26,6 +48,8 @@ export default async function PaymentsReceivePage() {
       wallets={[]}
       walletsError={null}
       issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}
+      enabledComplianceProviders={providerAccess?.enabledComplianceProviders ?? []}
+      enabledRampProviders={providerAccess?.enabledRampProviders ?? []}
     />
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -32,9 +32,10 @@ export default async function PaymentsReceivePage() {
   );
   const providerAccess =
     onboardingStatus.organization &&
-    (await fetchOrganizationProviderAccess(apiClient.request, onboardingStatus.organization.id).catch(
-      () => null
-    ));
+    (await fetchOrganizationProviderAccess(
+      apiClient.request,
+      onboardingStatus.organization.id
+    ).catch(() => null));
 
   return (
     <PaymentsActionPage

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -3,15 +3,9 @@ import { fetchOrganizationProviderAccess } from "@/lib/organization-provider-acc
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
+import type { OnboardingStatusResponse } from "../../onboarding-status";
 import { PaymentsActionPage } from "../payments-action-page";
 import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
-
-type OnboardingStatusResponse = {
-  linked: boolean;
-  organization: {
-    id: string;
-  } | null;
-};
 
 export default async function PaymentsReceivePage() {
   const { userId, orgId } = await auth();

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -32,9 +32,10 @@ export default async function PaymentsSendPage() {
   );
   const providerAccess =
     onboardingStatus.organization &&
-    (await fetchOrganizationProviderAccess(apiClient.request, onboardingStatus.organization.id).catch(
-      () => null
-    ));
+    (await fetchOrganizationProviderAccess(
+      apiClient.request,
+      onboardingStatus.organization.id
+    ).catch(() => null));
 
   return (
     <PaymentsActionPage

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -1,9 +1,17 @@
 import { getAuthEntryPath } from "@/lib/auth-entry";
+import { fetchOrganizationProviderAccess } from "@/lib/organization-provider-access";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { PaymentsActionPage } from "../payments-action-page";
 import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
+
+type OnboardingStatusResponse = {
+  linked: boolean;
+  organization: {
+    id: string;
+  } | null;
+};
 
 export default async function PaymentsSendPage() {
   const { userId, orgId } = await auth();
@@ -15,10 +23,24 @@ export default async function PaymentsSendPage() {
   }
 
   const apiClient = await createSdpApiClient();
-  const issuedTokenSymbolsResult = await fetchPaymentsIssuedTokenSymbols(apiClient.request);
+  const [issuedTokenSymbolsResult, onboardingStatus] = await Promise.all([
+    fetchPaymentsIssuedTokenSymbols(apiClient.request),
+    apiClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status").catch(
+      () =>
+        ({
+          linked: false,
+          organization: null,
+        }) satisfies OnboardingStatusResponse
+    ),
+  ]);
   const issuedTokenSymbolsByMint = Object.fromEntries(
     (issuedTokenSymbolsResult.data ?? []).map((token) => [token.mintAddress, token.symbol])
   );
+  const providerAccess =
+    onboardingStatus.organization &&
+    (await fetchOrganizationProviderAccess(apiClient.request, onboardingStatus.organization.id).catch(
+      () => null
+    ));
 
   return (
     <PaymentsActionPage
@@ -26,6 +48,8 @@ export default async function PaymentsSendPage() {
       wallets={[]}
       walletsError={null}
       issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}
+      enabledComplianceProviders={providerAccess?.enabledComplianceProviders ?? []}
+      enabledRampProviders={providerAccess?.enabledRampProviders ?? []}
     />
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/send/page.tsx
@@ -3,15 +3,9 @@ import { fetchOrganizationProviderAccess } from "@/lib/organization-provider-acc
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
+import type { OnboardingStatusResponse } from "../../onboarding-status";
 import { PaymentsActionPage } from "../payments-action-page";
 import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
-
-type OnboardingStatusResponse = {
-  linked: boolean;
-  organization: {
-    id: string;
-  } | null;
-};
 
 export default async function PaymentsSendPage() {
   const { userId, orgId } = await auth();

--- a/apps/sdp-web/src/app/dashboard/settings/organization-rpc-settings-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/organization-rpc-settings-form.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ORGANIZATION_RPC_PROVIDERS, type OrganizationRpcProvider } from "@sdp/types";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { updateOrganizationRpcSettingsAction } from "./actions";
 
@@ -167,16 +167,39 @@ const RPC_PROVIDER_LABELS: Record<OrganizationRpcProvider, string> = {
 
 export function OrganizationRpcSettingsForm({
   canManageSettings,
+  enabledProviders,
   organization,
 }: {
   canManageSettings: boolean;
+  enabledProviders: OrganizationRpcProvider[];
   organization: SettingsOrganization;
 }) {
   const rpcProvider = organization.settings?.rpcProvider ?? "default";
-  const [selectedProvider, setSelectedProvider] = useState<OrganizationRpcProvider>(rpcProvider);
+  const availableProviders = useMemo(
+    () =>
+      ORGANIZATION_RPC_PROVIDERS.filter((provider) =>
+        enabledProviders.includes(provider)
+      ) as OrganizationRpcProvider[],
+    [enabledProviders]
+  );
+  const hasEnabledProviders = availableProviders.length > 0;
+  const fallbackProvider =
+    availableProviders.find((provider) => provider === "default") ??
+    availableProviders[0] ??
+    "default";
+  const hasPersistedProviderEnabled =
+    hasEnabledProviders && availableProviders.includes(rpcProvider);
+  const [selectedProvider, setSelectedProvider] = useState<OrganizationRpcProvider>(
+    hasPersistedProviderEnabled ? rpcProvider : fallbackProvider
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isApplyingFallback, setIsApplyingFallback] = useState(false);
+
+  useEffect(() => {
+    setSelectedProvider(hasPersistedProviderEnabled ? rpcProvider : fallbackProvider);
+  }, [fallbackProvider, hasPersistedProviderEnabled, rpcProvider]);
 
   const saveProvider = async (provider: OrganizationRpcProvider) => {
     setIsSaving(true);
@@ -195,6 +218,15 @@ export function OrganizationRpcSettingsForm({
       setSelectedProvider(result.savedRpcProvider ?? provider);
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const applyFallbackProvider = async () => {
+    setIsApplyingFallback(true);
+    try {
+      await saveProvider(fallbackProvider);
+    } finally {
+      setIsApplyingFallback(false);
     }
   };
 
@@ -261,6 +293,37 @@ export function OrganizationRpcSettingsForm({
           </div>
         ) : null}
 
+        {!hasEnabledProviders ? (
+          <div className="rounded-xl border border-[rgba(158,43,56,0.2)] bg-[rgba(158,43,56,0.06)] px-3 py-2 text-sm text-[#9e2b38]">
+            No RPC providers are enabled for this organization in the current environment.
+          </div>
+        ) : null}
+
+        {hasEnabledProviders && !hasPersistedProviderEnabled ? (
+          <div className="rounded-xl border border-[rgba(180,83,9,0.22)] bg-[rgba(245,158,11,0.12)] px-3 py-2 text-sm text-[#8a5a00]">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p>
+                The saved RPC provider for this organization is no longer available on the current
+                tier. The form has fallen back to {RPC_PROVIDER_LABELS[fallbackProvider]} until you
+                save an enabled provider.
+              </p>
+              {canManageSettings ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  disabled={isSaving || isTesting || isApplyingFallback}
+                  onClick={() => {
+                    void applyFallbackProvider();
+                  }}
+                >
+                  {isApplyingFallback ? "Saving..." : "Save fallback"}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
         <div className="grid gap-2">
           <Label htmlFor="rpcProvider">RPC provider</Label>
           <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_112px] sm:items-center">
@@ -269,14 +332,14 @@ export function OrganizationRpcSettingsForm({
               name="rpcProvider"
               className="h-10 w-full min-w-0 rounded-lg border border-[rgba(28,28,29,0.16)] bg-white px-3 text-sm text-[#1c1c1d]"
               value={selectedProvider}
-              disabled={!canManageSettings || isSaving || isTesting}
+              disabled={!canManageSettings || !hasEnabledProviders || isSaving || isTesting}
               onChange={(event) => {
                 const nextProvider = event.currentTarget.value as typeof selectedProvider;
                 setSelectedProvider(nextProvider);
                 void saveProvider(nextProvider);
               }}
             >
-              {ORGANIZATION_RPC_PROVIDERS.map((provider) => (
+              {availableProviders.map((provider) => (
                 <option key={provider} value={provider}>
                   {RPC_PROVIDER_LABELS[provider]}
                 </option>
@@ -287,7 +350,7 @@ export function OrganizationRpcSettingsForm({
               size="sm"
               variant="secondary"
               className="w-full sm:w-[112px] sm:justify-center"
-              disabled={isTesting || isSaving}
+              disabled={!hasEnabledProviders || isTesting || isSaving}
               onClick={() => {
                 void testProvider();
               }}

--- a/apps/sdp-web/src/app/dashboard/settings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/settings/page.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { resolveDashboardAccess } from "@/lib/dashboard-access";
+import { fetchOrganizationProviderAccess } from "@/lib/organization-provider-access";
 import { createTimedTrace } from "@/lib/request-tracing";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
@@ -45,6 +46,7 @@ export default async function SettingsPage() {
   let organization: Organization | null = null;
   let isLinked = true;
   let loadError = false;
+  let enabledRpcProviders: OrganizationRpcProvider[] = [];
 
   try {
     const apiClient = await trace.step("create_sdp_api_client", () =>
@@ -88,10 +90,23 @@ export default async function SettingsPage() {
       loadError = true;
     }
 
+    if (organization) {
+      const resolvedOrganization = organization;
+      try {
+        const access = await trace.step("fetch_provider_access", () =>
+          fetchOrganizationProviderAccess(apiClient.request, resolvedOrganization.id)
+        );
+        enabledRpcProviders = access.enabledRpcProviders;
+      } catch {
+        enabledRpcProviders = ["default"];
+      }
+    }
+
     trace.log({
       ok: !loadError,
       isLinked,
       hasOrganization: Boolean(organization),
+      enabledRpcProviderCount: enabledRpcProviders.length,
       loadError,
     });
   } catch (error) {
@@ -129,6 +144,7 @@ export default async function SettingsPage() {
               <OrganizationRpcSettingsForm
                 organization={organization}
                 canManageSettings={dashboardAccess.capabilities.canManageOrgSettings}
+                enabledProviders={enabledRpcProviders}
               />
             ) : null}
 

--- a/apps/sdp-web/src/lib/organization-provider-access.ts
+++ b/apps/sdp-web/src/lib/organization-provider-access.ts
@@ -22,7 +22,9 @@ export async function fetchOrganizationProviderAccess(
   request: SdpApiClient["request"],
   organizationId: string
 ): Promise<DashboardOrganizationProviderAccess> {
-  const response = await request(`/v1/organizations/${encodeURIComponent(organizationId)}/provider-access`);
+  const response = await request(
+    `/v1/organizations/${encodeURIComponent(organizationId)}/provider-access`
+  );
   if (!response.ok) {
     const body = await response.text();
     throw new Error(`SDP API request failed (${response.status}): ${body}`);

--- a/apps/sdp-web/src/lib/organization-provider-access.ts
+++ b/apps/sdp-web/src/lib/organization-provider-access.ts
@@ -1,0 +1,50 @@
+import {
+  type KnownCustodyProvider,
+  isKnownCustodyProvider,
+} from "@/app/dashboard/custody/provider-catalog";
+import type { SdpApiClient } from "@/lib/sdp-api";
+import type {
+  ComplianceProviderId,
+  OrganizationProviderAvailabilityResponse,
+  OrganizationRpcProvider,
+  RampProviderId,
+} from "@sdp/types";
+
+export interface DashboardOrganizationProviderAccess
+  extends OrganizationProviderAvailabilityResponse {
+  enabledCustodyProviders: KnownCustodyProvider[];
+  enabledRpcProviders: OrganizationRpcProvider[];
+  enabledComplianceProviders: ComplianceProviderId[];
+  enabledRampProviders: RampProviderId[];
+}
+
+export async function fetchOrganizationProviderAccess(
+  request: SdpApiClient["request"],
+  organizationId: string
+): Promise<DashboardOrganizationProviderAccess> {
+  const response = await request(`/v1/organizations/${encodeURIComponent(organizationId)}/provider-access`);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`SDP API request failed (${response.status}): ${body}`);
+  }
+
+  const json = (await response.json()) as { data: OrganizationProviderAvailabilityResponse };
+  const data = json.data;
+
+  return {
+    ...data,
+    enabledCustodyProviders: Object.entries(data.providers.custody)
+      .filter(([, entry]) => entry.enabled)
+      .map(([provider]) => provider)
+      .filter(isKnownCustodyProvider),
+    enabledRpcProviders: Object.entries(data.providers.rpc)
+      .filter(([, entry]) => entry.enabled)
+      .map(([provider]) => provider as OrganizationRpcProvider),
+    enabledComplianceProviders: Object.entries(data.providers.compliance)
+      .filter(([, entry]) => entry.enabled)
+      .map(([provider]) => provider as ComplianceProviderId),
+    enabledRampProviders: Object.entries(data.providers.ramps)
+      .filter(([, entry]) => entry.enabled)
+      .map(([provider]) => provider as RampProviderId),
+  };
+}

--- a/packages/sdp-api-integration/src/helpers/integration.ts
+++ b/packages/sdp-api-integration/src/helpers/integration.ts
@@ -125,7 +125,7 @@ export async function resetIntegrationState(
 
   await db
     .prepare(
-      "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'free', 'active')"
+      "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
     )
     .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
     .run();

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -5,6 +5,7 @@
 export * from "./permissions";
 export * from "./custody";
 export * from "./organizations";
+export * from "./provider-access";
 export * from "./api-keys";
 export * from "./payments";
 export * from "./projects";

--- a/packages/sdp-types/src/organizations.ts
+++ b/packages/sdp-types/src/organizations.ts
@@ -67,9 +67,10 @@ export function normalizeOrganizationTier(value: string | null | undefined): Org
     return value;
   }
 
-  return LEGACY_ORGANIZATION_TIER_ALIASES[
-    value as keyof typeof LEGACY_ORGANIZATION_TIER_ALIASES
-  ] ?? "individual";
+  return (
+    LEGACY_ORGANIZATION_TIER_ALIASES[value as keyof typeof LEGACY_ORGANIZATION_TIER_ALIASES] ??
+    "individual"
+  );
 }
 
 export interface User {

--- a/packages/sdp-types/src/organizations.ts
+++ b/packages/sdp-types/src/organizations.ts
@@ -4,8 +4,9 @@
 
 import type { OrganizationCustodyRequest } from "./custody";
 import type { OrganizationRole } from "./permissions";
+import type { OrganizationProviderOverrides } from "./provider-access";
 
-export const ORGANIZATION_TIERS = ["free", "pro", "enterprise"] as const;
+export const ORGANIZATION_TIERS = ["free", "enterprise"] as const;
 export type OrganizationTier = (typeof ORGANIZATION_TIERS)[number];
 
 export const ORGANIZATION_STATUSES = ["active", "suspended", "deleted"] as const;
@@ -39,10 +40,36 @@ export interface OrganizationSettings {
   defaultEnvironment?: "sandbox" | "production";
   webhookSecret?: string;
   allowedIpAddresses?: string[];
+  providerOverrides?: OrganizationProviderOverrides;
   customRateLimits?: {
     requestsPerMinute?: number;
     requestsPerDay?: number;
   };
+}
+
+const LEGACY_ORGANIZATION_TIER_ALIASES = {
+  standard: "free",
+  starter: "free",
+  pro: "enterprise",
+  growth: "enterprise",
+} as const;
+
+export function isOrganizationTier(value: string | null | undefined): value is OrganizationTier {
+  return ORGANIZATION_TIERS.includes(value as OrganizationTier);
+}
+
+export function normalizeOrganizationTier(value: string | null | undefined): OrganizationTier {
+  if (!value) {
+    return "free";
+  }
+
+  if (isOrganizationTier(value)) {
+    return value;
+  }
+
+  return LEGACY_ORGANIZATION_TIER_ALIASES[
+    value as keyof typeof LEGACY_ORGANIZATION_TIER_ALIASES
+  ] ?? "free";
 }
 
 export interface User {

--- a/packages/sdp-types/src/organizations.ts
+++ b/packages/sdp-types/src/organizations.ts
@@ -6,7 +6,7 @@ import type { OrganizationCustodyRequest } from "./custody";
 import type { OrganizationRole } from "./permissions";
 import type { OrganizationProviderOverrides } from "./provider-access";
 
-export const ORGANIZATION_TIERS = ["free", "enterprise"] as const;
+export const ORGANIZATION_TIERS = ["individual", "enterprise"] as const;
 export type OrganizationTier = (typeof ORGANIZATION_TIERS)[number];
 
 export const ORGANIZATION_STATUSES = ["active", "suspended", "deleted"] as const;
@@ -48,8 +48,8 @@ export interface OrganizationSettings {
 }
 
 const LEGACY_ORGANIZATION_TIER_ALIASES = {
-  standard: "free",
-  starter: "free",
+  standard: "individual",
+  starter: "individual",
   pro: "enterprise",
   growth: "enterprise",
 } as const;
@@ -60,7 +60,7 @@ export function isOrganizationTier(value: string | null | undefined): value is O
 
 export function normalizeOrganizationTier(value: string | null | undefined): OrganizationTier {
   if (!value) {
-    return "free";
+    return "individual";
   }
 
   if (isOrganizationTier(value)) {
@@ -69,7 +69,7 @@ export function normalizeOrganizationTier(value: string | null | undefined): Org
 
   return LEGACY_ORGANIZATION_TIER_ALIASES[
     value as keyof typeof LEGACY_ORGANIZATION_TIER_ALIASES
-  ] ?? "free";
+  ] ?? "individual";
 }
 
 export interface User {

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -81,10 +81,10 @@ function applyOverrides<T extends string>(
 }
 
 const INDIVIDUAL_PROVIDER_DEFAULTS: OrganizationProviderEntitlements = {
-  custody: createBooleanRecord(CUSTODY_PROVIDERS, ["privy"]),
-  rpc: createBooleanRecord(ORGANIZATION_RPC_PROVIDERS, ["default"]),
+  custody: createBooleanRecord(CUSTODY_PROVIDERS, ["privy", "coinbase_cdp", "turnkey"]),
+  rpc: createBooleanRecord(ORGANIZATION_RPC_PROVIDERS, ["default", "helius", "triton"]),
   compliance: createBooleanRecord(COMPLIANCE_PROVIDERS, []),
-  ramps: createBooleanRecord(RAMP_PROVIDERS, []),
+  ramps: createBooleanRecord(RAMP_PROVIDERS, ["moonpay"]),
 };
 
 const ENTERPRISE_PROVIDER_DEFAULTS: OrganizationProviderEntitlements = {

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -1,0 +1,136 @@
+import { CUSTODY_PROVIDERS, type CustodyProvider } from "./custody";
+import {
+  ORGANIZATION_RPC_PROVIDERS,
+  type OrganizationRpcProvider,
+  type OrganizationTier,
+  normalizeOrganizationTier,
+} from "./organizations";
+
+export const COMPLIANCE_PROVIDERS = ["range", "elliptic", "trm", "chainalysis"] as const;
+export type ComplianceProviderId = (typeof COMPLIANCE_PROVIDERS)[number];
+
+export const RAMP_PROVIDERS = ["moonpay", "lightspark", "bvnk"] as const;
+export type RampProviderId = (typeof RAMP_PROVIDERS)[number];
+
+export const ORGANIZATION_PROVIDER_FAMILIES = [
+  "custody",
+  "rpc",
+  "compliance",
+  "ramps",
+] as const;
+export type OrganizationProviderFamily = (typeof ORGANIZATION_PROVIDER_FAMILIES)[number];
+
+export interface OrganizationProviderOverrides {
+  custody?: Partial<Record<CustodyProvider, boolean>>;
+  rpc?: Partial<Record<OrganizationRpcProvider, boolean>>;
+  compliance?: Partial<Record<ComplianceProviderId, boolean>>;
+  ramps?: Partial<Record<RampProviderId, boolean>>;
+}
+
+export interface ProviderAvailabilityEntry {
+  entitled: boolean;
+  configured: boolean;
+  enabled: boolean;
+}
+
+export interface OrganizationProviderAvailability {
+  custody: Record<CustodyProvider, ProviderAvailabilityEntry>;
+  rpc: Record<OrganizationRpcProvider, ProviderAvailabilityEntry>;
+  compliance: Record<ComplianceProviderId, ProviderAvailabilityEntry>;
+  ramps: Record<RampProviderId, ProviderAvailabilityEntry>;
+}
+
+export interface OrganizationProviderEntitlements {
+  custody: Record<CustodyProvider, boolean>;
+  rpc: Record<OrganizationRpcProvider, boolean>;
+  compliance: Record<ComplianceProviderId, boolean>;
+  ramps: Record<RampProviderId, boolean>;
+}
+
+export interface OrganizationProviderAvailabilityResponse {
+  tier: OrganizationTier;
+  providers: OrganizationProviderAvailability;
+}
+
+function createBooleanRecord<const T extends readonly string[]>(
+  values: T,
+  enabledValues: readonly T[number][]
+): Record<T[number], boolean> {
+  const enabledSet = new Set<string>(enabledValues);
+
+  return Object.fromEntries(
+    values.map((value) => [value, enabledSet.has(value)])
+  ) as Record<T[number], boolean>;
+}
+
+function applyOverrides<T extends string>(
+  base: Record<T, boolean>,
+  overrides?: Partial<Record<T, boolean>>
+): Record<T, boolean> {
+  if (!overrides) {
+    return { ...base };
+  }
+
+  const next = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (typeof value !== "boolean") {
+      continue;
+    }
+    if (key in next) {
+      next[key as T] = value;
+    }
+  }
+
+  return next;
+}
+
+const FREE_PROVIDER_DEFAULTS: OrganizationProviderEntitlements = {
+  custody: createBooleanRecord(CUSTODY_PROVIDERS, ["privy"]),
+  rpc: createBooleanRecord(ORGANIZATION_RPC_PROVIDERS, ["default"]),
+  compliance: createBooleanRecord(COMPLIANCE_PROVIDERS, []),
+  ramps: createBooleanRecord(RAMP_PROVIDERS, []),
+};
+
+const ENTERPRISE_PROVIDER_DEFAULTS: OrganizationProviderEntitlements = {
+  custody: createBooleanRecord(CUSTODY_PROVIDERS, [
+    "fireblocks",
+    "privy",
+    "coinbase_cdp",
+    "para",
+    "turnkey",
+    "dfns",
+    "anchorage",
+  ]),
+  rpc: createBooleanRecord(ORGANIZATION_RPC_PROVIDERS, [
+    "default",
+    "alchemy",
+    "helius",
+    "quicknode",
+    "triton",
+  ]),
+  compliance: createBooleanRecord(COMPLIANCE_PROVIDERS, [
+    "range",
+    "elliptic",
+    "trm",
+    "chainalysis",
+  ]),
+  ramps: createBooleanRecord(RAMP_PROVIDERS, ["moonpay", "lightspark", "bvnk"]),
+};
+
+export function resolveOrganizationProviderEntitlements(input: {
+  tier: string | null | undefined;
+  providerOverrides?: OrganizationProviderOverrides | null;
+}): { tier: OrganizationTier; providers: OrganizationProviderEntitlements } {
+  const tier = normalizeOrganizationTier(input.tier);
+  const defaults = tier === "enterprise" ? ENTERPRISE_PROVIDER_DEFAULTS : FREE_PROVIDER_DEFAULTS;
+
+  return {
+    tier,
+    providers: {
+      custody: applyOverrides(defaults.custody, input.providerOverrides?.custody),
+      rpc: applyOverrides(defaults.rpc, input.providerOverrides?.rpc),
+      compliance: applyOverrides(defaults.compliance, input.providerOverrides?.compliance),
+      ramps: applyOverrides(defaults.ramps, input.providerOverrides?.ramps),
+    },
+  };
+}

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -84,7 +84,7 @@ function applyOverrides<T extends string>(
   return next;
 }
 
-const FREE_PROVIDER_DEFAULTS: OrganizationProviderEntitlements = {
+const INDIVIDUAL_PROVIDER_DEFAULTS: OrganizationProviderEntitlements = {
   custody: createBooleanRecord(CUSTODY_PROVIDERS, ["privy"]),
   rpc: createBooleanRecord(ORGANIZATION_RPC_PROVIDERS, ["default"]),
   compliance: createBooleanRecord(COMPLIANCE_PROVIDERS, []),
@@ -122,7 +122,8 @@ export function resolveOrganizationProviderEntitlements(input: {
   providerOverrides?: OrganizationProviderOverrides | null;
 }): { tier: OrganizationTier; providers: OrganizationProviderEntitlements } {
   const tier = normalizeOrganizationTier(input.tier);
-  const defaults = tier === "enterprise" ? ENTERPRISE_PROVIDER_DEFAULTS : FREE_PROVIDER_DEFAULTS;
+  const defaults =
+    tier === "enterprise" ? ENTERPRISE_PROVIDER_DEFAULTS : INDIVIDUAL_PROVIDER_DEFAULTS;
 
   return {
     tier,

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -12,12 +12,7 @@ export type ComplianceProviderId = (typeof COMPLIANCE_PROVIDERS)[number];
 export const RAMP_PROVIDERS = ["moonpay", "lightspark", "bvnk"] as const;
 export type RampProviderId = (typeof RAMP_PROVIDERS)[number];
 
-export const ORGANIZATION_PROVIDER_FAMILIES = [
-  "custody",
-  "rpc",
-  "compliance",
-  "ramps",
-] as const;
+export const ORGANIZATION_PROVIDER_FAMILIES = ["custody", "rpc", "compliance", "ramps"] as const;
 export type OrganizationProviderFamily = (typeof ORGANIZATION_PROVIDER_FAMILIES)[number];
 
 export interface OrganizationProviderOverrides {
@@ -58,9 +53,10 @@ function createBooleanRecord<const T extends readonly string[]>(
 ): Record<T[number], boolean> {
   const enabledSet = new Set<string>(enabledValues);
 
-  return Object.fromEntries(
-    values.map((value) => [value, enabledSet.has(value)])
-  ) as Record<T[number], boolean>;
+  return Object.fromEntries(values.map((value) => [value, enabledSet.has(value)])) as Record<
+    T[number],
+    boolean
+  >;
 }
 
 function applyOverrides<T extends string>(


### PR DESCRIPTION
## Summary
- add free and enterprise organization provider tiering backed by Clerk org private metadata and a mirrored database enforcement layer
- gate custody, RPC, compliance, and ramp providers on the API and expose a hidden provider-access route for dashboard filtering
- add a local org tier sync helper so free, enterprise, and downgrade flows can be tested before rollout

## Validation
- pnpm --filter @sdp/api test
- pnpm --filter sdp-web typecheck
- pnpm typecheck
- local stack smoke at http://localhost:3000 and http://localhost:8787

## Notes
- everyone defaults to the free tier
- existing resources remain visible after downgrade, but new use of disabled providers is blocked server-side
- local testing was completed from the clean worktree at /tmp/sdp-free-enterprise-provider-tiers before opening this PR
