### PR TITLE
chore(compliance): clean up compliance schemas

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/compliance.ts
+++ b/apps/sdp-api/src/openapi/schemas/compliance.ts
@@ -1,11 +1,13 @@
-import { isoDateTimeSchema, z } from "./base";
+import {
+  complianceIntentSchema as complianceIntentSchemaBase,
+  screenAddressSchema as screenAddressSchemaBase,
+} from "../../routes/compliance/schemas";
+import { isoDateTimeSchema, withOpenApi, z } from "./base";
 
-export const complianceIntentSchema = z
-  .enum(["transfer_destination", "wallet_address_addition", "unknown"])
-  .openapi({
-    description: "Business intent for address screening.",
-    example: "transfer_destination",
-  });
+export const complianceIntentSchema = withOpenApi(complianceIntentSchemaBase, {
+  description: "Business intent for address screening.",
+  example: "transfer_destination",
+});
 
 export const complianceProviderNameSchema = z
   .enum(["range", "elliptic", "trm", "chainalysis"])
@@ -15,17 +17,20 @@ export const complianceProviderStatusSchema = z
   .enum(["ok", "unavailable", "error"])
   .openapi({ description: "Provider response status.", example: "ok" });
 
-export const addressScreeningRequestSchema = z
-  .object({
-    address: z.string().min(1).openapi({
+export const addressScreeningRequestSchema = screenAddressSchemaBase
+  .extend({
+    address: withOpenApi(screenAddressSchemaBase.shape.address, {
       description: "Address to screen.",
       example: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
     }),
-    network: z.string().min(1).max(64).default("solana").openapi({
+    network: withOpenApi(screenAddressSchemaBase.shape.network, {
       description: "Network identifier expected by the compliance provider.",
       example: "solana",
     }),
-    intent: complianceIntentSchema.default("unknown"),
+    intent: withOpenApi(screenAddressSchemaBase.shape.intent, {
+      description: "Business intent for address screening.",
+      example: "transfer_destination",
+    }),
   })
   .openapi({ description: "Address compliance screening request payload." });
 

--- a/apps/sdp-api/src/routes/compliance/schemas.ts
+++ b/apps/sdp-api/src/routes/compliance/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const complianceIntentSchema = z.enum([
+export const complianceIntentSchema = z.enum([
   "transfer_destination",
   "wallet_address_addition",
   "unknown",


### PR DESCRIPTION
## Summary

- Aligns the Compliance OpenAPI request schema with the runtime Zod schema used by the route handler.
- Exports the route-owned `complianceIntentSchema` so OpenAPI can decorate the same enum instead of redefining it.
- Keeps response schemas OpenAPI-only for now, matching the payments cleanup scope.

## Before

Compliance had a separate OpenAPI request schema that duplicated the route validation shape:

```ts
export const complianceIntentSchema = z
  .enum(["transfer_destination", "wallet_address_addition", "unknown"])
  .openapi({
    description: "Business intent for address screening.",
    example: "transfer_destination",
  });

export const addressScreeningRequestSchema = z
  .object({
    address: z.string().min(1).openapi({
      description: "Address to screen.",
      example: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
    }),
    network: z.string().min(1).max(64).default("solana").openapi({
      description: "Network identifier expected by the compliance provider.",
      example: "solana",
    }),
    intent: complianceIntentSchema.default("unknown"),
  })
  .openapi({ description: "Address compliance screening request payload." });
```

That could drift from the actual route parser:

```ts
export const screenAddressSchema = z.object({
  address: z.string().min(1),
  network: z
    .string()
    .min(1)
    .max(64)
    .optional()
    .default("solana")
    .transform((value) => value.trim().toLowerCase()),
  intent: complianceIntentSchema.optional().default("unknown"),
});
```

## After

OpenAPI now imports the route-owned schema as the base and only adds documentation metadata:

```ts
import {
  complianceIntentSchema as complianceIntentSchemaBase,
  screenAddressSchema as screenAddressSchemaBase,
} from "../../routes/compliance/schemas";
import { isoDateTimeSchema, withOpenApi, z } from "./base";

export const complianceIntentSchema = withOpenApi(complianceIntentSchemaBase, {
  description: "Business intent for address screening.",
  example: "transfer_destination",
});

export const addressScreeningRequestSchema = screenAddressSchemaBase
  .extend({
    address: withOpenApi(screenAddressSchemaBase.shape.address, {
      description: "Address to screen.",
      example: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
    }),
    network: withOpenApi(screenAddressSchemaBase.shape.network, {
      description: "Network identifier expected by the compliance provider.",
      example: "solana",
    }),
    intent: withOpenApi(screenAddressSchemaBase.shape.intent, {
      description: "Business intent for address screening.",
      example: "transfer_destination",
    }),
  })
  .openapi({ description: "Address compliance screening request payload." });
```

This keeps runtime behavior like optional/default `network`, network normalization, and default `intent` tied to the handler-owned schema.

## Spec-only note

`addressScreeningRequestSchema` is intentionally used for OpenAPI registration only. Current usage is limited to `apps/sdp-api/src/openapi/paths/compliance.ts`, where it is passed through `jsonContent(addressScreeningRequestSchema)` for `zod-to-openapi` generation. The live route still validates requests with `screenAddressSchema.safeParse(body)` in `apps/sdp-api/src/routes/compliance/handlers.ts`.

The `screenAddressSchemaBase.shape.network` decoration is intentional and follows the same pattern used in `apps/sdp-api/src/openapi/schemas/payments.ts`: reuse the exact route-owned field schema, including optional/default behavior and the trim/lowercase transform, then attach OpenAPI metadata with `withOpenApi(...)`. `@asteasolutions/zod-to-openapi@8.5.0` handles this field for spec generation; `pnpm -C apps/sdp-api openapi:generate` emits `network` as a string with min/max/default.

## Test Plan

- `pnpm -C apps/sdp-api exec biome check src/routes/compliance/schemas.ts src/openapi/schemas/compliance.ts`
- `pnpm -C apps/sdp-api exec vitest run src/routes/compliance.test.ts`
- `pnpm --filter @sdp/api typecheck`
- `pnpm -C apps/sdp-api openapi:generate`