### PR TITLE
fix(web): keep wallet actions button on one line

### DIFF
--- a/apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-actions-menu.tsx
@@ -133,12 +133,12 @@ export function WalletActionsMenu({
             type="button"
             variant="secondary"
             size="sm"
-            className={cn("min-w-[132px] justify-between", triggerClassName)}
+            className={cn("min-w-[132px] whitespace-nowrap", triggerClassName)}
+            iconRight={<ChevronDown className="size-4" />}
             aria-label={`Wallet actions for ${resolvedWalletLabel}`}
             disabled={isBusy}
           >
-            <span>{triggerLabel}</span>
-            <ChevronDown className="h-4 w-4" />
+            {triggerLabel}
           </Button>
         ) : (
           <Button


### PR DESCRIPTION
## Summary
- route the wallet detail Actions trigger chevron through the shared Button `iconRight` slot
- keep the Actions label and chevron on one row with `whitespace-nowrap`

## Validation
- `pnpm --filter sdp-web typecheck`
- `git diff --check`

## Notes
- `pnpm --filter sdp-web lint` currently fails before linting source because generated `.next-playwright` files trigger an ESLint/plugin compatibility error.
