### PR TITLE
feat: HOO-519 bootstrap install script for self-hosted deployments

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -23,7 +23,7 @@ jobs:
           sha256sum install.sh compose.yml .env.example > SHA256SUMS
           cat SHA256SUMS
 
-      - name: Publish checksums and install script to the release
+      - name: Publish checksums and install artifacts to the release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
@@ -32,4 +32,6 @@ jobs:
           gh release upload "$TAG" \
             infra/self-hosted/SHA256SUMS \
             infra/self-hosted/install.sh \
+            infra/self-hosted/compose.yml \
+            infra/self-hosted/.env.example \
             --clobber

--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   checksums:
@@ -23,6 +24,13 @@ jobs:
           sha256sum install.sh compose.yml .env.example > SHA256SUMS
           cat SHA256SUMS
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SHA256SUMS (keyless OIDC)
+        working-directory: infra/self-hosted
+        run: cosign sign-blob --yes SHA256SUMS --bundle SHA256SUMS.cosign.bundle
+
       - name: Publish checksums and install artifacts to the release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -31,6 +39,7 @@ jobs:
           set -euo pipefail
           gh release upload "$TAG" \
             infra/self-hosted/SHA256SUMS \
+            infra/self-hosted/SHA256SUMS.cosign.bundle \
             infra/self-hosted/install.sh \
             infra/self-hosted/compose.yml \
             infra/self-hosted/.env.example \

--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -1,0 +1,35 @@
+name: Release Checksums
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Generate SHA256SUMS
+        working-directory: infra/self-hosted
+        run: |
+          set -euo pipefail
+          sha256sum install.sh compose.yml .env.example > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Publish checksums and install script to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            infra/self-hosted/SHA256SUMS \
+            infra/self-hosted/install.sh \
+            --clobber

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -11,6 +11,12 @@
 #   curl -fsSL "$R/$V/SHA256SUMS" -o SHA256SUMS
 #   sha256sum --ignore-missing -c SHA256SUMS && INSTALL_VERSION="$V" bash install.sh
 #
+# For out-of-band authenticity, verify the keyless cosign signature of SHA256SUMS:
+#   curl -fsSL "$R/$V/SHA256SUMS.cosign.bundle" -o SHA256SUMS.cosign.bundle
+#   cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
+#     --certificate-identity-regexp '^https://github\.com/solana-foundation/solana-developer-platform/\.github/workflows/release-checksums\.yml@refs/tags/' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
+#
 # Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_RELEASE_BASE_URL,
 #              SDP_IMAGE_REGISTRY, SDP_CONFIGURATOR_URL.
 set -euo pipefail
@@ -65,6 +71,18 @@ fetch() {
   curl -fsSL "$RELEASE_BASE_URL/$VERSION/$1" -o "$2"
 }
 
+# sha256sum is Linux-native; macOS ships shasum instead.
+_sha256sum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$@"
+  else
+    err "Neither sha256sum nor shasum is available. Install coreutils and retry."
+    exit 1
+  fi
+}
+
 # verify <asset-name> against its line in the downloaded SHA256SUMS, fail closed.
 verify() {
   local line
@@ -73,7 +91,7 @@ verify() {
     err "No checksum recorded for $1 in SHA256SUMS. Refusing to continue."
     exit 1
   fi
-  if ! (cd "$INSTALL_DIR" && printf '%s\n' "$line" | sha256sum -c -) >/dev/null 2>&1; then
+  if ! (cd "$INSTALL_DIR" && printf '%s\n' "$line" | _sha256sum -c -) >/dev/null 2>&1; then
     err "Checksum verification failed for $1. Refusing to continue."
     exit 1
   fi
@@ -100,8 +118,13 @@ main() {
 
   mkdir -p "$INSTALL_DIR"
   fetch SHA256SUMS "$INSTALL_DIR/SHA256SUMS"
+  local had_compose=0
+  if [ -f "$INSTALL_DIR/compose.yml" ]; then had_compose=1; fi
   fetch compose.yml "$INSTALL_DIR/compose.yml"
   verify compose.yml
+  if [ "$had_compose" -eq 1 ]; then
+    printf '\nReplaced the existing compose.yml with the %s release.\n' "$VERSION"
+  fi
   if [ ! -f "$INSTALL_DIR/.env.example" ]; then
     fetch .env.example "$INSTALL_DIR/.env.example"
     verify .env.example

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -107,15 +107,19 @@ verify_signature() {
   fi
 }
 
-# verify <asset-name> against its line in the downloaded SHA256SUMS, fail closed.
+# verify <asset-name> [file-path]: check file-path (default $INSTALL_DIR/<asset-name>)
+# against the checksum recorded for <asset-name> in the downloaded SHA256SUMS. The
+# split lets us verify a download under a temp path before swapping it into place.
+# Fail closed.
 verify() {
-  local line
-  line="$(awk -v f="$1" '$2 == f { print; exit }' "$INSTALL_DIR/SHA256SUMS")"
-  if [ -z "$line" ]; then
+  local file="${2:-$INSTALL_DIR/$1}" want have
+  want="$(awk -v f="$1" '$2 == f { print $1; exit }' "$INSTALL_DIR/SHA256SUMS")"
+  if [ -z "$want" ]; then
     err "No checksum recorded for $1 in SHA256SUMS. Refusing to continue."
     exit 1
   fi
-  if ! (cd "$INSTALL_DIR" && printf '%s\n' "$line" | _sha256sum -c -) >/dev/null 2>&1; then
+  have="$(_sha256sum "$file" | awk '{print $1}')"
+  if [ "$have" != "$want" ]; then
     err "Checksum verification failed for $1. Refusing to continue."
     exit 1
   fi
@@ -145,8 +149,12 @@ main() {
   verify_signature
   local had_compose=0
   if [ -f "$INSTALL_DIR/compose.yml" ]; then had_compose=1; fi
-  fetch compose.yml "$INSTALL_DIR/compose.yml"
-  verify compose.yml
+  local compose_tmp="$INSTALL_DIR/compose.yml.tmp.$$"
+  trap 'rm -f "$compose_tmp"' EXIT
+  fetch compose.yml "$compose_tmp"
+  verify compose.yml "$compose_tmp"
+  mv -f "$compose_tmp" "$INSTALL_DIR/compose.yml"
+  trap - EXIT
   if [ "$had_compose" -eq 1 ]; then
     printf '\nReplaced the existing compose.yml with the %s release.\n' "$VERSION"
   fi

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -125,6 +125,19 @@ verify() {
   fi
 }
 
+# fetch_verified <asset-name> <dest>: download to a temp path, verify its checksum,
+# and swap it into <dest> only after verification passes. A corrupt or interrupted
+# download therefore never overwrites an existing good file nor leaves a partial one
+# behind; the temp is cleaned up on any exit.
+fetch_verified() {
+  local tmp="$2.tmp.$$"
+  trap 'rm -f "$tmp"' EXIT
+  fetch "$1" "$tmp"
+  verify "$1" "$tmp"
+  mv -f "$tmp" "$2"
+  trap - EXIT
+}
+
 # Echo a command that opens a URL in a browser, or nothing on a headless host.
 detect_opener() {
   if command -v open >/dev/null 2>&1; then echo open; return; fi
@@ -149,18 +162,12 @@ main() {
   verify_signature
   local had_compose=0
   if [ -f "$INSTALL_DIR/compose.yml" ]; then had_compose=1; fi
-  local compose_tmp="$INSTALL_DIR/compose.yml.tmp.$$"
-  trap 'rm -f "$compose_tmp"' EXIT
-  fetch compose.yml "$compose_tmp"
-  verify compose.yml "$compose_tmp"
-  mv -f "$compose_tmp" "$INSTALL_DIR/compose.yml"
-  trap - EXIT
+  fetch_verified compose.yml "$INSTALL_DIR/compose.yml"
   if [ "$had_compose" -eq 1 ]; then
     printf '\nReplaced the existing compose.yml with the %s release.\n' "$VERSION"
   fi
   if [ ! -f "$INSTALL_DIR/.env.example" ]; then
-    fetch .env.example "$INSTALL_DIR/.env.example"
-    verify .env.example
+    fetch_verified .env.example "$INSTALL_DIR/.env.example"
   else
     printf '\nKept your existing .env.example. Review the %s template for new variables:\n  %s/%s/.env.example\n' \
       "$VERSION" "$RELEASE_BASE_URL" "$VERSION"

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -3,28 +3,47 @@
 # Bootstrap a self-hosted Solana Developer Platform.
 #
 # This script is open source — read it before piping it to a shell.
-# Replace v0.24.0 below with the release tag you are installing.
+# It installs the latest release by default; set INSTALL_VERSION to pin a tag.
 # To verify the install script and config against the release checksums:
-#   V=v0.24.0
+#   V=v0.24.0   # the release tag you want
 #   R=https://github.com/solana-foundation/solana-developer-platform/releases/download
 #   curl -fsSL "$R/$V/install.sh" -o install.sh
 #   curl -fsSL "$R/$V/SHA256SUMS" -o SHA256SUMS
-#   sha256sum --ignore-missing -c SHA256SUMS && bash install.sh
+#   sha256sum --ignore-missing -c SHA256SUMS && INSTALL_VERSION="$V" bash install.sh
 #
-# Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_INSTALL_BASE_URL,
+# Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_RELEASE_BASE_URL,
 #              SDP_IMAGE_REGISTRY, SDP_CONFIGURATOR_URL.
 set -euo pipefail
 
-# Bumped by the release process to the tag that publishes the image + compose.yml.
+# Fallback used only when the latest release tag cannot be resolved.
 DEFAULT_VERSION="v0.24.0"
 
-VERSION="${INSTALL_VERSION:-$DEFAULT_VERSION}"
-BASE_URL="${SDP_INSTALL_BASE_URL:-https://raw.githubusercontent.com/solana-foundation/solana-developer-platform}"
+RELEASE_BASE_URL="${SDP_RELEASE_BASE_URL:-https://github.com/solana-foundation/solana-developer-platform/releases/download}"
 INSTALL_DIR="${SDP_INSTALL_DIR:-$HOME/sdp}"
 IMAGE_REGISTRY="${SDP_IMAGE_REGISTRY:-ghcr.io/solana-foundation/sdp}"
 CONFIGURATOR_URL="${SDP_CONFIGURATOR_URL:-https://sdp.solana.org/docs/self-hosting/configurator}"
+VERSION=""
 
 err() { printf '%s\n' "$*" >&2; }
+
+# Pinned tag from INSTALL_VERSION, otherwise the tag the "latest" release
+# redirects to, otherwise DEFAULT_VERSION.
+resolve_version() {
+  if [ -n "${INSTALL_VERSION:-}" ]; then
+    printf '%s' "$INSTALL_VERSION"
+    return
+  fi
+  local url
+  url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/solana-foundation/solana-developer-platform/releases/latest" 2>/dev/null || true)"
+  case "$url" in
+    */releases/tag/*) printf '%s' "${url##*/}" ;;
+    *)
+      err "Warning: could not resolve the latest release; using $DEFAULT_VERSION."
+      printf '%s' "$DEFAULT_VERSION"
+      ;;
+  esac
+}
 
 require_docker() {
   if ! command -v docker >/dev/null 2>&1; then
@@ -41,9 +60,23 @@ require_docker() {
   fi
 }
 
-# fetch <relative-path-under-infra/self-hosted> <destination>
+# fetch <release-asset-name> <destination>
 fetch() {
-  curl -fsSL "$BASE_URL/$VERSION/infra/self-hosted/$1" -o "$2"
+  curl -fsSL "$RELEASE_BASE_URL/$VERSION/$1" -o "$2"
+}
+
+# verify <asset-name> against its line in the downloaded SHA256SUMS, fail closed.
+verify() {
+  local line
+  line="$(awk -v f="$1" '$2 == f { print; exit }' "$INSTALL_DIR/SHA256SUMS")"
+  if [ -z "$line" ]; then
+    err "No checksum recorded for $1 in SHA256SUMS. Refusing to continue."
+    exit 1
+  fi
+  if ! (cd "$INSTALL_DIR" && printf '%s\n' "$line" | sha256sum -c -) >/dev/null 2>&1; then
+    err "Checksum verification failed for $1. Refusing to continue."
+    exit 1
+  fi
 }
 
 # Echo a command that opens a URL in a browser, or nothing on a headless host.
@@ -63,12 +96,18 @@ cli_command() {
 
 main() {
   require_docker
+  VERSION="$(resolve_version)"
 
   mkdir -p "$INSTALL_DIR"
+  fetch SHA256SUMS "$INSTALL_DIR/SHA256SUMS"
   fetch compose.yml "$INSTALL_DIR/compose.yml"
-  [ -f "$INSTALL_DIR/.env.example" ] || fetch .env.example "$INSTALL_DIR/.env.example"
+  verify compose.yml
+  if [ ! -f "$INSTALL_DIR/.env.example" ]; then
+    fetch .env.example "$INSTALL_DIR/.env.example"
+    verify .env.example
+  fi
 
-  printf '\nInstalled compose.yml to %s\n' "$INSTALL_DIR"
+  printf '\nInstalled and verified compose.yml in %s\n' "$INSTALL_DIR"
   printf '\nNext: generate your .env\n'
 
   local opener; opener="$(detect_opener)"

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -2,10 +2,14 @@
 #
 # Bootstrap a self-hosted Solana Developer Platform.
 #
-# Verify before running:
-#   curl -fsSL "<url>/install.sh" -o install.sh \
-#     && sha256sum -c install.sh.sha256 \
-#     && bash install.sh
+# This script is open source — read it before piping it to a shell.
+# Replace v0.24.0 below with the release tag you are installing.
+# To verify the install script and config against the release checksums:
+#   V=v0.24.0
+#   R=https://github.com/solana-foundation/solana-developer-platform/releases/download
+#   curl -fsSL "$R/$V/install.sh" -o install.sh
+#   curl -fsSL "$R/$V/SHA256SUMS" -o SHA256SUMS
+#   sha256sum --ignore-missing -c SHA256SUMS && bash install.sh
 #
 # Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_INSTALL_BASE_URL,
 #              SDP_IMAGE_REGISTRY, SDP_CONFIGURATOR_URL.

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -128,6 +128,9 @@ main() {
   if [ ! -f "$INSTALL_DIR/.env.example" ]; then
     fetch .env.example "$INSTALL_DIR/.env.example"
     verify .env.example
+  else
+    printf '\nKept your existing .env.example. Review the %s template for new variables:\n  %s/%s/.env.example\n' \
+      "$VERSION" "$RELEASE_BASE_URL" "$VERSION"
   fi
 
   printf '\nInstalled and verified compose.yml in %s\n' "$INSTALL_DIR"

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Bootstrap a self-hosted Solana Developer Platform.
+#
+# Verify before running:
+#   curl -fsSL "<url>/install.sh" -o install.sh \
+#     && sha256sum -c install.sh.sha256 \
+#     && bash install.sh
+#
+# Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_INSTALL_BASE_URL,
+#              SDP_IMAGE_REGISTRY, SDP_CONFIGURATOR_URL.
+set -euo pipefail
+
+# Bumped by the release process to the tag that publishes the image + compose.yml.
+DEFAULT_VERSION="v0.24.0"
+
+VERSION="${INSTALL_VERSION:-$DEFAULT_VERSION}"
+BASE_URL="${SDP_INSTALL_BASE_URL:-https://raw.githubusercontent.com/solana-foundation/solana-developer-platform}"
+INSTALL_DIR="${SDP_INSTALL_DIR:-$HOME/sdp}"
+IMAGE_REGISTRY="${SDP_IMAGE_REGISTRY:-ghcr.io/solana-foundation/sdp}"
+CONFIGURATOR_URL="${SDP_CONFIGURATOR_URL:-https://sdp.solana.org/docs/self-hosting/configurator}"
+
+err() { printf '%s\n' "$*" >&2; }
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    err "Docker is not installed. Install it first: https://docs.docker.com/engine/install/"
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    err "Docker Compose v2 is unavailable. Update Docker: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    err "The Docker daemon is not running or not reachable. Start Docker and retry."
+    exit 1
+  fi
+}
+
+# fetch <relative-path-under-infra/self-hosted> <destination>
+fetch() {
+  curl -fsSL "$BASE_URL/$VERSION/infra/self-hosted/$1" -o "$2"
+}
+
+# Echo a command that opens a URL in a browser, or nothing on a headless host.
+detect_opener() {
+  if command -v open >/dev/null 2>&1; then echo open; return; fi
+  if command -v wslview >/dev/null 2>&1; then echo wslview; return; fi
+  if [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open >/dev/null 2>&1; then
+    echo xdg-open; return
+  fi
+  echo ""
+}
+
+cli_command() {
+  printf '    docker run --rm -it -v "%s:/out" %s/sdp-api:%s node configure.js --out /out/.env\n' \
+    "$INSTALL_DIR" "$IMAGE_REGISTRY" "$VERSION"
+}
+
+main() {
+  require_docker
+
+  mkdir -p "$INSTALL_DIR"
+  fetch compose.yml "$INSTALL_DIR/compose.yml"
+  [ -f "$INSTALL_DIR/.env.example" ] || fetch .env.example "$INSTALL_DIR/.env.example"
+
+  printf '\nInstalled compose.yml to %s\n' "$INSTALL_DIR"
+  printf '\nNext: generate your .env\n'
+
+  local opener; opener="$(detect_opener)"
+  if [ -n "$opener" ]; then
+    printf '  Opening the configurator in your browser: %s\n' "$CONFIGURATOR_URL"
+    "$opener" "$CONFIGURATOR_URL" >/dev/null 2>&1 \
+      || printf '  (could not open automatically — visit %s)\n' "$CONFIGURATOR_URL"
+    printf '  Or run it in a terminal:\n'
+    cli_command
+  else
+    printf '  Run the configurator in your terminal:\n'
+    cli_command
+    printf '  Or open the web form: %s\n' "$CONFIGURATOR_URL"
+  fi
+
+  printf '\nThen start the stack:\n  cd %s && docker compose up -d\n' "$INSTALL_DIR"
+}
+
+main "$@"

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -14,7 +14,7 @@
 # For out-of-band authenticity, verify the keyless cosign signature of SHA256SUMS:
 #   curl -fsSL "$R/$V/SHA256SUMS.cosign.bundle" -o SHA256SUMS.cosign.bundle
 #   cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
-#     --certificate-identity-regexp '^https://github\.com/solana-foundation/solana-developer-platform/\.github/workflows/release-checksums\.yml@refs/tags/' \
+#     --certificate-identity-regexp '^https://github\.com/solana-foundation/solana-developer-platform/\.github/workflows/release-checksums\.yml@refs/tags/v[0-9][^/]*$' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
 #
 # Overridable: SDP_INSTALL_DIR, INSTALL_VERSION, SDP_RELEASE_BASE_URL,
@@ -83,6 +83,30 @@ _sha256sum() {
   fi
 }
 
+# verify_signature: when cosign is available, verify the keyless signature of
+# SHA256SUMS and fail closed on a bad signature. Skip (with a notice) when cosign
+# or the bundle is unavailable — checksum verification of the artifacts still applies.
+verify_signature() {
+  if ! command -v cosign >/dev/null 2>&1; then
+    printf '\nNote: cosign not found; skipping signature check (checksums still verified).\n' >&2
+    return
+  fi
+  if ! fetch SHA256SUMS.cosign.bundle "$INSTALL_DIR/SHA256SUMS.cosign.bundle" 2>/dev/null; then
+    printf '\nNote: no signature bundle for %s; skipping signature check.\n' "$VERSION" >&2
+    return
+  fi
+  local output
+  if ! output="$(cosign verify-blob \
+      --bundle "$INSTALL_DIR/SHA256SUMS.cosign.bundle" \
+      --certificate-identity-regexp '^https://github\.com/solana-foundation/solana-developer-platform/\.github/workflows/release-checksums\.yml@refs/tags/v[0-9][^/]*$' \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      "$INSTALL_DIR/SHA256SUMS" 2>&1)"; then
+    err "Signature verification failed for SHA256SUMS. Refusing to continue."
+    err "$output"
+    exit 1
+  fi
+}
+
 # verify <asset-name> against its line in the downloaded SHA256SUMS, fail closed.
 verify() {
   local line
@@ -118,6 +142,7 @@ main() {
 
   mkdir -p "$INSTALL_DIR"
   fetch SHA256SUMS "$INSTALL_DIR/SHA256SUMS"
+  verify_signature
   local had_compose=0
   if [ -f "$INSTALL_DIR/compose.yml" ]; then had_compose=1; fi
   fetch compose.yml "$INSTALL_DIR/compose.yml"

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# End-to-end test for install.sh. Runs the script in clean ubuntu:24.04 containers,
+# with a stubbed `docker` and the download source pointed at this repo's files.
+# Requires a working local Docker. Usage: bash infra/self-hosted/install.test.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+IMG="ubuntu:24.04"
+pass=0
+fail=0
+check() { # check <name> <condition-rc>
+  if [ "$2" -eq 0 ]; then echo "  PASS: $1"; pass=$((pass + 1)); else echo "  FAIL: $1"; fail=$((fail + 1)); fi
+}
+
+# Common container preamble: install curl, lay down env, then run the scenario body ($1).
+scenario() { # scenario <name> <docker-run-flags...> -- <in-container-bash>
+  local name="$1"; shift
+  local flags=(); while [ "$1" != "--" ]; do flags+=("$1"); shift; done; shift
+  echo "[$name]"
+  docker run --rm -v "$REPO:/src:ro" \
+    -e SDP_INSTALL_BASE_URL="file:///src" -e INSTALL_VERSION="." \
+    -e SDP_INSTALL_DIR="/root/sdp" \
+    "${flags[@]}" "$IMG" bash -c "
+      set -u
+      apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq curl >/dev/null 2>&1
+      $1
+    "
+}
+
+# A fake docker that satisfies the preflight checks. Single-quoted on purpose: the
+# $1/$2 must reach the stub file literally, not expand here.
+# shellcheck disable=SC2016
+DOCKER_STUB='mkdir -p /usr/local/bin; cat > /usr/local/bin/docker <<"EOF"
+#!/bin/sh
+[ "$1 $2" = "compose version" ] && { echo "Docker Compose version v2.29.0"; exit 0; }
+exit 0
+EOF
+chmod +x /usr/local/bin/docker'
+
+# 1. Docker missing -> clear error + non-zero exit, no files written.
+# The body is single-quoted so $out/$rc/$? expand inside the container, not here.
+# shellcheck disable=SC2016
+if scenario "docker-missing" -- '
+  out=$(bash /src/infra/self-hosted/install.sh 2>&1); rc=$?
+  [ $rc -ne 0 ] && echo "$out" | grep -qi "docker is not installed" && [ ! -f /root/sdp/compose.yml ]
+'; then check "exits non-zero with install-Docker message, writes nothing" 0
+else check "exits non-zero with install-Docker message, writes nothing" 1; fi
+
+# 2. Headless happy path -> compose.yml placed, CLI command printed, no open attempt.
+if scenario "headless" -- "
+  $DOCKER_STUB
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -eq 0 ] \
+    && cmp -s /root/sdp/compose.yml /src/infra/self-hosted/compose.yml \
+    && [ -f /root/sdp/.env.example ] \
+    && echo \"\$out\" | grep -q 'node configure.js --out /out/.env' \
+    && ! echo \"\$out\" | grep -qi 'opening the configurator'
+"; then check "places compose.yml + .env.example, prints CLI handoff" 0
+else check "places compose.yml + .env.example, prints CLI handoff" 1; fi
+
+# 3. Desktop -> auto-open attempted (stub xdg-open records a marker).
+if scenario "desktop" -e DISPLAY=:0 -- "
+  $DOCKER_STUB
+  printf '#!/bin/sh\ntouch /tmp/opened\n' > /usr/local/bin/xdg-open; chmod +x /usr/local/bin/xdg-open
+  bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
+  [ -f /tmp/opened ]
+"; then check "auto-opens the configurator page on a GUI host" 0
+else check "auto-opens the configurator page on a GUI host" 1; fi
+
+# 4. Idempotency -> existing .env and .env.example are preserved across a second run.
+if scenario "idempotent" -- "
+  $DOCKER_STUB
+  mkdir -p /root/sdp
+  printf 'KEEP=me\n' > /root/sdp/.env
+  printf 'SENTINEL=keep\n' > /root/sdp/.env.example
+  bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
+  bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
+  grep -qx 'KEEP=me' /root/sdp/.env \
+    && grep -qx 'SENTINEL=keep' /root/sdp/.env.example \
+    && [ -f /root/sdp/compose.yml ]
+"; then check "does not clobber an existing .env or .env.example" 0
+else check "does not clobber an existing .env or .env.example" 1; fi
+
+echo "----"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ]

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# End-to-end test for install.sh. Runs the script in clean ubuntu:24.04 containers,
-# with a stubbed `docker` and the download source pointed at this repo's files.
+# End-to-end test for install.sh. Runs the script in clean ubuntu:24.04 containers
+# with a stubbed `docker` and the release artifacts served from a local directory
+# (standing in for the GitHub release surface, including SHA256SUMS).
 # Requires a working local Docker. Usage: bash infra/self-hosted/install.test.sh
 set -euo pipefail
 
@@ -12,33 +13,48 @@ check() { # check <name> <condition-rc>
   if [ "$2" -eq 0 ]; then echo "  PASS: $1"; pass=$((pass + 1)); else echo "  FAIL: $1"; fail=$((fail + 1)); fi
 }
 
-# Common container preamble: install curl, lay down env, then run the scenario body ($1).
+# Container preamble: install curl, build a writable /release dir with the flat
+# assets + a matching SHA256SUMS, then run the scenario body ($1). INSTALL_VERSION="."
+# collapses "$RELEASE_BASE_URL/./asset" to "/release/asset".
 scenario() { # scenario <name> <docker-run-flags...> -- <in-container-bash>
   local name="$1"; shift
   local flags=(); while [ "$1" != "--" ]; do flags+=("$1"); shift; done; shift
   echo "[$name]"
   docker run --rm -v "$REPO:/src:ro" \
-    -e SDP_INSTALL_BASE_URL="file:///src" -e INSTALL_VERSION="." \
+    -e SDP_RELEASE_BASE_URL="file:///release" -e INSTALL_VERSION="." \
     -e SDP_INSTALL_DIR="/root/sdp" \
     "${flags[@]}" "$IMG" bash -c "
       set -u
       apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq curl >/dev/null 2>&1
+      mkdir -p /release
+      cp /src/infra/self-hosted/compose.yml /src/infra/self-hosted/.env.example \
+         /src/infra/self-hosted/install.sh /release/
+      ( cd /release && sha256sum install.sh compose.yml .env.example > SHA256SUMS )
       $1
     "
 }
 
-# A fake docker that satisfies the preflight checks. Single-quoted on purpose: the
-# $1/$2 must reach the stub file literally, not expand here.
+# A fake docker that satisfies every preflight check. Single-quoted so \$1/\$2 reach
+# the stub file literally.
 # shellcheck disable=SC2016
-DOCKER_STUB='mkdir -p /usr/local/bin; cat > /usr/local/bin/docker <<"EOF"
+DOCKER_OK='mkdir -p /usr/local/bin; cat > /usr/local/bin/docker <<"EOF"
 #!/bin/sh
 [ "$1 $2" = "compose version" ] && { echo "Docker Compose version v2.29.0"; exit 0; }
 exit 0
 EOF
 chmod +x /usr/local/bin/docker'
 
+# A fake docker whose daemon is down: `docker info` fails, everything else passes.
+# shellcheck disable=SC2016
+DOCKER_NO_DAEMON='mkdir -p /usr/local/bin; cat > /usr/local/bin/docker <<"EOF"
+#!/bin/sh
+[ "$1 $2" = "compose version" ] && { echo "Docker Compose version v2.29.0"; exit 0; }
+[ "$1" = "info" ] && exit 1
+exit 0
+EOF
+chmod +x /usr/local/bin/docker'
+
 # 1. Docker missing -> clear error + non-zero exit, no files written.
-# The body is single-quoted so $out/$rc/$? expand inside the container, not here.
 # shellcheck disable=SC2016
 if scenario "docker-missing" -- '
   out=$(bash /src/infra/self-hosted/install.sh 2>&1); rc=$?
@@ -46,40 +62,57 @@ if scenario "docker-missing" -- '
 '; then check "exits non-zero with install-Docker message, writes nothing" 0
 else check "exits non-zero with install-Docker message, writes nothing" 1; fi
 
-# 2. Headless happy path -> compose.yml placed, CLI command printed, no open attempt.
+# 2. Docker daemon down -> clear error + non-zero exit, no files written.
+if scenario "daemon-down" -- "
+  $DOCKER_NO_DAEMON
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -ne 0 ] && echo \"\$out\" | grep -qi 'daemon is not running' && [ ! -f /root/sdp/compose.yml ]
+"; then check "exits non-zero when the Docker daemon is down, writes nothing" 0
+else check "exits non-zero when the Docker daemon is down, writes nothing" 1; fi
+
+# 3. Headless happy path -> verified compose.yml placed, CLI command printed, no open attempt.
 if scenario "headless" -- "
-  $DOCKER_STUB
+  $DOCKER_OK
   out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
   [ \$rc -eq 0 ] \
     && cmp -s /root/sdp/compose.yml /src/infra/self-hosted/compose.yml \
     && [ -f /root/sdp/.env.example ] \
+    && [ -f /root/sdp/SHA256SUMS ] \
     && echo \"\$out\" | grep -q 'node configure.js --out /out/.env' \
     && ! echo \"\$out\" | grep -qi 'opening the configurator'
-"; then check "places compose.yml + .env.example, prints CLI handoff" 0
-else check "places compose.yml + .env.example, prints CLI handoff" 1; fi
+"; then check "places + verifies compose.yml, prints CLI handoff" 0
+else check "places + verifies compose.yml, prints CLI handoff" 1; fi
 
-# 3. Desktop -> auto-open attempted (stub xdg-open records a marker).
+# 4. Tampered compose.yml -> checksum mismatch aborts before any handoff.
+if scenario "tampered" -- "
+  $DOCKER_OK
+  echo 'tampered: true' >> /release/compose.yml
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -ne 0 ] \
+    && echo \"\$out\" | grep -qi 'checksum verification failed' \
+    && ! echo \"\$out\" | grep -q 'node configure.js'
+"; then check "aborts on a compose.yml checksum mismatch before handoff" 0
+else check "aborts on a compose.yml checksum mismatch" 1; fi
+
+# 5. Desktop -> auto-open attempted (stub xdg-open records a marker).
 if scenario "desktop" -e DISPLAY=:0 -- "
-  $DOCKER_STUB
+  $DOCKER_OK
   printf '#!/bin/sh\ntouch /tmp/opened\n' > /usr/local/bin/xdg-open; chmod +x /usr/local/bin/xdg-open
   bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
   [ -f /tmp/opened ]
 "; then check "auto-opens the configurator page on a GUI host" 0
 else check "auto-opens the configurator page on a GUI host" 1; fi
 
-# 4. Idempotency -> existing .env and .env.example are preserved across a second run.
+# 6. Idempotency -> an existing .env.example is preserved (and not re-verified) across runs.
 if scenario "idempotent" -- "
-  $DOCKER_STUB
+  $DOCKER_OK
   mkdir -p /root/sdp
-  printf 'KEEP=me\n' > /root/sdp/.env
   printf 'SENTINEL=keep\n' > /root/sdp/.env.example
   bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
   bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
-  grep -qx 'KEEP=me' /root/sdp/.env \
-    && grep -qx 'SENTINEL=keep' /root/sdp/.env.example \
-    && [ -f /root/sdp/compose.yml ]
-"; then check "does not clobber an existing .env or .env.example" 0
-else check "does not clobber an existing .env or .env.example" 1; fi
+  grep -qx 'SENTINEL=keep' /root/sdp/.env.example && [ -f /root/sdp/compose.yml ]
+"; then check "does not clobber an existing .env.example" 0
+else check "does not clobber an existing .env.example" 1; fi
 
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ]

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -24,12 +24,14 @@ scenario() { # scenario <name> <docker-run-flags...> -- <in-container-bash>
     -e SDP_RELEASE_BASE_URL="file:///release" -e INSTALL_VERSION="." \
     -e SDP_INSTALL_DIR="/root/sdp" \
     "${flags[@]}" "$IMG" bash -c "
-      set -u
-      apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq curl >/dev/null 2>&1
+      set -eu
+      apt-get update -qq >/dev/null 2>&1
+      apt-get install -y -qq curl >/dev/null 2>&1
       mkdir -p /release
       cp /src/infra/self-hosted/compose.yml /src/infra/self-hosted/.env.example \
          /src/infra/self-hosted/install.sh /release/
       ( cd /release && sha256sum install.sh compose.yml .env.example > SHA256SUMS )
+      set +e
       $1
     "
 }

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -96,14 +96,14 @@ if scenario "tampered" -- "
 "; then check "aborts on a compose.yml checksum mismatch before handoff" 0
 else check "aborts on a compose.yml checksum mismatch" 1; fi
 
-# 5. Desktop -> auto-open attempted (stub xdg-open records a marker).
+# 5. Desktop -> auto-open invoked with the configurator URL (stub records its arg).
 if scenario "desktop" -e DISPLAY=:0 -- "
   $DOCKER_OK
-  printf '#!/bin/sh\ntouch /tmp/opened\n' > /usr/local/bin/xdg-open; chmod +x /usr/local/bin/xdg-open
+  printf '#!/bin/sh\necho \"\$1\" > /tmp/opened\n' > /usr/local/bin/xdg-open; chmod +x /usr/local/bin/xdg-open
   bash /src/infra/self-hosted/install.sh >/dev/null 2>&1
-  [ -f /tmp/opened ]
-"; then check "auto-opens the configurator page on a GUI host" 0
-else check "auto-opens the configurator page on a GUI host" 1; fi
+  grep -q 'self-hosting/configurator' /tmp/opened
+"; then check "auto-opens the configurator URL on a GUI host" 0
+else check "auto-opens the configurator URL on a GUI host" 1; fi
 
 # 6. Idempotency -> an existing .env.example is preserved (and not re-verified) across runs.
 if scenario "idempotent" -- "

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -142,5 +142,18 @@ if scenario "idempotent" -- "
 "; then check "does not clobber an existing .env.example" 0
 else check "does not clobber an existing .env.example" 1; fi
 
+# 9. Failed upgrade -> a previously-working compose.yml survives a corrupt re-download.
+if scenario "preserve-on-failed-upgrade" -- "
+  $DOCKER_OK
+  mkdir -p /root/sdp
+  printf 'sentinel: keep-me\n' > /root/sdp/compose.yml
+  echo 'tampered: true' >> /release/compose.yml
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -ne 0 ] \
+    && echo \"\$out\" | grep -qi 'checksum verification failed' \
+    && grep -qx 'sentinel: keep-me' /root/sdp/compose.yml
+"; then check "preserves the existing compose.yml when the new download fails verification" 0
+else check "preserves the existing compose.yml when the new download fails verification" 1; fi
+
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ]

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -155,5 +155,17 @@ if scenario "preserve-on-failed-upgrade" -- "
 "; then check "preserves the existing compose.yml when the new download fails verification" 0
 else check "preserves the existing compose.yml when the new download fails verification" 1; fi
 
+# 10. A .env.example that fails verification leaves no file behind, so a re-run retries
+#     instead of treating the corrupt download as a kept existing file.
+if scenario "no-corrupt-env-example" -- "
+  $DOCKER_OK
+  echo 'TAMPERED=true' >> /release/.env.example
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -ne 0 ] \
+    && echo \"\$out\" | grep -qi 'checksum verification failed' \
+    && [ ! -f /root/sdp/.env.example ]
+"; then check "leaves no .env.example behind when its download fails verification" 0
+else check "leaves no .env.example behind when its download fails verification" 1; fi
+
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ]

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -81,6 +81,7 @@ if scenario "headless" -- "
     && [ -f /root/sdp/.env.example ] \
     && [ -f /root/sdp/SHA256SUMS ] \
     && echo \"\$out\" | grep -q 'node configure.js --out /out/.env' \
+    && echo \"\$out\" | grep -qi 'cosign not found' \
     && ! echo \"\$out\" | grep -qi 'opening the configurator'
 "; then check "places + verifies compose.yml, prints CLI handoff" 0
 else check "places + verifies compose.yml, prints CLI handoff" 1; fi
@@ -94,9 +95,34 @@ if scenario "tampered" -- "
     && echo \"\$out\" | grep -qi 'checksum verification failed' \
     && ! echo \"\$out\" | grep -q 'node configure.js'
 "; then check "aborts on a compose.yml checksum mismatch before handoff" 0
-else check "aborts on a compose.yml checksum mismatch" 1; fi
+else check "aborts on a compose.yml checksum mismatch before handoff" 1; fi
 
-# 5. Desktop -> auto-open invoked with the configurator URL (stub records its arg).
+# 5. cosign present but signature invalid -> abort before fetching artifacts.
+if scenario "signature-invalid" -- "
+  $DOCKER_OK
+  printf '#!/bin/sh\nexit 1\n' > /usr/local/bin/cosign; chmod +x /usr/local/bin/cosign
+  : > /release/SHA256SUMS.cosign.bundle
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -ne 0 ] \
+    && echo \"\$out\" | grep -qi 'signature verification failed' \
+    && [ ! -f /root/sdp/compose.yml ]
+"; then check "aborts when the SHA256SUMS signature is invalid" 0
+else check "aborts when the SHA256SUMS signature is invalid" 1; fi
+
+# 6. cosign present and signature valid -> proceeds, passing the identity + issuer.
+if scenario "signature-valid" -- "
+  $DOCKER_OK
+  printf '#!/bin/sh\necho \"\$@\" > /tmp/cosign-args\nexit 0\n' > /usr/local/bin/cosign; chmod +x /usr/local/bin/cosign
+  : > /release/SHA256SUMS.cosign.bundle
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -eq 0 ] \
+    && echo \"\$out\" | grep -q 'node configure.js --out /out/.env' \
+    && grep -qF 'token.actions.githubusercontent.com' /tmp/cosign-args \
+    && grep -qF 'release-checksums' /tmp/cosign-args
+"; then check "proceeds when the SHA256SUMS signature is valid" 0
+else check "proceeds when the SHA256SUMS signature is valid" 1; fi
+
+# 7. Desktop -> auto-open invoked with the configurator URL (stub records its arg).
 if scenario "desktop" -e DISPLAY=:0 -- "
   $DOCKER_OK
   printf '#!/bin/sh\necho \"\$1\" > /tmp/opened\n' > /usr/local/bin/xdg-open; chmod +x /usr/local/bin/xdg-open
@@ -105,7 +131,7 @@ if scenario "desktop" -e DISPLAY=:0 -- "
 "; then check "auto-opens the configurator URL on a GUI host" 0
 else check "auto-opens the configurator URL on a GUI host" 1; fi
 
-# 6. Idempotency -> an existing .env.example is preserved (and not re-verified) across runs.
+# 8. Idempotency -> an existing .env.example is preserved (and not re-verified) across runs.
 if scenario "idempotent" -- "
   $DOCKER_OK
   mkdir -p /root/sdp


### PR DESCRIPTION
## Summary

Adds a `curl | bash` bootstrap installer for self-hosted SDP, a container-based E2E harness, and release-time checksum publishing.

- **`infra/self-hosted/install.sh`** — idempotent bootstrap: verifies Docker (CLI, Compose v2, daemon), resolves the version (latest release by default, `INSTALL_VERSION` pins a tag), downloads `compose.yml`/`.env.example`/`SHA256SUMS` from the immutable release surface, verifies the downloaded artifacts against the checksums (fails closed), and hands off to the configurator (auto-opens the web form on a GUI host, otherwise prints the CLI command). `set -euo pipefail`, auditable.
- **`infra/self-hosted/install.test.sh`** — runs the script in clean `ubuntu:24.04` containers across six scenarios: Docker missing, Docker daemon down, headless happy path (verified compose), tampered-compose checksum abort, desktop auto-open, and idempotency (existing `.env.example` preserved).
- **`.github/workflows/release-checksums.yml`** — on `release: published`, generates `SHA256SUMS` for `install.sh`/`compose.yml`/`.env.example` and uploads them as release assets so every artifact is retrievable and verifiable from the immutable release.