### PR TITLE
fix: add tos notice to auth pages

### DIFF
--- a/apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/sdp-web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,9 +1,13 @@
+import { AuthTermsNotice } from "@/components/auth-terms-notice";
 import { SignIn } from "@clerk/nextjs";
 
 export default function SignInPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] px-6 py-10">
-      <SignIn routing="path" path="/sign-in" />
+      <div className="flex flex-col items-center gap-4">
+        <SignIn routing="path" path="/sign-in" />
+        <AuthTermsNotice />
+      </div>
     </div>
   );
 }

--- a/apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/sdp-web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,13 @@
+import { AuthTermsNotice } from "@/components/auth-terms-notice";
 import { SignUp } from "@clerk/nextjs";
 
 export default function SignUpPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] px-6 py-10">
-      <SignUp />
+      <div className="flex flex-col items-center gap-4">
+        <SignUp />
+        <AuthTermsNotice />
+      </div>
     </div>
   );
 }

--- a/apps/sdp-web/src/components/auth-terms-notice.tsx
+++ b/apps/sdp-web/src/components/auth-terms-notice.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+const TOS_HREF = "https://solana.com/tos";
+
+export function AuthTermsNotice() {
+  return (
+    <p className="max-w-sm text-center text-xs leading-5 text-[rgba(28,28,29,0.72)]">
+      By using the app, you agree to the{" "}
+      <Link
+        href={TOS_HREF}
+        target="_blank"
+        rel="noreferrer"
+        className="font-medium text-[#1c1c1d] underline underline-offset-2 transition-colors hover:text-black"
+      >
+        Solana Terms of Service
+      </Link>
+      .
+    </p>
+  );
+}

--- a/apps/sdp-web/src/components/auth-terms-notice.tsx
+++ b/apps/sdp-web/src/components/auth-terms-notice.tsx
@@ -12,7 +12,7 @@ export function AuthTermsNotice() {
         rel="noreferrer"
         className="font-medium text-[#1c1c1d] underline underline-offset-2 transition-colors hover:text-black"
       >
-        Solana Terms of Service
+        Solana Foundation Term Of Services
       </Link>
       .
     </p>


### PR DESCRIPTION
## Summary
- add a small terms notice below the sign-in form
- add the same notice below the sign-up form
- link the notice to https://solana.com/tos

## Testing
- Not run