### PR TITLE
fix: provider onboarding PDF links

### DIFF
--- a/apps/sdp-web/next.config.ts
+++ b/apps/sdp-web/next.config.ts
@@ -17,6 +17,10 @@ const nextConfig: NextConfig = {
         destination: `${docsProxyOrigin}/docs/postman/collection.json`,
       },
       {
+        source: "/provider-onboarding/:path*",
+        destination: `${docsProxyOrigin}/provider-onboarding/:path*`,
+      },
+      {
         source: "/docs",
         destination: `${docsProxyOrigin}/docs`,
       },


### PR DESCRIPTION
## Summary

- Adds a web rewrite for `/provider-onboarding/:path*` to the docs deployment origin.
- Leaves the existing criteria PDFs in `apps/sdp-docs/public/provider-onboarding` as the single source of truth.

## Root Cause

The provider onboarding docs page links to `/provider-onboarding/*.pdf`. Those PDFs already exist in the docs app and are served successfully from `https://docs.platform.solana.com/provider-onboarding/*.pdf`, but the canonical production domain `platform.solana.com` is served by `apps/sdp-web`. The web app only proxied `/docs/*`, so root-level `/provider-onboarding/*` requests never reached the docs deployment and returned 404.

## Validation

- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web build`
- Confirmed generated `.next/routes-manifest.json` contains `/provider-onboarding/:path* -> https://docs.platform.solana.com/provider-onboarding/:path*`
- Confirmed all three upstream docs asset URLs return HTTP 200:
  - `https://docs.platform.solana.com/provider-onboarding/custodial-wallet-vendor.pdf`
  - `https://docs.platform.solana.com/provider-onboarding/rpc-providers.pdf`
  - `https://docs.platform.solana.com/provider-onboarding/ramp-criteria.pdf`

Note: `pnpm --filter sdp-web lint` currently fails before linting this change because ESLint 10 + `eslint-plugin-react` errors while loading `react/display-name`, including against generated `.next-playwright` output. The same error occurs when targeting `next.config.ts` directly.
