### PR TITLE
fix: stabilize dashboard zero-state metrics

### DIFF
--- a/apps/sdp-web/src/app/dashboard/home-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/home-page.data.ts
@@ -100,7 +100,6 @@ function resolvePaymentsAddress(transfer: PaymentTransferSummary): string {
 export function computeTodaysVolume(transfers: PaymentTransferSummary[]): number | null {
   const now = new Date();
   const startOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  let hasNumericAmount = false;
 
   const total = transfers.reduce((sum, transfer) => {
     if (!transfer.createdAt) {
@@ -117,11 +116,10 @@ export function computeTodaysVolume(transfers: PaymentTransferSummary[]): number
       return sum;
     }
 
-    hasNumericAmount = true;
     return sum + amount;
   }, 0);
 
-  return hasNumericAmount ? total : null;
+  return total;
 }
 
 export function buildHomeActivityRows(

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -82,15 +82,19 @@ function MetricCard({
   error: string | null;
   hint?: string | null;
 }) {
+  const showUnavailableState = error !== null && value === null;
+
   return (
     <Card className="gap-0 rounded-[18px] border-[rgba(28,28,29,0.1)] py-0 shadow-none">
       <CardContent className="space-y-2 px-6 py-6">
         <p className="text-[15px] text-[rgba(28,28,29,0.56)]">{label}</p>
         <p className="text-[24px] leading-none font-medium tracking-[-0.03em] text-[#1c1c1d] sm:text-[30px]">
-          {error ? "Unavailable" : formatCurrencyAmount(value)}
+          {showUnavailableState ? "Unavailable" : formatCurrencyAmount(value)}
         </p>
-        {error ? <p className="text-sm text-[#9e2b38]">{error}</p> : null}
-        {!error && hint ? <p className="text-sm text-[rgba(28,28,29,0.56)]">{hint}</p> : null}
+        {showUnavailableState ? <p className="text-sm text-[#9e2b38]">{error}</p> : null}
+        {!showUnavailableState && hint ? (
+          <p className="text-sm text-[rgba(28,28,29,0.56)]">{hint}</p>
+        ) : null}
       </CardContent>
     </Card>
   );
@@ -117,17 +121,20 @@ export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: Home
       ? "No tracked balances found yet."
       : null;
   const todaysVolume = activitySnapshot?.todaysVolume ?? null;
-  const todaysVolumeError = activityRequestError
-    ? activityRequestError instanceof Error
-      ? activityRequestError.message
-      : "Activity is unavailable right now."
-    : (activitySnapshot?.activityError ?? null);
-  const activityRows = activitySnapshot?.activityRows ?? [];
+  const todaysVolumeError =
+    todaysVolume !== null
+      ? null
+      : activityRequestError
+        ? activityRequestError instanceof Error
+          ? activityRequestError.message
+          : "Activity is unavailable right now."
+        : (activitySnapshot?.activityError ?? null);
   const activityError = activityRequestError
     ? activityRequestError instanceof Error
       ? activityRequestError.message
       : "Activity is unavailable right now."
     : (activitySnapshot?.activityError ?? null);
+  const activityRows = activitySnapshot?.activityRows ?? [];
   const activityNotice = activitySnapshot?.activityNotice ?? null;
   const todaysVolumeHint = isWalletEmptyState
     ? "Payment activity will appear after you create a wallet."
@@ -135,6 +142,8 @@ export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: Home
       ? activitySnapshot
         ? "No payment volume recorded yet."
         : "Loading payment activity..."
+      : todaysVolume === 0
+        ? "No payment volume recorded yet."
       : null;
   const emptyActivityMessage = isWalletEmptyState
     ? "Create your first wallet to start tracking balances and activity."

--- a/apps/sdp-web/src/app/dashboard/home-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/home-workspace.tsx
@@ -17,6 +17,7 @@ import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import Link from "next/link";
+import type { HomeActivityRow } from "./home-page.data";
 import { fetchHomeActivity } from "./home-workspace.data";
 import { formatCurrencyAmount, formatDisplayAmount } from "./payments/payments-overview.utils";
 
@@ -24,6 +25,18 @@ interface HomeWorkspaceProps {
   totalBalance: number | null;
   totalBalanceError: string | null;
   wallets: PaymentsDashboardWallet[];
+}
+
+interface HomeWorkspaceActivityState {
+  isWalletEmptyState: boolean;
+  totalBalanceHint: string | null;
+  todaysVolume: number | null;
+  todaysVolumeError: string | null;
+  todaysVolumeHint: string | null;
+  activityError: string | null;
+  activityRows: HomeActivityRow[];
+  activityNotice: string | null;
+  emptyActivityMessage: string;
 }
 
 const HOME_ACTIVITY_KEY = "dashboard-home-activity";
@@ -100,6 +113,59 @@ function MetricCard({
   );
 }
 
+function resolveActivityRequestError(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Activity is unavailable right now.";
+}
+
+function buildHomeWorkspaceActivityState(
+  wallets: PaymentsDashboardWallet[],
+  totalBalance: number | null,
+  activitySnapshot: Awaited<ReturnType<typeof fetchHomeActivity>> | undefined,
+  activityRequestError: unknown
+): HomeWorkspaceActivityState {
+  const isWalletEmptyState = wallets.length === 0;
+  const requestError = resolveActivityRequestError(activityRequestError);
+  const todaysVolume = activitySnapshot?.todaysVolume ?? null;
+  const activityError = requestError ?? activitySnapshot?.activityError ?? null;
+
+  return {
+    isWalletEmptyState,
+    totalBalanceHint: isWalletEmptyState
+      ? "Create your first wallet to start tracking balances."
+      : totalBalance === null
+        ? "No tracked balances found yet."
+        : null,
+    todaysVolume,
+    todaysVolumeError:
+      todaysVolume !== null ? null : (requestError ?? activitySnapshot?.activityError ?? null),
+    todaysVolumeHint: isWalletEmptyState
+      ? "Payment activity will appear after you create a wallet."
+      : todaysVolume === null
+        ? activitySnapshot
+          ? "No payment volume recorded yet."
+          : "Loading payment activity..."
+        : todaysVolume === 0
+          ? "No payment volume recorded yet."
+          : null,
+    activityError,
+    activityRows: activitySnapshot?.activityRows ?? [],
+    activityNotice: activitySnapshot?.activityNotice ?? null,
+    emptyActivityMessage: isWalletEmptyState
+      ? "Create your first wallet to start tracking balances and activity."
+      : activitySnapshot
+        ? "No recent activity found yet."
+        : "Loading recent activity...",
+  };
+}
+
 export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: HomeWorkspaceProps) {
   const { dashboardAccess } = useDashboardWorkspace();
   const { data: activitySnapshot, error: activityRequestError } = usePersistedDashboardSWR(
@@ -114,42 +180,21 @@ export function HomeWorkspace({ totalBalance, totalBalanceError, wallets }: Home
       ttlMs: HOME_ACTIVITY_CACHE_TTL_MS,
     }
   );
-  const isWalletEmptyState = wallets.length === 0;
-  const totalBalanceHint = isWalletEmptyState
-    ? "Create your first wallet to start tracking balances."
-    : totalBalance === null
-      ? "No tracked balances found yet."
-      : null;
-  const todaysVolume = activitySnapshot?.todaysVolume ?? null;
-  const todaysVolumeError =
-    todaysVolume !== null
-      ? null
-      : activityRequestError
-        ? activityRequestError instanceof Error
-          ? activityRequestError.message
-          : "Activity is unavailable right now."
-        : (activitySnapshot?.activityError ?? null);
-  const activityError = activityRequestError
-    ? activityRequestError instanceof Error
-      ? activityRequestError.message
-      : "Activity is unavailable right now."
-    : (activitySnapshot?.activityError ?? null);
-  const activityRows = activitySnapshot?.activityRows ?? [];
-  const activityNotice = activitySnapshot?.activityNotice ?? null;
-  const todaysVolumeHint = isWalletEmptyState
-    ? "Payment activity will appear after you create a wallet."
-    : todaysVolume === null
-      ? activitySnapshot
-        ? "No payment volume recorded yet."
-        : "Loading payment activity..."
-      : todaysVolume === 0
-        ? "No payment volume recorded yet."
-      : null;
-  const emptyActivityMessage = isWalletEmptyState
-    ? "Create your first wallet to start tracking balances and activity."
-    : activitySnapshot
-      ? "No recent activity found yet."
-      : "Loading recent activity...";
+  const {
+    totalBalanceHint,
+    todaysVolume,
+    todaysVolumeError,
+    todaysVolumeHint,
+    activityError,
+    activityRows,
+    activityNotice,
+    emptyActivityMessage,
+  } = buildHomeWorkspaceActivityState(
+    wallets,
+    totalBalance,
+    activitySnapshot,
+    activityRequestError
+  );
 
   return (
     <div className="w-full space-y-8 py-2">

--- a/apps/sdp-web/src/app/dashboard/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/page.tsx
@@ -4,7 +4,10 @@ import { createSdpApiClient } from "@/lib/sdp-api";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { HomeWorkspace } from "./home-workspace";
-import { resolveTotalBalance } from "./payments/payments-overview.utils";
+import {
+  aggregateBalancesFromWallets,
+  resolveTotalBalance,
+} from "./payments/payments-overview.utils";
 import { fetchPaymentsAggregate, fetchPaymentsWallets } from "./payments/payments-page.data";
 
 export default async function DashboardPage() {
@@ -24,16 +27,22 @@ export default async function DashboardPage() {
     const [aggregateResult, walletsResult] = await Promise.all([
       trace.step("fetch_payments_aggregate", () => fetchPaymentsAggregate(apiClient.request)),
       trace.step("fetch_wallet_summaries", () =>
-        fetchPaymentsWallets(apiClient.request, { view: "summary" })
+        fetchPaymentsWallets(apiClient.request, { view: "summary", includeBalances: true })
       ),
     ]);
 
     const wallets = walletsResult.data ?? [];
     const isWalletEmptyState = walletsResult.ok && wallets.length === 0;
-    const totalBalance = resolveTotalBalance(aggregateResult.data?.balances ?? []);
+    const fallbackAggregateBalances =
+      walletsResult.ok && wallets.length > 0 ? aggregateBalancesFromWallets(wallets) : [];
+    const totalBalance = resolveTotalBalance(
+      aggregateResult.data?.balances ?? fallbackAggregateBalances
+    );
 
     const aggregateError =
-      aggregateResult.ok || isWalletEmptyState ? null : "Balance data is unavailable right now.";
+      aggregateResult.ok || isWalletEmptyState || totalBalance !== null
+        ? null
+        : "Balance data is unavailable right now.";
 
     trace.log({
       ok: true,

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -133,7 +133,7 @@ export function resolveCounterparty(transfer: TransferRecord): string {
 
 export function resolveTotalBalance(balances: CustodyWalletTokenBalance[]): number | null {
   if (balances.length === 0) {
-    return null;
+    return 0;
   }
 
   let hasNumericBalance = false;


### PR DESCRIPTION
## What changed

This fixes the dashboard's zero-state metric handling so a valid `0` balance or `0` daily volume is shown as real data instead of being treated like a missing value.

## Why

The dashboard was conflating `0` with `null` in a few places:
- `resolveTotalBalance()` returned `null` for an empty balance list
- `computeTodaysVolume()` returned `null` unless it saw a numeric amount
- the home page metric cards treated any error as fully unavailable, even when a fallback value existed
- the dashboard page did not request per-wallet balances for the summary fallback path

That combination caused the home dashboard to show `Unavailable` for states that should have rendered as `$0.00` with the normal empty-state hinting.

## Impact

- users now see `0` values for valid empty states instead of an unavailable error state
- the balance card can fall back to wallet summary balances when aggregate balance data is missing
- the volume card keeps the regular empty-state messaging when today's activity is zero

## Validation

- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web build`

## Notes

This PR was opened from a fresh branch off `main` so it only contains the dashboard zero-state fix and not the unrelated commits on the original working branch.
