### PR TITLE
docs: remove unfinished public wording

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/compliance.ts
+++ b/apps/sdp-api/src/openapi/schemas/compliance.ts
@@ -42,7 +42,7 @@ export const complianceProviderResultSchema = z
       example: "High risk",
     }),
     message: z.string().optional().openapi({
-      description: "Optional provider message (errors, TODO notices, etc).",
+      description: "Optional provider message, such as warnings or error details.",
     }),
     evaluatedAt: isoDateTimeSchema.openapi({
       description: "Timestamp when the provider result was produced.",

--- a/apps/sdp-docs/content/docs/guides/setup-wallets.mdx
+++ b/apps/sdp-docs/content/docs/guides/setup-wallets.mdx
@@ -55,7 +55,7 @@ Click **New wallet** in the top right. The modal has:
 
 - **Provider** — preselected when only one active provider can create wallets, otherwise selectable
 - **Capabilities** — provider feature chips for issuance, transfers, or compliance
-- **Wallet label** — descriptive name (placeholder: "Signing wallet")
+- **Wallet label** — descriptive name, for example "Signing wallet"
 
 Some providers can be connected but do not yet support provisioning additional wallets from the dashboard.
 


### PR DESCRIPTION
## Summary
- Remove unfinished `TODO notices` wording from the public compliance OpenAPI schema
- Replace public wallet guide `placeholder` language with example wording
- Re-scan public OpenAPI/docs surfaces for TODO/FIXME/placeholder/mock/fake-style wording

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter @sdp/api typecheck
- pnpm exec biome check apps/sdp-api/src/openapi/schemas/compliance.ts apps/sdp-docs/content/docs/guides/setup-wallets.mdx
- pnpm -C apps/sdp-docs generate:api
- pnpm --filter sdp-docs check:links
- pnpm --filter sdp-docs build
- pnpm -C apps/sdp-api exec tsx -e public OpenAPI wording smoke check
- git diff --check

Note: `check:links` needs generated API reference pages materialized locally, so I ran `pnpm -C apps/sdp-docs generate:api` first. Generated API files remain ignored and are not part of this diff.