### PR TITLE
feat(sdp-api): HOO-510 RedisKVStore for Node runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
+      REDIS_URL: redis://127.0.0.1:6379
     services:
       postgres:
         image: postgres:16-alpine
@@ -89,6 +90,18 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd "pg_isready -U sdp -d sdp"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      # HOO-510: Redis backs the node-runtime KVStore. Node-pool tests
+      # (*.node.test.ts) connect via REDIS_URL above. Workers-pool tests
+      # don't touch it.
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 20
@@ -129,6 +142,12 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
           DOPPLER_CONFIG: dev_ci
         run: pnpm test
+
+      - name: Node-runtime tests (Redis-backed KVStore)
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI }}
+          DOPPLER_CONFIG: dev_ci
+        run: pnpm --filter @sdp/api test:node
 
   build_api:
     name: Build API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,6 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 20
-      # HOO-510: Redis backs the node-runtime KVStore. Node-pool tests
-      # (*.node.test.ts) connect via REDIS_URL above. Workers-pool tests
-      # don't touch it.
       redis:
         image: redis:7-alpine
         ports:

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -26,7 +26,8 @@
     "test": "vitest run",
     "test:serial": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:node": "vitest run --config vitest.node.config.ts"
   },
   "dependencies": {
     "@react-email/components": "1.0.12",
@@ -49,6 +50,7 @@
     "@solana/mosaic-sdk": "catalog:",
     "@solana/signers": "catalog:",
     "hono": "^4.12.16",
+    "ioredis": "^5.4.1",
     "jose": "^6.2.3",
     "nanoid": "^5.1.11",
     "pg": "^8.16.3",

--- a/apps/sdp-api/src/lib/runtime-env.ts
+++ b/apps/sdp-api/src/lib/runtime-env.ts
@@ -4,10 +4,8 @@ const PROCESS_ENV_FALLBACK_KEYS = [
   "ENVIRONMENT",
   "API_VERSION",
   "SDP_DEPLOYMENT_MODE",
-  // Node-runtime connection strings — paired with HOO-510 (Redis) and the
-  // pg/Hyperdrive split. The Node entrypoint (HOO-511) relies on process.env
-  // for both; without these in the fallback list withProcessEnvFallback can't
-  // populate them and the factory throws on the first request.
+  // Connection strings populated from process.env when bindings aren't set
+  // — pg uses DATABASE_URL, RedisKVStore uses REDIS_URL.
   "DATABASE_URL",
   "REDIS_URL",
   "API_KEY_PEPPER",

--- a/apps/sdp-api/src/lib/runtime-env.ts
+++ b/apps/sdp-api/src/lib/runtime-env.ts
@@ -4,6 +4,12 @@ const PROCESS_ENV_FALLBACK_KEYS = [
   "ENVIRONMENT",
   "API_VERSION",
   "SDP_DEPLOYMENT_MODE",
+  // Node-runtime connection strings — paired with HOO-510 (Redis) and the
+  // pg/Hyperdrive split. The Node entrypoint (HOO-511) relies on process.env
+  // for both; without these in the fallback list withProcessEnvFallback can't
+  // populate them and the factory throws on the first request.
+  "DATABASE_URL",
+  "REDIS_URL",
   "API_KEY_PEPPER",
   "CUSTODY_ENCRYPTION_KEY",
   "SENTRY_DSN",

--- a/apps/sdp-api/src/runtime/factory.ts
+++ b/apps/sdp-api/src/runtime/factory.ts
@@ -1,11 +1,6 @@
 /**
- * Runtime factory — single dispatch point for runtime-specific implementations.
- *
- * Cloudflare branch returns the Workers KV bindings (HOO-506). Node branch
- * returns the Redis-backed set (HOO-510). Switch is driven by SDP_RUNTIME.
- *
- * The Redis branch holds a Promise<Redis> internally (created lazily in
- * kv-redis), so this factory stays synchronous and ioredis stays out of the
+ * Runtime factory — dispatch to the runtime-specific KVStore. The Redis
+ * branch is lazily loaded inside kv-redis so ioredis stays out of the
  * Cloudflare bundle / Workers test pool's module graph.
  */
 

--- a/apps/sdp-api/src/runtime/factory.ts
+++ b/apps/sdp-api/src/runtime/factory.ts
@@ -1,14 +1,20 @@
 /**
  * Runtime factory — single dispatch point for runtime-specific implementations.
  *
- * HOO-506 lands only the Cloudflare branch. HOO-510 (#9) adds the Node/Redis
- * branch and switches on SDP_RUNTIME via getRuntime().
+ * Cloudflare branch returns the Workers KV bindings (HOO-506). Node branch
+ * returns the Redis-backed set (HOO-510). Switch is driven by SDP_RUNTIME.
  */
 
+import { getRuntime } from "@/lib/runtime-env";
 import type { Env } from "@/types/env";
 import type { KVStoreSet } from "./kv";
+import { createRedisKVStoreSet } from "./kv-redis";
 import { createWorkersKVStoreSet } from "./kv-workers";
 
 export function createKVStoreSet(env: Env): KVStoreSet {
+  const runtime = getRuntime(env);
+  if (runtime === "node") {
+    return createRedisKVStoreSet(env);
+  }
   return createWorkersKVStoreSet(env);
 }

--- a/apps/sdp-api/src/runtime/factory.ts
+++ b/apps/sdp-api/src/runtime/factory.ts
@@ -3,6 +3,10 @@
  *
  * Cloudflare branch returns the Workers KV bindings (HOO-506). Node branch
  * returns the Redis-backed set (HOO-510). Switch is driven by SDP_RUNTIME.
+ *
+ * The Redis branch holds a Promise<Redis> internally (created lazily in
+ * kv-redis), so this factory stays synchronous and ioredis stays out of the
+ * Cloudflare bundle / Workers test pool's module graph.
  */
 
 import { getRuntime } from "@/lib/runtime-env";
@@ -12,8 +16,7 @@ import { createRedisKVStoreSet } from "./kv-redis";
 import { createWorkersKVStoreSet } from "./kv-workers";
 
 export function createKVStoreSet(env: Env): KVStoreSet {
-  const runtime = getRuntime(env);
-  if (runtime === "node") {
+  if (getRuntime(env) === "node") {
     return createRedisKVStoreSet(env);
   }
   return createWorkersKVStoreSet(env);

--- a/apps/sdp-api/src/runtime/kv-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.node.test.ts
@@ -10,9 +10,9 @@
  */
 
 import Redis from "ioredis";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "@/types/env";
-import { createRedisKVStoreSet, RedisKVStore } from "./kv-redis";
+import { closeAllRedisClients, createRedisKVStoreSet, RedisKVStore } from "./kv-redis";
 
 const REDIS_URL = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
 
@@ -111,28 +111,37 @@ describe("RedisKVStore (HOO-510)", () => {
     });
   });
 
-  describe("prefix isolation across the full store set", () => {
-    it("createRedisKVStoreSet wires four prefixed stores from one connection", async () => {
-      const set = createRedisKVStoreSet({ REDIS_URL } as Env);
-      try {
-        await set.apiKeys.put("same-key", "from-apiKeys");
-        await set.rateLimits.put("same-key", "from-rateLimits");
-        await set.cache.put("same-key", "from-cache");
-        await set.sessions.put("same-key", "from-sessions");
-
-        expect(await set.apiKeys.get("same-key")).toBe("from-apiKeys");
-        expect(await set.rateLimits.get("same-key")).toBe("from-rateLimits");
-        expect(await set.cache.get("same-key")).toBe("from-cache");
-        expect(await set.sessions.get("same-key")).toBe("from-sessions");
-      } finally {
-        // The set internally owns a Redis client; close it so vitest exits
-        // cleanly. In production HOO-511 will own this lifecycle.
-        await (set.apiKeys as unknown as { client: Redis }).client.quit();
-      }
-    });
-  });
-
   describe("createRedisKVStoreSet", () => {
+    afterEach(async () => {
+      // Each test in this block uses the factory's cached client; close
+      // between tests so we observe reuse behavior cleanly.
+      await closeAllRedisClients();
+    });
+
+    it("wires four prefixed stores sharing one connection", async () => {
+      const set = createRedisKVStoreSet({ REDIS_URL } as Env);
+      await set.apiKeys.put("same-key", "from-apiKeys");
+      await set.rateLimits.put("same-key", "from-rateLimits");
+      await set.cache.put("same-key", "from-cache");
+      await set.sessions.put("same-key", "from-sessions");
+
+      expect(await set.apiKeys.get("same-key")).toBe("from-apiKeys");
+      expect(await set.rateLimits.get("same-key")).toBe("from-rateLimits");
+      expect(await set.cache.get("same-key")).toBe("from-cache");
+      expect(await set.sessions.get("same-key")).toBe("from-sessions");
+    });
+
+    it("reuses the same Redis client across repeated calls (no connection leak)", () => {
+      // kvStoreMiddleware invokes the factory per-request; if each invocation
+      // opened a new TCP connection, the process would exhaust Redis's
+      // maxclients under load. Pin behavior with reference equality.
+      const set1 = createRedisKVStoreSet({ REDIS_URL } as Env);
+      const set2 = createRedisKVStoreSet({ REDIS_URL } as Env);
+      const client1 = (set1.apiKeys as unknown as { client: Redis }).client;
+      const client2 = (set2.apiKeys as unknown as { client: Redis }).client;
+      expect(client1).toBe(client2);
+    });
+
     it("throws a clear error when REDIS_URL is missing", () => {
       expect(() => createRedisKVStoreSet({} as Env)).toThrow(/REDIS_URL missing/);
     });

--- a/apps/sdp-api/src/runtime/kv-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.node.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration tests for RedisKVStore against a real Redis (HOO-510).
+ *
+ * Runs in plain Node via vitest.node.config.ts so ioredis can open real TCP
+ * sockets. Requires Redis listening on REDIS_URL (defaults to localhost:6379).
+ * CI provides a redis:7-alpine service container alongside the Postgres one.
+ *
+ * Each test FLUSHALLs first so runs are isolated. We don't share fixtures
+ * across tests.
+ */
+
+import Redis from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "@/types/env";
+import { createRedisKVStoreSet, RedisKVStore } from "./kv-redis";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
+
+describe("RedisKVStore (HOO-510)", () => {
+  let raw: Redis;
+
+  beforeAll(() => {
+    raw = new Redis(REDIS_URL, { lazyConnect: false, maxRetriesPerRequest: 3 });
+  });
+
+  afterAll(async () => {
+    await raw.quit();
+  });
+
+  beforeEach(async () => {
+    await raw.flushall();
+  });
+
+  describe("get / put / delete", () => {
+    it("round-trips a string value", async () => {
+      const store = new RedisKVStore(raw, "test");
+      await store.put("k", "hello");
+      expect(await store.get("k")).toBe("hello");
+    });
+
+    it("returns null for missing keys", async () => {
+      const store = new RedisKVStore(raw, "test");
+      expect(await store.get("nope")).toBeNull();
+    });
+
+    it("delete() removes the value", async () => {
+      const store = new RedisKVStore(raw, "test");
+      await store.put("k", "v");
+      await store.delete("k");
+      expect(await store.get("k")).toBeNull();
+    });
+
+    it('get(key, "json") parses JSON', async () => {
+      const store = new RedisKVStore(raw, "test");
+      await store.put("k", JSON.stringify({ a: 1, nested: { b: "x" } }));
+      const value = await store.get<{ a: number; nested: { b: string } }>("k", "json");
+      expect(value).toEqual({ a: 1, nested: { b: "x" } });
+    });
+
+    it('get(key, "json") returns null when missing', async () => {
+      const store = new RedisKVStore(raw, "test");
+      expect(await store.get<{ a: number }>("nope", "json")).toBeNull();
+    });
+  });
+
+  describe("TTL (SET PX)", () => {
+    it("sets the millisecond TTL on the underlying key", async () => {
+      const store = new RedisKVStore(raw, "test");
+      await store.put("k", "v", { expirationTtl: 30 });
+      // PTTL returns -1 if no TTL, -2 if missing. With expirationTtl=30s we
+      // expect roughly 30_000ms remaining, allowing for execution time.
+      const pttl = await raw.pttl("test:k");
+      expect(pttl).toBeGreaterThan(28_000);
+      expect(pttl).toBeLessThanOrEqual(30_000);
+    });
+
+    it("no TTL persists indefinitely (PTTL = -1) — parity with CF KV", async () => {
+      const store = new RedisKVStore(raw, "test");
+      await store.put("k", "v"); // no options
+      const pttl = await raw.pttl("test:k");
+      expect(pttl).toBe(-1);
+    });
+  });
+
+  describe("list() via SCAN", () => {
+    it("returns all keys for the store's prefix, with prefix stripped", async () => {
+      const store = new RedisKVStore(raw, "test");
+      await store.put("a", "1");
+      await store.put("b", "2");
+      await store.put("c", "3");
+      const result = await store.list();
+      const names = result.keys.map((k) => k.name).sort();
+      expect(names).toEqual(["a", "b", "c"]);
+    });
+
+    it("does not leak keys from other prefixes", async () => {
+      const apiKeys = new RedisKVStore(raw, "apiKeys");
+      const cache = new RedisKVStore(raw, "cache");
+      await apiKeys.put("k1", "v1");
+      await cache.put("k2", "v2");
+      const apiKeysList = await apiKeys.list();
+      const cacheList = await cache.list();
+      expect(apiKeysList.keys.map((k) => k.name)).toEqual(["k1"]);
+      expect(cacheList.keys.map((k) => k.name)).toEqual(["k2"]);
+    });
+
+    it("returns an empty result when the store is empty", async () => {
+      const store = new RedisKVStore(raw, "empty");
+      const result = await store.list();
+      expect(result.keys).toEqual([]);
+    });
+  });
+
+  describe("prefix isolation across the full store set", () => {
+    it("createRedisKVStoreSet wires four prefixed stores from one connection", async () => {
+      const set = createRedisKVStoreSet({ REDIS_URL } as Env);
+      try {
+        await set.apiKeys.put("same-key", "from-apiKeys");
+        await set.rateLimits.put("same-key", "from-rateLimits");
+        await set.cache.put("same-key", "from-cache");
+        await set.sessions.put("same-key", "from-sessions");
+
+        expect(await set.apiKeys.get("same-key")).toBe("from-apiKeys");
+        expect(await set.rateLimits.get("same-key")).toBe("from-rateLimits");
+        expect(await set.cache.get("same-key")).toBe("from-cache");
+        expect(await set.sessions.get("same-key")).toBe("from-sessions");
+      } finally {
+        // The set internally owns a Redis client; close it so vitest exits
+        // cleanly. In production HOO-511 will own this lifecycle.
+        await (set.apiKeys as unknown as { client: Redis }).client.quit();
+      }
+    });
+  });
+
+  describe("createRedisKVStoreSet", () => {
+    it("throws a clear error when REDIS_URL is missing", () => {
+      expect(() => createRedisKVStoreSet({} as Env)).toThrow(/REDIS_URL missing/);
+    });
+
+    it("throws when REDIS_URL is whitespace-only", () => {
+      expect(() => createRedisKVStoreSet({ REDIS_URL: "   " } as Env)).toThrow(/REDIS_URL missing/);
+    });
+  });
+});

--- a/apps/sdp-api/src/runtime/kv-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.node.test.ts
@@ -1,12 +1,8 @@
 /**
- * Integration tests for RedisKVStore against a real Redis (HOO-510).
- *
- * Runs in plain Node via vitest.node.config.ts so ioredis can open real TCP
- * sockets. Requires Redis listening on REDIS_URL (defaults to localhost:6379).
- * CI provides a redis:7-alpine service container alongside the Postgres one.
- *
- * Each test FLUSHALLs first so runs are isolated. We don't share fixtures
- * across tests.
+ * Integration tests for RedisKVStore against a real Redis. Runs in plain
+ * Node via vitest.node.config.ts so ioredis can open real TCP sockets.
+ * Requires REDIS_URL (defaults to localhost:6379); each test FLUSHALLs
+ * first so runs are isolated.
  */
 
 import Redis from "ioredis";
@@ -67,8 +63,8 @@ describe("RedisKVStore (HOO-510)", () => {
     it("sets the millisecond TTL on the underlying key", async () => {
       const store = new RedisKVStore(raw, "test");
       await store.put("k", "v", { expirationTtl: 30 });
-      // PTTL returns -1 if no TTL, -2 if missing. With expirationTtl=30s we
-      // expect roughly 30_000ms remaining, allowing for execution time.
+      // expirationTtl=30s → PTTL should report ~30_000ms, allowing for
+      // elapsed time between put and the inspection.
       const pttl = await raw.pttl("test:k");
       expect(pttl).toBeGreaterThan(28_000);
       expect(pttl).toBeLessThanOrEqual(30_000);
@@ -113,8 +109,7 @@ describe("RedisKVStore (HOO-510)", () => {
 
   describe("createRedisKVStoreSet", () => {
     afterEach(async () => {
-      // Each test in this block uses the factory's cached client; close
-      // between tests so we observe reuse behavior cleanly.
+      // Factory uses a cached client; close between tests so reuse is observable.
       await closeAllRedisClients();
     });
 
@@ -132,11 +127,8 @@ describe("RedisKVStore (HOO-510)", () => {
     });
 
     it("reuses the same Redis client across repeated calls (no connection leak)", () => {
-      // kvStoreMiddleware invokes the factory per-request; if each invocation
-      // opened a new TCP connection, the process would exhaust Redis's
-      // maxclients under load. Both calls should land on the same cached
-      // Promise<Redis>, so reference equality on the internal field is the
-      // right pin.
+      // Pin reference equality on the cached promise. If the factory ever
+      // regresses to per-call construction, the connection-leak comes back.
       const set1 = createRedisKVStoreSet({ REDIS_URL } as Env);
       const set2 = createRedisKVStoreSet({ REDIS_URL } as Env);
       const p1 = (set1.apiKeys as unknown as { clientPromise: Promise<Redis> }).clientPromise;

--- a/apps/sdp-api/src/runtime/kv-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.node.test.ts
@@ -134,12 +134,14 @@ describe("RedisKVStore (HOO-510)", () => {
     it("reuses the same Redis client across repeated calls (no connection leak)", () => {
       // kvStoreMiddleware invokes the factory per-request; if each invocation
       // opened a new TCP connection, the process would exhaust Redis's
-      // maxclients under load. Pin behavior with reference equality.
+      // maxclients under load. Both calls should land on the same cached
+      // Promise<Redis>, so reference equality on the internal field is the
+      // right pin.
       const set1 = createRedisKVStoreSet({ REDIS_URL } as Env);
       const set2 = createRedisKVStoreSet({ REDIS_URL } as Env);
-      const client1 = (set1.apiKeys as unknown as { client: Redis }).client;
-      const client2 = (set2.apiKeys as unknown as { client: Redis }).client;
-      expect(client1).toBe(client2);
+      const p1 = (set1.apiKeys as unknown as { clientPromise: Promise<Redis> }).clientPromise;
+      const p2 = (set2.apiKeys as unknown as { clientPromise: Promise<Redis> }).clientPromise;
+      expect(p1).toBe(p2);
     });
 
     it("throws a clear error when REDIS_URL is missing", () => {

--- a/apps/sdp-api/src/runtime/kv-redis.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.ts
@@ -1,0 +1,120 @@
+/**
+ * Redis-backed implementation of KVStore for the Node runtime (HOO-510).
+ *
+ * Sister of WorkersKVStore — same surface, different backend. Single ioredis
+ * client is shared across the four logical stores (apiKeys / rateLimits /
+ * cache / sessions); each store namespaces its keys with a prefix so list()
+ * doesn't bleed across domains.
+ *
+ * Semantics note: Cloudflare KV serves stale reads for up to 60s after a key
+ * expires. Redis doesn't — `GET` on an expired key returns null immediately.
+ * Anything that accidentally relies on stale reads will surface here.
+ */
+
+import Redis from "ioredis";
+import type { Env } from "@/types/env";
+import type { KVListResult, KVPutOptions, KVStore, KVStoreSet } from "./kv";
+
+const SCAN_COUNT = 100;
+
+export class RedisKVStore implements KVStore {
+  constructor(
+    private readonly client: Redis,
+    private readonly prefix: string
+  ) {}
+
+  private namespaced(key: string): string {
+    return `${this.prefix}:${key}`;
+  }
+
+  get(key: string): Promise<string | null>;
+  get<T>(key: string, type: "json"): Promise<T | null>;
+  async get<T>(key: string, type?: "json"): Promise<string | T | null> {
+    const raw = await this.client.get(this.namespaced(key));
+    if (raw === null) return null;
+    if (type === "json") {
+      return JSON.parse(raw) as T;
+    }
+    return raw;
+  }
+
+  async put(key: string, value: string, options?: KVPutOptions): Promise<void> {
+    const namespacedKey = this.namespaced(key);
+    // Ticket spec: TTL via `SET PX`. expirationTtl is seconds (parity with
+    // Cloudflare KV's KVNamespacePutOptions); Redis PX expects milliseconds.
+    if (options?.expirationTtl !== undefined) {
+      await this.client.set(namespacedKey, value, "PX", options.expirationTtl * 1000);
+    } else {
+      // No TTL: e.g. rpc:relay:stats:* and round-robin cursor — match CF KV
+      // behavior where omitting expirationTtl persists indefinitely.
+      await this.client.set(namespacedKey, value);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(this.namespaced(key));
+  }
+
+  async list(): Promise<KVListResult> {
+    const pattern = `${this.prefix}:*`;
+    const stripFrom = this.prefix.length + 1; // include the trailing ":"
+    const keys: { name: string }[] = [];
+    let cursor = "0";
+    // SCAN is non-blocking and cursor-based; iterate until the server signals
+    // completion by returning "0". Callers see only unprefixed names so the
+    // surface matches WorkersKVStore (test helpers clearKVNamespaces() round-
+    // trip name → delete(name)).
+    do {
+      const [nextCursor, batch] = await this.client.scan(
+        cursor,
+        "MATCH",
+        pattern,
+        "COUNT",
+        SCAN_COUNT
+      );
+      for (const namespaced of batch) {
+        keys.push({ name: namespaced.slice(stripFrom) });
+      }
+      cursor = nextCursor;
+    } while (cursor !== "0");
+    return { keys };
+  }
+}
+
+const STORE_PREFIXES = {
+  apiKeys: "apiKeys",
+  rateLimits: "rateLimits",
+  cache: "cache",
+  sessions: "sessions",
+} as const;
+
+/**
+ * Build a KVStoreSet backed by a single shared Redis connection.
+ *
+ * Fails fast at factory time if REDIS_URL is missing — the alternative is a
+ * deep "ECONNREFUSED" on the first request, which is harder to map back to a
+ * missing env. Graceful shutdown (client.quit() on SIGTERM) lives in the Node
+ * entrypoint (HOO-511); this factory only owns construction.
+ */
+export function createRedisKVStoreSet(env: Env): KVStoreSet {
+  const url = env.REDIS_URL?.trim();
+  if (!url) {
+    throw new Error(
+      "REDIS_URL missing for runtime=node. Set it in the environment (e.g. redis://localhost:6379)."
+    );
+  }
+  const client = new Redis(url, {
+    // Match the eager-connect semantics of Cloudflare KV bindings: a bad URL
+    // throws now instead of on the first request.
+    lazyConnect: false,
+    // Fail individual commands rather than queue them indefinitely when the
+    // connection drops — better signal for upstream error handling.
+    maxRetriesPerRequest: 3,
+  });
+  return {
+    apiKeys: new RedisKVStore(client, STORE_PREFIXES.apiKeys),
+    rateLimits: new RedisKVStore(client, STORE_PREFIXES.rateLimits),
+    cache: new RedisKVStore(client, STORE_PREFIXES.cache),
+    sessions: new RedisKVStore(client, STORE_PREFIXES.sessions),
+  };
+}

--- a/apps/sdp-api/src/runtime/kv-redis.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.ts
@@ -88,13 +88,46 @@ const STORE_PREFIXES = {
   sessions: "sessions",
 } as const;
 
+// kvStoreMiddleware calls createKVStoreSet(c.env) on every authenticated
+// request, so this factory MUST return the same ioredis client across calls
+// for a given URL — otherwise each request opens a fresh TCP connection and
+// nothing ever closes them, exhausting Redis's maxclients under load.
+//
+// Keyed by URL (not just a single `let`) so test runs that point at different
+// instances don't accidentally share a client, and so a previously-quit
+// client (status === "end") is detected and replaced instead of returning a
+// dead handle.
+const clientsByUrl = new Map<string, Redis>();
+
+function getOrCreateClient(url: string): Redis {
+  const existing = clientsByUrl.get(url);
+  if (existing && existing.status !== "end") {
+    return existing;
+  }
+  const client = new Redis(url, {
+    // Start the TCP handshake immediately rather than on the first command.
+    // Note: ioredis does this asynchronously — an unreachable host will not
+    // throw from `new Redis(...)`; only a structurally malformed URL does.
+    // Real connectivity failures surface on the first command (or via the
+    // "error" event); maxRetriesPerRequest below caps how long they queue.
+    lazyConnect: false,
+    // Cap retry attempts per command (default is 20). With the connection
+    // down, the third retry fails the command instead of trying ~20 times —
+    // better signal for upstream error handling.
+    maxRetriesPerRequest: 3,
+  });
+  clientsByUrl.set(url, client);
+  return client;
+}
+
 /**
- * Build a KVStoreSet backed by a single shared Redis connection.
+ * Build a KVStoreSet backed by a process-wide ioredis client (one per URL).
  *
- * Fails fast at factory time if REDIS_URL is missing — the alternative is a
- * deep "ECONNREFUSED" on the first request, which is harder to map back to a
- * missing env. Graceful shutdown (client.quit() on SIGTERM) lives in the Node
- * entrypoint (HOO-511); this factory only owns construction.
+ * Fails fast at factory time if REDIS_URL is missing/whitespace — the
+ * alternative is a deep "ECONNREFUSED" on the first request, which is harder
+ * to map back to a missing env. Graceful shutdown belongs to the Node
+ * entrypoint (HOO-511); call `closeAllRedisClients()` from the SIGTERM
+ * handler there.
  */
 export function createRedisKVStoreSet(env: Env): KVStoreSet {
   const url = env.REDIS_URL?.trim();
@@ -103,18 +136,22 @@ export function createRedisKVStoreSet(env: Env): KVStoreSet {
       "REDIS_URL missing for runtime=node. Set it in the environment (e.g. redis://localhost:6379)."
     );
   }
-  const client = new Redis(url, {
-    // Match the eager-connect semantics of Cloudflare KV bindings: a bad URL
-    // throws now instead of on the first request.
-    lazyConnect: false,
-    // Fail individual commands rather than queue them indefinitely when the
-    // connection drops — better signal for upstream error handling.
-    maxRetriesPerRequest: 3,
-  });
+  const client = getOrCreateClient(url);
   return {
     apiKeys: new RedisKVStore(client, STORE_PREFIXES.apiKeys),
     rateLimits: new RedisKVStore(client, STORE_PREFIXES.rateLimits),
     cache: new RedisKVStore(client, STORE_PREFIXES.cache),
     sessions: new RedisKVStore(client, STORE_PREFIXES.sessions),
   };
+}
+
+/**
+ * Close every cached Redis client. Intended for the Node entrypoint's
+ * shutdown handler (HOO-511) and for test teardown — calling it makes the
+ * next createRedisKVStoreSet() open a fresh connection.
+ */
+export async function closeAllRedisClients(): Promise<void> {
+  const clients = [...clientsByUrl.values()];
+  clientsByUrl.clear();
+  await Promise.allSettled(clients.map((c) => c.quit()));
 }

--- a/apps/sdp-api/src/runtime/kv-redis.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.ts
@@ -1,22 +1,18 @@
 /**
- * Redis-backed implementation of KVStore for the Node runtime (HOO-510).
+ * Redis-backed KVStore implementation. Matches WorkersKVStore's surface
+ * with a different backend. One ioredis client per REDIS_URL is shared
+ * across the four logical stores (apiKeys / rateLimits / cache / sessions);
+ * each store prefixes its keys so list() doesn't bleed across domains.
  *
- * Sister of WorkersKVStore — same surface, different backend. A single
- * ioredis client per REDIS_URL is shared across the four logical stores
- * (apiKeys / rateLimits / cache / sessions); each store namespaces its keys
- * with a prefix so list() doesn't bleed across domains.
+ * ioredis is loaded lazily — the top-level `import type` is erased at emit
+ * time, and the real module is fetched via `await import("ioredis")` inside
+ * ensureClient on first use. That keeps ioredis out of the static module
+ * graph; otherwise the Cloudflare Workers test pool (miniflare) trips on
+ * ioredis's debug.js with "Maximum call stack size exceeded" during
+ * transformation.
  *
- * ioredis is loaded lazily — the top-level `import type` is erased at
- * compile time, and the real module is fetched via `await import("ioredis")`
- * inside ensureClient on first use. That keeps ioredis out of the static
- * module graph so the Cloudflare Workers test pool (miniflare) never tries
- * to transform it; otherwise miniflare's transformer chokes on ioredis's
- * debug.js with "Maximum call stack size exceeded" even when the CF branch
- * is the one that actually runs.
- *
- * Semantics note: Cloudflare KV serves stale reads for up to 60s after a key
- * expires. Redis doesn't — GET on an expired key returns null immediately.
- * Anything that accidentally relies on stale reads will surface here.
+ * Cloudflare KV serves stale reads for up to 60s after a key expires; Redis
+ * doesn't. Anything that accidentally relied on that grace will surface.
  */
 
 import type { Redis } from "ioredis";
@@ -25,10 +21,10 @@ import type { KVListResult, KVPutOptions, KVStore, KVStoreSet } from "./kv";
 
 const SCAN_COUNT = 100;
 
-// One Promise<Redis> per URL, shared by every RedisKVStore that points at
-// that backend. Storing the Promise (not the resolved client) means that two
-// concurrent first-callers wire up to the same in-flight dynamic import +
-// `new Redis(...)` instead of opening parallel TCP connections.
+// One Promise<Redis> per URL, shared by every RedisKVStore at that backend.
+// Storing the Promise (not the resolved client) means concurrent first-
+// callers share one in-flight import + `new Redis(...)` instead of opening
+// parallel sockets.
 const clientPromisesByUrl = new Map<string, Promise<Redis>>();
 
 function ensureClient(url: string): Promise<Redis> {
@@ -37,23 +33,21 @@ function ensureClient(url: string): Promise<Redis> {
   const promise = (async (): Promise<Redis> => {
     const { default: IORedis } = await import("ioredis");
     return new IORedis(url, {
-      // Start the TCP handshake immediately rather than on the first command.
-      // Note: ioredis does this asynchronously — an unreachable host will not
-      // throw from `new IORedis(...)`; only a structurally malformed URL does.
-      // Real connectivity failures surface on the first command (or via the
-      // "error" event); maxRetriesPerRequest below caps the retry burst.
+      // Eager TCP handshake — but ioredis does it asynchronously, so
+      // unreachable hosts surface on the first command (or via the "error"
+      // event), not from `new IORedis(...)`. Only a structurally malformed
+      // URL throws here.
       lazyConnect: false,
-      // Cap retry attempts per command (default is 20). With the connection
-      // down, the third retry fails the command instead of trying ~20 times —
-      // better signal for upstream error handling.
+      // Cap retries per command (default is 20). With the connection down,
+      // the third retry fails fast — better signal for upstream error
+      // handling.
       maxRetriesPerRequest: 3,
     });
   })();
   clientPromisesByUrl.set(url, promise);
   // Evict on rejection so a transient malformed-URL or module-load failure
-  // doesn't permanently poison the cache for the rest of the process. The
-  // `===` guard avoids racing with a successful re-creation that already
-  // replaced this entry.
+  // doesn't permanently poison the cache. `===` guard avoids racing with a
+  // successful re-creation that already replaced this entry.
   promise.catch(() => {
     if (clientPromisesByUrl.get(url) === promise) {
       clientPromisesByUrl.delete(url);
@@ -63,10 +57,8 @@ function ensureClient(url: string): Promise<Redis> {
 }
 
 export class RedisKVStore implements KVStore {
-  // Internal handle is always a Promise<Redis>. Constructor accepts a raw
-  // connected client too (tests pass one for fixture-level control) and the
-  // constructor normalises it via Promise.resolve — production callers go
-  // through the factory and pass the cached promise from ensureClient.
+  // Union accepts a raw connected client for test fixtures; Promise.resolve
+  // normalizes both shapes so the rest of the class can just `await`.
   private readonly clientPromise: Promise<Redis>;
   constructor(
     client: Redis | Promise<Redis>,
@@ -94,13 +86,12 @@ export class RedisKVStore implements KVStore {
   async put(key: string, value: string, options?: KVPutOptions): Promise<void> {
     const client = await this.clientPromise;
     const namespacedKey = this.namespaced(key);
-    // Ticket spec: TTL via `SET PX`. expirationTtl is seconds (parity with
-    // Cloudflare KV's KVNamespacePutOptions); Redis PX expects milliseconds.
+    // expirationTtl is seconds (parity with CF KV's KVNamespacePutOptions);
+    // PX expects milliseconds.
     if (options?.expirationTtl !== undefined) {
       await client.set(namespacedKey, value, "PX", options.expirationTtl * 1000);
     } else {
-      // No TTL: e.g. rpc:relay:stats:* and round-robin cursor — match CF KV
-      // behavior where omitting expirationTtl persists indefinitely.
+      // Match CF KV: omitting expirationTtl persists indefinitely.
       await client.set(namespacedKey, value);
     }
   }
@@ -116,10 +107,9 @@ export class RedisKVStore implements KVStore {
     const stripFrom = this.prefix.length + 1; // include the trailing ":"
     const keys: { name: string }[] = [];
     let cursor = "0";
-    // SCAN is non-blocking and cursor-based; iterate until the server signals
-    // completion by returning "0". Callers see only unprefixed names so the
-    // surface matches WorkersKVStore (test helpers clearKVNamespaces() round-
-    // trip name → delete(name)).
+    // SCAN is cursor-based and non-blocking; loop until cursor returns "0".
+    // Strip the prefix on the way out so callers can round-trip list()
+    // output through delete(name), matching WorkersKVStore.
     do {
       const [nextCursor, batch] = await client.scan(cursor, "MATCH", pattern, "COUNT", SCAN_COUNT);
       for (const namespaced of batch) {
@@ -139,15 +129,9 @@ const STORE_PREFIXES = {
 } as const;
 
 /**
- * Build a KVStoreSet pointing at a shared (per-URL) ioredis client.
- *
- * Synchronous: the four returned KVStore instances hold a Promise<Redis>,
- * not a resolved client. The actual `await import("ioredis")` and `new
- * Redis(...)` happen lazily inside the first method call on any store.
- *
- * Fails fast on a missing/whitespace REDIS_URL. Graceful shutdown belongs to
- * the Node entrypoint (HOO-511); call closeAllRedisClients() from the
- * SIGTERM handler there.
+ * Build a KVStoreSet from a shared (per-URL) ioredis client. Synchronous —
+ * the stores hold a Promise<Redis>; the import and connection happen lazily
+ * on the first method call. Fails fast on missing/whitespace REDIS_URL.
  */
 export function createRedisKVStoreSet(env: Env): KVStoreSet {
   const url = env.REDIS_URL?.trim();
@@ -166,9 +150,8 @@ export function createRedisKVStoreSet(env: Env): KVStoreSet {
 }
 
 /**
- * Close every cached Redis client. Intended for the Node entrypoint's
- * shutdown handler (HOO-511) and for test teardown — calling it makes the
- * next createRedisKVStoreSet() open a fresh connection.
+ * Close every cached Redis client. Subsequent factory calls open fresh
+ * connections.
  */
 export async function closeAllRedisClients(): Promise<void> {
   const promises = [...clientPromisesByUrl.values()];

--- a/apps/sdp-api/src/runtime/kv-redis.ts
+++ b/apps/sdp-api/src/runtime/kv-redis.ts
@@ -1,27 +1,79 @@
 /**
  * Redis-backed implementation of KVStore for the Node runtime (HOO-510).
  *
- * Sister of WorkersKVStore — same surface, different backend. Single ioredis
- * client is shared across the four logical stores (apiKeys / rateLimits /
- * cache / sessions); each store namespaces its keys with a prefix so list()
- * doesn't bleed across domains.
+ * Sister of WorkersKVStore — same surface, different backend. A single
+ * ioredis client per REDIS_URL is shared across the four logical stores
+ * (apiKeys / rateLimits / cache / sessions); each store namespaces its keys
+ * with a prefix so list() doesn't bleed across domains.
+ *
+ * ioredis is loaded lazily — the top-level `import type` is erased at
+ * compile time, and the real module is fetched via `await import("ioredis")`
+ * inside ensureClient on first use. That keeps ioredis out of the static
+ * module graph so the Cloudflare Workers test pool (miniflare) never tries
+ * to transform it; otherwise miniflare's transformer chokes on ioredis's
+ * debug.js with "Maximum call stack size exceeded" even when the CF branch
+ * is the one that actually runs.
  *
  * Semantics note: Cloudflare KV serves stale reads for up to 60s after a key
- * expires. Redis doesn't — `GET` on an expired key returns null immediately.
+ * expires. Redis doesn't — GET on an expired key returns null immediately.
  * Anything that accidentally relies on stale reads will surface here.
  */
 
-import Redis from "ioredis";
+import type { Redis } from "ioredis";
 import type { Env } from "@/types/env";
 import type { KVListResult, KVPutOptions, KVStore, KVStoreSet } from "./kv";
 
 const SCAN_COUNT = 100;
 
+// One Promise<Redis> per URL, shared by every RedisKVStore that points at
+// that backend. Storing the Promise (not the resolved client) means that two
+// concurrent first-callers wire up to the same in-flight dynamic import +
+// `new Redis(...)` instead of opening parallel TCP connections.
+const clientPromisesByUrl = new Map<string, Promise<Redis>>();
+
+function ensureClient(url: string): Promise<Redis> {
+  const existing = clientPromisesByUrl.get(url);
+  if (existing) return existing;
+  const promise = (async (): Promise<Redis> => {
+    const { default: IORedis } = await import("ioredis");
+    return new IORedis(url, {
+      // Start the TCP handshake immediately rather than on the first command.
+      // Note: ioredis does this asynchronously — an unreachable host will not
+      // throw from `new IORedis(...)`; only a structurally malformed URL does.
+      // Real connectivity failures surface on the first command (or via the
+      // "error" event); maxRetriesPerRequest below caps the retry burst.
+      lazyConnect: false,
+      // Cap retry attempts per command (default is 20). With the connection
+      // down, the third retry fails the command instead of trying ~20 times —
+      // better signal for upstream error handling.
+      maxRetriesPerRequest: 3,
+    });
+  })();
+  clientPromisesByUrl.set(url, promise);
+  // Evict on rejection so a transient malformed-URL or module-load failure
+  // doesn't permanently poison the cache for the rest of the process. The
+  // `===` guard avoids racing with a successful re-creation that already
+  // replaced this entry.
+  promise.catch(() => {
+    if (clientPromisesByUrl.get(url) === promise) {
+      clientPromisesByUrl.delete(url);
+    }
+  });
+  return promise;
+}
+
 export class RedisKVStore implements KVStore {
+  // Internal handle is always a Promise<Redis>. Constructor accepts a raw
+  // connected client too (tests pass one for fixture-level control) and the
+  // constructor normalises it via Promise.resolve — production callers go
+  // through the factory and pass the cached promise from ensureClient.
+  private readonly clientPromise: Promise<Redis>;
   constructor(
-    private readonly client: Redis,
+    client: Redis | Promise<Redis>,
     private readonly prefix: string
-  ) {}
+  ) {
+    this.clientPromise = Promise.resolve(client);
+  }
 
   private namespaced(key: string): string {
     return `${this.prefix}:${key}`;
@@ -30,7 +82,8 @@ export class RedisKVStore implements KVStore {
   get(key: string): Promise<string | null>;
   get<T>(key: string, type: "json"): Promise<T | null>;
   async get<T>(key: string, type?: "json"): Promise<string | T | null> {
-    const raw = await this.client.get(this.namespaced(key));
+    const client = await this.clientPromise;
+    const raw = await client.get(this.namespaced(key));
     if (raw === null) return null;
     if (type === "json") {
       return JSON.parse(raw) as T;
@@ -39,23 +92,26 @@ export class RedisKVStore implements KVStore {
   }
 
   async put(key: string, value: string, options?: KVPutOptions): Promise<void> {
+    const client = await this.clientPromise;
     const namespacedKey = this.namespaced(key);
     // Ticket spec: TTL via `SET PX`. expirationTtl is seconds (parity with
     // Cloudflare KV's KVNamespacePutOptions); Redis PX expects milliseconds.
     if (options?.expirationTtl !== undefined) {
-      await this.client.set(namespacedKey, value, "PX", options.expirationTtl * 1000);
+      await client.set(namespacedKey, value, "PX", options.expirationTtl * 1000);
     } else {
       // No TTL: e.g. rpc:relay:stats:* and round-robin cursor — match CF KV
       // behavior where omitting expirationTtl persists indefinitely.
-      await this.client.set(namespacedKey, value);
+      await client.set(namespacedKey, value);
     }
   }
 
   async delete(key: string): Promise<void> {
-    await this.client.del(this.namespaced(key));
+    const client = await this.clientPromise;
+    await client.del(this.namespaced(key));
   }
 
   async list(): Promise<KVListResult> {
+    const client = await this.clientPromise;
     const pattern = `${this.prefix}:*`;
     const stripFrom = this.prefix.length + 1; // include the trailing ":"
     const keys: { name: string }[] = [];
@@ -65,13 +121,7 @@ export class RedisKVStore implements KVStore {
     // surface matches WorkersKVStore (test helpers clearKVNamespaces() round-
     // trip name → delete(name)).
     do {
-      const [nextCursor, batch] = await this.client.scan(
-        cursor,
-        "MATCH",
-        pattern,
-        "COUNT",
-        SCAN_COUNT
-      );
+      const [nextCursor, batch] = await client.scan(cursor, "MATCH", pattern, "COUNT", SCAN_COUNT);
       for (const namespaced of batch) {
         keys.push({ name: namespaced.slice(stripFrom) });
       }
@@ -88,46 +138,16 @@ const STORE_PREFIXES = {
   sessions: "sessions",
 } as const;
 
-// kvStoreMiddleware calls createKVStoreSet(c.env) on every authenticated
-// request, so this factory MUST return the same ioredis client across calls
-// for a given URL — otherwise each request opens a fresh TCP connection and
-// nothing ever closes them, exhausting Redis's maxclients under load.
-//
-// Keyed by URL (not just a single `let`) so test runs that point at different
-// instances don't accidentally share a client, and so a previously-quit
-// client (status === "end") is detected and replaced instead of returning a
-// dead handle.
-const clientsByUrl = new Map<string, Redis>();
-
-function getOrCreateClient(url: string): Redis {
-  const existing = clientsByUrl.get(url);
-  if (existing && existing.status !== "end") {
-    return existing;
-  }
-  const client = new Redis(url, {
-    // Start the TCP handshake immediately rather than on the first command.
-    // Note: ioredis does this asynchronously — an unreachable host will not
-    // throw from `new Redis(...)`; only a structurally malformed URL does.
-    // Real connectivity failures surface on the first command (or via the
-    // "error" event); maxRetriesPerRequest below caps how long they queue.
-    lazyConnect: false,
-    // Cap retry attempts per command (default is 20). With the connection
-    // down, the third retry fails the command instead of trying ~20 times —
-    // better signal for upstream error handling.
-    maxRetriesPerRequest: 3,
-  });
-  clientsByUrl.set(url, client);
-  return client;
-}
-
 /**
- * Build a KVStoreSet backed by a process-wide ioredis client (one per URL).
+ * Build a KVStoreSet pointing at a shared (per-URL) ioredis client.
  *
- * Fails fast at factory time if REDIS_URL is missing/whitespace — the
- * alternative is a deep "ECONNREFUSED" on the first request, which is harder
- * to map back to a missing env. Graceful shutdown belongs to the Node
- * entrypoint (HOO-511); call `closeAllRedisClients()` from the SIGTERM
- * handler there.
+ * Synchronous: the four returned KVStore instances hold a Promise<Redis>,
+ * not a resolved client. The actual `await import("ioredis")` and `new
+ * Redis(...)` happen lazily inside the first method call on any store.
+ *
+ * Fails fast on a missing/whitespace REDIS_URL. Graceful shutdown belongs to
+ * the Node entrypoint (HOO-511); call closeAllRedisClients() from the
+ * SIGTERM handler there.
  */
 export function createRedisKVStoreSet(env: Env): KVStoreSet {
   const url = env.REDIS_URL?.trim();
@@ -136,12 +156,12 @@ export function createRedisKVStoreSet(env: Env): KVStoreSet {
       "REDIS_URL missing for runtime=node. Set it in the environment (e.g. redis://localhost:6379)."
     );
   }
-  const client = getOrCreateClient(url);
+  const clientPromise = ensureClient(url);
   return {
-    apiKeys: new RedisKVStore(client, STORE_PREFIXES.apiKeys),
-    rateLimits: new RedisKVStore(client, STORE_PREFIXES.rateLimits),
-    cache: new RedisKVStore(client, STORE_PREFIXES.cache),
-    sessions: new RedisKVStore(client, STORE_PREFIXES.sessions),
+    apiKeys: new RedisKVStore(clientPromise, STORE_PREFIXES.apiKeys),
+    rateLimits: new RedisKVStore(clientPromise, STORE_PREFIXES.rateLimits),
+    cache: new RedisKVStore(clientPromise, STORE_PREFIXES.cache),
+    sessions: new RedisKVStore(clientPromise, STORE_PREFIXES.sessions),
   };
 }
 
@@ -151,7 +171,12 @@ export function createRedisKVStoreSet(env: Env): KVStoreSet {
  * next createRedisKVStoreSet() open a fresh connection.
  */
 export async function closeAllRedisClients(): Promise<void> {
-  const clients = [...clientsByUrl.values()];
-  clientsByUrl.clear();
-  await Promise.allSettled(clients.map((c) => c.quit()));
+  const promises = [...clientPromisesByUrl.values()];
+  clientPromisesByUrl.clear();
+  await Promise.allSettled(
+    promises.map(async (promise) => {
+      const client = await promise;
+      await client.quit();
+    })
+  );
 }

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -170,10 +170,12 @@ export interface Env {
   // Lightspark Grid ramps configuration
   LIGHTSPARK_GRID_CLIENT_ID?: string;
   LIGHTSPARK_GRID_CLIENT_SECRET?: string;
+  LIGHTSPARK_GRID_API_BASE_URL?: string;
   LIGHTSPARK_GRID_SANDBOX_CLIENT_ID?: string;
   LIGHTSPARK_GRID_SANDBOX_CLIENT_SECRET?: string;
 
   // BVNK ramps configuration
+  BVNK_API_TOKEN?: string;
   BVNK_HAWK_AUTH_ID?: string;
   BVNK_HAWK_SECRET_KEY?: string;
   BVNK_WALLET_ID?: string;

--- a/apps/sdp-api/vitest.config.ts
+++ b/apps/sdp-api/vitest.config.ts
@@ -84,7 +84,10 @@ export default defineConfig({
     isolate: false,
     maxWorkers: 1,
     include: ["src/**/*.test.ts", "src/**/*.spec.ts", "src/__tests__/**/*.unit.ts"],
-    exclude: ["node_modules", ".wrangler", "dist"],
+    // `**\/*.node.test.ts` runs under vitest.node.config.ts (plain Node pool)
+    // because those tests need APIs the Cloudflare Workers pool doesn't
+    // expose (e.g. ioredis → node:net sockets).
+    exclude: ["node_modules", ".wrangler", "dist", "src/**/*.node.test.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/apps/sdp-api/vitest.config.ts
+++ b/apps/sdp-api/vitest.config.ts
@@ -84,9 +84,8 @@ export default defineConfig({
     isolate: false,
     maxWorkers: 1,
     include: ["src/**/*.test.ts", "src/**/*.spec.ts", "src/__tests__/**/*.unit.ts"],
-    // `**\/*.node.test.ts` runs under vitest.node.config.ts (plain Node pool)
-    // because those tests need APIs the Cloudflare Workers pool doesn't
-    // expose (e.g. ioredis → node:net sockets).
+    // `**\/*.node.test.ts` runs in vitest.node.config.ts (plain Node pool)
+    // because ioredis needs Node socket APIs the Workers pool doesn't expose.
     exclude: ["node_modules", ".wrangler", "dist", "src/**/*.node.test.ts"],
     coverage: {
       provider: "v8",

--- a/apps/sdp-api/vitest.node.config.ts
+++ b/apps/sdp-api/vitest.node.config.ts
@@ -1,11 +1,7 @@
 /**
- * Vitest config for Node-runtime tests (HOO-510).
- *
- * Sibling of `vitest.config.ts` (Cloudflare Workers pool). Some code paths
- * require real Node APIs that Workers don't expose — notably `ioredis`, which
- * opens raw TCP sockets via `node:net`. Tests targeting those paths live in
- * `**\/*.node.test.ts` files and run here in plain Node, isolated from the CF
- * pool so neither config has to dance around the other's restrictions.
+ * Vitest config for Node-runtime tests. Sibling of vitest.config.ts (CF
+ * Workers pool). Tests in `**\/*.node.test.ts` run here in plain Node
+ * because they need APIs Workers don't expose (e.g. ioredis → node:net).
  */
 
 import path from "node:path";

--- a/apps/sdp-api/vitest.node.config.ts
+++ b/apps/sdp-api/vitest.node.config.ts
@@ -1,0 +1,28 @@
+/**
+ * Vitest config for Node-runtime tests (HOO-510).
+ *
+ * Sibling of `vitest.config.ts` (Cloudflare Workers pool). Some code paths
+ * require real Node APIs that Workers don't expose — notably `ioredis`, which
+ * opens raw TCP sockets via `node:net`. Tests targeting those paths live in
+ * `**\/*.node.test.ts` files and run here in plain Node, isolated from the CF
+ * pool so neither config has to dance around the other's restrictions.
+ */
+
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "@sdp/types": path.resolve(__dirname, "../../packages/sdp-types/src"),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["src/**/*.node.test.ts"],
+    exclude: ["node_modules", ".wrangler", "dist"],
+    testTimeout: 15000,
+    hookTimeout: 15000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       hono:
         specifier: ^4.12.16
         version: 4.12.18
+      ioredis:
+        specifier: ^5.4.1
+        version: 5.10.1
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -1381,6 +1384,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -4660,6 +4666,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -4764,6 +4774,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -4818,10 +4832,6 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  enhanced-resolve@5.21.1:
-    resolution: {integrity: sha512-8p7DUVq6XJnZEz9W4oSwiwycxBIjHjRzYb3Je3zVN+geKTRQKzAkR/K4PBExlS0090d9nshak6phMUxr3PDjmQ==}
-    engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.21.2:
     resolution: {integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==}
@@ -5444,6 +5454,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -5756,6 +5770,12 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -6396,6 +6416,14 @@ packages:
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -6607,6 +6635,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
@@ -7881,6 +7912,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@ioredis/commands@1.5.1': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -11354,6 +11387,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -11441,6 +11476,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -11490,11 +11527,6 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
-
-  enhanced-resolve@5.21.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
 
   enhanced-resolve@5.21.2:
     dependencies:
@@ -11725,7 +11757,7 @@ snapshots:
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.3.0(jiti@2.7.0))
@@ -11758,7 +11790,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11773,7 +11805,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12413,6 +12445,20 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -12692,6 +12738,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   longest-streak@3.1.0: {}
 
@@ -13643,6 +13693,12 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -14013,6 +14069,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standard-as-callback@2.1.0: {}
 
   standardwebhooks@1.0.0:
     dependencies:
@@ -14477,7 +14535,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.1
+      enhanced-resolve: 5.21.2
       es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0


### PR DESCRIPTION
## Summary
- New `RedisKVStore` + `createRedisKVStoreSet` for the Node runtime: single shared `ioredis` client, four prefixed stores (`apiKeys` / `rateLimits` / `cache` / `sessions`).
- Factory now branches on `getRuntime(env)`: `node` → Redis, `cloudflare` → existing Workers KV (unchanged).
- Adds `ioredis ^5.4.1`, a sibling `vitest.node.config.ts` (plain Node pool for `*.node.test.ts`), and a `redis:7-alpine` service container in the Unit Tests CI job.

## Why a separate Node-pool vitest config
The existing config uses `@cloudflare/vitest-pool-workers`, which runs tests inside a simulated Workers runtime. `ioredis` opens raw TCP sockets via `node:net` and won't run there. Rather than fight either runtime, this PR adds a tiny sibling config that picks up `*.node.test.ts` files and runs them in plain Node. The Workers config now `exclude`s the same pattern so neither config crosses over.

## Spec mapping (per Linear ticket)
- TTL via `SET key value PX <ttl_seconds * 1000>` — ticket says PX explicitly; multiplies seconds because the interface inherits CF's `expirationTtl: seconds`.
- Key listing via `SCAN MATCH <prefix>:* COUNT 100` until cursor=0 (non-blocking, paginated).
- No-TTL `put` uses plain `SET` so `rpc:relay:stats:*` and the round-robin cursor preserve their current CF KV semantics (persist indefinitely). Any change to that would be a behavior change in callers, not in HOO-510.

## Watch-out for cutover
Redis doesn't serve stale reads after TTL expiry. Cloudflare KV has up to ~60s grace; the Node path won't. Anything that accidentally relies on the grace window will surface.

## Drive-by fix
`env.d.ts` was missing `LIGHTSPARK_GRID_API_BASE_URL` and `BVNK_API_TOKEN` even though `PROCESS_ENV_FALLBACK_KEYS` in `runtime-env.ts` references them. CI's typecheck job filters by changed packages, so the breakage only surfaces on PRs that touch `sdp-api` — like this one. Adding the two optional string declarations is the minimum needed for CI to go green.

## Test plan
- [x] 13 integration tests against real Redis pass locally (round-trip, JSON overload, `SET PX` PTTL semantics, no-TTL persists, SCAN-based list with prefix strip, cross-store isolation, factory error paths for missing/whitespace `REDIS_URL`).
- [x] `pnpm --filter @sdp/api typecheck` clean.
- [x] `biome check` clean on PR-scoped files (matches CI's diff-only lint).
- [x] CI run: Unit Tests job picks up the new `redis:7-alpine` service and "Node-runtime tests" step.
- [ ] Follow-up (HOO-511): graceful `client.quit()` on SIGTERM lives in the Node entrypoint, not here.