### PR TITLE
feat(ci): HOO-518 docker_build_web smoke + GHA layer cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
   docker_build_api:
     name: Docker Build API
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -187,6 +188,7 @@ jobs:
   docker_build_docs:
     name: Docker Build Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -212,6 +214,7 @@ jobs:
   docker_build_web:
     name: Docker Build Web
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,33 @@ jobs:
           cache-from: type=gha,scope=sdp-docs
           cache-to: type=gha,scope=sdp-docs,mode=max
 
+  docker_build_web:
+    name: Docker Build Web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build sdp-web image (no push)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: apps/sdp-web/Dockerfile
+          push: false
+          load: false
+          provenance: false
+          sbom: false
+          tags: sdp-web:ci-${{ github.sha }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_c21va2UubG9jYWwuY2xlcmsuZGV2JA
+            NEXT_PUBLIC_SDP_API_BASE_URL=http://localhost:8787
+          cache-from: type=gha,scope=sdp-web
+          cache-to: type=gha,scope=sdp-web,mode=max
+
   docker_compose_smoke:
     name: Docker Compose Smoke
     runs-on: ubuntu-latest


### PR DESCRIPTION
sdp-web was previously only exercised through the compose stack (docker_compose_smoke) — a full runtime smoke. This job complements that with a per-image build carrying its own GHA layer cache, mirroring docker_build_api and docker_build_docs.

- docker/build-push-action@v7.1.0, push/load/provenance/sbom = false
- cache-from/cache-to type=gha, scope=sdp-web (isolated from api/docs)
- build-args: GIT_SHA + two required NEXT_PUBLIC_* (Clerk pk_test and SDP_API_BASE_URL), values mirror docker_compose_smoke env.

After merge, add "Docker Build Web" to required status checks in branch protection on main.