### PR TITLE
fix: remove SOL balances from wallet UI

### DIFF
--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -32,6 +32,7 @@ test.describe
 
       await walletCard.getByRole("link", { name: "Manage" }).click();
       await expect(page).toHaveURL(/\/dashboard\/wallets\/.+/);
+      await expect(page.getByText("SOL", { exact: true })).toHaveCount(0);
 
       await page.getByRole("button", { name: "Actions" }).click();
       await page.getByRole("menuitem", { name: "Prove ownership" }).click();

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
@@ -19,6 +19,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import {
+  filterNonSolBalances,
   formatCurrencyAmount,
   formatDisplayAmount,
   resolveTotalBalance,
@@ -143,7 +144,9 @@ export default async function WalletDetailPage({
 
   const provider =
     wallet.provider && isKnownCustodyProvider(wallet.provider) ? wallet.provider : null;
-  const balances = trackedBalances.length > 0 ? trackedBalances : [wallet.balance];
+  const balances = filterNonSolBalances(
+    trackedBalances.length > 0 ? trackedBalances : [wallet.balance]
+  );
   const totalBalance = resolveTotalBalance(balances);
   const purposeLabel = formatPurpose(wallet.purpose);
 

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -23,7 +23,7 @@ import QRCode from "qrcode";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
-import { isSolBalance } from "./payments-overview.utils";
+import { filterNonSolBalances, isSolBalance } from "./payments-overview.utils";
 import {
   type PaymentRampExecution,
   type PaymentWalletBalance,
@@ -156,7 +156,7 @@ function parseOptionalNumber(value: string): number | null {
 }
 
 function resolvePrimaryWalletBalance(wallet: PaymentsDashboardWallet | null) {
-  const supportedBalances = wallet?.balances?.filter((balance) => !isSolBalance(balance)) ?? [];
+  const supportedBalances = filterNonSolBalances(wallet?.balances ?? []);
 
   if (supportedBalances.length === 0) {
     return null;

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -66,6 +66,12 @@ export function isSolBalance(balance: Pick<CustodyWalletTokenBalance, "token" | 
   return balance.token.trim().toUpperCase() === "SOL" || balance.mint.trim() === SOL_MINT;
 }
 
+export function filterNonSolBalances<
+  TBalance extends Pick<CustodyWalletTokenBalance, "token" | "mint">,
+>(balances: TBalance[]): TBalance[] {
+  return balances.filter((balance) => !isSolBalance(balance));
+}
+
 export function formatDisplayAmount(value?: string, token?: string): string {
   if (!value) {
     return token ? `- ${token}` : "-";
@@ -138,12 +144,14 @@ export function resolveCounterparty(transfer: TransferRecord): string {
 }
 
 export function resolveTotalBalance(balances: CustodyWalletTokenBalance[]): number | null {
-  if (balances.length === 0) {
+  const supportedBalances = filterNonSolBalances(balances);
+
+  if (supportedBalances.length === 0) {
     return null;
   }
 
   let hasNumericBalance = false;
-  const total = balances.reduce((sum, balance) => {
+  const total = supportedBalances.reduce((sum, balance) => {
     const usdValue = resolveUsdBalanceValue(balance);
     if (usdValue === null) {
       return sum;
@@ -203,8 +211,7 @@ export function aggregateBalancesFromWallets(wallets: WalletRecord[]): CustodyWa
 export function normalizeAggregateBalances(
   balances: CustodyWalletTokenBalance[]
 ): CustodyWalletTokenBalance[] {
-  return balances
-    .filter((balance) => !isSolBalance(balance))
+  return filterNonSolBalances(balances)
     .filter((balance) => resolveUsdBalanceValue(balance) !== null)
     .sort((left, right) => {
       const leftIsUsdc = left.token.trim().toUpperCase() === "USDC";


### PR DESCRIPTION
## Summary
- remove SOL from wallet detail balances and wallet total calculations
- reuse a shared non-SOL balance helper across wallet and payments UI paths
- add a wallet e2e assertion that SOL does not appear on the wallet detail screen

## Testing
- pnpm --filter sdp-web typecheck
- Playwright wallet spec requires local E2E secrets (will rely on CI for full browser validation)

Closes PRO-1103