### PR TITLE
feat: HOO-519 bootstrap install script for self-hosted deployments

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -1,0 +1,35 @@
+name: Release Checksums
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Generate SHA256SUMS
+        working-directory: infra/self-hosted
+        run: |
+          set -euo pipefail
+          sha256sum install.sh compose.yml .env.example > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Publish checksums and install script to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            infra/self-hosted/SHA256SUMS \
+            infra/self-hosted/install.sh \
+            --clobber

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -2,10 +2,14 @@
 #
 # Bootstrap a self-hosted Solana Developer Platform.
 #
-# Verify before running:
-#   curl -fsSL "<url>/install.sh" -o install.sh \
-#     && sha256sum -c install.sh.sha256 \
-#     && bash install.sh
+# This script is open source — read it before piping it to a shell.
+# Replace v0.24.0 below with the release tag you are installing.
+# To verify the install script and config against the release checksums:
+#   V=v0.24.0
+#   R=https://github.com/solana-foundation/solana-developer-platform/releases/download
+#   curl -fsSL "$R/$V/install.sh" -o install.sh
+#   curl -fsSL "$R/$V/SHA256SUMS" -o SHA256SUMS
+#   sha256sum --ignore-missing -c SHA256SUMS && bash install.sh
 #
 # Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_INSTALL_BASE_URL,
 #              SDP_IMAGE_REGISTRY, SDP_CONFIGURATOR_URL.

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Bootstrap a self-hosted Solana Developer Platform.
+#
+# Verify before running:
+#   curl -fsSL "<url>/install.sh" -o install.sh \
+#     && sha256sum -c install.sh.sha256 \
+#     && bash install.sh
+#
+# Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_INSTALL_BASE_URL,
+#              SDP_IMAGE_REGISTRY, SDP_CONFIGURATOR_URL.
+set -euo pipefail
+
+# Bumped by the release process to the tag that publishes the image + compose.yml.
+DEFAULT_VERSION="v0.24.0"
+
+VERSION="${INSTALL_VERSION:-$DEFAULT_VERSION}"
+BASE_URL="${SDP_INSTALL_BASE_URL:-https://raw.githubusercontent.com/solana-foundation/solana-developer-platform}"
+INSTALL_DIR="${SDP_INSTALL_DIR:-$HOME/sdp}"
+IMAGE_REGISTRY="${SDP_IMAGE_REGISTRY:-ghcr.io/solana-foundation/sdp}"
+CONFIGURATOR_URL="${SDP_CONFIGURATOR_URL:-https://sdp.solana.org/docs/self-hosting/configurator}"
+
+err() { printf '%s\n' "$*" >&2; }
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    err "Docker is not installed. Install it first: https://docs.docker.com/engine/install/"
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    err "Docker Compose v2 is unavailable. Update Docker: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    err "The Docker daemon is not running or not reachable. Start Docker and retry."
+    exit 1
+  fi
+}
+
+# fetch <relative-path-under-infra/self-hosted> <destination>
+fetch() {
+  curl -fsSL "$BASE_URL/$VERSION/infra/self-hosted/$1" -o "$2"
+}
+
+# Echo a command that opens a URL in a browser, or nothing on a headless host.
+detect_opener() {
+  if command -v open >/dev/null 2>&1; then echo open; return; fi
+  if command -v wslview >/dev/null 2>&1; then echo wslview; return; fi
+  if [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open >/dev/null 2>&1; then
+    echo xdg-open; return
+  fi
+  echo ""
+}
+
+cli_command() {
+  printf '    docker run --rm -it -v "%s:/out" %s/sdp-api:%s node configure.js --out /out/.env\n' \
+    "$INSTALL_DIR" "$IMAGE_REGISTRY" "$VERSION"
+}
+
+main() {
+  require_docker
+
+  mkdir -p "$INSTALL_DIR"
+  fetch compose.yml "$INSTALL_DIR/compose.yml"
+  [ -f "$INSTALL_DIR/.env.example" ] || fetch .env.example "$INSTALL_DIR/.env.example"
+
+  printf '\nInstalled compose.yml to %s\n' "$INSTALL_DIR"
+  printf '\nNext: generate your .env\n'
+
+  local opener; opener="$(detect_opener)"
+  if [ -n "$opener" ]; then
+    printf '  Opening the configurator in your browser: %s\n' "$CONFIGURATOR_URL"
+    "$opener" "$CONFIGURATOR_URL" >/dev/null 2>&1 \
+      || printf '  (could not open automatically — visit %s)\n' "$CONFIGURATOR_URL"
+    printf '  Or run it in a terminal:\n'
+    cli_command
+  else
+    printf '  Run the configurator in your terminal:\n'
+    cli_command
+    printf '  Or open the web form: %s\n' "$CONFIGURATOR_URL"
+  fi
+
+  printf '\nThen start the stack:\n  cd %s && docker compose up -d\n' "$INSTALL_DIR"
+}
+
+main "$@"

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# End-to-end test for install.sh. Runs the script in clean ubuntu:24.04 containers,
+# with a stubbed `docker` and the download source pointed at this repo's files.
+# Requires a working local Docker. Usage: bash infra/self-hosted/install.test.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+IMG="ubuntu:24.04"
+pass=0
+fail=0
+check() { # check <name> <condition-rc>
+  if [ "$2" -eq 0 ]; then echo "  PASS: $1"; pass=$((pass + 1)); else echo "  FAIL: $1"; fail=$((fail + 1)); fi
+}
+
+# Common container preamble: install curl, lay down env, then run the scenario body ($1).
+scenario() { # scenario <name> <docker-run-flags...> -- <in-container-bash>
+  local name="$1"; shift
+  local flags=(); while [ "$1" != "--" ]; do flags+=("$1"); shift; done; shift
+  echo "[$name]"
+  docker run --rm -v "$REPO:/src:ro" \
+    -e SDP_INSTALL_BASE_URL="file:///src" -e INSTALL_VERSION="." \
+    -e SDP_INSTALL_DIR="/root/sdp" \
+    "${flags[@]}" "$IMG" bash -c "
+      set -u
+      apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq curl >/dev/null 2>&1
+      $1
+    "
+}
+
+# A fake docker that satisfies the preflight checks. Single-quoted on purpose: the
+# $1/$2 must reach the stub file literally, not expand here.
+# shellcheck disable=SC2016
+DOCKER_STUB='mkdir -p /usr/local/bin; cat > /usr/local/bin/docker <<"EOF"
+#!/bin/sh
+[ "$1 $2" = "compose version" ] && { echo "Docker Compose version v2.29.0"; exit 0; }
+exit 0
+EOF
+chmod +x /usr/local/bin/docker'
+
+# 1. Docker missing -> clear error + non-zero exit, no files written.
+# The body is single-quoted so $out/$rc/$? expand inside the container, not here.
+# shellcheck disable=SC2016
+if scenario "docker-missing" -- '
+  out=$(bash /src/infra/self-hosted/install.sh 2>&1); rc=$?
+  [ $rc -ne 0 ] && echo "$out" | grep -qi "docker is not installed" && [ ! -f /root/sdp/compose.yml ]
+'; then check "exits non-zero with install-Docker message, writes nothing" 0
+else check "exits non-zero with install-Docker message, writes nothing" 1; fi
+
+# 2. Headless happy path -> compose.yml placed, CLI command printed, no open attempt.
+if scenario "headless" -- "
+  $DOCKER_STUB
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -eq 0 ] \
+    && cmp -s /root/sdp/compose.yml /src/infra/self-hosted/compose.yml \
+    && [ -f /root/sdp/.env.example ] \
+    && echo \"\$out\" | grep -q 'node configure.js --out /out/.env' \
+    && ! echo \"\$out\" | grep -qi 'opening the configurator'
+"; then check "places compose.yml + .env.example, prints CLI handoff" 0
+else check "places compose.yml + .env.example, prints CLI handoff" 1; fi
+
+# 3. Desktop -> auto-open attempted (stub xdg-open records a marker).
+if scenario "desktop" -e DISPLAY=:0 -- "
+  $DOCKER_STUB
+  printf '#!/bin/sh\ntouch /tmp/opened\n' > /usr/local/bin/xdg-open; chmod +x /usr/local/bin/xdg-open
+  bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
+  [ -f /tmp/opened ]
+"; then check "auto-opens the configurator page on a GUI host" 0
+else check "auto-opens the configurator page on a GUI host" 1; fi
+
+# 4. Idempotency -> existing .env and .env.example are preserved across a second run.
+if scenario "idempotent" -- "
+  $DOCKER_STUB
+  mkdir -p /root/sdp
+  printf 'KEEP=me\n' > /root/sdp/.env
+  printf 'SENTINEL=keep\n' > /root/sdp/.env.example
+  bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
+  bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
+  grep -qx 'KEEP=me' /root/sdp/.env \
+    && grep -qx 'SENTINEL=keep' /root/sdp/.env.example \
+    && [ -f /root/sdp/compose.yml ]
+"; then check "does not clobber an existing .env or .env.example" 0
+else check "does not clobber an existing .env or .env.example" 1; fi
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds a `curl | bash` bootstrap install script for self-hosted SDP, an end-to-end test harness, and checksum publishing on release.

- **`infra/self-hosted/install.sh`** — idempotent bootstrap: verifies Docker (CLI, Compose v2, daemon), downloads the version-pinned `compose.yml` and `.env.example`, and hands off to the configurator (auto-opens the web form on a GUI host, otherwise prints the CLI command). `set -euo pipefail`, ~90 lines, auditable. Source/registry/version/dir are overridable via env vars.
- **`infra/self-hosted/install.test.sh`** — runs the script in clean `ubuntu:24.04` containers across four scenarios: Docker-missing error, headless happy path, desktop auto-open, and idempotency (does not clobber an existing `.env`/`.env.example`).
- **`.github/workflows/release-checksums.yml`** — on `release: published`, generates `SHA256SUMS` for `install.sh`/`compose.yml`/`.env.example` and uploads it plus `install.sh` as release assets. The script header points verification at these release-hosted artifacts so the script and its checksums come from the same immutable surface.

## Testing

- `bash infra/self-hosted/install.test.sh` — 4/4 pass on `ubuntu:24.04`.
- `shellcheck` clean on both scripts; `actionlint` clean on the workflow.
- `SHA256SUMS` generation + `sha256sum --ignore-missing -c` round-trips locally.

## Security

Short and auditable, fails closed on a missing Docker daemon, pins the downloaded compose to a release tag, and publishes checksums on the GitHub release for verification before running.