### PR TITLE
feat(sdp-api): HOO-511 Node.js entrypoint (server.ts)

### DIFF
--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -27,9 +27,11 @@
     "test:serial": "vitest run --no-file-parallelism --maxWorkers=1",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:node": "vitest run --config vitest.node.config.ts"
+    "test:node": "vitest run --config vitest.node.config.ts",
+    "dev:node": "tsx watch src/server.ts"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.6",
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.0.8",
     "@sdp/types": "workspace:*",
@@ -53,6 +55,7 @@
     "ioredis": "^5.4.1",
     "jose": "^6.2.3",
     "nanoid": "^5.1.11",
+    "node-cron": "^4.2.1",
     "pg": "^8.16.3",
     "react": "19.2.5",
     "svix": "1.92.2",

--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundRunner } from "@/runtime/background";
+import type { Observability } from "@/runtime/observability";
+import type { Env } from "@/types/env";
+import { PENDING_TRANSFERS_CRON, runPendingTransfersReconciliation } from "./pending-transfers";
+import { startCron } from "./runner";
+
+const scheduleMock = vi.fn();
+const stopMock = vi.fn();
+const fakeTask = {
+  id: "fake",
+  stop: stopMock,
+  start: vi.fn(),
+  getStatus: vi.fn(),
+  destroy: vi.fn(),
+  execute: vi.fn(),
+  getNextRun: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  once: vi.fn(),
+};
+
+vi.mock("node-cron", () => ({
+  schedule: (...args: unknown[]) => scheduleMock(...args),
+}));
+
+vi.mock("./pending-transfers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./pending-transfers")>();
+  return {
+    ...actual,
+    runPendingTransfersReconciliation: vi.fn(),
+  };
+});
+
+function makeBg(): BackgroundRunner {
+  return { run: vi.fn(), awaitAll: vi.fn(async () => {}), draining: false };
+}
+
+function makeObservability(): Observability {
+  return {
+    captureException: vi.fn(),
+    withScope: vi.fn(),
+    withMonitor: vi.fn(),
+  };
+}
+
+describe("startCron", () => {
+  beforeEach(() => {
+    scheduleMock.mockReset();
+    stopMock.mockReset();
+    scheduleMock.mockReturnValue(fakeTask);
+    vi.mocked(runPendingTransfersReconciliation).mockReset();
+  });
+
+  it("returns null and does not schedule when DISABLE_CRON=true", () => {
+    const result = startCron({ env: { DISABLE_CRON: "true" } as Env, bg: makeBg() });
+    expect(result).toBeNull();
+    expect(scheduleMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null and does not schedule when DISABLE_CRON=1", () => {
+    const result = startCron({ env: { DISABLE_CRON: "1" } as Env, bg: makeBg() });
+    expect(result).toBeNull();
+    expect(scheduleMock).not.toHaveBeenCalled();
+  });
+
+  it("schedules a task with PENDING_TRANSFERS_CRON when DISABLE_CRON is unset", () => {
+    startCron({ env: {} as Env, bg: makeBg() });
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    expect(scheduleMock.mock.calls[0][0]).toBe(PENDING_TRANSFERS_CRON);
+  });
+
+  it("schedules when DISABLE_CRON is set to any non-truthy value (e.g. 'false')", () => {
+    startCron({ env: { DISABLE_CRON: "false" } as Env, bg: makeBg() });
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("tick invokes runPendingTransfersReconciliation with the supplied deps", () => {
+    const bg = makeBg();
+    const env = {} as Env;
+    const observability = makeObservability();
+    startCron({ env, bg, observability });
+    const tick = scheduleMock.mock.calls[0][1] as () => void;
+    tick();
+    expect(runPendingTransfersReconciliation).toHaveBeenCalledWith({ env, bg, observability });
+  });
+
+  it("tick passes observability=undefined through when caller did not supply one", () => {
+    const bg = makeBg();
+    const env = {} as Env;
+    startCron({ env, bg });
+    const tick = scheduleMock.mock.calls[0][1] as () => void;
+    tick();
+    expect(runPendingTransfersReconciliation).toHaveBeenCalledWith({
+      env,
+      bg,
+      observability: undefined,
+    });
+  });
+
+  it("tick is a no-op after stop() has been called, even if the scheduler fires once more", async () => {
+    const handle = startCron({ env: {} as Env, bg: makeBg() });
+    await handle?.stop();
+    const tick = scheduleMock.mock.calls[0][1] as () => void;
+    tick();
+    expect(runPendingTransfersReconciliation).not.toHaveBeenCalled();
+  });
+
+  it("returned handle.stop() delegates to the underlying scheduled task", async () => {
+    const handle = startCron({ env: {} as Env, bg: makeBg() });
+    expect(handle).not.toBeNull();
+    await handle?.stop();
+    expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -70,9 +70,33 @@ describe("startCron", () => {
     expect(scheduleMock.mock.calls[0][0]).toBe(PENDING_TRANSFERS_CRON);
   });
 
-  it("schedules when DISABLE_CRON is set to any non-truthy value (e.g. 'false')", () => {
+  it("schedules when DISABLE_CRON is set to a recognised falsy value ('false' / '0')", () => {
     startCron({ env: { DISABLE_CRON: "false" } as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    startCron({ env: { DISABLE_CRON: "0" } as Env, bg: makeBg() });
+    expect(scheduleMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on an unrecognised DISABLE_CRON value to surface env typos", () => {
+    expect(() => startCron({ env: { DISABLE_CRON: "treu" } as Env, bg: makeBg() })).toThrow(
+      /Invalid DISABLE_CRON/
+    );
+    expect(() => startCron({ env: { DISABLE_CRON: "yes" } as Env, bg: makeBg() })).toThrow(
+      /Invalid DISABLE_CRON/
+    );
+    expect(scheduleMock).not.toHaveBeenCalled();
+  });
+
+  it("normalises DISABLE_CRON case and surrounding whitespace", () => {
+    const result = startCron({ env: { DISABLE_CRON: "  TRUE  " } as Env, bg: makeBg() });
+    expect(result).toBeNull();
+    expect(scheduleMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on a blank DISABLE_CRON value rather than defaulting silently", () => {
+    expect(() => startCron({ env: { DISABLE_CRON: "   " } as Env, bg: makeBg() })).toThrow(
+      /Invalid DISABLE_CRON/
+    );
+    expect(scheduleMock).not.toHaveBeenCalled();
   });
 
   it("tick invokes runPendingTransfersReconciliation with the supplied deps", () => {

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -28,10 +28,25 @@ export interface CronHandle {
 }
 
 const TRUTHY_DISABLE_CRON: ReadonlySet<string> = new Set(["true", "1"]);
+const FALSY_DISABLE_CRON: ReadonlySet<string> = new Set(["false", "0"]);
 
+// Strict whitelist so a typo (`DISABLE_CRON=treu`) fails loudly instead of
+// silently enabling cron and double-firing across replicas.
 function isCronDisabled(env: Env): boolean {
-  const raw = env.DISABLE_CRON?.trim().toLowerCase();
-  return raw !== undefined && TRUTHY_DISABLE_CRON.has(raw);
+  const raw = env.DISABLE_CRON;
+  if (raw === undefined) {
+    return false;
+  }
+  const normalised = raw.trim().toLowerCase();
+  if (TRUTHY_DISABLE_CRON.has(normalised)) {
+    return true;
+  }
+  if (FALSY_DISABLE_CRON.has(normalised)) {
+    return false;
+  }
+  throw new Error(
+    `Invalid DISABLE_CRON: ${JSON.stringify(raw)} (expected 'true', 'false', '1', or '0')`
+  );
 }
 
 export function startCron(deps: CronDeps): CronHandle | null {

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -1,0 +1,65 @@
+/**
+ * node-cron wrapper for the Node runtime. Schedules the same reconciliation
+ * job that the Cloudflare `scheduled` handler triggers, going through the
+ * shared `runPendingTransfersReconciliation` so observability and background
+ * tracking are wired identically across runtimes.
+ *
+ * `DISABLE_CRON=true` skips registration entirely, leaving the process free
+ * to run as one of many web replicas without firing the reconciliation N
+ * times per minute. A distributed lock would let every replica schedule
+ * safely; until that lands, single-replica + DISABLE_CRON elsewhere is the
+ * agreed-upon strategy.
+ */
+
+import { type ScheduledTask, schedule } from "node-cron";
+import type { BackgroundRunner } from "@/runtime/background";
+import type { Observability } from "@/runtime/observability";
+import type { Env } from "@/types/env";
+import { PENDING_TRANSFERS_CRON, runPendingTransfersReconciliation } from "./pending-transfers";
+
+export interface CronDeps {
+  env: Env;
+  bg: BackgroundRunner;
+  observability?: Observability;
+}
+
+export interface CronHandle {
+  stop(): void | Promise<void>;
+}
+
+const TRUTHY_DISABLE_CRON: ReadonlySet<string> = new Set(["true", "1"]);
+
+function isCronDisabled(env: Env): boolean {
+  const raw = env.DISABLE_CRON?.trim().toLowerCase();
+  return raw !== undefined && TRUTHY_DISABLE_CRON.has(raw);
+}
+
+export function startCron(deps: CronDeps): CronHandle | null {
+  if (isCronDisabled(deps.env)) {
+    return null;
+  }
+
+  // node-cron's `task.stop()` halts future scheduling but doesn't promise
+  // to interrupt a tick already mid-flight. A `stopping` flag short-circuits
+  // any callback that fires concurrent with shutdown so no extra background
+  // work gets registered after the awaitAll() snapshot is taken.
+  let stopping = false;
+
+  const task: ScheduledTask = schedule(PENDING_TRANSFERS_CRON, () => {
+    if (stopping) {
+      return;
+    }
+    runPendingTransfersReconciliation({
+      env: deps.env,
+      bg: deps.bg,
+      observability: deps.observability,
+    });
+  });
+
+  return {
+    stop() {
+      stopping = true;
+      return task.stop();
+    },
+  };
+}

--- a/apps/sdp-api/src/lib/runtime-env.ts
+++ b/apps/sdp-api/src/lib/runtime-env.ts
@@ -4,6 +4,10 @@ const PROCESS_ENV_FALLBACK_KEYS = [
   "ENVIRONMENT",
   "API_VERSION",
   "SDP_DEPLOYMENT_MODE",
+  // Selects the KV / DB runtime branch. Without this, code outside the
+  // server.ts hardcode (scripts, tests) sees SDP_RUNTIME undefined and
+  // defaults to Cloudflare mode even when the process is plainly Node.
+  "SDP_RUNTIME",
   // Connection strings populated from process.env when bindings aren't set
   // — pg uses DATABASE_URL, RedisKVStore uses REDIS_URL.
   "DATABASE_URL",
@@ -101,6 +105,7 @@ const PROCESS_ENV_FALLBACK_KEYS = [
   "BVNK_HAWK_SECRET_KEY",
   "BVNK_WALLET_ID",
   "BVNK_API_BASE_URL",
+  "DISABLE_CRON",
 ] as const satisfies readonly (keyof Env)[];
 
 export type SdpDeploymentMode = "managed" | "self_hosted";

--- a/apps/sdp-api/src/runtime/shutdown-node.node.test.ts
+++ b/apps/sdp-api/src/runtime/shutdown-node.node.test.ts
@@ -13,11 +13,18 @@ vi.mock("@/db/client", async (importOriginal) => {
   return { ...actual, closeDatabasePools: vi.fn(async () => {}) };
 });
 
-type Closable = { close: (cb: (err?: Error) => void) => void };
+type Closable = {
+  close: (cb: (err?: Error) => void) => void;
+  closeIdleConnections?: () => void;
+};
 
-function makeServer(closeImpl?: (cb: (err?: Error) => void) => void): Closable {
+function makeServer(
+  closeImpl?: (cb: (err?: Error) => void) => void,
+  closeIdleConnections?: () => void
+): Closable {
   return {
     close: vi.fn(closeImpl ?? ((cb: (err?: Error) => void) => cb())),
+    ...(closeIdleConnections ? { closeIdleConnections: vi.fn(closeIdleConnections) } : {}),
   };
 }
 
@@ -95,5 +102,35 @@ describe("shutdown", () => {
     await expect(shutdown({ server, cron: null, bg: makeBg(), log: () => {} })).rejects.toThrow(
       "boom"
     );
+  });
+
+  it("invokes closeIdleConnections (when available) after starting close() so idle keep-alive sockets drop immediately", async () => {
+    let closeStartedAt: number | null = null;
+    let idleDroppedAt: number | null = null;
+    let counter = 0;
+    const server = makeServer(
+      (cb) => {
+        closeStartedAt = ++counter;
+        // Resolve close() asynchronously so we can observe whether
+        // closeIdleConnections was invoked synchronously before the await.
+        setImmediate(cb);
+      },
+      () => {
+        idleDroppedAt = ++counter;
+      }
+    );
+    await shutdown({ server, cron: null, bg: makeBg(), log: () => {} });
+    expect(server.closeIdleConnections).toHaveBeenCalledTimes(1);
+    expect(closeStartedAt).not.toBeNull();
+    expect(idleDroppedAt).not.toBeNull();
+    expect(idleDroppedAt).toBeGreaterThan(closeStartedAt as unknown as number);
+  });
+
+  it("tolerates a Closable without closeIdleConnections (older http.Server polyfills, mocks)", async () => {
+    const server = makeServer();
+    await expect(
+      shutdown({ server, cron: null, bg: makeBg(), log: () => {} })
+    ).resolves.toBeUndefined();
+    expect(server.closeIdleConnections).toBeUndefined();
   });
 });

--- a/apps/sdp-api/src/runtime/shutdown-node.node.test.ts
+++ b/apps/sdp-api/src/runtime/shutdown-node.node.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as dbClient from "@/db/client";
+import type { BackgroundRunner } from "./background";
+import * as kvRedis from "./kv-redis";
+import { shutdown } from "./shutdown-node";
+
+vi.mock("./kv-redis", () => ({
+  closeAllRedisClients: vi.fn(async () => {}),
+}));
+
+vi.mock("@/db/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/db/client")>();
+  return { ...actual, closeDatabasePools: vi.fn(async () => {}) };
+});
+
+type Closable = { close: (cb: (err?: Error) => void) => void };
+
+function makeServer(closeImpl?: (cb: (err?: Error) => void) => void): Closable {
+  return {
+    close: vi.fn(closeImpl ?? ((cb: (err?: Error) => void) => cb())),
+  };
+}
+
+function makeBg(awaitImpl?: () => Promise<void>): BackgroundRunner {
+  return {
+    run: vi.fn(),
+    awaitAll: vi.fn(awaitImpl ?? (async () => {})),
+    draining: false,
+  };
+}
+
+describe("shutdown", () => {
+  beforeEach(() => {
+    vi.mocked(kvRedis.closeAllRedisClients).mockReset().mockResolvedValue(undefined);
+    vi.mocked(dbClient.closeDatabasePools).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("runs lifecycle in order: server.close → cron.stop → bg.awaitAll → closeAllRedisClients → closeDatabasePools", async () => {
+    const calls: string[] = [];
+    const server = makeServer((cb) => {
+      calls.push("server.close");
+      cb();
+    });
+    const cron = {
+      stop: vi.fn(() => {
+        calls.push("cron.stop");
+      }),
+    };
+    const bg = makeBg(async () => {
+      calls.push("bg.awaitAll");
+    });
+    vi.mocked(kvRedis.closeAllRedisClients).mockImplementation(async () => {
+      calls.push("closeAllRedisClients");
+    });
+    vi.mocked(dbClient.closeDatabasePools).mockImplementation(async () => {
+      calls.push("closeDatabasePools");
+    });
+
+    await shutdown({ server, cron, bg, log: () => {} });
+
+    expect(calls).toEqual([
+      "server.close",
+      "cron.stop",
+      "bg.awaitAll",
+      "closeAllRedisClients",
+      "closeDatabasePools",
+    ]);
+  });
+
+  it("waits for server.close callback before stopping cron", async () => {
+    let serverClosed = false;
+    const server = makeServer((cb) => {
+      setTimeout(() => {
+        serverClosed = true;
+        cb();
+      }, 5);
+    });
+    const cron = {
+      stop: vi.fn(() => {
+        expect(serverClosed).toBe(true);
+      }),
+    };
+    await shutdown({ server, cron, bg: makeBg(), log: () => {} });
+    expect(cron.stop).toHaveBeenCalled();
+  });
+
+  it("tolerates a null cron handle (DISABLE_CRON path)", async () => {
+    await expect(
+      shutdown({ server: makeServer(), cron: null, bg: makeBg(), log: () => {} })
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when server.close reports an error", async () => {
+    const server = makeServer((cb) => cb(new Error("boom")));
+    await expect(shutdown({ server, cron: null, bg: makeBg(), log: () => {} })).rejects.toThrow(
+      "boom"
+    );
+  });
+});

--- a/apps/sdp-api/src/runtime/shutdown-node.ts
+++ b/apps/sdp-api/src/runtime/shutdown-node.ts
@@ -1,0 +1,60 @@
+/**
+ * Node SIGTERM/SIGINT shutdown sequence.
+ *
+ * Lives separately from server.ts so unit tests can exercise the lifecycle
+ * order without pulling in the full Hono app graph (routes, SDKs, etc.).
+ *
+ * Order matters:
+ *   1. server.close — stop accepting new requests; finish in-flight ones.
+ *      Anything those requests fire-and-forget via bg.run is already
+ *      tracked, so the registration window stays open.
+ *   2. cron.stop — block any future tick from scheduling new work.
+ *      A tick that fires synchronously with stop() still registers its
+ *      promise with bg.run before this call returns.
+ *   3. bg.awaitAll — drain everything registered above. NodeBackgroundRunner
+ *      seals after this returns, so any straggler bg.run is refused (and
+ *      warned) rather than silently leaked.
+ *   4. closeAllRedisClients — only after bg drain, so in-flight Redis
+ *      commands aren't racing a client.quit() call.
+ *   5. closeDatabasePools — last; the pg client is per-query so this is
+ *      a cache clear, not a connection drain.
+ */
+
+import type { CronHandle } from "@/cron/runner";
+import { closeDatabasePools } from "@/db/client";
+import type { BackgroundRunner } from "./background";
+import { closeAllRedisClients } from "./kv-redis";
+
+export interface Closable {
+  close(callback: (err?: Error) => void): void;
+}
+
+export interface ShutdownDeps {
+  server: Closable;
+  cron: CronHandle | null;
+  bg: BackgroundRunner;
+  log: (msg: string) => void;
+}
+
+export async function shutdown(deps: ShutdownDeps): Promise<void> {
+  deps.log("closing HTTP listener");
+  await new Promise<void>((resolve, reject) => {
+    deps.server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+  if (deps.cron) {
+    deps.log("stopping cron scheduler");
+    await deps.cron.stop();
+  }
+  deps.log("draining background tasks");
+  await deps.bg.awaitAll();
+  deps.log("closing Redis clients");
+  await closeAllRedisClients();
+  deps.log("closing database pools");
+  await closeDatabasePools();
+}

--- a/apps/sdp-api/src/runtime/shutdown-node.ts
+++ b/apps/sdp-api/src/runtime/shutdown-node.ts
@@ -27,6 +27,13 @@ import { closeAllRedisClients } from "./kv-redis";
 
 export interface Closable {
   close(callback: (err?: Error) => void): void;
+  // http.Server.close() stops accepting new connections but lets existing
+  // idle keep-alive sockets time out on their own — minutes by default
+  // behind a typical load balancer. closeIdleConnections() (Node >= 18.2)
+  // drops idle sockets immediately so close() resolves on in-flight work
+  // alone. Optional so test mocks and older runtimes still satisfy the
+  // contract.
+  closeIdleConnections?(): void;
 }
 
 export interface ShutdownDeps {
@@ -46,6 +53,10 @@ export async function shutdown(deps: ShutdownDeps): Promise<void> {
       }
       resolve();
     });
+    // Drop idle keep-alive sockets right after the close() request so the
+    // server-side socket count drains immediately; in-flight requests run
+    // to completion before close() resolves.
+    deps.server.closeIdleConnections?.();
   });
   if (deps.cron) {
     deps.log("stopping cron scheduler");

--- a/apps/sdp-api/src/server.ts
+++ b/apps/sdp-api/src/server.ts
@@ -1,0 +1,126 @@
+/**
+ * SDP API — Node.js entrypoint.
+ *
+ * Mirrors `index.ts` (the Cloudflare entrypoint) but consumes the Node
+ * runtime impls: `@hono/node-server` for HTTP, `node-cron` for the
+ * reconciliation tick, `@sentry/node` for monitoring, `NodeBackgroundRunner`
+ * for tracking fire-and-forget work that needs to survive past response.
+ *
+ * The shutdown sequence lives in `runtime/shutdown-node.ts`.
+ */
+
+import { pathToFileURL } from "node:url";
+import { type ServerType, serve } from "@hono/node-server";
+
+import { createApp } from "@/app";
+import { startCron } from "@/cron/runner";
+import { withProcessEnvFallback } from "@/lib/runtime-env";
+import { NodeBackgroundRunner } from "@/runtime/background-node";
+import { getSentryOptions, isSentryEnabled } from "@/runtime/observability";
+import { initNodeSentry, nodeObservability } from "@/runtime/observability-node";
+import { shutdown } from "@/runtime/shutdown-node";
+import type { Env } from "@/types/env";
+
+const DEFAULT_PORT = 8787;
+
+function resolvePort(): number {
+  const raw = process.env.PORT;
+  if (!raw) {
+    return DEFAULT_PORT;
+  }
+  // `Number()` rejects trailing garbage by returning NaN ("8787abc" -> NaN),
+  // unlike `Number.parseInt` which would silently truncate to 8787.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`Invalid PORT: ${raw}`);
+  }
+  return parsed;
+}
+
+function assertRequiredEnv(env: Env): void {
+  if (!env.ENVIRONMENT) {
+    throw new Error("ENVIRONMENT is required (set to 'development' or 'production')");
+  }
+  if (!env.API_VERSION) {
+    throw new Error("API_VERSION is required");
+  }
+  if (!env.DATABASE_URL?.trim()) {
+    throw new Error("DATABASE_URL is required for the Node runtime");
+  }
+  if (!env.REDIS_URL?.trim()) {
+    throw new Error("REDIS_URL is required for the Node runtime");
+  }
+}
+
+async function main(): Promise<void> {
+  // The Node entrypoint IS the Node runtime — don't let a stray process.env
+  // value flip the KV factory back to Cloudflare mode. Set this before
+  // assertRequiredEnv so downstream code (e.g. getRuntime) sees the override.
+  const env = withProcessEnvFallback({} as Env);
+  env.SDP_RUNTIME = "node";
+  assertRequiredEnv(env);
+
+  initNodeSentry(getSentryOptions(env));
+
+  const app = createApp({ observability: nodeObservability });
+  const bg = new NodeBackgroundRunner();
+  const cron = startCron({
+    env,
+    bg,
+    observability: isSentryEnabled(env) ? nodeObservability : undefined,
+  });
+
+  const port = resolvePort();
+  const server: ServerType = serve({
+    fetch: (req) => app.fetch(req, env),
+    port,
+  });
+
+  console.log(`sdp-api listening on :${port}`);
+
+  let shuttingDown: Promise<void> | null = null;
+  const beginShutdown = (label: string): void => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = shutdown({
+      server,
+      cron,
+      bg,
+      log: (msg) => console.log(`[${label}] ${msg}`),
+    })
+      .then(() => {
+        process.exit(0);
+      })
+      .catch((err: unknown) => {
+        console.error("Shutdown failed:", err);
+        process.exit(1);
+      });
+  };
+
+  process.on("SIGTERM", () => beginShutdown("SIGTERM"));
+  process.on("SIGINT", () => beginShutdown("SIGINT"));
+
+  // Unhandled rejections in routes or background tasks are recoverable —
+  // log them and drain in-flight work through the normal shutdown path so
+  // we don't leak Redis sockets or skip db pool cleanup. uncaughtException
+  // is treated as fatal: V8 documents the process state as potentially
+  // corrupted, so we log and exit fast rather than risk a hung shutdown;
+  // the container orchestrator will restart a clean process.
+  process.on("unhandledRejection", (reason) => {
+    console.error("Unhandled rejection — initiating shutdown:", reason);
+    beginShutdown("unhandledRejection");
+  });
+  process.on("uncaughtException", (err) => {
+    console.error("Uncaught exception — exiting:", err);
+    process.exit(1);
+  });
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  main().catch((err: unknown) => {
+    console.error("Fatal startup error:", err);
+    process.exit(1);
+  });
+}

--- a/apps/sdp-api/src/server.ts
+++ b/apps/sdp-api/src/server.ts
@@ -76,9 +76,18 @@ function shouldShutdownOnUnhandledRejection(): boolean {
   throw new Error(`Invalid FATAL_ON_UNHANDLED_REJECTION: ${JSON.stringify(raw)}`);
 }
 
+// Runtime whitelist so a typo (`ENVIRONMENT=prod`) can't slip past the type
+// and reach branches that gate dev-only behaviour on `ENVIRONMENT === "production"`.
+const ALLOWED_ENVIRONMENTS: ReadonlySet<string> = new Set(["development", "production"]);
+
 function assertRequiredEnv(env: Env): void {
   if (!env.ENVIRONMENT) {
     throw new Error("ENVIRONMENT is required (set to 'development' or 'production')");
+  }
+  if (!ALLOWED_ENVIRONMENTS.has(env.ENVIRONMENT)) {
+    throw new Error(
+      `Invalid ENVIRONMENT: ${JSON.stringify(env.ENVIRONMENT)} (expected 'development' or 'production')`
+    );
   }
   if (!env.API_VERSION) {
     throw new Error("API_VERSION is required");

--- a/apps/sdp-api/src/server.ts
+++ b/apps/sdp-api/src/server.ts
@@ -22,6 +22,9 @@ import { shutdown } from "@/runtime/shutdown-node";
 import type { Env } from "@/types/env";
 
 const DEFAULT_PORT = 8787;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 25_000;
+const TRUTHY_ENV: ReadonlySet<string> = new Set(["true", "1"]);
+const FALSY_ENV: ReadonlySet<string> = new Set(["false", "0"]);
 
 function resolvePort(): number {
   const raw = process.env.PORT;
@@ -35,6 +38,42 @@ function resolvePort(): number {
     throw new Error(`Invalid PORT: ${raw}`);
   }
   return parsed;
+}
+
+function resolveShutdownTimeoutMs(): number {
+  const raw = process.env.SHUTDOWN_TIMEOUT_MS;
+  if (raw === undefined) {
+    return DEFAULT_SHUTDOWN_TIMEOUT_MS;
+  }
+  // SHUTDOWN_TIMEOUT_MS="" likely means a deploy script tried to set it
+  // and produced an empty string by accident; treat it as a typo rather
+  // than silently using the default.
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid SHUTDOWN_TIMEOUT_MS: ${JSON.stringify(raw)}`);
+  }
+  return parsed;
+}
+
+function shouldShutdownOnUnhandledRejection(): boolean {
+  const raw = process.env.FATAL_ON_UNHANDLED_REJECTION;
+  if (raw === undefined) {
+    return true;
+  }
+  // Case-insensitive on purpose: env vars are commonly assembled by
+  // shells, k8s manifests, and .env loaders that don't normalise case,
+  // so "True"/"FALSE" should behave like "true"/"false".
+  const normalised = raw.trim().toLowerCase();
+  if (normalised === "") {
+    throw new Error(`Invalid FATAL_ON_UNHANDLED_REJECTION: ${JSON.stringify(raw)}`);
+  }
+  if (TRUTHY_ENV.has(normalised)) {
+    return true;
+  }
+  if (FALSY_ENV.has(normalised)) {
+    return false;
+  }
+  throw new Error(`Invalid FATAL_ON_UNHANDLED_REJECTION: ${JSON.stringify(raw)}`);
 }
 
 function assertRequiredEnv(env: Env): void {
@@ -60,6 +99,12 @@ async function main(): Promise<void> {
   env.SDP_RUNTIME = "node";
   assertRequiredEnv(env);
 
+  // Validate boot-time process.env tunables before opening any sockets or
+  // initialising Sentry, so a typo fails immediately instead of after a
+  // partial startup.
+  const shutdownTimeoutMs = resolveShutdownTimeoutMs();
+  const fatalOnUnhandledRejection = shouldShutdownOnUnhandledRejection();
+
   initNodeSentry(getSentryOptions(env));
 
   const app = createApp({ observability: nodeObservability });
@@ -83,6 +128,18 @@ async function main(): Promise<void> {
     if (shuttingDown) {
       return;
     }
+    // Watchdog: if any step of the shutdown sequence hangs (a Redis client
+    // wedged on a TCP retry, a background task awaiting a DB query that
+    // never returns), the process would otherwise sit until the container
+    // orchestrator's SIGKILL grace period runs out. Force-exit before that
+    // so the orchestrator's restart loop is the only thing the operator
+    // has to reason about. .unref() so the timer doesn't itself keep the
+    // event loop alive if shutdown completes cleanly.
+    const watchdog = setTimeout(() => {
+      console.error(`[${label}] shutdown exceeded ${shutdownTimeoutMs}ms — forcing exit`);
+      process.exit(1);
+    }, shutdownTimeoutMs);
+    watchdog.unref();
     shuttingDown = shutdown({
       server,
       cron,
@@ -90,9 +147,11 @@ async function main(): Promise<void> {
       log: (msg) => console.log(`[${label}] ${msg}`),
     })
       .then(() => {
+        clearTimeout(watchdog);
         process.exit(0);
       })
       .catch((err: unknown) => {
+        clearTimeout(watchdog);
         console.error("Shutdown failed:", err);
         process.exit(1);
       });
@@ -101,16 +160,24 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => beginShutdown("SIGTERM"));
   process.on("SIGINT", () => beginShutdown("SIGINT"));
 
-  // Unhandled rejections in routes or background tasks are recoverable —
-  // log them and drain in-flight work through the normal shutdown path so
-  // we don't leak Redis sockets or skip db pool cleanup. uncaughtException
-  // is treated as fatal: V8 documents the process state as potentially
-  // corrupted, so we log and exit fast rather than risk a hung shutdown;
-  // the container orchestrator will restart a clean process.
+  // Unhandled rejections: by default initiate a graceful shutdown so the
+  // orchestrator restarts a clean process. Setting
+  // FATAL_ON_UNHANDLED_REJECTION=false keeps the process running and just
+  // logs the rejection — @sentry/node, when initialised, captures it
+  // regardless via its own listener. The default mirrors Node's terminate
+  // semantics from v15+ without being more aggressive; teams that
+  // tolerate transient rejections from third-party libraries can opt out.
   process.on("unhandledRejection", (reason) => {
-    console.error("Unhandled rejection — initiating shutdown:", reason);
-    beginShutdown("unhandledRejection");
+    if (fatalOnUnhandledRejection) {
+      console.error("Unhandled rejection — initiating shutdown:", reason);
+      beginShutdown("unhandledRejection");
+      return;
+    }
+    console.error("Unhandled rejection (non-fatal):", reason);
   });
+  // uncaughtException stays fatal: V8 documents the process state as
+  // potentially corrupted, so log and exit fast rather than risk a hung
+  // shutdown; the container orchestrator restarts a clean process.
   process.on("uncaughtException", (err) => {
     console.error("Uncaught exception — exiting:", err);
     process.exit(1);

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -29,6 +29,13 @@ export interface Env {
   // "node" uses DATABASE_URL + REDIS_URL.
   SDP_RUNTIME?: "cloudflare" | "node";
 
+  // When the Node entrypoint runs with multiple replicas, scheduling the
+  // reconciliation cron on every replica would fire the job N times per
+  // tick. Setting this to "true" or "1" makes startCron a no-op so only
+  // one designated replica drives the job. Ignored on Cloudflare (CF uses
+  // a single scheduled handler per deployment).
+  DISABLE_CRON?: string;
+
   // Environment variables
   ENVIRONMENT: "development" | "production";
   API_VERSION: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
 
   apps/sdp-api:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.6
+        version: 1.19.14(hono@4.12.18)
       '@react-email/components':
         specifier: 1.0.12
         version: 1.0.12(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -121,6 +124,9 @@ importers:
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
       pg:
         specifier: ^8.16.3
         version: 8.20.0
@@ -1211,6 +1217,12 @@ packages:
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -6097,6 +6109,10 @@ packages:
       sass:
         optional: true
 
+  node-cron@4.2.1:
+    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
+    engines: {node: '>=6.0.0'}
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -7800,6 +7816,10 @@ snapshots:
   '@heroicons/react@2.2.0(react@19.2.5)':
     dependencies:
       react: 19.2.5
+
+  '@hono/node-server@1.19.14(hono@4.12.18)':
+    dependencies:
+      hono: 4.12.18
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11756,7 +11776,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.3.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.3.0(jiti@2.7.0))
@@ -11779,7 +11799,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11794,14 +11814,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.3.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11816,7 +11836,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.3.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0)))(eslint@10.3.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.3.0(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13321,6 +13341,8 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-cron@4.2.1: {}
 
   node-exports-info@1.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `src/server.ts` — a Node.js process entrypoint that wires the runtime-neutral seams from earlier commits (process-env Env fallback, KVStore + Redis factory, NodeBackgroundRunner with SIGTERM drain, nodeObservability, createApp / runPendingTransfersReconciliation) into a Hono server bound to `@hono/node-server`, with a node-cron reconciliation tick and a graceful SIGTERM/SIGINT drain. Cloudflare Workers entrypoint (`src/index.ts`) untouched.
- Adds `src/runtime/shutdown-node.ts` — pure `shutdown(deps)` helper. Order: `server.close → cron.stop → bg.awaitAll → closeAllRedisClients → closeDatabasePools`. Lives next to `background-node` / `observability-node` so unit tests don't pull the full Hono app graph through `@solana/mosaic-sdk`, which has a directory-import resolution that trips the plain Node test pool.
- Adds `src/cron/runner.ts` — `startCron` returns `null` when `DISABLE_CRON ∈ {"true","1"}` (single-replica strategy until a distributed lock lands), otherwise schedules `PENDING_TRANSFERS_CRON` through node-cron and routes the tick through the shared `runPendingTransfersReconciliation`. A `stopping` closure flag short-circuits any tick that fires concurrent with shutdown so no late work gets registered after `awaitAll()`'s snapshot.

### Behaviour notes

- `main()` hardcodes `SDP_RUNTIME=node` after `withProcessEnvFallback({} as Env)` — the entrypoint IS the runtime; don't let a stray env value flip the KV factory back to Cloudflare mode.
- `assertRequiredEnv` fails loud at boot if `ENVIRONMENT`, `API_VERSION`, `DATABASE_URL`, or `REDIS_URL` is unset.
- `PORT` defaults to `8787` for parity with `wrangler dev`; non-numeric values (`"8787abc"`) reject via `Number()`-not-`parseInt`.
- SIGTERM and SIGINT route through a cached promise so a second signal is a no-op.
- `unhandledRejection` takes the graceful path; `uncaughtException` exits fast since V8 documents the process state as potentially corrupt.
- `import.meta.url === pathToFileURL(process.argv[1]).href` guard keeps `main()` from running on import.

## Test plan

- [x] `pnpm --filter @sdp/api typecheck` — green
- [x] `pnpm exec biome check` on changed files — green
- [x] `pnpm --filter @sdp/api test` (workers pool) — 440 passed, 14 skipped, 0 failed
- [x] `pnpm --filter @sdp/api test:node` on the new files — 12/12 passed
- [x] `pnpm --filter @sdp/api build` (`wrangler deploy --dry-run`) — green; CF entrypoint still builds
- [x] Smoke: `tsx src/server.ts` boots, `GET /health` → 200, `GET /` → 302, SIGTERM produces ordered drain log
- [x] Smoke: missing `DATABASE_URL` / `REDIS_URL` exits with `Fatal startup error: …`; `PORT=8787abc` exits with `Invalid PORT: 8787abc`
- [ ] CI green on this PR