### PR TITLE
chore: enforce pnpm release age gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -47,7 +47,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -101,7 +101,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -142,7 +142,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -168,7 +168,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -194,7 +194,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -265,7 +265,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -375,7 +375,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-sdp-api.yml
+++ b/.github/workflows/deploy-sdp-api.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.15.1
+          version: 10.16.0
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,6 @@
 # Security settings
 audit=true
+minimum-release-age=10080
 strict-peer-dependencies=true
 auto-install-peers=true
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "solana-developer-platform",
   "version": "0.19.4",
   "private": true,
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.16.0",
   "engines": {
     "node": ">=22.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=10.16.0"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
## Summary

- add pnpm `minimum-release-age=10080` so dependency resolution waits 7 days after package publication
- bump the repo pnpm pin and engine floor to 10.16.0, where `minimumReleaseAge` is supported
- update GitHub Actions pnpm setup versions to match the supported floor

## Validation

- `npx -y pnpm@10.16.0 config get minimum-release-age` -> `10080`
- `npx -y pnpm@10.16.0 install --frozen-lockfile --ignore-scripts`
- `git diff --check`