### PR TITLE
ci: skip secret-backed jobs for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
   test:
     name: Unit Tests
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
@@ -215,6 +216,7 @@ jobs:
 
   integration_tests_shard:
     name: Integration Tests (${{ matrix.name }})
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -317,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - integration_tests_shard
-    if: always()
+    if: always() && github.actor != 'dependabot[bot]'
     timeout-minutes: 5
     steps:
       - name: Check integration test results
@@ -332,6 +334,7 @@ jobs:
 
   browser_e2e:
     name: ${{ matrix.name }}
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:


### PR DESCRIPTION
## Summary
- Skip Doppler-backed unit, integration, and browser E2E jobs for Dependabot PRs
- Keep non-secret CI checks running for Dependabot updates
- Preserve full secret-aware CI for regular PRs and main pushes

## Verification
- Parsed `.github/workflows/ci.yml` with Ruby YAML loader

## Notes
Dependabot-triggered runs do not receive normal Actions secrets, so `secrets.DOPPLER_TOKEN_CI` is empty and the secret-backed jobs fail before tests start.