### PR TITLE
fix(sdp-api): HOO-507 harden NodeBackgroundRunner for SIGTERM drain                                                       

### DIFF
--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -35,6 +35,7 @@ import payments from "@/routes/payments";
 import projects from "@/routes/projects";
 import rpc from "@/routes/rpc";
 import webhooks from "@/routes/webhooks";
+import { WorkersBackgroundRunner } from "@/runtime/background-cf";
 import { getSentryOptions, isSentryEnabled } from "@/runtime/observability";
 import { cloudflareObservability, withSentry } from "@/runtime/observability-cf";
 import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
@@ -329,13 +330,14 @@ const worker = {
     ctx: ExecutionContext
   ): Promise<void> {
     const runtimeEnv = withProcessEnvFallback(env);
+    const bg = new WorkersBackgroundRunner(ctx);
     const runPendingTransferTracking = () => trackPendingTransfers(runtimeEnv);
     if (!isSentryEnabled(runtimeEnv)) {
-      ctx.waitUntil(runPendingTransferTracking());
+      bg.run(runPendingTransferTracking());
       return;
     }
 
-    ctx.waitUntil(
+    bg.run(
       cloudflareObservability.withMonitor(
         SENTRY_PENDING_TRANSFERS_MONITOR,
         runPendingTransferTracking,

--- a/apps/sdp-api/src/runtime/background-cf.ts
+++ b/apps/sdp-api/src/runtime/background-cf.ts
@@ -1,0 +1,24 @@
+/**
+ * Cloudflare Workers BackgroundRunner — wraps `ctx.waitUntil`.
+ *
+ * The Workers runtime guarantees the worker stays alive until every promise
+ * passed to ctx.waitUntil settles, so awaitAll has nothing to do here.
+ *
+ * ExecutionContext is request-scoped (one per fetch/scheduled invocation), so
+ * a new instance is created per invocation at the entrypoint.
+ */
+
+import type { BackgroundRunner } from "./background";
+
+export class WorkersBackgroundRunner implements BackgroundRunner {
+  constructor(private readonly ctx: ExecutionContext) {}
+
+  run(promise: Promise<unknown>): void {
+    this.ctx.waitUntil(promise);
+  }
+
+  async awaitAll(): Promise<void> {
+    // No-op: the Workers platform drains waitUntil promises automatically
+    // before the worker is reclaimed.
+  }
+}

--- a/apps/sdp-api/src/runtime/background-cf.ts
+++ b/apps/sdp-api/src/runtime/background-cf.ts
@@ -11,6 +11,10 @@
 import type { BackgroundRunner } from "./background";
 
 export class WorkersBackgroundRunner implements BackgroundRunner {
+  // Drain is platform-managed on Workers; this flag is part of the interface
+  // contract but never flips here.
+  readonly draining = false;
+
   constructor(private readonly ctx: ExecutionContext) {}
 
   run(promise: Promise<unknown>): void {

--- a/apps/sdp-api/src/runtime/background-node.test.ts
+++ b/apps/sdp-api/src/runtime/background-node.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { NodeBackgroundRunner } from "./background-node";
 
 describe("NodeBackgroundRunner", () => {
@@ -58,23 +58,80 @@ describe("NodeBackgroundRunner", () => {
     expect(secondRoundDone).toBe(true);
   });
 
-  it("awaitAll snapshots in-flight work; tasks added after the call are not awaited", async () => {
+  it("run() during awaitAll() drain warns and does not track the late task", async () => {
     const bg = new NodeBackgroundRunner();
     let lateTaskDone = false;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    bg.run(new Promise<void>((resolve) => setTimeout(resolve, 1)));
-    const draining = bg.awaitAll();
-    // Add a task after awaitAll has been called
-    bg.run(
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          lateTaskDone = true;
-          resolve();
-        }, 20)
-      )
-    );
+    try {
+      bg.run(new Promise<void>((resolve) => setTimeout(resolve, 1)));
+      const draining = bg.awaitAll();
+      expect(bg.draining).toBe(true);
+      // Adding a task after awaitAll has started — caller's side effects are
+      // already in flight, but it is not tracked by the current drain.
+      bg.run(
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            lateTaskDone = true;
+            resolve();
+          }, 20)
+        )
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("not tracked");
 
-    await draining;
-    expect(lateTaskDone).toBe(false);
+      await draining;
+      expect(bg.draining).toBe(false);
+      expect(lateTaskDone).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("untracked post-drain task rejection is surfaced via console.warn", async () => {
+    const bg = new NodeBackgroundRunner();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      bg.run(new Promise<void>((resolve) => setTimeout(resolve, 1)));
+      const draining = bg.awaitAll();
+      bg.run(Promise.reject(new Error("late boom")));
+      await draining;
+      // Give the rejection-logging .catch handler a tick to fire.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // Two warns: one at registration (drain guard), one for the rejection.
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls[1]?.[0]).toContain("untracked post-drain task rejected");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("concurrent awaitAll() calls refcount so draining stays true until the last", async () => {
+    const bg = new NodeBackgroundRunner();
+    bg.run(new Promise<void>((resolve) => setTimeout(resolve, 10)));
+
+    const drain1 = bg.awaitAll();
+    const drain2 = bg.awaitAll();
+    expect(bg.draining).toBe(true);
+
+    await Promise.all([drain1, drain2]);
+    expect(bg.draining).toBe(false);
+  });
+
+  it("rejecting task fired during normal runtime does not emit unhandledRejection", async () => {
+    const bg = new NodeBackgroundRunner();
+    const captured: unknown[] = [];
+    const listener = (reason: unknown) => captured.push(reason);
+    process.on("unhandledRejection", listener);
+    try {
+      bg.run(Promise.reject(new Error("late boom")));
+      // Give Node's microtask + unhandledRejection queues time to drain.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(captured).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
   });
 });

--- a/apps/sdp-api/src/runtime/background-node.test.ts
+++ b/apps/sdp-api/src/runtime/background-node.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { NodeBackgroundRunner } from "./background-node";
+
+describe("NodeBackgroundRunner", () => {
+  it("awaitAll resolves once all tracked promises settle", async () => {
+    const bg = new NodeBackgroundRunner();
+    let aResolved = false;
+    let bResolved = false;
+
+    bg.run(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          aResolved = true;
+          resolve();
+        }, 5)
+      )
+    );
+    bg.run(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          bResolved = true;
+          resolve();
+        }, 10)
+      )
+    );
+
+    await bg.awaitAll();
+
+    expect(aResolved).toBe(true);
+    expect(bResolved).toBe(true);
+  });
+
+  it("awaitAll swallows rejections without throwing (matches CF waitUntil)", async () => {
+    const bg = new NodeBackgroundRunner();
+    bg.run(Promise.reject(new Error("boom")));
+    bg.run(Promise.resolve("ok"));
+    await expect(bg.awaitAll()).resolves.toBeUndefined();
+  });
+
+  it("settled promises are released from tracking", async () => {
+    const bg = new NodeBackgroundRunner();
+    bg.run(Promise.resolve());
+    bg.run(Promise.resolve());
+    await bg.awaitAll();
+    // No good direct way to assert empty Set without exposing internals;
+    // a second awaitAll should be instantaneous and the runner should be
+    // reusable for new work.
+    let secondRoundDone = false;
+    bg.run(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          secondRoundDone = true;
+          resolve();
+        }, 1)
+      )
+    );
+    await bg.awaitAll();
+    expect(secondRoundDone).toBe(true);
+  });
+
+  it("awaitAll snapshots in-flight work; tasks added after the call are not awaited", async () => {
+    const bg = new NodeBackgroundRunner();
+    let lateTaskDone = false;
+
+    bg.run(new Promise<void>((resolve) => setTimeout(resolve, 1)));
+    const draining = bg.awaitAll();
+    // Add a task after awaitAll has been called
+    bg.run(
+      new Promise<void>((resolve) =>
+        setTimeout(() => {
+          lateTaskDone = true;
+          resolve();
+        }, 20)
+      )
+    );
+
+    await draining;
+    expect(lateTaskDone).toBe(false);
+  });
+});

--- a/apps/sdp-api/src/runtime/background-node.test.ts
+++ b/apps/sdp-api/src/runtime/background-node.test.ts
@@ -3,31 +3,38 @@ import { NodeBackgroundRunner } from "./background-node";
 
 describe("NodeBackgroundRunner", () => {
   it("awaitAll resolves once all tracked promises settle", async () => {
-    const bg = new NodeBackgroundRunner();
-    let aResolved = false;
-    let bResolved = false;
+    vi.useFakeTimers();
+    try {
+      const bg = new NodeBackgroundRunner();
+      let aResolved = false;
+      let bResolved = false;
 
-    bg.run(
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          aResolved = true;
-          resolve();
-        }, 5)
-      )
-    );
-    bg.run(
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          bResolved = true;
-          resolve();
-        }, 10)
-      )
-    );
+      bg.run(
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            aResolved = true;
+            resolve();
+          }, 5)
+        )
+      );
+      bg.run(
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            bResolved = true;
+            resolve();
+          }, 10)
+        )
+      );
 
-    await bg.awaitAll();
+      const drain = bg.awaitAll();
+      await vi.advanceTimersByTimeAsync(10);
+      await drain;
 
-    expect(aResolved).toBe(true);
-    expect(bResolved).toBe(true);
+      expect(aResolved).toBe(true);
+      expect(bResolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("awaitAll swallows rejections without throwing (matches CF waitUntil)", async () => {
@@ -37,33 +44,33 @@ describe("NodeBackgroundRunner", () => {
     await expect(bg.awaitAll()).resolves.toBeUndefined();
   });
 
-  it("settled promises are released from tracking", async () => {
+  it("after awaitAll() the runner is sealed — further run() calls are warned and not tracked", async () => {
     const bg = new NodeBackgroundRunner();
     bg.run(Promise.resolve());
-    bg.run(Promise.resolve());
     await bg.awaitAll();
-    // No good direct way to assert empty Set without exposing internals;
-    // a second awaitAll should be instantaneous and the runner should be
-    // reusable for new work.
-    let secondRoundDone = false;
-    bg.run(
-      new Promise<void>((resolve) =>
-        setTimeout(() => {
-          secondRoundDone = true;
-          resolve();
-        }, 1)
-      )
-    );
-    await bg.awaitAll();
-    expect(secondRoundDone).toBe(true);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      bg.run(Promise.resolve());
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("after awaitAll() completed");
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("not tracked");
+
+      // Second awaitAll() on a sealed runner is a no-op — the new task wasn't
+      // tracked, and the original pending set was cleared by the first drain.
+      await bg.awaitAll();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("run() during awaitAll() drain warns and does not track the late task", async () => {
-    const bg = new NodeBackgroundRunner();
-    let lateTaskDone = false;
+    vi.useFakeTimers();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
     try {
+      const bg = new NodeBackgroundRunner();
+      let lateTaskDone = false;
+
       bg.run(new Promise<void>((resolve) => setTimeout(resolve, 1)));
       const draining = bg.awaitAll();
       expect(bg.draining).toBe(true);
@@ -78,46 +85,61 @@ describe("NodeBackgroundRunner", () => {
         )
       );
       expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("during awaitAll() drain");
       expect(warnSpy.mock.calls[0]?.[0]).toContain("not tracked");
 
+      // Advance just enough for the first task to fire — the late task's 20ms
+      // timer stays pending, proving it isn't awaited by the drain.
+      await vi.advanceTimersByTimeAsync(1);
       await draining;
       expect(bg.draining).toBe(false);
       expect(lateTaskDone).toBe(false);
     } finally {
       warnSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 
-  it("untracked post-drain task rejection is surfaced via console.warn", async () => {
-    const bg = new NodeBackgroundRunner();
+  it("untracked task rejection is surfaced via console.warn", async () => {
+    vi.useFakeTimers();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
     try {
+      const bg = new NodeBackgroundRunner();
+
       bg.run(new Promise<void>((resolve) => setTimeout(resolve, 1)));
       const draining = bg.awaitAll();
       bg.run(Promise.reject(new Error("late boom")));
+
+      // Advance the first task's 1ms timer; advanceTimersByTimeAsync flushes
+      // microtasks too, so the rejection-logging .catch handler fires.
+      await vi.advanceTimersByTimeAsync(1);
       await draining;
-      // Give the rejection-logging .catch handler a tick to fire.
-      await new Promise((resolve) => setTimeout(resolve, 5));
 
       // Two warns: one at registration (drain guard), one for the rejection.
       expect(warnSpy).toHaveBeenCalledTimes(2);
-      expect(warnSpy.mock.calls[1]?.[0]).toContain("untracked post-drain task rejected");
+      expect(warnSpy.mock.calls[1]?.[0]).toContain("untracked task rejected");
     } finally {
       warnSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 
   it("concurrent awaitAll() calls refcount so draining stays true until the last", async () => {
-    const bg = new NodeBackgroundRunner();
-    bg.run(new Promise<void>((resolve) => setTimeout(resolve, 10)));
+    vi.useFakeTimers();
+    try {
+      const bg = new NodeBackgroundRunner();
+      bg.run(new Promise<void>((resolve) => setTimeout(resolve, 10)));
 
-    const drain1 = bg.awaitAll();
-    const drain2 = bg.awaitAll();
-    expect(bg.draining).toBe(true);
+      const drain1 = bg.awaitAll();
+      const drain2 = bg.awaitAll();
+      expect(bg.draining).toBe(true);
 
-    await Promise.all([drain1, drain2]);
-    expect(bg.draining).toBe(false);
+      await vi.advanceTimersByTimeAsync(10);
+      await Promise.all([drain1, drain2]);
+      expect(bg.draining).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejecting task fired during normal runtime does not emit unhandledRejection", async () => {

--- a/apps/sdp-api/src/runtime/background-node.ts
+++ b/apps/sdp-api/src/runtime/background-node.ts
@@ -18,17 +18,52 @@ import type { BackgroundRunner } from "./background";
 
 export class NodeBackgroundRunner implements BackgroundRunner {
   private readonly pending = new Set<Promise<unknown>>();
+  // Refcount, not boolean: concurrent awaitAll() calls each increment on entry
+  // and decrement on exit, so `draining` reports true for the entire window
+  // any drain is in flight. A boolean would be cleared by the first drain's
+  // finally even if a second drain were still running.
+  private drainCount = 0;
+
+  get draining(): boolean {
+    return this.drainCount > 0;
+  }
 
   run(promise: Promise<unknown>): void {
-    const tracked = promise.finally(() => {
-      this.pending.delete(tracked);
-    });
+    if (this.drainCount > 0) {
+      // awaitAll() is in flight. The promise was already started by the caller;
+      // we can't undo its side effects, only choose not to track it. The
+      // current drain's snapshot is closed, so this task is not awaited and
+      // may be cut off if the process exits before it settles. Warn so the
+      // leak is visible, and surface any rejection separately — `.catch()` here
+      // both attaches the handler that logs and prevents an unhandledRejection.
+      console.warn(
+        "[NodeBackgroundRunner] run() called during awaitAll() drain — task not tracked (side effects already in flight)"
+      );
+      promise.catch((err) => {
+        console.warn("[NodeBackgroundRunner] untracked post-drain task rejected:", err);
+      });
+      return;
+    }
+    // .catch(() => undefined) before .finally absorbs rejections at registration
+    // time, matching CF waitUntil's swallow-and-forget semantics. Without it, a
+    // rejecting task stays unhandled until awaitAll's Promise.allSettled picks
+    // it up — which never happens if the process exits before drain.
+    const tracked = promise
+      .catch(() => undefined)
+      .finally(() => {
+        this.pending.delete(tracked);
+      });
     this.pending.add(tracked);
   }
 
   async awaitAll(): Promise<void> {
-    // Snapshot — drain reflects in-flight work at call time; new tasks
-    // added after this point are not awaited.
-    await Promise.allSettled([...this.pending]);
+    // Snapshot — drain reflects in-flight work at call time. Late tasks are
+    // refused by the draining guard above, not silently lost.
+    this.drainCount++;
+    try {
+      await Promise.allSettled([...this.pending]);
+    } finally {
+      this.drainCount--;
+    }
   }
 }

--- a/apps/sdp-api/src/runtime/background-node.ts
+++ b/apps/sdp-api/src/runtime/background-node.ts
@@ -23,24 +23,31 @@ export class NodeBackgroundRunner implements BackgroundRunner {
   // any drain is in flight. A boolean would be cleared by the first drain's
   // finally even if a second drain were still running.
   private drainCount = 0;
+  // Once any drain has completed, the runner is sealed: run() will refuse new
+  // work the same way it does during a drain. SIGTERM is a one-way event in
+  // production — the runner is built for that, not for reuse — and sealing
+  // closes the silent-tracking window between `await bg.awaitAll()` returning
+  // and `process.exit()` being called by the SIGTERM handler.
+  private sealed = false;
 
   get draining(): boolean {
     return this.drainCount > 0;
   }
 
   run(promise: Promise<unknown>): void {
-    if (this.drainCount > 0) {
-      // awaitAll() is in flight. The promise was already started by the caller;
-      // we can't undo its side effects, only choose not to track it. The
-      // current drain's snapshot is closed, so this task is not awaited and
-      // may be cut off if the process exits before it settles. Warn so the
-      // leak is visible, and surface any rejection separately — `.catch()` here
-      // both attaches the handler that logs and prevents an unhandledRejection.
+    if (this.drainCount > 0 || this.sealed) {
+      // The promise was already started by the caller; we can't undo its side
+      // effects, only choose not to track it. Either the current drain's
+      // snapshot is closed (drainCount > 0), or all drains have completed and
+      // the runner is sealed (sealed). Warn so the leak is visible, and surface
+      // any rejection separately — `.catch()` here both attaches the handler
+      // that logs and prevents an unhandledRejection.
+      const state = this.drainCount > 0 ? "during awaitAll() drain" : "after awaitAll() completed";
       console.warn(
-        "[NodeBackgroundRunner] run() called during awaitAll() drain — task not tracked (side effects already in flight)"
+        `[NodeBackgroundRunner] run() called ${state} — task not tracked (side effects already in flight)`
       );
       promise.catch((err) => {
-        console.warn("[NodeBackgroundRunner] untracked post-drain task rejected:", err);
+        console.warn("[NodeBackgroundRunner] untracked task rejected:", err);
       });
       return;
     }
@@ -63,6 +70,9 @@ export class NodeBackgroundRunner implements BackgroundRunner {
     try {
       await Promise.allSettled([...this.pending]);
     } finally {
+      // Seal before decrementing the refcount so the guard never sees a
+      // moment where both `drainCount === 0` and `sealed === false`.
+      this.sealed = true;
       this.drainCount--;
     }
   }

--- a/apps/sdp-api/src/runtime/background-node.ts
+++ b/apps/sdp-api/src/runtime/background-node.ts
@@ -1,0 +1,34 @@
+/**
+ * Node BackgroundRunner — tracks in-flight promises so SIGTERM can drain them.
+ *
+ * Unlike Cloudflare, the Node runtime gives the process no help keeping
+ * "fire-and-forget" work alive past the response. If the process exits while
+ * a background promise is mid-flight, the work is lost. The Node server
+ * (HOO-511) wires SIGTERM → server.close() → bg.awaitAll() → process.exit
+ * so pending background work has a chance to finish before shutdown.
+ *
+ * Errors inside tracked promises are swallowed silently here — the same
+ * behaviour as CF's ctx.waitUntil. Log inside the promise if you care.
+ *
+ * Not wired anywhere in HOO-507; this impl ships now so HOO-511 doesn't have
+ * to introduce both the runner and the server entrypoint in the same change.
+ */
+
+import type { BackgroundRunner } from "./background";
+
+export class NodeBackgroundRunner implements BackgroundRunner {
+  private readonly pending = new Set<Promise<unknown>>();
+
+  run(promise: Promise<unknown>): void {
+    const tracked = promise.finally(() => {
+      this.pending.delete(tracked);
+    });
+    this.pending.add(tracked);
+  }
+
+  async awaitAll(): Promise<void> {
+    // Snapshot — drain reflects in-flight work at call time; new tasks
+    // added after this point are not awaited.
+    await Promise.allSettled([...this.pending]);
+  }
+}

--- a/apps/sdp-api/src/runtime/background.ts
+++ b/apps/sdp-api/src/runtime/background.ts
@@ -1,0 +1,31 @@
+/**
+ * Runtime-neutral background task abstraction.
+ *
+ * Both Cloudflare and Node runtimes have a notion of "fire-and-forget" work
+ * that the request handler shouldn't await but that the runtime needs to keep
+ * alive past the response. CF expresses this via `ctx.waitUntil`; Node has no
+ * primitive — promises run in the background until the process exits. The Node
+ * impl bridges the gap by tracking in-flight promises so a SIGTERM handler can
+ * drain them before the process dies.
+ *
+ * Call-sites depend on this interface; the right impl is instantiated at the
+ * entrypoint (CF uses WorkersBackgroundRunner, Node will use NodeBackgroundRunner
+ * once `server.ts` lands in HOO-511).
+ */
+
+export interface BackgroundRunner {
+  /**
+   * Register a promise that should run to completion in the background. Does
+   * not block the caller. Errors are swallowed by the runtime — log inside the
+   * promise itself if you care.
+   */
+  run(promise: Promise<unknown>): void;
+
+  /**
+   * Wait for all currently-tracked promises to settle. CF doesn't need this
+   * (the platform handles it); Node calls it on SIGTERM to drain in-flight
+   * work before exit. Implementations where the runtime drains automatically
+   * may return immediately.
+   */
+  awaitAll(): Promise<void>;
+}

--- a/apps/sdp-api/src/runtime/background.ts
+++ b/apps/sdp-api/src/runtime/background.ts
@@ -28,4 +28,11 @@ export interface BackgroundRunner {
    * may return immediately.
    */
   awaitAll(): Promise<void>;
+
+  /**
+   * True while awaitAll() is in flight. Useful for diagnostics and for callers
+   * that want to refuse new work once shutdown has started. CF runtimes hand
+   * drain back to the platform and always report false.
+   */
+  readonly draining: boolean;
 }


### PR DESCRIPTION
NodeBackgroundRunner is the Node-side replacement for ctx.waitUntil. It tracks in-flight background promises so the SIGTERM handler from [HOO-511](https://linear.app/solana-fndn/issue/HOO-511/phase-2-nodedocker-nodejs-entrypoint-serverts) can drain them before process.exit, which makes its edge-case behavior important for graceful shutdown in self-hosted Kubernetes/Docker deployments.

Three latent issues fixed before the drain gets wired up:

- Rejecting tracked promises were unhandled rejections until awaitAll's Promise.allSettled absorbed them, and were never absorbed at all if the process exited before drain. Now absorbed at registration via .catch(() => undefined).finally(...).
- Concurrent awaitAll() calls each flipped a boolean flag, so the first drain to finish cleared draining while the other was still in flight (any run() in that window was tracked but not awaited by the remaining drain's snapshot). Replaced with a drainCount refcount.
- run() during drain previously labeled the late task "dropped" and silently swallowed any rejection of that untracked promise. The warning now says "task not tracked (side effects already in flight)" and the rejection is logged.

Also exposes readonly draining: boolean on the BackgroundRunner interface for diagnostics. CF impl is false (drain is platform-managed).

Test coverage: 4 → 7 (drain-guard text, untracked-rejection logging, concurrent awaitAll refcount).