### PR TITLE
chore(kora): allow MagicBlock program in config

### DIFF
--- a/infra/kora/cloud-run/README.md
+++ b/infra/kora/cloud-run/README.md
@@ -21,10 +21,11 @@ Create these secrets before deploy:
 
 ## Required Allowed Programs
 
-Every Kora instance used by SDP must allow the sRFC-37 programs in addition to the standard System, Token, Token-2022, Associated Token, Memo, Address Lookup Table, and Compute Budget programs:
+Every Kora instance used by SDP must allow the sRFC-37 and MagicBlock private transfer programs in addition to the standard System, Token, Token-2022, Associated Token, Memo, Address Lookup Table, and Compute Budget programs:
 
 - `TACLkU6CiCdkQN2MjoyDkVg2yAH9zkxiHDsiztQ52TP` — Token-ACL
 - `GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz` — ABL / GATE
+- `SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2` — MagicBlock private transfer program
 
 This applies to the active devnet Kora surfaces:
 

--- a/infra/kora/cloud-run/check.sh
+++ b/infra/kora/cloud-run/check.sh
@@ -16,12 +16,13 @@ echo "Checking Kora payer signer..."
 curl -fsS "${headers[@]}" -X POST "${KORA_RPC_URL}" --data '{"jsonrpc":"2.0","id":1,"method":"getPayerSigner","params":[]}'
 echo
 
-echo "Checking Kora sRFC-37 allowed programs..."
+echo "Checking Kora required allowed programs..."
 config_response="$(curl -fsS "${headers[@]}" -X POST "${KORA_RPC_URL}" --data '{"jsonrpc":"2.0","id":2,"method":"getConfig","params":[]}')"
 KORA_CONFIG_RESPONSE="${config_response}" node <<'NODE'
 const requiredPrograms = [
-  "TACLkU6CiCdkQN2MjoyDkVg2yAH9zkxiHDsiztQ52TP",
-  "GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz",
+  ["TACLkU6CiCdkQN2MjoyDkVg2yAH9zkxiHDsiztQ52TP", "Token-ACL (sRFC-37)"],
+  ["GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz", "ABL / GATE"],
+  ["SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2", "MagicBlock private transfer"],
 ];
 
 const response = JSON.parse(process.env.KORA_CONFIG_RESPONSE ?? "{}");
@@ -32,11 +33,19 @@ if (response.error) {
 
 const allowedPrograms = response.result?.validation_config?.allowed_programs ?? [];
 
-const missingPrograms = requiredPrograms.filter((program) => !allowedPrograms.includes(program));
+const missingPrograms = requiredPrograms.filter(([program]) => !allowedPrograms.includes(program));
 if (missingPrograms.length > 0) {
-  console.error(`Missing Kora allowed programs: ${missingPrograms.join(", ")}`);
+  console.error(
+    `Missing Kora allowed programs: ${missingPrograms
+      .map(([program, label]) => `${program} (${label})`)
+      .join(", ")}`
+  );
   process.exit(1);
 }
 
-console.log(`Kora allows required sRFC-37 programs: ${requiredPrograms.join(", ")}`);
+console.log(
+  `Kora allows required programs: ${requiredPrograms
+    .map(([program, label]) => `${program} (${label})`)
+    .join(", ")}`
+);
 NODE

--- a/infra/kora/cloud-run/kora.devnet.toml
+++ b/infra/kora/cloud-run/kora.devnet.toml
@@ -36,6 +36,7 @@ allowed_programs = [
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
     "TACLkU6CiCdkQN2MjoyDkVg2yAH9zkxiHDsiztQ52TP",   # Token-ACL (sRFC-37)
     "GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz",  # ABL / GATE Program
+    "SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2",   # MagicBlock private transfer program
     "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",   # Memo Program
     "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table
     "ComputeBudget111111111111111111111111111111",   # Compute Budget

--- a/infra/kora/kora.toml
+++ b/infra/kora/kora.toml
@@ -30,7 +30,8 @@ max_signatures = 10
 price_source = "Mock"           # Use Mock for devnet (no real price oracle)
 allow_durable_transactions = false
 
-# Programs allowed for SDP Token-2022 issuance and sRFC-37 ACL operations
+# Programs allowed for SDP Token-2022 issuance, sRFC-37 ACL operations, and
+# MagicBlock private transfer transactions.
 allowed_programs = [
     "11111111111111111111111111111111",              # System Program
     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",   # Token Program (legacy)
@@ -38,6 +39,7 @@ allowed_programs = [
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
     "TACLkU6CiCdkQN2MjoyDkVg2yAH9zkxiHDsiztQ52TP",   # Token-ACL (sRFC-37)
     "GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz",  # ABL / GATE Program
+    "SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2",   # MagicBlock private transfer program
     "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",   # Memo Program
     "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table
     "ComputeBudget111111111111111111111111111111",   # Compute Budget


### PR DESCRIPTION
## Summary

- add MagicBlock's private transfer program to the SDP Kora allowlist
- keep local Kora and shared devnet Cloud Run config aligned
- update the Kora health check and operator notes so the required program is discoverable

## Why

MagicBlock private-transfer transactions include `SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2`. The shared devnet Kora service currently rejects those transactions because the program is not in `validation.allowed_programs`.

## Validation

- `bash -n infra/kora/cloud-run/check.sh`

The live devnet service still needs the Secret Manager config update and Cloud Run rollout after this config lands.
