### PR TITLE
fix: Clear and refetch wallet data when switching organizations

### DIFF
--- a/apps/sdp-web/src/app/dashboard/layout.tsx
+++ b/apps/sdp-web/src/app/dashboard/layout.tsx
@@ -18,8 +18,9 @@ export default async function DashboardLayout({ children }: { children: ReactNod
 
   return (
     <DashboardWorkspaceProvider
+      key={`${userId ?? "anonymous"}:${orgId ?? "no-org"}`}
       dashboardAccess={dashboardAccess}
-      dashboardCacheScope={{ orgId: orgId ?? null, userId: userId ?? null }}
+      serverDashboardCacheScope={{ orgId: orgId ?? null, userId: userId ?? null }}
     >
       <NetworkDebugProvider>
         <DashboardShell>{children}</DashboardShell>

--- a/apps/sdp-web/src/app/dashboard/layout.tsx
+++ b/apps/sdp-web/src/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { DashboardWorkspaceProvider } from "@/contexts/dashboard-workspace-conte
 import { NetworkDebugProvider } from "@/contexts/network-debug-context";
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { resolveDashboardAccess } from "@/lib/dashboard-access";
+import { type DashboardCacheScope, getDashboardCacheScopeKey } from "@/lib/dashboard-cache-scope";
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const { orgRole, orgId, userId } = await auth();
@@ -15,12 +16,16 @@ export default async function DashboardLayout({ children }: { children: ReactNod
   }
 
   const dashboardAccess = resolveDashboardAccess(orgRole);
+  const dashboardCacheScope = {
+    orgId: orgId ?? null,
+    userId: userId ?? null,
+  } satisfies DashboardCacheScope;
 
   return (
     <DashboardWorkspaceProvider
-      key={`${userId ?? "anonymous"}:${orgId ?? "no-org"}`}
+      key={getDashboardCacheScopeKey(dashboardCacheScope)}
       dashboardAccess={dashboardAccess}
-      serverDashboardCacheScope={{ orgId: orgId ?? null, userId: userId ?? null }}
+      serverDashboardCacheScope={dashboardCacheScope}
     >
       <NetworkDebugProvider>
         <DashboardShell>{children}</DashboardShell>

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -976,11 +976,7 @@ export function PaymentsActionPage({
   const [rampExecution, setRampExecution] = useState<PaymentRampExecution | null>(null);
   const shouldLoadWallets = branch !== null;
   const hasServerWalletSnapshot = wallets.length > 0 || walletsError !== null;
-  const {
-    data: swrWallets,
-    error: walletsFetchError,
-    isValidating: walletsRefreshing,
-  } = useSWR<PaymentsDashboardWallet[]>(
+  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
     shouldLoadWallets ? PAYMENTS_ACTION_WALLETS_KEY : null,
     () => fetchWallets(),
     {
@@ -998,7 +994,7 @@ export function PaymentsActionPage({
       ? walletsError
       : null;
   const hasWallets = liveWallets.length > 0;
-  const walletsLoading = shouldLoadWallets && walletsRefreshing && swrWallets === undefined;
+  const walletsLoading = shouldLoadWallets && swrWallets === undefined && !liveWalletsError;
 
   useEffect(() => {
     if (!hasWallets) {
@@ -1016,7 +1012,7 @@ export function PaymentsActionPage({
     [liveWallets, selectedWalletId]
   );
   const { data: selectedWalletBalancesSnapshot } = useSWR(
-    selectedWalletId ? [PAYMENTS_ACTION_WALLET_BALANCES_KEY, selectedWalletId] : null,
+    selectedWallet ? [PAYMENTS_ACTION_WALLET_BALANCES_KEY, selectedWallet.walletId] : null,
     ([, walletId]: readonly [string, string]) => fetchWalletBalances(walletId),
     {
       revalidateOnFocus: false,

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -14,15 +14,11 @@ import {
 import { SWRConfig } from "swr";
 import { Button } from "@/components/ui/button";
 import type { DashboardAccess } from "@/lib/dashboard-access";
+import { type DashboardCacheScope, getDashboardCacheScopeKey } from "@/lib/dashboard-cache-scope";
 import { DASHBOARD_SWR_CONFIG } from "@/lib/dashboard-swr-config";
 import { useDashboardUrlState } from "@/lib/dashboard-url-state";
 
 export type IssuanceWorkspaceTab = "tokens" | "playground";
-
-export interface DashboardCacheScope {
-  userId: string | null;
-  orgId: string | null;
-}
 
 export interface DashboardPlaygroundApiKeyOption {
   id: string;
@@ -51,10 +47,6 @@ type DashboardWorkspaceContextValue = {
 const DashboardWorkspaceContext = createContext<DashboardWorkspaceContextValue | undefined>(
   undefined
 );
-
-export function getDashboardCacheScopeKey(scope: DashboardCacheScope): string {
-  return `${scope.userId ?? "anonymous"}:${scope.orgId ?? "no-org"}`;
-}
 
 function DashboardScopeRefreshFallback() {
   const router = useRouter();

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { useAuth } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { SWRConfig } from "swr";
 import type { DashboardAccess } from "@/lib/dashboard-access";
 import { DASHBOARD_SWR_CONFIG } from "@/lib/dashboard-swr-config";
@@ -41,10 +51,29 @@ const DashboardWorkspaceContext = createContext<DashboardWorkspaceContextValue |
   undefined
 );
 
+export function getDashboardCacheScopeKey(scope: DashboardCacheScope): string {
+  return `${scope.userId ?? "anonymous"}:${scope.orgId ?? "no-org"}`;
+}
+
+function DashboardScopeRefreshFallback() {
+  return (
+    <main className="min-h-screen bg-[var(--sdp-shell-bg)] p-0 text-text-extra-high">
+      <div className="mx-auto max-w-5xl border border-border-extra-light bg-white/70 p-6">
+        <p className="text-sm text-text-low">Loading dashboard...</p>
+      </div>
+    </main>
+  );
+}
+
+const DASHBOARD_SCOPED_SWR_CONFIG = {
+  ...DASHBOARD_SWR_CONFIG,
+  provider: () => new Map(),
+};
+
 type DashboardWorkspaceProviderProps = {
   children: ReactNode;
   dashboardAccess: DashboardAccess;
-  dashboardCacheScope: DashboardCacheScope;
+  serverDashboardCacheScope: DashboardCacheScope;
   defaultProject?: string;
   initialSidebarOpen?: boolean;
 };
@@ -52,10 +81,12 @@ type DashboardWorkspaceProviderProps = {
 export function DashboardWorkspaceProvider({
   children,
   dashboardAccess,
-  dashboardCacheScope,
+  serverDashboardCacheScope,
   defaultProject = "Default Project",
   initialSidebarOpen = true,
 }: DashboardWorkspaceProviderProps) {
+  const auth = useAuth();
+  const router = useRouter();
   const { replaceSearchParams, searchParams } = useDashboardUrlState();
   const [isSidebarOpen, setSidebarOpenState] = useState(initialSidebarOpen);
   const [selectedProject, setSelectedProject] = useState(defaultProject);
@@ -63,6 +94,34 @@ export function DashboardWorkspaceProvider({
     DashboardPlaygroundApiKeyOption[]
   >([]);
   const [selectedPlaygroundApiKeyId, setSelectedPlaygroundApiKeyId] = useState<string | null>(null);
+  const liveDashboardCacheScope = useMemo<DashboardCacheScope>(
+    () =>
+      auth.isLoaded
+        ? {
+            orgId: auth.orgId ?? null,
+            userId: auth.userId ?? null,
+          }
+        : serverDashboardCacheScope,
+    [auth.isLoaded, auth.orgId, auth.userId, serverDashboardCacheScope]
+  );
+  const liveDashboardCacheScopeKey = useMemo(
+    () => getDashboardCacheScopeKey(liveDashboardCacheScope),
+    [liveDashboardCacheScope]
+  );
+  const serverDashboardCacheScopeKey = useMemo(
+    () => getDashboardCacheScopeKey(serverDashboardCacheScope),
+    [serverDashboardCacheScope]
+  );
+  const dashboardScopeIsFresh = liveDashboardCacheScopeKey === serverDashboardCacheScopeKey;
+  const shouldRenderScopeRefreshFallback = auth.isLoaded && !dashboardScopeIsFresh;
+
+  useEffect(() => {
+    if (!auth.isLoaded || liveDashboardCacheScopeKey === serverDashboardCacheScopeKey) {
+      return;
+    }
+
+    router.refresh();
+  }, [auth.isLoaded, liveDashboardCacheScopeKey, router, serverDashboardCacheScopeKey]);
 
   const issuanceTab: IssuanceWorkspaceTab = useMemo(() => {
     const tab = searchParams.get("tab");
@@ -102,7 +161,7 @@ export function DashboardWorkspaceProvider({
   const value = useMemo<DashboardWorkspaceContextValue>(
     () => ({
       dashboardAccess,
-      dashboardCacheScope,
+      dashboardCacheScope: liveDashboardCacheScope,
       isSidebarOpen,
       selectedProject,
       issuanceTab,
@@ -117,7 +176,7 @@ export function DashboardWorkspaceProvider({
     }),
     [
       dashboardAccess,
-      dashboardCacheScope,
+      liveDashboardCacheScope,
       isSidebarOpen,
       playgroundApiKeys,
       issuanceTab,
@@ -132,7 +191,9 @@ export function DashboardWorkspaceProvider({
 
   return (
     <DashboardWorkspaceContext.Provider value={value}>
-      <SWRConfig value={DASHBOARD_SWR_CONFIG}>{children}</SWRConfig>
+      <SWRConfig key={liveDashboardCacheScopeKey} value={DASHBOARD_SCOPED_SWR_CONFIG}>
+        {shouldRenderScopeRefreshFallback ? <DashboardScopeRefreshFallback /> : children}
+      </SWRConfig>
     </DashboardWorkspaceContext.Provider>
   );
 }
@@ -141,7 +202,6 @@ export function useDashboardWorkspace() {
   const context = useContext(DashboardWorkspaceContext);
 
   if (!context) {
-    // biome-ignore lint/security/noSecrets: This is a React hook guard message, not a secret.
     throw new Error("useDashboardWorkspace must be used within a DashboardWorkspaceProvider");
   }
 

--- a/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
+++ b/apps/sdp-web/src/contexts/dashboard-workspace-context.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from "react";
 import { SWRConfig } from "swr";
+import { Button } from "@/components/ui/button";
 import type { DashboardAccess } from "@/lib/dashboard-access";
 import { DASHBOARD_SWR_CONFIG } from "@/lib/dashboard-swr-config";
 import { useDashboardUrlState } from "@/lib/dashboard-url-state";
@@ -56,10 +57,15 @@ export function getDashboardCacheScopeKey(scope: DashboardCacheScope): string {
 }
 
 function DashboardScopeRefreshFallback() {
+  const router = useRouter();
+
   return (
     <main className="min-h-screen bg-[var(--sdp-shell-bg)] p-0 text-text-extra-high">
-      <div className="mx-auto max-w-5xl border border-border-extra-light bg-white/70 p-6">
+      <div className="mx-auto max-w-5xl space-y-4 border border-border-extra-light bg-white/70 p-6">
         <p className="text-sm text-text-low">Loading dashboard...</p>
+        <Button type="button" variant="ghost" size="sm" onClick={() => router.refresh()}>
+          Retry
+        </Button>
       </div>
     </main>
   );
@@ -110,7 +116,7 @@ export function DashboardWorkspaceProvider({
   );
   const serverDashboardCacheScopeKey = useMemo(
     () => getDashboardCacheScopeKey(serverDashboardCacheScope),
-    [serverDashboardCacheScope]
+    [serverDashboardCacheScope.orgId, serverDashboardCacheScope.userId]
   );
   const dashboardScopeIsFresh = liveDashboardCacheScopeKey === serverDashboardCacheScopeKey;
   const shouldRenderScopeRefreshFallback = auth.isLoaded && !dashboardScopeIsFresh;

--- a/apps/sdp-web/src/lib/dashboard-cache-scope.ts
+++ b/apps/sdp-web/src/lib/dashboard-cache-scope.ts
@@ -1,0 +1,8 @@
+export interface DashboardCacheScope {
+  userId: string | null;
+  orgId: string | null;
+}
+
+export function getDashboardCacheScopeKey(scope: DashboardCacheScope): string {
+  return `${scope.userId ?? "anonymous"}:${scope.orgId ?? "no-org"}`;
+}

--- a/apps/sdp-web/src/lib/dashboard-swr.tsx
+++ b/apps/sdp-web/src/lib/dashboard-swr.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useMemo } from "react";
 import useSWR, { type BareFetcher, type Key, type SWRConfiguration, type SWRResponse } from "swr";
-import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import {
+  getDashboardCacheScopeKey,
+  useDashboardWorkspace,
+} from "@/contexts/dashboard-workspace-context";
 
 export interface PersistedDashboardSnapshotConfig<Data> {
   key: string;
@@ -99,10 +102,11 @@ export function usePersistedDashboardSWR<Data, Error = unknown>(
   config: SWRConfiguration<Data, Error> = {},
   persistedConfig?: PersistedDashboardSnapshotConfig<Data>
 ): SWRResponse<Data, Error> {
-  const {
-    dashboardCacheScope: { orgId, userId },
-  } = useDashboardWorkspace();
-  const scopeKey = useMemo(() => `${userId ?? "anonymous"}:${orgId ?? "no-org"}`, [orgId, userId]);
+  const { dashboardCacheScope } = useDashboardWorkspace();
+  const scopeKey = useMemo(
+    () => getDashboardCacheScopeKey(dashboardCacheScope),
+    [dashboardCacheScope]
+  );
   const persistedKey = persistedConfig?.key;
   const persistedTtlMs = persistedConfig?.ttlMs;
   const persistedVersion = persistedConfig?.version ?? DEFAULT_PERSISTED_SNAPSHOT_VERSION;
@@ -130,9 +134,12 @@ export function usePersistedDashboardSWR<Data, Error = unknown>(
     return readPersistedDashboardSnapshot<Data>(scopeKey, normalizedPersistedConfig);
   }, [config.fallbackData, normalizedPersistedConfig, scopeKey]);
 
+  const fallbackData =
+    config.fallbackData !== undefined ? config.fallbackData : persistedFallbackData;
+
   const response = useSWR<Data, Error>(key, fetcher, {
     ...config,
-    fallbackData: config.fallbackData !== undefined ? config.fallbackData : persistedFallbackData,
+    fallbackData,
   });
 
   useEffect(() => {

--- a/apps/sdp-web/src/lib/dashboard-swr.tsx
+++ b/apps/sdp-web/src/lib/dashboard-swr.tsx
@@ -2,10 +2,8 @@
 
 import { useEffect, useMemo } from "react";
 import useSWR, { type BareFetcher, type Key, type SWRConfiguration, type SWRResponse } from "swr";
-import {
-  getDashboardCacheScopeKey,
-  useDashboardWorkspace,
-} from "@/contexts/dashboard-workspace-context";
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { getDashboardCacheScopeKey } from "@/lib/dashboard-cache-scope";
 
 export interface PersistedDashboardSnapshotConfig<Data> {
   key: string;


### PR DESCRIPTION
## What Changed

https://github.com/user-attachments/assets/4c005220-bdb6-4e8e-9898-065d5881c157

- Scoped dashboard SWR/cache state by active Clerk user/org.
- Refreshes dashboard server data when Clerk org changes.
- Prevents stale payment wallets, balances, and transfers from carrying across org switches.

## Why
Org switching could leave previous-org payment data visible or selectable until a manual refresh.

## Impact
Users see freshly scoped dashboard/payment data after switching organizations. A brief loading fallback may appear during refresh.