### PR TITLE
chore(deps): bundle zod and openapi updates

### DIFF
--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -51,10 +51,10 @@
     "pg": "^8.16.3",
     "react": "19.2.5",
     "svix": "1.90.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@asteasolutions/zod-to-openapi": "7.2.0",
+    "@asteasolutions/zod-to-openapi": "8.5.0",
     "@cloudflare/vitest-pool-workers": "^0.14.5",
     "@cloudflare/workers-types": "^4.20260413.1",
     "@types/pg": "^8.15.6",

--- a/apps/sdp-api/src/openapi/schemas/admin.ts
+++ b/apps/sdp-api/src/openapi/schemas/admin.ts
@@ -1,5 +1,5 @@
 import { addEntrySchema as addEntrySchemaBase } from "../../routes/allowlist/schemas";
-import { z } from "./base";
+import { withOpenApi, z } from "./base";
 import { allowlistEntryIdParamSchema, isoDateTimeSchema } from "./base";
 
 export const allowlistEntrySchema = z
@@ -34,19 +34,19 @@ export const allowlistEntriesResponseSchema = z
 
 export const addAdminAllowlistEntryRequestSchema = addEntrySchemaBase
   .extend({
-    type: addEntrySchemaBase.shape.type.openapi({
+    type: withOpenApi(addEntrySchemaBase.shape.type, {
       description: "Allowlist entry type.",
       example: "email",
     }),
-    value: addEntrySchemaBase.shape.value.openapi({
+    value: withOpenApi(addEntrySchemaBase.shape.value, {
       description: "Email or domain to allowlist.",
       example: "example.com",
     }),
-    tier: addEntrySchemaBase.shape.tier.openapi({
+    tier: withOpenApi(addEntrySchemaBase.shape.tier, {
       description: "Optional allowlist tier.",
       example: "standard",
     }),
-    notes: addEntrySchemaBase.shape.notes.openapi({
+    notes: withOpenApi(addEntrySchemaBase.shape.notes, {
       description: "Optional notes.",
       example: "Approved partner",
     }),

--- a/apps/sdp-api/src/openapi/schemas/api-keys.ts
+++ b/apps/sdp-api/src/openapi/schemas/api-keys.ts
@@ -4,7 +4,7 @@ import {
   apiKeyRotateSchema as apiKeyRotateSchemaBase,
   apiKeyUpdateSchema as apiKeyUpdateSchemaBase,
 } from "../../routes/api-keys/schemas";
-import { z } from "./base";
+import { withOpenApi, z } from "./base";
 import {
   apiKeyIdParamSchema,
   apiKeyPrefixSchema,
@@ -212,61 +212,61 @@ export const revokeApiKeyResponseSchema = z
 
 export const createApiKeyRequestSchema = apiKeyCreateSchemaBase
   .extend({
-    name: apiKeyCreateSchemaBase.shape.name.openapi({
+    name: withOpenApi(apiKeyCreateSchemaBase.shape.name, {
       description: "Friendly name for the API key.",
       example: "Primary Key",
     }),
-    description: apiKeyCreateSchemaBase.shape.description.openapi({
+    description: withOpenApi(apiKeyCreateSchemaBase.shape.description, {
       description: "Optional key description.",
       example: "Used by backend service.",
     }),
-    role: apiKeyCreateSchemaBase.shape.role.openapi({
+    role: withOpenApi(apiKeyCreateSchemaBase.shape.role, {
       description: "Role assigned to this API key.",
       example: "api_developer",
     }),
-    environment: apiKeyCreateSchemaBase.shape.environment.openapi({
+    environment: withOpenApi(apiKeyCreateSchemaBase.shape.environment, {
       description: "Target environment for the key.",
       example: "sandbox",
     }),
-    walletScope: apiKeyCreateSchemaBase.shape.walletScope.openapi({
+    walletScope: withOpenApi(apiKeyCreateSchemaBase.shape.walletScope, {
       description:
         "Explicit wallet access mode. Use 'all' to allow every wallet in scope or 'selected' to bind specific wallets.",
       example: "selected",
     }),
-    allowedIps: apiKeyCreateSchemaBase.shape.allowedIps.openapi({
+    allowedIps: withOpenApi(apiKeyCreateSchemaBase.shape.allowedIps, {
       description: "Optional list of CIDR ranges allowed to use the key.",
       example: ["203.0.113.0/24"],
     }),
-    expiresAt: apiKeyCreateSchemaBase.shape.expiresAt.openapi({
+    expiresAt: withOpenApi(apiKeyCreateSchemaBase.shape.expiresAt, {
       description: "Optional expiration timestamp.",
       example: "2025-12-31T00:00:00.000Z",
     }),
-    permissions: apiKeyCreateSchemaBase.shape.permissions.openapi({
+    permissions: withOpenApi(apiKeyCreateSchemaBase.shape.permissions, {
       description: "Optional explicit permission set. Requires admin access.",
       example: ["tokens:read", "tokens:write"],
     }),
-    signingWalletId: apiKeyCreateSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(apiKeyCreateSchemaBase.shape.signingWalletId, {
       description: "Optional default custody wallet ID to bind this key to.",
       example: "privy_wallet_123",
     }),
-    signingWalletIds: apiKeyCreateSchemaBase.shape.signingWalletIds.openapi({
+    signingWalletIds: withOpenApi(apiKeyCreateSchemaBase.shape.signingWalletIds, {
       description:
         "Optional list of custody wallet IDs to bind to this key. The first wallet becomes default unless signingWalletId is explicitly set.",
       example: ["privy_wallet_123", "dfns_wallet_456"],
     }),
-    walletBindings: apiKeyCreateSchemaBase.shape.walletBindings.openapi({
+    walletBindings: withOpenApi(apiKeyCreateSchemaBase.shape.walletBindings, {
       description:
         "Optional wallet-level permission bindings. Use this to attach multiple wallets with scoped permissions.",
     }),
-    provisionWallet: apiKeyCreateSchemaBase.shape.provisionWallet.openapi({
+    provisionWallet: withOpenApi(apiKeyCreateSchemaBase.shape.provisionWallet, {
       description: "If true, provisions a new custody wallet and binds it to the key.",
       example: false,
     }),
-    walletLabel: apiKeyCreateSchemaBase.shape.walletLabel.openapi({
+    walletLabel: withOpenApi(apiKeyCreateSchemaBase.shape.walletLabel, {
       description: "Optional label for a provisioned wallet.",
       example: "Mint authority wallet",
     }),
-    walletPurpose: apiKeyCreateSchemaBase.shape.walletPurpose.openapi({
+    walletPurpose: withOpenApi(apiKeyCreateSchemaBase.shape.walletPurpose, {
       description: "Optional purpose for a provisioned wallet.",
       example: "mint_authority",
     }),
@@ -275,41 +275,41 @@ export const createApiKeyRequestSchema = apiKeyCreateSchemaBase
 
 export const updateApiKeyRequestSchema = apiKeyUpdateSchemaBase
   .extend({
-    name: apiKeyUpdateSchemaBase.shape.name.openapi({
+    name: withOpenApi(apiKeyUpdateSchemaBase.shape.name, {
       description: "Updated key name.",
       example: "Primary Key Updated",
     }),
-    description: apiKeyUpdateSchemaBase.shape.description.openapi({
+    description: withOpenApi(apiKeyUpdateSchemaBase.shape.description, {
       description: "Updated description. Use null to clear.",
       example: "Rotated key for new service.",
     }),
-    walletScope: apiKeyUpdateSchemaBase.shape.walletScope.openapi({
+    walletScope: withOpenApi(apiKeyUpdateSchemaBase.shape.walletScope, {
       description:
         "Updated wallet access mode. Provide this when changing wallet bindings, or by itself to reset the key to all wallets.",
       example: "all",
     }),
-    allowedIps: apiKeyUpdateSchemaBase.shape.allowedIps.openapi({
+    allowedIps: withOpenApi(apiKeyUpdateSchemaBase.shape.allowedIps, {
       description: "Updated IP allowlist. Use null to clear.",
       example: ["203.0.113.0/24"],
     }),
-    expiresAt: apiKeyUpdateSchemaBase.shape.expiresAt.openapi({
+    expiresAt: withOpenApi(apiKeyUpdateSchemaBase.shape.expiresAt, {
       description: "Updated expiration. Use null to clear.",
       example: "2026-01-01T00:00:00.000Z",
     }),
-    permissions: apiKeyUpdateSchemaBase.shape.permissions.openapi({
+    permissions: withOpenApi(apiKeyUpdateSchemaBase.shape.permissions, {
       description: "Updated explicit permission set. Use null to revert to role defaults.",
       example: ["tokens:read", "tokens:write"],
     }),
-    signingWalletId: apiKeyUpdateSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(apiKeyUpdateSchemaBase.shape.signingWalletId, {
       description: "Updated default signing wallet binding. Use null to clear all wallet bindings.",
       example: "privy_wallet_123",
     }),
-    signingWalletIds: apiKeyUpdateSchemaBase.shape.signingWalletIds.openapi({
+    signingWalletIds: withOpenApi(apiKeyUpdateSchemaBase.shape.signingWalletIds, {
       description:
         "Updated list of wallet IDs bound to this key. Use null to clear all wallet bindings.",
       example: ["privy_wallet_123", "dfns_wallet_456"],
     }),
-    walletBindings: apiKeyUpdateSchemaBase.shape.walletBindings.openapi({
+    walletBindings: withOpenApi(apiKeyUpdateSchemaBase.shape.walletBindings, {
       description:
         "Updated wallet-level permission bindings. Use null to clear all wallet bindings.",
     }),
@@ -318,7 +318,7 @@ export const updateApiKeyRequestSchema = apiKeyUpdateSchemaBase
 
 export const rotateApiKeyRequestSchema = apiKeyRotateSchemaBase
   .extend({
-    gracePeriodHours: apiKeyRotateSchemaBase.shape.gracePeriodHours.openapi({
+    gracePeriodHours: withOpenApi(apiKeyRotateSchemaBase.shape.gracePeriodHours, {
       description: "Grace period for the old key before revocation.",
       example: 24,
     }),

--- a/apps/sdp-api/src/openapi/schemas/base.ts
+++ b/apps/sdp-api/src/openapi/schemas/base.ts
@@ -5,6 +5,17 @@ extendZodWithOpenApi(z);
 
 export { z };
 
+type OpenApiArgs = [unknown, unknown?, unknown?];
+type OpenApiMethod = (this: z.ZodType, ...args: OpenApiArgs) => z.ZodType;
+
+export function withOpenApi<T extends z.ZodType>(schema: T, ...args: OpenApiArgs): T {
+  const openapi =
+    (schema as { openapi?: OpenApiMethod }).openapi ??
+    (z.ZodType as unknown as { prototype: { openapi: OpenApiMethod } }).prototype.openapi;
+
+  return openapi.apply(schema, args) as T;
+}
+
 export const isoDateTimeSchema = z.string().datetime().openapi({
   description: "ISO 8601 timestamp.",
   example: "2025-01-01T00:00:00.000Z",
@@ -142,7 +153,7 @@ export const errorSchema = z
     code: errorCodeSchema,
     message: z.string().openapi({ description: "Human-readable error message." }),
     details: z
-      .record(z.unknown())
+      .record(z.string(), z.unknown())
       .optional()
       .openapi({ description: "Optional error details for debugging." }),
   })

--- a/apps/sdp-api/src/openapi/schemas/custody.ts
+++ b/apps/sdp-api/src/openapi/schemas/custody.ts
@@ -7,7 +7,7 @@ import {
   switchSigningSchema as switchSigningSchemaBase,
   updateWalletSchema as updateWalletSchemaBase,
 } from "../../routes/custody/schemas";
-import { z } from "./base";
+import { withOpenApi, z } from "./base";
 import {
   isoDateTimeSchema,
   projectIdParamSchema,
@@ -15,15 +15,15 @@ import {
   walletIdParamSchema,
 } from "./base";
 
-export const initializeSigningRequestSchema = initializeSigningSchemaBase.openapi({
+export const initializeSigningRequestSchema = withOpenApi(initializeSigningSchemaBase, {
   description: "Initialize wallet signing provider for the organization or project.",
 });
 
-export const switchSigningRequestSchema = switchSigningSchemaBase.openapi({
+export const switchSigningRequestSchema = withOpenApi(switchSigningSchemaBase, {
   description: "Switch the active wallet signing provider for the organization or project.",
 });
 
-export const signerCheckRequestSchema = signerCheckSchemaBase.openapi({
+export const signerCheckRequestSchema = withOpenApi(signerCheckSchemaBase, {
   description:
     "Optional memo payload for signer check. Signing wallet is resolved from the API key binding.",
 });
@@ -40,15 +40,15 @@ export const createCustodyWalletRequestSchema = createWalletSchemaBase
         "Optional provider target. Defaults to the currently resolved default provider for the scope.",
       example: "privy",
     }),
-    label: createWalletSchemaBase.shape.label.openapi({
+    label: withOpenApi(createWalletSchemaBase.shape.label, {
       description: "Optional label for the new wallet.",
       example: "Mint authority wallet",
     }),
-    purpose: createWalletSchemaBase.shape.purpose.openapi({
+    purpose: withOpenApi(createWalletSchemaBase.shape.purpose, {
       description: "Optional semantic purpose for the wallet.",
       example: "mint_authority",
     }),
-    setDefault: createWalletSchemaBase.shape.setDefault.openapi({
+    setDefault: withOpenApi(createWalletSchemaBase.shape.setDefault, {
       description: "Set this wallet as the default signer for the active wallet signing config.",
       example: true,
     }),
@@ -87,7 +87,7 @@ export const deleteWalletRequestSchema = deleteWalletSchemaBase
 
 export const updateCustodyWalletRequestSchema = updateWalletSchemaBase
   .extend({
-    label: updateWalletSchemaBase.shape.label.openapi({
+    label: withOpenApi(updateWalletSchemaBase.shape.label, {
       description: "Optional wallet label. Set to null to clear the label.",
       example: "Treasury signer",
     }),

--- a/apps/sdp-api/src/openapi/schemas/issuance.ts
+++ b/apps/sdp-api/src/openapi/schemas/issuance.ts
@@ -11,7 +11,7 @@ import {
   updateAuthoritySchema as updateAuthoritySchemaBase,
   updateTokenSchema as updateTokenSchemaBase,
 } from "../../routes/issuance/schemas";
-import { z } from "./base";
+import { withOpenApi, z } from "./base";
 import {
   apiKeyIdParamSchema,
   base64Schema,
@@ -257,7 +257,7 @@ export const tokenTransactionSchema = z
       example: "AQID",
     }),
     params: z
-      .record(z.unknown())
+      .record(z.string(), z.unknown())
       .openapi({ description: "Operation parameters captured for audit." }),
     slot: z
       .number()
@@ -665,35 +665,35 @@ const templateOverridesOpenApiSchema = z
 
 export const createTokenRequestSchema = createTokenSchemaBase
   .extend({
-    name: createTokenSchemaBase.shape.name.openapi({
+    name: withOpenApi(createTokenSchemaBase.shape.name, {
       description: "Token name.",
       example: "Example Token",
     }),
-    symbol: createTokenSchemaBase.shape.symbol.openapi({
+    symbol: withOpenApi(createTokenSchemaBase.shape.symbol, {
       description: "Ticker symbol.",
       example: "EXM",
     }),
-    decimals: createTokenSchemaBase.shape.decimals.openapi({
+    decimals: withOpenApi(createTokenSchemaBase.shape.decimals, {
       description: "Token decimals.",
       example: 6,
     }),
-    description: createTokenSchemaBase.shape.description.openapi({
+    description: withOpenApi(createTokenSchemaBase.shape.description, {
       description: "Token description.",
       example: "Example token description.",
     }),
-    uri: createTokenSchemaBase.shape.uri.openapi({
+    uri: withOpenApi(createTokenSchemaBase.shape.uri, {
       description: "Metadata URI passed to on-chain token metadata (points to off-chain JSON).",
       example: "https://example.com/metadata.json",
     }),
-    imageUrl: createTokenSchemaBase.shape.imageUrl.openapi({
+    imageUrl: withOpenApi(createTokenSchemaBase.shape.imageUrl, {
       description: "Token image URL.",
       example: "https://example.com/token.png",
     }),
-    maxSupply: createTokenSchemaBase.shape.maxSupply.openapi({
+    maxSupply: withOpenApi(createTokenSchemaBase.shape.maxSupply, {
       description: "Maximum supply as a string (UI units).",
       example: "1000000",
     }),
-    template: createTokenSchemaBase.shape.template.openapi({
+    template: withOpenApi(createTokenSchemaBase.shape.template, {
       description: "Token template preset. Defaults to 'custom' if not specified.",
       example: "stablecoin",
     }),
@@ -709,15 +709,15 @@ export const createTokenRequestSchema = createTokenSchemaBase
         },
       },
     }),
-    requiresAllowlist: createTokenSchemaBase.shape.requiresAllowlist.openapi({
+    requiresAllowlist: withOpenApi(createTokenSchemaBase.shape.requiresAllowlist, {
       description: "Require allowlist checks for transfers.",
       example: true,
     }),
-    isMintable: createTokenSchemaBase.shape.isMintable.openapi({
+    isMintable: withOpenApi(createTokenSchemaBase.shape.isMintable, {
       description: "Allow minting after creation.",
       example: true,
     }),
-    isFreezable: createTokenSchemaBase.shape.isFreezable.openapi({
+    isFreezable: withOpenApi(createTokenSchemaBase.shape.isFreezable, {
       description: "Allow freezing token accounts.",
       example: true,
     }),
@@ -726,27 +726,27 @@ export const createTokenRequestSchema = createTokenSchemaBase
 
 export const updateTokenRequestSchema = updateTokenSchemaBase
   .extend({
-    name: updateTokenSchemaBase.shape.name.openapi({
+    name: withOpenApi(updateTokenSchemaBase.shape.name, {
       description:
         "Updated token name. For deployed tokens, this updates on-chain Token-2022 metadata using the current metadata authority.",
       example: "Example Token Updated",
     }),
-    description: updateTokenSchemaBase.shape.description.openapi({
+    description: withOpenApi(updateTokenSchemaBase.shape.description, {
       description:
         "Updated token description. For deployed tokens, this writes the on-chain `description` metadata field. Use null to clear the displayed value.",
       example: "Updated token description.",
     }),
-    uri: updateTokenSchemaBase.shape.uri.openapi({
+    uri: withOpenApi(updateTokenSchemaBase.shape.uri, {
       description:
         "Updated metadata URI. For deployed tokens, this updates the on-chain Token-2022 metadata URI using the current metadata authority. Use null to clear.",
       example: "https://example.com/metadata.json",
     }),
-    imageUrl: updateTokenSchemaBase.shape.imageUrl.openapi({
+    imageUrl: withOpenApi(updateTokenSchemaBase.shape.imageUrl, {
       description:
         "Updated image URL. For deployed tokens, this writes the on-chain `image` metadata field. Use null to clear the displayed value.",
       example: "https://example.com/token.png",
     }),
-    status: updateTokenSchemaBase.shape.status.openapi({
+    status: withOpenApi(updateTokenSchemaBase.shape.status, {
       description: "Token operational status.",
       example: "active",
     }),
@@ -755,11 +755,11 @@ export const updateTokenRequestSchema = updateTokenSchemaBase
 
 export const mintRequestSchema = mintSchemaBase
   .extend({
-    signingWalletId: mintSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(mintSchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this action.",
       example: "wal_example",
     }),
-    mint: mintSchemaBase.shape.mint.openapi({
+    mint: withOpenApi(mintSchemaBase.shape.mint, {
       description: "Mint operation details.",
       example: {
         destination: "So11111111111111111111111111111111111111112",
@@ -767,7 +767,7 @@ export const mintRequestSchema = mintSchemaBase
         memo: "Payout",
       },
     }),
-    options: mintSchemaBase.shape.options.openapi({
+    options: withOpenApi(mintSchemaBase.shape.options, {
       description: "Mint execution options.",
       example: { priorityFee: "low", simulate: true },
     }),
@@ -776,11 +776,11 @@ export const mintRequestSchema = mintSchemaBase
 
 export const burnRequestSchema = burnSchemaBase
   .extend({
-    signingWalletId: burnSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(burnSchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this action.",
       example: "wal_example",
     }),
-    burn: burnSchemaBase.shape.burn.openapi({
+    burn: withOpenApi(burnSchemaBase.shape.burn, {
       description: "Burn operation details.",
       example: {
         source: "So11111111111111111111111111111111111111112",
@@ -788,7 +788,7 @@ export const burnRequestSchema = burnSchemaBase
         memo: "Correction",
       },
     }),
-    options: burnSchemaBase.shape.options.openapi({
+    options: withOpenApi(burnSchemaBase.shape.options, {
       description: "Burn execution options.",
       example: { priorityFee: "low", simulate: true },
     }),
@@ -797,11 +797,11 @@ export const burnRequestSchema = burnSchemaBase
 
 export const seizeRequestSchema = seizeSchemaBase
   .extend({
-    signingWalletId: seizeSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(seizeSchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this action.",
       example: "wal_example",
     }),
-    seize: seizeSchemaBase.shape.seize.openapi({
+    seize: withOpenApi(seizeSchemaBase.shape.seize, {
       description: "Forced transfer details.",
       example: {
         source: "So11111111111111111111111111111111111111112",
@@ -811,7 +811,7 @@ export const seizeRequestSchema = seizeSchemaBase
         memo: "Compliance seizure",
       },
     }),
-    options: seizeSchemaBase.shape.options.openapi({
+    options: withOpenApi(seizeSchemaBase.shape.options, {
       description: "Seize execution options.",
       example: { priorityFee: "low", simulate: true },
     }),
@@ -820,11 +820,11 @@ export const seizeRequestSchema = seizeSchemaBase
 
 export const forceBurnRequestSchema = forceBurnSchemaBase
   .extend({
-    signingWalletId: forceBurnSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(forceBurnSchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this action.",
       example: "wal_example",
     }),
-    forceBurn: forceBurnSchemaBase.shape.forceBurn.openapi({
+    forceBurn: withOpenApi(forceBurnSchemaBase.shape.forceBurn, {
       description: "Forced burn details.",
       example: {
         source: "So11111111111111111111111111111111111111112",
@@ -833,7 +833,7 @@ export const forceBurnRequestSchema = forceBurnSchemaBase
         memo: "Compliance burn",
       },
     }),
-    options: forceBurnSchemaBase.shape.options.openapi({
+    options: withOpenApi(forceBurnSchemaBase.shape.options, {
       description: "Force burn execution options.",
       example: { priorityFee: "low", simulate: true },
     }),
@@ -842,18 +842,18 @@ export const forceBurnRequestSchema = forceBurnSchemaBase
 
 export const updateAuthorityRequestSchema = updateAuthoritySchemaBase
   .extend({
-    signingWalletId: updateAuthoritySchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(updateAuthoritySchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this action.",
       example: "wal_example",
     }),
-    authority: updateAuthoritySchemaBase.shape.authority.openapi({
+    authority: withOpenApi(updateAuthoritySchemaBase.shape.authority, {
       description: "Authority update details.",
       example: {
         role: "mint",
         newAuthority: "So11111111111111111111111111111111111111112",
       },
     }),
-    options: updateAuthoritySchemaBase.shape.options.openapi({
+    options: withOpenApi(updateAuthoritySchemaBase.shape.options, {
       description: "Authority update options.",
       example: { priorityFee: "low", simulate: true },
     }),
@@ -862,7 +862,7 @@ export const updateAuthorityRequestSchema = updateAuthoritySchemaBase
 
 export const pauseTokenRequestSchema = pauseTokenSchemaBase
   .extend({
-    options: pauseTokenSchemaBase.shape.options.openapi({
+    options: withOpenApi(pauseTokenSchemaBase.shape.options, {
       description: "Pause/unpause options.",
       example: { priorityFee: "low", simulate: true },
     }),
@@ -871,16 +871,16 @@ export const pauseTokenRequestSchema = pauseTokenSchemaBase
 
 export const freezeAccountRequestSchema = freezeSchemaBase
   .extend({
-    accountAddress: freezeSchemaBase.shape.accountAddress.openapi({
+    accountAddress: withOpenApi(freezeSchemaBase.shape.accountAddress, {
       description:
         "Wallet or token account address to freeze. SDP resolves the associated token account automatically when a wallet address is provided.",
       example: "So11111111111111111111111111111111111111112",
     }),
-    reason: freezeSchemaBase.shape.reason.openapi({
+    reason: withOpenApi(freezeSchemaBase.shape.reason, {
       description: "Optional reason for freezing.",
       example: "Compliance hold",
     }),
-    signingWalletId: freezeSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(freezeSchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this request.",
       example: "privy_abcd1234",
     }),
@@ -889,12 +889,12 @@ export const freezeAccountRequestSchema = freezeSchemaBase
 
 export const unfreezeAccountRequestSchema = unfreezeSchemaBase
   .extend({
-    accountAddress: unfreezeSchemaBase.shape.accountAddress.openapi({
+    accountAddress: withOpenApi(unfreezeSchemaBase.shape.accountAddress, {
       description:
         "Wallet or token account address to unfreeze. SDP resolves the associated token account automatically when a wallet address is provided.",
       example: "So11111111111111111111111111111111111111112",
     }),
-    signingWalletId: unfreezeSchemaBase.shape.signingWalletId.openapi({
+    signingWalletId: withOpenApi(unfreezeSchemaBase.shape.signingWalletId, {
       description: "Optional custody wallet ID to use as the signer for this request.",
       example: "privy_abcd1234",
     }),
@@ -903,11 +903,11 @@ export const unfreezeAccountRequestSchema = unfreezeSchemaBase
 
 export const addTokenAllowlistRequestSchema = addTokenAllowlistSchemaBase
   .extend({
-    address: addTokenAllowlistSchemaBase.shape.address.openapi({
+    address: withOpenApi(addTokenAllowlistSchemaBase.shape.address, {
       description: "Wallet address to allowlist.",
       example: "So11111111111111111111111111111111111111112",
     }),
-    label: addTokenAllowlistSchemaBase.shape.label.openapi({
+    label: withOpenApi(addTokenAllowlistSchemaBase.shape.label, {
       description: "Optional label for the allowlist entry.",
       example: "Treasury",
     }),
@@ -988,7 +988,7 @@ export const tokenTemplateInfoSchema = z
       description: "Extensions that can be configured for this template.",
       example: ["scaledUiAmount", "interestBearing"],
     }),
-    defaultExtensions: z.record(z.unknown()).openapi({
+    defaultExtensions: z.record(z.string(), z.unknown()).openapi({
       description: "Default extension values used by this template.",
       example: {
         defaultAccountState: "initialized",

--- a/apps/sdp-api/src/openapi/schemas/organizations.ts
+++ b/apps/sdp-api/src/openapi/schemas/organizations.ts
@@ -4,7 +4,7 @@ import {
   inviteSchema as inviteSchemaBase,
 } from "../../routes/members/schemas";
 import { updateOrgSchema as updateOrgSchemaBase } from "../../routes/organizations/schemas";
-import { z } from "./base";
+import { withOpenApi, z } from "./base";
 import {
   invitationIdSchema,
   isoDateTimeSchema,
@@ -132,11 +132,11 @@ export const inviteMemberResponseSchema = z
 
 export const updateOrganizationRequestSchema = updateOrgSchemaBase
   .extend({
-    name: updateOrgSchemaBase.shape.name.openapi({
+    name: withOpenApi(updateOrgSchemaBase.shape.name, {
       description: "Updated organization name.",
       example: "Example Org Updated",
     }),
-    settings: updateOrgSchemaBase.shape.settings.openapi({
+    settings: withOpenApi(updateOrgSchemaBase.shape.settings, {
       description: "Organization settings to update.",
       example: {
         rpcProvider: "default",
@@ -149,11 +149,11 @@ export const updateOrganizationRequestSchema = updateOrgSchemaBase
 
 export const inviteMemberRequestSchema = inviteSchemaBase
   .extend({
-    email: inviteSchemaBase.shape.email.openapi({
+    email: withOpenApi(inviteSchemaBase.shape.email, {
       description: "Invitee email address.",
       example: "dev@example.com",
     }),
-    role: inviteSchemaBase.shape.role.openapi({
+    role: withOpenApi(inviteSchemaBase.shape.role, {
       description: "Role assigned to the invited member.",
       example: "member",
     }),
@@ -162,11 +162,11 @@ export const inviteMemberRequestSchema = inviteSchemaBase
 
 export const acceptInvitationRequestSchema = acceptSchemaBase
   .extend({
-    token: acceptSchemaBase.shape.token.openapi({
+    token: withOpenApi(acceptSchemaBase.shape.token, {
       description: "Invitation token from email.",
       example: "invitation_token",
     }),
-    name: acceptSchemaBase.shape.name.openapi({
+    name: withOpenApi(acceptSchemaBase.shape.name, {
       description: "Optional name to set for the user.",
       example: "Example User",
     }),

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -27,7 +27,7 @@ export const custodyConfigSchema = z
   .object({
     provider: custodyProviderSchema,
     config: z
-      .record(z.unknown())
+      .record(z.string(), z.unknown())
       .optional()
       .openapi({ description: "Provider-specific configuration payload." }),
   })
@@ -367,7 +367,7 @@ const rampProviderSchema = z.enum(["moonpay", "lightspark", "bvnk"]).openapi({
 const bvnkComplianceSchema = z
   .object({
     partyDetails: z
-      .array(z.record(z.unknown()))
+      .array(z.record(z.string(), z.unknown()))
       .min(1)
       .openapi({ description: "BVNK party details payload. Required for BVNK off-ramp flows." }),
   })

--- a/apps/sdp-api/src/openapi/schemas/projects.ts
+++ b/apps/sdp-api/src/openapi/schemas/projects.ts
@@ -6,7 +6,7 @@ import {
   updateProjectSchema as updateProjectSchemaBase,
 } from "../../routes/projects/schemas";
 import { apiKeyListItemSchema } from "./api-keys";
-import { z } from "./base";
+import { withOpenApi, z } from "./base";
 import {
   isoDateTimeSchema,
   orgIdParamSchema,
@@ -32,7 +32,7 @@ export const projectSettingsSchema = z
       example: "https://example.com/webhook",
     }),
     metadata: z
-      .record(z.string())
+      .record(z.string(), z.string())
       .optional()
       .openapi({
         description: "Arbitrary metadata key/value pairs.",
@@ -143,23 +143,23 @@ export const listProjectApiKeysResponseSchema = z
 
 export const createProjectRequestSchema = createProjectSchemaBase
   .extend({
-    name: createProjectSchemaBase.shape.name.openapi({
+    name: withOpenApi(createProjectSchemaBase.shape.name, {
       description: "Project name.",
       example: "Payments",
     }),
-    slug: createProjectSchemaBase.shape.slug.openapi({
+    slug: withOpenApi(createProjectSchemaBase.shape.slug, {
       description: "Optional URL-friendly slug.",
       example: "payments",
     }),
-    description: createProjectSchemaBase.shape.description.openapi({
+    description: withOpenApi(createProjectSchemaBase.shape.description, {
       description: "Optional project description.",
       example: "Project for payments workflows.",
     }),
-    environment: createProjectSchemaBase.shape.environment.openapi({
+    environment: withOpenApi(createProjectSchemaBase.shape.environment, {
       description: "Project environment.",
       example: "sandbox",
     }),
-    settings: createProjectSchemaBase.shape.settings.openapi({
+    settings: withOpenApi(createProjectSchemaBase.shape.settings, {
       description: "Optional project settings.",
       example: {
         rpcProvider: "default",
@@ -172,19 +172,19 @@ export const createProjectRequestSchema = createProjectSchemaBase
 
 export const updateProjectRequestSchema = updateProjectSchemaBase
   .extend({
-    name: updateProjectSchemaBase.shape.name.openapi({
+    name: withOpenApi(updateProjectSchemaBase.shape.name, {
       description: "Updated project name.",
       example: "Payments Updated",
     }),
-    description: updateProjectSchemaBase.shape.description.openapi({
+    description: withOpenApi(updateProjectSchemaBase.shape.description, {
       description: "Updated description. Use null to clear.",
       example: "Updated project description.",
     }),
-    environment: updateProjectSchemaBase.shape.environment.openapi({
+    environment: withOpenApi(updateProjectSchemaBase.shape.environment, {
       description: "Updated project environment.",
       example: "production",
     }),
-    settings: updateProjectSchemaBase.shape.settings.openapi({
+    settings: withOpenApi(updateProjectSchemaBase.shape.settings, {
       description: "Updated project settings. Use null to clear.",
       example: {
         rpcProvider: "custom",
@@ -196,11 +196,11 @@ export const updateProjectRequestSchema = updateProjectSchemaBase
 
 export const addProjectMemberRequestSchema = addMemberSchemaBase
   .extend({
-    userId: addMemberSchemaBase.shape.userId.openapi({
+    userId: withOpenApi(addMemberSchemaBase.shape.userId, {
       description: "User identifier to add to the project.",
       example: "usr_example",
     }),
-    role: addMemberSchemaBase.shape.role.openapi({
+    role: withOpenApi(addMemberSchemaBase.shape.role, {
       description: "Role for the project member.",
       example: "developer",
     }),
@@ -209,7 +209,7 @@ export const addProjectMemberRequestSchema = addMemberSchemaBase
 
 export const updateProjectMemberRequestSchema = updateMemberSchemaBase
   .extend({
-    role: updateMemberSchemaBase.shape.role.openapi({
+    role: withOpenApi(updateMemberSchemaBase.shape.role, {
       description: "Updated project member role.",
       example: "admin",
     }),

--- a/apps/sdp-api/src/openapi/schemas/rpc.ts
+++ b/apps/sdp-api/src/openapi/schemas/rpc.ts
@@ -35,7 +35,7 @@ const rpcProviderStatsSchema = z
     }),
     lastStatusCode: z.number().int().nullable().openapi({ example: 200 }),
     lastMethod: z.string().nullable().openapi({ example: "sendTransaction" }),
-    origins: z.record(z.number().int().nonnegative()).openapi({
+    origins: z.record(z.string(), z.number().int().nonnegative()).openapi({
       description: "Best-effort per-origin request counters.",
       example: { "https://dashboard.example.com": 12 },
     }),

--- a/apps/sdp-api/src/routes/projects/schemas.ts
+++ b/apps/sdp-api/src/routes/projects/schemas.ts
@@ -18,7 +18,7 @@ export const createProjectSchema = z.object({
       rpcProvider: projectRpcProviderSchema.optional(),
       rpcEndpoint: z.string().url().optional(),
       webhookUrl: z.string().url().optional(),
-      metadata: z.record(z.string()).optional(),
+      metadata: z.record(z.string(), z.string()).optional(),
     })
     .optional()
     .superRefine((value, ctx) => {
@@ -45,7 +45,7 @@ export const updateProjectSchema = z.object({
       rpcProvider: projectRpcProviderSchema.optional(),
       rpcEndpoint: z.string().url().optional(),
       webhookUrl: z.string().url().optional(),
-      metadata: z.record(z.string()).optional(),
+      metadata: z.record(z.string(), z.string()).optional(),
     })
     .nullable()
     .optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,12 +120,12 @@ importers:
         specifier: 1.90.0
         version: 1.90.0
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@asteasolutions/zod-to-openapi':
-        specifier: 7.2.0
-        version: 7.2.0(zod@3.25.76)
+        specifier: 8.5.0
+        version: 8.5.0(zod@4.3.6)
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.14.5
         version: 0.14.5(@cloudflare/workers-types@4.20260413.1)(@vitest/runner@4.1.4)(@vitest/snapshot@4.1.4)(vitest@4.1.4)
@@ -364,10 +364,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@asteasolutions/zod-to-openapi@7.2.0':
-    resolution: {integrity: sha512-Va+Fq1QzKkSgmiYINSp3cASFhMsbdRH/kmCk2feijhC+yNjGoC056CRqihrVFhR8MY8HOZHdlYm2Ns2lmszCiw==}
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
-      zod: ^3.20.2
+      zod: ^4.0.0
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -7197,10 +7197,10 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@asteasolutions/zod-to-openapi@7.2.0(zod@3.25.76)':
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.3.6)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@babel/code-frame@7.29.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Bumps @sdp/api from zod 3.25.x to zod 4.3.6.
- Bumps @asteasolutions/zod-to-openapi from 7.2.0 to 8.5.0 so OpenAPI generation uses the Zod 4-compatible adapter.
- Updates Zod 4 record callsites to the explicit key/value signature while preserving existing metadata semantics.
- Regenerated OpenAPI, API reference docs, AI resources, and Postman collection; no generated API/docs artifacts changed.

Supersedes Dependabot PRs #209 and #210.

## Validation
- [x] pnpm --filter @sdp/api typecheck
- [x] pnpm --filter @sdp/api openapi:generate
- [x] pnpm --filter sdp-docs generate:api
- [x] pnpm --filter sdp-docs check:links
- [x] pnpm --filter @sdp/api build
- [x] pnpm typecheck
- [x] pnpm lint (passes with existing Biome unused-suppression warnings in integration tests)
- [x] pnpm --filter sdp-docs build
- [ ] pnpm --filter @sdp/api test (blocked locally: Postgres at 127.0.0.1:5432 unavailable; pnpm db:postgres:up is blocked because Docker daemon is not running)
