### PR TITLE
fix: support configurable issuance token setup

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/issuance.ts
+++ b/apps/sdp-api/src/openapi/schemas/issuance.ts
@@ -970,7 +970,7 @@ export const tokenTemplateInfoSchema = z
     }),
     maxDecimals: z.number().int().openapi({
       description: "Maximum allowed decimals for this template.",
-      example: 9,
+      example: 18,
     }),
     requiresAllowlist: z.boolean().openapi({
       description: "Whether allowlists are required for this template by default.",

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -208,6 +208,28 @@ describe("Issuance Routes", () => {
       expect(body.data.token.decimals).toBe(9);
     });
 
+    it("creates token with mixed-case symbol", async () => {
+      const res = await app.request(
+        "/v1/issuance/tokens",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            name: "Mixed Case Symbol Token",
+            symbol: "UsdX9",
+          }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.token.symbol).toBe("UsdX9");
+    });
+
     it("returns 400 for invalid symbol", async () => {
       const res = await app.request(
         "/v1/issuance/tokens",
@@ -219,7 +241,7 @@ describe("Issuance Routes", () => {
           },
           body: JSON.stringify({
             name: "Invalid Symbol Token",
-            symbol: "invalid_symbol", // lowercase and underscore
+            symbol: "invalid_symbol",
           }),
         },
         env
@@ -1409,10 +1431,12 @@ describe("Issuance Routes", () => {
         const stablecoin = body.data.templates.find((t: { id: string }) => t.id === "stablecoin");
         expect(stablecoin).toBeDefined();
         expect(stablecoin.name).toBe("Stablecoin");
+        expect(stablecoin.maxDecimals).toBe(18);
         const tokenized = body.data.templates.find(
           (t: { id: string }) => t.id === "tokenized-security"
         );
         expect(tokenized).toBeDefined();
+        expect(tokenized.maxDecimals).toBe(18);
         const custom = body.data.templates.find((t: { id: string }) => t.id === "custom");
         expect(custom).toBeDefined();
         const arcade = body.data.templates.find((t: { id: string }) => t.id === "arcade");
@@ -1434,6 +1458,23 @@ describe("Issuance Routes", () => {
         const body = await res.json();
         expect(body.data.template.id).toBe("stablecoin");
         expect(body.data.template.name).toBe("Stablecoin");
+        expect(body.data.template.maxDecimals).toBe(18);
+      });
+
+      it("returns tokenized security template", async () => {
+        const res = await app.request(
+          "/v1/issuance/templates/tokenized-security",
+          {
+            headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
+          },
+          env
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data.template.id).toBe("tokenized-security");
+        expect(body.data.template.name).toBe("Tokenized Security");
+        expect(body.data.template.maxDecimals).toBe(18);
       });
 
       it("does not return arcade template", async () => {
@@ -1539,6 +1580,58 @@ describe("Issuance Routes", () => {
       expect(res.status).toBe(201);
       const body = await res.json();
       expect(body.data.token.decimals).toBe(6);
+    });
+
+    it("creates stablecoin with mixed-case symbol and decimal override", async () => {
+      const res = await app.request(
+        "/v1/issuance/tokens",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            name: "Custom Stablecoin Decimals",
+            symbol: "Usd7",
+            template: "stablecoin",
+            decimals: 7,
+          }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.token.template).toBe("stablecoin");
+      expect(body.data.token.symbol).toBe("Usd7");
+      expect(body.data.token.decimals).toBe(7);
+    });
+
+    it("creates tokenized security with decimal override", async () => {
+      const res = await app.request(
+        "/v1/issuance/tokens",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            name: "Custom Security Decimals",
+            symbol: "Sec12",
+            template: "tokenized-security",
+            decimals: 12,
+          }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.data.token.template).toBe("tokenized-security");
+      expect(body.data.token.decimals).toBe(12);
+      expect(body.data.token.requiresAllowlist).toBe(true);
     });
 
     it("creates token with extension override", async () => {

--- a/apps/sdp-api/src/services/issuance/templates/definitions.ts
+++ b/apps/sdp-api/src/services/issuance/templates/definitions.ts
@@ -34,7 +34,7 @@ export const TEMPLATE_DEFINITIONS: Record<CanonicalTemplate, TokenTemplateDefini
     name: "Stablecoin",
     description: "USD-backed stablecoins with compliance controls.",
     decimals: 6,
-    maxDecimals: 9,
+    maxDecimals: 18,
     requiresAllowlist: false,
     allowlistOverridable: true,
     extensions: {
@@ -70,7 +70,7 @@ export const TEMPLATE_DEFINITIONS: Record<CanonicalTemplate, TokenTemplateDefini
     name: "Tokenized Security",
     description: "Regulated assets with allowlist defaults and higher precision.",
     decimals: 8,
-    maxDecimals: 8,
+    maxDecimals: 18,
     requiresAllowlist: true,
     allowlistOverridable: false,
     extensions: {

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -120,7 +120,7 @@ test.describe
     test("2. user can create a new pending token draft from the UI", async ({ page }) => {
       const draftSuffix = String(Date.now()).slice(-4);
       const draftName = `E2E UI Draft ${draftSuffix}`;
-      const draftSymbol = `E2E${draftSuffix}`;
+      const draftSymbol = `UsD${draftSuffix}`;
 
       await gotoIssuanceDashboard(page);
       await page.getByRole("button", { name: "Create draft" }).click();
@@ -134,6 +134,7 @@ test.describe
         .fill(`https://example.com/metadata/e2e-ui-draft-${draftSuffix}.json`);
       await page.getByLabel("Token Name").fill(draftName);
       await page.getByLabel("Symbol").fill(draftSymbol);
+      await page.getByLabel("Decimals").fill("7");
       await page.getByRole("button", { name: "Continue" }).click();
 
       await page
@@ -149,9 +150,37 @@ test.describe
         })
         .toBeGreaterThan(0);
       await expect(page.getByRole("heading", { name: draftName, exact: true })).toBeVisible();
+      await expect(page.getByText(draftSymbol, { exact: true })).toBeVisible();
+      const draftCard = page
+        .locator("article")
+        .filter({ has: page.getByRole("heading", { name: draftName, exact: true }) })
+        .first();
+      await draftCard.getByRole("link", { name: "Manage", exact: true }).click();
+      await expect(page.getByTestId("overview-row-decimals")).toContainText("7");
     });
 
-    test("3. user can deploy the seeded pending token and see it become active", async ({
+    test("3. user only sees configured extension rows on the allowlist-enabled token", async ({
+      page,
+    }) => {
+      await gotoToken(page, fixtures.tokens.allowlisted.id);
+      await openTab(page, "Extensions");
+
+      await expect(page.getByTestId("extension-row-template")).toContainText("stablecoin");
+      await expect(page.getByTestId("extension-row-allowlist")).toContainText("Enabled");
+      await expect(page.getByTestId("extension-row-mintable")).toContainText("Enabled");
+      await expect(page.getByTestId("extension-row-freezable")).toContainText("Enabled");
+      await expect(page.getByTestId("extension-row-default-account-state")).toContainText(
+        "initialized"
+      );
+
+      await expect(page.getByTestId("extension-row-transfer-fee")).toHaveCount(0);
+      await expect(page.getByTestId("extension-row-scaled-ui")).toHaveCount(0);
+      await expect(page.getByTestId("extension-row-transfer-hook")).toHaveCount(0);
+      await expect(page.getByTestId("extension-row-interest-bearing")).toHaveCount(0);
+      await expect(page.getByTestId("extension-row-non-transferable")).toHaveCount(0);
+    });
+
+    test("4. user can deploy the seeded pending token and see it become active", async ({
       page,
     }) => {
       await gotoToken(page, fixtures.tokens.pending.id);
@@ -181,7 +210,7 @@ test.describe
       await expect(page.getByRole("button", { name: "Deploy" })).toHaveCount(0);
     });
 
-    test("4. user can update metadata on the seeded active token", async ({ page }) => {
+    test("5. user can update metadata on the seeded active token", async ({ page }) => {
       const updatedName = "E2E Allowlist Stable Updated";
       const updatedDescription = "Updated by Playwright issuance e2e.";
       const updatedUri = "https://example.com/metadata/e2e-allowlisted-stable-updated.json";
@@ -206,7 +235,7 @@ test.describe
       await expect(page.getByLabel("Image URL")).toHaveValue(updatedImageUrl);
     });
 
-    test("5. user can update an authority including the None confirmation flow", async ({
+    test("6. user can update an authority including the None confirmation flow", async ({
       page,
     }) => {
       const rowTestId = "permission-row-permanent-delegate";
@@ -236,7 +265,7 @@ test.describe
       await waitForPermissionRowValue(page, rowTestId, "None");
     });
 
-    test("6. user can add and remove allowlist entries on the allowlist-enabled token", async ({
+    test("7. user can add and remove allowlist entries on the allowlist-enabled token", async ({
       page,
     }) => {
       await gotoToken(page, fixtures.tokens.allowlisted.id);
@@ -262,7 +291,7 @@ test.describe
       await expect(page.getByTestId("allowlist-summary-card")).toContainText("0 entries");
     });
 
-    test("7. user can mint and burn tokens with supply and transactions updating", async ({
+    test("8. user can mint and burn tokens with supply and transactions updating", async ({
       page,
     }) => {
       await gotoToken(page, fixtures.tokens.open.id);
@@ -296,7 +325,7 @@ test.describe
       await expect(page.getByTestId("fund-management-row-burn")).toBeVisible();
     });
 
-    test("8. user can freeze and unfreeze using a wallet address in the UI", async ({ page }) => {
+    test("9. user can freeze and unfreeze using a wallet address in the UI", async ({ page }) => {
       await gotoToken(page, fixtures.tokens.open.id);
 
       await openFundManagementAction(page, "mint");
@@ -332,7 +361,7 @@ test.describe
       await expect(page.getByTestId("frozen-accounts-summary-card")).toContainText("0 accounts");
     });
 
-    test("9. user can pause and unpause the token from compliance controls", async ({ page }) => {
+    test("10. user can pause and unpause the token from compliance controls", async ({ page }) => {
       await gotoToken(page, fixtures.tokens.open.id);
       await openTab(page, "Compliance");
 

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-header.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-header.tsx
@@ -74,7 +74,7 @@ export function TokenManagementHeader({
                   <Copy className="h-4 w-4" />
                 </button>
               ) : null}
-              <span className="rounded-full border border-[rgba(28,28,29,0.1)] bg-white px-3 py-1 text-[13px] font-medium text-[rgba(28,28,29,0.62)] uppercase">
+              <span className="rounded-full border border-[rgba(28,28,29,0.1)] bg-white px-3 py-1 text-[13px] font-medium text-[rgba(28,28,29,0.62)]">
                 {tokenSymbol}
               </span>
             </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-management-workspace.utils.ts
@@ -968,6 +968,62 @@ export function getForceBurnValidationReason(args: {
 }
 
 export function getExtensionRows(token: Token): ExtensionRow[] {
+  const configuredExtensionRows: ExtensionRow[] = [];
+
+  if (token.extensions?.defaultAccountState) {
+    configuredExtensionRows.push({
+      id: "default-account-state",
+      title: "Default Account State",
+      helper: "Default state for newly created token accounts.",
+      value: token.extensions.defaultAccountState,
+    });
+  }
+
+  if (token.extensions?.transferFee) {
+    configuredExtensionRows.push({
+      id: "transfer-fee",
+      title: "Transfer Fee",
+      helper: "Fee configuration for token transfers.",
+      value: "Configured",
+    });
+  }
+
+  if (token.extensions?.scaledUiAmount) {
+    configuredExtensionRows.push({
+      id: "scaled-ui",
+      title: "Scaled UI Amount",
+      helper: "UI supply multiplier controls.",
+      value: "Configured",
+    });
+  }
+
+  if (token.extensions?.transferHook) {
+    configuredExtensionRows.push({
+      id: "transfer-hook",
+      title: "Transfer Hook",
+      helper: "Custom transfer logic program hook.",
+      value: "Configured",
+    });
+  }
+
+  if (token.extensions?.interestBearing) {
+    configuredExtensionRows.push({
+      id: "interest-bearing",
+      title: "Interest Bearing",
+      helper: "Interest-rate based balance updates.",
+      value: "Configured",
+    });
+  }
+
+  if (token.extensions?.nonTransferable) {
+    configuredExtensionRows.push({
+      id: "non-transferable",
+      title: "Non-transferable",
+      helper: "Disables standard transfers between accounts.",
+      value: "Enabled",
+    });
+  }
+
   return [
     {
       id: "template",
@@ -997,42 +1053,7 @@ export function getExtensionRows(token: Token): ExtensionRow[] {
       helper: "Allows freeze/unfreeze account controls.",
       value: token.isFreezable ? "Enabled" : "Disabled",
     },
-    {
-      id: "default-account-state",
-      title: "Default Account State",
-      helper: "Default state for newly created token accounts.",
-      value: token.extensions?.defaultAccountState ?? "initialized",
-    },
-    {
-      id: "transfer-fee",
-      title: "Transfer Fee",
-      helper: "Fee configuration for token transfers.",
-      value: token.extensions?.transferFee ? "Configured" : "Not configured",
-    },
-    {
-      id: "scaled-ui",
-      title: "Scaled UI Amount",
-      helper: "UI supply multiplier controls.",
-      value: token.extensions?.scaledUiAmount ? "Configured" : "Not configured",
-    },
-    {
-      id: "transfer-hook",
-      title: "Transfer Hook",
-      helper: "Custom transfer logic program hook.",
-      value: token.extensions?.transferHook ? "Configured" : "Not configured",
-    },
-    {
-      id: "interest-bearing",
-      title: "Interest Bearing",
-      helper: "Interest-rate based balance updates.",
-      value: token.extensions?.interestBearing ? "Configured" : "Not configured",
-    },
-    {
-      id: "non-transferable",
-      title: "Non-transferable",
-      helper: "Disables standard transfers between accounts.",
-      value: token.extensions?.nonTransferable ? "Enabled" : "Disabled",
-    },
+    ...configuredExtensionRows,
   ];
 }
 

--- a/apps/sdp-web/src/app/dashboard/issuance/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/actions.ts
@@ -2,6 +2,7 @@
 
 import { sdpApiRequest } from "@/lib/sdp-api";
 import { revalidatePath } from "next/cache";
+import { isValidTokenDecimals } from "./create-token-modal.utils";
 import { issuanceTemplateCatalog } from "./template-catalog";
 
 type ActionState = "idle" | "success" | "error";
@@ -146,8 +147,7 @@ export async function createIssuanceTokenAction(
   }
 
   if (decimalsRaw) {
-    const parsed = Number.parseInt(decimalsRaw, 10);
-    if (!Number.isFinite(parsed) || parsed < 0 || parsed > 18) {
+    if (!isValidTokenDecimals(decimalsRaw)) {
       return {
         state: "error",
         message: "Decimals must be between 0 and 18.",
@@ -155,6 +155,8 @@ export async function createIssuanceTokenAction(
         tokenName: null,
       };
     }
+
+    const parsed = Number.parseInt(decimalsRaw, 10);
     payload.decimals = parsed;
   }
 

--- a/apps/sdp-web/src/app/dashboard/issuance/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/actions.ts
@@ -50,9 +50,7 @@ export async function createIssuanceTokenAction(
 ): Promise<CreateIssuanceTokenResult> {
   const uri = String(formData.get("uri") ?? "").trim();
   const name = String(formData.get("name") ?? "").trim();
-  const symbol = String(formData.get("symbol") ?? "")
-    .trim()
-    .toUpperCase();
+  const symbol = String(formData.get("symbol") ?? "").trim();
   const template = String(formData.get("template") ?? "custom").trim();
   const description = String(formData.get("description") ?? "").trim();
   const signingWalletId = String(formData.get("signingWalletId") ?? "").trim();
@@ -99,10 +97,10 @@ export async function createIssuanceTokenAction(
     };
   }
 
-  if (!symbol || !/^[A-Z0-9.]{1,10}$/.test(symbol)) {
+  if (!symbol || !/^[A-Za-z0-9.]{1,10}$/.test(symbol)) {
     return {
       state: "error",
-      message: "Symbol must be 1-10 characters, uppercase letters, numbers, or periods.",
+      message: "Symbol must be 1-10 characters using letters, numbers, or periods.",
       tokenId: null,
       tokenName: null,
     };

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-identity-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-identity-step.tsx
@@ -5,12 +5,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { motion } from "motion/react";
 import type { IdentityValidation, TemplateSelection, TokenDraft } from "./create-token-modal.types";
-import { normalizeSymbol } from "./create-token-modal.utils";
+import { getDecimalsHelperText, normalizeSymbol } from "./create-token-modal.utils";
 
 interface CreateTokenIdentityStepProps {
   template: TemplateSelection;
   draft: TokenDraft;
-  decimalOptions: ReadonlyArray<TokenDraft["decimals"]>;
   validation: IdentityValidation;
   canContinue: boolean;
   onDraftChange: (patch: Partial<TokenDraft>) => void;
@@ -21,7 +20,6 @@ interface CreateTokenIdentityStepProps {
 export function CreateTokenIdentityStep({
   template,
   draft,
-  decimalOptions,
   validation,
   canContinue,
   onDraftChange,
@@ -96,45 +94,28 @@ export function CreateTokenIdentityStep({
           </div>
 
           <div className="grid gap-2">
-            <Label>
+            <Label htmlFor="issuance-token-decimals">
               Decimals{" "}
               <span aria-hidden className="text-[#c71f37]">
                 *
               </span>
               <span className="sr-only"> (required)</span>
             </Label>
-            <div
-              aria-required="true"
-              className={[
-                "grid gap-2",
-                decimalOptions.length > 1 ? "grid-cols-2" : "grid-cols-1",
-              ].join(" ")}
-            >
-              {decimalOptions.map((value) => {
-                const isSelected = draft.decimals === value;
-                return (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => onDraftChange({ decimals: value })}
-                    className={[
-                      "h-10 rounded-lg border px-3 text-sm font-medium transition-colors",
-                      isSelected
-                        ? "border-[#1c1c1d] bg-[rgba(28,28,29,0.05)] text-[#1c1c1d]"
-                        : "border-[rgba(28,28,29,0.16)] bg-white text-[rgba(28,28,29,0.72)] hover:bg-[rgba(28,28,29,0.03)]",
-                    ].join(" ")}
-                  >
-                    {value}
-                  </button>
-                );
-              })}
-            </div>
+            <Input
+              id="issuance-token-decimals"
+              type="number"
+              min="0"
+              max="18"
+              step="1"
+              inputMode="numeric"
+              value={draft.decimals}
+              onChange={(event) => onDraftChange({ decimals: event.currentTarget.value })}
+              placeholder="e.g., 6"
+              aria-invalid={draft.decimals.length > 0 && !validation.decimalsValid}
+              required
+            />
             <p className="text-base text-[rgba(28,28,29,0.62)]">
-              {template === "stablecoin"
-                ? "Stablecoin defaults to 6 decimals."
-                : template === "custom"
-                  ? "Custom tokens default to 9 decimals."
-                  : "Tokenized Security uses 8 decimals."}
+              {getDecimalsHelperText(template)}
             </p>
           </div>
         </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-identity-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-identity-step.tsx
@@ -114,6 +114,11 @@ export function CreateTokenIdentityStep({
               aria-invalid={draft.decimals.length > 0 && !validation.decimalsValid}
               required
             />
+            {draft.decimals.length > 0 && !validation.decimalsValid ? (
+              <p className="text-sm text-[#c71f37]" role="alert">
+                Enter a whole number between 0 and 18.
+              </p>
+            ) : null}
             <p className="text-base text-[rgba(28,28,29,0.62)]">
               {getDecimalsHelperText(template)}
             </p>

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
@@ -21,8 +21,8 @@ import {
   getDefaultAccessControlMode,
   getTemplateDefaultDecimals,
   getTemplateTitle,
-  isValidTokenDecimals,
   isValidMetadataUri,
+  isValidTokenDecimals,
   isValidTokenSymbol,
 } from "./create-token-modal.utils";
 import { TemplateSelectionStep } from "./create-token-template-selection-step";

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.tsx
@@ -19,10 +19,11 @@ import {
   createInitialDraft,
   getAccessControlAvailability,
   getDefaultAccessControlMode,
-  getTemplateDecimalOptions,
   getTemplateDefaultDecimals,
   getTemplateTitle,
+  isValidTokenDecimals,
   isValidMetadataUri,
+  isValidTokenSymbol,
 } from "./create-token-modal.utils";
 import { TemplateSelectionStep } from "./create-token-template-selection-step";
 
@@ -57,16 +58,14 @@ export function CreateIssuanceTokenModal({
   const isOpen = open ?? isOpenInternal;
 
   const template = flow.kind === "creation" ? flow.template : draft.template;
-  const decimalOptions = template ? getTemplateDecimalOptions(template) : [];
   const uri = draft.uri.trim();
   const name = draft.name.trim();
   const symbol = draft.symbol.trim();
   const identityValidation = {
     uriValid: isValidMetadataUri(uri),
     nameValid: name.length > 0 && name.length <= 100,
-    symbolValid: /^[A-Z0-9.]{1,10}$/.test(symbol),
-    decimalsValid:
-      template !== null && getTemplateDecimalOptions(template).includes(draft.decimals),
+    symbolValid: isValidTokenSymbol(symbol),
+    decimalsValid: template !== null && isValidTokenDecimals(draft.decimals),
   };
   const isIdentityStep = flow.kind === "creation" && flow.step === "identity";
   const isFeaturesStep = flow.kind === "creation" && flow.step === "features";
@@ -247,7 +246,6 @@ export function CreateIssuanceTokenModal({
                   <CreateTokenIdentityStep
                     template={template}
                     draft={draft}
-                    decimalOptions={decimalOptions}
                     validation={{
                       ...identityValidation,
                       isValid: canContinueFromIdentity,

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.types.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.types.ts
@@ -18,7 +18,7 @@ export interface TokenDraft {
   name: string;
   symbol: string;
   signingWalletId: string;
-  decimals: "" | "0" | "6" | "8" | "9";
+  decimals: string;
   accessControlMode: AccessControlMode;
 }
 

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
@@ -167,7 +167,7 @@ export function isValidTokenDecimals(value: string): boolean {
   }
 
   const parsed = Number.parseInt(value, 10);
-  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 18;
+  return parsed >= 0 && parsed <= 18;
 }
 
 export function getDecimalsHelperText(template: TemplateSelection): string {

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
@@ -99,20 +99,6 @@ export function getTemplateDefaultDecimals(template: TemplateSelection): TokenDr
   }
 }
 
-export function getTemplateDecimalOptions(
-  template: TemplateSelection
-): ReadonlyArray<TokenDraft["decimals"]> {
-  switch (template) {
-    case "stablecoin":
-    case "custom":
-      return ["6", "9"];
-    case "tokenized-security":
-      return ["8"];
-    default:
-      return ["6", "9"];
-  }
-}
-
 export function getDefaultAccessControlMode(template: TemplateSelection): AccessControlMode {
   return template === "tokenized-security" ? "allowlist" : "blocklist";
 }
@@ -169,7 +155,32 @@ export function isValidMetadataUri(value: string): boolean {
 
 export function normalizeSymbol(symbol: string): string {
   return symbol
-    .toUpperCase()
-    .replace(/[^A-Z0-9.]/g, "")
+    .replace(/[^A-Za-z0-9.]/g, "")
     .slice(0, 10);
+}
+
+export function isValidTokenSymbol(symbol: string): boolean {
+  return /^[A-Za-z0-9.]{1,10}$/.test(symbol);
+}
+
+export function isValidTokenDecimals(value: string): boolean {
+  if (!/^\d+$/.test(value)) {
+    return false;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 18;
+}
+
+export function getDecimalsHelperText(template: TemplateSelection): string {
+  switch (template) {
+    case "stablecoin":
+      return "Stablecoin defaults to 6 decimals, but you can choose any value from 0 to 18.";
+    case "custom":
+      return "Custom tokens default to 9 decimals. Choose any value from 0 to 18.";
+    case "tokenized-security":
+      return "Tokenized Security defaults to 8 decimals, but you can choose any value from 0 to 18.";
+    default:
+      return "Choose any value from 0 to 18.";
+  }
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/create-token-modal.utils.ts
@@ -154,9 +154,7 @@ export function isValidMetadataUri(value: string): boolean {
 }
 
 export function normalizeSymbol(symbol: string): string {
-  return symbol
-    .replace(/[^A-Za-z0-9.]/g, "")
-    .slice(0, 10);
+  return symbol.replace(/[^A-Za-z0-9.]/g, "").slice(0, 10);
 }
 
 export function isValidTokenSymbol(symbol: string): boolean {

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -272,7 +272,7 @@ export function IssuanceWorkspace({
                       </div>
                     );
                   })()}
-                  <p className="text-sm font-medium tracking-wide text-[rgba(28,28,29,0.58)] uppercase">
+                  <p className="text-sm font-medium tracking-wide text-[rgba(28,28,29,0.58)]">
                     {token.symbol}
                   </p>
                   <h3 className="mt-1 text-[30px] leading-[1.1] font-medium text-[#1c1c1d]">


### PR DESCRIPTION
## Summary
- allow mixed-case issuance symbols to be entered, validated, and displayed without forced uppercasing
- make stablecoin and tokenized security decimals configurable up to 18 in the dashboard and template metadata
- hide issuance extension rows unless the token actually has that extension configured
- add API and Playwright regression coverage for the updated issuance flows

## Linear
- PRO-1109
- PRO-1112
- PRO-1114
- PRO-1116

## Validation
- `pnpm typecheck`
- `cd apps/sdp-api && ./node_modules/.bin/vitest run src/routes/issuance.test.ts`
- `pnpm --filter sdp-web exec playwright test --config=playwright.config.ts --project=issuance --grep "2\\.|3\\."`
