### PR TITLE
fix: sponsor MagicBlock gasless transfers with Kora

### DIFF
--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -9,6 +9,8 @@ import {
   createTransactionMessage,
   generateKeyPairSigner,
   getBase64EncodedWireTransaction,
+  getCompiledTransactionMessageDecoder,
+  getTransactionDecoder,
   pipe,
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
@@ -87,6 +89,7 @@ const TEST_BVNK_WALLET_ID = "a:24122329329347:HsdJVhW:1";
 const TEST_BVNK_API_BASE_URL = "https://api.sandbox.bvnk.test";
 const TEST_MAGICBLOCK_API_BASE_URL = "https://payments.magicblock.test";
 const TEST_MAGICBLOCK_AUTH_TOKEN = "magicblock_auth_token";
+const TEST_MAGICBLOCK_SPONSOR_FEE_PAYER = "CrankS2fXgMGvQJ3VBrZmRfGrfogDY6pq5YcgkPEpSNf";
 const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 const MOONPAY_PARAM_BASE_CURRENCY_AMOUNT = "baseCurrencyAmount";
 const MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID = "externalCustomerId";
@@ -217,10 +220,12 @@ async function seedAuthAndWallet(): Promise<void> {
 }
 
 function buildMagicBlockTestTransactionBase64(params?: {
+  feePayer?: string;
   source?: string;
   destination?: string;
   additionalSigner?: string;
 }): string {
+  const feePayer = address(params?.feePayer ?? params?.source ?? TEST_SOLANA_ADDRESSES.wallet1);
   const source = address(params?.source ?? TEST_SOLANA_ADDRESSES.wallet1);
   const destination = address(params?.destination ?? TEST_SOLANA_ADDRESSES.wallet2);
   const instructions = [
@@ -243,7 +248,7 @@ function buildMagicBlockTestTransactionBase64(params?: {
 
   const message = pipe(
     createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayer(source, m),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
     (m) =>
       setTransactionMessageLifetimeUsingBlockhash(
         {
@@ -2049,6 +2054,101 @@ describe("Payments routes", () => {
           split: 2,
           minDelayMs: "0",
           maxDelayMs: "1000",
+          gasless: true,
+        });
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("replaces a MagicBlock gasless sponsor signer with Kora during execution", async () => {
+      env.MAGICBLOCK_PRIVATE_PAYMENTS_API_BASE_URL = TEST_MAGICBLOCK_API_BASE_URL;
+      const sourceSigner = await generateKeyPairSigner();
+      await updateSeededWalletPublicKey(sourceSigner.address);
+      createRpcMock.mockReturnValueOnce({
+        getTokenSupply: () => ({
+          send: async () => ({ value: { decimals: 6 } }),
+        }),
+      } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+      createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+      const signAndSendMock = vi
+        .fn()
+        .mockResolvedValue(
+          "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy"
+        );
+      createFeePaymentAdapterMock.mockReturnValueOnce({
+        providerId: "mock",
+        getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+        signAsFeePayer: vi.fn(),
+        signAndSend: signAndSendMock,
+      } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            kind: "transfer",
+            version: "v0",
+            transactionBase64: buildMagicBlockTestTransactionBase64({
+              feePayer: TEST_MAGICBLOCK_SPONSOR_FEE_PAYER,
+              source: sourceSigner.address,
+            }),
+            sendTo: "base",
+            recentBlockhash: "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N",
+            lastValidBlockHeight: 123456,
+            instructionCount: 5,
+            requiredSigners: [TEST_MAGICBLOCK_SPONSOR_FEE_PAYER, sourceSigner.address],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      );
+
+      try {
+        const res = await app.request(
+          "/v1/payments/transfers",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              source: TEST_WALLET_ID,
+              destination: TEST_SOLANA_ADDRESSES.wallet2,
+              token: DEVNET_USDC_MINT,
+              amount: "5",
+              privateTransfer: {
+                provider: "magicblock",
+                magicBlock: {},
+              },
+            }),
+          },
+          env
+        );
+
+        expect(res.status).toBe(200);
+        expect(signAndSendMock).toHaveBeenCalledTimes(1);
+        const [encodedTransaction] = signAndSendMock.mock.calls[0] ?? [];
+        const transaction = getTransactionDecoder().decode(encodedTransaction as Uint8Array);
+        const message = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+        expect(message.staticAccounts[0]).toBe(TEST_KORA_FEE_PAYER);
+        expect(message.staticAccounts[1]).toBe(sourceSigner.address);
+        expect(message.staticAccounts).not.toContain(TEST_MAGICBLOCK_SPONSOR_FEE_PAYER);
+        expect(Object.keys(transaction.signatures)).toContain(TEST_KORA_FEE_PAYER);
+        expect(Object.keys(transaction.signatures)).toContain(sourceSigner.address);
+        expect(Object.keys(transaction.signatures)).not.toContain(
+          TEST_MAGICBLOCK_SPONSOR_FEE_PAYER
+        );
+        const [, init] = fetchSpy.mock.calls[0] ?? [];
+        const providerPayload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        expect(providerPayload).toMatchObject({
+          from: sourceSigner.address,
+          visibility: "private",
+          fromBalance: "base",
+          toBalance: "base",
+          gasless: true,
         });
       } finally {
         fetchSpy.mockRestore();

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1955,6 +1955,44 @@ describe("Payments routes", () => {
       }
     });
 
+    it("rejects MagicBlock execution when gasless sponsorship is explicitly disabled", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      try {
+        const res = await app.request(
+          "/v1/payments/transfers",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              source: TEST_WALLET_ID,
+              destination: TEST_SOLANA_ADDRESSES.wallet2,
+              token: DEVNET_USDC_MINT,
+              amount: "1",
+              privateTransfer: {
+                provider: "magicblock",
+                magicBlock: {
+                  gasless: false,
+                },
+              },
+            }),
+          },
+          env
+        );
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error: { code: string; message: string } };
+        expect(body.error.code).toBe("BAD_REQUEST");
+        expect(body.error.message).toContain("requires gasless transactions");
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     it("executes a MagicBlock private transfer that settles to base balance", async () => {
       env.MAGICBLOCK_PRIVATE_PAYMENTS_API_BASE_URL = TEST_MAGICBLOCK_API_BASE_URL;
       const sourceSigner = await generateKeyPairSigner();

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -458,9 +458,9 @@ type MagicBlockProductOptions = Extract<
 
 function buildMagicBlockProviderTransferOptions(
   options: MagicBlockProductOptions,
-  overrides?: { gasless?: boolean }
+  context?: { koraSponsoredExecution?: boolean }
 ): MagicBlockProviderTransferOptions {
-  const gasless = overrides?.gasless ?? options.gasless;
+  const gasless = context?.koraSponsoredExecution ? true : options.gasless;
 
   return {
     ...(options.validator ? { validator: options.validator } : {}),
@@ -508,7 +508,7 @@ async function prepareMagicBlockPrivateTransferForOperation(params: {
   operation: OutboundPaymentOperation;
   privateTransfer: PrivateTransferRequest;
   memo?: string;
-  forceGasless?: boolean;
+  koraSponsoredExecution?: boolean;
 }): Promise<{
   prepared: PreparedTransferPayload;
   metadata: PreparedPrivateTransferMetadata;
@@ -546,11 +546,20 @@ async function prepareMagicBlockPrivateTransferForOperation(params: {
     amount: Number(amountBaseUnits),
     memo,
     options: buildMagicBlockProviderTransferOptions(privateTransfer.magicBlock, {
-      gasless: params.forceGasless ? true : undefined,
+      koraSponsoredExecution: params.koraSponsoredExecution,
     }),
   });
 
   return mapMagicBlockPreparedTransfer(magicBlockPrepared);
+}
+
+function assertMagicBlockKoraSponsoredExecutionOptions(options: MagicBlockProductOptions): void {
+  if (options.gasless === false) {
+    throw new AppError(
+      "BAD_REQUEST",
+      "MagicBlock private transfer execution is sponsored by Kora and requires gasless transactions. Remove gasless or set it to true."
+    );
+  }
 }
 
 function decodeMagicBlockPreparedTransaction(serializedTx: string) {
@@ -574,14 +583,15 @@ function decodeMagicBlockPreparedTransaction(serializedTx: string) {
   return { transaction, compiledMessage, existingFeePayer };
 }
 
+type DecodedMagicBlockPreparedTransaction = ReturnType<typeof decodeMagicBlockPreparedTransaction>;
+
 function addSponsoredFeePayerToPreparedTransaction(
-  serializedTx: string,
+  decoded: DecodedMagicBlockPreparedTransaction,
   feePayer: Address,
   requiredSigners: string[],
   options?: { replaceExistingFeePayer?: boolean }
 ) {
-  const { transaction, compiledMessage, existingFeePayer } =
-    decodeMagicBlockPreparedTransaction(serializedTx);
+  const { transaction, compiledMessage, existingFeePayer } = decoded;
 
   if (existingFeePayer === feePayer) {
     return transaction;
@@ -707,7 +717,8 @@ async function executePreparedPrivateTransfer(
   const walletsByAddress = new Map(wallets.map((wallet) => [wallet.publicKey, wallet]));
   const signerWallets = new Map<string, CustodyWallet>();
   const requiredSigners = [...new Set(metadata.magicBlock.requiredSigners)];
-  const existingFeePayer = decodeMagicBlockPreparedTransaction(serializedTx).existingFeePayer;
+  const decodedTransaction = decodeMagicBlockPreparedTransaction(serializedTx);
+  const existingFeePayer = decodedTransaction.existingFeePayer;
   const shouldReplaceProviderFeePayer =
     requiredSigners.includes(existingFeePayer) && !walletsByAddress.has(existingFeePayer);
   const custodyRequiredSigners = shouldReplaceProviderFeePayer
@@ -749,7 +760,7 @@ async function executePreparedPrivateTransfer(
   const feePayment = getFeePayment(c);
   const feePayer = await feePayment.getFeePayer();
   const transaction = addSponsoredFeePayerToPreparedTransaction(
-    serializedTx,
+    decodedTransaction,
     feePayer,
     custodyRequiredSigners,
     { replaceExistingFeePayer: shouldReplaceProviderFeePayer }
@@ -1612,12 +1623,15 @@ export async function createTransfer(c: AppContext) {
 
   const privateTransfer = parsed.data.privateTransfer as PrivateTransferRequest | undefined;
   if (privateTransfer) {
+    assertMagicBlockKoraSponsoredExecutionOptions(privateTransfer.magicBlock);
     const mapped = await prepareMagicBlockPrivateTransferForOperation({
       c,
       operation,
       privateTransfer,
       memo: parsed.data.memo,
-      forceGasless: true,
+      // MagicBlock's gasless response separates the source signer from the provider sponsor.
+      // SDP swaps that sponsor slot for Kora before signing and submission.
+      koraSponsoredExecution: true,
     });
     const transferType: TransferType = "transfer_confidential";
     const transfer = await createTransferRecord(c, {

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -457,8 +457,11 @@ type MagicBlockProductOptions = Extract<
 >["magicBlock"];
 
 function buildMagicBlockProviderTransferOptions(
-  options: MagicBlockProductOptions
+  options: MagicBlockProductOptions,
+  overrides?: { gasless?: boolean }
 ): MagicBlockProviderTransferOptions {
+  const gasless = overrides?.gasless ?? options.gasless;
+
   return {
     ...(options.validator ? { validator: options.validator } : {}),
     ...(options.initIfMissing !== undefined ? { initIfMissing: options.initIfMissing } : {}),
@@ -472,7 +475,7 @@ function buildMagicBlockProviderTransferOptions(
     ...(options.maxDelayMs !== undefined ? { maxDelayMs: options.maxDelayMs } : {}),
     ...(options.clientRefId !== undefined ? { clientRefId: options.clientRefId } : {}),
     ...(options.split !== undefined ? { split: options.split } : {}),
-    ...(options.gasless !== undefined ? { gasless: options.gasless } : {}),
+    ...(gasless !== undefined ? { gasless } : {}),
     ...(options.legacy !== undefined ? { legacy: options.legacy } : {}),
   };
 }
@@ -505,6 +508,7 @@ async function prepareMagicBlockPrivateTransferForOperation(params: {
   operation: OutboundPaymentOperation;
   privateTransfer: PrivateTransferRequest;
   memo?: string;
+  forceGasless?: boolean;
 }): Promise<{
   prepared: PreparedTransferPayload;
   metadata: PreparedPrivateTransferMetadata;
@@ -541,17 +545,15 @@ async function prepareMagicBlockPrivateTransferForOperation(params: {
     mint: mintAddress,
     amount: Number(amountBaseUnits),
     memo,
-    options: buildMagicBlockProviderTransferOptions(privateTransfer.magicBlock),
+    options: buildMagicBlockProviderTransferOptions(privateTransfer.magicBlock, {
+      gasless: params.forceGasless ? true : undefined,
+    }),
   });
 
   return mapMagicBlockPreparedTransfer(magicBlockPrepared);
 }
 
-function addSponsoredFeePayerToPreparedTransaction(
-  serializedTx: string,
-  feePayer: Address,
-  requiredSigners: string[]
-) {
+function decodeMagicBlockPreparedTransaction(serializedTx: string) {
   const txBytes = Buffer.from(serializedTx, "base64");
   const transaction = getTransactionDecoder().decode(txBytes);
   const compiledMessage = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
@@ -569,6 +571,18 @@ function addSponsoredFeePayerToPreparedTransaction(
     throw new AppError("PROVIDER_UNAVAILABLE", "MagicBlock transaction has no fee payer.");
   }
 
+  return { transaction, compiledMessage, existingFeePayer };
+}
+
+function addSponsoredFeePayerToPreparedTransaction(
+  serializedTx: string,
+  feePayer: Address,
+  requiredSigners: string[],
+  options?: { replaceExistingFeePayer?: boolean }
+) {
+  const { transaction, compiledMessage, existingFeePayer } =
+    decodeMagicBlockPreparedTransaction(serializedTx);
+
   if (existingFeePayer === feePayer) {
     return transaction;
   }
@@ -578,6 +592,30 @@ function addSponsoredFeePayerToPreparedTransaction(
       "PROVIDER_UNAVAILABLE",
       "MagicBlock transaction already includes the Kora fee payer in a non-fee-payer position."
     );
+  }
+
+  if (options?.replaceExistingFeePayer) {
+    const { [existingFeePayer]: _existingFeePayerSignature, ...remainingSignatures } =
+      transaction.signatures;
+    const sponsoredMessage = {
+      ...compiledMessage,
+      staticAccounts: [feePayer, ...compiledMessage.staticAccounts.slice(1)],
+    };
+
+    const messageBytes = getCompiledTransactionMessageEncoder().encode(
+      sponsoredMessage
+    ) as typeof transaction.messageBytes;
+    const signatures = {
+      [feePayer]: null,
+      ...remainingSignatures,
+    } as typeof transaction.signatures;
+
+    return {
+      messageBytes,
+      signatures: {
+        ...signatures,
+      },
+    };
   }
 
   const signerCount = compiledMessage.header.numSignerAccounts;
@@ -669,15 +707,21 @@ async function executePreparedPrivateTransfer(
   const walletsByAddress = new Map(wallets.map((wallet) => [wallet.publicKey, wallet]));
   const signerWallets = new Map<string, CustodyWallet>();
   const requiredSigners = [...new Set(metadata.magicBlock.requiredSigners)];
+  const existingFeePayer = decodeMagicBlockPreparedTransaction(serializedTx).existingFeePayer;
+  const shouldReplaceProviderFeePayer =
+    requiredSigners.includes(existingFeePayer) && !walletsByAddress.has(existingFeePayer);
+  const custodyRequiredSigners = shouldReplaceProviderFeePayer
+    ? requiredSigners.filter((signer) => signer !== existingFeePayer)
+    : requiredSigners;
 
-  for (const requiredSigner of requiredSigners) {
+  for (const requiredSigner of custodyRequiredSigners) {
     const wallet = walletsByAddress.get(requiredSigner);
     if (wallet) {
       signerWallets.set(wallet.publicKey, wallet);
     }
   }
 
-  const missingSignerCount = requiredSigners.length - signerWallets.size;
+  const missingSignerCount = custodyRequiredSigners.length - signerWallets.size;
   if (missingSignerCount > 0) {
     throw new AppError(
       "BAD_REQUEST",
@@ -707,7 +751,8 @@ async function executePreparedPrivateTransfer(
   const transaction = addSponsoredFeePayerToPreparedTransaction(
     serializedTx,
     feePayer,
-    requiredSigners
+    custodyRequiredSigners,
+    { replaceExistingFeePayer: shouldReplaceProviderFeePayer }
   );
   const signedTransaction =
     signers.length > 0
@@ -1572,6 +1617,7 @@ export async function createTransfer(c: AppContext) {
       operation,
       privateTransfer,
       memo: parsed.data.memo,
+      forceGasless: true,
     });
     const transferType: TransferType = "transfer_confidential";
     const transfer = await createTransferRecord(c, {


### PR DESCRIPTION
## Summary

- force server-side MagicBlock private transfer execution to request MagicBlock gasless transaction shape
- replace MagicBlock's provider sponsor signer with the configured Kora fee payer before signing/submitting
- keep requiring the source wallet signer to be SDP-controlled, and cover the sponsor replacement path in payments tests

## Root cause

MagicBlock gasless transfers return a prepared transaction that includes MagicBlock's sponsor signer as the fee payer plus the source wallet signer. SDP previously treated every required signer as an SDP custody wallet, so execution could reject the MagicBlock sponsor signer instead of replacing it with Kora.

## Validation

- `pnpm --filter @sdp/api exec biome check src/routes/payments/handlers/transfers.ts src/routes/payments.test.ts`
- `pnpm --filter @sdp/api exec vitest run --config vitest.workers.config.ts src/routes/payments.test.ts`
- `pnpm --filter @sdp/api typecheck`
