### PR TITLE
fix: batch Cloudflare Worker secret uploads

### DIFF
--- a/.github/workflows/deploy-sdp-api.yml
+++ b/.github/workflows/deploy-sdp-api.yml
@@ -236,8 +236,18 @@ jobs:
             echo "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID must be present in Doppler config ${DOPPLER_CONFIG_NAME}." >&2
             exit 1
           fi
-          node scripts/project-secrets.mjs cloudflare --out "${RUNNER_TEMP}/cloudflare-secrets.json"
-          pnpm --filter @sdp/api exec wrangler secret bulk "${RUNNER_TEMP}/cloudflare-secrets.json" --env "${TARGET_ENV}" --config "${WRANGLER_CONFIG_PATH}"
+          secrets_dir="${RUNNER_TEMP}/cloudflare-secret-batches"
+          node scripts/project-secrets.mjs cloudflare-batches --out-dir "${secrets_dir}" --batch-size 25
+          shopt -s nullglob
+          batch_count=0
+          for secrets_file in "${secrets_dir}"/*.json; do
+            batch_count=$((batch_count + 1))
+            echo "Syncing Worker secret batch ${batch_count} from ${secrets_file}"
+            pnpm --filter @sdp/api exec wrangler secret bulk "${secrets_file}" --env "${TARGET_ENV}" --config "${WRANGLER_CONFIG_PATH}"
+          done
+          if [ "${batch_count}" -eq 0 ]; then
+            echo "No Worker secrets to sync."
+          fi
 
       - name: Deploy Worker
         run: pnpm --filter @sdp/api exec wrangler deploy --env "${TARGET_ENV}" --config "${WRANGLER_CONFIG_PATH}"

--- a/scripts/project-secrets.mjs
+++ b/scripts/project-secrets.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { parseArgs } from "node:util";
 import { CLOUDFLARE_SECRET_KEYS, DOCKER_ENV_KEYS } from "./secret-keys.mjs";
 
@@ -21,6 +22,37 @@ function emit(contents, outPath) {
 function writeCloudflareSecretPayload(outPath) {
   const payload = Object.fromEntries(collectEntries(CLOUDFLARE_SECRET_KEYS));
   emit(`${JSON.stringify(payload, null, 2)}\n`, outPath);
+}
+
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${optionName} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function writeCloudflareSecretBatches(outDir, batchSize) {
+  if (!outDir) {
+    throw new Error("cloudflare-batches requires --out-dir.");
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const entries = collectEntries(CLOUDFLARE_SECRET_KEYS);
+  if (entries.length === 0) {
+    process.stdout.write("wrote 0 Cloudflare secret batches\n");
+    return;
+  }
+
+  const totalBatches = Math.ceil(entries.length / batchSize);
+  for (let i = 0; i < totalBatches; i += 1) {
+    const batch = entries.slice(i * batchSize, (i + 1) * batchSize);
+    const payload = Object.fromEntries(batch);
+    const batchNumber = String(i + 1).padStart(3, "0");
+    const outPath = path.join(outDir, `cloudflare-secrets-${batchNumber}.json`);
+    emit(`${JSON.stringify(payload, null, 2)}\n`, outPath);
+  }
 }
 
 function ensureDockerSafe(key, value) {
@@ -52,6 +84,7 @@ function printUsage() {
     [
       "Usage:",
       "  node scripts/project-secrets.mjs cloudflare [--out /tmp/cloudflare-secrets.json]",
+      "  node scripts/project-secrets.mjs cloudflare-batches --out-dir /tmp/cloudflare-secrets [--batch-size 25]",
       "  node scripts/project-secrets.mjs docker [--out /tmp/.env.docker]",
       "",
     ].join("\n")
@@ -61,7 +94,9 @@ function printUsage() {
 const { positionals, values } = parseArgs({
   allowPositionals: true,
   options: {
+    "batch-size": { type: "string", default: "25" },
     out: { type: "string" },
+    "out-dir": { type: "string" },
   },
 });
 
@@ -71,6 +106,12 @@ try {
   switch (command) {
     case "cloudflare":
       writeCloudflareSecretPayload(values.out);
+      break;
+    case "cloudflare-batches":
+      writeCloudflareSecretBatches(
+        values["out-dir"],
+        parsePositiveInteger(values["batch-size"], "--batch-size")
+      );
       break;
     case "docker":
       writeDockerEnvFile(values.out);

--- a/scripts/project-secrets.test.mjs
+++ b/scripts/project-secrets.test.mjs
@@ -79,11 +79,60 @@ test("cloudflare output stays valid JSON without committed or local-only keys", 
   assert.equal(payload.DATABASE_URL, undefined);
 });
 
+test("cloudflare-batches writes JSON files up to the requested batch size", () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), `sdp-cloudflare-batches-${process.pid}-`));
+  try {
+    const result = run(
+      "cloudflare-batches",
+      {
+        CLERK_AUDIENCE: "audience",
+        CLERK_JWKS_URL: "https://clerk.test/jwks",
+        CLERK_SECRET_KEY: "sk_test_clerk",
+        CLERK_WEBHOOK_SECRET: "whsec_test",
+        PRIVY_APP_SECRET: "privy_secret",
+        SOLANA_NETWORK: "mainnet-beta",
+      },
+      ["--out-dir", outDir, "--batch-size", "2"]
+    );
+    assert.equal(result.status, 0, result.stderr);
+
+    const files = fs.readdirSync(outDir).sort();
+    assert.deepEqual(files, [
+      "cloudflare-secrets-001.json",
+      "cloudflare-secrets-002.json",
+      "cloudflare-secrets-003.json",
+    ]);
+
+    const payloads = files.map((file) =>
+      JSON.parse(fs.readFileSync(path.join(outDir, file), "utf8"))
+    );
+    assert.deepEqual(Object.keys(payloads[0]), ["CLERK_JWKS_URL", "CLERK_AUDIENCE"]);
+    assert.deepEqual(Object.keys(payloads[1]), ["CLERK_SECRET_KEY", "CLERK_WEBHOOK_SECRET"]);
+    assert.deepEqual(Object.keys(payloads[2]), ["PRIVY_APP_SECRET"]);
+    assert.equal(payloads[0].SOLANA_NETWORK, undefined);
+  } finally {
+    fs.rmSync(outDir, { force: true, recursive: true });
+  }
+});
+
+test("cloudflare-batches writes no files when no Cloudflare secrets are set", () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), `sdp-cloudflare-empty-${process.pid}-`));
+  try {
+    const result = run("cloudflare-batches", {}, ["--out-dir", outDir]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /wrote 0 Cloudflare secret batches/);
+    assert.deepEqual(fs.readdirSync(outDir), []);
+  } finally {
+    fs.rmSync(outDir, { force: true, recursive: true });
+  }
+});
+
 test("unknown command exits non-zero and prints usage", () => {
   const result = run("nonsense");
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Usage:/);
   assert.match(result.stderr, /cloudflare/);
+  assert.match(result.stderr, /cloudflare-batches/);
   assert.match(result.stderr, /docker/);
 });
 


### PR DESCRIPTION
## Summary
- Add a `cloudflare-batches` projection mode that writes Worker secrets in JSON batches.
- Update the SDP API deploy workflow to upload each batch separately.
- Cover batching and empty-secret behavior in the script tests.

## Why
Cloudflare now rejects `wrangler secret bulk` requests with more than 25 secrets. The latest main deploy had 59 populated Worker secrets, so syncing everything in one request failed before deployment.

## Validation
- `pnpm test:scripts`
- `pnpm exec biome check --write scripts/project-secrets.mjs scripts/project-secrets.test.mjs .github/workflows/deploy-sdp-api.yml`
- `git diff --check`