### PR TITLE
feat: enable pay/deposit routes behind FF

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/layout.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/layout.tsx
@@ -1,0 +1,11 @@
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+import { DASHBOARD_FEATURE_FLAGS } from "@/lib/dashboard-feature-flags";
+
+export default function CounterpartyLayout({ children }: { children: ReactNode }) {
+  if (!DASHBOARD_FEATURE_FLAGS.paymentsV2) {
+    notFound();
+  }
+
+  return children;
+}

--- a/apps/sdp-web/src/app/dashboard/payments/deposit/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/deposit/page.tsx
@@ -8,7 +8,7 @@ import type { OnboardingStatusResponse } from "../../onboarding-status";
 import { PaymentsActionPage } from "../payments-action-page";
 import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 
-export default async function PaymentsSendPage() {
+export default async function PaymentsDepositPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
     redirect(await getAuthEntryPath());
@@ -16,8 +16,8 @@ export default async function PaymentsSendPage() {
   if (!orgId) {
     redirect("/dashboard");
   }
-  if (DASHBOARD_FEATURE_FLAGS.paymentsV2) {
-    redirect("/dashboard/payments/pay");
+  if (!DASHBOARD_FEATURE_FLAGS.paymentsV2) {
+    redirect("/dashboard/payments/receive");
   }
 
   const apiClient = await createSdpApiClient();
@@ -42,7 +42,8 @@ export default async function PaymentsSendPage() {
 
   return (
     <PaymentsActionPage
-      mode="send"
+      mode="receive"
+      actionLabel="Deposit"
       wallets={[]}
       walletsError={null}
       issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}

--- a/apps/sdp-web/src/app/dashboard/payments/pay/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/pay/page.tsx
@@ -8,7 +8,7 @@ import type { OnboardingStatusResponse } from "../../onboarding-status";
 import { PaymentsActionPage } from "../payments-action-page";
 import { fetchPaymentsIssuedTokenSymbols } from "../payments-page.data";
 
-export default async function PaymentsSendPage() {
+export default async function PaymentsPayPage() {
   const { userId, orgId } = await auth();
   if (!userId) {
     redirect(await getAuthEntryPath());
@@ -16,8 +16,8 @@ export default async function PaymentsSendPage() {
   if (!orgId) {
     redirect("/dashboard");
   }
-  if (DASHBOARD_FEATURE_FLAGS.paymentsV2) {
-    redirect("/dashboard/payments/pay");
+  if (!DASHBOARD_FEATURE_FLAGS.paymentsV2) {
+    redirect("/dashboard/payments/send");
   }
 
   const apiClient = await createSdpApiClient();
@@ -43,6 +43,7 @@ export default async function PaymentsSendPage() {
   return (
     <PaymentsActionPage
       mode="send"
+      actionLabel="Pay"
       wallets={[]}
       walletsError={null}
       issuedTokenSymbolsByMint={issuedTokenSymbolsByMint}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx
@@ -46,6 +46,7 @@ import { ProviderRiskTable } from "./provider-risk-table";
 
 interface PaymentsActionPageProps {
   mode: "send" | "receive";
+  actionLabel?: string;
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
   issuedTokenSymbolsByMint: Record<string, string>;
@@ -380,14 +381,19 @@ function buildRampReviewRows(input: RampReviewRowsInput): SummaryRow[] {
 
 function resolveStepSequence(
   mode: "send" | "receive",
-  branch: ActionBranch | null
+  branch: ActionBranch | null,
+  actionLabel: string
 ): StepDefinition[] {
+  const actionLabelLower = actionLabel.toLowerCase();
+  const depositActionPhrase =
+    actionLabelLower === "receive" ? "receive funds into" : `${actionLabelLower} into`;
+
   if (!branch) {
     return [
       {
         id: "branch",
         label: "Flow",
-        title: `Choose a ${mode} flow`,
+        title: `Choose a ${actionLabelLower} flow`,
         description:
           mode === "send"
             ? "Choose whether you are sending to another wallet or starting an off-ramp."
@@ -401,7 +407,7 @@ function resolveStepSequence(
       {
         id: "branch",
         label: "Flow",
-        title: "Choose a send flow",
+        title: `Choose a ${actionLabelLower} flow`,
         description: "Wallet transfer keeps the flow inside SDP wallets and Solana addresses.",
       },
       {
@@ -424,7 +430,7 @@ function resolveStepSequence(
       {
         id: "branch",
         label: "Flow",
-        title: "Choose a receive flow",
+        title: `Choose a ${actionLabelLower} flow`,
         description: "Wallet deposit shows the wallet details needed to receive funds directly.",
       },
       {
@@ -435,9 +441,9 @@ function resolveStepSequence(
       },
       {
         id: "deposit",
-        label: "Receive",
-        title: "Receive funds",
-        description: "Use this address or QR code to deposit into the selected wallet.",
+        label: actionLabel,
+        title: `${actionLabel} funds`,
+        description: `Use this address or QR code to ${depositActionPhrase} the selected wallet.`,
       },
     ];
   }
@@ -446,7 +452,7 @@ function resolveStepSequence(
     {
       id: "branch",
       label: "Flow",
-      title: `Choose a ${mode} flow`,
+      title: `Choose a ${actionLabelLower} flow`,
       description:
         branch === "onramp"
           ? "On-ramp flows move fiat into the selected wallet through a provider."
@@ -534,7 +540,7 @@ function ReviewSummaryCard({ rows }: { rows: Array<{ label: string; value: React
   );
 }
 
-function WalletAddressQrCode({ address }: { address: string }) {
+function WalletAddressQrCode({ address, actionVerb }: { address: string; actionVerb: string }) {
   const [qrCodeUrl, setQrCodeUrl] = useState("");
 
   useEffect(() => {
@@ -592,7 +598,7 @@ function WalletAddressQrCode({ address }: { address: string }) {
         </div>
         <div className="min-w-0 flex-1 space-y-3">
           <p className="text-sm text-text-low">
-            Scan this QR code or copy the address to receive funds into the selected wallet.
+            Scan this QR code or copy the address to {actionVerb} funds into the selected wallet.
           </p>
           <div className="rounded-2xl border border-border-extra-light bg-white px-4 py-3">
             <p className="break-all font-mono text-xs text-text-medium">{address}</p>
@@ -1204,6 +1210,7 @@ function RampProviderFields({
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this component intentionally coordinates the full multi-step payments flow in one place.
 export function PaymentsActionPage({
   mode,
+  actionLabel,
   wallets,
   walletsError,
   issuedTokenSymbolsByMint,
@@ -1212,6 +1219,12 @@ export function PaymentsActionPage({
 }: PaymentsActionPageProps) {
   const { sdpEnvironment } = useDashboardWorkspace();
   const router = useRouter();
+  const actionTitle = actionLabel ?? (mode === "send" ? "Send" : "Receive");
+  const actionVerb = actionTitle.toLowerCase();
+  const transferActionDescription =
+    actionTitle === "Pay"
+      ? "Pay from an SDP wallet to a destination Solana address."
+      : `${actionTitle} funds from an SDP wallet to a destination Solana address.`;
 
   const [branch, setBranch] = useState<ActionBranch | null>(null);
   const [provider, setProvider] = useState<RampProviderId | null>(null);
@@ -1329,7 +1342,10 @@ export function PaymentsActionPage({
     }
   }, [assetOptions, selectedAsset]);
 
-  const steps = useMemo(() => resolveStepSequence(mode, branch), [branch, mode]);
+  const steps = useMemo(
+    () => resolveStepSequence(mode, branch, actionTitle),
+    [actionTitle, branch, mode]
+  );
   const safeStepIndex = Math.min(stepIndex, steps.length - 1);
   const currentStep = steps[safeStepIndex] ?? steps[0];
 
@@ -1982,7 +1998,7 @@ export function PaymentsActionPage({
           <ActionChoiceCard
             active={branch === "wallet_transfer"}
             title="Wallet transfer"
-            description="Send funds from an SDP wallet to a destination Solana address."
+            description={transferActionDescription}
             icon={<ArrowUpRight className="size-5" />}
             onClick={() => selectBranch("wallet_transfer")}
           />
@@ -2006,7 +2022,7 @@ export function PaymentsActionPage({
           <ActionChoiceCard
             active={branch === "wallet_deposit"}
             title="Wallet deposit"
-            description="Receive funds directly into one of your SDP wallets."
+            description={`${actionTitle} funds directly into one of your SDP wallets.`}
             icon={<ArrowDownLeft className="size-5" />}
             onClick={() => selectBranch("wallet_deposit")}
           />
@@ -2463,7 +2479,7 @@ export function PaymentsActionPage({
           },
         ]}
       />
-      <WalletAddressQrCode address={selectedWallet?.publicKey ?? ""} />
+      <WalletAddressQrCode address={selectedWallet?.publicKey ?? ""} actionVerb={actionVerb} />
     </div>
   );
 
@@ -2504,7 +2520,7 @@ export function PaymentsActionPage({
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 py-8">
         <div className="space-y-3 text-center">
           <p className="text-[44px] leading-none font-medium tracking-[-0.04em] text-text-extra-high">
-            {isSendAction ? "Send" : "Receive"}
+            {actionTitle}
           </p>
           <p className="text-base text-text-low">
             You need at least one wallet before you can start this flow.

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx
@@ -16,6 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { DASHBOARD_FEATURE_FLAGS } from "@/lib/dashboard-feature-flags";
 import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
 import {
   formatCurrencyAmount,
@@ -193,28 +194,30 @@ export function PaymentsOverview({
 
   return (
     <div className="grid min-w-0 gap-6 overflow-x-hidden">
-      <SectionEntry>
-        <div className="flex min-w-0 flex-wrap items-center gap-3">
-          <Button
-            type="button"
-            className="rounded-full px-5 whitespace-nowrap"
-            disabled={!hasWallets}
-            iconLeft={<ArrowUpRight className="size-4" />}
-            onClick={() => router.push("/dashboard/payments/send")}
-          >
-            Send
-          </Button>
-          <Button
-            type="button"
-            className="rounded-full px-5 whitespace-nowrap"
-            disabled={!hasWallets}
-            iconLeft={<ArrowDownLeft className="size-4" />}
-            onClick={() => router.push("/dashboard/payments/receive")}
-          >
-            Receive
-          </Button>
-        </div>
-      </SectionEntry>
+      {DASHBOARD_FEATURE_FLAGS.paymentsV2 ? null : (
+        <SectionEntry>
+          <div className="flex min-w-0 flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              className="rounded-full px-5 whitespace-nowrap"
+              disabled={!hasWallets}
+              iconLeft={<ArrowUpRight className="size-4" />}
+              onClick={() => router.push("/dashboard/payments/send")}
+            >
+              Send
+            </Button>
+            <Button
+              type="button"
+              className="rounded-full px-5 whitespace-nowrap"
+              disabled={!hasWallets}
+              iconLeft={<ArrowDownLeft className="size-4" />}
+              onClick={() => router.push("/dashboard/payments/receive")}
+            >
+              Receive
+            </Button>
+          </div>
+        </SectionEntry>
+      )}
 
       <SectionEntry delay={0.04}>
         <div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,1fr)]">

--- a/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/receive/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getAuthEntryPath } from "@/lib/auth-entry";
+import { DASHBOARD_FEATURE_FLAGS } from "@/lib/dashboard-feature-flags";
 import { fetchProviderAvailability } from "@/lib/provider-availability";
 import { createSdpApiClient } from "@/lib/sdp-api";
 import type { OnboardingStatusResponse } from "../../onboarding-status";
@@ -14,6 +15,9 @@ export default async function PaymentsReceivePage() {
   }
   if (!orgId) {
     redirect("/dashboard");
+  }
+  if (DASHBOARD_FEATURE_FLAGS.paymentsV2) {
+    redirect("/dashboard/payments/deposit");
   }
 
   const apiClient = await createSdpApiClient();

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -70,11 +70,11 @@ const navSections: NavSection[] = [
         label: "Payments",
         href: "/dashboard/payments",
         icon: ArrowLeftRightIcon,
-        children: DASHBOARD_FEATURE_FLAGS.paymentsSubmenu
+        children: DASHBOARD_FEATURE_FLAGS.paymentsV2
           ? [
               { label: "Counterparty", href: "/dashboard/payments/counterparty" },
-              { label: "Pay", href: "/dashboard/pay", disabled: true },
-              { label: "Deposit", href: "/dashboard/deposit", disabled: true },
+              { label: "Pay", href: "/dashboard/payments/pay" },
+              { label: "Deposit", href: "/dashboard/payments/deposit" },
             ]
           : [],
       },
@@ -323,7 +323,13 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
     };
   }
   if (pathname.startsWith("/dashboard/payments/")) {
-    const actionTitle = pathname.endsWith("/receive") ? "Receive" : "Send";
+    const actionTitle = pathname.startsWith("/dashboard/payments/deposit")
+      ? "Deposit"
+      : pathname.startsWith("/dashboard/payments/pay")
+        ? "Pay"
+        : pathname.endsWith("/receive")
+          ? "Receive"
+          : "Send";
 
     return {
       title: "",

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -371,9 +371,14 @@ function isItemActive(pathname: string, href: string): boolean {
     return pathname.startsWith("/dashboard/wallets") || pathname.startsWith("/dashboard/custody");
   }
   if (href === "/dashboard/payments") {
+    const isGatedPaymentsV2Route =
+      pathname.startsWith("/dashboard/payments/pay") ||
+      pathname.startsWith("/dashboard/payments/deposit");
+
     return (
       pathname.startsWith("/dashboard/payments") &&
-      !pathname.startsWith("/dashboard/payments/counterparty")
+      !pathname.startsWith("/dashboard/payments/counterparty") &&
+      (DASHBOARD_FEATURE_FLAGS.paymentsV2 || !isGatedPaymentsV2Route)
     );
   }
   return pathname === href || pathname.startsWith(`${href}/`);

--- a/apps/sdp-web/src/lib/dashboard-feature-flags.ts
+++ b/apps/sdp-web/src/lib/dashboard-feature-flags.ts
@@ -1,3 +1,3 @@
 export const DASHBOARD_FEATURE_FLAGS = {
-  paymentsSubmenu: false,
+  paymentsV2: false,
 } as const;


### PR DESCRIPTION
## Summary
- Adds duplicated `/dashboard/payments/pay` and `/dashboard/payments/deposit` routes for the new Pay and Deposit labels while keeping the existing Send and Receive routes in place.
- Updates the Payments sidebar submenu to use `DASHBOARD_FEATURE_FLAGS.paymentsV2` and link to Counterparty, Pay, and Deposit when the flag is enabled.
- Reuses the existing payments action flow with route-specific labels so the new routes render as Pay/Deposit without changing the underlying send/receive modes.

FF OFF
<img width="3456" height="2083" alt="CleanShot 2026-05-29 at 15 31 11@2x" src="https://github.com/user-attachments/assets/931cb635-a7c2-4017-83c9-1bdbea669b90" />

FF ON
<img width="3456" height="2081" alt="CleanShot 2026-05-29 at 15 35 05@2x" src="https://github.com/user-attachments/assets/6e933a3f-c53b-42ad-8f4d-48a8d81610a5" />

other routes should 404


## Feature flag behavior
`DASHBOARD_FEATURE_FLAGS.paymentsV2` gates the new Payments navigation and entry points:
- When `true`, the Payments submenu is shown with Counterparty, Pay, and Deposit; the overview Send/Receive CTA row is hidden; `/dashboard/payments/send` redirects to `/dashboard/payments/pay`; `/dashboard/payments/receive` redirects to `/dashboard/payments/deposit`.
- When `false`, the Payments submenu stays hidden; the overview still shows the existing Send and Receive buttons; `/dashboard/payments/send` and `/dashboard/payments/receive` continue to render the legacy flows; the new Pay/Deposit routes redirect back to their legacy Send/Receive counterparts.

## Test plan
- `pnpm --filter sdp-web exec next typegen && pnpm --filter sdp-web typecheck`
- `pnpm exec biome check apps/sdp-web/src/app/dashboard/payments/payments-action-page.tsx apps/sdp-web/src/app/dashboard/payments/payments-overview.tsx apps/sdp-web/src/app/dashboard/payments/send/page.tsx apps/sdp-web/src/app/dashboard/payments/receive/page.tsx apps/sdp-web/src/app/dashboard/payments/pay/page.tsx apps/sdp-web/src/app/dashboard/payments/deposit/page.tsx apps/sdp-web/src/components/dashboard-shell.tsx`