### PR TITLE
fix: remove SOL balances from payments UI (PRO-1126)

### DIFF
--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -57,6 +57,7 @@ test.describe
 
       const assetSelect = app.getByRole("combobox", { name: "Asset" });
       await assetSelect.click();
+      await expect(page.getByRole("option", { name: "SOL", exact: true })).toHaveCount(0);
       await page.getByRole("option", { name: transferTokenSymbol, exact: true }).click();
       await expect(assetSelect).toContainText(transferTokenSymbol);
       await app.getByLabel("Amount").fill("1");

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -23,6 +23,7 @@ import QRCode from "qrcode";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
+import { isSolBalance } from "./payments-overview.utils";
 import {
   type PaymentRampExecution,
   type PaymentWalletBalance,
@@ -34,7 +35,6 @@ import {
   getDevnetExplorerUrl,
   runComplianceCheck,
 } from "./payments-workspace.data";
-import { isSolBalance } from "./payments-overview.utils";
 import type { ComplianceSnapshot } from "./payments-workspace.types";
 import { ProviderRiskTable } from "./provider-risk-table";
 

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -34,6 +34,7 @@ import {
   getDevnetExplorerUrl,
   runComplianceCheck,
 } from "./payments-workspace.data";
+import { isSolBalance } from "./payments-overview.utils";
 import type { ComplianceSnapshot } from "./payments-workspace.types";
 import { ProviderRiskTable } from "./provider-risk-table";
 
@@ -46,7 +47,7 @@ interface PaymentsActionPageProps {
   enabledRampProviders: RampProviderId[];
 }
 
-const REQUIRED_ACTION_ASSETS = ["SOL", "USDC"] as const;
+const REQUIRED_ACTION_ASSETS = ["USDC"] as const;
 const MOONPAY_ONRAMP_MIN_USD = 20;
 const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 const PAYMENTS_ACTION_WALLET_BALANCES_KEY = "payments-action-wallet-balances";
@@ -156,16 +157,18 @@ function parseOptionalNumber(value: string): number | null {
 }
 
 function resolvePrimaryWalletBalance(wallet: PaymentsDashboardWallet | null) {
-  if (!wallet?.balances || wallet.balances.length === 0) {
+  const supportedBalances = wallet?.balances?.filter((balance) => !isSolBalance(balance)) ?? [];
+
+  if (supportedBalances.length === 0) {
     return null;
   }
 
   return (
-    wallet.balances.find((balance) => {
+    supportedBalances.find((balance) => {
       const numericValue = Number(balance.uiAmount);
       return Number.isFinite(numericValue) && numericValue > 0;
     }) ??
-    wallet.balances[0] ??
+    supportedBalances[0] ??
     null
   );
 }
@@ -228,19 +231,17 @@ function getWalletActionLabel(
 
 function resolveWalletActionAssets(
   wallet: PaymentsDashboardWallet | null,
-  issuedTokenSymbolsByMint: Record<string, string>,
-  options?: {
-    includeSol?: boolean;
-  }
+  issuedTokenSymbolsByMint: Record<string, string>
 ): string[] {
-  const includeSol = options?.includeSol ?? true;
-  const assetSet = new Set<string>(
-    REQUIRED_ACTION_ASSETS.filter((asset) => includeSol || asset !== "SOL")
-  );
+  const assetSet = new Set<string>(REQUIRED_ACTION_ASSETS);
 
   for (const balance of wallet?.balances ?? []) {
+    if (isSolBalance(balance)) {
+      continue;
+    }
+
     const token = resolveBalanceDisplayToken(balance, issuedTokenSymbolsByMint);
-    if (token && (includeSol || token !== "SOL")) {
+    if (token) {
       assetSet.add(token);
     }
   }
@@ -1044,11 +1045,8 @@ export function PaymentsActionPage({
   const isOnrampBranch = branch === "onramp";
   const isOfframpBranch = branch === "offramp";
   const assetOptions = useMemo(
-    () =>
-      resolveWalletActionAssets(selectedWalletWithBalances, issuedTokenSymbolsByMint, {
-        includeSol: !(isOnrampBranch || isOfframpBranch),
-      }),
-    [isOfframpBranch, isOnrampBranch, issuedTokenSymbolsByMint, selectedWalletWithBalances]
+    () => resolveWalletActionAssets(selectedWalletWithBalances, issuedTokenSymbolsByMint),
+    [issuedTokenSymbolsByMint, selectedWalletWithBalances]
   );
   const selectedAssetBalance = useMemo(
     () =>

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -139,7 +139,6 @@ const OFFRAMP_PROVIDER_OPTIONS: ProviderOption[] = [
 ];
 
 const KNOWN_ASSET_MINTS: Record<string, string[]> = {
-  SOL: [SOL_MINT],
   USDC: [DEVNET_USDC_MINT, MAINNET_USDC_MINT],
 };
 

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
@@ -22,6 +22,7 @@ import {
   formatDirection,
   formatDisplayAmount,
   formatTimestamp,
+  normalizeAggregateBalances,
   resolveAggregateBalanceDisplayToken,
   resolveCounterparty,
   resolveTotalBalance,
@@ -174,7 +175,10 @@ export function PaymentsOverview({
       ? transfersError
       : null;
   const isRefreshing = aggregateRefreshing || transfersRefreshing;
-  const aggregateBalances = useMemo(() => liveAggregate?.balances ?? [], [liveAggregate]);
+  const aggregateBalances = useMemo(
+    () => normalizeAggregateBalances(liveAggregate?.balances ?? []),
+    [liveAggregate]
+  );
   const topAggregateBalances = useMemo(
     () => selectTopAggregateBalanceRows(aggregateBalances, issuedTokenSymbolsByMint),
     [aggregateBalances, issuedTokenSymbolsByMint]

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -62,9 +62,7 @@ export function resolveUsdBalanceValue(
   return resolveFallbackUsdValue(balance);
 }
 
-export function isSolBalance(
-  balance: Pick<CustodyWalletTokenBalance, "token" | "mint">
-): boolean {
+export function isSolBalance(balance: Pick<CustodyWalletTokenBalance, "token" | "mint">): boolean {
   return balance.token.trim().toUpperCase() === "SOL" || balance.mint.trim() === SOL_MINT;
 }
 

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -9,6 +9,8 @@ import type {
 const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 // biome-ignore lint/nursery/noSecrets: Mainnet USDC mint address constant, not a secret.
 const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+// biome-ignore lint/nursery/noSecrets: Solana native mint address constant, not a secret.
+const SOL_MINT = "So11111111111111111111111111111111111111112";
 
 function parseIntegerAmount(value: string): bigint | null {
   if (!/^\d+$/.test(value)) {
@@ -58,6 +60,12 @@ export function resolveUsdBalanceValue(
   }
 
   return resolveFallbackUsdValue(balance);
+}
+
+export function isSolBalance(
+  balance: Pick<CustodyWalletTokenBalance, "token" | "mint">
+): boolean {
+  return balance.token.trim().toUpperCase() === "SOL" || balance.mint.trim() === SOL_MINT;
 }
 
 export function formatDisplayAmount(value?: string, token?: string): string {
@@ -198,7 +206,7 @@ export function normalizeAggregateBalances(
   balances: CustodyWalletTokenBalance[]
 ): CustodyWalletTokenBalance[] {
   return balances
-    .filter((balance) => balance.token.trim().toUpperCase() !== "SOL")
+    .filter((balance) => !isSolBalance(balance))
     .filter((balance) => resolveUsdBalanceValue(balance) !== null)
     .sort((left, right) => {
       const leftIsUsdc = left.token.trim().toUpperCase() === "USDC";


### PR DESCRIPTION
## Summary
- remove SOL from the payments overview balance cards by normalizing aggregate balances before display
- stop surfacing SOL as a selectable payments asset in the send/receive flows while leaving the underlying API support unchanged
- add a payments e2e assertion that the asset picker no longer offers SOL in the wallet transfer flow

## Why
Payments was still surfacing SOL balances in the dashboard experience, which made the product intent unclear and conflicted with the decision for `PRO-1126` to remove SOL balances from payments.

## Impact
Users in Payments now see supported token balances instead of SOL in the overview and action flows, reducing confusion without changing the public payments API surface.

## Validation
- `pnpm --filter sdp-web typecheck` *(fails in the current repo baseline because generated `.next` validator targets and several `motion` / `@solana/design-system` modules are unresolved locally)*
- `pnpm --filter sdp-web test:e2e:dashboard -- --grep "dashboard payments e2e"` *(blocked locally because Playwright requires `CLERK_SECRET_KEY` via `doppler run` or env)*
- targeted diff review for the four touched files
