### PR TITLE
docs: add self-hosted co-signer hosting guidance

### DIFF
--- a/apps/sdp-docs/content/docs/self-hosting/external-co-signers.mdx
+++ b/apps/sdp-docs/content/docs/self-hosting/external-co-signers.mdx
@@ -1,0 +1,50 @@
+---
+title: External Co-Signers
+description: Host provider-specific signing automation outside the default self-hosted SDP stack.
+---
+
+Some signing providers need an operator-managed co-signer or automation process
+in addition to the SDP API. Run those processes outside the default self-hosted
+SDP stack.
+
+`infra/self-hosted/compose.yml` is intentionally unchanged by default. It starts
+the SDP API, web app, docs app, database, cache, and migrations. Provider
+co-signers are separate operational services because they usually have their own
+secret handling, identity, ingress, and availability requirements.
+
+## Production pattern
+
+Use a managed container service such as Google Cloud Run, or the equivalent in
+your cloud, for provider-specific co-signer runtimes.
+
+- Use the provider- or operator-supplied co-signer image and runtime.
+- Store co-signer secrets in a cloud secret manager, not in the SDP compose file.
+- Run the co-signer with a dedicated service account that can read only the
+  secrets it needs.
+- Configure ingress and invoker IAM for the provider flow. Prefer private or
+  authenticated ingress when the provider does not require a public callback.
+- Set `minScale` to `1` when callback latency or provider availability matters;
+  use scale-to-zero only when cold starts are acceptable.
+- Keep development, staging, and production co-signers separated by provider
+  account, cloud project, service account, and secrets.
+- Alert on failed signing attempts, container restarts, authentication failures,
+  and stale or expired key material.
+
+## Utila readiness
+
+Utila is the motivating future provider for this pattern. When Utila signer
+support lands, the co-signer should be hosted as an external operator service,
+for example on Cloud Run, while SDP keeps its API, web, docs, database, and cache
+inside the normal self-hosted stack.
+
+This page does not make Utila a live SDP signing provider. Do not set
+`SIGNING_PROVIDER=utila` until the Utila signer integration explicitly adds that
+provider option and the required runtime configuration.
+
+Operator scaffolding for a Utila Cloud Run deployment lives in
+`infra/utila/cloud-run/`.
+
+That scaffold is intended to host the co-signer endpoint before Utila becomes a
+default self-hosted service. Operators can deploy their own co-signer image,
+protect the endpoint with Cloud Run IAM or runtime-level request verification,
+and pass the resulting service URL and token into a custom SDP Utila integration.

--- a/apps/sdp-docs/content/docs/self-hosting/meta.json
+++ b/apps/sdp-docs/content/docs/self-hosting/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Self-Hosting",
-  "pages": ["configurator"]
+  "pages": ["configurator", "external-co-signers"]
 }

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -3344,6 +3344,59 @@ run `docker compose up -d`.
 
 ---
 
+### External Co-Signers
+Source: https://platform.solana.com/docs/self-hosting/external-co-signers
+
+> Host provider-specific signing automation outside the default self-hosted SDP stack.
+
+Some signing providers need an operator-managed co-signer or automation process
+in addition to the SDP API. Run those processes outside the default self-hosted
+SDP stack.
+
+`infra/self-hosted/compose.yml` is intentionally unchanged by default. It starts
+the SDP API, web app, docs app, database, cache, and migrations. Provider
+co-signers are separate operational services because they usually have their own
+secret handling, identity, ingress, and availability requirements.
+
+## Production pattern
+
+Use a managed container service such as Google Cloud Run, or the equivalent in
+your cloud, for provider-specific co-signer runtimes.
+
+- Use the provider- or operator-supplied co-signer image and runtime.
+- Store co-signer secrets in a cloud secret manager, not in the SDP compose file.
+- Run the co-signer with a dedicated service account that can read only the
+  secrets it needs.
+- Configure ingress and invoker IAM for the provider flow. Prefer private or
+  authenticated ingress when the provider does not require a public callback.
+- Set `minScale` to `1` when callback latency or provider availability matters;
+  use scale-to-zero only when cold starts are acceptable.
+- Keep development, staging, and production co-signers separated by provider
+  account, cloud project, service account, and secrets.
+- Alert on failed signing attempts, container restarts, authentication failures,
+  and stale or expired key material.
+
+## Utila readiness
+
+Utila is the motivating future provider for this pattern. When Utila signer
+support lands, the co-signer should be hosted as an external operator service,
+for example on Cloud Run, while SDP keeps its API, web, docs, database, and cache
+inside the normal self-hosted stack.
+
+This page does not make Utila a live SDP signing provider. Do not set
+`SIGNING_PROVIDER=utila` until the Utila signer integration explicitly adds that
+provider option and the required runtime configuration.
+
+Operator scaffolding for a Utila Cloud Run deployment lives in
+`infra/utila/cloud-run/`.
+
+That scaffold is intended to host the co-signer endpoint before Utila becomes a
+default self-hosted service. Operators can deploy their own co-signer image,
+protect the endpoint with Cloud Run IAM or runtime-level request verification,
+and pass the resulting service URL and token into a custom SDP Utila integration.
+
+---
+
 ## Reference
 
 ### Reference
@@ -3659,6 +3712,7 @@ Source: https://platform.solana.com/docs/reference/api/payments
 | `POST` | `/v1/payments/ramps/offramp/execute` | Execute off-ramp |
 | `GET` | `/v1/payments/ramps/onramp/currency` | List on-ramp currency support |
 | `POST` | `/v1/payments/ramps/onramp/execute` | Execute on-ramp |
+| `POST` | `/v1/payments/ramps/onramp/quote` | Create on-ramp quote |
 | `POST` | `/v1/payments/ramps/sandbox/simulate` | Simulate sandbox transfer |
 | `GET` | `/v1/payments/transfers` | List transfers |
 | `POST` | `/v1/payments/transfers` | Execute transfer (custody) |

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1235,6 +1235,30 @@
           }
         },
         {
+          "name": "Create on-ramp quote",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseUrl}}/v1/payments/ramps/onramp/quote",
+            "description": "Creates a provider-specific on-ramp quote. Hosted providers return a hosted URL; instruction-based providers return manual funding instructions.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"moonpay\",\n  \"counterpartyId\": \"counterparty_example\",\n  \"destinationWallet\": \"wal_example\",\n  \"cryptoToken\": \"USDC\",\n  \"fiatCurrency\": \"USD\",\n  \"fiatAmount\": \"100.00\",\n  \"redirectUrl\": \"https://example.com/onramp/complete\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          }
+        },
+        {
           "name": "Execute on-ramp",
           "request": {
             "method": "POST",

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -71,5 +71,7 @@ FEE_PAYMENT_PROVIDER=native
 # Observability (optional)
 # SENTRY_DSN=
 
-# Other optional integrations (compliance, fiat ramps, more signing backends) use the
-# same mechanism; see the self-hosting docs.
+# Provider co-signers and automation should be hosted outside the default compose
+# stack; see /docs/self-hosting/external-co-signers and infra/utila/cloud-run.
+# Other optional integrations (compliance, fiat ramps, more signing backends) use
+# the same mechanism; see the self-hosting docs.

--- a/infra/utila/cloud-run/.env.example
+++ b/infra/utila/cloud-run/.env.example
@@ -1,0 +1,38 @@
+# Copy to .env.local and fill in before running ./deploy.sh.
+# These values configure the external co-signer Cloud Run service only; they are
+# not SDP API environment variables.
+
+GCP_PROJECT_ID=your-gcp-project-id
+GCP_REGION=us-central1
+
+COSIGNER_SERVICE_NAME=utila-cosigner-dev
+COSIGNER_ENVIRONMENT=dev
+COSIGNER_IMAGE=your-region-docker.pkg.dev/your-gcp-project-id/your-repository/your-utila-cosigner-image:tag
+
+# The deploy script creates this service account if it does not exist.
+COSIGNER_SERVICE_ACCOUNT=utila-cosigner-runtime
+
+# Keep private/internal where possible. Use "all" only when the co-signer
+# runtime must receive public callbacks or SDP reaches it from outside GCP.
+COSIGNER_INGRESS=internal-and-cloud-load-balancing
+COSIGNER_ALLOW_UNAUTHENTICATED=false
+
+COSIGNER_MIN_SCALE=1
+COSIGNER_MAX_SCALE=3
+COSIGNER_CONTAINER_PORT=8080
+
+# Secret Manager secret names and versions exposed to the co-signer runtime.
+# Pin key material and auth tokens to reviewed versions; rotate with a new Cloud
+# Run revision.
+COSIGNER_CONFIG_SECRET=utila-cosigner-config
+COSIGNER_CONFIG_SECRET_VERSION=latest
+COSIGNER_PRIVATE_KEY_SECRET=utila-cosigner-private-key
+COSIGNER_PRIVATE_KEY_SECRET_VERSION=1
+COSIGNER_AUTH_TOKEN_SECRET=utila-cosigner-auth-token
+COSIGNER_AUTH_TOKEN_SECRET_VERSION=1
+
+# Optional local files. If set, deploy.sh creates the secrets when missing and
+# adds a new Secret Manager version from these files.
+COSIGNER_CONFIG_FILE=
+COSIGNER_PRIVATE_KEY_FILE=
+COSIGNER_AUTH_TOKEN_FILE=

--- a/infra/utila/cloud-run/README.md
+++ b/infra/utila/cloud-run/README.md
@@ -1,0 +1,181 @@
+# Utila Co-Signer on Cloud Run
+
+This folder is operator scaffolding for hosting a Utila external co-signer on
+Google Cloud Run. It does not define an SDP-owned co-signer image, does not add
+Utila as a selectable SDP signing provider, and does not change the default
+self-hosted compose stack.
+
+Use a Utila- or operator-supplied co-signer runtime. Replace every placeholder in
+`service.template.yaml` with the image, command, environment variables, and
+Secret Manager references required by that runtime.
+
+## What this enables
+
+This scaffold lets you host the co-signer service before Utila is part of the
+default self-hosted SDP stack:
+
+- Cloud Run hosts the operator-supplied co-signer image.
+- Secret Manager stores provider config, private key material, and a runtime
+  authentication token for SDP-to-co-signer calls.
+- A dedicated runtime service account can read only those secrets.
+- The deploy script prints a Cloud Run URL that your own SDP Utila integration
+  can call once the integration wiring exists.
+
+The co-signer remains an external service. SDP self-hosted compose stays focused
+on the API, web, docs, database, cache, and migrations.
+
+## Cloud layout
+
+Create one Cloud Run service per environment:
+
+- Separate GCP projects or folders for development, staging, and production.
+- A dedicated runtime service account for each co-signer service.
+- Secret Manager entries scoped to the matching environment.
+- Separate Utila vaults, policies, keys, or API credentials for each
+  environment.
+
+Keep the co-signer outside `infra/self-hosted/compose.yml`. The compose stack
+runs SDP; the co-signer is a provider-specific operational service.
+
+## Secrets
+
+Store all co-signer configuration and key material in Secret Manager. Do not
+commit secrets to this repo and do not add them to the self-hosted `.env` file
+unless a later signer integration documents an SDP API variable.
+
+Typical secret categories:
+
+- Provider API credentials.
+- Co-signer private key material or encrypted key material.
+- Runtime authentication token shared with your SDP Utila integration.
+- Webhook or callback verification secrets.
+- Optional provider policy configuration.
+
+Grant the Cloud Run runtime service account `roles/secretmanager.secretAccessor`
+only on the secrets required by that environment.
+
+Pin private key secret versions in Cloud Run revisions instead of using
+`latest`. Rotate by deploying a new revision that points at the new version, then
+shift traffic after validation.
+
+## Ingress and IAM
+
+Choose ingress based on how the Utila co-signer runtime communicates:
+
+- If the runtime only polls Utila or makes outbound calls, keep ingress private
+  or disabled where the runtime supports it.
+- If Utila must call the service over HTTP, allow only the required ingress path
+  and use Cloud Run invoker IAM, an HTTPS load balancer, or another supported
+  authentication layer.
+- Avoid `allUsers` invoker unless the provider flow requires a public callback
+  and request verification is enforced by the co-signer runtime.
+
+## Scaling
+
+Use `minScale: 1` for production if missed callbacks, slow cold starts, or key
+availability would block transaction signing. Scale to zero is acceptable for
+development and low-availability environments when cold starts are understood.
+
+Set a conservative `maxScale` until the provider rate limits and signing policy
+limits are known.
+
+## Logging and alerts
+
+Route Cloud Run logs to your normal observability stack. Alert on:
+
+- Failed signing or co-signing attempts.
+- Authentication or request verification failures.
+- Container restarts and crash loops.
+- Secret access failures.
+- Stale key material, expired certificates, or policy drift.
+
+Avoid logging private key material, provider tokens, full unsigned transaction
+payloads, or customer-identifying metadata.
+
+## Key rotation
+
+Plan key rotation before production:
+
+1. Add new provider credentials or key material in Secret Manager.
+2. Deploy a new Cloud Run revision that can read the new secret version.
+3. Confirm Utila policies accept the new co-signer identity.
+4. Shift traffic to the new revision.
+5. Revoke or disable the old credential after validation.
+
+Keep rollback steps documented for each environment.
+
+## Deploy sketch
+
+The exact command depends on the Utila co-signer runtime. A typical Cloud Run
+setup looks like:
+
+```bash
+gcloud config set project YOUR_GCP_PROJECT_ID
+
+gcloud iam service-accounts create utila-cosigner-runtime \
+  --display-name="Utila co-signer runtime"
+
+gcloud secrets create utila-cosigner-config --replication-policy=automatic
+gcloud secrets versions add utila-cosigner-config --data-file=./config.json
+
+gcloud secrets create utila-cosigner-private-key --replication-policy=automatic
+gcloud secrets versions add utila-cosigner-private-key --data-file=./private-key.txt
+
+gcloud secrets create utila-cosigner-auth-token --replication-policy=automatic
+gcloud secrets versions add utila-cosigner-auth-token --data-file=./auth-token.txt
+
+gcloud secrets add-iam-policy-binding utila-cosigner-config \
+  --member=serviceAccount:utila-cosigner-runtime@YOUR_GCP_PROJECT_ID.iam.gserviceaccount.com \
+  --role=roles/secretmanager.secretAccessor
+
+gcloud secrets add-iam-policy-binding utila-cosigner-private-key \
+  --member=serviceAccount:utila-cosigner-runtime@YOUR_GCP_PROJECT_ID.iam.gserviceaccount.com \
+  --role=roles/secretmanager.secretAccessor
+
+gcloud secrets add-iam-policy-binding utila-cosigner-auth-token \
+  --member=serviceAccount:utila-cosigner-runtime@YOUR_GCP_PROJECT_ID.iam.gserviceaccount.com \
+  --role=roles/secretmanager.secretAccessor
+
+gcloud run services replace rendered.service.yaml --region YOUR_REGION
+```
+
+Before production, render or replace the template placeholders, verify
+ingress/IAM, and confirm the co-signer has environment-specific Utila policy
+approval.
+
+For the scripted path:
+
+```bash
+cp infra/utila/cloud-run/.env.example infra/utila/cloud-run/.env.local
+$EDITOR infra/utila/cloud-run/.env.local
+infra/utila/cloud-run/deploy.sh infra/utila/cloud-run/.env.local
+```
+
+`deploy.sh` creates the runtime service account when needed, creates the listed
+Secret Manager secrets when missing, optionally adds new secret versions from the
+files in `.env.local`, grants the service account secret access, renders
+`service.template.yaml`, applies it to Cloud Run, and prints the service URL.
+It also syncs public invoker access with `COSIGNER_ALLOW_UNAUTHENTICATED`,
+removing any existing `allUsers` invoker binding when the flag is `false`.
+
+Set `COSIGNER_ALLOW_UNAUTHENTICATED=true` only when the runtime must be
+reachable without Cloud Run IAM. In that mode the co-signer runtime must verify
+each request, for example with the `COSIGNER_AUTH_TOKEN` secret. Re-run the
+script with `COSIGNER_ALLOW_UNAUTHENTICATED=false` to lock down a service that
+was previously public.
+
+If your co-signer image expects different environment variable names, edit
+`service.template.yaml` before deploying. Keep the Cloud Run service account,
+ingress, scaling, and secret-version pinning pattern intact.
+
+## SDP integration boundary
+
+This scaffold is a prerequisite for the Utila signer integration. The signer
+integration should later add the SDP API configuration and runtime wiring that
+lets SDP talk to Utila. Until that lands, this folder is hosting guidance only.
+
+For a custom Utila integration, point the integration at the deployed Cloud Run
+URL and use a token or IAM strategy that matches the co-signer runtime. Keep the
+runtime URL, auth token, and provider-specific variables out of
+`infra/self-hosted/.env.example` until the Utila signer integration owns those
+fields.

--- a/infra/utila/cloud-run/deploy.sh
+++ b/infra/utila/cloud-run/deploy.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${1:-}"
+
+if [[ -n "$ENV_FILE" ]]; then
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing env file: $ENV_FILE" >&2
+    exit 1
+  fi
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+require() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: $name" >&2
+    exit 1
+  fi
+}
+
+require_file_if_set() {
+  local name="$1"
+  local path="${!name:-}"
+  if [[ -n "$path" && ! -f "$path" ]]; then
+    echo "$name points at a missing file: $path" >&2
+    exit 1
+  fi
+}
+
+ensure_secret() {
+  local secret_name="$1"
+  local source_file="$2"
+
+  if ! gcloud secrets describe "$secret_name" >/dev/null 2>&1; then
+    if [[ -z "$source_file" ]]; then
+      echo "Secret $secret_name does not exist and no source file was provided." >&2
+      exit 1
+    fi
+    gcloud secrets create "$secret_name" --replication-policy=automatic
+  fi
+
+  if [[ -n "$source_file" ]]; then
+    gcloud secrets versions add "$secret_name" --data-file="$source_file"
+  fi
+
+  gcloud secrets add-iam-policy-binding "$secret_name" \
+    --member="serviceAccount:${COSIGNER_SERVICE_ACCOUNT_EMAIL}" \
+    --role=roles/secretmanager.secretAccessor \
+    --quiet >/dev/null
+}
+
+for var in \
+  GCP_PROJECT_ID \
+  GCP_REGION \
+  COSIGNER_SERVICE_NAME \
+  COSIGNER_ENVIRONMENT \
+  COSIGNER_IMAGE \
+  COSIGNER_INGRESS \
+  COSIGNER_CONFIG_SECRET \
+  COSIGNER_CONFIG_SECRET_VERSION \
+  COSIGNER_PRIVATE_KEY_SECRET \
+  COSIGNER_PRIVATE_KEY_SECRET_VERSION \
+  COSIGNER_AUTH_TOKEN_SECRET \
+  COSIGNER_AUTH_TOKEN_SECRET_VERSION; do
+  require "$var"
+done
+
+COSIGNER_SERVICE_ACCOUNT="${COSIGNER_SERVICE_ACCOUNT:-utila-cosigner-runtime}"
+COSIGNER_SERVICE_ACCOUNT_EMAIL="${COSIGNER_SERVICE_ACCOUNT_EMAIL:-${COSIGNER_SERVICE_ACCOUNT}@${GCP_PROJECT_ID}.iam.gserviceaccount.com}"
+COSIGNER_MIN_SCALE="${COSIGNER_MIN_SCALE:-1}"
+COSIGNER_MAX_SCALE="${COSIGNER_MAX_SCALE:-3}"
+COSIGNER_CONTAINER_PORT="${COSIGNER_CONTAINER_PORT:-8080}"
+COSIGNER_ALLOW_UNAUTHENTICATED="${COSIGNER_ALLOW_UNAUTHENTICATED:-false}"
+
+if [[ "$COSIGNER_ALLOW_UNAUTHENTICATED" != "true" && "$COSIGNER_ALLOW_UNAUTHENTICATED" != "false" ]]; then
+  echo "COSIGNER_ALLOW_UNAUTHENTICATED must be true or false." >&2
+  exit 1
+fi
+
+export \
+  GCP_PROJECT_ID \
+  GCP_REGION \
+  COSIGNER_SERVICE_NAME \
+  COSIGNER_ENVIRONMENT \
+  COSIGNER_IMAGE \
+  COSIGNER_INGRESS \
+  COSIGNER_SERVICE_ACCOUNT_EMAIL \
+  COSIGNER_MIN_SCALE \
+  COSIGNER_MAX_SCALE \
+  COSIGNER_CONTAINER_PORT \
+  COSIGNER_CONFIG_SECRET \
+  COSIGNER_CONFIG_SECRET_VERSION \
+  COSIGNER_PRIVATE_KEY_SECRET \
+  COSIGNER_PRIVATE_KEY_SECRET_VERSION \
+  COSIGNER_AUTH_TOKEN_SECRET \
+  COSIGNER_AUTH_TOKEN_SECRET_VERSION
+
+require_file_if_set COSIGNER_CONFIG_FILE
+require_file_if_set COSIGNER_PRIVATE_KEY_FILE
+require_file_if_set COSIGNER_AUTH_TOKEN_FILE
+
+gcloud config set project "$GCP_PROJECT_ID" >/dev/null
+
+if ! gcloud iam service-accounts describe "$COSIGNER_SERVICE_ACCOUNT_EMAIL" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "$COSIGNER_SERVICE_ACCOUNT" \
+    --display-name="Utila co-signer runtime"
+fi
+
+ensure_secret "$COSIGNER_CONFIG_SECRET" "${COSIGNER_CONFIG_FILE:-}"
+ensure_secret "$COSIGNER_PRIVATE_KEY_SECRET" "${COSIGNER_PRIVATE_KEY_FILE:-}"
+ensure_secret "$COSIGNER_AUTH_TOKEN_SECRET" "${COSIGNER_AUTH_TOKEN_FILE:-}"
+
+RENDERED="$(mktemp "${TMPDIR:-/tmp}/utila-cosigner-service.XXXXXX.yaml")"
+trap 'rm -f "$RENDERED"' EXIT
+
+node - "$SCRIPT_DIR/service.template.yaml" "$RENDERED" <<'JS'
+const fs = require("node:fs");
+
+const [templatePath, outputPath] = process.argv.slice(2);
+const keys = [
+  "COSIGNER_SERVICE_NAME",
+  "COSIGNER_ENVIRONMENT",
+  "COSIGNER_INGRESS",
+  "COSIGNER_MIN_SCALE",
+  "COSIGNER_MAX_SCALE",
+  "COSIGNER_SERVICE_ACCOUNT_EMAIL",
+  "COSIGNER_IMAGE",
+  "COSIGNER_CONTAINER_PORT",
+  "COSIGNER_CONFIG_SECRET",
+  "COSIGNER_CONFIG_SECRET_VERSION",
+  "COSIGNER_PRIVATE_KEY_SECRET",
+  "COSIGNER_PRIVATE_KEY_SECRET_VERSION",
+  "COSIGNER_AUTH_TOKEN_SECRET",
+  "COSIGNER_AUTH_TOKEN_SECRET_VERSION",
+];
+
+let content = fs.readFileSync(templatePath, "utf8");
+for (const key of keys) {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing ${key}`);
+  }
+  content = content.split(`__${key}__`).join(value);
+}
+
+fs.writeFileSync(outputPath, content);
+JS
+
+gcloud run services replace "$RENDERED" --region "$GCP_REGION"
+
+if [[ "$COSIGNER_ALLOW_UNAUTHENTICATED" == "true" ]]; then
+  gcloud run services add-iam-policy-binding "$COSIGNER_SERVICE_NAME" \
+    --region "$GCP_REGION" \
+    --member=allUsers \
+    --role=roles/run.invoker \
+    --quiet >/dev/null
+else
+  gcloud run services remove-iam-policy-binding "$COSIGNER_SERVICE_NAME" \
+    --region "$GCP_REGION" \
+    --member=allUsers \
+    --role=roles/run.invoker \
+    --quiet >/dev/null 2>&1 || true
+fi
+
+SERVICE_URL="$(gcloud run services describe "$COSIGNER_SERVICE_NAME" \
+  --region "$GCP_REGION" \
+  --format='value(status.url)')"
+
+cat <<EOF
+Utila co-signer Cloud Run service deployed.
+
+Service: ${COSIGNER_SERVICE_NAME}
+Region:  ${GCP_REGION}
+URL:     ${SERVICE_URL}
+
+Use this URL with the Utila SDP integration once its runtime wiring is present.
+EOF

--- a/infra/utila/cloud-run/service.template.yaml
+++ b/infra/utila/cloud-run/service.template.yaml
@@ -1,0 +1,46 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: __COSIGNER_SERVICE_NAME__
+  labels:
+    app: utila-cosigner
+    env: __COSIGNER_ENVIRONMENT__
+  annotations:
+    # Set to "all" only when the provider requires a public callback and the
+    # co-signer runtime verifies every request.
+    run.googleapis.com/ingress: __COSIGNER_INGRESS__
+spec:
+  template:
+    metadata:
+      annotations:
+        # Use "1" for production when callback latency or signing availability
+        # matters. Scale to zero is usually only appropriate for development.
+        autoscaling.knative.dev/minScale: "__COSIGNER_MIN_SCALE__"
+        autoscaling.knative.dev/maxScale: "__COSIGNER_MAX_SCALE__"
+    spec:
+      serviceAccountName: __COSIGNER_SERVICE_ACCOUNT_EMAIL__
+      containers:
+        - image: __COSIGNER_IMAGE__
+          ports:
+            - name: http1
+              containerPort: __COSIGNER_CONTAINER_PORT__
+          env:
+            # Replace these placeholder names with the variables required by
+            # the Utila- or operator-supplied co-signer runtime.
+            - name: COSIGNER_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: __COSIGNER_CONFIG_SECRET__
+                  key: __COSIGNER_CONFIG_SECRET_VERSION__
+            - name: COSIGNER_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: __COSIGNER_PRIVATE_KEY_SECRET__
+                  # Pin private key material to a reviewed Secret Manager
+                  # version. Deploy a new revision to rotate.
+                  key: "__COSIGNER_PRIVATE_KEY_SECRET_VERSION__"
+            - name: COSIGNER_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: __COSIGNER_AUTH_TOKEN_SECRET__
+                  key: "__COSIGNER_AUTH_TOKEN_SECRET_VERSION__"


### PR DESCRIPTION
## Summary
- Add self-hosted external co-signer hosting guidance, with Utila/Cloud Run as the motivating future case.
- Add deployable Utila Cloud Run operator scaffolding: env example, Secret Manager/IAM wiring, rendered service template, and deploy script.
- Make the deploy script keep public invoker access in sync, including removing `allUsers` when `COSIGNER_ALLOW_UNAUTHENTICATED=false`.
- Add a small self-hosted env note pointing operators to the external co-signer docs.

## Notes
- Prerequisite for #386 and intended to merge before the Utila signer PR.
- Intentionally does not expose Utila as a live SDP signing provider.
- The default self-hosted compose stack stays unchanged; the co-signer is hosted externally.
- Custom Utila integrations can point at the deployed Cloud Run URL and auth-token strategy until the Utila signer PR adds owned `UTILA_*` env/configurator/runtime wiring.
- Production use remains blocked on deploying the external co-signer infrastructure/runtime.

## Testing
- `bash -n infra/utila/cloud-run/deploy.sh`
- Rendered `infra/utila/cloud-run/service.template.yaml` from `.env.example` and verified no placeholders remain.
- `pnpm --filter sdp-docs check:links`
- `NEXT_PUBLIC_SDP_DOCS_URL=https://platform.solana.com/docs pnpm --filter sdp-docs build`
- `git diff --check`

## Review Status
- Greptile loop completed: `5/5` on `08d25e7e600076e3dff7dafa3b897158e5153b9f`.
- CI is green with no failures.