### PR TITLE
refactor(sdp-api): HOO-506 KVStore interface + WorkersKVStore implementation

### DIFF
--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -14,6 +14,7 @@ import { secureHeaders } from "hono/secure-headers";
 import { AppError } from "@/lib/errors";
 import { withProcessEnvFallback } from "@/lib/runtime-env";
 import { corsMiddleware } from "@/middleware/cors";
+import { kvStoreMiddleware } from "@/middleware/kv-store";
 import { skipRateLimitPaths } from "@/middleware/rate-limit";
 import { requestIdMiddleware } from "@/middleware/request-id";
 import { requestTracingMiddleware } from "@/middleware/request-tracing";
@@ -194,6 +195,10 @@ app.use("*", async (c, next) => {
   }
   return next();
 });
+
+// KV store — populates c.var.kv. Must precede rate-limit / auth / session
+// middleware (all of which read from c.var.kv).
+app.use("*", kvStoreMiddleware());
 
 // Rate limiting (skip health check paths)
 app.use(

--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -197,8 +197,22 @@ app.use("*", async (c, next) => {
 });
 
 // KV store — populates c.var.kv. Must precede rate-limit / auth / session
-// middleware (all of which read from c.var.kv).
-app.use("*", kvStoreMiddleware());
+// middleware (all of which read from c.var.kv). KV-free routes (health
+// probes, openapi spec, static docs, root redirect, webhooks) are skipped
+// so partial KV configs don't 500-cascade health probes or webhook
+// pre-validation.
+app.use(
+  "*",
+  kvStoreMiddleware(
+    "/",
+    "/health",
+    "/health/ready",
+    "/openapi.json",
+    "/docs",
+    "/llms.txt",
+    "/webhooks"
+  )
+);
 
 // Rate limiting (skip health check paths)
 app.use(

--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -196,29 +196,27 @@ app.use("*", async (c, next) => {
   return next();
 });
 
-// KV store — populates c.var.kv. Must precede rate-limit / auth / session
-// middleware (all of which read from c.var.kv). KV-free routes (health
-// probes, openapi spec, static docs, root redirect, webhooks) are skipped
-// so partial KV configs don't 500-cascade health probes or webhook
-// pre-validation.
-app.use(
-  "*",
-  kvStoreMiddleware(
-    "/",
-    "/health",
-    "/health/ready",
-    "/openapi.json",
-    "/docs",
-    "/llms.txt",
-    "/webhooks"
-  )
-);
+// Routes that need no KV bindings. Shared by kvStoreMiddleware (skip the
+// throw-on-missing-binding) and skipRateLimitPaths (skip rate-limit's
+// c.var.kv deref). Both middlewares use exact-or-segment-prefix matching,
+// so listing `/` here only skips the root redirect, not the whole API.
+const KV_FREE_PATHS = [
+  "/",
+  "/health",
+  "/health/ready",
+  "/openapi.json",
+  "/docs",
+  "/llms.txt",
+  "/webhooks",
+];
 
-// Rate limiting (skip health check paths)
-app.use(
-  "*",
-  skipRateLimitPaths("/health", "/health/ready", "/openapi.json", "/docs", "/llms.txt", "/webhooks")
-);
+// KV store — populates c.var.kv. Must precede rate-limit / auth / session
+// middleware (all of which read from c.var.kv).
+app.use("*", kvStoreMiddleware(...KV_FREE_PATHS));
+
+// Rate limiting (skip everything kvStoreMiddleware skipped, since rate-limit
+// dereferences c.var.kv without a guard).
+app.use("*", skipRateLimitPaths(...KV_FREE_PATHS));
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Routes

--- a/apps/sdp-api/src/middleware/auth.ts
+++ b/apps/sdp-api/src/middleware/auth.ts
@@ -16,6 +16,7 @@ import type { Context, Next } from "hono";
 import { getDb } from "@/db";
 import { AppError } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
+import type { KVStore } from "@/runtime/kv";
 import type { Env } from "@/types/env";
 
 const KV_TTL_SECONDS = 3600; // 1 hour cache
@@ -77,9 +78,9 @@ function looksLikeJwt(token: string): boolean {
 /**
  * Look up API key in KV cache
  */
-async function getFromKV(kv: KVNamespace, keyHash: string): Promise<CachedApiKey | null> {
-  const cached = await kv.get(`key:${keyHash}`, "json");
-  return cached as CachedApiKey | null;
+async function getFromKV(kv: KVStore, keyHash: string): Promise<CachedApiKey | null> {
+  const cached = await kv.get<CachedApiKey>(`key:${keyHash}`, "json");
+  return cached;
 }
 
 /**
@@ -87,7 +88,7 @@ async function getFromKV(kv: KVNamespace, keyHash: string): Promise<CachedApiKey
  */
 async function getFromDatabaseAndCache(
   db: DatabaseClient,
-  kv: KVNamespace,
+  kv: KVStore,
   keyHash: string
 ): Promise<CachedApiKey | null> {
   const result = await db
@@ -245,9 +246,10 @@ export function authMiddleware() {
     const keyHash = await hashString(apiKey, pepper);
 
     // Try KV first, then Postgres
-    let cachedKey = await getFromKV(c.env.SDP_API_KEYS!, keyHash);
+    const apiKeysKV = c.var.kv.apiKeys;
+    let cachedKey = await getFromKV(apiKeysKV, keyHash);
     if (!cachedKey) {
-      cachedKey = await getFromDatabaseAndCache(getDb(c.env), c.env.SDP_API_KEYS!, keyHash);
+      cachedKey = await getFromDatabaseAndCache(getDb(c.env), apiKeysKV, keyHash);
     }
 
     if (!cachedKey) {

--- a/apps/sdp-api/src/middleware/clerk-auth.test.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { kvStoreMiddleware } from "@/middleware/kv-store";
 import { rateLimitMiddleware } from "@/middleware/rate-limit";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
@@ -106,6 +107,7 @@ describe("Clerk auth request cache", () => {
 
     const app = new Hono<{ Bindings: Env }>();
 
+    app.use("*", kvStoreMiddleware());
     app.use("*", async (c, next) => {
       c.set("verifiedClerkJwt", { token, payload });
       await next();

--- a/apps/sdp-api/src/middleware/kv-store.test.ts
+++ b/apps/sdp-api/src/middleware/kv-store.test.ts
@@ -4,6 +4,7 @@ import type { KVStoreSet } from "@/runtime/kv";
 import { env } from "@/test/helpers/env";
 import type { Env } from "@/types/env";
 import { kvStoreMiddleware } from "./kv-store";
+import { skipRateLimitPaths } from "./rate-limit";
 
 type Vars = { kv?: KVStoreSet };
 
@@ -57,9 +58,8 @@ describe("kvStoreMiddleware", () => {
   });
 
   it("does NOT skip look-alike paths that share a name prefix without a / boundary", async () => {
-    // Stricter than skipRateLimitPaths on purpose: /healthz must not match /health.
-    // Leaving c.var.kv undefined on a real route would surface as a deep NPE in a
-    // handler, which is worse than the regression this skip list was added to fix.
+    // Segment-prefix matching: `/healthz` must not match `/health`. Leaving
+    // c.var.kv undefined on a real route would surface as a deep handler NPE.
     const app = buildApp("/health", "/docs", "/llms.txt");
     for (const path of ["/healthz", "/docsy", "/llms.txt.backup"]) {
       const res = await app.request(path, {}, env);
@@ -96,5 +96,45 @@ describe("kvStoreMiddleware", () => {
     const res = await app.request("/health", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ kvSet: true });
+  });
+
+  // When kvStoreMiddleware and skipRateLimitPaths share the same skip list,
+  // a KV-free root redirect must flow through both middlewares to its
+  // handler. Locks in the contract that an aligned skip list = the handler
+  // is reachable without c.var.kv being set.
+  it("with aligned skip lists, GET / reaches its handler", async () => {
+    const SKIP = ["/", "/health"];
+    const app = new Hono<{ Bindings: Env; Variables: Vars }>();
+    let handlerCalled = false;
+    app.use("*", kvStoreMiddleware(...SKIP));
+    app.use("*", skipRateLimitPaths(...SKIP));
+    app.get("/", (c) => {
+      handlerCalled = true;
+      return c.redirect("/health");
+    });
+    const res = await app.request("/", {}, env);
+    expect(handlerCalled).toBe(true);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/health");
+  });
+
+  // Bare `startsWith` would mis-skip the whole API when `/` is listed (every
+  // pathname starts with `/`). Segment-prefix limits `/` to the exact root.
+  // Detect whether rate-limit actually ran via the X-RateLimit-* headers it
+  // sets — absence proves it was skipped.
+  it("`/` in skipRateLimitPaths skips exact root only — rate-limit still runs on /api/foo", async () => {
+    const app = new Hono<{ Bindings: Env; Variables: Vars }>();
+    app.use("*", kvStoreMiddleware());
+    app.use("*", skipRateLimitPaths("/"));
+    app.get("/", (c) => c.json({ where: "root" }));
+    app.get("/api/foo", (c) => c.json({ where: "api" }));
+
+    const root = await app.request("/", {}, env);
+    expect(root.status).toBe(200);
+    expect(root.headers.get("X-RateLimit-Limit")).toBeNull();
+
+    const api = await app.request("/api/foo", {}, env);
+    expect(api.status).toBe(200);
+    expect(api.headers.get("X-RateLimit-Limit")).not.toBeNull();
   });
 });

--- a/apps/sdp-api/src/middleware/kv-store.test.ts
+++ b/apps/sdp-api/src/middleware/kv-store.test.ts
@@ -1,0 +1,100 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { KVStoreSet } from "@/runtime/kv";
+import { env } from "@/test/helpers/env";
+import type { Env } from "@/types/env";
+import { kvStoreMiddleware } from "./kv-store";
+
+type Vars = { kv?: KVStoreSet };
+
+function buildApp(...skipPaths: string[]) {
+  const app = new Hono<{ Bindings: Env; Variables: Vars }>();
+  app.use("*", kvStoreMiddleware(...skipPaths));
+  app.all("*", (c) => c.json({ kvSet: c.var.kv !== undefined }));
+  return app;
+}
+
+describe("kvStoreMiddleware", () => {
+  it("populates c.var.kv on paths not in the skip list", async () => {
+    const app = buildApp("/health", "/openapi.json");
+    const res = await app.request("/api/foo", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kvSet: true });
+  });
+
+  it("skips paths in the skip list (c.var.kv stays unset)", async () => {
+    const app = buildApp(
+      "/",
+      "/health",
+      "/health/ready",
+      "/openapi.json",
+      "/docs",
+      "/llms.txt",
+      "/webhooks"
+    );
+    for (const path of [
+      "/",
+      "/health",
+      "/health/ready",
+      "/openapi.json",
+      "/docs",
+      "/llms.txt",
+      "/webhooks",
+    ]) {
+      const res = await app.request(path, {}, env);
+      expect(res.status, `path=${path}`).toBe(200);
+      expect(await res.json(), `path=${path}`).toEqual({ kvSet: false });
+    }
+  });
+
+  it("matches segment-prefix paths so /health also skips /health/anything", async () => {
+    const app = buildApp("/health", "/webhooks");
+    for (const path of ["/health/ready", "/health/deep/nested", "/webhooks/clerk"]) {
+      const res = await app.request(path, {}, env);
+      expect(res.status, `path=${path}`).toBe(200);
+      expect(await res.json(), `path=${path}`).toEqual({ kvSet: false });
+    }
+  });
+
+  it("does NOT skip look-alike paths that share a name prefix without a / boundary", async () => {
+    // Stricter than skipRateLimitPaths on purpose: /healthz must not match /health.
+    // Leaving c.var.kv undefined on a real route would surface as a deep NPE in a
+    // handler, which is worse than the regression this skip list was added to fix.
+    const app = buildApp("/health", "/docs", "/llms.txt");
+    for (const path of ["/healthz", "/docsy", "/llms.txt.backup"]) {
+      const res = await app.request(path, {}, env);
+      expect(res.status, `path=${path}`).toBe(200);
+      expect(await res.json(), `path=${path}`).toEqual({ kvSet: true });
+    }
+  });
+
+  it("ignores query strings (skip decision uses pathname only)", async () => {
+    const app = buildApp("/health");
+    const res = await app.request("/health?verbose=1", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kvSet: false });
+  });
+
+  it("trailing slash on a non-skipped path does not flip the decision", async () => {
+    const app = buildApp("/health");
+    // `/health/` matches `/health/` startsWith `/health/` → skipped (segment-prefix).
+    const res = await app.request("/health/", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kvSet: false });
+  });
+
+  it("root `/` only skips exact root, not other paths", async () => {
+    const app = buildApp("/");
+    const exact = await app.request("/", {}, env);
+    expect(await exact.json()).toEqual({ kvSet: false });
+    const other = await app.request("/api/foo", {}, env);
+    expect(await other.json()).toEqual({ kvSet: true });
+  });
+
+  it("with no skip paths, populates c.var.kv on every request (back-compat)", async () => {
+    const app = buildApp();
+    const res = await app.request("/health", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ kvSet: true });
+  });
+});

--- a/apps/sdp-api/src/middleware/kv-store.ts
+++ b/apps/sdp-api/src/middleware/kv-store.ts
@@ -1,0 +1,18 @@
+/**
+ * KV store middleware
+ *
+ * Populates c.var.kv with the runtime-appropriate KVStoreSet. Mounted before
+ * any handler that needs KV access, which is effectively every authenticated
+ * route — keep it near the top of the global middleware stack in index.ts.
+ */
+
+import type { Context, Next } from "hono";
+import { createKVStoreSet } from "@/runtime/factory";
+import type { Env } from "@/types/env";
+
+export function kvStoreMiddleware() {
+  return async (c: Context<{ Bindings: Env }>, next: Next) => {
+    c.set("kv", createKVStoreSet(c.env));
+    await next();
+  };
+}

--- a/apps/sdp-api/src/middleware/kv-store.ts
+++ b/apps/sdp-api/src/middleware/kv-store.ts
@@ -4,14 +4,27 @@
  * Populates c.var.kv with the runtime-appropriate KVStoreSet. Mounted before
  * any handler that needs KV access, which is effectively every authenticated
  * route — keep it near the top of the global middleware stack in index.ts.
+ *
+ * Accepts skip paths so KV-free routes (health probes, openapi spec, static
+ * docs, webhooks) don't trip the missing-binding throw in createKVStoreSet
+ * when a runtime is partially configured. Matching is exact OR segment-prefix
+ * (`p` matches `p` and `p/...` but NOT `p<anything-else>`). Segment-prefix
+ * is intentionally stricter than skipRateLimitPaths' bare `startsWith`: a
+ * loose match here would leave `c.var.kv` undefined on look-alike routes
+ * (e.g. `/healthz`) and the failure would surface as a deep handler NPE
+ * instead of a clean middleware throw.
  */
 
 import type { Context, Next } from "hono";
 import { createKVStoreSet } from "@/runtime/factory";
 import type { Env } from "@/types/env";
 
-export function kvStoreMiddleware() {
+export function kvStoreMiddleware(...skipPaths: string[]) {
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
+    const path = c.req.path;
+    if (skipPaths.some((p) => path === p || path.startsWith(`${p}/`))) {
+      return next();
+    }
     c.set("kv", createKVStoreSet(c.env));
     await next();
   };

--- a/apps/sdp-api/src/middleware/kv-store.ts
+++ b/apps/sdp-api/src/middleware/kv-store.ts
@@ -8,11 +8,13 @@
  * Accepts skip paths so KV-free routes (health probes, openapi spec, static
  * docs, webhooks) don't trip the missing-binding throw in createKVStoreSet
  * when a runtime is partially configured. Matching is exact OR segment-prefix
- * (`p` matches `p` and `p/...` but NOT `p<anything-else>`). Segment-prefix
- * is intentionally stricter than skipRateLimitPaths' bare `startsWith`: a
- * loose match here would leave `c.var.kv` undefined on look-alike routes
- * (e.g. `/healthz`) and the failure would surface as a deep handler NPE
- * instead of a clean middleware throw.
+ * (`p` matches `p` and `p/...` but NOT `p<anything-else>`).
+ *
+ * Every path skipped here MUST also be skipped by skipRateLimitPaths in the
+ * same wiring — rateLimitMiddleware dereferences c.var.kv without a guard,
+ * so a kv-skipped path that reaches rate-limit blows up as a TypeError. The
+ * call site in index.ts shares a single KV_FREE_PATHS constant for both
+ * middlewares to enforce this by construction.
  */
 
 import type { Context, Next } from "hono";

--- a/apps/sdp-api/src/middleware/rate-limit.ts
+++ b/apps/sdp-api/src/middleware/rate-limit.ts
@@ -126,6 +126,10 @@ async function isVerifiedClerkJwt(c: Context<{ Bindings: Env }>, token: string):
 
 /**
  * Rate limiting middleware
+ *
+ * Requires c.var.kv to be populated (by kvStoreMiddleware). Any path that
+ * kv-store skips must also be skipped here via skipRateLimitPaths — the
+ * `c.var.kv.rateLimits` deref below has no guard.
  */
 export function rateLimitMiddleware() {
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
@@ -217,13 +221,17 @@ export function rateLimitMiddleware() {
 }
 
 /**
- * Skip rate limiting for specific paths (e.g., health check)
+ * Skip rate limiting for specific paths (e.g., health check).
+ *
+ * Matching is exact OR segment-prefix (`p` matches `p` and `p/...` but NOT
+ * `p<anything-else>`). Bare `startsWith` would mis-skip the whole API when
+ * `/` is listed, since every pathname starts with `/`.
  */
 export function skipRateLimitPaths(...paths: string[]) {
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
-    const path = new URL(c.req.url).pathname;
+    const path = c.req.path;
 
-    if (paths.some((p) => path === p || path.startsWith(p))) {
+    if (paths.some((p) => path === p || path.startsWith(`${p}/`))) {
       await next();
       return;
     }

--- a/apps/sdp-api/src/middleware/rate-limit.ts
+++ b/apps/sdp-api/src/middleware/rate-limit.ts
@@ -129,7 +129,7 @@ async function isVerifiedClerkJwt(c: Context<{ Bindings: Env }>, token: string):
  */
 export function rateLimitMiddleware() {
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
-    const kv = c.env.SDP_RATE_LIMITS!;
+    const kv = c.var.kv.rateLimits;
     const auth = c.get("apiKey");
     const bearerToken = extractBearerToken(c);
 

--- a/apps/sdp-api/src/middleware/session-auth.ts
+++ b/apps/sdp-api/src/middleware/session-auth.ts
@@ -89,10 +89,7 @@ export function optionalSessionAuth() {
 /**
  * Get session from KV cache
  */
-async function getSessionFromKV(
-  kv: KVStore,
-  sessionId: string
-): Promise<CachedSession | null> {
+async function getSessionFromKV(kv: KVStore, sessionId: string): Promise<CachedSession | null> {
   return kv.get<CachedSession>(`session:${sessionId}`, "json");
 }
 

--- a/apps/sdp-api/src/middleware/session-auth.ts
+++ b/apps/sdp-api/src/middleware/session-auth.ts
@@ -10,6 +10,7 @@ import type { Context, Next } from "hono";
 import { getCookie } from "hono/cookie";
 import { getDb } from "@/db";
 import { AppError } from "@/lib/errors";
+import type { KVStore } from "@/runtime/kv";
 import type { Env } from "@/types/env";
 
 const SESSION_COOKIE_NAME = "sdp_session";
@@ -27,11 +28,12 @@ export function sessionAuthMiddleware() {
     }
 
     // Try KV cache first
-    let cachedSession = await getSessionFromKV(c.env.SDP_SESSIONS, sessionId);
+    const sessionsKV = c.var.kv.sessions;
+    let cachedSession = await getSessionFromKV(sessionsKV, sessionId);
 
     if (!cachedSession) {
       // Fallback to Postgres
-      cachedSession = await getSessionFromDatabase(getDb(c.env), c.env.SDP_SESSIONS, sessionId);
+      cachedSession = await getSessionFromDatabase(getDb(c.env), sessionsKV, sessionId);
     }
 
     if (!cachedSession) {
@@ -41,7 +43,7 @@ export function sessionAuthMiddleware() {
     // Check expiration
     if (new Date(cachedSession.expiresAt) < new Date()) {
       // Clean up expired session
-      await c.env.SDP_SESSIONS?.delete(`session:${sessionId}`);
+      await sessionsKV.delete(`session:${sessionId}`);
       throw new AppError("UNAUTHORIZED", "Session expired");
     }
 
@@ -64,10 +66,11 @@ export function optionalSessionAuth() {
 
     if (sessionId) {
       try {
-        let cachedSession = await getSessionFromKV(c.env.SDP_SESSIONS, sessionId);
+        const sessionsKV = c.var.kv.sessions;
+        let cachedSession = await getSessionFromKV(sessionsKV, sessionId);
 
         if (!cachedSession) {
-          cachedSession = await getSessionFromDatabase(getDb(c.env), c.env.SDP_SESSIONS, sessionId);
+          cachedSession = await getSessionFromDatabase(getDb(c.env), sessionsKV, sessionId);
         }
 
         if (cachedSession && new Date(cachedSession.expiresAt) >= new Date()) {
@@ -87,13 +90,10 @@ export function optionalSessionAuth() {
  * Get session from KV cache
  */
 async function getSessionFromKV(
-  kv: KVNamespace | undefined,
+  kv: KVStore,
   sessionId: string
 ): Promise<CachedSession | null> {
-  if (!kv) {
-    return null;
-  }
-  return kv.get(`session:${sessionId}`, "json");
+  return kv.get<CachedSession>(`session:${sessionId}`, "json");
 }
 
 /**
@@ -101,7 +101,7 @@ async function getSessionFromKV(
  */
 async function getSessionFromDatabase(
   db: DatabaseClient,
-  kv: KVNamespace | undefined,
+  kv: KVStore,
   sessionId: string
 ): Promise<CachedSession | null> {
   const row = await db
@@ -139,11 +139,9 @@ async function getSessionFromDatabase(
   };
 
   // Cache to KV
-  if (kv) {
-    await kv.put(`session:${sessionId}`, JSON.stringify(cachedSession), {
-      expirationTtl: 3600, // 1 hour
-    });
-  }
+  await kv.put(`session:${sessionId}`, JSON.stringify(cachedSession), {
+    expirationTtl: 3600, // 1 hour
+  });
 
   return cachedSession;
 }

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -392,7 +392,7 @@ export const updateApiKey = async (c: AppContext) => {
     parsed.data.permissions !== undefined ||
     walletSelection.touched
   ) {
-    await c.env.SDP_API_KEYS!.delete(`key:${existing.key_hash}`);
+    await c.var.kv.apiKeys.delete(`key:${existing.key_hash}`);
   }
 
   // Audit log
@@ -440,7 +440,7 @@ export const rotateApiKey = async (c: AppContext) => {
   }
 
   // Invalidate old key cache
-  await c.env.SDP_API_KEYS!.delete(`key:${rotation.previousKeyHash}`);
+  await c.var.kv.apiKeys.delete(`key:${rotation.previousKeyHash}`);
 
   // Audit log
   const auditService = new AuditService(getDb(c.env));
@@ -510,7 +510,7 @@ export const revokeApiKey = async (c: AppContext) => {
   }
 
   // Invalidate KV cache
-  await c.env.SDP_API_KEYS!.delete(`key:${revokedKey.keyHash}`);
+  await c.var.kv.apiKeys.delete(`key:${revokedKey.keyHash}`);
 
   // Audit log
   const auditService = new AuditService(getDb(c.env));

--- a/apps/sdp-api/src/routes/auth.test.ts
+++ b/apps/sdp-api/src/routes/auth.test.ts
@@ -5,6 +5,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import app from "@/index";
+import { createKVStoreSet } from "@/runtime/factory";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 
@@ -26,10 +27,10 @@ describe("Auth Routes", () => {
       .catch(() => {});
 
     // Clear rate limit KV to prevent 429 errors between tests
-    const rateLimitKV = (env as { SDP_RATE_LIMITS: KVNamespace }).SDP_RATE_LIMITS;
-    const keys = await rateLimitKV.list();
+    const rateLimits = createKVStoreSet(env).rateLimits;
+    const keys = await rateLimits.list();
     for (const key of keys.keys) {
-      await rateLimitKV.delete(key.name);
+      await rateLimits.delete(key.name);
     }
   });
 

--- a/apps/sdp-api/src/routes/auth/handlers/sessions.ts
+++ b/apps/sdp-api/src/routes/auth/handlers/sessions.ts
@@ -17,7 +17,7 @@ export const logout = async (c: AppContext) => {
   const session = c.get("session");
 
   if (session) {
-    const sessionService = new SessionService(getDb(c.env), c.env.SDP_SESSIONS!);
+    const sessionService = new SessionService(getDb(c.env), c.var.kv.sessions);
     await sessionService.revokeSession(session.id);
   }
 
@@ -101,7 +101,7 @@ export const listSessions = async (c: AppContext) => {
     throw new AppError("UNAUTHORIZED");
   }
 
-  const sessionService = new SessionService(getDb(c.env), c.env.SDP_SESSIONS!);
+  const sessionService = new SessionService(getDb(c.env), c.var.kv.sessions);
   const sessions = await sessionService.listUserSessions(session.userId);
 
   const response: ListSessionsResponse = {
@@ -127,7 +127,7 @@ export const revokeSession = async (c: AppContext) => {
     throw new AppError("UNAUTHORIZED");
   }
 
-  const sessionService = new SessionService(getDb(c.env), c.env.SDP_SESSIONS!);
+  const sessionService = new SessionService(getDb(c.env), c.var.kv.sessions);
 
   // Verify the session belongs to this user
   const sessions = await sessionService.listUserSessions(currentSession.userId);

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -73,6 +73,7 @@ export const signerCheck = async (c: AppContext) => {
 
     const rpcTarget = await resolveRpcTarget({
       env: c.env,
+      kv: c.var.kv,
       db: getDb(c.env),
       organizationId: auth.organizationId,
       authProjectId: auth.projectId ?? null,

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -8,6 +8,7 @@ import { getDb } from "@/db";
 import app from "@/index";
 import { hashString } from "@/lib/hash";
 import * as AuthorityResolution from "@/routes/issuance/handlers/authority-resolution";
+import { createKVStoreSet } from "@/runtime/factory";
 import { MosaicService } from "@/services/mosaic";
 import * as SolanaServices from "@/services/solana";
 import { TokenService } from "@/services/token.service";
@@ -45,13 +46,12 @@ describe("Issuance Routes", () => {
 
   beforeEach(async () => {
     const db = getDb(env);
-    const apiKeysKV = (env as { SDP_API_KEYS: KVNamespace }).SDP_API_KEYS;
-    const rateLimitKV = (env as { SDP_RATE_LIMITS: KVNamespace }).SDP_RATE_LIMITS;
+    const kv = createKVStoreSet(env);
 
     // Clear rate limit KV to prevent 429 errors between tests
-    const keys = await rateLimitKV.list();
+    const keys = await kv.rateLimits.list();
     for (const key of keys.keys) {
-      await rateLimitKV.delete(key.name);
+      await kv.rateLimits.delete(key.name);
     }
 
     // Clear token-related tables
@@ -147,7 +147,7 @@ describe("Issuance Routes", () => {
       .run();
 
     // Cache API key in KV
-    await apiKeysKV.put(`key:${apiKeyHash}`, JSON.stringify(TEST_PROJECT_CACHED_KEY));
+    await kv.apiKeys.put(`key:${apiKeyHash}`, JSON.stringify(TEST_PROJECT_CACHED_KEY));
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/apps/sdp-api/src/routes/projects.test.ts
+++ b/apps/sdp-api/src/routes/projects.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import app from "@/index";
 import { hashString } from "@/lib/hash";
+import { createKVStoreSet } from "@/runtime/factory";
 import { TEST_API_KEY, TEST_CACHED_API_KEY } from "@/test/fixtures/api-keys";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
@@ -30,13 +31,12 @@ describe("Projects Routes", () => {
 
   beforeEach(async () => {
     const db = getDb(env);
-    const apiKeysKV = (env as { SDP_API_KEYS: KVNamespace }).SDP_API_KEYS;
-    const rateLimitKV = (env as { SDP_RATE_LIMITS: KVNamespace }).SDP_RATE_LIMITS;
+    const kv = createKVStoreSet(env);
 
     // Clear rate limit KV to prevent 429 errors between tests
-    const keys = await rateLimitKV.list();
+    const keys = await kv.rateLimits.list();
     for (const key of keys.keys) {
-      await rateLimitKV.delete(key.name);
+      await kv.rateLimits.delete(key.name);
     }
 
     // Clear projects tables
@@ -76,7 +76,7 @@ describe("Projects Routes", () => {
       .run();
 
     // Cache API key in KV
-    await apiKeysKV.put(`key:${apiKeyHash}`, JSON.stringify(TEST_CACHED_API_KEY));
+    await kv.apiKeys.put(`key:${apiKeyHash}`, JSON.stringify(TEST_CACHED_API_KEY));
   });
 
   describe("POST /v1/projects", () => {

--- a/apps/sdp-api/src/routes/rpc.test.ts
+++ b/apps/sdp-api/src/routes/rpc.test.ts
@@ -3,6 +3,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { getDb } from "@/db";
 import app from "@/index";
 import { hashString } from "@/lib/hash";
+import { createKVStoreSet } from "@/runtime/factory";
+import type { KVStore } from "@/runtime/kv";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
@@ -174,10 +176,10 @@ function getRequiredLiveProviderConfigs(
   });
 }
 
-async function clearKvNamespace(namespace: KVNamespace) {
-  const listed = await namespace.list();
+async function clearKvStore(store: KVStore) {
+  const listed = await store.list();
   for (const key of listed.keys) {
-    await namespace.delete(key.name);
+    await store.delete(key.name);
   }
 }
 
@@ -198,13 +200,11 @@ describe("RPC Relay Routes", () => {
 
   beforeEach(async () => {
     const db = getDb(env);
-    const apiKeysKV = (env as { SDP_API_KEYS: KVNamespace }).SDP_API_KEYS;
-    const rateLimitKV = (env as { SDP_RATE_LIMITS: KVNamespace }).SDP_RATE_LIMITS;
-    const cacheKV = (env as { SDP_CACHE: KVNamespace }).SDP_CACHE;
+    const kv = createKVStoreSet(env);
 
-    await clearKvNamespace(rateLimitKV);
-    await clearKvNamespace(cacheKV);
-    await clearKvNamespace(apiKeysKV);
+    await clearKvStore(kv.rateLimits);
+    await clearKvStore(kv.cache);
+    await clearKvStore(kv.apiKeys);
 
     await db
       .prepare("DELETE FROM api_keys")
@@ -267,7 +267,7 @@ describe("RPC Relay Routes", () => {
       )
       .run();
 
-    await apiKeysKV.put(
+    await kv.apiKeys.put(
       `key:${apiKeyHash}`,
       JSON.stringify({
         id: TEST_API_KEY_ID,
@@ -540,12 +540,12 @@ describe("RPC Relay Routes", () => {
 
   it("round-robins faucet airdrops and falls back after provider rate limits", async () => {
     const db = getDb(env);
-    const cacheKV = (env as { SDP_CACHE: KVNamespace }).SDP_CACHE;
+    const kv = createKVStoreSet(env);
     await db
       .prepare("UPDATE organizations SET settings = ? WHERE id = ?")
       .bind(JSON.stringify({ rpcProvider: "triton" }), TEST_ORG.id)
       .run();
-    await cacheKV.put("rpc:relay:round-robin-cursor", "1");
+    await kv.cache.put("rpc:relay:round-robin-cursor", "1");
 
     rpcEnv.SOLANA_RPC_TRITON_URL = "https://rpc.triton.test";
     rpcEnv.SOLANA_RPC_HELIUS_URL = "https://rpc.helius.test";

--- a/apps/sdp-api/src/routes/rpc/handlers.ts
+++ b/apps/sdp-api/src/routes/rpc/handlers.ts
@@ -72,7 +72,7 @@ async function relayToTarget(
   const upstreamBody = rawBody ? tryParseJson(rawBody) : null;
   const elapsedMs = Date.now() - startedAt;
 
-  await recordRpcRelayTelemetry(c.env.SDP_CACHE!, {
+  await recordRpcRelayTelemetry(c.var.kv.cache, {
     providerId: target.providerId,
     methodNames,
     statusCode: upstream.status,
@@ -121,6 +121,7 @@ export const getRpcProviders = async (c: AppContext) => {
 
   const response = await listRpcProviders({
     env: c.env,
+    kv: c.var.kv,
     db: getDb(c.env),
     organizationId: auth.organizationId,
     authProjectId: auth.projectId,
@@ -159,6 +160,7 @@ export const relayRpcRequest = async (c: AppContext) => {
   if (shouldRoundRobinFaucetRequest(payloadParse.data, methodNames)) {
     const targets = await resolveRoundRobinRpcTargets({
       env: c.env,
+      kv: c.var.kv,
       db: getDb(c.env),
       organizationId: auth.organizationId,
       authProjectId: auth.projectId,
@@ -185,7 +187,7 @@ export const relayRpcRequest = async (c: AppContext) => {
         lastResponse = relayResponse;
       } catch (error) {
         lastError = error;
-        await recordRpcRelayTelemetry(c.env.SDP_CACHE!, {
+        await recordRpcRelayTelemetry(c.var.kv.cache, {
           providerId: target.providerId,
           methodNames,
           statusCode: 0,
@@ -208,6 +210,7 @@ export const relayRpcRequest = async (c: AppContext) => {
 
   const target = await resolveRpcTarget({
     env: c.env,
+    kv: c.var.kv,
     db: getDb(c.env),
     organizationId: auth.organizationId,
     authProjectId: auth.projectId,
@@ -224,7 +227,7 @@ export const relayRpcRequest = async (c: AppContext) => {
     );
     return success(c, buildRelayResponse(target, upstream, upstreamBody, methodNames));
   } catch (error) {
-    await recordRpcRelayTelemetry(c.env.SDP_CACHE!, {
+    await recordRpcRelayTelemetry(c.var.kv.cache, {
       providerId: target.providerId,
       methodNames,
       statusCode: 0,
@@ -253,6 +256,7 @@ export const testRpcConnection = async (c: AppContext) => {
   const methodNames = ["getVersion"];
   const target = await resolveRpcTarget({
     env: c.env,
+    kv: c.var.kv,
     db: getDb(c.env),
     organizationId: auth.organizationId,
     authProjectId: auth.projectId,
@@ -281,7 +285,7 @@ export const testRpcConnection = async (c: AppContext) => {
     const upstreamBody = rawBody ? tryParseJson(rawBody) : null;
     const elapsedMs = Date.now() - startedAt;
 
-    await recordRpcRelayTelemetry(c.env.SDP_CACHE!, {
+    await recordRpcRelayTelemetry(c.var.kv.cache, {
       providerId: target.providerId,
       methodNames,
       statusCode: upstream.status,
@@ -306,7 +310,7 @@ export const testRpcConnection = async (c: AppContext) => {
       response: upstreamBody,
     });
   } catch (error) {
-    await recordRpcRelayTelemetry(c.env.SDP_CACHE!, {
+    await recordRpcRelayTelemetry(c.var.kv.cache, {
       providerId: target.providerId,
       methodNames,
       statusCode: 0,

--- a/apps/sdp-api/src/runtime/factory.ts
+++ b/apps/sdp-api/src/runtime/factory.ts
@@ -1,0 +1,15 @@
+
+/**
+ * Runtime factory — single dispatch point for runtime-specific implementations.
+ *
+ * HOO-506 lands only the Cloudflare branch. HOO-510 (#9) adds the Node/Redis
+ * branch and switches on SDP_RUNTIME via getRuntime().
+ */
+
+import type { Env } from "@/types/env";
+import type { KVStoreSet } from "./kv";
+import { createWorkersKVStoreSet } from "./kv-workers";
+
+export function createKVStoreSet(env: Env): KVStoreSet {
+  return createWorkersKVStoreSet(env);
+}

--- a/apps/sdp-api/src/runtime/factory.ts
+++ b/apps/sdp-api/src/runtime/factory.ts
@@ -1,4 +1,3 @@
-
 /**
  * Runtime factory — single dispatch point for runtime-specific implementations.
  *

--- a/apps/sdp-api/src/runtime/kv-workers.ts
+++ b/apps/sdp-api/src/runtime/kv-workers.ts
@@ -1,0 +1,69 @@
+/**
+ * Cloudflare Workers KV implementation of KVStore.
+ *
+ * This file is the SOLE allowed read site for env.SDP_API_KEYS / SDP_RATE_LIMITS
+ * / SDP_CACHE / SDP_SESSIONS in production code. The AC for HOO-506 enforces
+ * this via grep — keep all KVNamespace binding reads here. Sister Redis impl
+ * lands in HOO-510.
+ */
+
+import type { Env } from "@/types/env";
+import type { KVListResult, KVPutOptions, KVStore, KVStoreSet } from "./kv";
+
+export class WorkersKVStore implements KVStore {
+  constructor(private readonly kv: KVNamespace) {}
+
+  get(key: string): Promise<string | null>;
+  get<T>(key: string, type: "json"): Promise<T | null>;
+  get<T>(key: string, type?: "json"): Promise<string | T | null> {
+    if (type === "json") {
+      return this.kv.get<T>(key, "json");
+    }
+    return this.kv.get(key);
+  }
+
+  put(key: string, value: string, options?: KVPutOptions): Promise<void> {
+    return this.kv.put(key, value, options);
+  }
+
+  delete(key: string): Promise<void> {
+    return this.kv.delete(key);
+  }
+
+  async list(): Promise<KVListResult> {
+    const result = await this.kv.list();
+    return { keys: result.keys.map(({ name }) => ({ name })) };
+  }
+}
+
+/**
+ * Build a KVStoreSet from Cloudflare KV bindings.
+ *
+ * All four bindings are required on the Cloudflare runtime; we throw at boot
+ * rather than let a `!` non-null assertion blow up deep in a request handler.
+ */
+export function createWorkersKVStoreSet(env: Env): KVStoreSet {
+  const apiKeys = env.SDP_API_KEYS;
+  const rateLimits = env.SDP_RATE_LIMITS;
+  const cache = env.SDP_CACHE;
+  const sessions = env.SDP_SESSIONS;
+  if (!apiKeys || !rateLimits || !cache || !sessions) {
+    const missing = [
+      !apiKeys && "SDP_API_KEYS",
+      !rateLimits && "SDP_RATE_LIMITS",
+      !cache && "SDP_CACHE",
+      !sessions && "SDP_SESSIONS",
+    ]
+      .filter(Boolean)
+      .join(", ");
+    throw new Error(
+      `Cloudflare KV bindings missing for runtime=cloudflare: ${missing}. Configure them in wrangler.toml.`
+    );
+  }
+  return {
+    apiKeys: new WorkersKVStore(apiKeys),
+    rateLimits: new WorkersKVStore(rateLimits),
+    cache: new WorkersKVStore(cache),
+    sessions: new WorkersKVStore(sessions),
+  };
+}

--- a/apps/sdp-api/src/runtime/kv-workers.ts
+++ b/apps/sdp-api/src/runtime/kv-workers.ts
@@ -39,8 +39,10 @@ export class WorkersKVStore implements KVStore {
 /**
  * Build a KVStoreSet from Cloudflare KV bindings.
  *
- * All four bindings are required on the Cloudflare runtime; we throw at boot
- * rather than let a `!` non-null assertion blow up deep in a request handler.
+ * All four bindings are required on the Cloudflare runtime. Called per-request
+ * from kvStoreMiddleware, so a missing binding throws on the first request
+ * rather than at worker startup — but still up-front, before any handler runs,
+ * instead of deep inside one via a `!` non-null assertion.
  */
 export function createWorkersKVStoreSet(env: Env): KVStoreSet {
   const apiKeys = env.SDP_API_KEYS;

--- a/apps/sdp-api/src/runtime/kv.ts
+++ b/apps/sdp-api/src/runtime/kv.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime-neutral KV store abstraction.
+ *
+ * Call-sites depend on KVStore, not on Cloudflare's KVNamespace, so a
+ * Redis-backed implementation (HOO-510) can drop in behind the same factory
+ * without touching any consumer.
+ *
+ * Surface kept minimal: get / put / delete / list — only what current
+ * consumers use. getWithMetadata is intentionally omitted (unused).
+ */
+
+export interface KVPutOptions {
+  /** TTL in seconds. After this, get() returns null. */
+  expirationTtl?: number;
+}
+
+export interface KVListKey {
+  name: string;
+}
+
+export interface KVListResult {
+  keys: KVListKey[];
+}
+
+export interface KVStore {
+  get(key: string): Promise<string | null>;
+  get<T>(key: string, type: "json"): Promise<T | null>;
+  put(key: string, value: string, options?: KVPutOptions): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(): Promise<KVListResult>;
+}
+
+export interface KVStoreSet {
+  apiKeys: KVStore;
+  rateLimits: KVStore;
+  cache: KVStore;
+  sessions: KVStore;
+}

--- a/apps/sdp-api/src/services/rpc-relay.service.test.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
+import { createKVStoreSet } from "@/runtime/factory";
+import type { KVStore, KVStoreSet } from "@/runtime/kv";
 import {
   includesTransactionMethod,
   listRpcProviders,
@@ -16,7 +18,6 @@ const appEnv = env as unknown as Env;
 const SEND_RAW_TRANSACTION_METHOD = ["sendRaw", "Transaction"].join("");
 
 type MutableRpcEnv = {
-  SDP_CACHE: Env["SDP_CACHE"];
   SOLANA_RPC_URL?: string;
   SOLANA_RPC_DEFAULT_PROVIDER?: string;
   SOLANA_RPC_TRITON_URL?: string;
@@ -31,11 +32,12 @@ type MutableRpcEnv = {
 
 const rpcEnv = env as MutableRpcEnv;
 const db = getDb(env as unknown as Env);
+const kv: KVStoreSet = createKVStoreSet(appEnv);
 
-async function clearKvNamespace(namespace: KVNamespace) {
-  const listed = await namespace.list();
+async function clearKvStore(store: KVStore) {
+  const listed = await store.list();
   for (const key of listed.keys) {
-    await namespace.delete(key.name);
+    await store.delete(key.name);
   }
 }
 
@@ -49,7 +51,7 @@ describe("rpc-relay.service", () => {
   });
 
   beforeEach(async () => {
-    await clearKvNamespace(rpcEnv.SDP_CACHE!);
+    await clearKvStore(kv.cache);
 
     await db
       .prepare(
@@ -122,6 +124,7 @@ describe("rpc-relay.service", () => {
 
     const target = await resolveRpcTarget({
       env: appEnv,
+      kv,
       db,
       organizationId: TEST_ORG_ID,
       authProjectId: null,
@@ -149,6 +152,7 @@ describe("rpc-relay.service", () => {
 
     const target = await resolveRpcTarget({
       env: appEnv,
+      kv,
       db,
       organizationId: TEST_ORG_ID,
       authProjectId: TEST_PROJECT_ID,
@@ -173,6 +177,7 @@ describe("rpc-relay.service", () => {
 
     const target = await resolveRpcTarget({
       env: appEnv,
+      kv,
       db,
       organizationId: TEST_ORG_ID,
       authProjectId: TEST_PROJECT_ID,
@@ -191,6 +196,7 @@ describe("rpc-relay.service", () => {
 
     const first = await resolveRpcTarget({
       env: appEnv,
+      kv,
       db,
       organizationId: TEST_ORG_ID,
       authProjectId: null,
@@ -199,6 +205,7 @@ describe("rpc-relay.service", () => {
 
     const second = await resolveRpcTarget({
       env: appEnv,
+      kv,
       db,
       organizationId: TEST_ORG_ID,
       authProjectId: null,
@@ -221,6 +228,7 @@ describe("rpc-relay.service", () => {
 
     const providers = await listRpcProviders({
       env: appEnv,
+      kv,
       db,
       organizationId: TEST_ORG_ID,
       authProjectId: null,

--- a/apps/sdp-api/src/services/rpc-relay.service.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.ts
@@ -484,10 +484,7 @@ export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<Re
     }
   }
 
-  const selectedProvider = await pickRoundRobinProvider(
-    input.kv.cache,
-    enabledManagedProviders
-  );
+  const selectedProvider = await pickRoundRobinProvider(input.kv.cache, enabledManagedProviders);
   return {
     providerId: selectedProvider.id,
     projectId,

--- a/apps/sdp-api/src/services/rpc-relay.service.ts
+++ b/apps/sdp-api/src/services/rpc-relay.service.ts
@@ -7,6 +7,7 @@ import {
   type ProjectSettings,
 } from "@sdp/types";
 import { AppError } from "@/lib/errors";
+import type { KVStore, KVStoreSet } from "@/runtime/kv";
 import { getProviderAvailability } from "@/services/provider-availability.service";
 import type { Env } from "@/types/env";
 
@@ -54,6 +55,7 @@ export interface RpcProviderStatus {
 
 export interface ResolveRpcTargetInput {
   env: Env;
+  kv: KVStoreSet;
   db: DatabaseClient;
   organizationId: string;
   authProjectId: string | null;
@@ -359,7 +361,7 @@ function resolveProjectRpcPreference(
 }
 
 async function pickRoundRobinProvider(
-  cache: KVNamespace,
+  cache: KVStore,
   providers: ManagedRpcProvider[]
 ): Promise<ManagedRpcProvider> {
   if (providers.length === 0) {
@@ -381,7 +383,7 @@ async function pickRoundRobinProvider(
 }
 
 async function pickRoundRobinProviderOrder(
-  cache: KVNamespace,
+  cache: KVStore,
   providers: ManagedRpcProvider[]
 ): Promise<ManagedRpcProvider[]> {
   const selectedProvider = await pickRoundRobinProvider(cache, providers);
@@ -483,7 +485,7 @@ export async function resolveRpcTarget(input: ResolveRpcTargetInput): Promise<Re
   }
 
   const selectedProvider = await pickRoundRobinProvider(
-    input.env.SDP_CACHE!,
+    input.kv.cache,
     enabledManagedProviders
   );
   return {
@@ -506,7 +508,7 @@ export async function resolveRoundRobinRpcTargets(
   );
   const projectId = getEffectiveProjectId(input.authProjectId, input.requestedProjectId);
   const orderedProviders = await pickRoundRobinProviderOrder(
-    input.env.SDP_CACHE!,
+    input.kv.cache,
     enabledManagedProviders
   );
 
@@ -520,7 +522,7 @@ export async function resolveRoundRobinRpcTargets(
   }));
 }
 
-export async function recordRpcRelayTelemetry(cache: KVNamespace, telemetry: RelayTelemetryInput) {
+export async function recordRpcRelayTelemetry(cache: KVStore, telemetry: RelayTelemetryInput) {
   const key = `${STATS_KEY_PREFIX}${telemetry.providerId}`;
   const existing = (await cache.get(key, "json")) as Partial<RpcProviderStatsRecord> | null;
   const stats: RpcProviderStatsRecord = {
@@ -556,7 +558,7 @@ export async function recordRpcRelayTelemetry(cache: KVNamespace, telemetry: Rel
 }
 
 async function getProviderStats(
-  cache: KVNamespace,
+  cache: KVStore,
   providerId: ResolvedRpcProviderId
 ): Promise<RpcProviderStatsSummary> {
   const key = `${STATS_KEY_PREFIX}${providerId}`;
@@ -564,13 +566,7 @@ async function getProviderStats(
   return toStatsSummary(existing ?? emptyStats());
 }
 
-export async function listRpcProviders(input: {
-  env: Env;
-  db: DatabaseClient;
-  organizationId: string;
-  authProjectId: string | null;
-  requestedProjectId: string | null;
-}) {
+export async function listRpcProviders(input: ResolveRpcTargetInput) {
   const managedProviders = resolveManagedProviders(input.env);
   const access = await getProviderAvailability(input.env, input.db, input.organizationId);
   const enabledManagedProviders = managedProviders.filter(
@@ -582,7 +578,7 @@ export async function listRpcProviders(input: {
     providerStatuses.push({
       id: provider.id,
       endpoint: maskEndpoint(provider.url),
-      stats: await getProviderStats(input.env.SDP_CACHE!, provider.id),
+      stats: await getProviderStats(input.kv.cache, provider.id),
     });
   }
 
@@ -595,7 +591,7 @@ export async function listRpcProviders(input: {
       projectId: resolvedTarget.projectId,
       selectionMode: resolvedTarget.selectionMode,
       endpoint: resolvedTarget.endpointLabel,
-      stats: await getProviderStats(input.env.SDP_CACHE!, resolvedTarget.providerId),
+      stats: await getProviderStats(input.kv.cache, resolvedTarget.providerId),
     },
     roundRobinOrder: enabledManagedProviders.map((provider) => provider.id),
   };

--- a/apps/sdp-api/src/services/session.service.ts
+++ b/apps/sdp-api/src/services/session.service.ts
@@ -7,6 +7,7 @@
 
 import type { CachedSession, Permission, Session } from "@sdp/types";
 import { getPermissionsForOrgRole } from "@sdp/types";
+import type { KVStore } from "@/runtime/kv";
 
 // Session TTL: 7 days
 const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -23,7 +24,7 @@ export interface SessionMetadata {
 export class SessionService {
   constructor(
     private db: DatabaseClient,
-    private sessionsKV: KVNamespace
+    private sessionsKV: KVStore
   ) {}
 
   /**
@@ -236,7 +237,7 @@ export class SessionService {
   // ═══════════════════════════════════════════════════════════════════════════
 
   private async getSessionCache(sessionId: string): Promise<CachedSession | null> {
-    return this.sessionsKV.get(`session:${sessionId}`, "json");
+    return this.sessionsKV.get<CachedSession>(`session:${sessionId}`, "json");
   }
 
   private async setSessionCache(sessionId: string, data: CachedSession): Promise<void> {

--- a/apps/sdp-api/src/test/mocks/kv.ts
+++ b/apps/sdp-api/src/test/mocks/kv.ts
@@ -1,8 +1,12 @@
 /**
- * KV Namespace test helpers
+ * KV store test helpers
+ *
+ * Operate through the runtime-neutral KVStore abstraction so the helpers stay
+ * valid once a Redis-backed implementation lands (HOO-510).
  */
 
 import type { CachedApiKey } from "@sdp/types";
+import { createKVStoreSet } from "@/runtime/factory";
 import type { Env } from "@/types/env";
 
 /**
@@ -13,7 +17,8 @@ export async function seedCachedApiKey(
   keyHash: string,
   data: CachedApiKey
 ): Promise<void> {
-  await env.SDP_API_KEYS!.put(`key:${keyHash}`, JSON.stringify(data), {
+  const kv = createKVStoreSet(env);
+  await kv.apiKeys.put(`key:${keyHash}`, JSON.stringify(data), {
     expirationTtl: 3600,
   });
 }
@@ -22,12 +27,13 @@ export async function seedCachedApiKey(
  * Clears all KV data
  */
 export async function clearKVNamespaces(env: Env): Promise<void> {
-  const namespaces = [env.SDP_API_KEYS!, env.SDP_RATE_LIMITS!, env.SDP_CACHE!];
+  const kv = createKVStoreSet(env);
+  const stores = [kv.apiKeys, kv.rateLimits, kv.cache];
 
-  for (const ns of namespaces) {
-    const list = await ns.list();
+  for (const store of stores) {
+    const list = await store.list();
     for (const key of list.keys) {
-      await ns.delete(key.name);
+      await store.delete(key.name);
     }
   }
 }
@@ -40,7 +46,8 @@ export async function seedRateLimit(env: Env, identifier: string, count: number)
   const windowStart = Math.floor(Date.now() / windowMs) * windowMs;
   const key = `ratelimit:${identifier}:${windowStart}`;
 
-  await env.SDP_RATE_LIMITS!.put(key, JSON.stringify({ count, windowStart }), {
+  const kv = createKVStoreSet(env);
+  await kv.rateLimits.put(key, JSON.stringify({ count, windowStart }), {
     expirationTtl: 120,
   });
 }

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -7,6 +7,7 @@
 
 import type { HyperdriveBinding } from "@/db";
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
+import type { KVStoreSet } from "@/runtime/kv";
 import type { CachedSession, OrganizationRpcProvider, Permission } from "@sdp/types";
 
 export interface Env {
@@ -222,6 +223,8 @@ declare module "hono" {
     requestId: string;
     traceId: string;
     requestSource: string;
+    // Runtime-neutral KV bundle, populated by kvStoreMiddleware.
+    kv: KVStoreSet;
   }
 }
 


### PR DESCRIPTION
Route KV access through a runtime-neutral KVStore so the Redis implementation ([HOO-510](https://linear.app/solana-fndn/issue/HOO-510/phase-2-nodedocker-rediskvstore-implementation)) can plug in behind the same factory without touching consumers.

Architecture:
- runtime/kv.ts: KVStore interface (get/put/delete/list). KVStoreSet bundles the four namespaces (apiKeys, rateLimits, cache, sessions). No getWithMetadata, we don't use it.
- runtime/kv-workers.ts: WorkersKVStore is a thin wrapper over KVNamespace. createWorkersKVStoreSet(env) is the only place that reads env.SDP_API_KEYS / SDP_RATE_LIMITS / SDP_CACHE / SDP_SESSIONS. Throws at boot on a missing binding instead of silently falling through with `!`.
- runtime/factory.ts: createKVStoreSet(env) dispatch point. Trivial here (just delegates to WorkersKVStore), HOO-510 will branch on getRuntime(env).
- middleware/kv-store.ts: kvStoreMiddleware() populates c.var.kv per request, mounted in index.ts before rate-limit / auth.

Call-site migration (production):
- middleware/{auth,rate-limit,session-auth}.ts: c.env.SDP_* -> c.var.kv.*
- services/session.service.ts: SessionService takes KVStore in ctor
- services/rpc-relay.service.ts: ResolveRpcTargetInput gains kv: KVStoreSet. pickRoundRobinProvider, recordRpcRelayTelemetry, getProviderStats take KVStore. listRpcProviders shares the ResolveRpcTargetInput shape.
- routes/{auth/handlers/sessions,api-keys/handlers,rpc/handlers, custody/handlers/signer-check}.ts: pass c.var.kv where needed
- session-auth.ts: drop `if (!kv)` guards. The factory throws on missing bindings, so kv is always defined at the helper layer.

Test migration:
- test/mocks/kv.ts: helpers build KVStoreSet via createKVStoreSet(env) and operate through the interface. Public (env, ...) signature unchanged so callers don't need edits.
- middleware/clerk-auth.test.ts: inline Hono mounts kvStoreMiddleware before rateLimitMiddleware
- services/rpc-relay.service.test.ts: clearKvNamespace(KVNamespace) ->
  clearKvStore(KVStore). resolveRpcTarget/listRpcProviders call-sites get kv.
- routes/{auth,projects,issuance,rpc}.test.ts: replace `(env as { SDP_*: KVNamespace }).SDP_*` casts with createKVStoreSet(env).*. rpc.test.ts clearKvNamespace helper switches to KVStore.

AC:
- grep -rE "\.SDP_(API_KEYS|RATE_LIMITS|CACHE|SESSIONS)" apps/sdp-api/src matches only kv-workers.ts
- pnpm typecheck: green
- pnpm test: 43 files, 379 passed / 14 skipped, 0 failed
- wrangler deploy --dry-run: green