### PR TITLE
fix: make homepage dashboard CTA sign in

### DIFF
--- a/apps/sdp-web/src/app/page.tsx
+++ b/apps/sdp-web/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { auth } from "@clerk/nextjs/server";
 import { DEFAULT_SDP_DOCS_URL } from "@sdp/types";
 import Image from "next/image";
 import Link from "next/link";
@@ -8,9 +7,7 @@ const docsHref =
   (process.env.NODE_ENV === "development" ? "http://localhost:3001/docs" : DEFAULT_SDP_DOCS_URL);
 const waitlistHref = "https://solanafoundation.typeform.com/to/PLfMTDQs";
 
-export default async function Home() {
-  const { userId } = await auth();
-
+export default function Home() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] text-[#1c1c1d]">
       <header className="border-b border-[rgba(28,28,29,0.08)]">
@@ -24,10 +21,10 @@ export default async function Home() {
               Docs
             </Link>
             <Link
-              href={userId ? "/dashboard" : "/sign-in"}
-              className="inline-flex h-9 items-center justify-center rounded-lg bg-[rgba(28,28,29,0.08)] px-3 text-sm font-semibold text-[#1c1c1d] transition-colors hover:bg-[rgba(28,28,29,0.14)]"
+              href="/sign-in"
+              className="inline-flex h-9 items-center justify-center rounded-lg bg-[#0f0f10] px-3 text-sm font-semibold text-white transition-colors hover:bg-black"
             >
-              {userId ? "Dashboard" : "Sign in"}
+              Dashboard
             </Link>
           </div>
         </div>

--- a/apps/sdp-web/src/lib/auth-entry.ts
+++ b/apps/sdp-web/src/lib/auth-entry.ts
@@ -10,6 +10,7 @@ export async function getAuthEntryPath(): Promise<string> {
 
 export async function shouldLoadClerkForPath(pathname: string): Promise<boolean> {
   return (
+    pathname === "/" ||
     pathname === "/dashboard" ||
     pathname.startsWith("/dashboard/") ||
     pathname === "/allowlist" ||


### PR DESCRIPTION
## Summary
- make the homepage Dashboard CTA a primary button
- point the CTA to `/sign-in`
- leave this as an untested hotfix

## Testing
- Not run (untested hotfix)