### PR TITLE
feat(pro-1218): counterparty model migration on database

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0003_counterparties.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0003_counterparties.sql
@@ -1,0 +1,33 @@
+-- Counterparties: provider-agnostic identity records for payments / ramps flows.
+-- Each counterparty is scoped to (organization_id, project_id).
+-- The `identity` column is JSONB so adding provider-specific fields later does
+-- not require a migration. Field-level validation runs at the application
+-- layer via Zod; the database only guarantees the column is a JSON object.
+
+CREATE TABLE IF NOT EXISTS counterparties (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    external_id TEXT,
+    entity_type TEXT NOT NULL DEFAULT 'individual',
+    display_name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    identity JSONB NOT NULL DEFAULT '{}'::jsonb,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    CONSTRAINT counterparties_identity_is_object CHECK (jsonb_typeof(identity) = 'object')
+);
+
+-- Default list: scoped to (org, project), newest first.
+CREATE INDEX IF NOT EXISTS idx_counterparties_org_project_created
+    ON counterparties(organization_id, project_id, created_at DESC)
+    WHERE is_active;
+
+-- External-id idempotency: unique per (org, project), null-tolerant.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_counterparties_org_project_external_id
+    ON counterparties(organization_id, project_id, external_id)
+    WHERE external_id IS NOT NULL AND is_active;

--- a/apps/sdp-api/src/db/migrations/postgres/0003_counterparties.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0003_counterparties.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS counterparties (
     organization_id TEXT NOT NULL,
     project_id TEXT NOT NULL,
     external_id TEXT,
-    entity_type TEXT NOT NULL DEFAULT 'individual',
+    entity_type TEXT NOT NULL,
     display_name TEXT NOT NULL,
     email TEXT NOT NULL,
     identity JSONB NOT NULL DEFAULT '{}'::jsonb,

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
@@ -162,12 +162,7 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
                AND external_id = ?
                AND is_active = ?`
         )
-        .bind(
-          params.organizationId,
-          params.projectId,
-          params.externalId,
-          params.isActive ?? true
-        )
+        .bind(params.organizationId, params.projectId, params.externalId, params.isActive ?? true)
         .first<Record<string, unknown>>();
       return row ? mapCounterpartyRow(row) : null;
     },

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
@@ -29,11 +29,16 @@ function mapCounterpartyRow(row: Record<string, unknown>): CounterpartyRow {
 
 async function getCounterpartyByIdInternal(
   db: AppDb,
-  counterpartyId: string
+  params: { counterpartyId: string; organizationId: string; projectId: string }
 ): Promise<CounterpartyRow | null> {
   const row = await db
-    .prepare("SELECT * FROM counterparties WHERE id = ?")
-    .bind(counterpartyId)
+    .prepare(
+      `SELECT * FROM counterparties
+         WHERE id = ?
+           AND organization_id = ?
+           AND project_id = ?`
+    )
+    .bind(params.counterpartyId, params.organizationId, params.projectId)
     .first<Record<string, unknown>>();
   return row ? mapCounterpartyRow(row) : null;
 }
@@ -74,7 +79,11 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
         )
         .run();
 
-      return getCounterpartyByIdInternal(db, input.id);
+      return getCounterpartyByIdInternal(db, {
+        counterpartyId: input.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
     },
 
     async updateCounterparty(input: UpdateCounterpartyInput) {
@@ -110,7 +119,11 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
         return null;
       }
 
-      return getCounterpartyByIdInternal(db, input.counterpartyId);
+      return getCounterpartyByIdInternal(db, {
+        counterpartyId: input.counterpartyId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
     },
 
     async archiveCounterparty(input: ArchiveCounterpartyInput) {
@@ -131,7 +144,11 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
         return null;
       }
 
-      return getCounterpartyByIdInternal(db, input.counterpartyId);
+      return getCounterpartyByIdInternal(db, {
+        counterpartyId: input.counterpartyId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
     },
 
     async getCounterpartyById(params) {

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
@@ -1,0 +1,213 @@
+import type { CounterpartyEntityType, CounterpartyIdentity } from "@sdp/types";
+import type { AppDb } from "@/db";
+import type {
+  ArchiveCounterpartyInput,
+  CounterpartiesRepository,
+  CounterpartyRow,
+  CreateCounterpartyInput,
+  ListCounterpartiesInput,
+  ListCounterpartiesResult,
+  UpdateCounterpartyInput,
+} from "./counterparty.repository";
+
+function mapCounterpartyRow(row: Record<string, unknown>): CounterpartyRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    external_id: row.external_id as string | null,
+    entity_type: row.entity_type as CounterpartyEntityType,
+    display_name: row.display_name as string,
+    email: row.email as string,
+    identity: row.identity as CounterpartyIdentity,
+    is_active: row.is_active as boolean,
+    created_by: row.created_by as string | null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
+async function getCounterpartyByIdInternal(
+  db: AppDb,
+  counterpartyId: string
+): Promise<CounterpartyRow | null> {
+  const row = await db
+    .prepare("SELECT * FROM counterparties WHERE id = ?")
+    .bind(counterpartyId)
+    .first<Record<string, unknown>>();
+  return row ? mapCounterpartyRow(row) : null;
+}
+
+export function createPostgresCounterpartiesRepository(db: AppDb): CounterpartiesRepository {
+  return {
+    async createCounterparty(input: CreateCounterpartyInput) {
+      await db
+        .prepare(
+          `INSERT INTO counterparties (
+             id,
+             organization_id,
+             project_id,
+             external_id,
+             entity_type,
+             display_name,
+             email,
+             identity,
+             is_active,
+             created_by,
+             created_at,
+             updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          input.id,
+          input.organizationId,
+          input.projectId,
+          input.externalId,
+          input.entityType,
+          input.displayName,
+          input.email,
+          input.identity,
+          true,
+          input.createdBy,
+          input.createdAt,
+          input.updatedAt
+        )
+        .run();
+
+      return getCounterpartyByIdInternal(db, input.id);
+    },
+
+    async updateCounterparty(input: UpdateCounterpartyInput) {
+      const rowsAffected = await db
+        .prepare(
+          `UPDATE counterparties
+             SET external_id = CASE WHEN ?::boolean THEN ? ELSE external_id END,
+                 entity_type = COALESCE(?, entity_type),
+                 display_name = COALESCE(?, display_name),
+                 email = COALESCE(?, email),
+                 identity = COALESCE(?, identity),
+                 updated_at = ?
+           WHERE id = ?
+             AND organization_id = ?
+             AND project_id = ?
+             AND is_active = TRUE`
+        )
+        .bind(
+          input.externalId !== undefined,
+          input.externalId ?? null,
+          input.entityType ?? null,
+          input.displayName ?? null,
+          input.email ?? null,
+          input.identity ?? null,
+          input.updatedAt,
+          input.counterpartyId,
+          input.organizationId,
+          input.projectId
+        )
+        .run();
+
+      if (rowsAffected === 0) {
+        return null;
+      }
+
+      return getCounterpartyByIdInternal(db, input.counterpartyId);
+    },
+
+    async archiveCounterparty(input: ArchiveCounterpartyInput) {
+      const result = await db
+        .prepare(
+          `UPDATE counterparties
+             SET is_active = FALSE,
+                 updated_at = ?
+           WHERE id = ?
+             AND organization_id = ?
+             AND project_id = ?
+             AND is_active = TRUE`
+        )
+        .bind(input.updatedAt, input.counterpartyId, input.organizationId, input.projectId)
+        .run();
+
+      if (result === 0) {
+        return null;
+      }
+
+      return getCounterpartyByIdInternal(db, input.counterpartyId);
+    },
+
+    async getCounterpartyById(params) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM counterparties
+             WHERE id = ?
+               AND organization_id = ?
+               AND project_id = ?
+               AND is_active = ?`
+        )
+        .bind(
+          params.counterpartyId,
+          params.organizationId,
+          params.projectId,
+          params.isActive ?? true
+        )
+        .first<Record<string, unknown>>();
+      return row ? mapCounterpartyRow(row) : null;
+    },
+
+    async getCounterpartyByExternalId(params) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM counterparties
+             WHERE organization_id = ?
+               AND project_id = ?
+               AND external_id = ?
+               AND is_active = ?`
+        )
+        .bind(
+          params.organizationId,
+          params.projectId,
+          params.externalId,
+          params.isActive ?? true
+        )
+        .first<Record<string, unknown>>();
+      return row ? mapCounterpartyRow(row) : null;
+    },
+
+    async listCounterparties(params: ListCounterpartiesInput): Promise<ListCounterpartiesResult> {
+      const [rowsResult, countRow] = await Promise.all([
+        db
+          .prepare(
+            `SELECT *
+               FROM counterparties
+              WHERE organization_id = ?
+                AND project_id = ?
+                AND (?::boolean OR is_active = TRUE)
+              ORDER BY created_at DESC
+              LIMIT ? OFFSET ?`
+          )
+          .bind(
+            params.organizationId,
+            params.projectId,
+            params.includeInactive ?? false,
+            params.limit,
+            params.offset
+          )
+          .all<Record<string, unknown>>(),
+        db
+          .prepare(
+            `SELECT COUNT(*)::int AS total
+               FROM counterparties
+              WHERE organization_id = ?
+                AND project_id = ?
+                AND (?::boolean OR is_active = TRUE)`
+          )
+          .bind(params.organizationId, params.projectId, params.includeInactive ?? false)
+          .first<{ total: number }>(),
+      ]);
+
+      return {
+        rows: rowsResult.results.map(mapCounterpartyRow),
+        total: countRow?.total ?? 0,
+      };
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.ts
@@ -1,7 +1,4 @@
-import type {
-  CounterpartyEntityType,
-  CounterpartyIdentity,
-} from "@sdp/types";
+import type { CounterpartyEntityType, CounterpartyIdentity } from "@sdp/types";
 import type { RepositoryDbClient } from "./base";
 
 export interface CounterpartyRow {

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.ts
@@ -1,0 +1,89 @@
+import type {
+  CounterpartyEntityType,
+  CounterpartyIdentity,
+} from "@sdp/types";
+import type { RepositoryDbClient } from "./base";
+
+export interface CounterpartyRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  external_id: string | null;
+  entity_type: CounterpartyEntityType;
+  display_name: string;
+  email: string;
+  identity: CounterpartyIdentity;
+  is_active: boolean;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateCounterpartyInput {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  externalId: string | null;
+  entityType: CounterpartyEntityType;
+  displayName: string;
+  email: string;
+  identity: CounterpartyIdentity;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateCounterpartyInput {
+  counterpartyId: string;
+  organizationId: string;
+  projectId: string;
+  externalId?: string | null;
+  entityType?: CounterpartyEntityType;
+  displayName?: string;
+  email?: string;
+  identity?: CounterpartyIdentity;
+  updatedAt: string;
+}
+
+export interface ArchiveCounterpartyInput {
+  counterpartyId: string;
+  organizationId: string;
+  projectId: string;
+  updatedAt: string;
+}
+
+export interface ListCounterpartiesInput {
+  organizationId: string;
+  projectId: string;
+  includeInactive?: boolean;
+  limit: number;
+  offset: number;
+}
+
+export interface ListCounterpartiesResult {
+  rows: CounterpartyRow[];
+  total: number;
+}
+
+export interface CounterpartiesRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface CounterpartiesRepository {
+  createCounterparty(input: CreateCounterpartyInput): Promise<CounterpartyRow | null>;
+  updateCounterparty(input: UpdateCounterpartyInput): Promise<CounterpartyRow | null>;
+  archiveCounterparty(input: ArchiveCounterpartyInput): Promise<CounterpartyRow | null>;
+  getCounterpartyById(params: {
+    counterpartyId: string;
+    organizationId: string;
+    projectId: string;
+    isActive?: boolean;
+  }): Promise<CounterpartyRow | null>;
+  getCounterpartyByExternalId(params: {
+    externalId: string;
+    organizationId: string;
+    projectId: string;
+    isActive?: boolean;
+  }): Promise<CounterpartyRow | null>;
+  listCounterparties(params: ListCounterpartiesInput): Promise<ListCounterpartiesResult>;
+}

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -1,5 +1,16 @@
 export type { RepositoryDbClient } from "./base";
 export type {
+  ArchiveCounterpartyInput,
+  CounterpartiesRepository,
+  CounterpartiesRepositoryContext,
+  CounterpartyRow,
+  CreateCounterpartyInput,
+  ListCounterpartiesInput,
+  ListCounterpartiesResult,
+  UpdateCounterpartyInput,
+} from "./counterparty.repository";
+export { createPostgresCounterpartiesRepository } from "./counterparty.repository.postgres";
+export type {
   CreatePaymentTransferInput,
   PaymentsRepository,
   PaymentsRepositoryContext,
@@ -13,7 +24,11 @@ export type {
   UpsertPaymentWalletPolicyInput,
 } from "./payments.repository";
 export { createPostgresPaymentsRepository } from "./payments.repository.postgres";
-export { createPaymentsRepository, createTokenRepository } from "./repository-factory";
+export {
+  createCounterpartiesRepository,
+  createPaymentsRepository,
+  createTokenRepository,
+} from "./repository-factory";
 export type {
   ListTokensOptions,
   TokenRepository,

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -1,5 +1,7 @@
 import { getDb } from "@/db";
 import type { Env } from "@/types/env";
+import type { CounterpartiesRepository } from "./counterparty.repository";
+import { createPostgresCounterpartiesRepository } from "./counterparty.repository.postgres";
 import type { PaymentsRepository } from "./payments.repository";
 import { createPostgresPaymentsRepository } from "./payments.repository.postgres";
 import type { TokenRepository } from "./token.repository";
@@ -7,6 +9,10 @@ import { createPostgresTokenRepository } from "./token.repository.postgres";
 
 export function createPaymentsRepository(env: Env): PaymentsRepository {
   return createPostgresPaymentsRepository(getDb(env));
+}
+
+export function createCounterpartiesRepository(env: Env): CounterpartiesRepository {
+  return createPostgresCounterpartiesRepository(getDb(env));
 }
 
 export function createTokenRepository(env: Env): TokenRepository {

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -1,0 +1,75 @@
+import { COUNTERPARTY_ID_TYPES } from "@sdp/types";
+import { z } from "zod";
+
+// TODO: strict country / subdivision validation deferred — see follow-up ticket
+// under PRO-1217. Until then, accept any string and let downstream providers
+// reject invalid codes.
+const countryCodeSchema = z.string().min(2).max(8);
+const subdivisionCodeSchema = z.string().min(1).max(16);
+
+const counterpartyAddressSchema = z.object({
+  line1: z.string().min(1).max(512),
+  line2: z.string().max(512).optional(),
+  city: z.string().min(1).max(256),
+  postalCode: z.string().max(32).optional(),
+  countryCode: countryCodeSchema,
+  subdivisionCode: subdivisionCodeSchema.optional(),
+});
+
+const counterpartyGovernmentIdSchema = z.object({
+  type: z.enum(COUNTERPARTY_ID_TYPES),
+  number: z.string().min(1).max(128),
+  issueCountry: countryCodeSchema,
+  subdivisionCode: subdivisionCodeSchema.optional(),
+  issueDate: z.iso.date().optional(),
+  expiryDate: z.iso.date().optional(),
+});
+
+export const counterpartyIdentitySchema = z
+  .object({
+    firstName: z.string().min(1).max(256).optional(),
+    middleName: z.string().max(256).optional(),
+    lastName: z.string().min(1).max(256).optional(),
+    secondLastName: z.string().max(256).optional(),
+    dateOfBirth: z.iso.date().optional(),
+    phone: z.string().min(1).max(64).optional(),
+    address: counterpartyAddressSchema.optional(),
+    birthCountryCode: countryCodeSchema.optional(),
+    citizenshipCountryCode: countryCodeSchema.optional(),
+    governmentId: counterpartyGovernmentIdSchema.optional(),
+  })
+  .passthrough();
+
+export const counterpartyEntityTypeSchema = z.enum(["individual", "business"]);
+
+export const counterpartyIdParamsSchema = z.object({
+  counterpartyId: z.string().min(1),
+});
+
+export const createCounterpartySchema = z.object({
+  externalId: z.string().min(1).max(256).optional(),
+  entityType: counterpartyEntityTypeSchema.optional(),
+  displayName: z.string().min(1).max(512),
+  email: z.string().email().max(512),
+  projectId: z.string().min(1).optional(),
+  identity: counterpartyIdentitySchema.optional(),
+});
+
+export const updateCounterpartySchema = z
+  .object({
+    externalId: z.string().min(1).max(256).nullable().optional(),
+    entityType: counterpartyEntityTypeSchema.optional(),
+    displayName: z.string().min(1).max(512).optional(),
+    email: z.string().email().max(512).optional(),
+    identity: counterpartyIdentitySchema.optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+export const listCounterpartiesQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  projectId: z.string().min(1).optional(),
+  includeInactive: z.coerce.boolean().default(false),
+});

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -48,7 +48,7 @@ export const counterpartyIdParamsSchema = z.object({
 
 export const createCounterpartySchema = z.object({
   externalId: z.string().min(1).max(256).optional(),
-  entityType: counterpartyEntityTypeSchema.optional(),
+  entityType: counterpartyEntityTypeSchema,
   displayName: z.string().min(1).max(512),
   email: z.string().email().max(512),
   projectId: z.string().min(1).optional(),

--- a/packages/sdp-types/package.json
+++ b/packages/sdp-types/package.json
@@ -14,6 +14,11 @@
       "import": "./src/organizations.ts",
       "default": "./src/organizations.ts"
     },
+    "./counterparties": {
+      "types": "./src/counterparties.ts",
+      "import": "./src/counterparties.ts",
+      "default": "./src/counterparties.ts"
+    },
     "./custody": {
       "types": "./src/custody.ts",
       "import": "./src/custody.ts",

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -1,0 +1,76 @@
+export type CounterpartyEntityType = "individual" | "business";
+
+export const COUNTERPARTY_ID_TYPES = ["PAS", "DRV", "STA", "GOV"] as const;
+export type CounterpartyIdType = (typeof COUNTERPARTY_ID_TYPES)[number];
+
+export interface CounterpartyAddress {
+  line1: string;
+  line2?: string;
+  city: string;
+  postalCode?: string;
+  countryCode: string;
+  subdivisionCode?: string;
+}
+
+export interface CounterpartyGovernmentId {
+  type: CounterpartyIdType;
+  number: string;
+  issueCountry: string;
+  subdivisionCode?: string;
+  issueDate?: string;
+  expiryDate?: string;
+}
+
+export interface CounterpartyIdentity {
+  firstName?: string;
+  middleName?: string;
+  lastName?: string;
+  secondLastName?: string;
+  dateOfBirth?: string;
+  phone?: string;
+  address?: CounterpartyAddress;
+  birthCountryCode?: string;
+  citizenshipCountryCode?: string;
+  governmentId?: CounterpartyGovernmentId;
+  [extension: string]: unknown;
+}
+
+export interface Counterparty {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  externalId: string | null;
+  entityType: CounterpartyEntityType;
+  displayName: string;
+  email: string;
+  identity: CounterpartyIdentity;
+  isActive: boolean;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateCounterpartyRequest {
+  projectId?: string;
+  externalId?: string;
+  entityType?: CounterpartyEntityType;
+  displayName: string;
+  email: string;
+  identity?: CounterpartyIdentity;
+}
+
+export interface UpdateCounterpartyRequest {
+  externalId?: string | null;
+  entityType?: CounterpartyEntityType;
+  displayName?: string;
+  email?: string;
+  identity?: CounterpartyIdentity;
+}
+
+export interface CounterpartyResponse {
+  counterparty: Counterparty;
+}
+
+export interface ListCounterpartiesResponse {
+  counterparties: Counterparty[];
+}

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -73,4 +73,7 @@ export interface CounterpartyResponse {
 
 export interface ListCounterpartiesResponse {
   counterparties: Counterparty[];
+  total: number;
+  page: number;
+  pageSize: number;
 }

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -53,7 +53,7 @@ export interface Counterparty {
 export interface CreateCounterpartyRequest {
   projectId?: string;
   externalId?: string;
-  entityType?: CounterpartyEntityType;
+  entityType: CounterpartyEntityType;
   displayName: string;
   email: string;
   identity?: CounterpartyIdentity;

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from "./api-keys";
+export * from "./counterparties";
 export * from "./custody";
 export * from "./organizations";
 export * from "./payments";

--- a/packages/sdp-types/src/permissions.ts
+++ b/packages/sdp-types/src/permissions.ts
@@ -15,6 +15,10 @@ export const PERMISSIONS = [
   "payments:read",
   "payments:write",
 
+  // Counterparty permissions
+  "counterparties:read",
+  "counterparties:write",
+
   // Wallet permissions
   "wallets:read",
   "wallets:write",
@@ -80,6 +84,8 @@ export const ORGANIZATION_ROLES = {
       "tokens:admin",
       "payments:read",
       "payments:write",
+      "counterparties:read",
+      "counterparties:write",
       "wallets:read",
       "wallets:write",
       "webhooks:read",
@@ -105,6 +111,8 @@ export const ORGANIZATION_ROLES = {
       "tokens:write",
       "payments:read",
       "payments:write",
+      "counterparties:read",
+      "counterparties:write",
       "wallets:read",
       "wallets:write",
       "webhooks:read",
@@ -140,6 +148,8 @@ export const API_KEY_ROLES = {
       "tokens:write",
       "payments:read",
       "payments:write",
+      "counterparties:read",
+      "counterparties:write",
       "wallets:read",
       "wallets:write",
       "compliance:read",
@@ -152,6 +162,7 @@ export const API_KEY_ROLES = {
     permissions: [
       "tokens:read",
       "payments:read",
+      "counterparties:read",
       "wallets:read",
       "compliance:read",
       "webhooks:read",
@@ -230,6 +241,8 @@ export const PROJECT_ROLES = {
       "tokens:write",
       "payments:read",
       "payments:write",
+      "counterparties:read",
+      "counterparties:write",
       "wallets:read",
       "wallets:write",
     ] as Permission[],


### PR DESCRIPTION
## Summary

Phase 1 of counterparty management: introduces the `counterparties` table, shared TypeScript types, repository contract + Postgres implementation, and the `counterparties:read|write` permissions. No routes are wired in this PR — those land in a follow-up that consumes the repository.

## Migration: `counterparties` table

| Column | Type | Nullable | Default | Notes |
|---|---|---|---|---|
| `id` | `TEXT` | PK | — | application-generated |
| `organization_id` | `TEXT` | not null | — | FK → `organizations(id)` ON DELETE CASCADE |
| `project_id` | `TEXT` | not null | — | FK → `projects(id)` ON DELETE CASCADE |
| `external_id` | `TEXT` | nullable | — | unique per `(org, project)` while active |
| `entity_type` | `TEXT` | not null | — | `'individual'` / `'business'` (app-enforced) |
| `display_name` | `TEXT` | not null | — | |
| `email` | `TEXT` | not null | — | |
| `identity` | `JSONB` | not null | `'{}'::jsonb` | `CHECK (jsonb_typeof(identity) = 'object')` |
| `is_active` | `BOOLEAN` | not null | `TRUE` | archive by setting `FALSE` |
| `created_by` | `TEXT` | nullable | — | |
| `created_at` | `TEXT` | not null | `sdp_iso_now()` | ISO-8601 string |
| `updated_at` | `TEXT` | not null | `sdp_iso_now()` | ISO-8601 string |

### Indexes

| Index | Columns | Predicate | Purpose |
|---|---|---|---|
| `idx_counterparties_org_project_created` | `(organization_id, project_id, created_at DESC)` | `WHERE is_active` | default scoped list, newest first |
| `idx_counterparties_org_project_external_id` UNIQUE | `(organization_id, project_id, external_id)` | `WHERE external_id IS NOT NULL AND is_active` | external-id idempotency, null-tolerant |

## Shared types — `@sdp/types/counterparties`

| Export | Kind | Shape |
|---|---|---|
| `Counterparty` | interface | full record returned to clients |
| `CounterpartyEntityType` | union | `'individual' \| 'business'` |
| `CounterpartyIdentity` | interface | `firstName?`, `lastName?`, `dateOfBirth?`, `phone?`, `address?`, `governmentId?`, …, `[ext: string]: unknown` |
| `CounterpartyAddress` | interface | `line1`, `city`, `countryCode`, optional `line2`/`postalCode`/`subdivisionCode` |
| `CounterpartyGovernmentId` | interface | `type`, `number`, `issueCountry`, optional `subdivisionCode`/`issueDate`/`expiryDate` |
| `CounterpartyIdType` | union | `'PAS' \| 'DRV' \| 'STA' \| 'GOV'` |
| `COUNTERPARTY_ID_TYPES` | const tuple | `['PAS', 'DRV', 'STA', 'GOV']` |
| `CreateCounterpartyRequest` | interface | request DTO |
| `UpdateCounterpartyRequest` | interface | request DTO (tri-state `externalId`) |
| `CounterpartyResponse` | interface | `{ counterparty }` |
| `ListCounterpartiesResponse` | interface | `{ counterparties[] }` |

## Permissions

| Permission | Granted to |
|---|---|
| `counterparties:read` | org `owner`, org `admin`, api-key `admin`, api-key `read-only`, project `admin` |
| `counterparties:write` | org `owner`, org `admin`, api-key `admin`, project `admin` |

## Repository — `CounterpartiesRepository`

| Method | Behavior |
|---|---|
| `createCounterparty` | insert; relies on unique partial index for external-id idempotency |
| `updateCounterparty` | single static UPDATE using `COALESCE` per field + `CASE` for tri-state `external_id`; scoped to `is_active = TRUE` |
| `archiveCounterparty` | sets `is_active = FALSE`; returns `null` if no active row matched |
| `getCounterpartyById({ isActive? })` | parameterized active filter, defaults to `true` |
| `getCounterpartyByExternalId({ isActive? })` | parameterized active filter, defaults to `true` |
| `listCounterparties` | paged `(org, project)` list, optional `includeInactive`, returns rows + total |

## Rollback

No down-migration tooling in this repo yet, so manually:

```sql
BEGIN;
DROP TABLE IF EXISTS counterparties;
DELETE FROM schema_migrations WHERE version = '0003_counterparties.sql';
COMMIT;
```

## Test plan

- [ ] `pnpm db:migrate:local` applies cleanly; `\d counterparties` shows the table + both indexes
- [ ] `pnpm typecheck` passes for `@sdp/api` and `@sdp/types`
- [ ] Manual rollback SQL above leaves the DB in a clean state and re-running `db:migrate:local` reapplies
- [ ] Follow-up routes PR can import `createCounterpartiesRepository` from `@/db/repositories`
