### PR TITLE
feat: add devnet faucet wallet action

### DIFF
--- a/apps/sdp-web/src/app/dashboard/custody/actions.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/actions.ts
@@ -1,8 +1,13 @@
 "use server";
 
+import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { sdpApiFetch, sdpApiRequest } from "@/lib/sdp-api";
+
+const DEVNET_FAUCET_RPC_URL = "https://api.devnet.solana.com";
+const DEVNET_FAUCET_LAMPORTS = 1_000_000_000;
+const SOLANA_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
 function getString(formData: FormData, key: string): string {
   return String(formData.get(key) ?? "").trim();
@@ -302,11 +307,32 @@ interface WalletSignerCheckResponse {
   signature: string;
 }
 
+interface SolanaRpcAirdropResponse {
+  result?: string;
+  error?: {
+    code?: number;
+    message?: string;
+    data?: unknown;
+  };
+}
+
 export type WalletSignerCheckActionResult =
   | {
       status: "success";
       walletId: string;
       signature: string;
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+export type WalletFaucetActionResult =
+  | {
+      status: "success";
+      walletId: string;
+      signature: string;
+      amountSol: number;
     }
   | {
       status: "error";
@@ -373,5 +399,75 @@ export async function checkWalletSignerMemoAction(
         // Best-effort cleanup of short-lived key.
       }
     }
+  }
+}
+
+export async function requestDevnetSolanaFaucetAction(
+  walletId: string,
+  walletAddress: string
+): Promise<WalletFaucetActionResult> {
+  const resolvedWalletId = walletId.trim();
+  const resolvedWalletAddress = walletAddress.trim();
+  if (!resolvedWalletId) {
+    return { status: "error", message: "walletId is required" };
+  }
+  if (!SOLANA_ADDRESS_PATTERN.test(resolvedWalletAddress)) {
+    return { status: "error", message: "A valid wallet address is required" };
+  }
+
+  const { orgId, userId } = await auth();
+  if (!userId || !orgId) {
+    return { status: "error", message: "Sign in to request devnet SOL." };
+  }
+
+  try {
+    const response = await fetch(DEVNET_FAUCET_RPC_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: crypto.randomUUID(),
+        method: "requestAirdrop",
+        params: [resolvedWalletAddress, DEVNET_FAUCET_LAMPORTS],
+      }),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return {
+        status: "error",
+        message: `Devnet faucet request failed with HTTP ${response.status}.`,
+      };
+    }
+
+    const payload = (await response.json()) as SolanaRpcAirdropResponse;
+    if (payload.error) {
+      return {
+        status: "error",
+        message: payload.error.message ?? "Devnet faucet request failed.",
+      };
+    }
+    if (!payload.result) {
+      return { status: "error", message: "Devnet faucet returned no transaction signature." };
+    }
+
+    revalidatePath("/dashboard/custody");
+    revalidatePath("/dashboard/wallets");
+    revalidatePath(`/dashboard/custody/${encodeURIComponent(resolvedWalletId)}`);
+    revalidatePath(`/dashboard/wallets/${encodeURIComponent(resolvedWalletId)}`);
+
+    return {
+      status: "success",
+      walletId: resolvedWalletId,
+      signature: payload.result,
+      amountSol: DEVNET_FAUCET_LAMPORTS / 1_000_000_000,
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      message: extractErrorMessage(error),
+    };
   }
 }

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { ChevronDown, Ellipsis, ShieldCheck } from "lucide-react";
+import { ChevronDown, Droplets, Ellipsis, ShieldCheck } from "lucide-react";
 import { useTransition } from "react";
 import { toast } from "sonner";
-import { checkWalletSignerMemoAction } from "@/app/dashboard/custody/actions";
+import {
+  checkWalletSignerMemoAction,
+  requestDevnetSolanaFaucetAction,
+} from "@/app/dashboard/custody/actions";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
@@ -80,6 +84,47 @@ export function WalletActionsMenu({
     });
   };
 
+  const requestDevnetSol = () => {
+    const toastId = toast.loading("Requesting devnet SOL.", {
+      position: "bottom-right",
+    });
+
+    startTransition(() => {
+      void (async () => {
+        const result = await requestDevnetSolanaFaucetAction(walletId, walletAddress);
+
+        if (result.status === "success") {
+          const explorerUrl = getDevnetExplorerUrl(result.signature);
+
+          toast.success(`${result.amountSol} devnet SOL requested.`, {
+            id: toastId,
+            description: (
+              <span>
+                Faucet transaction submitted.{" "}
+                <a
+                  href={explorerUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  View on Solana Explorer
+                </a>
+              </span>
+            ),
+            position: "bottom-right",
+          });
+          return;
+        }
+
+        toast.error("Devnet faucet failed.", {
+          id: toastId,
+          description: result.message,
+          position: "bottom-right",
+        });
+      })();
+    });
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -108,7 +153,7 @@ export function WalletActionsMenu({
           </Button>
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
+      <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem
           onSelect={runSignerCheck}
           disabled={isBusy || !dashboardAccess.capabilities.canUseWalletSignerCheck}
@@ -119,6 +164,11 @@ export function WalletActionsMenu({
             : dashboardAccess.capabilities.canUseWalletSignerCheck
               ? "Prove ownership"
               : "Prove ownership (admin only)"}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={requestDevnetSol} disabled={isBusy}>
+          <Droplets className="h-4 w-4" />
+          {isBusy ? "Requesting..." : "Request devnet SOL"}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- add an authenticated devnet Solana faucet server action for wallet public keys
- add a wallet actions dropdown item to request 1 devnet SOL
- show Sonner loading, success, and error states with a Solana Explorer link on success

## Verification
- pnpm --filter sdp-web typecheck
- pnpm exec biome check apps/sdp-web/src/app/dashboard/custody/actions.ts apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
- pnpm lint
- pnpm --filter sdp-web build

Note: pnpm --filter sdp-web lint currently crashes before linting app files with eslint-plugin-react against ESLint 10 in next.config.ts.