### PR TITLE
docs: simplify README and public OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,83 @@
 # Solana Developer Platform
 
-Maintainer guidance for Doppler-backed secrets and deploy setup lives in [docs/ops/doppler-secrets.md](docs/ops/doppler-secrets.md).
+Solana Developer Platform is an API, dashboard, and docs workspace for building Solana-based issuance, payments, wallet, and compliance workflows.
 
-## Community & Governance
+SDP is **devnet-only for now**. Mainnet support is not part of the public getting-started path yet.
+
+Self-hosting and deployment guides are coming.
+
+## Workspace
+
+- `apps/sdp-api`: Cloudflare Workers API, OpenAPI source, route handlers, and data integrations
+- `apps/sdp-web`: dashboard application
+- `apps/sdp-docs`: public documentation site and generated API reference
+- `packages/sdp-types`: shared runtime types and product constants
+
+## Providers
+
+SDP requires credentials from the providers you enable. Provider accounts, API keys, wallets, policies, and compliance settings are managed with those providers directly.
+
+RPC:
+
+- Solana devnet RPC
+- Alchemy
+- Helius
+- QuickNode
+- Triton
+
+Custody and wallets:
+
+- Enterprise custody and institutional wallets: Fireblocks, DFNS, Anchorage
+- Embedded or server-wallet infrastructure: Privy, Coinbase CDP, Para, Turnkey
+- Local signer: development only
+
+Compliance:
+
+- Range
+- Elliptic
+- TRM Labs
+- Chainalysis
+
+Payment ramps:
+
+- MoonPay
+- Lightspark Grid
+- BVNK
+
+## Local Development
+
+Prerequisites:
+
+- Node `>=20`
+- `pnpm` `10.15.1`
+- Provider credentials for the integrations you want to exercise
+- Doppler access or equivalent local environment variables
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Run the development stack:
+
+```bash
+pnpm dev
+```
+
+Example API environment values are documented in `apps/sdp-api/.dev.vars.example`.
+
+## Checks
+
+```bash
+pnpm typecheck
+pnpm --filter @sdp/api test
+pnpm --filter sdp-docs build
+```
+
+## Community
 
 - [License](./LICENSE)
 - [Security policy](./SECURITY.md)
 - [Contributing guide](./CONTRIBUTING.md)
 - [Code owners](./.github/CODEOWNERS)
-
-## Release Operations
-
-This repo uses a two-environment release model for the API:
-
-- `main` deploys the API to `dev`
-- semver tags `vX.Y.Z` deploy the API to `production`
-- legacy tags in the form `solana-developer-platform-vX.Y.Z` are still accepted for rollback compatibility
-- production rollback is a manual redeploy of a previous semver tag
-
-### GitHub Setup
-
-Configure these before relying on the release flow:
-
-- GitHub environments: `dev` and `production`
-- GitHub environment secrets:
-  - `dev.DOPPLER_TOKEN`
-  - `production.DOPPLER_TOKEN`
-- Repository secret:
-  - `DOPPLER_TOKEN_CI`
-- Repository secret:
-  - `RELEASE_PLEASE_TOKEN`
-
-Cloudflare credentials, deployment-time API secrets, and Vercel app env should now live in Doppler rather than GitHub. See [docs/ops/doppler-secrets.md](docs/ops/doppler-secrets.md) for the exact cutover steps and required config coverage.
-
-The repo maps GitHub/Vercel environments to these Doppler configs:
-
-- GitHub `dev` deploys -> Doppler `dev`
-- GitHub `production` deploys -> Doppler `prd`
-- secret-aware CI jobs -> Doppler `dev_ci`
-- Vercel Preview sync -> Doppler `stg`
-
-`RELEASE_PLEASE_TOKEN` must be a PAT or GitHub App token with at least `contents: write` and `pull-requests: write`. The default `GITHUB_TOKEN` is not sufficient if you want the tag created by Release Please to trigger the production deploy workflow.
-
-### Release Flow
-
-1. Open PRs against `main` with semantic titles such as `feat: ...`, `fix: ...`, or `perf: ...`.
-2. Merge changes into `main`.
-3. Release Please opens or updates the release PR.
-4. Merge the release PR to create a Git tag like `v1.2.3`.
-5. The tag push triggers the production deploy workflow automatically.
-
-### Rollback
-
-To roll back production:
-
-1. Open GitHub Actions.
-2. Run `Deploy SDP API`.
-3. Set `environment=production`.
-4. Set `ref` to the previously released tag, for example `v1.2.2`.
-   Legacy release tags like `solana-developer-platform-v0.2.0` are also accepted.
-5. Leave `run_migrations=false` unless you explicitly need to run migrations.
-
-Important: code rollback is supported, but schema rollback is not automated. Production migrations should remain backward-compatible with the previously deployed application version.
-
-## Integration Tests (Devnet)
-
-The integration test suite runs against Solana **devnet** and signs real transactions using the **Privy custody** provider.
-
-### Prereqs
-
-- Node `>=20`
-- `pnpm` (repo pins `pnpm@10.15.1`)
-
-### Required Environment Variables
-
-Integration tests require:
-
-- `SOLANA_RPC_URL`
-  - Example: `https://api.devnet.solana.com`
-- `KORA_RPC_URL`
-  - Example: `https://your-kora-devnet-instance.us-central1.run.app`
-- `PRIVY_APP_ID`
-- `PRIVY_APP_SECRET`
-
-Optional (recommended):
-
-- `KORA_API_KEY`
-  - Only required if your Kora endpoint needs it.
-- `KORA_MIN_BALANCE_LAMPORTS`
-  - Optional preflight threshold for the Kora fee payer balance.
-
-### Run Integration Tests
-
-From the repo root:
-
-```bash
-export DOPPLER_CONFIG=your-dev-config
-export SOLANA_RPC_URL="https://api.devnet.solana.com"
-export PRIVY_APP_ID="..."
-export PRIVY_APP_SECRET="..."
-
-export KORA_RPC_URL="https://your-kora-devnet-instance.us-central1.run.app"
-# export KORA_API_KEY="..."
-
-pnpm test:integration
-```
-
-Notes:
-
-- The suite includes Kora tests. Kora connectivity/funding is validated up-front (fail-fast).
-- The suite initializes a Privy signer for the integration org and uses DB-backed default signer resolution.
-- If you want to run only the Kora smoke test: `pnpm kora:devnet:test`.
-- Root-level secret-aware commands such as `pnpm dev`, `pnpm dev:api:local`, `pnpm dev:web`, `pnpm test`, and `pnpm test:integration` already run through Doppler. If you bypass the root scripts, wrap the command yourself with `doppler run --config "${DOPPLER_CONFIG}" -- ...`.

--- a/apps/sdp-api/src/openapi/spec.test.ts
+++ b/apps/sdp-api/src/openapi/spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createOpenApiDocument } from "./spec";
+import { createOpenApiDocument, createPublicOpenApiDocument } from "./spec";
 
 describe("OpenAPI spec", () => {
   it("documents path-based versioning policy", () => {
@@ -23,5 +23,32 @@ describe("OpenAPI spec", () => {
     const refreshPath = doc.paths?.["/v1/issuance/tokens/{tokenId}/supply/refresh"]?.post;
     expect(refreshPath).toBeDefined();
     expect(refreshPath?.operationId).toBe("refreshTokenSupply");
+  });
+
+  it("limits the public document to supported public API families", () => {
+    const doc = createPublicOpenApiDocument();
+
+    expect(doc.tags?.map((tag) => tag.name)).toEqual([
+      "Health",
+      "API Keys",
+      "Wallets",
+      "Projects",
+      "Issuance",
+      "Payments",
+      "Compliance",
+    ]);
+
+    expect(doc.paths?.["/v1/auth/me"]).toBeUndefined();
+    expect(doc.paths?.["/v1/organizations/{orgId}"]).toBeUndefined();
+    expect(doc.paths?.["/v1/members"]).toBeUndefined();
+    expect(doc.paths?.["/v1/rpc/providers"]).toBeUndefined();
+    expect(doc.paths?.["/admin/allowlist"]).toBeUndefined();
+    expect(doc.paths?.["/v1/onboarding/status"]).toBeUndefined();
+    expect(doc.components?.securitySchemes?.sessionCookie).toBeUndefined();
+    expect(doc.components?.securitySchemes?.adminKey).toBeUndefined();
+
+    expect(doc.paths?.["/health"]?.get).toBeDefined();
+    expect(doc.paths?.["/v1/wallets"]?.get).toBeDefined();
+    expect(doc.paths?.["/v1/payments/transfers"]?.post).toBeDefined();
   });
 });

--- a/apps/sdp-api/src/openapi/spec.ts
+++ b/apps/sdp-api/src/openapi/spec.ts
@@ -16,9 +16,48 @@ import { registerPaymentsPaths } from "./paths/payments";
 import { registerProjectPaths } from "./paths/projects";
 import { registerRpcPaths } from "./paths/rpc";
 
-export function createOpenApiDocument(): OpenAPIObject {
-  const registry = new OpenAPIRegistry();
+const PUBLIC_OPENAPI_TAGS = [
+  { name: "Health", description: "Service health and readiness endpoints." },
+  { name: "API Keys", description: "API key management endpoints." },
+  {
+    name: "Wallets",
+    description: "Wallet signing provider configuration and wallet management.",
+  },
+  { name: "Projects", description: "Project and project member management." },
+  { name: "Issuance", description: "Token issuance, allowlists, and lifecycle operations." },
+  {
+    name: "Payments",
+    description: "Wallet balances, transfer execution, policies, and ramps.",
+  },
+  { name: "Compliance", description: "Risk and compliance screening endpoints." },
+];
 
+const INTERNAL_OPENAPI_TAGS = [
+  { name: "Organizations", description: "Organization provisioning and settings." },
+  { name: "Members", description: "Organization membership invitations and roles." },
+  { name: "Auth", description: "Session authentication and management." },
+  { name: "RPC", description: "Managed Solana RPC relay and provider telemetry." },
+  { name: "Admin", description: "Administrative allowlist management." },
+  { name: "Onboarding", description: "Clerk organization sync status." },
+];
+
+const OPENAPI_TAGS = [
+  PUBLIC_OPENAPI_TAGS[0],
+  INTERNAL_OPENAPI_TAGS[0],
+  PUBLIC_OPENAPI_TAGS[1],
+  INTERNAL_OPENAPI_TAGS[1],
+  INTERNAL_OPENAPI_TAGS[2],
+  PUBLIC_OPENAPI_TAGS[2],
+  PUBLIC_OPENAPI_TAGS[3],
+  INTERNAL_OPENAPI_TAGS[3],
+  PUBLIC_OPENAPI_TAGS[4],
+  PUBLIC_OPENAPI_TAGS[5],
+  PUBLIC_OPENAPI_TAGS[6],
+  INTERNAL_OPENAPI_TAGS[4],
+  INTERNAL_OPENAPI_TAGS[5],
+];
+
+function registerApiKeyAuth(registry: OpenAPIRegistry) {
   registry.registerComponent("securitySchemes", "apiKeyAuth", {
     type: "http",
     scheme: "bearer",
@@ -26,7 +65,9 @@ export function createOpenApiDocument(): OpenAPIObject {
     description:
       "Use Authorization: Bearer sk_test_... or sk_live_... with a base64url-encoded suffix.",
   });
+}
 
+function registerInternalSecuritySchemes(registry: OpenAPIRegistry) {
   registry.registerComponent("securitySchemes", "sessionCookie", {
     type: "apiKey",
     in: "cookie",
@@ -40,7 +81,19 @@ export function createOpenApiDocument(): OpenAPIObject {
     name: "X-Admin-Key",
     description: "Admin key for internal allowlist management.",
   });
+}
 
+function registerPublicPaths(registry: OpenAPIRegistry) {
+  registerHealthPaths(registry);
+  registerApiKeyPaths(registry);
+  registerCustodyPaths(registry);
+  registerProjectPaths(registry);
+  registerIssuancePaths(registry);
+  registerPaymentsPaths(registry);
+  registerCompliancePaths(registry);
+}
+
+function registerAllPaths(registry: OpenAPIRegistry) {
   registerHealthPaths(registry);
   registerOrganizationPaths(registry);
   registerApiKeyPaths(registry);
@@ -54,6 +107,19 @@ export function createOpenApiDocument(): OpenAPIObject {
   registerCompliancePaths(registry);
   registerAdminPaths(registry);
   registerOnboardingPaths(registry);
+}
+
+function createDocument({ publicOnly }: { publicOnly: boolean }): OpenAPIObject {
+  const registry = new OpenAPIRegistry();
+
+  registerApiKeyAuth(registry);
+
+  if (publicOnly) {
+    registerPublicPaths(registry);
+  } else {
+    registerInternalSecuritySchemes(registry);
+    registerAllPaths(registry);
+  }
 
   const generator = new OpenApiGeneratorV3(registry.definitions);
 
@@ -62,30 +128,11 @@ export function createOpenApiDocument(): OpenAPIObject {
     info: {
       title: "Solana Developer Platform API",
       version: "0.1.0",
-      description:
-        "Production-only OpenAPI spec generated from API schemas and routes. API versioning is path-based: /v1 is the current contract, and breaking changes are introduced under a new path major (for example /v2). The OpenAPI info.version tracks spec/document revision for the current path contract.",
+      description: publicOnly
+        ? "Public OpenAPI spec generated from supported API schemas and routes. API versioning is path-based: /v1 is the current contract, and breaking changes are introduced under a new path major (for example /v2). The OpenAPI info.version tracks spec/document revision for the current path contract."
+        : "Production-only OpenAPI spec generated from API schemas and routes. API versioning is path-based: /v1 is the current contract, and breaking changes are introduced under a new path major (for example /v2). The OpenAPI info.version tracks spec/document revision for the current path contract.",
     },
-    tags: [
-      { name: "Health", description: "Service health and readiness endpoints." },
-      { name: "Organizations", description: "Organization provisioning and settings." },
-      { name: "API Keys", description: "API key management endpoints." },
-      { name: "Members", description: "Organization membership invitations and roles." },
-      { name: "Auth", description: "Session authentication and management." },
-      {
-        name: "Wallets",
-        description: "Wallet signing provider configuration and wallet management.",
-      },
-      { name: "Projects", description: "Project and project member management." },
-      { name: "RPC", description: "Managed Solana RPC relay and provider telemetry." },
-      { name: "Issuance", description: "Token issuance, allowlists, and lifecycle operations." },
-      {
-        name: "Payments",
-        description: "Wallet balances, transfer execution, policies, and ramps.",
-      },
-      { name: "Compliance", description: "Risk and compliance screening endpoints." },
-      { name: "Admin", description: "Administrative allowlist management." },
-      { name: "Onboarding", description: "Clerk organization sync status." },
-    ],
+    tags: publicOnly ? PUBLIC_OPENAPI_TAGS : OPENAPI_TAGS,
     servers: [
       {
         url: "http://localhost:8787",
@@ -97,4 +144,12 @@ export function createOpenApiDocument(): OpenAPIObject {
       },
     ],
   });
+}
+
+export function createOpenApiDocument(): OpenAPIObject {
+  return createDocument({ publicOnly: false });
+}
+
+export function createPublicOpenApiDocument(): OpenAPIObject {
+  return createDocument({ publicOnly: true });
 }

--- a/apps/sdp-api/src/openapi/spec.ts
+++ b/apps/sdp-api/src/openapi/spec.ts
@@ -16,45 +16,55 @@ import { registerPaymentsPaths } from "./paths/payments";
 import { registerProjectPaths } from "./paths/projects";
 import { registerRpcPaths } from "./paths/rpc";
 
-const PUBLIC_OPENAPI_TAGS = [
-  { name: "Health", description: "Service health and readiness endpoints." },
-  { name: "API Keys", description: "API key management endpoints." },
-  {
+const OPENAPI_TAG = {
+  HEALTH: { name: "Health", description: "Service health and readiness endpoints." },
+  ORGANIZATIONS: { name: "Organizations", description: "Organization provisioning and settings." },
+  API_KEYS: { name: "API Keys", description: "API key management endpoints." },
+  MEMBERS: { name: "Members", description: "Organization membership invitations and roles." },
+  AUTH: { name: "Auth", description: "Session authentication and management." },
+  WALLETS: {
     name: "Wallets",
     description: "Wallet signing provider configuration and wallet management.",
   },
-  { name: "Projects", description: "Project and project member management." },
-  { name: "Issuance", description: "Token issuance, allowlists, and lifecycle operations." },
-  {
+  PROJECTS: { name: "Projects", description: "Project and project member management." },
+  RPC: { name: "RPC", description: "Managed Solana RPC relay and provider telemetry." },
+  ISSUANCE: {
+    name: "Issuance",
+    description: "Token issuance, allowlists, and lifecycle operations.",
+  },
+  PAYMENTS: {
     name: "Payments",
     description: "Wallet balances, transfer execution, policies, and ramps.",
   },
-  { name: "Compliance", description: "Risk and compliance screening endpoints." },
-];
+  COMPLIANCE: { name: "Compliance", description: "Risk and compliance screening endpoints." },
+  ADMIN: { name: "Admin", description: "Administrative allowlist management." },
+  ONBOARDING: { name: "Onboarding", description: "Clerk organization sync status." },
+} as const;
 
-const INTERNAL_OPENAPI_TAGS = [
-  { name: "Organizations", description: "Organization provisioning and settings." },
-  { name: "Members", description: "Organization membership invitations and roles." },
-  { name: "Auth", description: "Session authentication and management." },
-  { name: "RPC", description: "Managed Solana RPC relay and provider telemetry." },
-  { name: "Admin", description: "Administrative allowlist management." },
-  { name: "Onboarding", description: "Clerk organization sync status." },
+const PUBLIC_OPENAPI_TAGS = [
+  OPENAPI_TAG.HEALTH,
+  OPENAPI_TAG.API_KEYS,
+  OPENAPI_TAG.WALLETS,
+  OPENAPI_TAG.PROJECTS,
+  OPENAPI_TAG.ISSUANCE,
+  OPENAPI_TAG.PAYMENTS,
+  OPENAPI_TAG.COMPLIANCE,
 ];
 
 const OPENAPI_TAGS = [
-  PUBLIC_OPENAPI_TAGS[0],
-  INTERNAL_OPENAPI_TAGS[0],
-  PUBLIC_OPENAPI_TAGS[1],
-  INTERNAL_OPENAPI_TAGS[1],
-  INTERNAL_OPENAPI_TAGS[2],
-  PUBLIC_OPENAPI_TAGS[2],
-  PUBLIC_OPENAPI_TAGS[3],
-  INTERNAL_OPENAPI_TAGS[3],
-  PUBLIC_OPENAPI_TAGS[4],
-  PUBLIC_OPENAPI_TAGS[5],
-  PUBLIC_OPENAPI_TAGS[6],
-  INTERNAL_OPENAPI_TAGS[4],
-  INTERNAL_OPENAPI_TAGS[5],
+  OPENAPI_TAG.HEALTH,
+  OPENAPI_TAG.ORGANIZATIONS,
+  OPENAPI_TAG.API_KEYS,
+  OPENAPI_TAG.MEMBERS,
+  OPENAPI_TAG.AUTH,
+  OPENAPI_TAG.WALLETS,
+  OPENAPI_TAG.PROJECTS,
+  OPENAPI_TAG.RPC,
+  OPENAPI_TAG.ISSUANCE,
+  OPENAPI_TAG.PAYMENTS,
+  OPENAPI_TAG.COMPLIANCE,
+  OPENAPI_TAG.ADMIN,
+  OPENAPI_TAG.ONBOARDING,
 ];
 
 function registerApiKeyAuth(registry: OpenAPIRegistry) {

--- a/apps/sdp-api/src/routes/openapi.ts
+++ b/apps/sdp-api/src/routes/openapi.ts
@@ -3,12 +3,12 @@
  */
 
 import { Hono } from "hono";
-import { createOpenApiDocument } from "@/openapi/spec";
+import { createPublicOpenApiDocument } from "@/openapi/spec";
 import type { Env } from "@/types/env";
 
 const openapi = new Hono<{ Bindings: Env }>();
 
-const document = createOpenApiDocument();
+const document = createPublicOpenApiDocument();
 
 openapi.get("/", (c) => {
   c.header("Cache-Control", "public, max-age=300");


### PR DESCRIPTION
## Summary
- Replace the maintainer/deploy-focused root README with a minimal public README
- Call out that SDP is devnet-only for now and that self-hosting/deployment guides are coming
- List provider categories for RPC, custody/wallets, compliance, and payment ramps
- Clarify that provider credentials are required for enabled integrations
- Serve a public-only OpenAPI document from `/openapi.json` while keeping the full internal generator available in code
- Add regression coverage that excludes internal OpenAPI route families and internal security schemes from the public document

## Validation
- git diff --check
- pnpm --filter @sdp/api typecheck
- pnpm exec biome check README.md apps/sdp-api/src/openapi/spec.ts apps/sdp-api/src/routes/openapi.ts apps/sdp-api/src/openapi/spec.test.ts
- pnpm exec vitest run src/openapi/spec.test.ts --pool forks