### PR TITLE
feat: model counterparty accounts

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0006_counterparty_payment_accounts.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0006_counterparty_payment_accounts.sql
@@ -1,0 +1,71 @@
+-- Counterparty accounts: reusable recipient/payment identifiers attached to a
+-- counterparty. Following Polar's payout account pattern, raw provider-owned
+-- financial credentials should live with the provider when possible; SDP stores
+-- non-secret recipient identifiers and durable provider refs/sanitized metadata.
+--
+-- Also extends counterparties with provider_data: counterparty-level provider
+-- handles (e.g. Grid customerId) that are 1:1 with the identity and shared
+-- across all of its accounts. Account-specific provider handles live in
+-- counterparty_accounts.provider_account_data.
+--
+-- account_kind is intentionally left as open TEXT (no CHECK constraint) so new
+-- payout rails can be added without a migration. Current allowed values are
+-- enforced at the application layer via COUNTERPARTY_ACCOUNT_KINDS in
+-- @sdp/types: 'bank_account' | 'crypto_wallet'.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   pg_constraint
+        WHERE  conname = 'counterparties_id_org_project_key'
+    ) THEN
+        ALTER TABLE counterparties ADD CONSTRAINT counterparties_id_org_project_key
+            UNIQUE (id, organization_id, project_id);
+    END IF;
+END $$;
+
+ALTER TABLE counterparties
+    ADD COLUMN IF NOT EXISTS provider_data JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   pg_constraint
+        WHERE  conname = 'counterparties_provider_data_is_object'
+    ) THEN
+        ALTER TABLE counterparties
+            ADD CONSTRAINT counterparties_provider_data_is_object
+            CHECK (jsonb_typeof(provider_data) = 'object');
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS counterparty_accounts (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    counterparty_id TEXT NOT NULL,
+    account_kind TEXT NOT NULL,
+    label TEXT,
+    details JSONB NOT NULL DEFAULT '{}'::jsonb,
+    provider_account_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (counterparty_id, organization_id, project_id)
+        REFERENCES counterparties(id, organization_id, project_id)
+        ON DELETE CASCADE,
+    CONSTRAINT counterparty_accounts_details_is_object CHECK (jsonb_typeof(details) = 'object'),
+    CONSTRAINT counterparty_accounts_provider_account_data_is_object CHECK (jsonb_typeof(provider_account_data) = 'object'),
+    CONSTRAINT counterparty_accounts_status_check CHECK (status IN ('active', 'archived'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_counterparty_accounts_counterparty_status_created
+    ON counterparty_accounts(counterparty_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_counterparty_accounts_org_project_kind_created
+    ON counterparty_accounts(organization_id, project_id, account_kind, created_at DESC)
+    WHERE status = 'active';

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
@@ -1,0 +1,218 @@
+import type {
+  CounterpartyAccountDetails,
+  CounterpartyAccountKind,
+  CounterpartyAccountProviderData,
+  CounterpartyAccountStatus,
+} from "@sdp/types";
+import type { AppDb } from "@/db";
+import type {
+  ArchiveCounterpartyAccountInput,
+  CounterpartyAccountRow,
+  CounterpartyAccountsRepository,
+  CreateCounterpartyAccountInput,
+  ListCounterpartyAccountsByCounterpartyInput,
+  ListCounterpartyAccountsResult,
+  UpdateCounterpartyAccountInput,
+} from "./counterparty-account.repository";
+import { generateCounterpartyAccountId } from "./counterparty-account.repository";
+
+function mapCounterpartyAccountRow(row: Record<string, unknown>): CounterpartyAccountRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    counterparty_id: row.counterparty_id as string,
+    account_kind: row.account_kind as CounterpartyAccountKind,
+    label: (row.label as string | null) ?? null,
+    details: row.details as CounterpartyAccountDetails,
+    provider_account_data: row.provider_account_data as CounterpartyAccountProviderData,
+    status: row.status as CounterpartyAccountStatus,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
+async function getCounterpartyAccountByIdInternal(
+  db: AppDb,
+  params: { counterpartyAccountId: string; organizationId: string; projectId: string }
+): Promise<CounterpartyAccountRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT * FROM counterparty_accounts
+         WHERE id = ?
+           AND organization_id = ?
+           AND project_id = ?`
+    )
+    .bind(params.counterpartyAccountId, params.organizationId, params.projectId)
+    .first<Record<string, unknown>>();
+  return row ? mapCounterpartyAccountRow(row) : null;
+}
+
+export function createPostgresCounterpartyAccountsRepository(
+  db: AppDb
+): CounterpartyAccountsRepository {
+  return {
+    async createCounterpartyAccount(input: CreateCounterpartyAccountInput) {
+      const id = generateCounterpartyAccountId();
+
+      await db
+        .prepare(
+          `INSERT INTO counterparty_accounts (
+             id,
+             organization_id,
+             project_id,
+             counterparty_id,
+             account_kind,
+             label,
+             details,
+             provider_account_data
+           ) VALUES (?, ?, ?, ?, ?, ?, COALESCE(?, '{}'::jsonb), COALESCE(?, '{}'::jsonb))`
+        )
+        .bind(
+          id,
+          input.organizationId,
+          input.projectId,
+          input.counterpartyId,
+          input.accountKind,
+          input.label ?? null,
+          input.details ?? null,
+          input.providerAccountData ?? null
+        )
+        .run();
+
+      return getCounterpartyAccountByIdInternal(db, {
+        counterpartyAccountId: id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async updateCounterpartyAccount(input: UpdateCounterpartyAccountInput) {
+      const rowsAffected = await db
+        .prepare(
+          `UPDATE counterparty_accounts
+             SET label = CASE WHEN ?::boolean THEN ? ELSE label END,
+                 details = COALESCE(?, details),
+                 provider_account_data = COALESCE(?, provider_account_data),
+                 updated_at = sdp_iso_now()
+           WHERE id = ?
+             AND organization_id = ?
+             AND project_id = ?
+             AND status = 'active'`
+        )
+        .bind(
+          input.label !== undefined,
+          input.label ?? null,
+          input.details ?? null,
+          input.providerAccountData ?? null,
+          input.counterpartyAccountId,
+          input.organizationId,
+          input.projectId
+        )
+        .run();
+
+      if (rowsAffected === 0) {
+        return null;
+      }
+
+      return getCounterpartyAccountByIdInternal(db, {
+        counterpartyAccountId: input.counterpartyAccountId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async archiveCounterpartyAccount(input: ArchiveCounterpartyAccountInput) {
+      const result = await db
+        .prepare(
+          `UPDATE counterparty_accounts
+             SET status = 'archived',
+                 updated_at = sdp_iso_now()
+           WHERE id = ?
+             AND organization_id = ?
+             AND project_id = ?
+             AND status = 'active'`
+        )
+        .bind(input.counterpartyAccountId, input.organizationId, input.projectId)
+        .run();
+
+      if (result === 0) {
+        return null;
+      }
+
+      return getCounterpartyAccountByIdInternal(db, {
+        counterpartyAccountId: input.counterpartyAccountId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async getCounterpartyAccountById(params) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM counterparty_accounts
+             WHERE id = ?
+               AND organization_id = ?
+               AND project_id = ?
+               AND status = 'active'`
+        )
+        .bind(params.counterpartyAccountId, params.organizationId, params.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapCounterpartyAccountRow(row) : null;
+    },
+
+    async listCounterpartyAccountsByCounterparty(
+      params: ListCounterpartyAccountsByCounterpartyInput
+    ): Promise<ListCounterpartyAccountsResult> {
+      const [rowsResult, countRow] = await Promise.all([
+        db
+          .prepare(
+            `SELECT *
+               FROM counterparty_accounts
+              WHERE counterparty_id = ?
+                AND organization_id = ?
+                AND project_id = ?
+                AND (?::boolean OR status = 'active')
+                AND (?::text IS NULL OR account_kind = ?::text)
+              ORDER BY created_at DESC
+              LIMIT ? OFFSET ?`
+          )
+          .bind(
+            params.counterpartyId,
+            params.organizationId,
+            params.projectId,
+            params.includeArchived ?? false,
+            params.accountKind ?? null,
+            params.accountKind ?? null,
+            params.limit,
+            params.offset
+          )
+          .all<Record<string, unknown>>(),
+        db
+          .prepare(
+            `SELECT COUNT(*)::int AS total
+               FROM counterparty_accounts
+              WHERE counterparty_id = ?
+                AND organization_id = ?
+                AND project_id = ?
+                AND (?::boolean OR status = 'active')
+                AND (?::text IS NULL OR account_kind = ?::text)`
+          )
+          .bind(
+            params.counterpartyId,
+            params.organizationId,
+            params.projectId,
+            params.includeArchived ?? false,
+            params.accountKind ?? null,
+            params.accountKind ?? null
+          )
+          .first<{ total: number }>(),
+      ]);
+
+      return {
+        rows: rowsResult.results.map(mapCounterpartyAccountRow),
+        total: countRow?.total ?? 0,
+      };
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
@@ -95,7 +95,8 @@ export function createPostgresCounterpartyAccountsRepository(
                  details = COALESCE(?, details),
                  provider_account_data = COALESCE(?, provider_account_data),
                  updated_at = sdp_iso_now()
-           WHERE id = ?
+           WHERE counterparty_id = ?
+             AND id = ?
              AND organization_id = ?
              AND project_id = ?
              AND status = 'active'`
@@ -105,6 +106,7 @@ export function createPostgresCounterpartyAccountsRepository(
           input.label ?? null,
           input.details ?? null,
           input.providerAccountData ?? null,
+          input.counterpartyId,
           input.counterpartyAccountId,
           input.organizationId,
           input.projectId
@@ -128,12 +130,18 @@ export function createPostgresCounterpartyAccountsRepository(
           `UPDATE counterparty_accounts
              SET status = 'archived',
                  updated_at = sdp_iso_now()
-           WHERE id = ?
+           WHERE counterparty_id = ?
+             AND id = ?
              AND organization_id = ?
              AND project_id = ?
              AND status = 'active'`
         )
-        .bind(input.counterpartyAccountId, input.organizationId, input.projectId)
+        .bind(
+          input.counterpartyId,
+          input.counterpartyAccountId,
+          input.organizationId,
+          input.projectId
+        )
         .run();
 
       if (result === 0) {
@@ -151,12 +159,18 @@ export function createPostgresCounterpartyAccountsRepository(
       const row = await db
         .prepare(
           `SELECT * FROM counterparty_accounts
-             WHERE id = ?
+             WHERE counterparty_id = ?
+               AND id = ?
                AND organization_id = ?
                AND project_id = ?
                AND status = 'active'`
         )
-        .bind(params.counterpartyAccountId, params.organizationId, params.projectId)
+        .bind(
+          params.counterpartyId,
+          params.counterpartyAccountId,
+          params.organizationId,
+          params.projectId
+        )
         .first<Record<string, unknown>>();
       return row ? mapCounterpartyAccountRow(row) : null;
     },

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
@@ -151,12 +151,18 @@ export function createPostgresCounterpartyAccountsRepository(
       const row = await db
         .prepare(
           `SELECT * FROM counterparty_accounts
-             WHERE id = ?
+             WHERE counterparty_id = ?
+               AND id = ?
                AND organization_id = ?
                AND project_id = ?
                AND status = 'active'`
         )
-        .bind(params.counterpartyAccountId, params.organizationId, params.projectId)
+        .bind(
+          params.counterpartyId,
+          params.counterpartyAccountId,
+          params.organizationId,
+          params.projectId
+        )
         .first<Record<string, unknown>>();
       return row ? mapCounterpartyAccountRow(row) : null;
     },

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
@@ -151,18 +151,12 @@ export function createPostgresCounterpartyAccountsRepository(
       const row = await db
         .prepare(
           `SELECT * FROM counterparty_accounts
-             WHERE counterparty_id = ?
-               AND id = ?
+             WHERE id = ?
                AND organization_id = ?
                AND project_id = ?
                AND status = 'active'`
         )
-        .bind(
-          params.counterpartyId,
-          params.counterpartyAccountId,
-          params.organizationId,
-          params.projectId
-        )
+        .bind(params.counterpartyAccountId, params.organizationId, params.projectId)
         .first<Record<string, unknown>>();
       return row ? mapCounterpartyAccountRow(row) : null;
     },

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.test.ts
@@ -1,0 +1,411 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
+import { createPostgresCounterpartiesRepository } from "./counterparty.repository.postgres";
+import type { CounterpartyAccountsRepository } from "./counterparty-account.repository";
+import { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_cpta_repo_test";
+
+describe("CounterpartyAccountsRepository (postgres)", () => {
+  let repo: CounterpartyAccountsRepository;
+
+  beforeAll(async () => {
+    await seedTestDatabase(env as Parameters<typeof seedTestDatabase>[0]);
+  });
+
+  afterAll(async () => {
+    await clearTestDatabase(env as Parameters<typeof clearTestDatabase>[0]);
+  });
+
+  beforeEach(async () => {
+    const db = getDb(env);
+    await db.prepare("DELETE FROM counterparty_accounts").run();
+    await db.prepare("DELETE FROM counterparties").run();
+    await db.prepare("DELETE FROM projects").run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', 'test-project', 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_USER.id)
+      .run();
+
+    repo = createPostgresCounterpartyAccountsRepository(db);
+  });
+
+  async function seedCounterparty(externalId: string | null = null) {
+    const counterpartiesRepo = createPostgresCounterpartiesRepository(getDb(env));
+    const row = await counterpartiesRepo.createCounterparty({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      externalId,
+      entityType: "individual",
+      displayName: "Acme Recipient",
+      email: "acme@example.com",
+      identity: { firstName: "Acme" },
+      createdBy: TEST_USER.id,
+    });
+    if (!row) {
+      throw new Error("failed to seed counterparty");
+    }
+    return row;
+  }
+
+  describe("createCounterpartyAccount", () => {
+    it("inserts and returns the row with generated id", async () => {
+      const counterparty = await seedCounterparty();
+
+      const row = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "crypto_wallet",
+        label: "Alice's Solana",
+        details: { network: "solana", address: "7xK...Pump" },
+        providerAccountData: { provider: "grid", gridExternalAccountId: "ext_abc" },
+      });
+
+      expect(row).not.toBeNull();
+      expect(row?.id).toMatch(/^counterparty_account_/);
+      expect(row?.counterparty_id).toBe(counterparty.id);
+      expect(row?.account_kind).toBe("crypto_wallet");
+      expect(row?.label).toBe("Alice's Solana");
+      expect(row?.details).toMatchObject({ network: "solana", address: "7xK...Pump" });
+      expect(row?.provider_account_data).toMatchObject({ provider: "grid" });
+      expect(row?.status).toBe("active");
+    });
+
+    it("defaults details and provider_account_data to {} when omitted", async () => {
+      const counterparty = await seedCounterparty();
+
+      const row = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+
+      expect(row?.label).toBeNull();
+      expect(row?.details).toEqual({});
+      expect(row?.provider_account_data).toEqual({});
+    });
+  });
+
+  describe("getCounterpartyAccountById", () => {
+    it("requires matching counterpartyId — returns null for wrong counterparty", async () => {
+      const cptyA = await seedCounterparty("ext_A");
+      const cptyB = await seedCounterparty("ext_B");
+
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: cptyA.id,
+        accountKind: "crypto_wallet",
+      });
+
+      const wrong = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyB.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(wrong).toBeNull();
+
+      const right = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyA.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(right?.id).toBe(account?.id);
+    });
+
+    it("returns null for archived rows", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+
+      await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+
+      const result = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("listCounterpartyAccountsByCounterparty", () => {
+    it("returns only active accounts by default, newest first", async () => {
+      const counterparty = await seedCounterparty();
+
+      const first = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+        label: "first",
+      });
+      const second = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "crypto_wallet",
+        label: "second",
+      });
+      await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: first?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+
+      const { rows, total } = await repo.listCounterpartyAccountsByCounterparty({
+        counterpartyId: counterparty.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        limit: 50,
+        offset: 0,
+      });
+
+      expect(total).toBe(1);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(second?.id);
+    });
+
+    it("includes archived rows when includeArchived is true", async () => {
+      const counterparty = await seedCounterparty();
+      const first = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+      await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: first?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+
+      const { total } = await repo.listCounterpartyAccountsByCounterparty({
+        counterpartyId: counterparty.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        includeArchived: true,
+        limit: 50,
+        offset: 0,
+      });
+      expect(total).toBe(1);
+    });
+
+    it("filters by accountKind when provided", async () => {
+      const counterparty = await seedCounterparty();
+      await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+      await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "crypto_wallet",
+      });
+
+      const { rows, total } = await repo.listCounterpartyAccountsByCounterparty({
+        counterpartyId: counterparty.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        accountKind: "crypto_wallet",
+        limit: 50,
+        offset: 0,
+      });
+
+      expect(total).toBe(1);
+      expect(rows[0].account_kind).toBe("crypto_wallet");
+    });
+
+    it("scopes by counterpartyId — accounts on a sibling counterparty are excluded", async () => {
+      const cptyA = await seedCounterparty("ext_A");
+      const cptyB = await seedCounterparty("ext_B");
+      await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: cptyA.id,
+        accountKind: "bank_account",
+      });
+      await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: cptyB.id,
+        accountKind: "crypto_wallet",
+      });
+
+      const { rows: rowsA, total: totalA } = await repo.listCounterpartyAccountsByCounterparty({
+        counterpartyId: cptyA.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        limit: 50,
+        offset: 0,
+      });
+      expect(totalA).toBe(1);
+      expect(rowsA[0].counterparty_id).toBe(cptyA.id);
+    });
+  });
+
+  describe("updateCounterpartyAccount", () => {
+    it("patches label, details, and providerAccountData", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "crypto_wallet",
+        label: "old",
+        details: { network: "solana", address: "old" },
+      });
+
+      const updated = await repo.updateCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        label: "new",
+        details: { network: "solana", address: "new" },
+        providerAccountData: { provider: "grid", gridExternalAccountId: "ext_new" },
+      });
+
+      expect(updated?.label).toBe("new");
+      expect(updated?.details).toMatchObject({ address: "new" });
+      expect(updated?.provider_account_data).toMatchObject({ gridExternalAccountId: "ext_new" });
+    });
+
+    it("nulls label when explicitly set to null (sentinel pattern)", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+        label: "starts non-null",
+      });
+
+      const updated = await repo.updateCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        label: null,
+      });
+      expect(updated?.label).toBeNull();
+    });
+
+    it("leaves label untouched when omitted (sentinel guards against undefined-as-null)", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+        label: "keep me",
+      });
+
+      const updated = await repo.updateCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        details: { currency: "USD" },
+      });
+      expect(updated?.label).toBe("keep me");
+    });
+
+    it("returns null when target row is archived", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+      await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+
+      const result = await repo.updateCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        label: "should not stick",
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("archiveCounterpartyAccount", () => {
+    it("marks an active row archived", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+
+      const archived = await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(archived?.status).toBe("archived");
+    });
+
+    it("returns null when already archived", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+      await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      const second = await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(second).toBeNull();
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.test.ts
@@ -110,32 +110,23 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
   });
 
   describe("getCounterpartyAccountById", () => {
-    it("requires matching counterpartyId — returns null for wrong counterparty", async () => {
-      const cptyA = await seedCounterparty("ext_A");
-      const cptyB = await seedCounterparty("ext_B");
-
+    it("returns the row when active", async () => {
+      const counterparty = await seedCounterparty();
       const account = await repo.createCounterpartyAccount({
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
-        counterpartyId: cptyA.id,
+        counterpartyId: counterparty.id,
         accountKind: "crypto_wallet",
+        label: "Alice's Solana",
       });
 
-      const wrong = await repo.getCounterpartyAccountById({
+      const row = await repo.getCounterpartyAccountById({
         counterpartyAccountId: account?.id ?? "",
-        counterpartyId: cptyB.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
-      expect(wrong).toBeNull();
-
-      const right = await repo.getCounterpartyAccountById({
-        counterpartyAccountId: account?.id ?? "",
-        counterpartyId: cptyA.id,
-        organizationId: TEST_ORG.id,
-        projectId: TEST_PROJECT_ID,
-      });
-      expect(right?.id).toBe(account?.id);
+      expect(row?.id).toBe(account?.id);
+      expect(row?.label).toBe("Alice's Solana");
     });
 
     it("returns null for archived rows", async () => {
@@ -155,11 +146,27 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const result = await repo.getCounterpartyAccountById({
         counterpartyAccountId: account?.id ?? "",
-        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
       expect(result).toBeNull();
+    });
+
+    it("returns null when org or project doesn't match (tenancy guard)", async () => {
+      const counterparty = await seedCounterparty();
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: counterparty.id,
+        accountKind: "bank_account",
+      });
+
+      const wrongProject = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        organizationId: TEST_ORG.id,
+        projectId: "prj_does_not_exist",
+      });
+      expect(wrongProject).toBeNull();
     });
   });
 

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.test.ts
@@ -110,7 +110,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
   });
 
   describe("getCounterpartyAccountById", () => {
-    it("returns the row when active", async () => {
+    it("returns the row when active and counterparty matches", async () => {
       const counterparty = await seedCounterparty();
       const account = await repo.createCounterpartyAccount({
         organizationId: TEST_ORG.id,
@@ -122,11 +122,31 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const row = await repo.getCounterpartyAccountById({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
       expect(row?.id).toBe(account?.id);
       expect(row?.label).toBe("Alice's Solana");
+    });
+
+    it("returns null when counterpartyId does not own the account (cross-counterparty defense)", async () => {
+      const cptyA = await seedCounterparty("ext_A");
+      const cptyB = await seedCounterparty("ext_B");
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: cptyA.id,
+        accountKind: "crypto_wallet",
+      });
+
+      const result = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyB.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(result).toBeNull();
     });
 
     it("returns null for archived rows", async () => {
@@ -140,12 +160,14 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       await repo.archiveCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
 
       const result = await repo.getCounterpartyAccountById({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
@@ -163,6 +185,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const wrongProject = await repo.getCounterpartyAccountById({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: "prj_does_not_exist",
       });
@@ -190,6 +213,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
       });
       await repo.archiveCounterpartyAccount({
         counterpartyAccountId: first?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
@@ -217,6 +241,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
       });
       await repo.archiveCounterpartyAccount({
         counterpartyAccountId: first?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
@@ -302,6 +327,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const updated = await repo.updateCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
         label: "new",
@@ -326,6 +352,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const updated = await repo.updateCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
         label: null,
@@ -345,6 +372,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const updated = await repo.updateCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
         details: { currency: "USD" },
@@ -362,17 +390,48 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
       });
       await repo.archiveCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
 
       const result = await repo.updateCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
         label: "should not stick",
       });
       expect(result).toBeNull();
+    });
+
+    it("returns null when counterpartyId doesn't own the account (cross-counterparty defense)", async () => {
+      const cptyA = await seedCounterparty("ext_A");
+      const cptyB = await seedCounterparty("ext_B");
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: cptyA.id,
+        accountKind: "bank_account",
+        label: "owned by A",
+      });
+
+      const result = await repo.updateCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyB.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        label: "spoofed by B",
+      });
+      expect(result).toBeNull();
+
+      const untouched = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyA.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(untouched?.label).toBe("owned by A");
     });
   });
 
@@ -388,6 +447,7 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
 
       const archived = await repo.archiveCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
@@ -404,15 +464,44 @@ describe("CounterpartyAccountsRepository (postgres)", () => {
       });
       await repo.archiveCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
       const second = await repo.archiveCounterpartyAccount({
         counterpartyAccountId: account?.id ?? "",
+        counterpartyId: counterparty.id,
         organizationId: TEST_ORG.id,
         projectId: TEST_PROJECT_ID,
       });
       expect(second).toBeNull();
+    });
+
+    it("returns null when counterpartyId doesn't own the account (cross-counterparty defense)", async () => {
+      const cptyA = await seedCounterparty("ext_A");
+      const cptyB = await seedCounterparty("ext_B");
+      const account = await repo.createCounterpartyAccount({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+        counterpartyId: cptyA.id,
+        accountKind: "bank_account",
+      });
+
+      const spoofed = await repo.archiveCounterpartyAccount({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyB.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(spoofed).toBeNull();
+
+      const stillActive = await repo.getCounterpartyAccountById({
+        counterpartyAccountId: account?.id ?? "",
+        counterpartyId: cptyA.id,
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      });
+      expect(stillActive?.status).toBe("active");
     });
   });
 });

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
@@ -36,6 +36,7 @@ export interface CreateCounterpartyAccountInput {
 
 export interface UpdateCounterpartyAccountInput {
   counterpartyAccountId: string;
+  counterpartyId: string;
   organizationId: string;
   projectId: string;
   label?: string | null;
@@ -45,6 +46,7 @@ export interface UpdateCounterpartyAccountInput {
 
 export interface ArchiveCounterpartyAccountInput {
   counterpartyAccountId: string;
+  counterpartyId: string;
   organizationId: string;
   projectId: string;
 }
@@ -80,6 +82,7 @@ export interface CounterpartyAccountsRepository {
   ): Promise<CounterpartyAccountRow | null>;
   getCounterpartyAccountById(params: {
     counterpartyAccountId: string;
+    counterpartyId: string;
     organizationId: string;
     projectId: string;
   }): Promise<CounterpartyAccountRow | null>;

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
@@ -80,7 +80,6 @@ export interface CounterpartyAccountsRepository {
   ): Promise<CounterpartyAccountRow | null>;
   getCounterpartyAccountById(params: {
     counterpartyAccountId: string;
-    counterpartyId: string;
     organizationId: string;
     projectId: string;
   }): Promise<CounterpartyAccountRow | null>;

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
@@ -1,0 +1,89 @@
+import type {
+  CounterpartyAccountDetails,
+  CounterpartyAccountKind,
+  CounterpartyAccountProviderData,
+  CounterpartyAccountStatus,
+} from "@sdp/types";
+import type { RepositoryDbClient } from "./base";
+
+export function generateCounterpartyAccountId(): string {
+  return `counterparty_account_${crypto.randomUUID()}`;
+}
+
+export interface CounterpartyAccountRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  counterparty_id: string;
+  account_kind: CounterpartyAccountKind;
+  label: string | null;
+  details: CounterpartyAccountDetails;
+  provider_account_data: CounterpartyAccountProviderData;
+  status: CounterpartyAccountStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateCounterpartyAccountInput {
+  organizationId: string;
+  projectId: string;
+  counterpartyId: string;
+  accountKind: CounterpartyAccountKind;
+  label?: string | null;
+  details?: CounterpartyAccountDetails;
+  providerAccountData?: CounterpartyAccountProviderData;
+}
+
+export interface UpdateCounterpartyAccountInput {
+  counterpartyAccountId: string;
+  organizationId: string;
+  projectId: string;
+  label?: string | null;
+  details?: CounterpartyAccountDetails;
+  providerAccountData?: CounterpartyAccountProviderData;
+}
+
+export interface ArchiveCounterpartyAccountInput {
+  counterpartyAccountId: string;
+  organizationId: string;
+  projectId: string;
+}
+
+export interface ListCounterpartyAccountsByCounterpartyInput {
+  counterpartyId: string;
+  organizationId: string;
+  projectId: string;
+  accountKind?: CounterpartyAccountKind;
+  includeArchived?: boolean;
+  limit: number;
+  offset: number;
+}
+
+export interface ListCounterpartyAccountsResult {
+  rows: CounterpartyAccountRow[];
+  total: number;
+}
+
+export interface CounterpartyAccountsRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface CounterpartyAccountsRepository {
+  createCounterpartyAccount(
+    input: CreateCounterpartyAccountInput
+  ): Promise<CounterpartyAccountRow | null>;
+  updateCounterpartyAccount(
+    input: UpdateCounterpartyAccountInput
+  ): Promise<CounterpartyAccountRow | null>;
+  archiveCounterpartyAccount(
+    input: ArchiveCounterpartyAccountInput
+  ): Promise<CounterpartyAccountRow | null>;
+  getCounterpartyAccountById(params: {
+    counterpartyAccountId: string;
+    organizationId: string;
+    projectId: string;
+  }): Promise<CounterpartyAccountRow | null>;
+  listCounterpartyAccountsByCounterparty(
+    params: ListCounterpartyAccountsByCounterpartyInput
+  ): Promise<ListCounterpartyAccountsResult>;
+}

--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.ts
@@ -80,6 +80,7 @@ export interface CounterpartyAccountsRepository {
   ): Promise<CounterpartyAccountRow | null>;
   getCounterpartyAccountById(params: {
     counterpartyAccountId: string;
+    counterpartyId: string;
     organizationId: string;
     projectId: string;
   }): Promise<CounterpartyAccountRow | null>;

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
@@ -1,4 +1,9 @@
-import type { CounterpartyEntityType, CounterpartyIdentity, CounterpartyStatus } from "@sdp/types";
+import type {
+  CounterpartyEntityType,
+  CounterpartyIdentity,
+  CounterpartyProviderData,
+  CounterpartyStatus,
+} from "@sdp/types";
 import type { AppDb } from "@/db";
 import type {
   ArchiveCounterpartyInput,
@@ -21,6 +26,7 @@ function mapCounterpartyRow(row: Record<string, unknown>): CounterpartyRow {
     display_name: row.display_name as string,
     email: row.email as string,
     identity: row.identity as CounterpartyIdentity,
+    provider_data: row.provider_data as CounterpartyProviderData,
     status: row.status as CounterpartyStatus,
     created_by: row.created_by as string | null,
     created_at: row.created_at as string,
@@ -60,9 +66,10 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
              display_name,
              email,
              identity,
+             provider_data,
              status,
              created_by
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)`
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, '{}'::jsonb), 'active', ?)`
         )
         .bind(
           id,
@@ -73,6 +80,7 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
           input.displayName,
           input.email,
           input.identity,
+          input.providerData ?? null,
           input.createdBy
         )
         .run();
@@ -93,6 +101,7 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
                  display_name = COALESCE(?, display_name),
                  email = COALESCE(?, email),
                  identity = COALESCE(?, identity),
+                 provider_data = COALESCE(?, provider_data),
                  updated_at = sdp_iso_now()
            WHERE id = ?
              AND organization_id = ?
@@ -106,6 +115,7 @@ export function createPostgresCounterpartiesRepository(db: AppDb): Counterpartie
           input.displayName ?? null,
           input.email ?? null,
           input.identity ?? null,
+          input.providerData ?? null,
           input.counterpartyId,
           input.organizationId,
           input.projectId

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.ts
@@ -1,4 +1,9 @@
-import type { CounterpartyEntityType, CounterpartyIdentity, CounterpartyStatus } from "@sdp/types";
+import type {
+  CounterpartyEntityType,
+  CounterpartyIdentity,
+  CounterpartyProviderData,
+  CounterpartyStatus,
+} from "@sdp/types";
 import type { RepositoryDbClient } from "./base";
 
 export function generateCounterpartyId(): string {
@@ -14,6 +19,7 @@ export interface CounterpartyRow {
   display_name: string;
   email: string;
   identity: CounterpartyIdentity;
+  provider_data: CounterpartyProviderData;
   status: CounterpartyStatus;
   created_by: string | null;
   created_at: string;
@@ -28,6 +34,7 @@ export interface CreateCounterpartyInput {
   displayName: string;
   email: string;
   identity: CounterpartyIdentity;
+  providerData?: CounterpartyProviderData;
   createdBy: string | null;
 }
 
@@ -40,6 +47,7 @@ export interface UpdateCounterpartyInput {
   displayName?: string;
   email?: string;
   identity?: CounterpartyIdentity;
+  providerData?: CounterpartyProviderData;
 }
 
 export interface ArchiveCounterpartyInput {

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -1,5 +1,16 @@
 export type { RepositoryDbClient } from "./base";
 export type {
+  ArchiveCounterpartyAccountInput,
+  CounterpartyAccountRow,
+  CounterpartyAccountsRepository,
+  CounterpartyAccountsRepositoryContext,
+  CreateCounterpartyAccountInput,
+  ListCounterpartyAccountsByCounterpartyInput,
+  ListCounterpartyAccountsResult,
+  UpdateCounterpartyAccountInput,
+} from "./counterparty-account.repository";
+export { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
+export type {
   ArchiveCounterpartyInput,
   CounterpartiesRepository,
   CounterpartiesRepositoryContext,
@@ -26,6 +37,7 @@ export type {
 export { createPostgresPaymentsRepository } from "./payments.repository.postgres";
 export {
   createCounterpartiesRepository,
+  createCounterpartyAccountsRepository,
   createPaymentsRepository,
   createTokenRepository,
 } from "./repository-factory";

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -1,16 +1,5 @@
 export type { RepositoryDbClient } from "./base";
 export type {
-  ArchiveCounterpartyAccountInput,
-  CounterpartyAccountRow,
-  CounterpartyAccountsRepository,
-  CounterpartyAccountsRepositoryContext,
-  CreateCounterpartyAccountInput,
-  ListCounterpartyAccountsByCounterpartyInput,
-  ListCounterpartyAccountsResult,
-  UpdateCounterpartyAccountInput,
-} from "./counterparty-account.repository";
-export { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
-export type {
   ArchiveCounterpartyInput,
   CounterpartiesRepository,
   CounterpartiesRepositoryContext,
@@ -21,6 +10,17 @@ export type {
   UpdateCounterpartyInput,
 } from "./counterparty.repository";
 export { createPostgresCounterpartiesRepository } from "./counterparty.repository.postgres";
+export type {
+  ArchiveCounterpartyAccountInput,
+  CounterpartyAccountRow,
+  CounterpartyAccountsRepository,
+  CounterpartyAccountsRepositoryContext,
+  CreateCounterpartyAccountInput,
+  ListCounterpartyAccountsByCounterpartyInput,
+  ListCounterpartyAccountsResult,
+  UpdateCounterpartyAccountInput,
+} from "./counterparty-account.repository";
+export { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 export type {
   CreatePaymentTransferInput,
   PaymentsRepository,

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -1,9 +1,9 @@
 import { getDb } from "@/db";
 import type { Env } from "@/types/env";
-import type { CounterpartyAccountsRepository } from "./counterparty-account.repository";
-import { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 import type { CounterpartiesRepository } from "./counterparty.repository";
 import { createPostgresCounterpartiesRepository } from "./counterparty.repository.postgres";
+import type { CounterpartyAccountsRepository } from "./counterparty-account.repository";
+import { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 import type { PaymentsRepository } from "./payments.repository";
 import { createPostgresPaymentsRepository } from "./payments.repository.postgres";
 import type { TokenRepository } from "./token.repository";

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -1,5 +1,7 @@
 import { getDb } from "@/db";
 import type { Env } from "@/types/env";
+import type { CounterpartyAccountsRepository } from "./counterparty-account.repository";
+import { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 import type { CounterpartiesRepository } from "./counterparty.repository";
 import { createPostgresCounterpartiesRepository } from "./counterparty.repository.postgres";
 import type { PaymentsRepository } from "./payments.repository";
@@ -13,6 +15,10 @@ export function createPaymentsRepository(env: Env): PaymentsRepository {
 
 export function createCounterpartiesRepository(env: Env): CounterpartiesRepository {
   return createPostgresCounterpartiesRepository(getDb(env));
+}
+
+export function createCounterpartyAccountsRepository(env: Env): CounterpartyAccountsRepository {
+  return createPostgresCounterpartyAccountsRepository(getDb(env));
 }
 
 export function createTokenRepository(env: Env): TokenRepository {

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -23,6 +23,7 @@ const POSTGRES_TEST_TABLES = [
   "issuance_transactions",
   "issued_token_extensions",
   "issued_tokens",
+  "counterparty_accounts",
   "counterparties",
   "magic_links",
   "sessions",

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -38,6 +38,8 @@ export interface CounterpartyIdentity {
 
 export type CounterpartyStatus = "active" | "archived";
 
+export type CounterpartyProviderData = Record<string, unknown>;
+
 export interface Counterparty {
   id: string;
   organizationId: string;
@@ -78,4 +80,27 @@ export interface ListCounterpartiesResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+export const COUNTERPARTY_ACCOUNT_KINDS = ["bank_account", "crypto_wallet"] as const;
+export type CounterpartyAccountKind = (typeof COUNTERPARTY_ACCOUNT_KINDS)[number];
+
+export type CounterpartyAccountStatus = "active" | "archived";
+
+export type CounterpartyAccountDetails = Record<string, unknown>;
+
+export type CounterpartyAccountProviderData = Record<string, unknown>;
+
+export interface CounterpartyAccount {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  counterpartyId: string;
+  accountKind: CounterpartyAccountKind;
+  label: string | null;
+  details: CounterpartyAccountDetails;
+  providerAccountData: CounterpartyAccountProviderData;
+  status: CounterpartyAccountStatus;
+  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
## Summary

Phase 1 of counterparty payment-account management — the data layer that downstream onramp / offramp / payout flows will sit on top of. Provider-agnostic by design: programmatic providers (Grid, BVNK) and hosted/webhook providers (MoonPay) both slot in without schema changes.

## Schema changes

**New table `counterparty_accounts`** — payout destinations attached to a counterparty.

| Column | Notes |
|---|---|
| `id` (PK) | `counterparty_account_{uuid}` — generated in repo, not by caller |
| `counterparty_id` (FK) | composite FK on `(counterparty_id, org, project)` |
| `account_kind` | open TEXT (no CHECK) — currently `bank_account \| crypto_wallet`; enforced at app via `COUNTERPARTY_ACCOUNT_KINDS` |
| `label` | nullable display string (user-supplied nickname — the only display field SDP owns) |
| `details` | JSONB — self-sufficient destination info we can transact with *without* calling a provider |
| `provider_account_data` | JSONB — provider handles namespaced by provider key |
| `status` | `active \| archived` (soft delete only) |

**Extends `counterparties` with `provider_data` JSONB** — counterparty-level provider handles (e.g. Grid customerId) that are 1:1 with the identity and shared across all of its accounts.

**Indexes**:
- `(counterparty_id, status, created_at DESC)` — list-by-counterparty hot path
- `(organization_id, project_id, account_kind, created_at DESC) WHERE status='active'` — future project-scoped listing

## What lives where — the storage rule

The rule is **minimum surface area** — SDP stores only what it genuinely owns or what it can't fetch back:

| | `details` | `provider_account_data.<provider>` |
|---|---|---|
| **Crypto wallet** | `{ currency, network, address }` — the chain address IS our reference, self-sufficient for tx construction | provider handle only (`{ gridExternalAccountId }`); often optional since we can transact directly |
| **Bank account** | `{}` — empty, always | **provider handle only** (`{ gridExternalAccountId }`); display fields (last4, bank name, currency, paymentRails) are **fetched live** from Grid/BVNK at render time |
| **Sensitive PII** (full account #, IBAN, routing #) | **never stored — lives with provider only** | **never stored — only the handle** |

**Exception**: webhook-only providers like MoonPay have no fetch-back endpoint, so we cache whatever sanitized fields they push us once — because if we don't capture it from the webhook, we lose it.

## Repository surface

```ts
createCounterpartyAccount(input)
updateCounterpartyAccount(input)        // sentinel-boolean for nullable label
archiveCounterpartyAccount(input)       // status -> 'archived'
getCounterpartyAccountById(params)      // PK lookup, org+project tenancy guard
listCounterpartyAccountsByCounterparty(params)   // hits the (counterparty_id, ...) index
```

ID generation lives in the repo (`generateCounterpartyAccountId()`), never in callers. `details` and `providerAccountData` default to `{}` when omitted (mirrors SQL `DEFAULT '{}'::jsonb`).

## End-to-end flow: USDC → USD offramp via Grid

Walking through the lifecycle of a single bank account from creation to use, on the strict storage model.

### Step 1 — Onboard a bank account

User clicks "Add USD bank" in the dashboard. SDP forwards KYC data (sourced from `counterparty.identity`) into Grid; Grid stores the real account, we keep only the handle.

```
Frontend ──POST /counterparties/:id/accounts────►  SDP API
                                                     │
                                                     ▼
                                  reads counterparty.identity (KYC payload)
                                                     │
SDP ──POST /grid/customers/external-accounts────►  Grid
       { customerId, accountInfo:{ accountType:"USD_ACCOUNT", routingNumber, accountNumber, ... } }
                                                     │
                                                     ▼  { id: "ext_acct_USD_111", ... }
SDP writes counterparty_accounts row, returns to frontend.
```

After step 1, the DB row is:

```jsonc
{
  id: "counterparty_account_1111",
  counterparty_id: "counterparty_a1b2c3",
  account_kind: "bank_account",
  label: "Mercury USD",           // user-supplied nickname
  details: {},                    // ← never populated for bank
  provider_account_data: {
    grid: { gridExternalAccountId: "ext_acct_USD_111" }
  },
  status: "active"
}
```

SDP **never sees** `routingNumber` / `accountNumber` again after the forward call — they're only in flight, never persisted.

### Step 2 — List accounts (live enrichment for bank rows)

User opens the "Payment methods" tab. The dashboard needs `{ Mercury •• 4242 (USD) }` — but the DB only has the handle.

```
Frontend ──GET /counterparties/:id/accounts────►  SDP API
                                                     │
                                                     ▼
                              repo.listCounterpartyAccountsByCounterparty()
                                  ──► rows with handles only
                                                     │
                                  for each bank_account row:
                                                     │
SDP ──GET /grid/external-accounts/ext_acct_USD_111──►  Grid
                                                     │
                                                     ▼  { bankName:"Mercury", last4:"4242",
                                                        currency:"USD", paymentRails:["ACH"], ... }
                                  merge into response (NOT written back to DB)
                                                     │
Frontend renders: "Mercury •• 4242  (USD · ACH)"
```

Crypto rows skip the fetch — `details` already has `{ currency, network, address }`. The enrichment fan-out only applies to bank rows.

**Caching note (out of scope for this PR):** the provider adapter can hold a short-TTL cache of the Grid response to absorb dashboard refreshes. Cache is in-process or KV, not in our DB.

### Step 3 — Execute an offramp using the bank account

User has internal USDC, picks the Mercury USD bank, and runs an offramp.

```
Frontend ──POST /offramps  { counterpartyAccountId:"counterparty_account_1111",
                              amount:10000, sourceCurrency:"USDC" }
                                                     │
                                                     ▼
                              SDP loads counterparty + counterparty_account from DB
                                  ──► counterparty.provider_data.grid.customerId = "cust_grd_xyz"
                                  ──► provider_account_data.grid.gridExternalAccountId = "ext_acct_USD_111"
                                                     │
SDP ──POST /grid/quotes──────────────────────────►  Grid
       {
         source: { sourceType:"ACCOUNT", accountId:"<internalUsdcAccount>" },
         destination: { destinationType:"ACCOUNT",
                        accountId:"ext_acct_USD_111", currency:"USD" },
         lockedCurrencyAmount: 10000,
         lockedCurrencySide:"SENDING"
       }
                                                     │
                                                     ▼  { quoteId, exchangeRate, fees, ... }
SDP records quote in (future) transfers table, returns to frontend for confirmation
                                                     │
User confirms ──POST /offramps/:quoteId/execute─►  SDP ──POST /grid/quotes/:id/execute──►  Grid
                                                     │
                              Grid emits webhooks → SDP updates transfer status
```

The bank account row itself isn't touched during the offramp — only read. The state machine lives on the (future) `transfers` table; this PR sets the stage.

## Other providers in the same model

### BVNK — multi-provider on the same counterparty

Same Acme Corp later opens a EUR / SEPA receivable via BVNK. The counterparty + identity stay the same; BVNK gets its own namespace inside `provider_data`, and we add a third account row.

```jsonc
// counterparties row (now multi-tenant under provider_data)
{
  id: "counterparty_a1b2c3",
  provider_data: {
    grid: { customerId: "cust_grd_xyz" },
    bvnk: { beneficiaryId: "ben_bvnk_abc" }
  }
}

// new counterparty_accounts row
{
  id: "counterparty_account_3333",
  account_kind: "bank_account",
  label: "Acme EUR / SEPA",
  details: {},
  provider_account_data: {
    bvnk: { bvnkAccountId: "acct_bvnk_eur_333" }
  }
}
```

Listing/offramp flow is symmetric to Grid — just the provider adapter changes. If the *same physical bank account* ever ends up registered with two providers, the row can hold both keys under `provider_account_data`, keeping the UI list de-duped.

### MoonPay — hosted/webhook (for context, not in this PR)

MoonPay has no `POST /external-accounts` and no fetch-back endpoint. Account onboarding happens inside their widget; we receive the final state via webhook. Because we can't fetch it again, the webhook handler caches sanitized metadata directly into `provider_account_data` (the storage-rule exception):

```jsonc
{
  account_kind: "bank_account",
  details: {},
  provider_account_data: {
    moonpay: {
      bankAccountId: "ba_mp_...",
      last4: "4242",
      currency: "USD",
      source: "webhook"
    }
  }
}
```

Transactions for MoonPay live entirely at the `transfers` layer — there's no quote-and-execute API surface to mirror.

## Test plan

- [x] `pnpm typecheck` clean across `@sdp/api` + `@sdp/types`
- [x] `pnpm lint` — no new errors, 22 pre-existing warnings untouched
- [x] `counterparty-account.repository.test.ts` — 15 tests covering create / get / list / update / archive, including:
  - id generation prefix
  - `details` + `providerAccountData` defaulting to `{}` when omitted
  - `getById` tenancy guard (wrong project → null)
  - `getById` archived row → null
  - `listByCounterparty` active-only default, `includeArchived`, `accountKind` filter, counterparty scoping
  - `update` label sentinel (null vs undefined vs string)
  - `update` on archived row → null
  - `archive` idempotency (second call → null)
- [x] Existing counterparty routes test still passes