### PR TITLE
feat(pro-1250): add in counterparty openapi schema

### DIFF
--- a/apps/sdp-api/src/openapi/paths/counterparties.ts
+++ b/apps/sdp-api/src/openapi/paths/counterparties.ts
@@ -1,0 +1,128 @@
+import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+import {
+  counterpartyIdParamSchema,
+  createCounterpartyRequestSchema,
+  errorResponseSchema,
+  listCounterpartiesQuerySchema,
+  updateCounterpartyRequestSchema,
+} from "../schemas";
+import { errorResponses, jsonContent } from "./helpers";
+import { counterpartyResponse, listCounterpartiesResponse } from "./responses";
+
+export function registerCounterpartyPaths(registry: OpenAPIRegistry) {
+  registry.registerPath({
+    method: "get",
+    path: "/v1/counterparties",
+    tags: ["Counterparties"],
+    summary: "List counterparties",
+    operationId: "listCounterparties",
+    description: "Lists counterparties for the authenticated organization.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      query: listCounterpartiesQuerySchema,
+    },
+    responses: {
+      200: {
+        description: "Counterparties list",
+        content: jsonContent(listCounterpartiesResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/counterparties",
+    tags: ["Counterparties"],
+    summary: "Create counterparty",
+    operationId: "createCounterparty",
+    description:
+      "Creates a counterparty. If externalId is provided, it must be unique within the organization.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: jsonContent(createCounterpartyRequestSchema),
+      },
+    },
+    responses: {
+      201: {
+        description: "Counterparty created",
+        content: jsonContent(counterpartyResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/counterparties/{counterpartyId}",
+    tags: ["Counterparties"],
+    summary: "Get counterparty",
+    operationId: "getCounterparty",
+    description: "Gets counterparty details by id.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      params: z.object({
+        counterpartyId: counterpartyIdParamSchema,
+      }),
+    },
+    responses: {
+      200: {
+        description: "Counterparty",
+        content: jsonContent(counterpartyResponse),
+      },
+      ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/v1/counterparties/{counterpartyId}",
+    tags: ["Counterparties"],
+    summary: "Update counterparty",
+    operationId: "updateCounterparty",
+    description:
+      "Updates counterparty attributes. At least one field must be provided. Use null on externalId to clear it.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      params: z.object({
+        counterpartyId: counterpartyIdParamSchema,
+      }),
+      body: {
+        required: true,
+        content: jsonContent(updateCounterpartyRequestSchema),
+      },
+    },
+    responses: {
+      200: {
+        description: "Counterparty updated",
+        content: jsonContent(counterpartyResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/counterparties/{counterpartyId}",
+    tags: ["Counterparties"],
+    summary: "Archive counterparty",
+    operationId: "archiveCounterparty",
+    description: "Archives a counterparty. Archived counterparties are hidden from default lists.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      params: z.object({
+        counterpartyId: counterpartyIdParamSchema,
+      }),
+    },
+    responses: {
+      204: {
+        description: "Counterparty archived",
+      },
+      ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
+    },
+  });
+}

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -7,6 +7,7 @@ import {
   allowlistEntrySchema,
   apiKeyDetailSchema,
   apiKeyResponseSchema,
+  counterpartyResponseSchema,
   currentUserResponseSchema,
   custodyConfigResponseSchema,
   custodyConfigsResponseSchema,
@@ -26,6 +27,7 @@ import {
   frozenAccountSchema,
   inviteMemberResponseSchema,
   listApiKeysResponseSchema,
+  listCounterpartiesResponseSchema,
   listMembersResponseSchema,
   listProjectApiKeysResponseSchema,
   listProjectMembersResponseSchema,
@@ -78,6 +80,9 @@ export const apiKeyDetailResponse = successResponseSchema(apiKeyDetailSchema);
 export const apiKeyCreateResponse = successResponseSchema(apiKeyResponseSchema);
 export const apiKeyRotateResponse = successResponseSchema(rotateApiKeyResponseSchema);
 export const apiKeyRevokeResponse = successResponseSchema(revokeApiKeyResponseSchema);
+
+export const counterpartyResponse = successResponseSchema(counterpartyResponseSchema);
+export const listCounterpartiesResponse = successResponseSchema(listCounterpartiesResponseSchema);
 
 export const projectResponse = successResponseSchema(projectResponseSchema);
 export const listProjectsResponse = successResponseSchema(listProjectsResponseSchema);

--- a/apps/sdp-api/src/openapi/schemas/base.ts
+++ b/apps/sdp-api/src/openapi/schemas/base.ts
@@ -21,6 +21,11 @@ export const isoDateTimeSchema = z.string().datetime().openapi({
   example: "2025-01-01T00:00:00.000Z",
 });
 
+export const isoDateSchema = z.iso.date().openapi({
+  description: "ISO 8601 calendar date (YYYY-MM-DD).",
+  example: "1990-01-15",
+});
+
 export const idempotencyKeyHeaderSchema = z.string().min(1).openapi({
   description: "Idempotency key for safely retrying mutating requests.",
   example: "idempotency_example_12345",

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -11,6 +11,7 @@ import {
   updateCounterpartyObjectSchema as updateCounterpartyObjectSchemaBase,
 } from "../../routes/counterparties/schemas";
 import {
+  isoDateSchema,
   isoDateTimeSchema,
   orgIdParamSchema,
   projectIdParamSchema,
@@ -18,11 +19,6 @@ import {
   withOpenApi,
   z,
 } from "./base";
-
-const isoDateSchema = withOpenApi(z.string(), {
-  description: "ISO 8601 calendar date (YYYY-MM-DD).",
-  example: "1990-01-15",
-});
 
 export const counterpartyIdParamSchema = withOpenApi(counterpartyIdSchemaBase, {
   description: "Counterparty identifier.",
@@ -275,5 +271,8 @@ export const updateCounterpartyRequestSchema = withOpenApi(
       description: "Updated identity details. Replaces the existing identity object.",
     }),
   }),
-  { description: "Update counterparty request body. At least one field must be provided." }
+  {
+    description: "Update counterparty request body. At least one field must be provided.",
+    minProperties: 1,
+  }
 );

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -1,0 +1,279 @@
+import {
+  counterpartyAddressSchema as counterpartyAddressSchemaBase,
+  counterpartyEntityTypeSchema as counterpartyEntityTypeSchemaBase,
+  counterpartyGovernmentIdSchema as counterpartyGovernmentIdSchemaBase,
+  counterpartyIdentitySchema as counterpartyIdentitySchemaBase,
+  counterpartyIdSchema as counterpartyIdSchemaBase,
+  counterpartyIdTypeSchema as counterpartyIdTypeSchemaBase,
+  counterpartyStatusSchema as counterpartyStatusSchemaBase,
+  createCounterpartySchema as createCounterpartySchemaBase,
+  listCounterpartiesQuerySchema as listCounterpartiesQuerySchemaBase,
+  updateCounterpartyObjectSchema as updateCounterpartyObjectSchemaBase,
+} from "../../routes/counterparties/schemas";
+import {
+  isoDateTimeSchema,
+  orgIdParamSchema,
+  projectIdParamSchema,
+  userIdSchema,
+  withOpenApi,
+  z,
+} from "./base";
+
+const isoDateSchema = withOpenApi(z.string(), {
+  description: "ISO 8601 calendar date (YYYY-MM-DD).",
+  example: "1990-01-15",
+});
+
+export const counterpartyIdParamSchema = withOpenApi(counterpartyIdSchemaBase, {
+  description: "Counterparty identifier.",
+  example: "cp_example",
+});
+
+export const counterpartyEntityTypeSchema = withOpenApi(counterpartyEntityTypeSchemaBase, {
+  description: "Counterparty entity type.",
+  example: "individual",
+});
+
+export const counterpartyStatusSchema = withOpenApi(counterpartyStatusSchemaBase, {
+  description: "Counterparty status.",
+  example: "active",
+});
+
+export const counterpartyIdTypeSchema = withOpenApi(counterpartyIdTypeSchemaBase, {
+  description:
+    "Government ID document type: PAS (passport), DRV (driver's license), STA (state/national ID), GOV (other government-issued).",
+  example: "PAS",
+});
+
+export const counterpartyAddressSchema = withOpenApi(
+  counterpartyAddressSchemaBase.extend({
+    line1: withOpenApi(counterpartyAddressSchemaBase.shape.line1, {
+      description: "Street address line 1.",
+      example: "123 Main St",
+    }),
+    line2: withOpenApi(counterpartyAddressSchemaBase.shape.line2, {
+      description: "Street address line 2.",
+      example: "Apt 4B",
+    }),
+    city: withOpenApi(counterpartyAddressSchemaBase.shape.city, {
+      description: "City.",
+      example: "San Francisco",
+    }),
+    postalCode: withOpenApi(counterpartyAddressSchemaBase.shape.postalCode, {
+      description: "Postal or ZIP code.",
+      example: "94105",
+    }),
+    countryCode: withOpenApi(counterpartyAddressSchemaBase.shape.countryCode, {
+      description: "ISO 3166-1 country code.",
+      example: "US",
+    }),
+    subdivisionCode: withOpenApi(counterpartyAddressSchemaBase.shape.subdivisionCode, {
+      description: "ISO 3166-2 subdivision code (state, province, region).",
+      example: "US-CA",
+    }),
+  }),
+  { description: "Postal address for a counterparty." }
+);
+
+export const counterpartyGovernmentIdSchema = withOpenApi(
+  counterpartyGovernmentIdSchemaBase.extend({
+    type: counterpartyIdTypeSchema,
+    number: withOpenApi(counterpartyGovernmentIdSchemaBase.shape.number, {
+      description: "Government ID number.",
+      example: "X12345678",
+    }),
+    issueCountry: withOpenApi(counterpartyGovernmentIdSchemaBase.shape.issueCountry, {
+      description: "ISO 3166-1 country code of the issuing authority.",
+      example: "US",
+    }),
+    subdivisionCode: withOpenApi(counterpartyGovernmentIdSchemaBase.shape.subdivisionCode, {
+      description: "ISO 3166-2 subdivision code of the issuing authority.",
+      example: "US-CA",
+    }),
+    issueDate: withOpenApi(isoDateSchema.optional(), {
+      description: "Issue date (YYYY-MM-DD).",
+      example: "2018-06-01",
+    }),
+    expiryDate: withOpenApi(isoDateSchema.optional(), {
+      description: "Expiry date (YYYY-MM-DD).",
+      example: "2028-06-01",
+    }),
+  }),
+  { description: "Government-issued identity document." }
+);
+
+export const counterpartyIdentitySchema = withOpenApi(
+  counterpartyIdentitySchemaBase.extend({
+    firstName: withOpenApi(counterpartyIdentitySchemaBase.shape.firstName, {
+      description: "Given name.",
+      example: "Jane",
+    }),
+    middleName: withOpenApi(counterpartyIdentitySchemaBase.shape.middleName, {
+      description: "Middle name.",
+      example: "Q",
+    }),
+    lastName: withOpenApi(counterpartyIdentitySchemaBase.shape.lastName, {
+      description: "Family name.",
+      example: "Doe",
+    }),
+    secondLastName: withOpenApi(counterpartyIdentitySchemaBase.shape.secondLastName, {
+      description: "Second family name (used in some locales).",
+      example: "Garcia",
+    }),
+    dateOfBirth: withOpenApi(isoDateSchema.optional(), {
+      description: "Date of birth (YYYY-MM-DD).",
+      example: "1990-01-15",
+    }),
+    phone: withOpenApi(counterpartyIdentitySchemaBase.shape.phone, {
+      description: "Contact phone number in E.164 format.",
+      example: "+14155551234",
+    }),
+    address: counterpartyAddressSchema.optional(),
+    birthCountryCode: withOpenApi(counterpartyIdentitySchemaBase.shape.birthCountryCode, {
+      description: "ISO 3166-1 country code of birth.",
+      example: "US",
+    }),
+    citizenshipCountryCode: withOpenApi(
+      counterpartyIdentitySchemaBase.shape.citizenshipCountryCode,
+      {
+        description: "ISO 3166-1 country code of citizenship.",
+        example: "US",
+      }
+    ),
+    governmentId: counterpartyGovernmentIdSchema.optional(),
+  }),
+  {
+    description:
+      "Identity details for the counterparty. Additional provider-specific fields are accepted and preserved.",
+  }
+);
+
+export const counterpartySchema = withOpenApi(
+  z.object({
+    id: counterpartyIdParamSchema,
+    organizationId: orgIdParamSchema,
+    projectId: withOpenApi(projectIdParamSchema.nullable(), {
+      description: "Project scope when the counterparty is project-scoped.",
+    }),
+    externalId: withOpenApi(z.string().nullable(), {
+      description: "Caller-supplied identifier for cross-system reference.",
+      example: "customer_42",
+    }),
+    entityType: counterpartyEntityTypeSchema,
+    displayName: withOpenApi(z.string(), {
+      description: "Human-readable display name.",
+      example: "Jane Doe",
+    }),
+    email: withOpenApi(z.string(), {
+      description: "Primary contact email.",
+      example: "jane@example.com",
+    }),
+    identity: counterpartyIdentitySchema,
+    status: counterpartyStatusSchema,
+    createdBy: withOpenApi(userIdSchema.nullable(), {
+      description: "User who created the counterparty. Null when created via API key.",
+    }),
+    createdAt: withOpenApi(isoDateTimeSchema, {
+      description: "Creation timestamp.",
+      example: "2025-01-01T00:00:00.000Z",
+    }),
+    updatedAt: withOpenApi(isoDateTimeSchema, {
+      description: "Last update timestamp.",
+      example: "2025-01-02T00:00:00.000Z",
+    }),
+  }),
+  { description: "Counterparty record." }
+);
+
+export const counterpartyResponseSchema = withOpenApi(
+  z.object({
+    counterparty: counterpartySchema,
+  }),
+  { description: "Counterparty response payload." }
+);
+
+export const listCounterpartiesResponseSchema = withOpenApi(
+  z.object({
+    counterparties: withOpenApi(z.array(counterpartySchema), {
+      description: "Counterparties.",
+    }),
+    total: withOpenApi(z.number().int().nonnegative(), {
+      description: "Total counterparties matching the query.",
+      example: 42,
+    }),
+    page: withOpenApi(z.number().int().positive(), {
+      description: "Current page number.",
+      example: 1,
+    }),
+    pageSize: withOpenApi(z.number().int().positive(), {
+      description: "Items per page.",
+      example: 20,
+    }),
+  }),
+  { description: "Paginated list of counterparties." }
+);
+
+export const listCounterpartiesQuerySchema = listCounterpartiesQuerySchemaBase.extend({
+  page: withOpenApi(listCounterpartiesQuerySchemaBase.shape.page, {
+    description: "Page number (1-based).",
+    example: 1,
+  }),
+  pageSize: withOpenApi(listCounterpartiesQuerySchemaBase.shape.pageSize, {
+    description: "Items per page (max 100).",
+    example: 20,
+  }),
+  includeArchived: withOpenApi(listCounterpartiesQuerySchemaBase.shape.includeArchived, {
+    description: "Include archived counterparties in results.",
+    example: false,
+  }),
+});
+
+export const createCounterpartyRequestSchema = withOpenApi(
+  createCounterpartySchemaBase.extend({
+    externalId: withOpenApi(createCounterpartySchemaBase.shape.externalId, {
+      description: "Caller-supplied identifier for cross-system reference.",
+      example: "customer_42",
+    }),
+    entityType: withOpenApi(createCounterpartySchemaBase.shape.entityType, {
+      description: "Counterparty entity type.",
+      example: "individual",
+    }),
+    displayName: withOpenApi(createCounterpartySchemaBase.shape.displayName, {
+      description: "Human-readable display name.",
+      example: "Jane Doe",
+    }),
+    email: withOpenApi(createCounterpartySchemaBase.shape.email, {
+      description: "Primary contact email.",
+      example: "jane@example.com",
+    }),
+    identity: withOpenApi(counterpartyIdentitySchema.optional(), {
+      description: "Optional identity details. Required completeness depends on downstream KYC.",
+    }),
+  }),
+  { description: "Create counterparty request body." }
+);
+
+export const updateCounterpartyRequestSchema = withOpenApi(
+  updateCounterpartyObjectSchemaBase.extend({
+    externalId: withOpenApi(updateCounterpartyObjectSchemaBase.shape.externalId, {
+      description: "Updated external ID. Use null to clear.",
+      example: "customer_42",
+    }),
+    entityType: withOpenApi(updateCounterpartyObjectSchemaBase.shape.entityType, {
+      description: "Updated counterparty entity type.",
+      example: "business",
+    }),
+    displayName: withOpenApi(updateCounterpartyObjectSchemaBase.shape.displayName, {
+      description: "Updated display name.",
+      example: "Jane Q. Doe",
+    }),
+    email: withOpenApi(updateCounterpartyObjectSchemaBase.shape.email, {
+      description: "Updated contact email.",
+      example: "jane.doe@example.com",
+    }),
+    identity: withOpenApi(counterpartyIdentitySchema.optional(), {
+      description: "Updated identity details. Replaces the existing identity object.",
+    }),
+  }),
+  { description: "Update counterparty request body. At least one field must be provided." }
+);

--- a/apps/sdp-api/src/openapi/schemas/index.ts
+++ b/apps/sdp-api/src/openapi/schemas/index.ts
@@ -3,6 +3,7 @@ export * from "./api-keys";
 export * from "./auth";
 export * from "./base";
 export * from "./compliance";
+export * from "./counterparties";
 export * from "./custody";
 export * from "./health";
 export * from "./issuance";

--- a/apps/sdp-api/src/openapi/spec.test.ts
+++ b/apps/sdp-api/src/openapi/spec.test.ts
@@ -36,6 +36,7 @@ describe("OpenAPI spec", () => {
       "Issuance",
       "Payments",
       "Compliance",
+      "Counterparties",
     ]);
 
     expect(doc.paths?.["/v1/auth/me"]).toBeUndefined();

--- a/apps/sdp-api/src/openapi/spec.ts
+++ b/apps/sdp-api/src/openapi/spec.ts
@@ -6,6 +6,7 @@ import { registerAdminPaths } from "./paths/admin";
 import { registerApiKeyPaths } from "./paths/api-keys";
 import { registerAuthPaths } from "./paths/auth";
 import { registerCompliancePaths } from "./paths/compliance";
+import { registerCounterpartyPaths } from "./paths/counterparties";
 import { registerCustodyPaths } from "./paths/custody";
 import { registerHealthPaths } from "./paths/health";
 import { registerIssuancePaths } from "./paths/issuance";
@@ -37,6 +38,10 @@ const OPENAPI_TAG = {
     description: "Wallet balances, transfer execution, policies, and ramps.",
   },
   COMPLIANCE: { name: "Compliance", description: "Risk and compliance screening endpoints." },
+  COUNTERPARTIES: {
+    name: "Counterparties",
+    description: "Counterparty (customer/beneficiary) identity records.",
+  },
   ADMIN: { name: "Admin", description: "Administrative allowlist management." },
   ONBOARDING: { name: "Onboarding", description: "Clerk organization sync status." },
 } as const;
@@ -49,6 +54,7 @@ const PUBLIC_OPENAPI_TAGS = [
   OPENAPI_TAG.ISSUANCE,
   OPENAPI_TAG.PAYMENTS,
   OPENAPI_TAG.COMPLIANCE,
+  OPENAPI_TAG.COUNTERPARTIES,
 ];
 
 const OPENAPI_TAGS = [
@@ -63,6 +69,7 @@ const OPENAPI_TAGS = [
   OPENAPI_TAG.ISSUANCE,
   OPENAPI_TAG.PAYMENTS,
   OPENAPI_TAG.COMPLIANCE,
+  OPENAPI_TAG.COUNTERPARTIES,
   OPENAPI_TAG.ADMIN,
   OPENAPI_TAG.ONBOARDING,
 ];
@@ -101,6 +108,7 @@ function registerPublicPaths(registry: OpenAPIRegistry) {
   registerIssuancePaths(registry);
   registerPaymentsPaths(registry);
   registerCompliancePaths(registry);
+  registerCounterpartyPaths(registry);
 }
 
 function registerAllPaths(registry: OpenAPIRegistry) {
@@ -115,6 +123,7 @@ function registerAllPaths(registry: OpenAPIRegistry) {
   registerIssuancePaths(registry);
   registerPaymentsPaths(registry);
   registerCompliancePaths(registry);
+  registerCounterpartyPaths(registry);
   registerAdminPaths(registry);
   registerOnboardingPaths(registry);
 }

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 const countryCodeSchema = z.string().min(2).max(8);
 const subdivisionCodeSchema = z.string().min(1).max(16);
 
-const counterpartyAddressSchema = z.object({
+export const counterpartyAddressSchema = z.object({
   line1: z.string().min(1).max(512),
   line2: z.string().max(512).optional(),
   city: z.string().min(1).max(256),
@@ -16,8 +16,10 @@ const counterpartyAddressSchema = z.object({
   subdivisionCode: subdivisionCodeSchema.optional(),
 });
 
-const counterpartyGovernmentIdSchema = z.object({
-  type: z.enum(COUNTERPARTY_ID_TYPES),
+export const counterpartyIdTypeSchema = z.enum(COUNTERPARTY_ID_TYPES);
+
+export const counterpartyGovernmentIdSchema = z.object({
+  type: counterpartyIdTypeSchema,
   number: z.string().min(1).max(128),
   issueCountry: countryCodeSchema,
   subdivisionCode: subdivisionCodeSchema.optional(),
@@ -40,8 +42,12 @@ export const counterpartyIdentitySchema = z.looseObject({
 
 export const counterpartyEntityTypeSchema = z.enum(["individual", "business"]);
 
+export const counterpartyStatusSchema = z.enum(["active", "archived"]);
+
+export const counterpartyIdSchema = z.string().min(1);
+
 export const counterpartyIdParamsSchema = z.object({
-  counterpartyId: z.string().min(1),
+  counterpartyId: counterpartyIdSchema,
 });
 
 export const createCounterpartySchema = z.object({
@@ -52,17 +58,18 @@ export const createCounterpartySchema = z.object({
   identity: counterpartyIdentitySchema.optional(),
 });
 
-export const updateCounterpartySchema = z
-  .object({
-    externalId: z.string().min(1).max(256).nullable().optional(),
-    entityType: counterpartyEntityTypeSchema.optional(),
-    displayName: z.string().min(1).max(512).optional(),
-    email: z.email().max(512).optional(),
-    identity: counterpartyIdentitySchema.optional(),
-  })
-  .refine((value) => Object.keys(value).length > 0, {
-    message: "At least one field must be provided",
-  });
+export const updateCounterpartyObjectSchema = z.object({
+  externalId: z.string().min(1).max(256).nullable().optional(),
+  entityType: counterpartyEntityTypeSchema.optional(),
+  displayName: z.string().min(1).max(512).optional(),
+  email: z.email().max(512).optional(),
+  identity: counterpartyIdentitySchema.optional(),
+});
+
+export const updateCounterpartySchema = updateCounterpartyObjectSchema.refine(
+  (value) => Object.keys(value).length > 0,
+  { message: "At least one field must be provided" }
+);
 
 export const listCounterpartiesQuerySchema = z.object({
   page: z.coerce.number().int().positive().default(1),


### PR DESCRIPTION
## Summary

Adds OpenAPI documentation for the counterparties API. Reuses Zod schemas from `routes/counterparties/schemas.ts` so the contract can't drift from the handlers.

Endpoints documented:

- `GET    /v1/counterparties`
- `POST   /v1/counterparties`
- `GET    /v1/counterparties/{counterpartyId}`
- `PATCH  /v1/counterparties/{counterpartyId}`
- `DELETE /v1/counterparties/{counterpartyId}`

## Examples

Create:

```bash
curl -X POST https://api.solana.org/v1/counterparties \
  -H "Authorization: Bearer sk_test_..." \
  -H "Content-Type: application/json" \
  -d '{
    "externalId": "customer_42",
    "entityType": "individual",
    "displayName": "Jane Doe",
    "email": "jane@example.com",
    "identity": {
      "firstName": "Jane",
      "lastName": "Doe",
      "dateOfBirth": "1990-01-15",
      "phone": "+14155551234",
      "address": {
        "line1": "123 Main St",
        "city": "San Francisco",
        "postalCode": "94105",
        "countryCode": "US",
        "subdivisionCode": "US-CA"
      },
      "governmentId": {
        "type": "PAS",
        "number": "X12345678",
        "issueCountry": "US",
        "expiryDate": "2028-06-01"
      }
    }
  }'
```

Response:

```json
{
  "data": {
    "counterparty": {
      "id": "cp_example",
      "organizationId": "org_example",
      "projectId": null,
      "externalId": "customer_42",
      "entityType": "individual",
      "displayName": "Jane Doe",
      "email": "jane@example.com",
      "identity": { "...": "..." },
      "status": "active",
      "createdBy": "usr_example",
      "createdAt": "2025-01-01T00:00:00.000Z",
      "updatedAt": "2025-01-01T00:00:00.000Z"
    }
  },
  "meta": { "requestId": "req_example", "timestamp": "2025-01-01T00:00:00.000Z" }
}
```

List (paginated, archived hidden by default):

```bash
curl "https://api.solana.org/v1/counterparties?page=1&pageSize=20&includeArchived=false" \
  -H "Authorization: Bearer sk_test_..."
```

## Test plan

- [x] \`pnpm openapi:generate\` regenerates \`generated/openapi.json\` with all 5 operations
- [x] \`vitest run src/openapi/spec.test.ts\` — 4/4 passing (public tag list updated)
- [x] \`vitest run src/routes/counterparties\` — 13/13 passing (schema split didn't break handlers)
- [x] \`biome check\` clean on all changed files