### PR TITLE
fix(web): align API playground status badges

### DIFF
--- a/apps/sdp-web/src/components/api-playground-shell.tsx
+++ b/apps/sdp-web/src/components/api-playground-shell.tsx
@@ -953,12 +953,17 @@ export function ApiPlaygroundShell({
                   boxShadow: "inset 0 1px 0 var(--code-block-header-border)",
                 }}
               >
-                <span className="text-text-low">Status:</span>
-                <Badge variant={statusToneVariant}>{statusLabel}</Badge>
+                <span className="leading-none text-text-low">Status:</span>
+                <Badge
+                  className="h-6 whitespace-nowrap px-2.5 leading-none"
+                  variant={statusToneVariant}
+                >
+                  {statusLabel}
+                </Badge>
                 {executionResult ? (
-                  <Badge className="gap-1">
-                    <Clock3 className="h-3 w-3" />
-                    {executionResult.durationMs}ms
+                  <Badge className="h-6 whitespace-nowrap px-2.5 leading-none [&>span]:inline-flex [&>span]:items-center [&>span]:gap-1.5 [&>span]:leading-none">
+                    <Clock3 className="inline-block size-3 shrink-0" aria-hidden="true" />
+                    <span className="tabular-nums">{executionResult.durationMs}ms</span>
                   </Badge>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary

- Align the API playground response footer badges shown after a request executes.
- Give the status and duration badges a fixed height and no-wrap text behavior.
- Keep the clock icon centered with the duration text and use tabular numbers for stable timing display.

## Why

The duration badge could render with the clock icon and elapsed time split vertically, as shown in the attached screenshot. The badge now keeps the icon and text on a single centered row.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec biome format --write apps/sdp-web/src/components/api-playground-shell.tsx`
- `pnpm exec biome check apps/sdp-web/src/components/api-playground-shell.tsx`
- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web build`

Note: the focused Biome check exits successfully and still reports an existing warning in the same file for a literal example string containing `${API_KEY}`.
