### PR TITLE
fix: default new organizations to enterprise tier

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0001_initial_schema.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0001_initial_schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS organizations (
     id TEXT PRIMARY KEY,                              
     name TEXT NOT NULL,
     slug TEXT NOT NULL UNIQUE,
-    tier TEXT NOT NULL DEFAULT 'individual',          
+    tier TEXT NOT NULL DEFAULT 'enterprise',          
     status TEXT NOT NULL DEFAULT 'active',            
     settings TEXT,                                    
     created_at TEXT NOT NULL DEFAULT sdp_datetime_now(),

--- a/apps/sdp-api/src/db/migrations/postgres/0002_default_organization_tier_enterprise.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0002_default_organization_tier_enterprise.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organizations
+ALTER COLUMN tier SET DEFAULT 'enterprise';

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -204,6 +204,39 @@ describe("Clerk webhooks", () => {
     });
   });
 
+  it("defaults new Clerk organizations to enterprise when SDP tier metadata is missing", async () => {
+    const created = await sendClerkWebhook({
+      type: "organization.created",
+      data: {
+        id: "org_clerk_enterprise_default",
+        name: "Enterprise By Default",
+        slug: "enterprise-by-default",
+      },
+    });
+
+    expect(created.status).toBe(200);
+
+    const createdOrg = await getDb(env)
+      .prepare(
+        `SELECT o.name, o.slug, o.tier
+         FROM organizations o
+         JOIN auth_organization_identities aoi ON aoi.organization_id = o.id
+         WHERE aoi.provider = 'clerk' AND aoi.provider_org_id = ?`
+      )
+      .bind("org_clerk_enterprise_default")
+      .first<{
+        name: string;
+        slug: string;
+        tier: string;
+      }>();
+
+    expect(createdOrg).toEqual({
+      name: "Enterprise By Default",
+      slug: "enterprise-by-default",
+      tier: "enterprise",
+    });
+  });
+
   it("keeps Clerk identity email aligned with the local user when a new email is taken", async () => {
     await getDb(env).batch([
       getDb(env)

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -241,7 +241,7 @@ async function ensureOrganizationMapping(
       getDb(c.env)
         .prepare(
           `INSERT INTO organizations (id, name, slug, tier, status)
-           VALUES (?, ?, ?, 'individual', 'active')`
+           VALUES (?, ?, ?, 'enterprise', 'active')`
         )
         .bind(orgId, orgName, slug),
       getDb(c.env)

--- a/apps/sdp-api/src/services/organization-provider-access.service.test.ts
+++ b/apps/sdp-api/src/services/organization-provider-access.service.test.ts
@@ -212,7 +212,7 @@ describe("organization-provider-access.service", () => {
     });
   });
 
-  it("defaults to individual and clears provider overrides when Clerk metadata is absent", async () => {
+  it("defaults to enterprise and clears provider overrides when Clerk metadata is absent", async () => {
     await getDb(env)
       .prepare("UPDATE organizations SET tier = ?, settings = ? WHERE id = ?")
       .bind(
@@ -241,7 +241,7 @@ describe("organization-provider-access.service", () => {
       .bind(TEST_ORG_ID)
       .first<{ tier: string; settings: string | null }>();
 
-    expect(organization?.tier).toBe("individual");
+    expect(organization?.tier).toBe("enterprise");
     expect(organization?.settings ? JSON.parse(organization.settings) : null).toEqual({
       rpcProvider: "helius",
     });

--- a/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts
@@ -531,7 +531,7 @@ async function fundWalletToLamports(
 }
 
 export async function ensureUnlinkedOrg(identity: ClerkTestIdentity): Promise<void> {
-  await setClerkOrganizationTier(identity.organizationId, "individual");
+  await setClerkOrganizationTier(identity.organizationId, "enterprise");
 
   await withDatabaseClient(async (client) => {
     await client.query("BEGIN");
@@ -552,7 +552,7 @@ export async function ensureLinkedOrg(
   options?: EnsureLinkedOrgOptions
 ): Promise<PlaywrightOrganizationFixture> {
   const organization = buildPlaywrightOrganizationFixture(identity);
-  const tier = options?.tier ?? "individual";
+  const tier = options?.tier ?? "enterprise";
 
   await setClerkOrganizationTier(identity.organizationId, tier);
 

--- a/packages/sdp-types/src/organizations.ts
+++ b/packages/sdp-types/src/organizations.ts
@@ -59,17 +59,16 @@ export function isOrganizationTier(value: string | null | undefined): value is O
 
 export function normalizeOrganizationTier(value: string | null | undefined): OrganizationTier {
   if (!value) {
-    return "individual";
+    return "enterprise";
   }
 
   if (isOrganizationTier(value)) {
     return value;
   }
 
-  return (
-    LEGACY_ORGANIZATION_TIER_ALIASES[value as keyof typeof LEGACY_ORGANIZATION_TIER_ALIASES] ??
-    "individual"
-  );
+  const legacyTier =
+    LEGACY_ORGANIZATION_TIER_ALIASES[value as keyof typeof LEGACY_ORGANIZATION_TIER_ALIASES];
+  return legacyTier ?? "individual";
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- default new Clerk organizations to the enterprise tier when SDP metadata is absent
- change the webhook fallback insert and Postgres schema default to enterprise
- cover the defaulting behavior in webhook/provider-access tests and align local dashboard bootstrap helpers

## Why
New organizations should start on the enterprise tier by default, even when Clerk organization metadata does not explicitly set an SDP tier yet.

## Validation
- `pnpm --filter @sdp/types typecheck`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter sdp-web typecheck`
- `pnpm exec biome check packages/sdp-types/src/organizations.ts apps/sdp-api/src/routes/webhooks/handlers.ts apps/sdp-api/src/routes/webhooks.test.ts apps/sdp-api/src/services/organization-provider-access.service.test.ts apps/sdp-web/playwright/support/local-dashboard-bootstrap.ts`

## Notes
- `pnpm typecheck` is currently blocked by an unrelated docs generator issue in `sdp-docs` (`../../.source` missing).
- The API Vitest worker suites are blocked locally because Docker/Postgres is not available in this environment.
