### PR TITLE
fix: render Wrangler config from Doppler for API deploys

### DIFF
--- a/.github/workflows/deploy-sdp-api.yml
+++ b/.github/workflows/deploy-sdp-api.yml
@@ -175,7 +175,8 @@ jobs:
 
       - name: Fetch Doppler config
         id: doppler
-        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        # v2.0.0 pinned to an immutable commit because this action injects deploy secrets.
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534
         with:
           doppler-token: ${{ secrets.DOPPLER_TOKEN }}
           inject-env-vars: true

--- a/.github/workflows/deploy-sdp-api.yml
+++ b/.github/workflows/deploy-sdp-api.yml
@@ -110,9 +110,6 @@ jobs:
             exit 1
           fi
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v4
-
       - name: Validate Cloud SQL migration identity
         if: ${{ github.event_name == 'push' || inputs.run_migrations }}
         env:
@@ -176,12 +173,24 @@ jobs:
           kill "${proxy_pid}" || true
           exit 1
 
+      - name: Fetch Doppler config
+        id: doppler
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          inject-env-vars: true
+
+      - name: Validate fetched Doppler config
+        run: |
+          set -euo pipefail
+          if [ "${DOPPLER_CONFIG:-}" != "${DOPPLER_CONFIG_NAME}" ]; then
+            echo "Fetched Doppler config '${DOPPLER_CONFIG:-<unset>}' does not match expected '${DOPPLER_CONFIG_NAME}'." >&2
+            exit 1
+          fi
+
       - name: Migrate Postgres
         if: ${{ github.event_name == 'push' || inputs.run_migrations }}
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
-          doppler run --config "${DOPPLER_CONFIG_NAME}" -- bash <<'EOF'
           set -euo pipefail
           if [ -z "${DATABASE_URL:-}" ]; then
             echo "DATABASE_URL is not configured in Doppler config ${DOPPLER_CONFIG_NAME}; skipping Postgres migrations."
@@ -204,7 +213,6 @@ jobs:
           )"
 
           pnpm --filter @sdp/api "db:migrate:${TARGET_ENV}"
-          EOF
 
       - name: Stop Cloud SQL Auth Proxy
         if: ${{ always() && (github.event_name == 'push' || inputs.run_migrations) }}
@@ -213,21 +221,22 @@ jobs:
             kill "${CLOUD_SQL_PROXY_PID}" || true
           fi
 
-      - name: Sync Worker secrets
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      - name: Render Wrangler config
         run: |
-          doppler run --config "${DOPPLER_CONFIG_NAME}" -- bash <<'EOF'
+          set -euo pipefail
+          wrangler_config_path="${GITHUB_WORKSPACE}/apps/sdp-api/.wrangler.${TARGET_ENV}.generated.toml"
+          node scripts/render-wrangler-config.mjs --env "${TARGET_ENV}" --out "${wrangler_config_path}"
+          echo "WRANGLER_CONFIG_PATH=${wrangler_config_path}" >> "${GITHUB_ENV}"
+
+      - name: Sync Worker secrets
+        run: |
           set -euo pipefail
           if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
             echo "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID must be present in Doppler config ${DOPPLER_CONFIG_NAME}." >&2
             exit 1
           fi
           node scripts/project-secrets.mjs cloudflare --out "${RUNNER_TEMP}/cloudflare-secrets.json"
-          pnpm --filter @sdp/api exec wrangler secret bulk "${RUNNER_TEMP}/cloudflare-secrets.json" --env "${TARGET_ENV}"
-          EOF
+          pnpm --filter @sdp/api exec wrangler secret bulk "${RUNNER_TEMP}/cloudflare-secrets.json" --env "${TARGET_ENV}" --config "${WRANGLER_CONFIG_PATH}"
 
       - name: Deploy Worker
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: doppler run --config "${DOPPLER_CONFIG_NAME}" -- pnpm --filter @sdp/api exec wrangler deploy --env "${TARGET_ENV}"
+        run: pnpm --filter @sdp/api exec wrangler deploy --env "${TARGET_ENV}" --config "${WRANGLER_CONFIG_PATH}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .next/
 apps/**/.next/
 apps/sdp-api/generated/
+apps/sdp-api/.wrangler.*.generated.toml
 
 # Cloudflare
 .wrangler/

--- a/docs/ops/doppler-secrets.md
+++ b/docs/ops/doppler-secrets.md
@@ -4,7 +4,8 @@ SDP now treats Doppler as the single source of truth for secret and environment-
 
 The runtime model does not change:
 
-- `wrangler.toml` remains the source of truth for Worker bindings and committed non-secret vars
+- `wrangler.toml` remains the source of truth for Worker binding names and committed local defaults
+- environment-specific Cloudflare binding IDs live in Doppler and are rendered into a temporary Wrangler config during deploy
 - Cloudflare remains the deployed runtime store for Worker secrets
 - Vercel remains the deployed runtime store for `sdp-web` and `sdp-docs`
 - GitHub Actions keeps only Doppler bootstrap tokens plus non-secret deploy metadata
@@ -66,6 +67,12 @@ At minimum, the Doppler configs used by automation must include:
 - Cloudflare deploy credentials:
   - `CLOUDFLARE_API_TOKEN`
   - `CLOUDFLARE_ACCOUNT_ID`
+- Cloudflare deploy binding IDs:
+  - `CLOUDFLARE_HYPERDRIVE_ID`
+  - `CLOUDFLARE_KV_SDP_API_KEYS_ID`
+  - `CLOUDFLARE_KV_SDP_RATE_LIMITS_ID`
+  - `CLOUDFLARE_KV_SDP_CACHE_ID`
+  - `CLOUDFLARE_KV_SDP_SESSIONS_ID`
 - API deploy and migration values:
   - `DATABASE_URL`
   - `API_KEY_PEPPER`
@@ -110,10 +117,10 @@ Do not keep `apps/sdp-api/.dev.vars` in place while using `doppler run`. The loc
 ## CI and Deploy Behavior
 
 - Secret-aware CI jobs fetch runtime env directly from Doppler with `DOPPLER_TOKEN_CI`.
-- The API deploy workflow fetches deploy-time env from the target Doppler config using the GitHub environment secret `DOPPLER_TOKEN`.
+- The API deploy workflow fetches deploy-time env from the target Doppler config using the GitHub environment secret `DOPPLER_TOKEN` and the Doppler Secrets Fetch action.
 - The API deploy workflow reads non-secret Cloud SQL identity metadata from GitHub environment variables.
 - Postgres migrations connect through Google Workload Identity and Cloud SQL Auth Proxy; the Doppler `DATABASE_URL` host is rewritten to the local proxy only for the migration process.
-- The deploy workflow syncs the allowlisted Worker secret set via `wrangler secret bulk` before `wrangler deploy`.
+- The deploy workflow renders a temporary Wrangler config with Doppler-backed Cloudflare binding IDs, then syncs the allowlisted Worker secret set via `wrangler secret bulk` before `wrangler deploy`.
 
 Keep these deploy identity values in GitHub environment variables rather than Doppler:
 

--- a/scripts/render-wrangler-config.mjs
+++ b/scripts/render-wrangler-config.mjs
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+const TARGETS = new Set(["dev", "production"]);
+
+const BINDING_REPLACEMENTS = [
+  {
+    envVar: "CLOUDFLARE_HYPERDRIVE_ID",
+    placeholders: {
+      dev: "your_dev_hyperdrive_id",
+      production: "your_production_hyperdrive_id",
+    },
+  },
+  {
+    envVar: "CLOUDFLARE_KV_SDP_API_KEYS_ID",
+    placeholders: {
+      dev: "your_dev_api_keys_kv_id",
+      production: "your_production_api_keys_kv_id",
+    },
+  },
+  {
+    envVar: "CLOUDFLARE_KV_SDP_RATE_LIMITS_ID",
+    placeholders: {
+      dev: "your_dev_rate_limits_kv_id",
+      production: "your_production_rate_limits_kv_id",
+    },
+  },
+  {
+    envVar: "CLOUDFLARE_KV_SDP_CACHE_ID",
+    placeholders: {
+      dev: "your_dev_cache_kv_id",
+      production: "your_production_cache_kv_id",
+    },
+  },
+  {
+    envVar: "CLOUDFLARE_KV_SDP_SESSIONS_ID",
+    placeholders: {
+      dev: "your_dev_sessions_kv_id",
+      production: "your_production_sessions_kv_id",
+    },
+  },
+];
+
+function isPlaceholderLike(value) {
+  return (
+    value === "0".repeat(32) ||
+    value.includes("{") ||
+    value.includes("}") ||
+    value.startsWith("your_") ||
+    value.includes("_your_")
+  );
+}
+
+function requireBindingValue(envVar) {
+  const value = process.env[envVar]?.trim();
+
+  if (!value) {
+    throw new Error(`${envVar} must be set before rendering Wrangler config.`);
+  }
+
+  if (isPlaceholderLike(value)) {
+    throw new Error(`${envVar} still looks like a placeholder.`);
+  }
+
+  return value;
+}
+
+function renderWranglerConfig({ configPath, outPath, target }) {
+  let contents = fs.readFileSync(configPath, "utf8");
+
+  for (const replacement of BINDING_REPLACEMENTS) {
+    const placeholder = replacement.placeholders[target];
+    const value = requireBindingValue(replacement.envVar);
+
+    if (!contents.includes(placeholder)) {
+      throw new Error(`Expected placeholder ${placeholder} was not found in ${configPath}.`);
+    }
+
+    contents = contents.replaceAll(placeholder, value);
+  }
+
+  const remainingTargetPlaceholders = BINDING_REPLACEMENTS.map(
+    (replacement) => replacement.placeholders[target]
+  ).filter((placeholder) => contents.includes(placeholder));
+
+  if (remainingTargetPlaceholders.length > 0) {
+    throw new Error(
+      `Wrangler config still contains unresolved ${target} placeholders: ${remainingTargetPlaceholders.join(", ")}`
+    );
+  }
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, contents, "utf8");
+  process.stdout.write(`Rendered ${target} Wrangler config at ${outPath}\n`);
+}
+
+function printUsage() {
+  process.stderr.write(
+    [
+      "Usage:",
+      "  node scripts/render-wrangler-config.mjs --env <dev|production> --out /tmp/wrangler.toml [--config apps/sdp-api/wrangler.toml]",
+      "",
+    ].join("\n")
+  );
+}
+
+const { values } = parseArgs({
+  options: {
+    config: { type: "string", default: "apps/sdp-api/wrangler.toml" },
+    env: { type: "string" },
+    out: { type: "string" },
+  },
+});
+
+try {
+  const target = values.env;
+
+  if (!target || !TARGETS.has(target)) {
+    throw new Error("--env must be one of: dev, production");
+  }
+
+  if (!values.out) {
+    throw new Error("--out is required");
+  }
+
+  renderWranglerConfig({
+    configPath: values.config,
+    outPath: values.out,
+    target,
+  });
+} catch (error) {
+  printUsage();
+  const message = error instanceof Error ? error.message : "Unknown Wrangler config render error";
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/render-wrangler-config.mjs
+++ b/scripts/render-wrangler-config.mjs
@@ -1,8 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
 const TARGETS = new Set(["dev", "production"]);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_CONFIG_PATH = path.join(REPO_ROOT, "apps/sdp-api/wrangler.toml");
 
 const BINDING_REPLACEMENTS = [
   {
@@ -107,7 +110,7 @@ function printUsage() {
 
 const { values } = parseArgs({
   options: {
-    config: { type: "string", default: "apps/sdp-api/wrangler.toml" },
+    config: { type: "string", default: DEFAULT_CONFIG_PATH },
     env: { type: "string" },
     out: { type: "string" },
   },


### PR DESCRIPTION
## Summary

- replace deploy-time `doppler run` wrappers with `dopplerhq/secrets-fetch-action@v2.0.0`
- render a temporary `apps/sdp-api/.wrangler.<env>.generated.toml` from Doppler-backed Cloudflare binding IDs before `wrangler secret bulk` and `wrangler deploy`
- validate that the fetched Doppler config matches the expected deploy target config
- document the required Doppler binding ID keys and ignore generated Wrangler deploy configs

## Why

The sanitized `wrangler.toml` now keeps placeholder KV namespace and Hyperdrive IDs in git. The latest `Deploy SDP API` run failed because Wrangler deployed with those placeholders, for example `your_dev_rate_limits_kv_id`. Doppler can fetch the real IDs into the runner, but Wrangler still needs those IDs in the config file it reads.

This keeps the committed Wrangler config OSS-safe while rendering the real binding IDs into a temporary config during deploy.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec biome check .github/workflows/deploy-sdp-api.yml docs/ops/doppler-secrets.md scripts/render-wrangler-config.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-sdp-api.yml"); puts "yaml ok"'`
- `git diff --check`
- dev fake binding render + `wrangler deploy --dry-run --config apps/sdp-api/.wrangler.dev.generated.toml --env dev`
- production fake binding render + `wrangler deploy --dry-run --config apps/sdp-api/.wrangler.production.generated.toml --env production`
- `pnpm lint` (passes with existing unused suppression warnings)
- `pnpm --filter ./apps/sdp-api build`

## Follow-up

Before merging/running deploy, the `dev` and `prd` Doppler configs need these keys populated:

- `CLOUDFLARE_HYPERDRIVE_ID`
- `CLOUDFLARE_KV_SDP_API_KEYS_ID`
- `CLOUDFLARE_KV_SDP_RATE_LIMITS_ID`
- `CLOUDFLARE_KV_SDP_CACHE_ID`
- `CLOUDFLARE_KV_SDP_SESSIONS_ID`
