### PR TITLE
feat: configure onramp base

### DIFF
--- a/apps/sdp-api/src/lib/ramps/fetch.ts
+++ b/apps/sdp-api/src/lib/ramps/fetch.ts
@@ -1,0 +1,65 @@
+import type { RampProviderId } from "@sdp/types/provider-access";
+import { AppError, type ErrorCode } from "@/lib/errors";
+
+export interface ProviderRequestInit<TBody> {
+  method: "GET" | "POST";
+  headers?: HeadersInit;
+  body?: TBody;
+}
+
+export function classifyProviderStatus(status: number): ErrorCode {
+  if (status === 429) return "RATE_LIMITED";
+  if (status >= 500) return "PROVIDER_UNAVAILABLE";
+  return "BAD_REQUEST";
+}
+
+export function extractProviderErrorMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== "object") return fallback;
+  const record = payload as { error?: { message?: unknown }; message?: unknown; reason?: unknown };
+  const message = record.error?.message ?? record.message ?? record.reason;
+  return typeof message === "string" && message.trim() ? message : fallback;
+}
+
+export async function providerFetchJson<TResponse, TBody = never>(
+  provider: RampProviderId,
+  url: string,
+  init: ProviderRequestInit<TBody>
+): Promise<TResponse> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: init.method,
+      headers: { "Content-Type": "application/json", ...init.headers },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    });
+  } catch {
+    throw new AppError("PROVIDER_UNAVAILABLE", `Failed to reach the ${provider} API`, { provider });
+  }
+
+  const raw = await response.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (!response.ok) {
+    throw new AppError(
+      classifyProviderStatus(response.status),
+      extractProviderErrorMessage(
+        parsed,
+        `${provider} request failed with status ${response.status}`
+      ),
+      { provider, providerStatus: response.status }
+    );
+  }
+
+  if (parsed === undefined) {
+    throw new AppError("PROVIDER_UNAVAILABLE", `${provider} returned an unparseable response`, {
+      provider,
+    });
+  }
+
+  return parsed as TResponse;
+}

--- a/apps/sdp-api/src/lib/ramps/fetch.ts
+++ b/apps/sdp-api/src/lib/ramps/fetch.ts
@@ -8,6 +8,7 @@ export interface ProviderRequestInit<TBody> {
 }
 
 export function classifyProviderStatus(status: number): ErrorCode {
+  if (status === 409) return "CONFLICT";
   if (status === 429) return "RATE_LIMITED";
   if (status >= 500) return "PROVIDER_UNAVAILABLE";
   return "BAD_REQUEST";

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -1,3 +1,4 @@
+import type { LightsparkPaymentRampInstruction } from "@sdp/types";
 import { parseFiatCurrency } from "@sdp/types/payment-rails";
 import {
   basicAuthHeader,
@@ -7,7 +8,97 @@ import {
   SOLANA_ASSET_TO_RAIL,
 } from "../common";
 import { RAMP_RAIL_DUMPS } from "../constants";
+import { type ProviderRequestInit, providerFetchJson } from "../fetch";
 import type { ProviderRampSupport, RampDumpReader, RampProviderClient } from "../types";
+
+/** Connection details for live Grid API calls. */
+export interface LightsparkConfig {
+  tokenId: string;
+  clientSecret: string;
+  apiBaseUrl: string;
+}
+
+export type LightsparkCustomerType = "INDIVIDUAL" | "BUSINESS";
+
+export interface CreateLightsparkCustomerInput {
+  platformCustomerId: string;
+  customerType: LightsparkCustomerType;
+  fullName: string;
+  email?: string;
+}
+
+export interface LightsparkCustomer {
+  id: string;
+}
+
+interface GridCreateCustomerBody {
+  platformCustomerId: string;
+  customerType: LightsparkCustomerType;
+  fullName: string;
+  email?: string;
+}
+
+interface GridCustomerResponse {
+  id: string;
+}
+
+interface GridCreateQuoteBody {
+  source: {
+    sourceType: "REALTIME_FUNDING";
+    customerId: string;
+    currency: string;
+  };
+  destination: {
+    destinationType: "ACCOUNT";
+    accountId: string;
+    currency: string;
+  };
+  lockedCurrencySide: "SENDING" | "RECEIVING";
+  lockedCurrencyAmount: number;
+  description: string;
+}
+
+interface GridPaymentInstruction {
+  accountOrWalletInfo: LightsparkPaymentRampInstruction["accountOrWalletInfo"];
+  instructionsNotes?: string;
+  isPlatformAccount?: boolean;
+}
+
+interface GridQuoteResponse {
+  id: string;
+  status: string;
+  paymentInstructions?: GridPaymentInstruction[];
+  exchangeRate: number;
+  totalSendingAmount: number;
+  totalReceivingAmount: number;
+  feesIncluded: number;
+  expiresAt: string;
+}
+
+export interface CreateLightsparkOnrampQuoteInput {
+  /** Grid customer that will fund the quote in real time. */
+  customerId: string;
+  /** Grid external account id the crypto will be delivered to (e.g. ExternalAccount:...). */
+  destinationAccountId: string;
+  /** Source fiat currency code (e.g. USD). */
+  fiatCurrency: string;
+  /** Destination crypto currency code (e.g. USDC). */
+  cryptoCurrency: string;
+  /** Locked sending amount in the fiat currency's smallest unit (cents). */
+  fiatAmountMinorUnits: number;
+  description?: string;
+}
+
+export interface LightsparkQuote {
+  id: string;
+  status?: string;
+  paymentInstructions?: LightsparkPaymentRampInstruction[];
+  exchangeRate?: number;
+  totalSendingAmount?: number;
+  totalReceivingAmount?: number;
+  feesIncluded?: number;
+  expiresAt?: string;
+}
 
 interface LightsparkSupportedCurrency {
   currencyCode?: string;
@@ -73,4 +164,86 @@ export class LightsparkRampClient implements RampProviderClient {
       await readDump<LightsparkConfigDump>(RAMP_RAIL_DUMPS.lightspark.config.file)
     );
   }
+
+  private async request<TResponse, TBody = never>(
+    config: LightsparkConfig,
+    path: string,
+    init: ProviderRequestInit<TBody>
+  ): Promise<TResponse> {
+    const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
+    const url = new URL(path, base);
+
+    return providerFetchJson<TResponse, TBody>(this.id, url.toString(), {
+      ...init,
+      headers: {
+        Authorization: basicAuthHeader(config.tokenId, config.clientSecret),
+        ...init.headers,
+      },
+    });
+  }
+
+  /** Creates a native Grid customer for a counterparty (KYC'd buyer). */
+  async createCustomer(
+    config: LightsparkConfig,
+    input: CreateLightsparkCustomerInput
+  ): Promise<LightsparkCustomer> {
+    const response = await this.request<GridCustomerResponse, GridCreateCustomerBody>(
+      config,
+      "customers",
+      {
+        method: "POST",
+        body: {
+          platformCustomerId: input.platformCustomerId,
+          customerType: input.customerType,
+          fullName: input.fullName,
+          ...(input.email ? { email: input.email } : {}),
+        },
+      }
+    );
+
+    return { id: response.id };
+  }
+
+  /** Creates a just-in-time (real-time funded) onramp quote and locks the FX rate. */
+  async createOnrampQuote(
+    config: LightsparkConfig,
+    input: CreateLightsparkOnrampQuoteInput
+  ): Promise<LightsparkQuote> {
+    const response = await this.request<GridQuoteResponse, GridCreateQuoteBody>(config, "quotes", {
+      method: "POST",
+      body: {
+        source: {
+          sourceType: "REALTIME_FUNDING",
+          customerId: input.customerId,
+          currency: input.fiatCurrency,
+        },
+        destination: {
+          destinationType: "ACCOUNT",
+          accountId: input.destinationAccountId,
+          currency: input.cryptoCurrency,
+        },
+        lockedCurrencySide: "SENDING",
+        lockedCurrencyAmount: input.fiatAmountMinorUnits,
+        description: input.description ?? "SDP onramp",
+      },
+    });
+
+    return parseLightsparkQuote(response);
+  }
+}
+
+function parseLightsparkQuote(raw: GridQuoteResponse): LightsparkQuote {
+  return {
+    id: raw.id,
+    status: raw.status,
+    paymentInstructions: raw.paymentInstructions?.map((instruction) => ({
+      provider: "lightspark" as const,
+      ...instruction,
+    })),
+    exchangeRate: raw.exchangeRate,
+    totalSendingAmount: raw.totalSendingAmount,
+    totalReceivingAmount: raw.totalReceivingAmount,
+    feesIncluded: raw.feesIncluded,
+    expiresAt: raw.expiresAt,
+  };
 }

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -1,5 +1,6 @@
 import type { LightsparkPaymentRampInstruction } from "@sdp/types";
 import { parseFiatCurrency } from "@sdp/types/payment-rails";
+import { AppError } from "@/lib/errors";
 import {
   basicAuthHeader,
   createProviderRampSupport,
@@ -40,6 +41,10 @@ interface GridCreateCustomerBody {
 
 interface GridCustomerResponse {
   id: string;
+}
+
+interface GridCustomerListResponse {
+  data: GridCustomerResponse[];
 }
 
 interface GridCreateQuoteBody {
@@ -202,6 +207,43 @@ export class LightsparkRampClient implements RampProviderClient {
     );
 
     return { id: response.id };
+  }
+
+  /** Looks up an existing Grid customer by the platform-side id we assigned. */
+  async findCustomerByPlatformId(
+    config: LightsparkConfig,
+    platformCustomerId: string
+  ): Promise<LightsparkCustomer | null> {
+    const query = new URLSearchParams({ platformCustomerId, limit: "1" });
+    const response = await this.request<GridCustomerListResponse>(
+      config,
+      `customers?${query.toString()}`,
+      { method: "GET" }
+    );
+    const [existing] = response.data;
+    return existing ? { id: existing.id } : null;
+  }
+
+  /**
+   * Idempotent customer creation keyed on platformCustomerId. Grid rejects a
+   * duplicate platformCustomerId with 409; we recover by returning the customer
+   * that already exists, so concurrent callers converge instead of orphaning one.
+   */
+  async getOrCreateCustomer(
+    config: LightsparkConfig,
+    input: CreateLightsparkCustomerInput
+  ): Promise<LightsparkCustomer> {
+    try {
+      return await this.createCustomer(config, input);
+    } catch (error) {
+      if (error instanceof AppError && error.code === "CONFLICT") {
+        const existing = await this.findCustomerByPlatformId(config, input.platformCustomerId);
+        if (existing) {
+          return existing;
+        }
+      }
+      throw error;
+    }
   }
 
   /** Creates a just-in-time (real-time funded) onramp quote and locks the FX rate. */

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 
 import {
+  createOnrampQuoteRequestSchema,
   createTransferRequestSchema,
   errorResponseSchema,
   executeOfframpRequestSchema,
@@ -20,6 +21,7 @@ import {
   offrampExecutionResponse,
   onrampCurrenciesResponse,
   onrampExecutionResponse,
+  onrampQuoteResponse,
   prepareTransferResponse,
   sandboxTransferSimulationResponse,
   transferListResponse,
@@ -231,6 +233,30 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
         content: jsonContent(offrampCurrenciesResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/payments/ramps/onramp/quote",
+    tags: ["Payments"],
+    summary: "Create on-ramp quote",
+    operationId: "createPaymentOnrampQuote",
+    description:
+      "Creates a provider-specific on-ramp quote. Hosted providers return a hosted URL; instruction-based providers return manual funding instructions.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      body: {
+        required: true,
+        content: jsonContent(createOnrampQuoteRequestSchema),
+      },
+    },
+    responses: {
+      200: {
+        description: "On-ramp quote created",
+        content: jsonContent(onrampQuoteResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
     },
   });
 

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -39,6 +39,7 @@ import {
   onboardingStatusResponseSchema,
   onrampCurrenciesResponseSchema,
   onrampExecutionResponseSchema,
+  onrampQuoteResponseSchema,
   organizationSchema,
   paginatedResponseSchema,
   prepareBurnResponseSchema,
@@ -155,6 +156,7 @@ export const transferListResponse = paginatedResponseSchema(transferSchema);
 export const onrampCurrenciesResponse = successResponseSchema(onrampCurrenciesResponseSchema);
 export const offrampCurrenciesResponse = successResponseSchema(offrampCurrenciesResponseSchema);
 export const onrampExecutionResponse = successResponseSchema(onrampExecutionResponseSchema);
+export const onrampQuoteResponse = successResponseSchema(onrampQuoteResponseSchema);
 export const offrampExecutionResponse = successResponseSchema(offrampExecutionResponseSchema);
 export const sandboxTransferSimulationResponse = successResponseSchema(
   sandboxTransferSimulationResponseSchema

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -1,5 +1,6 @@
 import { OFFRAMP_CRYPTO_RAILS, ONRAMP_CRYPTO_RAILS, RAMP_PROVIDERS } from "@sdp/types";
 import {
+  createOnrampQuoteSchema as createOnrampQuoteSchemaBase,
   createTransferSchema as createTransferSchemaBase,
   executeOfframpSchema as executeOfframpSchemaBase,
   executeOnrampSchema as executeOnrampSchemaBase,
@@ -520,6 +521,53 @@ export const executeOnrampRequestSchema = executeOnrampSchemaBase
     },
   });
 
+export const createOnrampQuoteRequestSchema = createOnrampQuoteSchemaBase
+  .extend({
+    provider: withOpenApi(createOnrampQuoteSchemaBase.shape.provider, {
+      description:
+        "Ramp provider identifier. MoonPay returns a hosted widget URL; Lightspark returns manual funding instructions.",
+      example: "moonpay",
+    }),
+    counterpartyId: withOpenApi(createOnrampQuoteSchemaBase.shape.counterpartyId, {
+      description:
+        "SDP counterparty ID. Provider-native customer records may be resolved or created from this counterparty.",
+      example: "counterparty_example",
+    }),
+    destinationWallet: withOpenApi(createOnrampQuoteSchemaBase.shape.destinationWallet, {
+      description: "Destination wallet ID or Solana address for purchased crypto.",
+      example: "wal_example",
+    }),
+    cryptoToken: withOpenApi(createOnrampQuoteSchemaBase.shape.cryptoToken, {
+      description: "Crypto token symbol or provider currency code.",
+      example: "USDC",
+    }),
+    fiatCurrency: withOpenApi(createOnrampQuoteSchemaBase.shape.fiatCurrency, {
+      description: "Fiat currency for on-ramp.",
+      example: "USD",
+    }),
+    fiatAmount: withOpenApi(createOnrampQuoteSchemaBase.shape.fiatAmount, {
+      description: "Fiat amount to on-ramp.",
+      example: "100.00",
+    }),
+    redirectUrl: withOpenApi(createOnrampQuoteSchemaBase.shape.redirectUrl, {
+      description: "Optional return URL after hosted provider flow completes.",
+      example: "https://example.com/onramp/complete",
+    }),
+  })
+  .openapi({
+    description:
+      "Create an on-ramp quote. The response uses `deliveryMode` to indicate whether the client should display manual instructions or open a hosted provider flow.",
+    example: {
+      provider: "moonpay",
+      counterpartyId: "counterparty_example",
+      destinationWallet: "wal_example",
+      cryptoToken: "USDC",
+      fiatCurrency: "USD",
+      fiatAmount: "100.00",
+      redirectUrl: "https://example.com/onramp/complete",
+    },
+  });
+
 export const executeOfframpRequestSchema = executeOfframpSchemaBase
   .extend({
     provider: withOpenApi(executeOfframpSchemaBase.shape.provider, {
@@ -689,6 +737,50 @@ const rampPaymentInstructionSchema = z.discriminatedUnion("provider", [
   lightsparkRampPaymentInstructionSchema,
 ]);
 
+const onrampQuoteSchema = z
+  .object({
+    id: z.string().openapi({ description: "Quote identifier.", example: "ramp_quote_example" }),
+    provider: z.enum(["moonpay", "lightspark"]).openapi({
+      description: "Provider that created the quote.",
+      example: "moonpay",
+    }),
+    status: z
+      .enum(["pending", "processing", "completed", "failed"])
+      .openapi({ description: "Quote status.", example: "pending" }),
+    deliveryMode: z.enum(["manual_instructions", "hosted"]).openapi({
+      description:
+        "`hosted` means open `hostedUrl`; `manual_instructions` means display `paymentInstructions`.",
+      example: "hosted",
+    }),
+    hostedUrl: z
+      .string()
+      .url()
+      .optional()
+      .openapi({ description: "Provider-hosted URL for hosted quote delivery." }),
+    exchangeRate: z
+      .number()
+      .optional()
+      .openapi({ description: "Units of destination crypto per unit of source fiat." }),
+    totalSendingAmount: z.number().optional().openapi({
+      description: "Total sending amount in fiat smallest units, including provider fees.",
+    }),
+    totalReceivingAmount: z
+      .number()
+      .optional()
+      .openapi({ description: "Final crypto amount received in smallest units." }),
+    feesIncluded: z
+      .number()
+      .optional()
+      .openapi({ description: "Fees included in the sending amount, in fiat smallest units." }),
+    expiresAt: isoDateTimeSchema
+      .optional()
+      .openapi({ description: "Timestamp when the quote expires." }),
+    paymentInstructions: z.array(rampPaymentInstructionSchema).optional().openapi({
+      description: "Manual funding instructions for instruction-based quote delivery.",
+    }),
+  })
+  .openapi({ description: "On-ramp quote details." });
+
 const onrampCurrencyPairSchema = z
   .object({
     source: z.string().openapi({ description: "Fiat source currency code.", example: "USD" }),
@@ -836,6 +928,12 @@ export const onrampExecutionResponseSchema = z
     ramp: onrampExecutionSchema.openapi({ description: "On-ramp execution details." }),
   })
   .openapi({ description: "On-ramp execution response payload." });
+
+export const onrampQuoteResponseSchema = z
+  .object({
+    quote: onrampQuoteSchema.openapi({ description: "On-ramp quote details." }),
+  })
+  .openapi({ description: "On-ramp quote response payload." });
 
 export const offrampExecutionResponseSchema = z
   .object({

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -326,6 +326,44 @@ async function seedWalletPolicy(params: {
   ]);
 }
 
+async function seedCounterparty(params?: {
+  id?: string;
+  externalId?: string | null;
+}): Promise<string> {
+  const id = params?.id ?? `counterparty_${crypto.randomUUID()}`;
+  await getDb(env)
+    .prepare(
+      `INSERT INTO counterparties (
+         id,
+         organization_id,
+         project_id,
+         external_id,
+         entity_type,
+         display_name,
+         email,
+         identity,
+         provider_data,
+         status,
+         created_by
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)`
+    )
+    .bind(
+      id,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      params?.externalId ?? null,
+      "individual",
+      "MoonPay Test Counterparty",
+      "moonpay-counterparty@example.com",
+      {},
+      {},
+      TEST_USER.id
+    )
+    .run();
+
+  return id;
+}
+
 describe("Payments routes", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -689,6 +727,61 @@ describe("Payments routes", () => {
     expect(redirect.searchParams.get("redirectURL")).toBe("https://example.com/onramp-done");
     expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("kyc_ref_123");
     assertMoonPaySignature(redirect);
+  });
+
+  it("creates a hosted MoonPay on-ramp quote URL", async () => {
+    const counterpartyId = await seedCounterparty({ externalId: "moonpay_user_123" });
+
+    const res = await app.request(
+      "/v1/payments/ramps/onramp/quote",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          counterpartyId,
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "USDC",
+          fiatCurrency: "USD",
+          fiatAmount: "120.50",
+          redirectUrl: "https://example.com/onramp-done",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        quote: {
+          id: string;
+          provider: string;
+          status: string;
+          deliveryMode: string;
+          hostedUrl: string;
+        };
+      };
+    };
+
+    expect(body.data.quote.id.startsWith("ramp_quote_")).toBe(true);
+    expect(body.data.quote.provider).toBe("moonpay");
+    expect(body.data.quote.status).toBe("pending");
+    expect(body.data.quote.deliveryMode).toBe("hosted");
+
+    const hostedUrl = new URL(body.data.quote.hostedUrl);
+    expect(hostedUrl.origin).toBe(TEST_MOONPAY_ONRAMP_URL);
+    expect(hostedUrl.searchParams.get("apiKey")).toBe(TEST_MOONPAY_API_KEY);
+    expect(hostedUrl.searchParams.get("baseCurrencyCode")).toBe("usd");
+    expect(hostedUrl.searchParams.get(MOONPAY_PARAM_BASE_CURRENCY_AMOUNT)).toBe("120.50");
+    expect(hostedUrl.searchParams.get("currencyCode")).toBe("usdc_sol");
+    expect(hostedUrl.searchParams.get("walletAddress")).toBe(TEST_SOLANA_ADDRESSES.wallet1);
+    expect(hostedUrl.searchParams.get("redirectURL")).toBe("https://example.com/onramp-done");
+    expect(hostedUrl.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("moonpay_user_123");
+    expect(hostedUrl.searchParams.get("externalTransactionId")).toBe(body.data.quote.id);
+    assertMoonPaySignature(hostedUrl);
   });
 
   it("creates a signed MoonPay off-ramp session URL", async () => {

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -1,5 +1,6 @@
 export { getWalletBalances, getWalletPolicy, updateWalletPolicy } from "./handlers/balances";
 export {
+  createOnrampQuote,
   executeOfframp,
   executeOnramp,
   listOfframpCurrencies,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -19,6 +19,8 @@ import type {
 import { parseDecimalAmount } from "@/lib/amount";
 import { requireProjectId } from "@/lib/auth";
 import { AppError, providerNotConfigured } from "@/lib/errors";
+import { basicAuthHeader } from "@/lib/ramps/common";
+import { providerFetchJson } from "@/lib/ramps/fetch";
 import { LightsparkRampClient } from "@/lib/ramps/providers/lightspark";
 import { success } from "@/lib/response";
 import { isAddress } from "@/lib/solana";
@@ -340,10 +342,6 @@ function getBvnkConfig(c: AppContext): BvnkConfig {
   };
 }
 
-function encodeBasicAuth(value: string): string {
-  return Buffer.from(value, "utf8").toString("base64");
-}
-
 function safeParseJson(value: string): unknown | null {
   try {
     return JSON.parse(value) as unknown;
@@ -606,39 +604,15 @@ async function lightsparkRequest(
     body?: unknown;
   }
 ): Promise<unknown> {
-  const apiBaseUrl = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
-  const url = new URL(path, apiBaseUrl);
-  const auth = encodeBasicAuth(`${config.tokenId}:${config.clientSecret}`);
+  const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
+  const url = new URL(path, base);
 
-  const response = await fetch(url.toString(), {
-    method: init.method,
+  return providerFetchJson("lightspark", url.toString(), {
+    ...init,
     headers: {
-      Authorization: `Basic ${auth}`,
-      "Content-Type": "application/json",
+      Authorization: basicAuthHeader(config.tokenId, config.clientSecret),
     },
-    body: init.body === undefined ? undefined : JSON.stringify(init.body),
   });
-
-  const raw = await response.text();
-  const parsed = safeParseJson(raw);
-
-  if (!response.ok) {
-    const parsedMessage =
-      parsed && typeof parsed === "object"
-        ? ((parsed as { message?: unknown; error?: unknown; reason?: unknown }).message ??
-          (parsed as { message?: unknown; error?: unknown; reason?: unknown }).error ??
-          (parsed as { message?: unknown; error?: unknown; reason?: unknown }).reason)
-        : undefined;
-
-    const message =
-      typeof parsedMessage === "string" && parsedMessage.length > 0
-        ? parsedMessage
-        : `Lightspark request failed with status ${response.status}`;
-
-    throw new AppError("BAD_REQUEST", message);
-  }
-
-  return parsed ?? {};
 }
 
 function normalizeLightsparkCurrencyCode(value: string): string {
@@ -1300,7 +1274,7 @@ async function ensureLightsparkCustomer(
     return existing;
   }
 
-  const customer = await lightsparkClient.createCustomer(config, {
+  const customer = await lightsparkClient.getOrCreateCustomer(config, {
     platformCustomerId: counterparty.id,
     customerType: counterparty.entity_type === "business" ? "BUSINESS" : "INDIVIDUAL",
     fullName: counterparty.display_name,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -1271,15 +1271,18 @@ async function executeRampWithProvider(
 
 const lightsparkClient = new LightsparkRampClient();
 
+function readLightsparkData(
+  providerData: CounterpartyRow["provider_data"]
+): Record<string, unknown> {
+  const lightspark = providerData.lightspark;
+  return lightspark && typeof lightspark === "object"
+    ? (lightspark as Record<string, unknown>)
+    : {};
+}
+
 function readLightsparkCustomerId(providerData: CounterpartyRow["provider_data"]): string | null {
-  const lightspark = (providerData as { lightspark?: unknown }).lightspark;
-  if (lightspark && typeof lightspark === "object") {
-    const customerId = (lightspark as { customerId?: unknown }).customerId;
-    if (typeof customerId === "string" && customerId.length > 0) {
-      return customerId;
-    }
-  }
-  return null;
+  const customerId = readLightsparkData(providerData).customerId;
+  return typeof customerId === "string" && customerId.length > 0 ? customerId : null;
 }
 
 /**
@@ -1304,11 +1307,7 @@ async function ensureLightsparkCustomer(
     email: counterparty.email,
   });
 
-  const existingLightspark =
-    counterparty.provider_data.lightspark &&
-    typeof counterparty.provider_data.lightspark === "object"
-      ? (counterparty.provider_data.lightspark as Record<string, unknown>)
-      : {};
+  const existingLightspark = readLightsparkData(counterparty.provider_data);
 
   await repo.updateCounterparty({
     counterpartyId: counterparty.id,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -2,6 +2,7 @@ import type {
   LightsparkPaymentRampInstruction,
   PaymentRampExecution,
   PaymentRampExecutionStatus,
+  PaymentRampQuote,
   SdpEnvironment,
 } from "@sdp/types";
 import {
@@ -11,14 +12,22 @@ import {
   type RampFiatCurrency,
 } from "@sdp/types/generated/ramp-support";
 import { getDb } from "@/db";
+import type {
+  CounterpartiesRepository,
+  CounterpartyRow,
+} from "@/db/repositories/counterparty.repository";
 import { parseDecimalAmount } from "@/lib/amount";
+import { requireProjectId } from "@/lib/auth";
 import { AppError, providerNotConfigured } from "@/lib/errors";
+import { LightsparkRampClient } from "@/lib/ramps/providers/lightspark";
 import { success } from "@/lib/response";
 import { isAddress } from "@/lib/solana";
+import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { assertProviderAvailable } from "@/services/provider-availability.service";
 import type { AppContext } from "../context";
 import { assertWalletPolicyAllowsTransfer } from "../policy";
 import {
+  createOnrampQuoteSchema,
   executeOfframpSchema,
   executeOnrampSchema,
   listOfframpCurrenciesQuerySchema,
@@ -1258,6 +1267,173 @@ async function executeRampWithProvider(
   }
 
   return await provider.executeOfframp(c, scope, input);
+}
+
+const lightsparkClient = new LightsparkRampClient();
+
+function readLightsparkCustomerId(providerData: CounterpartyRow["provider_data"]): string | null {
+  const lightspark = (providerData as { lightspark?: unknown }).lightspark;
+  if (lightspark && typeof lightspark === "object") {
+    const customerId = (lightspark as { customerId?: unknown }).customerId;
+    if (typeof customerId === "string" && customerId.length > 0) {
+      return customerId;
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns the Grid customer id for a counterparty, lazily creating the native
+ * Lightspark customer (and persisting it into provider_data) on first use.
+ */
+async function ensureLightsparkCustomer(
+  repo: CounterpartiesRepository,
+  config: LightsparkConfig,
+  counterparty: CounterpartyRow,
+  projectId: string
+): Promise<string> {
+  const existing = readLightsparkCustomerId(counterparty.provider_data);
+  if (existing) {
+    return existing;
+  }
+
+  const customer = await lightsparkClient.createCustomer(config, {
+    platformCustomerId: counterparty.id,
+    customerType: counterparty.entity_type === "business" ? "BUSINESS" : "INDIVIDUAL",
+    fullName: counterparty.display_name,
+    email: counterparty.email,
+  });
+
+  const existingLightspark =
+    counterparty.provider_data.lightspark &&
+    typeof counterparty.provider_data.lightspark === "object"
+      ? (counterparty.provider_data.lightspark as Record<string, unknown>)
+      : {};
+
+  await repo.updateCounterparty({
+    counterpartyId: counterparty.id,
+    organizationId: counterparty.organization_id,
+    projectId,
+    providerData: {
+      ...counterparty.provider_data,
+      lightspark: { ...existingLightspark, customerId: customer.id },
+    },
+  });
+
+  return customer.id;
+}
+
+export async function createOnrampQuote(c: AppContext) {
+  const body = await c.req.json();
+  const parsed = createOnrampQuoteSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new AppError("BAD_REQUEST", "Invalid request body", {
+      errors: parsed.error.flatten().fieldErrors,
+    });
+  }
+
+  const input = parsed.data;
+  const scope = await resolveScope(c);
+  await resolveRampProvider(c, input.provider, scope.auth.organizationId);
+
+  const projectId = requireProjectId(c);
+  const repo = getCounterpartiesRepository(c);
+  const counterparty = await repo.getCounterpartyById({
+    counterpartyId: input.counterpartyId,
+    organizationId: scope.auth.organizationId,
+    projectId,
+  });
+  if (!counterparty) {
+    throw new AppError("NOT_FOUND", "Counterparty not found");
+  }
+
+  if (input.provider === "moonpay") {
+    const destinationWalletAddress = resolveWalletAddress(
+      scope.wallets,
+      input.destinationWallet,
+      "destinationWallet",
+      scope.auth,
+      ["payments:write"]
+    );
+    const amount = toPositiveNumberAmount(input.fiatAmount, "fiatAmount");
+    if (amount < MOONPAY_ONRAMP_MIN_USD) {
+      throw new AppError(
+        "BAD_REQUEST",
+        `MoonPay on-ramp requires fiatAmount to be at least ${MOONPAY_ONRAMP_MIN_USD} USD`
+      );
+    }
+
+    const moonPay = getMoonPayConfig(c);
+    const fiatCurrency = resolveFiatCurrency(input);
+    const quoteId = `ramp_quote_${crypto.randomUUID()}`;
+    const hostedUrl = await buildSignedMoonPayWidgetUrl(moonPay.onrampUrl, moonPay.secretKey, {
+      apiKey: moonPay.apiKey,
+      baseCurrencyCode: fiatCurrency.toLowerCase(),
+      baseCurrencyAmount: input.fiatAmount,
+      currencyCode: normalizeMoonPayCurrencyCode(input.cryptoToken),
+      walletAddress: destinationWalletAddress,
+      redirectURL: input.redirectUrl,
+      externalCustomerId: counterparty.external_id ?? counterparty.id,
+      externalTransactionId: quoteId,
+    });
+
+    const result: PaymentRampQuote = {
+      provider: "moonpay",
+      id: quoteId,
+      status: "pending",
+      deliveryMode: "hosted",
+      hostedUrl,
+    };
+
+    return success(c, { quote: result });
+  }
+
+  const config = getLightsparkConfig(c);
+  const customerId = await ensureLightsparkCustomer(repo, config, counterparty, projectId);
+
+  const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
+  const fiatCurrency = resolveFiatCurrency(input);
+  const fiatAmountMinorUnits = toLightsparkMinorUnitsInteger(
+    parseDecimalAmount(input.fiatAmount, 2),
+    "fiatAmount"
+  );
+  const destinationWalletAddress = resolveWalletAddress(
+    scope.wallets,
+    input.destinationWallet,
+    "destinationWallet",
+    scope.auth,
+    ["payments:write"]
+  );
+  const destinationAccountId = await resolveLightsparkOnrampDestinationAccountId(
+    config,
+    customerId,
+    destinationWalletAddress,
+    cryptoCurrency
+  );
+
+  const quote = await lightsparkClient.createOnrampQuote(config, {
+    customerId,
+    destinationAccountId,
+    fiatCurrency,
+    cryptoCurrency,
+    fiatAmountMinorUnits,
+  });
+
+  const result: PaymentRampQuote = {
+    provider: "lightspark",
+    id: quote.id,
+    status: mapLightsparkQuoteStatus(quote.status),
+    deliveryMode: "manual_instructions",
+    exchangeRate: quote.exchangeRate,
+    totalSendingAmount: quote.totalSendingAmount,
+    totalReceivingAmount: quote.totalReceivingAmount,
+    feesIncluded: quote.feesIncluded,
+    expiresAt: quote.expiresAt,
+    paymentInstructions: quote.paymentInstructions,
+  };
+
+  return success(c, { quote: result });
 }
 
 export async function executeOnramp(c: AppContext) {

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -3,6 +3,7 @@ import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
+  createOnrampQuote,
   createTransfer,
   executeOfframp,
   executeOnramp,
@@ -47,6 +48,11 @@ payments.get("/transfers", requirePermissions("payments:read"), listTransfers);
 payments.get("/transfers/:transferId", requirePermissions("payments:read"), getTransfer);
 payments.get("/ramps/onramp/currency", requirePermissions("payments:read"), listOnrampCurrencies);
 payments.get("/ramps/offramp/currency", requirePermissions("payments:read"), listOfframpCurrencies);
+payments.post(
+  "/ramps/onramp/quote",
+  requirePermissions("payments:write", "wallets:read"),
+  createOnrampQuote
+);
 payments.post(
   "/ramps/onramp/execute",
   requirePermissions("payments:write", "wallets:read"),

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -190,6 +190,16 @@ export const executeOnrampSchema = z.object({
   bvnkCompliance: bvnkComplianceSchema.optional(),
 });
 
+export const createOnrampQuoteSchema = z.object({
+  provider: z.enum(["lightspark", "moonpay"]),
+  counterpartyId: z.string().min(1),
+  destinationWallet: z.string().min(1),
+  cryptoToken: rampCurrencyCodeSchema,
+  fiatCurrency: rampFiatCurrencySchema.optional(),
+  fiatAmount: paymentAmountSchema,
+  redirectUrl: z.string().url().optional(),
+});
+
 export const executeOfframpSchema = z.object({
   provider: rampProviderSchema,
   sourceWallet: z.string().min(1),

--- a/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
+++ b/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
@@ -50,6 +50,7 @@ describe("wallet-scoped route coverage inventory", () => {
       "GET /wallets/:walletId/policies",
       "POST /ramps/offramp/execute",
       "POST /ramps/onramp/execute",
+      "POST /ramps/onramp/quote",
       "POST /transfers",
       "POST /transfers/prepare",
       "PUT /wallets/:walletId/policies",

--- a/apps/sdp-web/src/app/api/dashboard/payments/ramps/[direction]/quote/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/ramps/[direction]/quote/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { createSdpApiClient } from "@/lib/sdp-api";
+
+type RouteContext = {
+  params: Promise<{ direction: string }>;
+};
+
+async function readParams(context: RouteContext) {
+  const resolved = await context.params;
+  return resolved.direction;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const direction = await readParams(context);
+    if (direction !== "onramp") {
+      return NextResponse.json(
+        {
+          error: {
+            message: "Unsupported ramp quote direction",
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.text();
+    const apiClient = await createSdpApiClient();
+    const response = await apiClient.request(`/v1/payments/ramps/${direction}/quote`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body,
+    });
+
+    const responseBody = await response.text();
+    const contentType = response.headers.get("Content-Type") ?? "application/json";
+
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        "Content-Type": contentType,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          message: error instanceof Error ? error.message : "Ramp quote request failed",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-action-page-v2.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-action-page-v2.tsx
@@ -1,35 +1,14 @@
 "use client";
 
 import type { ComplianceProviderId, PaymentsDashboardWallet, RampProviderId } from "@sdp/types";
-import { PlusIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
-import { toast } from "sonner";
-import useSWR from "swr";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import {
-  DEFAULT_RAMP_PAIR,
-  findRampPair,
-  ONRAMP_PAIRS,
-  RAMP_PROVIDER_OPTIONS,
-  type SelectedRampPair,
-} from "@/lib/ramps";
-import { useZodForm } from "@/lib/use-zod-form";
+import { RAMP_PROVIDER_LOGOS, RAMP_PROVIDER_OPTIONS } from "@/lib/ramps";
 import { cn } from "@/lib/utils";
 import { CounterpartyCreateDialog } from "./counterparty/counterparty-create-dialog";
-import {
-  type CounterpartiesResult,
-  fetchAllCounterparties,
-  fetchWallets,
-} from "./payments-workspace.data";
-import { CounterpartySelector } from "./ramps/components/counterparty-selector";
-import { RampPairProviderSelector } from "./ramps/components/ramp-pair-provider-selector";
-import {
-  counterpartySelectionSchema,
-  depositAmountSchema,
-  depositSelectionSchema,
-  INITIAL_ONRAMP_FIELDS,
-} from "./ramps/components/schema";
+import type { CounterpartiesResult } from "./payments-workspace.data";
+import { OnrampStepContent } from "./ramps/components/onramp-step-content";
+import { STEPS, useOnrampWizard } from "./use-onramp-wizard";
 
 interface PaymentsActionPageProps {
   mode: "send" | "receive";
@@ -42,93 +21,45 @@ interface PaymentsActionPageProps {
   counterpartiesResult: CounterpartiesResult;
 }
 
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
-const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
+function getRampProviderLabel(provider: RampProviderId): string {
+  return RAMP_PROVIDER_OPTIONS.find((option) => option.id === provider)?.title ?? provider;
+}
 
-const STEPS = [
-  { label: "Counterparty", title: "Who is this deposit for?" },
-  { label: "Deposit", title: "How much would you like to deposit?" },
-  { label: "Step 3", title: "Coming soon" },
-  { label: "Step 4", title: "Coming soon" },
-] as const;
+function PoweredByRampProvider({ provider }: { provider: RampProviderId }) {
+  const providerLabel = getRampProviderLabel(provider);
 
-const STEP_SCHEMAS = [counterpartySelectionSchema, depositAmountSchema, null, null] as const;
-
-export function PaymentsActionPage({
-  wallets,
-  walletsError,
-  enabledRampProviders,
-  counterpartiesResult,
-}: PaymentsActionPageProps) {
-  const router = useRouter();
-
-  const [stepIndex, setStepIndex] = useState(0);
-  const [selectedRampPair, setSelectedRampPair] = useState<SelectedRampPair>(DEFAULT_RAMP_PAIR);
-  const form = useZodForm(depositSelectionSchema, INITIAL_ONRAMP_FIELDS);
-  const { values: onrampFields, setField } = form;
-
-  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
-    PAYMENTS_ACTION_WALLETS_KEY,
-    () => fetchWallets({ includeBalances: true }),
-    {
-      fallbackData: wallets.length > 0 ? wallets : undefined,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
+  return (
+    <div className="flex items-center justify-center gap-2 text-sm text-text-low">
+      <span>Powered by</span>
+      <Image
+        src={RAMP_PROVIDER_LOGOS[provider]}
+        alt=""
+        width={24}
+        height={24}
+        className="size-6 rounded-md object-contain"
+      />
+      <span className="font-medium text-text-medium">{providerLabel}</span>
+    </div>
   );
-  const liveWallets = swrWallets ?? wallets;
-  const walletsLoading = swrWallets === undefined && !walletsFetchError;
-  const liveWalletsError = walletsFetchError
-    ? walletsFetchError instanceof Error
-      ? walletsFetchError.message
-      : "Request failed."
-    : swrWallets === undefined
-      ? walletsError
-      : null;
+}
 
-  const { data: liveCounterpartiesResult, mutate: mutateCounterparties } = useSWR(
-    PAYMENTS_ACTION_COUNTERPARTIES_KEY,
-    fetchAllCounterparties,
-    {
-      fallbackData: counterpartiesResult,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
-  );
-  const [counterpartyDialogOpen, setCounterpartyDialogOpen] = useState(false);
-
-  const selectedWallet = useMemo(
-    () => liveWallets.find((wallet) => wallet.walletId === onrampFields.walletId) ?? null,
-    [liveWallets, onrampFields.walletId]
-  );
-
-  const stepSchema = STEP_SCHEMAS[stepIndex];
-  const canProceed = useMemo(
-    () => (stepSchema ? stepSchema.safeParse(onrampFields).success : true),
-    [stepSchema, onrampFields]
-  );
-
-  const isLastStep = stepIndex === STEPS.length - 1;
-  const currentStep = STEPS[stepIndex];
-
-  const handlePrimary = () => {
-    if (!canProceed) {
-      return;
-    }
-    if (isLastStep) {
-      toast.info("Next step coming soon.");
-      return;
-    }
-    setStepIndex((current) => current + 1);
-  };
-
-  const handleSecondary = () => {
-    if (stepIndex === 0) {
-      router.push("/dashboard/payments");
-      return;
-    }
-    setStepIndex((current) => Math.max(0, current - 1));
-  };
+export function PaymentsActionPage(props: PaymentsActionPageProps) {
+  const wizard = useOnrampWizard(props);
+  const {
+    stepIndex,
+    currentStep,
+    isLastStep,
+    canProceed,
+    liveWalletsError,
+    walletsLoading,
+    onrampQuote,
+    hostedQuoteLoading,
+    counterpartyDialogOpen,
+    setCounterpartyDialogOpen,
+    handlePrimary,
+    handleSecondary,
+    handleCounterpartyCreated,
+  } = wizard;
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 py-6">
@@ -165,67 +96,11 @@ export function PaymentsActionPage({
           </div>
         ) : null}
 
-        {stepIndex === 0 ? (
-          <div className="space-y-3">
-            <button
-              type="button"
-              onClick={() => setCounterpartyDialogOpen(true)}
-              className="flex w-full items-center gap-3 rounded-2xl border border-dashed border-border-light px-4 py-3.5 text-left transition-colors hover:border-border-medium hover:bg-border-extra-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50"
-            >
-              <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-border-extra-light text-text-extra-high">
-                <PlusIcon className="size-4" />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block text-sm font-medium text-text-extra-high">
-                  Add counterparty
-                </span>
-                <span className="block text-sm text-text-low">
-                  Create a new buyer to deposit for if they aren&apos;t in the list yet.
-                </span>
-              </span>
-            </button>
-            <CounterpartySelector
-              counterpartiesResult={liveCounterpartiesResult}
-              value={onrampFields.counterpartyId || null}
-              onChange={(id) => setField("counterpartyId", id)}
-            />
-          </div>
-        ) : stepIndex === 1 ? (
-          enabledRampProviders.length === 0 ? (
-            <div className="rounded-2xl border border-border-light bg-border-extra-light px-5 py-5 text-sm text-text-low">
-              No on-ramp providers are enabled for this organization.
-            </div>
-          ) : (
-            <RampPairProviderSelector
-              direction="onramp"
-              pairs={ONRAMP_PAIRS}
-              enabledRampProviders={enabledRampProviders}
-              providerOptions={RAMP_PROVIDER_OPTIONS}
-              wallets={liveWallets}
-              walletsLoading={walletsLoading}
-              selectedWallet={selectedWallet}
-              selectedPair={selectedRampPair}
-              selectedProvider={onrampFields.provider}
-              amount={onrampFields.amount}
-              onAmountChange={(value) => setField("amount", value)}
-              onAmountBlur={() => {}}
-              onWalletChange={(walletId) => setField("walletId", walletId)}
-              onPairChange={(nextPair) => {
-                setSelectedRampPair(nextPair);
-                const support = findRampPair(ONRAMP_PAIRS, nextPair);
-                if (onrampFields.provider && !support?.providers.includes(onrampFields.provider)) {
-                  setField("provider", null);
-                }
-              }}
-              onProviderSelect={(nextProvider) => setField("provider", nextProvider)}
-            />
-          )
-        ) : (
-          <div className="grid place-items-center rounded-2xl border border-dashed border-border-light bg-border-extra-light px-6 py-16 text-center">
-            <p className="text-lg font-medium text-text-extra-high">Coming soon</p>
-            <p className="mt-1 text-sm text-text-low">This step isn&apos;t built yet.</p>
-          </div>
-        )}
+        <OnrampStepContent wizard={wizard} />
+
+        {stepIndex === 2 && onrampQuote ? (
+          <PoweredByRampProvider provider={onrampQuote.provider} />
+        ) : null}
       </div>
 
       <div className="sticky bottom-0 z-10 mx-auto mt-auto flex w-full max-w-3xl flex-col gap-3 pt-4 pb-1 sm:flex-row sm:justify-between">
@@ -240,25 +115,17 @@ export function PaymentsActionPage({
         <Button
           type="button"
           className="h-14 rounded-full text-base"
-          disabled={!canProceed || (stepIndex === 1 && walletsLoading)}
-          onClick={handlePrimary}
+          disabled={hostedQuoteLoading || !canProceed || (stepIndex === 1 && walletsLoading)}
+          onClick={() => void handlePrimary()}
         >
-          {isLastStep ? "Done" : "Next"}
+          {hostedQuoteLoading ? "Opening..." : isLastStep ? "Done" : "Next"}
         </Button>
       </div>
 
       <CounterpartyCreateDialog
         open={counterpartyDialogOpen}
         onClose={() => setCounterpartyDialogOpen(false)}
-        onCreated={(created) => {
-          setField("counterpartyId", created.id);
-          void mutateCounterparties(
-            (prev) =>
-              prev ? { ...prev, data: [created, ...prev.data] } : { ok: true, data: [created] },
-            { revalidate: true }
-          );
-          setCounterpartyDialogOpen(false);
-        }}
+        onCreated={handleCounterpartyCreated}
       />
     </div>
   );

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -118,6 +118,72 @@ export function formatTimestamp(value?: string): string {
   }).format(date);
 }
 
+export function getCurrencyDecimals(currency: string): number {
+  const normalized = currency.trim().toUpperCase();
+  if (normalized === "USD") return 2;
+  if (normalized === "USDC" || normalized === "USDT") return 6;
+  if (normalized === "SOL") return 9;
+  if (normalized === "BTC") return 8;
+  return 2;
+}
+
+export function formatMinorCurrencyAmount(
+  amount: number | undefined,
+  currency: string
+): string | null {
+  if (amount === undefined || !Number.isFinite(amount)) {
+    return null;
+  }
+
+  const decimals = getCurrencyDecimals(currency);
+  const value = amount / 10 ** decimals;
+  return `${value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  })} ${currency.toUpperCase()}`;
+}
+
+export function formatRampQuoteExpiry(expiresAt: string | undefined): string | null {
+  if (!expiresAt) {
+    return null;
+  }
+
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function formatRampQuoteTimeRemaining(
+  expiresAt: string | undefined,
+  nowMs = Date.now()
+): string | null {
+  if (!expiresAt) {
+    return null;
+  }
+
+  const expiresAtMs = new Date(expiresAt).getTime();
+  if (Number.isNaN(expiresAtMs)) {
+    return null;
+  }
+
+  const remainingSeconds = Math.max(0, Math.ceil((expiresAtMs - nowMs) / 1000));
+  if (remainingSeconds === 0) {
+    return "Expired";
+  }
+
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
 export function formatDirection(direction?: string): string {
   if (!direction) {
     return "Unknown";

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -4,6 +4,7 @@ import type {
   PaymentTransferSummary as TransferRecord,
   PaymentsDashboardWallet as WalletRecord,
 } from "@sdp/types";
+import { CRYPTO_ASSET_DECIMALS, type CryptoAssetSymbol } from "@sdp/types/payment-rails";
 
 // biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
 const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
@@ -118,15 +119,6 @@ export function formatTimestamp(value?: string): string {
   }).format(date);
 }
 
-export function getCurrencyDecimals(currency: string): number {
-  const normalized = currency.trim().toUpperCase();
-  if (normalized === "USD") return 2;
-  if (normalized === "USDC" || normalized === "USDT") return 6;
-  if (normalized === "SOL") return 9;
-  if (normalized === "BTC") return 8;
-  return 2;
-}
-
 export function formatMinorCurrencyAmount(
   amount: number | undefined,
   currency: string
@@ -135,7 +127,7 @@ export function formatMinorCurrencyAmount(
     return null;
   }
 
-  const decimals = getCurrencyDecimals(currency);
+  const decimals = CRYPTO_ASSET_DECIMALS[currency as CryptoAssetSymbol] ?? 2;
   const value = amount / 10 ** decimals;
   return `${value.toLocaleString(undefined, {
     minimumFractionDigits: 0,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import type { PaymentRampInstruction, PaymentRampQuote } from "@sdp/types";
+import { Tab, TabList, Tabs } from "@solana/design-system/tabs";
+import {
+  ArrowDownLeft,
+  CheckCircle2Icon,
+  Clock3,
+  CoinsIcon,
+  CopyIcon,
+  DollarSignIcon,
+  LandmarkIcon,
+  PlusIcon,
+  WalletIcon,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { ONRAMP_PAIRS, RAMP_PROVIDER_OPTIONS } from "@/lib/ramps";
+import {
+  formatMinorCurrencyAmount,
+  formatRampQuoteExpiry,
+  formatRampQuoteTimeRemaining,
+} from "../../payments-overview.utils";
+import { type OnrampWizard, toRampCryptoToken } from "../../use-onramp-wizard";
+import { CounterpartySelector } from "./counterparty-selector";
+import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
+
+async function copyPaymentInstruction(label: string, value: string) {
+  try {
+    await navigator.clipboard.writeText(value);
+    toast.success(`${label} copied.`, {
+      position: "bottom-right",
+    });
+  } catch {
+    toast.error(`Failed to copy ${label.toLowerCase()}.`, {
+      position: "bottom-right",
+    });
+  }
+}
+
+function PaymentInstructionField({ label, value }: { label: string; value?: string }) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl bg-border-extra-light px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-low">{label}</p>
+          <p className="mt-1 break-all font-mono text-sm text-text-extra-high">{value}</p>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          size="xs"
+          iconLeft={<CopyIcon />}
+          onClick={() => void copyPaymentInstruction(label, value)}
+        >
+          Copy
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function QuoteSummaryField({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value?: string | null;
+}) {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-start gap-3 rounded-xl bg-border-extra-light px-4 py-3">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-white text-text-medium">
+        {icon}
+      </span>
+      <div className="min-w-0">
+        <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-low">{label}</p>
+        <p className="mt-1 break-all text-sm font-medium text-text-extra-high">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function QuoteExpiryTabLabel({ expiresAt }: { expiresAt?: string }) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const timeRemaining = formatRampQuoteTimeRemaining(expiresAt, nowMs);
+
+  useEffect(() => {
+    if (!expiresAt) {
+      return;
+    }
+
+    setNowMs(Date.now());
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(intervalId);
+  }, [expiresAt]);
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span>Instructions</span>
+      {timeRemaining ? (
+        <span className="rounded-full bg-border-extra-light px-2 py-0.5 text-[11px] font-medium text-text-medium">
+          {timeRemaining}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function ManualQuoteSummary({
+  quote,
+  fiatCurrency,
+  cryptoToken,
+}: {
+  quote: Extract<PaymentRampQuote, { deliveryMode: "manual_instructions" }>;
+  fiatCurrency: string;
+  cryptoToken: string;
+}) {
+  const finalAmount = formatMinorCurrencyAmount(quote.totalReceivingAmount, cryptoToken);
+  const sendingAmount = formatMinorCurrencyAmount(quote.totalSendingAmount, fiatCurrency);
+  const feesIncluded = formatMinorCurrencyAmount(quote.feesIncluded, fiatCurrency);
+  const exchangeRate =
+    quote.exchangeRate !== undefined
+      ? `1 ${fiatCurrency.toUpperCase()} = ${quote.exchangeRate} ${cryptoToken.toUpperCase()}`
+      : null;
+  const expiresAt = formatRampQuoteExpiry(quote.expiresAt);
+
+  if (!finalAmount && !sendingAmount && !feesIncluded && !exchangeRate && !expiresAt) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4 text-left">
+      <div>
+        <p className="text-sm font-medium text-text-extra-high">Quote Summary</p>
+        <p className="mt-1 text-sm text-text-low">Locked pricing for this funding instruction.</p>
+      </div>
+      <div className="grid gap-3 lg:grid-cols-2">
+        <QuoteSummaryField
+          icon={<CoinsIcon className="size-4" />}
+          label="Final amount"
+          value={finalAmount}
+        />
+        <QuoteSummaryField
+          icon={<WalletIcon className="size-4" />}
+          label="Deposit amount"
+          value={sendingAmount}
+        />
+        <QuoteSummaryField
+          icon={<DollarSignIcon className="size-4" />}
+          label="Fees included"
+          value={feesIncluded}
+        />
+        <QuoteSummaryField
+          icon={<ArrowDownLeft className="size-4" />}
+          label="Exchange rate"
+          value={exchangeRate}
+        />
+        <QuoteSummaryField icon={<Clock3 className="size-4" />} label="Expires" value={expiresAt} />
+      </div>
+    </div>
+  );
+}
+
+function ManualInstructionsQuote({
+  amount,
+  quote,
+  fiatCurrency,
+  cryptoToken,
+  instructions,
+  simulateQuote,
+}: {
+  amount: string;
+  quote: Extract<PaymentRampQuote, { deliveryMode: "manual_instructions" }>;
+  fiatCurrency: string;
+  cryptoToken: string;
+  instructions: PaymentRampInstruction[];
+  simulateQuote?: {
+    loading: boolean;
+    succeeded: boolean;
+    onClick: () => void;
+  };
+}) {
+  const [activeTab, setActiveTab] = useState<"instructions" | "summary">("instructions");
+
+  return (
+    <div className="h-[480px] space-y-6 overflow-y-auto">
+      <div className="flex items-start gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-border-extra-light text-text-extra-high">
+          <LandmarkIcon className="size-5" />
+        </span>
+        <div>
+          <p className="text-sm font-medium text-text-extra-high">Manual Funding Instructions</p>
+          <p className="mt-2 text-sm text-text-low">
+            Send {amount ? `$${amount}` : "the quoted amount"} using one of the supported rails.
+            Include the reference exactly so the provider can match the deposit to this quote.
+          </p>
+        </div>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => {
+          if (value === "instructions" || value === "summary") {
+            setActiveTab(value);
+          }
+        }}
+      >
+        <TabList>
+          <Tab value="instructions">
+            <QuoteExpiryTabLabel expiresAt={quote.expiresAt} />
+          </Tab>
+          <Tab value="summary">Quote Summary</Tab>
+        </TabList>
+      </Tabs>
+
+      {activeTab === "instructions" ? (
+        instructions.map((instruction, index) => {
+          const info = instruction.accountOrWalletInfo;
+          return (
+            <div
+              key={`${info.reference ?? info.accountNumber ?? info.address ?? index}`}
+              className="space-y-4"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded-full bg-border-extra-light px-3 py-1 text-xs font-medium text-text-medium">
+                    {info.accountType.replaceAll("_", " ")}
+                  </span>
+                  {info.assetType ? (
+                    <span className="rounded-full bg-border-extra-light px-3 py-1 text-xs font-medium text-text-medium">
+                      {info.assetType}
+                    </span>
+                  ) : null}
+                </div>
+                {index === 0 && simulateQuote ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    iconLeft={simulateQuote.succeeded ? <CheckCircle2Icon /> : <DollarSignIcon />}
+                    onClick={simulateQuote.onClick}
+                    disabled={simulateQuote.loading || simulateQuote.succeeded}
+                  >
+                    {simulateQuote.succeeded
+                      ? "Quote Simulated"
+                      : simulateQuote.loading
+                        ? "Simulating..."
+                        : "Simulate Quote"}
+                  </Button>
+                ) : null}
+              </div>
+              <div className="grid gap-3 lg:grid-cols-2">
+                <PaymentInstructionField label="Bank name" value={info.bankName} />
+                <PaymentInstructionField label="Routing number" value={info.routingNumber} />
+                <PaymentInstructionField label="Account number" value={info.accountNumber} />
+                <PaymentInstructionField label="Wallet address" value={info.address} />
+              </div>
+              <PaymentInstructionField label="Reference" value={info.reference} />
+              {info.paymentRails?.length ? (
+                <div className="rounded-xl bg-border-extra-light px-4 py-3">
+                  <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-low">
+                    Supported rails
+                  </p>
+                  <p className="mt-1 text-sm text-text-extra-high">
+                    {info.paymentRails.join(", ")}
+                  </p>
+                </div>
+              ) : null}
+              {instruction.instructionsNotes ? (
+                <div className="rounded-xl bg-border-extra-light px-4 py-3">
+                  <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-low">
+                    Notes
+                  </p>
+                  <p className="mt-1 text-sm text-text-extra-high">
+                    {instruction.instructionsNotes}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          );
+        })
+      ) : (
+        <ManualQuoteSummary quote={quote} fiatCurrency={fiatCurrency} cryptoToken={cryptoToken} />
+      )}
+    </div>
+  );
+}
+
+export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
+  const {
+    stepIndex,
+    enabledRampProviders,
+    liveCounterpartiesResult,
+    onrampFields,
+    setField,
+    setCounterpartyDialogOpen,
+    liveWallets,
+    walletsLoading,
+    selectedWallet,
+    selectedRampPair,
+    onrampQuote,
+    quoteSimulationLoading,
+    quoteSimulationSucceeded,
+    simulateCurrentQuote,
+    handlePairChange,
+  } = wizard;
+
+  if (stepIndex === 0) {
+    return (
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={() => setCounterpartyDialogOpen(true)}
+          className="flex w-full items-center gap-3 rounded-2xl border border-dashed border-border-light px-4 py-3.5 text-left transition-colors hover:border-border-medium hover:bg-border-extra-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50"
+        >
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-border-extra-light text-text-extra-high">
+            <PlusIcon className="size-4" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium text-text-extra-high">Add counterparty</span>
+            <span className="block text-sm text-text-low">
+              Create a new buyer to deposit for if they aren&apos;t in the list yet.
+            </span>
+          </span>
+        </button>
+        <CounterpartySelector
+          counterpartiesResult={liveCounterpartiesResult}
+          value={onrampFields.counterpartyId || null}
+          onChange={(id) => setField("counterpartyId", id)}
+        />
+      </div>
+    );
+  }
+
+  if (stepIndex === 1) {
+    if (enabledRampProviders.length === 0) {
+      return (
+        <div className="rounded-2xl border border-border-light bg-border-extra-light px-5 py-5 text-sm text-text-low">
+          No on-ramp providers are enabled for this organization.
+        </div>
+      );
+    }
+
+    return (
+      <RampPairProviderSelector
+        direction="onramp"
+        pairs={ONRAMP_PAIRS}
+        enabledRampProviders={enabledRampProviders}
+        providerOptions={RAMP_PROVIDER_OPTIONS}
+        wallets={liveWallets}
+        walletsLoading={walletsLoading}
+        selectedWallet={selectedWallet}
+        selectedPair={selectedRampPair}
+        selectedProvider={onrampFields.provider}
+        amount={onrampFields.amount}
+        onAmountChange={(value) => setField("amount", value)}
+        onAmountBlur={() => {}}
+        onWalletChange={(walletId) => setField("walletId", walletId)}
+        onPairChange={handlePairChange}
+        onProviderSelect={(nextProvider) => setField("provider", nextProvider)}
+      />
+    );
+  }
+
+  if (stepIndex === 2 && onrampQuote?.deliveryMode === "hosted") {
+    return (
+      <div className="overflow-hidden rounded-2xl">
+        <iframe
+          title={`${onrampQuote.provider} on-ramp`}
+          src={onrampQuote.hostedUrl}
+          className="h-[480px] w-full border-0"
+          allow="accelerometer; autoplay; camera; encrypted-media; fullscreen; geolocation; gyroscope; payment"
+        />
+      </div>
+    );
+  }
+
+  if (stepIndex === 2 && onrampQuote?.deliveryMode === "manual_instructions") {
+    return (
+      <ManualInstructionsQuote
+        amount={onrampFields.amount.trim()}
+        quote={onrampQuote}
+        fiatCurrency={selectedRampPair.fiatCurrency}
+        cryptoToken={toRampCryptoToken(selectedRampPair.assetRail)}
+        instructions={onrampQuote.paymentInstructions ?? []}
+        simulateQuote={
+          onrampQuote.provider === "lightspark"
+            ? {
+                loading: quoteSimulationLoading,
+                succeeded: quoteSimulationSucceeded,
+                onClick: () => void simulateCurrentQuote(),
+              }
+            : undefined
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="grid place-items-center rounded-2xl border border-dashed border-border-light bg-border-extra-light px-6 py-16 text-center">
+      <p className="text-lg font-medium text-text-extra-high">Coming soon</p>
+      <p className="mt-1 text-sm text-text-low">This step isn&apos;t built yet.</p>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/use-onramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/use-onramp-wizard.ts
@@ -1,0 +1,280 @@
+"use client";
+
+import type {
+  Counterparty,
+  PaymentRampQuote,
+  PaymentsDashboardWallet,
+  RampProviderId,
+} from "@sdp/types";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import useSWR from "swr";
+import { DEFAULT_RAMP_PAIR, findRampPair, ONRAMP_PAIRS, type SelectedRampPair } from "@/lib/ramps";
+import { useZodForm } from "@/lib/use-zod-form";
+import {
+  type CounterpartiesResult,
+  fetchAllCounterparties,
+  fetchWallets,
+  getApiError,
+  simulateSandboxTransfer,
+} from "./payments-workspace.data";
+import {
+  counterpartySelectionSchema,
+  depositAmountSchema,
+  depositSelectionSchema,
+  INITIAL_ONRAMP_FIELDS,
+} from "./ramps/components/schema";
+
+const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
+const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
+
+export const STEPS = [
+  { label: "Counterparty", title: "Who is this deposit for?" },
+  { label: "Deposit", title: "How much would you like to deposit?" },
+  { label: "Provider", title: "Complete your deposit" },
+  { label: "Step 4", title: "Coming soon" },
+] as const;
+
+const STEP_SCHEMAS = [counterpartySelectionSchema, depositAmountSchema, null, null] as const;
+
+export function toRampCryptoToken(assetRail: SelectedRampPair["assetRail"]): string {
+  return assetRail.split(".")[0]?.toUpperCase() ?? assetRail.toUpperCase();
+}
+
+async function createOnrampQuote(payload: Record<string, unknown>): Promise<PaymentRampQuote> {
+  const response = await fetch("/api/dashboard/payments/ramps/onramp/quote", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = (await response.json().catch(() => ({}))) as {
+    data?: { quote?: PaymentRampQuote };
+    error?: { message?: string };
+  };
+
+  if (!response.ok) {
+    throw new Error(getApiError(body, `Ramp quote request failed (${response.status}).`));
+  }
+
+  if (!body.data?.quote) {
+    throw new Error("Ramp quote response is missing quote details.");
+  }
+
+  return body.data.quote;
+}
+
+interface UseOnrampWizardProps {
+  wallets: PaymentsDashboardWallet[];
+  walletsError: string | null;
+  enabledRampProviders: RampProviderId[];
+  counterpartiesResult: CounterpartiesResult;
+}
+
+export function useOnrampWizard({
+  wallets,
+  walletsError,
+  enabledRampProviders,
+  counterpartiesResult,
+}: UseOnrampWizardProps) {
+  const router = useRouter();
+
+  const [stepIndex, setStepIndex] = useState(0);
+  const [selectedRampPair, setSelectedRampPair] = useState<SelectedRampPair>(DEFAULT_RAMP_PAIR);
+  const [hostedQuoteLoading, setHostedQuoteLoading] = useState(false);
+  const [onrampQuote, setOnrampQuote] = useState<PaymentRampQuote | null>(null);
+  const [quoteSimulationLoading, setQuoteSimulationLoading] = useState(false);
+  const [quoteSimulationSucceeded, setQuoteSimulationSucceeded] = useState(false);
+  const [counterpartyDialogOpen, setCounterpartyDialogOpen] = useState(false);
+  const form = useZodForm(depositSelectionSchema, INITIAL_ONRAMP_FIELDS);
+  const { values: onrampFields, setField } = form;
+
+  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
+    PAYMENTS_ACTION_WALLETS_KEY,
+    () => fetchWallets({ includeBalances: true }),
+    {
+      fallbackData: wallets.length > 0 ? wallets : undefined,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const liveWallets = swrWallets ?? wallets;
+  const walletsLoading = swrWallets === undefined && !walletsFetchError;
+  const liveWalletsError = walletsFetchError
+    ? walletsFetchError instanceof Error
+      ? walletsFetchError.message
+      : "Request failed."
+    : swrWallets === undefined
+      ? walletsError
+      : null;
+
+  const { data: liveCounterpartiesResult, mutate: mutateCounterparties } = useSWR(
+    PAYMENTS_ACTION_COUNTERPARTIES_KEY,
+    fetchAllCounterparties,
+    {
+      fallbackData: counterpartiesResult,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+
+  const selectedWallet = useMemo(
+    () => liveWallets.find((wallet) => wallet.walletId === onrampFields.walletId) ?? null,
+    [liveWallets, onrampFields.walletId]
+  );
+
+  const stepSchema = STEP_SCHEMAS[stepIndex];
+  const canProceed = useMemo(
+    () => (stepSchema ? stepSchema.safeParse(onrampFields).success : true),
+    [stepSchema, onrampFields]
+  );
+
+  const isLastStep = stepIndex === STEPS.length - 1;
+  const currentStep = STEPS[stepIndex];
+
+  const createQuoteAndAdvance = async () => {
+    const parsed = depositSelectionSchema.safeParse(onrampFields);
+    if (!parsed.success || !onrampFields.provider) {
+      return;
+    }
+
+    setHostedQuoteLoading(true);
+    const toastId = toast.loading("Creating quote.", {
+      position: "bottom-right",
+    });
+
+    try {
+      const quote = await createOnrampQuote({
+        provider: onrampFields.provider,
+        counterpartyId: onrampFields.counterpartyId,
+        destinationWallet: onrampFields.walletId,
+        cryptoToken: toRampCryptoToken(selectedRampPair.assetRail),
+        fiatCurrency: selectedRampPair.fiatCurrency,
+        fiatAmount: onrampFields.amount.trim(),
+        redirectUrl: `${window.location.origin}/dashboard/payments`,
+      });
+
+      setOnrampQuote(quote);
+      setQuoteSimulationLoading(false);
+      setQuoteSimulationSucceeded(false);
+      setStepIndex(2);
+      setHostedQuoteLoading(false);
+      toast.success(quote.deliveryMode === "hosted" ? "Widget ready." : "Quote ready.", {
+        id: toastId,
+        position: "bottom-right",
+      });
+    } catch (error) {
+      setHostedQuoteLoading(false);
+      toast.error("Unable to create quote.", {
+        id: toastId,
+        description: error instanceof Error ? error.message : "Ramp quote request failed.",
+        position: "bottom-right",
+      });
+    }
+  };
+
+  const handlePrimary = async () => {
+    if (!canProceed) {
+      return;
+    }
+    if (stepIndex === 1) {
+      await createQuoteAndAdvance();
+      return;
+    }
+    if (isLastStep) {
+      toast.info("Next step coming soon.");
+      return;
+    }
+    setStepIndex((current) => current + 1);
+  };
+
+  const handleSecondary = () => {
+    if (stepIndex === 0) {
+      router.push("/dashboard/payments");
+      return;
+    }
+    setStepIndex((current) => Math.max(0, current - 1));
+  };
+
+  const handlePairChange = (nextPair: SelectedRampPair) => {
+    setSelectedRampPair(nextPair);
+    const support = findRampPair(ONRAMP_PAIRS, nextPair);
+    if (onrampFields.provider && !support?.providers.includes(onrampFields.provider)) {
+      setField("provider", null);
+    }
+  };
+
+  const handleCounterpartyCreated = (created: Counterparty) => {
+    setField("counterpartyId", created.id);
+    void mutateCounterparties(
+      (prev) => (prev ? { ...prev, data: [created, ...prev.data] } : { ok: true, data: [created] }),
+      { revalidate: true }
+    );
+    setCounterpartyDialogOpen(false);
+  };
+
+  const simulateCurrentQuote = async () => {
+    if (onrampQuote?.provider !== "lightspark") {
+      return;
+    }
+
+    setQuoteSimulationLoading(true);
+    const toastId = toast.loading("Simulating quote funding.", {
+      position: "bottom-right",
+    });
+
+    try {
+      await simulateSandboxTransfer({
+        provider: "lightspark",
+        payload: {
+          quoteId: onrampQuote.id,
+          currencyCode: "USD",
+        },
+      });
+      setQuoteSimulationSucceeded(true);
+      toast.success("Quote funding simulated.", {
+        id: toastId,
+        position: "bottom-right",
+      });
+    } catch (error) {
+      toast.error("Quote simulation failed.", {
+        id: toastId,
+        description: error instanceof Error ? error.message : "Sandbox simulation failed.",
+        position: "bottom-right",
+      });
+    } finally {
+      setQuoteSimulationLoading(false);
+    }
+  };
+
+  return {
+    enabledRampProviders,
+    stepIndex,
+    currentStep,
+    isLastStep,
+    canProceed,
+    liveWallets,
+    walletsLoading,
+    liveWalletsError,
+    liveCounterpartiesResult,
+    selectedWallet,
+    selectedRampPair,
+    onrampFields,
+    setField,
+    onrampQuote,
+    hostedQuoteLoading,
+    quoteSimulationLoading,
+    quoteSimulationSucceeded,
+    counterpartyDialogOpen,
+    setCounterpartyDialogOpen,
+    handlePrimary,
+    handleSecondary,
+    handlePairChange,
+    handleCounterpartyCreated,
+    simulateCurrentQuote,
+  };
+}
+
+export type OnrampWizard = ReturnType<typeof useOnrampWizard>;

--- a/packages/sdp-types/src/payment-rails.ts
+++ b/packages/sdp-types/src/payment-rails.ts
@@ -27,6 +27,17 @@ export function getCryptoRailAssetLabel(assetRail: CryptoRailId): string {
   return CRYPTO_RAIL_ASSET_LABELS[assetRail];
 }
 
+export type CryptoAssetSymbol = (typeof CRYPTO_RAIL_ASSET_LABELS)[CryptoRailId];
+
+/** On-chain decimals per crypto asset symbol; fiat falls back to 2 minor units. */
+export const CRYPTO_ASSET_DECIMALS = {
+  SOL: 9,
+  USDC: 6,
+  USDT: 6,
+  USDG: 6,
+  PYUSD: 6,
+} as const satisfies Record<CryptoAssetSymbol, number>;
+
 export interface OnrampPairSupport<FiatCurrency extends string = FiatCurrencyCode> {
   source: FiatCurrency;
   dest: CryptoRailId;

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -140,6 +140,8 @@ export interface LightsparkPaymentRampInstruction {
 
 export type PaymentRampInstruction = LightsparkPaymentRampInstruction;
 
+export type PaymentRampQuoteDeliveryMode = "manual_instructions" | "hosted";
+
 interface BasePaymentRampExecution {
   id: string;
   status: PaymentRampExecutionStatus;
@@ -155,4 +157,33 @@ export type PaymentRampExecution =
   | (BasePaymentRampExecution & {
       provider: Exclude<RampProviderId, "lightspark">;
       paymentInstructions?: never;
+    });
+
+interface BasePaymentRampQuote {
+  id: string;
+  provider: RampProviderId;
+  status: PaymentRampExecutionStatus;
+  deliveryMode: PaymentRampQuoteDeliveryMode;
+}
+
+export type PaymentRampQuote =
+  | (BasePaymentRampQuote & {
+      provider: "lightspark";
+      deliveryMode: "manual_instructions";
+      /** Units of destination crypto per unit of source fiat. */
+      exchangeRate?: number;
+      /** Total sending amount in the fiat currency's smallest unit, including provider fees. */
+      totalSendingAmount?: number;
+      /** Final crypto amount received in its smallest unit. */
+      totalReceivingAmount?: number;
+      /** Fees included in the sending amount, denominated in the fiat currency's smallest unit. */
+      feesIncluded?: number;
+      /** ISO timestamp after which the locked rate is no longer valid. */
+      expiresAt?: string;
+      paymentInstructions?: LightsparkPaymentRampInstruction[];
+    })
+  | (BasePaymentRampQuote & {
+      provider: "moonpay";
+      deliveryMode: "hosted";
+      hostedUrl: string;
     });


### PR DESCRIPTION
## Summary

Phase 2 of onramp provider integration: adds the **on-ramp quote** flow end to end, with Lightspark (Grid) as the first native provider, plus a shared HTTP layer for ramp providers and a multi-step on-ramp wizard in the dashboard.

<img width="3456" height="2083" alt="CleanShot 2026-06-02 at 11 17 44@2x" src="https://github.com/user-attachments/assets/ced17f6d-87d1-47fa-a1e4-1d233f11ae05" />

## API (`sdp-api`)

- **New endpoint `POST /ramps/onramp/quote`** (wallet-scoped: `payments:write` + `wallets:read`) — creates a just-in-time funded Grid quote and returns either manual funding instructions or a hosted widget URL.
- **Generic provider HTTP util** (`lib/ramps/fetch.ts`) — `providerFetchJson<TResponse, TBody>()` centralizes JSON requests: transport failures → `PROVIDER_UNAVAILABLE`, status → `AppError` mapping (`409 → CONFLICT`, `429 → RATE_LIMITED`, `5xx → PROVIDER_UNAVAILABLE`), and provider error-message extraction. Both the Lightspark client and the handler-local `lightsparkRequest` now share this one path, removing the previously divergent fetch/error implementations.
- **Lightspark client** (`lib/ramps/providers/lightspark.ts`) — native Grid customer + JIT onramp quote, typed against the Grid OpenAPI schema. Customer creation is **idempotent**: Grid enforces uniqueness on `platformCustomerId` (our counterparty id), so `getOrCreateCustomer` recovers from a `409 CONFLICT` by looking the existing customer up — concurrent quote requests converge on one customer instead of orphaning a Grid record.

## Types (`@sdp/types`)

- Adds `PaymentRampQuote`, `PaymentRampQuoteDeliveryMode`, `BasePaymentRampQuote` (manual-instructions vs hosted delivery modes), consumed by the web onramp wizard.

## Web (`sdp-web`)

- **On-ramp wizard** — multi-step deposit flow (counterparty → amount/provider → funding). Logic extracted into a `useOnrampWizard` hook and the step rendering into `OnrampStepContent`, keeping `PaymentsActionPage` a thin orchestrator (resolves the cognitive-complexity lint).
- New `app/api/dashboard/payments/ramps/[direction]/quote` route + quote-formatting utils.

## Tests

- `payments.test.ts` covers the onramp quote/execute paths; `wallet-scope-route-coverage.test.ts` updated to track `POST /ramps/onramp/quote` as wallet-scoped.

## Follow-ups

- Dedicated test for the Lightspark quote path including the 409-recovery / concurrency case.
