### PR TITLE
fix: allow ecosystem clerk redirects

### DIFF
--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -5,6 +5,11 @@ import { Toaster } from "sonner";
 import { shouldLoadClerkForPath } from "@/lib/auth-entry";
 import "./globals.css";
 
+const ALLOWED_SATELLITE_REDIRECT_ORIGINS = [
+  "https://ecosystem.solana.com",
+  "https://bookface-git-main-solana-foundation.vercel.app",
+];
+
 export const metadata: Metadata = {
   title: "Solana Developer Platform",
   description: "SDP dashboard",
@@ -23,6 +28,7 @@ export default async function RootLayout({
       signUpUrl="/sign-up"
       signInFallbackRedirectUrl="/dashboard"
       signUpFallbackRedirectUrl="/dashboard"
+      allowedRedirectOrigins={ALLOWED_SATELLITE_REDIRECT_ORIGINS}
       afterSignOutUrl="/sign-in"
     >
       {children}


### PR DESCRIPTION
## Summary
- read allowed Clerk satellite redirect origins from `CLERK_ALLOWED_SATELLITE_REDIRECT_ORIGINS`
- keep sister-project origins in environment/Doppler instead of hardcoding Ecosystem URLs into SDP
- enables shared Clerk primary auth to return users to approved satellite apps like Ecosystem

## Required env
Doppler is configured as:

```
dev/dev_personal/dev_ci/stg: https://bookface-git-main-solana-foundation.vercel.app
prd: https://ecosystem.solana.com,https://bookface-git-main-solana-foundation.vercel.app
```

Production keeps the Bookface dev origin for now because Bookface dev currently authenticates through the production primary auth domain (`platform.solana.com`). Once Bookface dev has a separate primary auth URL, production can drop that dev origin.

## Test plan
- pnpm --filter sdp-web typecheck
