### PR TITLE
docs: fix public API readiness references

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ The REST API provides these public endpoints (all require API key or session tok
 
 | Family | Purpose | Examples |
 |---|---|---|
-| **Wallets** | Create and manage blockchain accounts | `/v1/wallets/create`, `/v1/wallets/list` |
-| **Issuance** | Mint and manage SPL tokens | `/v1/issuance/tokens/mint`, `/v1/issuance/tokens/freeze` |
-| **Payments** | Send SOL and tokens | `/v1/payments/transfer`, `/v1/payments/batch` |
-| **Compliance** | Screen addresses and transactions | `/v1/compliance/screen-address` |
-| **Projects** | API project management | `/v1/projects/*` |
-| **API Keys** | Manage access tokens | `/v1/api-keys/*` |
+| **Wallets** | Create and manage blockchain accounts | `/v1/wallets`, `/v1/wallets/initialize` |
+| **Issuance** | Mint and manage SPL tokens | `/v1/issuance/tokens`, `/v1/issuance/tokens/{tokenId}/mint` |
+| **Payments** | Send SOL and tokens | `/v1/payments/transfers`, `/v1/payments/transfers/prepare` |
+| **Compliance** | Screen addresses and transactions | `/v1/compliance/address-screenings` |
+| **Projects** | API project management | `/v1/projects` |
+| **API Keys** | Manage access tokens | `/v1/api-keys` |
 | **Health** | Service status | `GET /health` |
 
 **Full API Reference**: https://platform.solana.com/docs

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -85,7 +85,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     summary: "Update wallet policy",
     operationId: "updatePaymentWalletPolicy",
     description:
-      "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/custody.",
+      "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/wallets.",
     security: [{ apiKeyAuth: [] }],
     request: {
       params: z.object({

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -89,7 +89,7 @@ export const walletPolicySchema = z
   })
   .openapi({
     description:
-      "Payment policy configuration for a custody-managed wallet. Wallet lifecycle belongs to /v1/custody, while payment controls are internally stored as typed policy records.",
+      "Payment policy configuration for a custody-managed wallet. Wallet lifecycle belongs to /v1/wallets, while payment controls are internally stored as typed policy records.",
   });
 
 export const updateWalletPolicyRequestSchema = z
@@ -214,7 +214,7 @@ export const prepareTransferRequestSchema = z
   })
   .openapi({
     description:
-      "Prepare transfer request payload for a custody-managed source wallet. Wallet provisioning is handled by /v1/custody.",
+      "Prepare transfer request payload for a custody-managed source wallet. Wallet provisioning is handled by /v1/wallets.",
   });
 
 export const transferTypeSchema = z

--- a/apps/sdp-api/src/routes/payments/wallets.ts
+++ b/apps/sdp-api/src/routes/payments/wallets.ts
@@ -29,10 +29,7 @@ export type ResolvedScope = Awaited<ReturnType<typeof resolveScope>>;
 export function resolveWallet(wallets: CustodyWallet[], walletId: string): CustodyWallet {
   const wallet = wallets.find((entry) => entry.walletId === walletId);
   if (!wallet) {
-    throw new AppError(
-      "NOT_FOUND",
-      "Wallet not found. Provision wallets through /v1/wallets"
-    );
+    throw new AppError("NOT_FOUND", "Wallet not found. Provision wallets through /v1/wallets");
   }
   return wallet;
 }

--- a/apps/sdp-api/src/routes/payments/wallets.ts
+++ b/apps/sdp-api/src/routes/payments/wallets.ts
@@ -31,7 +31,7 @@ export function resolveWallet(wallets: CustodyWallet[], walletId: string): Custo
   if (!wallet) {
     throw new AppError(
       "NOT_FOUND",
-      "Wallet not found. Provision wallets through /v1/custody/wallets"
+      "Wallet not found. Provision wallets through /v1/wallets"
     );
   }
   return wallet;

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1129,7 +1129,7 @@
               }
             ],
             "url": "{{baseUrl}}/v1/payments/wallets/{{walletId}}/policies",
-            "description": "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/custody.",
+            "description": "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/wallets.",
             "body": {
               "mode": "raw",
               "raw": "{\n  \"destinationAllowlist\": [\n    \"So11111111111111111111111111111111111111112\"\n  ],\n  \"maxTransferAmount\": \"100.00\",\n  \"maxDailyAmount\": \"100.00\"\n}",


### PR DESCRIPTION
## Summary
- replace stale root README API examples with current public endpoint paths
- remove remaining `/v1/custody` wording from payment/wallet public API text
- regenerate the public Postman collection from the OpenAPI source

## Checks
- pnpm -C apps/sdp-docs generate:api
- pnpm --filter sdp-docs check:links
- pnpm --filter @sdp/api typecheck
- targeted rg scan for stale README shortcut endpoints and `/v1/custody` public references
