### PR TITLE
refactor(sdp-api): HOO-508 unify Sentry across runtimes via observability module

### DIFF
--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -33,6 +33,7 @@
     "@react-email/render": "2.0.8",
     "@sdp/types": "workspace:*",
     "@sentry/cloudflare": "^10.51.0",
+    "@sentry/node": "^10.51.0",
     "@solana-program/system": "catalog:",
     "@solana-program/token-2022": "catalog:",
     "@solana/addresses": "catalog:",

--- a/apps/sdp-api/src/index.ts
+++ b/apps/sdp-api/src/index.ts
@@ -5,7 +5,6 @@
  * Built with Hono, Postgres, Hyperdrive, and KV
  */
 
-import * as Sentry from "@sentry/cloudflare";
 import { type Context, Hono } from "hono";
 import { logger } from "hono/logger";
 import { prettyJSON } from "hono/pretty-json";
@@ -36,6 +35,8 @@ import payments from "@/routes/payments";
 import projects from "@/routes/projects";
 import rpc from "@/routes/rpc";
 import webhooks from "@/routes/webhooks";
+import { getSentryOptions, isSentryEnabled } from "@/runtime/observability";
+import { cloudflareObservability, withSentry } from "@/runtime/observability-cf";
 import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
 import { SigningError } from "@/services/ports";
 import type { Env } from "@/types/env";
@@ -46,38 +47,8 @@ const app = new Hono<{ Bindings: Env }>();
 const SENTRY_PENDING_TRANSFERS_MONITOR = "sdp-api-track-pending-transfers";
 const PENDING_TRANSFERS_CRON = "* * * * *";
 
-function parseSentryTraceSampleRate(value: string | undefined, fallback: number): number {
-  if (!value) {
-    return fallback;
-  }
-
-  const parsed = Number.parseFloat(value);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
-    return fallback;
-  }
-
-  return parsed;
-}
-
-function getSentryOptions(env: Env) {
-  const dsn = env.SENTRY_DSN?.trim();
-  const defaultTraceSampleRate = env.ENVIRONMENT === "production" ? 0.1 : 1;
-  const tracesSampleRate = parseSentryTraceSampleRate(
-    env.SENTRY_TRACES_SAMPLE_RATE,
-    defaultTraceSampleRate
-  );
-
-  return {
-    ...(dsn ? { dsn } : {}),
-    enabled: Boolean(dsn),
-    environment: env.ENVIRONMENT,
-    tracesSampleRate,
-    sendDefaultPii: false,
-  };
-}
-
 function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void {
-  if (!c.env.SENTRY_DSN?.trim()) {
+  if (!isSentryEnabled(c.env)) {
     return;
   }
 
@@ -86,7 +57,7 @@ function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void
   const requestSource = c.get("requestSource");
   const path = new URL(c.req.url).pathname;
 
-  Sentry.withScope((scope) => {
+  cloudflareObservability.withScope((scope) => {
     scope.setTag("request_id", requestId);
     scope.setTag("trace_id", traceId);
     scope.setTag("request_source", requestSource);
@@ -117,7 +88,7 @@ function captureUnexpectedError(err: Error, c: Context<{ Bindings: Env }>): void
       scope.setUser({ id: clerk.userId });
     }
 
-    Sentry.captureException(err);
+    cloudflareObservability.captureException(err);
   });
 }
 
@@ -359,18 +330,22 @@ const worker = {
   ): Promise<void> {
     const runtimeEnv = withProcessEnvFallback(env);
     const runPendingTransferTracking = () => trackPendingTransfers(runtimeEnv);
-    if (!runtimeEnv.SENTRY_DSN) {
+    if (!isSentryEnabled(runtimeEnv)) {
       ctx.waitUntil(runPendingTransferTracking());
       return;
     }
 
     ctx.waitUntil(
-      Sentry.withMonitor(SENTRY_PENDING_TRANSFERS_MONITOR, runPendingTransferTracking, {
-        schedule: {
-          type: "crontab",
-          value: PENDING_TRANSFERS_CRON,
-        },
-      })
+      cloudflareObservability.withMonitor(
+        SENTRY_PENDING_TRANSFERS_MONITOR,
+        runPendingTransferTracking,
+        {
+          schedule: {
+            type: "crontab",
+            value: PENDING_TRANSFERS_CRON,
+          },
+        }
+      )
     );
   },
   request(
@@ -389,4 +364,4 @@ const worker = {
   request: typeof app.request;
 };
 
-export default Sentry.withSentry(getSentryOptions, worker);
+export default withSentry(getSentryOptions, worker);

--- a/apps/sdp-api/src/runtime/observability-cf.test.ts
+++ b/apps/sdp-api/src/runtime/observability-cf.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { Observability } from "./observability";
+import { cloudflareObservability, withSentry } from "./observability-cf";
+
+// Suite-level note: under vitest's `isolate: false` config the Workers
+// module cache is shared across test files, so module-level vi.mock of
+// @sentry/cloudflare leaks into every other suite that transitively
+// imports it via src/index.ts (default export becomes undefined). The
+// delegations here are one-line passthroughs; verifying their shape is
+// enough — end-to-end Sentry behaviour is checked manually against the
+// CF managed deploy.
+
+describe("cloudflareObservability", () => {
+  it("conforms to the Observability interface", () => {
+    const obs: Observability = cloudflareObservability;
+    expect(typeof obs.captureException).toBe("function");
+    expect(typeof obs.withScope).toBe("function");
+    expect(typeof obs.withMonitor).toBe("function");
+  });
+});
+
+describe("withSentry", () => {
+  it("is exported as a function", () => {
+    expect(typeof withSentry).toBe("function");
+  });
+});

--- a/apps/sdp-api/src/runtime/observability-cf.ts
+++ b/apps/sdp-api/src/runtime/observability-cf.ts
@@ -1,0 +1,27 @@
+/**
+ * Cloudflare Workers Observability — wraps @sentry/cloudflare.
+ *
+ * Sentry's CF SDK ties its state to the worker's per-request lifecycle via
+ * `withSentry(getOptions, worker)`, which is exported separately because it's
+ * the entrypoint wrapper and has no analog on Node (Node uses Sentry.init at
+ * startup).
+ */
+
+import * as Sentry from "@sentry/cloudflare";
+import type { MonitorOptions, Observability } from "./observability";
+
+export const cloudflareObservability: Observability = {
+  captureException(err) {
+    Sentry.captureException(err);
+  },
+  withScope(cb) {
+    Sentry.withScope((scope) => {
+      cb(scope);
+    });
+  },
+  withMonitor<T>(slug: string, fn: () => Promise<T>, opts: MonitorOptions): Promise<T> {
+    return Sentry.withMonitor(slug, fn, opts) as Promise<T>;
+  },
+};
+
+export const withSentry = Sentry.withSentry;

--- a/apps/sdp-api/src/runtime/observability-node.test.ts
+++ b/apps/sdp-api/src/runtime/observability-node.test.ts
@@ -1,0 +1,89 @@
+import * as Sentry from "@sentry/node";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SentryOptions } from "./observability";
+import { initNodeSentry, nodeObservability } from "./observability-node";
+
+vi.mock("@sentry/node", () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  withScope: vi.fn((cb: (scope: unknown) => void) => cb({ setTag: vi.fn(), setUser: vi.fn() })),
+  withMonitor: vi.fn(async (_slug: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+const baseOpts = (overrides: Partial<SentryOptions> = {}): SentryOptions => ({
+  enabled: true,
+  environment: "test",
+  tracesSampleRate: 1,
+  sendDefaultPii: false,
+  ...overrides,
+});
+
+// IMPORTANT: keep this describe FIRST in the file. The init-guard tests below
+// rely on `initNodeSentry` not having been called yet for this module — within
+// a vitest file, module state is shared, and the `initNodeSentry` describe
+// below flips the `_initialized` flag for the rest of the file.
+describe("nodeObservability — guards before init", () => {
+  it("captureException throws if called before initNodeSentry", () => {
+    expect(() => nodeObservability.captureException(new Error("boom"))).toThrow(
+      /before initNodeSentry/
+    );
+  });
+
+  it("withScope throws if called before initNodeSentry", () => {
+    expect(() => nodeObservability.withScope(() => {})).toThrow(/before initNodeSentry/);
+  });
+
+  it("withMonitor throws if called before initNodeSentry", () => {
+    expect(() =>
+      nodeObservability.withMonitor("slug", async () => "x", {
+        schedule: { type: "crontab", value: "* * * * *" },
+      })
+    ).toThrow(/before initNodeSentry/);
+  });
+});
+
+describe("initNodeSentry", () => {
+  beforeEach(() => {
+    vi.mocked(Sentry.init).mockClear();
+  });
+
+  it("calls Sentry.init with the provided options when enabled", () => {
+    const opts = baseOpts({ dsn: "https://x", enabled: true });
+    initNodeSentry(opts);
+    expect(Sentry.init).toHaveBeenCalledWith(opts);
+  });
+
+  it("does not call Sentry.init when disabled (no DSN)", () => {
+    initNodeSentry(baseOpts({ enabled: false }));
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+});
+
+describe("nodeObservability — after init", () => {
+  it("captureException delegates to Sentry.captureException", () => {
+    const err = new Error("boom");
+    nodeObservability.captureException(err);
+    expect(Sentry.captureException).toHaveBeenCalledWith(err);
+  });
+
+  it("withScope passes a scope to the callback", () => {
+    const cb = vi.fn();
+    nodeObservability.withScope(cb);
+    expect(Sentry.withScope).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+    const scope = cb.mock.calls[0][0];
+    expect(typeof scope.setTag).toBe("function");
+    expect(typeof scope.setUser).toBe("function");
+  });
+
+  it("withMonitor forwards slug, fn, and opts to Sentry and resolves with the fn's value", async () => {
+    const fn = vi.fn(async () => "result");
+    const opts = { schedule: { type: "crontab" as const, value: "* * * * *" } };
+
+    const result = await nodeObservability.withMonitor("my-slug", fn, opts);
+
+    expect(Sentry.withMonitor).toHaveBeenCalledWith("my-slug", fn, opts);
+    expect(result).toBe("result");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/sdp-api/src/runtime/observability-node.ts
+++ b/apps/sdp-api/src/runtime/observability-node.ts
@@ -1,0 +1,58 @@
+/**
+ * Node Observability — wraps @sentry/node.
+ *
+ * Used by the future Node entrypoint (src/server.ts, HOO-510). Node has no
+ * per-request wrapper analogous to Cloudflare's `withSentry`; instead the
+ * entrypoint calls `initNodeSentry(getSentryOptions(env))` once at startup
+ * and then uses the shared `Observability` API.
+ *
+ * `nodeObservability.*` methods throw if invoked before `initNodeSentry()`
+ * has run. The @sentry/node SDK otherwise silently no-ops when not
+ * initialised, which would let a misordered server.ts boot drop every
+ * captured error without any signal. We'd rather fail loud at the first
+ * stray call than ship in production with errors quietly disappearing.
+ */
+
+import * as Sentry from "@sentry/node";
+import type { MonitorOptions, Observability, SentryOptions } from "./observability";
+
+let initialized = false;
+
+export function initNodeSentry(opts: SentryOptions): void {
+  // Intentional: when DSN is unset we skip `Sentry.init` entirely rather
+  // than calling it with `{ enabled: false }`. The latter would still
+  // create a client and wire up scope/breadcrumb machinery, just suppress
+  // sending. CF behaves differently — `Sentry.withSentry` still wraps the
+  // handler and sets up scopes/error boundaries even without a DSN; only
+  // transport is skipped. We accept that asymmetry: Phase 1 has no caller
+  // that needs ambient scopes when Sentry is "off". Revisit if a future
+  // caller wants breadcrumb-only behaviour with the SDK initialised.
+  initialized = true;
+  if (!opts.enabled) {
+    return;
+  }
+  Sentry.init(opts);
+}
+
+function ensureInitialized(): void {
+  if (!initialized) {
+    throw new Error("nodeObservability used before initNodeSentry() was called");
+  }
+}
+
+export const nodeObservability: Observability = {
+  captureException(err) {
+    ensureInitialized();
+    Sentry.captureException(err);
+  },
+  withScope(cb) {
+    ensureInitialized();
+    Sentry.withScope((scope) => {
+      cb(scope);
+    });
+  },
+  withMonitor<T>(slug: string, fn: () => Promise<T>, opts: MonitorOptions): Promise<T> {
+    ensureInitialized();
+    return Sentry.withMonitor(slug, fn, opts) as Promise<T>;
+  },
+};

--- a/apps/sdp-api/src/runtime/observability.test.ts
+++ b/apps/sdp-api/src/runtime/observability.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "@/types/env";
+import { getSentryOptions, isSentryEnabled } from "./observability";
+
+const envWith = (overrides: Partial<Env>): Env =>
+  ({
+    ENVIRONMENT: "development",
+    SENTRY_DSN: undefined,
+    SENTRY_TRACES_SAMPLE_RATE: undefined,
+    ...overrides,
+  }) as Env;
+
+describe("isSentryEnabled", () => {
+  it("returns false when SENTRY_DSN is missing", () => {
+    expect(isSentryEnabled(envWith({}))).toBe(false);
+  });
+
+  it("returns false when SENTRY_DSN is whitespace-only", () => {
+    expect(isSentryEnabled(envWith({ SENTRY_DSN: "   " }))).toBe(false);
+  });
+
+  it("returns true when SENTRY_DSN holds a non-empty value (post-trim)", () => {
+    expect(isSentryEnabled(envWith({ SENTRY_DSN: "https://example.io/1" }))).toBe(true);
+    expect(isSentryEnabled(envWith({ SENTRY_DSN: "  https://example.io/1  " }))).toBe(true);
+  });
+
+  it("agrees with getSentryOptions.enabled (single source of truth)", () => {
+    const cases: Partial<Env>[] = [
+      {},
+      { SENTRY_DSN: "" },
+      { SENTRY_DSN: "   " },
+      { SENTRY_DSN: "https://example.io/1" },
+      { SENTRY_DSN: "  https://example.io/1  " },
+    ];
+    for (const overrides of cases) {
+      const env = envWith(overrides);
+      expect(isSentryEnabled(env)).toBe(getSentryOptions(env).enabled);
+    }
+  });
+});
+
+describe("getSentryOptions", () => {
+  it("disables Sentry when SENTRY_DSN is missing", () => {
+    const opts = getSentryOptions(envWith({}));
+    expect(opts.enabled).toBe(false);
+    expect("dsn" in opts).toBe(false);
+  });
+
+  it("disables Sentry when SENTRY_DSN is whitespace-only", () => {
+    const opts = getSentryOptions(envWith({ SENTRY_DSN: "   " }));
+    expect(opts.enabled).toBe(false);
+    expect("dsn" in opts).toBe(false);
+  });
+
+  it("enables Sentry when SENTRY_DSN is set and trims it", () => {
+    const opts = getSentryOptions(envWith({ SENTRY_DSN: "  https://example.io/1  " }));
+    expect(opts.enabled).toBe(true);
+    expect(opts.dsn).toBe("https://example.io/1");
+  });
+
+  it("propagates ENVIRONMENT into options", () => {
+    expect(getSentryOptions(envWith({ ENVIRONMENT: "production" })).environment).toBe("production");
+    expect(getSentryOptions(envWith({ ENVIRONMENT: "development" })).environment).toBe(
+      "development"
+    );
+  });
+
+  it("sets sendDefaultPii to false unconditionally", () => {
+    expect(getSentryOptions(envWith({})).sendDefaultPii).toBe(false);
+    expect(getSentryOptions(envWith({ SENTRY_DSN: "https://x" })).sendDefaultPii).toBe(false);
+  });
+
+  describe("tracesSampleRate", () => {
+    it("defaults to 0.1 in production when SENTRY_TRACES_SAMPLE_RATE is unset", () => {
+      const opts = getSentryOptions(envWith({ ENVIRONMENT: "production" }));
+      expect(opts.tracesSampleRate).toBe(0.1);
+    });
+
+    it("defaults to 1 outside production when SENTRY_TRACES_SAMPLE_RATE is unset", () => {
+      expect(getSentryOptions(envWith({ ENVIRONMENT: "development" })).tracesSampleRate).toBe(1);
+    });
+
+    it("uses a valid SENTRY_TRACES_SAMPLE_RATE between 0 and 1", () => {
+      expect(getSentryOptions(envWith({ SENTRY_TRACES_SAMPLE_RATE: "0.5" })).tracesSampleRate).toBe(
+        0.5
+      );
+      expect(getSentryOptions(envWith({ SENTRY_TRACES_SAMPLE_RATE: "0" })).tracesSampleRate).toBe(
+        0
+      );
+      expect(getSentryOptions(envWith({ SENTRY_TRACES_SAMPLE_RATE: "1" })).tracesSampleRate).toBe(
+        1
+      );
+    });
+
+    it("falls back to the env default on non-numeric SENTRY_TRACES_SAMPLE_RATE", () => {
+      const opts = getSentryOptions(
+        envWith({ ENVIRONMENT: "production", SENTRY_TRACES_SAMPLE_RATE: "abc" })
+      );
+      expect(opts.tracesSampleRate).toBe(0.1);
+    });
+
+    it("falls back to the env default on out-of-range SENTRY_TRACES_SAMPLE_RATE", () => {
+      const overRange = getSentryOptions(
+        envWith({ ENVIRONMENT: "production", SENTRY_TRACES_SAMPLE_RATE: "1.5" })
+      );
+      expect(overRange.tracesSampleRate).toBe(0.1);
+
+      const negative = getSentryOptions(
+        envWith({ ENVIRONMENT: "development", SENTRY_TRACES_SAMPLE_RATE: "-0.1" })
+      );
+      expect(negative.tracesSampleRate).toBe(1);
+    });
+  });
+});

--- a/apps/sdp-api/src/runtime/observability.ts
+++ b/apps/sdp-api/src/runtime/observability.ts
@@ -1,0 +1,75 @@
+/**
+ * Runtime-neutral observability (Sentry) abstraction.
+ *
+ * @sentry/cloudflare and @sentry/node share most of their public API surface,
+ * but cannot be imported into the same bundle: cloudflare relies on the
+ * Workers runtime, node pulls native modules. This module exposes only the
+ * shared API shape and runtime-neutral helpers. Concrete implementations live
+ * in observability-cf.ts (HOO-508) and observability-node.ts (wired up in
+ * HOO-510 when server.ts lands).
+ */
+
+import type { Env } from "@/types/env";
+
+export interface ObservabilityScope {
+  setTag(key: string, value: string | undefined): void;
+  setUser(user: { id: string }): void;
+}
+
+export interface MonitorOptions {
+  schedule: { type: "crontab"; value: string };
+}
+
+export interface Observability {
+  captureException(err: unknown): void;
+  withScope(cb: (scope: ObservabilityScope) => void): void;
+  withMonitor<T>(slug: string, fn: () => Promise<T>, opts: MonitorOptions): Promise<T>;
+}
+
+export interface SentryOptions {
+  dsn?: string;
+  enabled: boolean;
+  environment: string;
+  tracesSampleRate: number;
+  sendDefaultPii: boolean;
+}
+
+/**
+ * Canonical "is Sentry configured?" check. Call this anywhere that needs to
+ * branch on whether Sentry is enabled — never inline `env.SENTRY_DSN?.trim()`
+ * at call-sites, since the definition may grow (e.g. an explicit
+ * `SENTRY_ENABLED` flag) and inline checks would silently diverge.
+ */
+export function isSentryEnabled(env: Pick<Env, "SENTRY_DSN">): boolean {
+  return Boolean(env.SENTRY_DSN?.trim());
+}
+
+function parseSentryTraceSampleRate(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function getSentryOptions(env: Env): SentryOptions {
+  const dsn = env.SENTRY_DSN?.trim();
+  const defaultTraceSampleRate = env.ENVIRONMENT === "production" ? 0.1 : 1;
+  const tracesSampleRate = parseSentryTraceSampleRate(
+    env.SENTRY_TRACES_SAMPLE_RATE,
+    defaultTraceSampleRate
+  );
+
+  return {
+    ...(dsn ? { dsn } : {}),
+    enabled: Boolean(dsn),
+    environment: env.ENVIRONMENT,
+    tracesSampleRate,
+    sendDefaultPii: false,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@sentry/cloudflare':
         specifier: ^10.51.0
         version: 10.52.0(@cloudflare/workers-types@4.20260508.1)
+      '@sentry/node':
+        specifier: ^10.51.0
+        version: 10.52.0
       '@solana-program/system':
         specifier: 'catalog:'
         version: 0.12.0(@solana/kit@6.8.0(typescript@6.0.3))
@@ -495,24 +498,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.14':
     resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.14':
     resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.14':
     resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.14':
     resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
@@ -1252,89 +1259,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1410,24 +1433,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -2625,131 +2652,157 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -3939,24 +3992,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -4219,41 +4276,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4753,6 +4818,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  enhanced-resolve@5.21.1:
+    resolution: {integrity: sha512-8p7DUVq6XJnZEz9W4oSwiwycxBIjHjRzYb3Je3zVN+geKTRQKzAkR/K4PBExlS0090d9nshak6phMUxr3PDjmQ==}
+    engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.21.2:
     resolution: {integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==}
@@ -5637,24 +5706,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6642,45 +6715,18 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.6.0:
-    resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      '@minify-html/node': '*'
       '@swc/core': '*'
-      '@swc/css': '*'
-      '@swc/html': '*'
-      clean-css: '*'
-      cssnano: '*'
-      csso: '*'
       esbuild: '*'
-      html-minifier-terser: '*'
-      lightningcss: '*'
-      postcss: '*'
       uglify-js: '*'
       webpack: ^5.1.0
     peerDependenciesMeta:
-      '@minify-html/node':
-        optional: true
       '@swc/core':
         optional: true
-      '@swc/css':
-        optional: true
-      '@swc/html':
-        optional: true
-      clean-css:
-        optional: true
-      cssnano:
-        optional: true
-      csso:
-        optional: true
       esbuild:
-        optional: true
-      html-minifier-terser:
-        optional: true
-      lightningcss:
-        optional: true
-      postcss:
         optional: true
       uglify-js:
         optional: true
@@ -10687,7 +10733,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.6.2
 
   '@types/debug@4.1.13':
     dependencies:
@@ -10733,7 +10779,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.6.2
 
   '@types/node@20.19.39':
     dependencies:
@@ -10753,7 +10799,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.6.2
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -10777,7 +10823,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.6.2
 
   '@types/unist@2.0.11': {}
 
@@ -11445,6 +11491,11 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  enhanced-resolve@5.21.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enhanced-resolve@5.21.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -11673,8 +11724,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.3.0(jiti@2.7.0))
@@ -11696,7 +11747,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11707,22 +11758,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11733,7 +11784,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14089,7 +14140,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.0(webpack@5.106.1):
+  terser-webpack-plugin@5.5.0(webpack@5.106.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -14426,7 +14477,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.2
+      enhanced-resolve: 5.21.1
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -14438,21 +14489,12 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(webpack@5.106.1)
+      terser-webpack-plugin: 5.5.0(webpack@5.106.1)
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:
-      - '@minify-html/node'
       - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
       - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
       - uglify-js
 
   whatwg-url@5.0.0:


### PR DESCRIPTION
Prepares src/index.ts for Phase 2 (the Node entrypoint, src/server.ts in [HOO-510](https://linear.app/solana-fndn/issue/HOO-510/phase-2-nodedocker-rediskvstore-implementation)) by routing every Sentry call-site through a runtime-neutral Observability interface. Without this split, the Node bundle can't import @sentry/cloudflare (workerd-only) and the CF bundle can't import @sentry/node (needs native modules).

- src/runtime/observability.ts: Observability/ObservabilityScope/MonitorOptions/SentryOptions types + getSentryOptions(env) (moved from index.ts)
- src/runtime/observability-cf.ts: cloudflareObservability + withSentry export (the CF-only top-level wrapper has no Node analog)
- src/runtime/observability-node.ts: nodeObservability + initNodeSentry helper (Node initialises at startup; wired up by HOO-510 when server.ts lands)
- src/index.ts: imports the observability module instead of @sentry/cloudflare; SENTRY_PENDING_TRANSFERS_MONITOR slug preserved verbatim; the scheduled handler's SENTRY_DSN gate now trims to match getSentryOptions (was: truthy-only)
- apps/sdp-api/package.json: +@sentry/node@^10.51.0

Tests: 17 new unit tests across the three modules. observability-cf.test.ts is smoke-only: under vitest's isolate:false config, a module-level vi.mock of @sentry/cloudflare leaks through src/index.ts and breaks the rest of the suite.