### PR TITLE
feat(counterparty): payment accounts CRUD + manage page

### DIFF
--- a/apps/sdp-api/src/routes/counterparties/index.ts
+++ b/apps/sdp-api/src/routes/counterparties/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
+import counterpartyAccounts from "../counterparty-accounts";
 import {
   archiveCounterparty,
   createCounterparty,
@@ -28,5 +29,7 @@ counterparties.delete(
   requirePermissions("counterparties:write"),
   archiveCounterparty
 );
+
+counterparties.route("/:counterpartyId/accounts", counterpartyAccounts);
 
 export default counterparties;

--- a/apps/sdp-api/src/routes/counterparty-accounts/context.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/context.ts
@@ -1,0 +1,16 @@
+import type { Context } from "hono";
+import {
+  createCounterpartiesRepository,
+  createCounterpartyAccountsRepository,
+} from "@/db/repositories";
+import type { Env } from "@/types/env";
+
+export type AppContext = Context<{ Bindings: Env }>;
+
+export function getCounterpartyAccountsRepository(c: AppContext) {
+  return createCounterpartyAccountsRepository(c.env);
+}
+
+export function getCounterpartiesRepository(c: AppContext) {
+  return createCounterpartiesRepository(c.env);
+}

--- a/apps/sdp-api/src/routes/counterparty-accounts/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/handlers.ts
@@ -25,6 +25,7 @@ import {
   counterpartyAccountListParamsSchema,
   counterpartyAccountParamsSchema,
   createCounterpartyAccountSchema,
+  cryptoWalletDetailsSchema,
   listCounterpartyAccountsQuerySchema,
   updateCounterpartyAccountSchema,
 } from "./schemas";
@@ -190,7 +191,29 @@ export const updateCounterpartyAccount = async (c: AppContext) => {
     throw badRequest("Invalid request body", { errors: z.treeifyError(parsed.error) });
   }
 
-  const updated = await getCounterpartyAccountsRepository(c).updateCounterpartyAccount({
+  const repo = getCounterpartyAccountsRepository(c);
+
+  if (parsed.data.details !== undefined) {
+    const existing = await repo.getCounterpartyAccountById({
+      counterpartyAccountId: params.data.counterpartyAccountId,
+      counterpartyId: params.data.counterpartyId,
+      organizationId: auth.organizationId,
+      projectId,
+    });
+    if (!existing) {
+      throw notFound("Counterparty account");
+    }
+    if (existing.account_kind === "crypto_wallet") {
+      const result = cryptoWalletDetailsSchema.safeParse(parsed.data.details);
+      if (!result.success) {
+        throw badRequest("Invalid crypto_wallet details", {
+          errors: z.treeifyError(result.error),
+        });
+      }
+    }
+  }
+
+  const updated = await repo.updateCounterpartyAccount({
     counterpartyAccountId: params.data.counterpartyAccountId,
     counterpartyId: params.data.counterpartyId,
     organizationId: auth.organizationId,

--- a/apps/sdp-api/src/routes/counterparty-accounts/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/handlers.ts
@@ -1,0 +1,251 @@
+import type {
+  CounterpartyAccount,
+  CounterpartyAccountResponse,
+  ListCounterpartyAccountsResponse,
+} from "@sdp/types";
+import { z } from "zod";
+import { getDb } from "@/db";
+import type { CounterpartyAccountRow } from "@/db/repositories/counterparty-account.repository";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import {
+  badRequest,
+  badRequestParams,
+  badRequestQuery,
+  internalError,
+  notFound,
+} from "@/lib/errors";
+import { created, noContent, success } from "@/lib/response";
+import { AuditService } from "@/services/audit.service";
+import {
+  type AppContext,
+  getCounterpartiesRepository,
+  getCounterpartyAccountsRepository,
+} from "./context";
+import {
+  counterpartyAccountListParamsSchema,
+  counterpartyAccountParamsSchema,
+  createCounterpartyAccountSchema,
+  listCounterpartyAccountsQuerySchema,
+  updateCounterpartyAccountSchema,
+} from "./schemas";
+
+function mapToCounterpartyAccount(row: CounterpartyAccountRow): CounterpartyAccount {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    projectId: row.project_id,
+    counterpartyId: row.counterparty_id,
+    accountKind: row.account_kind,
+    label: row.label,
+    details: row.details,
+    providerAccountData: row.provider_account_data,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function assertCounterpartyExists(
+  c: AppContext,
+  counterpartyId: string,
+  organizationId: string,
+  projectId: string
+) {
+  const counterparty = await getCounterpartiesRepository(c).getCounterpartyById({
+    counterpartyId,
+    organizationId,
+    projectId,
+  });
+  if (!counterparty) {
+    throw notFound("Counterparty");
+  }
+}
+
+export const listCounterpartyAccounts = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = counterpartyAccountListParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const query = listCounterpartyAccountsQuerySchema.safeParse(c.req.query());
+  if (!query.success) {
+    throw badRequestQuery({ errors: z.treeifyError(query.error) });
+  }
+
+  await assertCounterpartyExists(c, params.data.counterpartyId, auth.organizationId, projectId);
+
+  const { page, pageSize, includeArchived, accountKind } = query.data;
+  const { rows, total } = await getCounterpartyAccountsRepository(
+    c
+  ).listCounterpartyAccountsByCounterparty({
+    counterpartyId: params.data.counterpartyId,
+    organizationId: auth.organizationId,
+    projectId,
+    accountKind,
+    includeArchived,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+  });
+
+  const response: ListCounterpartyAccountsResponse = {
+    accounts: rows.map(mapToCounterpartyAccount),
+    total,
+    page,
+    pageSize,
+  };
+
+  return success(c, response);
+};
+
+export const getCounterpartyAccount = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = counterpartyAccountParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const account = await getCounterpartyAccountsRepository(c).getCounterpartyAccountById({
+    counterpartyAccountId: params.data.counterpartyAccountId,
+    counterpartyId: params.data.counterpartyId,
+    organizationId: auth.organizationId,
+    projectId,
+  });
+
+  if (!account) {
+    throw notFound("Counterparty account");
+  }
+
+  const response: CounterpartyAccountResponse = { account: mapToCounterpartyAccount(account) };
+  return success(c, response);
+};
+
+export const createCounterpartyAccount = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = counterpartyAccountListParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const body = await c.req.json();
+  const parsed = createCounterpartyAccountSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", { errors: z.treeifyError(parsed.error) });
+  }
+
+  await assertCounterpartyExists(c, params.data.counterpartyId, auth.organizationId, projectId);
+
+  const account = await getCounterpartyAccountsRepository(c).createCounterpartyAccount({
+    organizationId: auth.organizationId,
+    projectId,
+    counterpartyId: params.data.counterpartyId,
+    accountKind: parsed.data.accountKind,
+    label: parsed.data.label ?? null,
+    details: parsed.data.details ?? {},
+    providerAccountData: parsed.data.providerAccountData ?? {},
+  });
+
+  if (!account) {
+    throw internalError("Failed to create counterparty account");
+  }
+
+  const auditService = new AuditService(getDb(c.env));
+  await auditService.log(c, {
+    organizationId: auth.organizationId,
+    userId: auth.userId ?? undefined,
+    apiKeyId: auth.apiKeyId ?? undefined,
+    action: "create",
+    resourceType: "counterparty_account",
+    resourceId: account.id,
+    metadata: {
+      counterpartyId: params.data.counterpartyId,
+      accountKind: parsed.data.accountKind,
+    },
+  });
+
+  const response: CounterpartyAccountResponse = { account: mapToCounterpartyAccount(account) };
+  return created(c, response);
+};
+
+export const updateCounterpartyAccount = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = counterpartyAccountParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const body = await c.req.json();
+  const parsed = updateCounterpartyAccountSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", { errors: z.treeifyError(parsed.error) });
+  }
+
+  const updated = await getCounterpartyAccountsRepository(c).updateCounterpartyAccount({
+    counterpartyAccountId: params.data.counterpartyAccountId,
+    counterpartyId: params.data.counterpartyId,
+    organizationId: auth.organizationId,
+    projectId,
+    ...parsed.data,
+  });
+
+  if (!updated) {
+    throw notFound("Counterparty account");
+  }
+
+  const auditService = new AuditService(getDb(c.env));
+  await auditService.log(c, {
+    organizationId: auth.organizationId,
+    userId: auth.userId ?? undefined,
+    apiKeyId: auth.apiKeyId ?? undefined,
+    action: "update",
+    resourceType: "counterparty_account",
+    resourceId: updated.id,
+    metadata: { changedFields: Object.keys(parsed.data) },
+  });
+
+  const response: CounterpartyAccountResponse = { account: mapToCounterpartyAccount(updated) };
+  return success(c, response);
+};
+
+export const archiveCounterpartyAccount = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = counterpartyAccountParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const archived = await getCounterpartyAccountsRepository(c).archiveCounterpartyAccount({
+    counterpartyAccountId: params.data.counterpartyAccountId,
+    counterpartyId: params.data.counterpartyId,
+    organizationId: auth.organizationId,
+    projectId,
+  });
+
+  if (!archived) {
+    throw notFound("Counterparty account");
+  }
+
+  const auditService = new AuditService(getDb(c.env));
+  await auditService.log(c, {
+    organizationId: auth.organizationId,
+    userId: auth.userId ?? undefined,
+    apiKeyId: auth.apiKeyId ?? undefined,
+    action: "delete",
+    resourceType: "counterparty_account",
+    resourceId: archived.id,
+  });
+
+  return noContent(c);
+};

--- a/apps/sdp-api/src/routes/counterparty-accounts/index.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/index.ts
@@ -1,0 +1,38 @@
+import { Hono } from "hono";
+import { requirePermissions } from "@/middleware/auth";
+import type { Env } from "@/types/env";
+import {
+  archiveCounterpartyAccount,
+  createCounterpartyAccount,
+  getCounterpartyAccount,
+  listCounterpartyAccounts,
+  updateCounterpartyAccount,
+} from "./handlers";
+
+// Mounted under /counterparties/:counterpartyId/accounts. Auth and project
+// context middleware are applied by the parent counterparties router.
+const counterpartyAccounts = new Hono<{ Bindings: Env }>();
+
+counterpartyAccounts.get("/", requirePermissions("counterparties:read"), listCounterpartyAccounts);
+counterpartyAccounts.post(
+  "/",
+  requirePermissions("counterparties:write"),
+  createCounterpartyAccount
+);
+counterpartyAccounts.get(
+  "/:counterpartyAccountId",
+  requirePermissions("counterparties:read"),
+  getCounterpartyAccount
+);
+counterpartyAccounts.patch(
+  "/:counterpartyAccountId",
+  requirePermissions("counterparties:write"),
+  updateCounterpartyAccount
+);
+counterpartyAccounts.delete(
+  "/:counterpartyAccountId",
+  requirePermissions("counterparties:write"),
+  archiveCounterpartyAccount
+);
+
+export default counterpartyAccounts;

--- a/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
@@ -6,7 +6,7 @@ export const counterpartyAccountKindSchema = z.enum(COUNTERPARTY_ACCOUNT_KINDS);
 
 const jsonObjectSchema = z.record(z.string(), z.unknown());
 
-const cryptoWalletDetailsSchema = z
+export const cryptoWalletDetailsSchema = z
   .object({
     network: z.string().min(1).max(64),
     address: z.string().min(1).max(256),

--- a/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
@@ -1,0 +1,72 @@
+import { COUNTERPARTY_ACCOUNT_KINDS } from "@sdp/types";
+import { z } from "zod";
+import { isAddress } from "@/lib/solana";
+
+export const counterpartyAccountKindSchema = z.enum(COUNTERPARTY_ACCOUNT_KINDS);
+
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+
+const cryptoWalletDetailsSchema = z
+  .object({
+    network: z.string().min(1).max(64),
+    address: z.string().min(1).max(256),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.network === "solana" &&
+      !(value.address.length >= 32 && value.address.length <= 44 && isAddress(value.address))
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["address"],
+        message: "address must be a base58 Solana address",
+      });
+    }
+  });
+
+export const createCounterpartyAccountSchema = z
+  .object({
+    accountKind: counterpartyAccountKindSchema,
+    label: z.string().min(1).max(256).optional(),
+    details: jsonObjectSchema.optional(),
+    providerAccountData: jsonObjectSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.accountKind === "crypto_wallet") {
+      const result = cryptoWalletDetailsSchema.safeParse(value.details);
+      if (!result.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["details"],
+          message: "crypto_wallet accounts require details.network and details.address",
+        });
+      }
+    }
+  });
+
+export const updateCounterpartyAccountObjectSchema = z.object({
+  label: z.string().min(1).max(256).nullable().optional(),
+  details: jsonObjectSchema.optional(),
+  providerAccountData: jsonObjectSchema.optional(),
+});
+
+export const updateCounterpartyAccountSchema = updateCounterpartyAccountObjectSchema.refine(
+  (value) => Object.keys(value).length > 0,
+  { message: "At least one field must be provided" }
+);
+
+export const counterpartyAccountParamsSchema = z.object({
+  counterpartyId: z.string().min(1),
+  counterpartyAccountId: z.string().min(1),
+});
+
+export const counterpartyAccountListParamsSchema = z.object({
+  counterpartyId: z.string().min(1),
+});
+
+export const listCounterpartyAccountsQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  includeArchived: z.coerce.boolean().default(false),
+  accountKind: counterpartyAccountKindSchema.optional(),
+});

--- a/apps/sdp-api/src/services/audit.service.ts
+++ b/apps/sdp-api/src/services/audit.service.ts
@@ -53,7 +53,8 @@ export type ResourceType =
   // Transaction resources
   | "transaction"
   | "signing_request"
-  | "counterparty";
+  | "counterparty"
+  | "counterparty_account";
 
 export interface AuditLogEntry {
   organizationId?: string;

--- a/apps/sdp-web/src/app/api/dashboard/counterparty/[counterpartyId]/accounts/[accountId]/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/counterparty/[counterpartyId]/accounts/[accountId]/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+
+type RouteContext = { params: Promise<{ counterpartyId: string; accountId: string }> };
+
+function accountPath(counterpartyId: string, accountId: string): string {
+  return `/v1/counterparties/${encodeURIComponent(counterpartyId)}/accounts/${encodeURIComponent(accountId)}`;
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const trace = createTimedTrace("route.dashboard.counterparty.accounts.update", request);
+
+  try {
+    const { counterpartyId, accountId } = await context.params;
+    const body = await request.text();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.counterparty.accounts.api")
+    );
+    const response = await apiClient.request(accountPath(counterpartyId, accountId), {
+      method: "PATCH",
+      body,
+    });
+    const responseBody = await response.text();
+
+    logRouteResult(trace, response.status);
+
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to update counterparty account",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to update counterparty account" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  const trace = createTimedTrace("route.dashboard.counterparty.accounts.delete", request);
+
+  try {
+    const { counterpartyId, accountId } = await context.params;
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.counterparty.accounts.api")
+    );
+    const response = await apiClient.request(accountPath(counterpartyId, accountId), {
+      method: "DELETE",
+    });
+    const body = await response.text();
+
+    logRouteResult(trace, response.status);
+
+    return new NextResponse(response.status === 204 ? null : body, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to delete counterparty account",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to delete counterparty account" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/counterparty/[counterpartyId]/accounts/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/counterparty/[counterpartyId]/accounts/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+
+type RouteContext = { params: Promise<{ counterpartyId: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  const trace = createTimedTrace("route.dashboard.counterparty.accounts.list", request);
+
+  try {
+    const { counterpartyId } = await context.params;
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.counterparty.accounts.api")
+    );
+    const search = new URL(request.url).searchParams.toString();
+    const response = await apiClient.request(
+      `/v1/counterparties/${encodeURIComponent(counterpartyId)}/accounts${search ? `?${search}` : ""}`
+    );
+    const body = await response.text();
+
+    logRouteResult(trace, response.status);
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to fetch counterparty accounts",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch counterparty accounts" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const trace = createTimedTrace("route.dashboard.counterparty.accounts.create", request);
+
+  try {
+    const { counterpartyId } = await context.params;
+    const body = await request.text();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.counterparty.accounts.api")
+    );
+    const response = await apiClient.request(
+      `/v1/counterparties/${encodeURIComponent(counterpartyId)}/accounts`,
+      { method: "POST", body }
+    );
+    const responseBody = await response.text();
+
+    logRouteResult(trace, response.status);
+
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to create counterparty account",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to create counterparty account" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/counterparty/[counterpartyId]/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/counterparty/[counterpartyId]/route.ts
@@ -100,7 +100,7 @@ export async function DELETE(request: Request, context: RouteContext) {
 
     logRouteResult(trace, response.status);
 
-    return new NextResponse(body, {
+    return new NextResponse(response.status === 204 ? null : body, {
       status: response.status,
       headers: {
         "Content-Type": response.headers.get("Content-Type") ?? "application/json",

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/[counterpartyId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/[counterpartyId]/page.tsx
@@ -1,0 +1,48 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import { getAuthEntryPath } from "@/lib/auth-entry";
+import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
+import { fetchCounterpartyDetail } from "../counterparty-detail.data";
+import { CounterpartyDetailWorkspace } from "../counterparty-detail-workspace";
+
+export const dynamic = "force-dynamic";
+
+export default async function CounterpartyDetailRoute({
+  params,
+}: {
+  params: Promise<{ counterpartyId: string }>;
+}) {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect(await getAuthEntryPath());
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  const { counterpartyId } = await params;
+
+  return withDashboardPageTrace(
+    "dashboard.counterparty.detail.page",
+    async ({ trace, apiClient }) => {
+      const detail = await trace.step("fetch_counterparty_detail", () =>
+        fetchCounterpartyDetail(apiClient.request, counterpartyId)
+      );
+
+      trace.log({ ok: detail.counterparty !== null, accounts: detail.accounts.length });
+
+      if (!detail.counterparty) {
+        notFound();
+      }
+
+      return (
+        <div className="flex h-full min-h-0 w-full flex-col">
+          <CounterpartyDetailWorkspace
+            counterparty={detail.counterparty}
+            initialAccounts={detail.accounts}
+          />
+        </div>
+      );
+    }
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/add-external-account-dialog.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/add-external-account-dialog.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { CounterpartyAccount } from "@sdp/types";
+import { Modal } from "@/components/ui/modal";
+import { CryptoAccountForm } from "./crypto-account-form";
+
+interface AddExternalAccountDialogProps {
+  isOpen: boolean;
+  counterpartyId: string;
+  onAdded: (account: CounterpartyAccount) => void;
+  onClose: () => void;
+}
+
+export function AddExternalAccountDialog({
+  isOpen,
+  counterpartyId,
+  onAdded,
+  onClose,
+}: AddExternalAccountDialogProps) {
+  return (
+    <Modal isOpen={isOpen} ariaLabel="Add external account" onClose={onClose} size="md">
+      <div className="space-y-5 p-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium tracking-tight text-text-extra-high">
+            Add external account
+          </h2>
+          <p className="text-sm text-text-medium">
+            Attach a crypto wallet for this counterparty. The address is screened for risk before
+            it's added.
+          </p>
+        </div>
+        <CryptoAccountForm
+          counterpartyId={counterpartyId}
+          onAdded={(account) => {
+            onAdded(account);
+            onClose();
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/confirm-risky-account-dialog.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/confirm-risky-account-dialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Loader2Icon, ShieldAlertIcon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import type { ComplianceProviderResult } from "@/lib/compliance";
+import { formatRiskScore, toProviderLabel } from "../payments-workspace.data";
+
+interface ConfirmRiskyAccountDialogProps {
+  isOpen: boolean;
+  providers: ComplianceProviderResult[];
+  /** False when screening could not be completed (e.g. provider unavailable). */
+  screened?: boolean;
+  onConfirm: () => Promise<void>;
+  onClose: () => void;
+}
+
+export function ConfirmRiskyAccountDialog({
+  isOpen,
+  providers,
+  screened = true,
+  onConfirm,
+  onClose,
+}: ConfirmRiskyAccountDialogProps) {
+  const [confirming, setConfirming] = useState(false);
+
+  async function handleConfirm() {
+    setConfirming(true);
+    try {
+      await onConfirm();
+    } finally {
+      setConfirming(false);
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      ariaLabel="Confirm risky wallet"
+      onClose={confirming ? undefined : onClose}
+      size="sm"
+    >
+      <div className="space-y-5 p-6">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 text-status-error-text">
+            <ShieldAlertIcon className="size-5" />
+          </span>
+          <div className="space-y-1">
+            <h2 className="text-lg font-medium tracking-tight text-text-extra-high">
+              {screened ? "This wallet was flagged" : "Couldn't screen this wallet"}
+            </h2>
+            <p className="text-sm text-text-medium">
+              {screened
+                ? `The following risk ${providers.length === 1 ? "analysis" : "analyses"} flagged this wallet as high risk. Confirm you're okay adding it anyway.`
+                : "We couldn't run a risk screening on this address (compliance screening isn't available). Confirm you're okay adding it without a screen."}
+            </p>
+          </div>
+        </div>
+
+        {providers.length > 0 && (
+          <ul className="space-y-2">
+            {providers.map((result) => (
+              <li
+                key={result.provider}
+                className="flex items-center justify-between gap-3 rounded-xl border border-[rgba(158,43,56,0.2)] bg-[rgba(158,43,56,0.06)] px-3 py-2 text-sm text-status-error-text"
+              >
+                <span className="font-medium">{toProviderLabel(result.provider)}</span>
+                <span className="text-xs">{formatRiskScore(result)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex items-center justify-end gap-3">
+          <Button type="button" variant="outline" onClick={onClose} disabled={confirming}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={confirming}
+            iconLeft={confirming ? <Loader2Icon className="animate-spin" /> : undefined}
+          >
+            {confirming ? "Adding" : "Add anyway"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-context.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-context.tsx
@@ -42,6 +42,11 @@ interface CounterpartyCreateContextValue {
   submit: () => Promise<void>;
   submitting: boolean;
   submitError: string | null;
+
+  // After a successful create we move to an optional "attach accounts" phase
+  // for the freshly created counterparty.
+  createdCounterparty: Counterparty | null;
+  finish: () => void;
 }
 
 const CounterpartyCreateContext = createContext<CounterpartyCreateContextValue | null>(null);
@@ -65,6 +70,7 @@ export function CounterpartyCreateProvider({
   const [direction, setDirection] = useState<1 | -1>(1);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [createdCounterparty, setCreatedCounterparty] = useState<Counterparty | null>(null);
 
   const steps = useMemo(() => getSteps(basics.values.entityType), [basics.values.entityType]);
   const currentStepId = steps[step] ?? "basics";
@@ -125,23 +131,29 @@ export function CounterpartyCreateProvider({
         return;
       }
 
-      toast.success("Counterparty created", { position: "bottom-right" });
-
-      if (onCreated) {
-        const created = result.data?.data?.counterparty;
-        if (created) {
-          onCreated(created);
-        }
+      const created = result.data?.data?.counterparty ?? null;
+      if (!created) {
+        setSubmitError("Counterparty was created but could not be loaded.");
         return;
       }
 
-      router.refresh();
-      router.push("/dashboard/payments/counterparty");
+      toast.success("Counterparty created", { position: "bottom-right" });
+      setCreatedCounterparty(created);
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function finish() {
+    if (onCreated && createdCounterparty) {
+      onCreated(createdCounterparty);
+      return;
+    }
+
+    router.refresh();
+    router.push("/dashboard/payments/counterparty");
   }
 
   return (
@@ -159,6 +171,8 @@ export function CounterpartyCreateProvider({
         submit,
         submitting,
         submitError,
+        createdCounterparty,
+        finish,
       }}
     >
       {children}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-page.tsx
@@ -6,6 +6,7 @@ import { StepFooter } from "./components/step-footer";
 import { StepIndicator } from "./components/step-indicator";
 import { useCounterpartyCreate } from "./counterparty-create-context";
 import type { StepId } from "./counterparty-create-schemas";
+import { CryptoAccountsPhase } from "./crypto-accounts-phase";
 
 const stepMeta: Record<StepId, { label: string; title: string; description: string }> = {
   basics: {
@@ -37,10 +38,14 @@ const variants = {
 };
 
 export function CounterpartyCreatePage() {
-  const { step, steps, currentStepId, direction } = useCounterpartyCreate();
+  const { step, steps, currentStepId, direction, createdCounterparty } = useCounterpartyCreate();
+
+  if (createdCounterparty) {
+    return <CryptoAccountsPhase />;
+  }
 
   return (
-    <div className="mx-auto flex h-[40rem] max-w-xl flex-col py-4">
+    <div className="mx-auto flex h-[70vh] max-w-xl flex-col py-4">
       <StepIndicator steps={steps} step={step} />
 
       <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-schemas.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-schemas.ts
@@ -50,6 +50,19 @@ export const addressSchema = z.object({
   subdivisionCode: optionalUppercase(16),
 });
 
+// Only Solana is accepted for now; the list is the seam for adding networks later.
+export const CRYPTO_ACCOUNT_NETWORKS = ["solana"] as const;
+export type CryptoAccountNetwork = (typeof CRYPTO_ACCOUNT_NETWORKS)[number];
+
+export const cryptoAccountSchema = z.object({
+  label: optionalString(256),
+  network: z.enum(CRYPTO_ACCOUNT_NETWORKS),
+  address: z.string().trim().min(1, "Required").max(256),
+});
+
+export type CryptoAccountData = z.input<typeof cryptoAccountSchema>;
+export type CryptoAccountClean = z.output<typeof cryptoAccountSchema>;
+
 export type StepId = "basics" | "identity" | "address" | "review";
 
 export type BasicsData = z.input<typeof basicsSchema>;

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail-workspace.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import type { Counterparty, CounterpartyAccount } from "@sdp/types";
+import {
+  CakeIcon,
+  CalendarIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  CopyIcon,
+  FlagIcon,
+  GlobeIcon,
+  HashIcon,
+  IdCardIcon,
+  MailIcon,
+  MapPinIcon,
+  PhoneIcon,
+  PlusIcon,
+  ShieldCheckIcon,
+  Trash2Icon,
+  UserIcon,
+  UsersIcon,
+  WalletIcon,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { DashboardWorkspaceOverviewPanel } from "@/components/dashboard-workspace-panel";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { dashboardFetch } from "@/lib/dashboard-fetch";
+import { useCopy } from "@/lib/use-copy";
+import { cn } from "@/lib/utils";
+import { toTitleCase } from "../../activity-format-utils";
+import { AddExternalAccountDialog } from "./add-external-account-dialog";
+import { DeleteCounterpartyDialog } from "./delete-counterparty-dialog";
+
+interface CounterpartyDetailWorkspaceProps {
+  counterparty: Counterparty;
+  initialAccounts: CounterpartyAccount[];
+}
+
+type InfoRowData = { label: string; value: string; icon: ReactNode; mono?: boolean };
+
+function FieldList({ rows }: { rows: InfoRowData[] }) {
+  return (
+    <dl className="grid gap-x-6 gap-y-4 sm:grid-flow-col sm:grid-rows-3">
+      {rows.map((row) => (
+        <div key={row.label} className="flex min-w-0 items-start gap-3">
+          <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-border-light text-text-medium [&_svg]:size-4">
+            {row.icon}
+          </span>
+          <div className="min-w-0 space-y-1">
+            <dt className="text-xs font-medium uppercase tracking-wide text-text-medium">
+              {row.label}
+            </dt>
+            <dd
+              className={cn(
+                "truncate text-sm text-text-extra-high",
+                row.mono && "font-mono text-xs"
+              )}
+              title={row.value}
+            >
+              {row.value}
+            </dd>
+          </div>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function buildPersonalInfoRows(counterparty: Counterparty): InfoRowData[] {
+  const identity = counterparty.identity ?? {};
+  const rows: InfoRowData[] = [];
+
+  const fullName = [
+    identity.firstName,
+    identity.middleName,
+    identity.lastName,
+    identity.secondLastName,
+  ]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" ");
+  if (fullName) rows.push({ label: "Full name", value: fullName, icon: <UserIcon /> });
+  if (identity.dateOfBirth) {
+    rows.push({ label: "Date of birth", value: identity.dateOfBirth, icon: <CakeIcon /> });
+  }
+  if (identity.phone) rows.push({ label: "Phone", value: identity.phone, icon: <PhoneIcon /> });
+
+  const address = identity.address;
+  if (address) {
+    const formatted = [
+      address.line1,
+      address.line2,
+      address.city,
+      address.subdivisionCode,
+      address.postalCode,
+      address.countryCode,
+    ]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join(", ");
+    if (formatted) rows.push({ label: "Address", value: formatted, icon: <MapPinIcon /> });
+  }
+
+  if (identity.birthCountryCode) {
+    rows.push({ label: "Birth country", value: identity.birthCountryCode, icon: <GlobeIcon /> });
+  }
+  if (identity.citizenshipCountryCode) {
+    rows.push({ label: "Citizenship", value: identity.citizenshipCountryCode, icon: <FlagIcon /> });
+  }
+  if (identity.governmentId) {
+    rows.push({
+      label: "Government ID",
+      value: `${identity.governmentId.type} · ${identity.governmentId.number}`,
+      icon: <IdCardIcon />,
+      mono: true,
+    });
+  }
+
+  return rows;
+}
+
+export function CounterpartyDetailWorkspace({
+  counterparty,
+  initialAccounts,
+}: CounterpartyDetailWorkspaceProps) {
+  const router = useRouter();
+  const { copy, copied } = useCopy(1200);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [accounts, setAccounts] = useState(initialAccounts);
+  const [addOpen, setAddOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const personalInfoRows = buildPersonalInfoRows(counterparty);
+
+  async function confirmDelete() {
+    const result = await dashboardFetch(
+      `/api/dashboard/counterparty/${encodeURIComponent(counterparty.id)}`,
+      { method: "DELETE" }
+    );
+    if (!result.ok) {
+      toast.error(result.error, { position: "bottom-right" });
+      return;
+    }
+    toast.success(`${counterparty.displayName} deleted`, { position: "bottom-right" });
+    router.push("/dashboard/payments/counterparty");
+  }
+
+  return (
+    <DashboardWorkspaceOverviewPanel className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-3xl font-medium tracking-tight text-text-extra-high">
+            {counterparty.displayName}
+          </h2>
+          <p className="text-sm text-text-medium">
+            {toTitleCase(counterparty.entityType)} · Counterparty
+          </p>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button type="button" variant="outline" size="sm" iconRight={<ChevronDownIcon />}>
+              Manage
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem
+              className="text-status-error-text focus:text-status-error-text [&_svg]:size-4"
+              onSelect={() => setDeleteOpen(true)}
+            >
+              <Trash2Icon />
+              Delete counterparty
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="space-y-3">
+          <h3 className="text-2xl font-medium text-text-extra-high">Identity</h3>
+          <div className="rounded-2xl border border-border-light bg-white p-5 shadow-sm">
+            <FieldList
+              rows={[
+                { label: "Display name", value: counterparty.displayName, icon: <UserIcon /> },
+                { label: "Type", value: toTitleCase(counterparty.entityType), icon: <UsersIcon /> },
+                { label: "Email", value: counterparty.email, icon: <MailIcon /> },
+                { label: "External ID", value: counterparty.externalId ?? "—", icon: <HashIcon /> },
+                {
+                  label: "Status",
+                  value: toTitleCase(counterparty.status),
+                  icon: <ShieldCheckIcon />,
+                },
+                {
+                  label: "Created",
+                  value: new Date(counterparty.createdAt).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "2-digit",
+                    year: "numeric",
+                  }),
+                  icon: <CalendarIcon />,
+                },
+              ]}
+            />
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <h3 className="text-2xl font-medium text-text-extra-high">Personal information</h3>
+          <div className="rounded-2xl border border-border-light bg-white p-5 shadow-sm">
+            {personalInfoRows.length > 0 ? (
+              <FieldList rows={personalInfoRows} />
+            ) : (
+              <p className="text-sm text-text-low">No personal information on file.</p>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-2xl font-medium text-text-extra-high">External accounts</h3>
+          <Button type="button" size="sm" iconLeft={<PlusIcon />} onClick={() => setAddOpen(true)}>
+            Add External Account
+          </Button>
+        </div>
+        {accounts.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-border-medium py-10 text-center">
+            <WalletIcon className="size-7 text-text-extra-low" />
+            <p className="text-sm text-text-low">No external accounts yet.</p>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-2xl border border-border-light bg-white shadow-sm">
+            {accounts.map((account) => {
+              const details = account.details as { network?: string; address?: string };
+              return (
+                <div
+                  key={account.id}
+                  className="flex items-center justify-between gap-4 border-b border-border-light px-4 py-3 last:border-b-0"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-text-extra-high">
+                      {account.label ?? "Crypto wallet"}
+                    </p>
+                    <div className="flex items-center gap-1.5">
+                      <p className="truncate font-mono text-xs text-text-medium">
+                        {details.address}
+                      </p>
+                      {details.address && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          aria-label="Copy address"
+                          onClick={() => {
+                            if (!details.address) return;
+                            setCopiedId(account.id);
+                            void copy(details.address);
+                            toast.success("Address copied", { position: "bottom-right" });
+                          }}
+                        >
+                          {copied && copiedId === account.id ? (
+                            <CheckIcon className="text-status-success-text" />
+                          ) : (
+                            <CopyIcon />
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                  <span className="shrink-0 text-xs text-text-medium">{details.network}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <AddExternalAccountDialog
+        isOpen={addOpen}
+        counterpartyId={counterparty.id}
+        onAdded={(account) => setAccounts((prev) => [account, ...prev])}
+        onClose={() => setAddOpen(false)}
+      />
+
+      <DeleteCounterpartyDialog
+        isOpen={deleteOpen}
+        displayName={counterparty.displayName}
+        onConfirm={confirmDelete}
+        onClose={() => setDeleteOpen(false)}
+      />
+    </DashboardWorkspaceOverviewPanel>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail.data.ts
@@ -1,0 +1,32 @@
+import type {
+  Counterparty,
+  CounterpartyAccount,
+  CounterpartyResponse,
+  ListCounterpartyAccountsResponse,
+} from "@sdp/types";
+import type { SdpApiClient } from "@/lib/sdp-api";
+
+export async function fetchCounterpartyDetail(
+  request: SdpApiClient["request"],
+  counterpartyId: string
+): Promise<{ counterparty: Counterparty | null; accounts: CounterpartyAccount[] }> {
+  const encoded = encodeURIComponent(counterpartyId);
+  const [counterpartyRes, accountsRes] = await Promise.all([
+    request(`/v1/counterparties/${encoded}`),
+    request(`/v1/counterparties/${encoded}/accounts?pageSize=100`),
+  ]);
+
+  let counterparty: Counterparty | null = null;
+  if (counterpartyRes.ok) {
+    const json = (await counterpartyRes.json()) as { data?: CounterpartyResponse };
+    counterparty = json.data?.counterparty ?? null;
+  }
+
+  let accounts: CounterpartyAccount[] = [];
+  if (accountsRes.ok) {
+    const json = (await accountsRes.json()) as { data?: ListCounterpartyAccountsResponse };
+    accounts = json.data?.accounts ?? [];
+  }
+
+  return { counterparty, accounts };
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-page.data.ts
@@ -1,23 +1,37 @@
-import type { Counterparty, ListCounterpartiesResponse } from "@sdp/types";
+import type { Counterparty, ListCounterpartiesResponse, PaginatedResponse } from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
 
+export const COUNTERPARTY_PAGE_SIZE = 10;
+
 export async function fetchCounterparties(
-  request: SdpApiClient["request"]
-): Promise<{ ok: boolean; data: Counterparty[]; error?: string }> {
+  request: SdpApiClient["request"],
+  options: { page?: number; pageSize?: number } = {}
+): Promise<PaginatedResponse<Counterparty>> {
+  const page = options.page ?? 1;
+  const pageSize = options.pageSize ?? COUNTERPARTY_PAGE_SIZE;
+
   try {
     const response = await request(
-      `/v1/counterparties?${new URLSearchParams({ page: "1", pageSize: "100" }).toString()}`
+      `/v1/counterparties?${new URLSearchParams({
+        page: String(page),
+        pageSize: String(pageSize),
+      }).toString()}`
     );
     if (!response.ok) {
       const body = await response.text();
-      return { ok: false, data: [], error: body };
+      return { ok: false, data: [], total: 0, error: body };
     }
     const json = (await response.json()) as { data?: ListCounterpartiesResponse };
-    return { ok: true, data: json.data?.counterparties ?? [] };
+    return {
+      ok: true,
+      data: json.data?.counterparties ?? [],
+      total: json.data?.total ?? 0,
+    };
   } catch (error) {
     return {
       ok: false,
       data: [],
+      total: 0,
       error: error instanceof Error ? error.message : "Unable to load counterparties",
     };
   }

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-workspace.tsx
@@ -1,21 +1,30 @@
 "use client";
 
 import type { Counterparty } from "@sdp/types";
-import { PlusIcon, UsersIcon } from "lucide-react";
+import { MoreHorizontalIcon, PlusIcon, Trash2Icon, UserIcon, UsersIcon } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { ApiPlaygroundShellSkeleton } from "@/components/api-playground-shell-skeleton";
 import { DashboardWorkspaceTabShell } from "@/components/dashboard-workspace-tab-shell";
+import { ArrowPagination } from "@/components/ui/arrow-pagination";
 import { Button } from "@/components/ui/button";
 import {
   Card,
   CardAction,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -25,9 +34,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { dashboardFetch } from "@/lib/dashboard-fetch";
 import { getStoredApiKeySecret } from "@/lib/playground-api-keys";
 import { toTitleCase } from "../../activity-format-utils";
 import type { CounterpartyPlaygroundView } from "./counterparty-playground-config";
+import { DeleteCounterpartyDialog } from "./delete-counterparty-dialog";
+import { useCounterpartyDirectory } from "./use-counterparty-directory";
 
 const CounterpartyPlayground = dynamic(
   () => import("./counterparty-playground").then((module) => module.CounterpartyPlayground),
@@ -44,24 +56,31 @@ interface CounterpartyApiKeyOption {
 
 interface CounterpartyWorkspaceProps {
   initialCounterparties: Counterparty[];
+  initialTotal: number;
   apiKeys: CounterpartyApiKeyOption[];
   apiBaseUrl: string | null;
 }
 
 export function CounterpartyWorkspace({
   initialCounterparties,
+  initialTotal,
   apiKeys,
   apiBaseUrl,
 }: CounterpartyWorkspaceProps) {
   const router = useRouter();
   const { counterpartyTab, selectedPlaygroundApiKeyId, setPlaygroundApiKeys } =
     useDashboardWorkspace();
-  const [counterparties, setCounterparties] = useState(initialCounterparties);
   const isPlaygroundTab = counterpartyTab === "playground";
 
-  useEffect(() => {
-    setCounterparties(initialCounterparties);
-  }, [initialCounterparties]);
+  const {
+    page,
+    setPage,
+    counterparties,
+    total,
+    pageCount,
+    summary: pageSummary,
+    removeOptimistic,
+  } = useCounterpartyDirectory(initialCounterparties, initialTotal);
 
   useEffect(() => {
     setPlaygroundApiKeys(apiKeys);
@@ -103,98 +122,177 @@ export function CounterpartyWorkspace({
     [counterparties]
   );
 
+  const [pendingDelete, setPendingDelete] = useState<Counterparty | null>(null);
+
+  async function confirmDelete() {
+    if (!pendingDelete) return;
+    const target = pendingDelete;
+
+    // Optimistically drop the row, then reconcile with the server below.
+    removeOptimistic(target.id);
+    setPendingDelete(null);
+
+    const result = await dashboardFetch(
+      `/api/dashboard/counterparty/${encodeURIComponent(target.id)}`,
+      { method: "DELETE" }
+    );
+    if (!result.ok) {
+      toast.error(result.error, { position: "bottom-right" });
+      router.refresh(); // restore the optimistically-removed row
+      return;
+    }
+    toast.success(`${target.displayName} deleted`, { position: "bottom-right" });
+    router.refresh();
+  }
+
   return (
-    <DashboardWorkspaceTabShell
-      isPlaygroundTab={isPlaygroundTab}
-      overviewClassName="space-y-6"
-      overviewKey="counterparty-overview-tab"
-      playgroundKey="counterparty-playground-tab"
-      overview={
-        <Card className="flex flex-1 flex-col">
-          <CardHeader>
-            <CardTitle>Directory</CardTitle>
-            <CardDescription>
-              Registered individuals and businesses in your workspace.
-            </CardDescription>
-            {counterparties.length > 0 && (
-              <CardAction>
-                <Button
-                  type="button"
-                  iconLeft={<PlusIcon />}
-                  onClick={() => router.push("/dashboard/payments/counterparty/create")}
-                >
-                  Create
-                </Button>
-              </CardAction>
-            )}
-          </CardHeader>
-          <CardContent className="flex flex-1 flex-col">
-            {counterparties.length === 0 ? (
-              <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-border-medium py-16 text-center">
-                <UsersIcon className="h-10 w-10 text-text-extra-low" />
-                <div className="space-y-1">
-                  <p className="text-sm font-medium text-text-extra-high">No counterparties yet</p>
-                  <p className="text-sm text-text-low">
-                    Add your first individual or business to get started.
-                  </p>
+    <>
+      <DashboardWorkspaceTabShell
+        isPlaygroundTab={isPlaygroundTab}
+        overviewClassName="flex min-h-0 flex-col overflow-hidden"
+        overviewKey="counterparty-overview-tab"
+        playgroundKey="counterparty-playground-tab"
+        overview={
+          <Card className="flex min-h-0 flex-1 flex-col">
+            <CardHeader>
+              <CardTitle>Directory</CardTitle>
+              <CardDescription>
+                Registered individuals and businesses in your workspace.
+              </CardDescription>
+              {total > 0 && (
+                <CardAction>
+                  <Button
+                    type="button"
+                    iconLeft={<PlusIcon />}
+                    onClick={() => router.push("/dashboard/payments/counterparty/create")}
+                  >
+                    Create
+                  </Button>
+                </CardAction>
+              )}
+            </CardHeader>
+            <CardContent className="flex min-h-0 flex-1 flex-col">
+              {total === 0 ? (
+                <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-border-medium py-16 text-center">
+                  <UsersIcon className="h-10 w-10 text-text-extra-low" />
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-text-extra-high">
+                      No counterparties yet
+                    </p>
+                    <p className="text-sm text-text-low">
+                      Add your first individual or business to get started.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    iconLeft={<PlusIcon />}
+                    onClick={() => router.push("/dashboard/payments/counterparty/create")}
+                  >
+                    Create
+                  </Button>
                 </div>
-                <Button
-                  type="button"
-                  iconLeft={<PlusIcon />}
-                  onClick={() => router.push("/dashboard/payments/counterparty/create")}
-                >
-                  Create
-                </Button>
-              </div>
-            ) : (
-              <Table className="[&_table]:table-fixed">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[22%]">Display name</TableHead>
-                    <TableHead className="w-[11%]">Type</TableHead>
-                    <TableHead className="w-[22%]">Email</TableHead>
-                    <TableHead className="w-[16%]">External ID</TableHead>
-                    <TableHead className="w-[14%]">Created</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {counterparties.map((cp) => (
-                    <TableRow key={cp.id}>
-                      <TableCell className="font-medium">
-                        <span className="block truncate">{cp.displayName}</span>
-                      </TableCell>
-                      <TableCell className="text-xs">
-                        <span className="block truncate">{toTitleCase(cp.entityType)}</span>
-                      </TableCell>
-                      <TableCell className="text-xs">
-                        <span className="block truncate">{cp.email}</span>
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">
-                        <span className="block truncate">{cp.externalId ?? "—"}</span>
-                      </TableCell>
-                      <TableCell className="text-xs text-text-medium">
-                        {new Date(cp.createdAt).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "2-digit",
-                          year: "numeric",
-                        })}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              ) : (
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <Table className="[&_table]:table-fixed">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-[30%]">Display name</TableHead>
+                        <TableHead className="w-[12%]">Type</TableHead>
+                        <TableHead className="w-[24%]">Email</TableHead>
+                        <TableHead className="w-[16%]">External ID</TableHead>
+                        <TableHead className="w-[18%]">Created</TableHead>
+                        <TableHead className="w-[56px]" />
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {counterparties.map((cp) => (
+                        <TableRow key={cp.id}>
+                          <TableCell className="font-medium">
+                            <span className="block truncate">{cp.displayName}</span>
+                          </TableCell>
+                          <TableCell className="text-sm">
+                            <span className="block truncate">{toTitleCase(cp.entityType)}</span>
+                          </TableCell>
+                          <TableCell className="text-sm">
+                            <span className="block truncate">{cp.email}</span>
+                          </TableCell>
+                          <TableCell className="font-mono text-sm">
+                            <span className="block truncate">{cp.externalId ?? "—"}</span>
+                          </TableCell>
+                          <TableCell className="text-sm text-text-medium">
+                            {new Date(cp.createdAt).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "2-digit",
+                              year: "numeric",
+                            })}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  aria-label="Counterparty actions"
+                                >
+                                  <MoreHorizontalIcon />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent>
+                                <DropdownMenuItem
+                                  className="text-xs [&_svg]:size-3.5"
+                                  onSelect={() =>
+                                    router.push(`/dashboard/payments/counterparty/${cp.id}`)
+                                  }
+                                >
+                                  <UserIcon />
+                                  Manage Counterparty
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  className="text-xs text-status-error-text focus:text-status-error-text [&_svg]:size-3.5"
+                                  onSelect={() => setPendingDelete(cp)}
+                                >
+                                  <Trash2Icon />
+                                  Delete Counterparty
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+            {total > 0 && (
+              <CardFooter className="shrink-0 border-t border-border-light">
+                <ArrowPagination
+                  className="w-full"
+                  page={page}
+                  pageCount={pageCount}
+                  onPageChange={setPage}
+                  summary={pageSummary}
+                />
+              </CardFooter>
             )}
-          </CardContent>
-        </Card>
-      }
-      playground={
-        <CounterpartyPlayground
-          apiBaseUrl={apiBaseUrl}
-          apiKeyValue={playgroundApiKeyValue}
-          hasActiveApiKeys={apiKeys.length > 0}
-          counterparties={playgroundCounterparties}
-        />
-      }
-    />
+          </Card>
+        }
+        playground={
+          <CounterpartyPlayground
+            apiBaseUrl={apiBaseUrl}
+            apiKeyValue={playgroundApiKeyValue}
+            hasActiveApiKeys={apiKeys.length > 0}
+            counterparties={playgroundCounterparties}
+          />
+        }
+      />
+      <DeleteCounterpartyDialog
+        isOpen={pendingDelete !== null}
+        displayName={pendingDelete?.displayName ?? null}
+        onConfirm={confirmDelete}
+        onClose={() => setPendingDelete(null)}
+      />
+    </>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/crypto-account-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/crypto-account-form.tsx
@@ -63,7 +63,9 @@ export function CryptoAccountForm({ counterpartyId, onAdded }: CryptoAccountForm
     setSubmitting(false);
 
     if (!result.ok) {
+      setConfirm(null);
       setError(result.error);
+      toast.error(result.error, { position: "bottom-right" });
       return;
     }
 
@@ -75,9 +77,6 @@ export function CryptoAccountForm({ counterpartyId, onAdded }: CryptoAccountForm
     setConfirm(null);
   }
 
-  // Always screen the address first. Require confirmation both when a high-risk
-  // flag comes back AND when screening can't be completed (e.g. no enterprise
-  // compliance provider) — the user must acknowledge before adding.
   async function handleAdd() {
     if (!trimmedAddress) return;
     setError(null);

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/crypto-account-form.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/crypto-account-form.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import type { CounterpartyAccount, CounterpartyAccountResponse } from "@sdp/types";
+import { Loader2Icon, PlusIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ComplianceProviderResult } from "@/lib/compliance";
+import { dashboardFetch } from "@/lib/dashboard-fetch";
+import { getHighRiskProviders, runComplianceCheck } from "../payments-workspace.data";
+import { ConfirmRiskyAccountDialog } from "./confirm-risky-account-dialog";
+import { CRYPTO_ACCOUNT_NETWORKS, type CryptoAccountNetwork } from "./counterparty-create-schemas";
+
+const NETWORK_LABELS: Record<CryptoAccountNetwork, string> = {
+  solana: "Solana",
+};
+
+const NETWORK_OPTIONS = CRYPTO_ACCOUNT_NETWORKS.map((value) => ({
+  value,
+  label: NETWORK_LABELS[value],
+}));
+
+interface CryptoAccountFormProps {
+  counterpartyId: string;
+  onAdded?: (account: CounterpartyAccount) => void;
+}
+
+export function CryptoAccountForm({ counterpartyId, onAdded }: CryptoAccountFormProps) {
+  const [label, setLabel] = useState("");
+  const [network, setNetwork] = useState<CryptoAccountNetwork>("solana");
+  const [address, setAddress] = useState("");
+
+  const [screening, setScreening] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<{
+    providers: ComplianceProviderResult[];
+    screened: boolean;
+  } | null>(null);
+
+  const trimmedAddress = address.trim();
+  const busy = screening || submitting;
+
+  async function createAccount() {
+    setSubmitting(true);
+    setError(null);
+
+    const result = await dashboardFetch<{ data: CounterpartyAccountResponse }>(
+      `/api/dashboard/counterparty/${encodeURIComponent(counterpartyId)}/accounts`,
+      {
+        method: "POST",
+        body: {
+          accountKind: "crypto_wallet",
+          label: label.trim() || undefined,
+          details: { network, address: trimmedAddress },
+        },
+      }
+    );
+
+    setSubmitting(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    const account = result.data?.data?.account;
+    if (account) onAdded?.(account);
+    toast.success("Crypto account attached", { position: "bottom-right" });
+    setLabel("");
+    setAddress("");
+    setConfirm(null);
+  }
+
+  // Always screen the address first. Require confirmation both when a high-risk
+  // flag comes back AND when screening can't be completed (e.g. no enterprise
+  // compliance provider) — the user must acknowledge before adding.
+  async function handleAdd() {
+    if (!trimmedAddress) return;
+    setError(null);
+    setScreening(true);
+
+    let flagged: ComplianceProviderResult[] = [];
+    let screened = true;
+    try {
+      const snapshot = await runComplianceCheck(trimmedAddress, "wallet_address_addition");
+      flagged = getHighRiskProviders(snapshot);
+    } catch {
+      screened = false;
+    } finally {
+      setScreening(false);
+    }
+
+    if (!screened || flagged.length > 0) {
+      setConfirm({ providers: flagged, screened });
+      return;
+    }
+    await createAccount();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <Label className="text-sm font-medium text-text-low" htmlFor="account-label">
+          Label <span className="font-normal text-text-extra-low">(optional)</span>
+        </Label>
+        <Input
+          id="account-label"
+          size="xl"
+          placeholder="e.g. Alice's Solana wallet"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+        />
+      </div>
+
+      <Combobox
+        label="Network"
+        value={network}
+        onChange={(next) => {
+          const match = CRYPTO_ACCOUNT_NETWORKS.find((n) => n === next);
+          if (match) setNetwork(match);
+        }}
+        options={NETWORK_OPTIONS}
+        placeholder="Select network"
+        searchable={false}
+      />
+
+      <div className="flex flex-col gap-2">
+        <Label className="text-sm font-medium text-text-low" htmlFor="account-address">
+          Wallet address
+        </Label>
+        <Input
+          id="account-address"
+          size="xl"
+          placeholder="Destination wallet address"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+      </div>
+
+      {error && <p className="text-sm text-status-error-text">{error}</p>}
+
+      {screening ? (
+        <div className="flex items-center gap-2 text-sm text-text-medium">
+          <Loader2Icon className="size-4 animate-spin" />
+          Screening address for risk…
+        </div>
+      ) : (
+        <Button
+          type="button"
+          onClick={() => void handleAdd()}
+          disabled={busy || !trimmedAddress}
+          iconLeft={submitting ? <Loader2Icon className="animate-spin" /> : <PlusIcon />}
+        >
+          {submitting ? "Adding" : "Add account"}
+        </Button>
+      )}
+
+      <ConfirmRiskyAccountDialog
+        isOpen={confirm !== null}
+        providers={confirm?.providers ?? []}
+        screened={confirm?.screened ?? true}
+        onConfirm={createAccount}
+        onClose={() => setConfirm(null)}
+      />
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/crypto-accounts-phase.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/crypto-accounts-phase.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { CounterpartyAccount } from "@sdp/types";
+import { CheckCircle2Icon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useCounterpartyCreate } from "./counterparty-create-context";
+import { CryptoAccountForm } from "./crypto-account-form";
+
+export function CryptoAccountsPhase() {
+  const { createdCounterparty, finish } = useCounterpartyCreate();
+  const [accounts, setAccounts] = useState<CounterpartyAccount[]>([]);
+
+  if (!createdCounterparty) return null;
+
+  return (
+    <div className="mx-auto flex h-[70vh] max-w-xl flex-col py-4">
+      <div className="flex items-center gap-2 text-status-success-text">
+        <CheckCircle2Icon className="size-5" />
+        <span className="text-sm font-medium">{createdCounterparty.displayName} created</span>
+      </div>
+
+      <div className="mt-6 min-h-0 flex-1 space-y-6 overflow-y-auto pr-1">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-medium tracking-tight text-text-extra-high">
+            Add a crypto account
+          </h2>
+          <p className="text-sm text-text-medium">
+            Optionally add a crypto wallet for this counterparty. You can skip this and add accounts
+            later.
+          </p>
+        </div>
+
+        {accounts.length > 0 && (
+          <ul className="space-y-2">
+            {accounts.map((account) => {
+              const details = account.details as { network?: string; address?: string };
+              return (
+                <li
+                  key={account.id}
+                  className="flex items-center justify-between rounded-xl border border-border-primary px-3 py-2 text-sm"
+                >
+                  <span className="text-text-high">{account.label ?? "Crypto wallet"}</span>
+                  <span className="truncate pl-3 font-mono text-xs text-text-medium">
+                    {details.network} · {details.address}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <CryptoAccountForm
+          counterpartyId={createdCounterparty.id}
+          onAdded={(account) => setAccounts((prev) => [account, ...prev])}
+        />
+      </div>
+
+      <div className="mt-6 flex items-center justify-between gap-3">
+        <Button type="button" variant="outline" onClick={finish}>
+          {accounts.length > 0 ? "Done" : "Skip"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/delete-counterparty-dialog.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/delete-counterparty-dialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Loader2Icon } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+
+interface DeleteCounterpartyDialogProps {
+  isOpen: boolean;
+  displayName: string | null;
+  onConfirm: () => Promise<void>;
+  onClose: () => void;
+}
+
+export function DeleteCounterpartyDialog({
+  isOpen,
+  displayName,
+  onConfirm,
+  onClose,
+}: DeleteCounterpartyDialogProps) {
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleConfirm() {
+    setDeleting(true);
+    try {
+      await onConfirm();
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      ariaLabel="Delete counterparty"
+      onClose={deleting ? undefined : onClose}
+      size="sm"
+    >
+      <div className="space-y-5 p-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium tracking-tight text-text-extra-high">
+            Delete counterparty
+          </h2>
+          <p className="text-sm text-text-medium">
+            {displayName ? (
+              <>
+                Are you sure you want to delete <span className="font-medium">{displayName}</span>?
+                This will archive the counterparty and its accounts.
+              </>
+            ) : (
+              "Are you sure you want to delete this counterparty?"
+            )}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-3">
+          <Button type="button" variant="outline" onClick={onClose} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={deleting}
+            iconLeft={deleting ? <Loader2Icon className="animate-spin" /> : undefined}
+          >
+            {deleting ? "Deleting" : "Delete"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/page.tsx
@@ -29,6 +29,7 @@ export default async function CounterpartyPage() {
       ok: true,
       counterpartiesOk: counterpartiesResult.ok,
       counterpartiesCount: counterpartiesResult.data.length,
+      counterpartiesTotal: counterpartiesResult.total,
       apiKeysOk: apiKeysResult.ok,
       apiKeysCount: apiKeysResult.data?.length ?? 0,
     });
@@ -37,6 +38,7 @@ export default async function CounterpartyPage() {
       <div className="flex h-full min-h-0 w-full flex-col">
         <CounterpartyWorkspace
           initialCounterparties={counterpartiesResult.data}
+          initialTotal={counterpartiesResult.total}
           apiKeys={apiKeysResult.data ?? []}
           apiBaseUrl={apiBaseUrl}
         />

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/use-counterparty-directory.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/use-counterparty-directory.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import type { Counterparty, ListCounterpartiesResponse } from "@sdp/types";
+import { useEffect, useRef, useState } from "react";
+import { dashboardFetch } from "@/lib/dashboard-fetch";
+import { COUNTERPARTY_PAGE_SIZE } from "./counterparty-page.data";
+
+interface UseCounterpartyDirectoryResult {
+  page: number;
+  setPage: (page: number) => void;
+  counterparties: Counterparty[];
+  total: number;
+  pageCount: number;
+  summary: string;
+  loading: boolean;
+  error: string | null;
+  /** Optimistically drop a counterparty from the current page before the server confirms. */
+  removeOptimistic: (counterpartyId: string) => void;
+}
+
+/**
+ * Server-driven pagination for the counterparty directory. Page 1 is seeded
+ * from the SSR payload; subsequent pages are fetched through the dashboard proxy
+ * so the API does the slicing via its page/pageSize parameters.
+ */
+export function useCounterpartyDirectory(
+  initialCounterparties: Counterparty[],
+  initialTotal: number
+): UseCounterpartyDirectoryResult {
+  const pageSize = COUNTERPARTY_PAGE_SIZE;
+  const [page, setPage] = useState(1);
+  const [counterparties, setCounterparties] = useState(initialCounterparties);
+  const [total, setTotal] = useState(initialTotal);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // The current page already holds server data on first render (page 1 / a fresh
+  // SSR payload), so skip the fetch that would otherwise fire for it.
+  const skipNextFetch = useRef(true);
+
+  useEffect(() => {
+    setCounterparties(initialCounterparties);
+    setTotal(initialTotal);
+    setPage(1);
+    skipNextFetch.current = true;
+  }, [initialCounterparties, initialTotal]);
+
+  useEffect(() => {
+    if (skipNextFetch.current) {
+      skipNextFetch.current = false;
+      return;
+    }
+
+    let aborted = false;
+    setLoading(true);
+    setError(null);
+
+    void dashboardFetch<{ data: ListCounterpartiesResponse }>(
+      `/api/dashboard/counterparty?page=${page}&pageSize=${pageSize}`
+    ).then((result) => {
+      if (aborted) return;
+      if (result.ok) {
+        setCounterparties(result.data.data.counterparties);
+        setTotal(result.data.data.total);
+      } else {
+        setError(result.error);
+      }
+      setLoading(false);
+    });
+
+    return () => {
+      aborted = true;
+    };
+  }, [page]);
+
+  function removeOptimistic(counterpartyId: string) {
+    setCounterparties((prev) => prev.filter((cp) => cp.id !== counterpartyId));
+    setTotal((prev) => Math.max(0, prev - 1));
+  }
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const summary =
+    total === 0
+      ? "0 of 0"
+      : `${(page - 1) * pageSize + 1}–${Math.min(page * pageSize, total)} of ${total}`;
+
+  return {
+    page,
+    setPage,
+    counterparties,
+    total,
+    pageCount,
+    summary,
+    loading,
+    error,
+    removeOptimistic,
+  };
+}

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/use-counterparty-directory.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/use-counterparty-directory.ts
@@ -34,20 +34,17 @@ export function useCounterpartyDirectory(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // The current page already holds server data on first render (page 1 / a fresh
-  // SSR payload), so skip the fetch that would otherwise fire for it.
-  const skipNextFetch = useRef(true);
+  const loadedPageRef = useRef(1);
 
   useEffect(() => {
     setCounterparties(initialCounterparties);
     setTotal(initialTotal);
     setPage(1);
-    skipNextFetch.current = true;
+    loadedPageRef.current = 1;
   }, [initialCounterparties, initialTotal]);
 
   useEffect(() => {
-    if (skipNextFetch.current) {
-      skipNextFetch.current = false;
+    if (page === loadedPageRef.current) {
       return;
     }
 
@@ -62,6 +59,7 @@ export function useCounterpartyDirectory(
       if (result.ok) {
         setCounterparties(result.data.data.counterparties);
         setTotal(result.data.data.total);
+        loadedPageRef.current = page;
       } else {
         setError(result.error);
       }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -156,6 +156,11 @@ function resolveRiskTone(result: ComplianceProviderResult): RiskTone {
   return "neutral";
 }
 
+/** Providers that flagged the address as high risk (red tone). */
+export function getHighRiskProviders(snapshot: ComplianceSnapshot): ComplianceProviderResult[] {
+  return snapshot.providers.filter((result) => resolveRiskTone(result) === "red");
+}
+
 export function riskToneClassName(result: ComplianceProviderResult): string {
   const tone = resolveRiskTone(result);
   if (tone === "green") {

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -221,6 +221,36 @@ function DashboardTopBar({
   );
 }
 
+function getCounterpartyRoutePageConfig(pathname: string): DashboardPageConfig | null {
+  if (pathname === "/dashboard/payments/counterparty/create") {
+    return {
+      title: "",
+      hideTitle: true,
+      showHeaderNavRow: true,
+      centeredTitle: "New Counterparty",
+      topBarLeadingContent: (
+        <HeaderBackAction
+          href="/dashboard/payments/counterparty"
+          label="Back to Counterparty"
+          compactOnMobile
+        />
+      ),
+      contentWidthClass: "max-w-xl",
+    };
+  }
+  if (pathname.startsWith("/dashboard/payments/counterparty/")) {
+    return {
+      title: "Manage Counterparty",
+      contentWidthClass: "max-w-none",
+      backAction: {
+        href: "/dashboard/payments/counterparty",
+        label: "Back to Counterparty",
+      },
+    };
+  }
+  return null;
+}
+
 function getDashboardPageConfig(pathname: string): DashboardPageConfig {
   if (pathname === "/dashboard") {
     return {
@@ -299,21 +329,9 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
       contentWidthClass: "max-w-none",
     };
   }
-  if (pathname.startsWith("/dashboard/payments/counterparty/")) {
-    return {
-      title: "",
-      hideTitle: true,
-      showHeaderNavRow: true,
-      centeredTitle: "New Counterparty",
-      topBarLeadingContent: (
-        <HeaderBackAction
-          href="/dashboard/payments/counterparty"
-          label="Back to Counterparty"
-          compactOnMobile
-        />
-      ),
-      contentWidthClass: "max-w-xl",
-    };
+  const counterpartyRouteConfig = getCounterpartyRoutePageConfig(pathname);
+  if (counterpartyRouteConfig) {
+    return counterpartyRouteConfig;
   }
   if (pathname === "/dashboard/payments") {
     return {
@@ -608,6 +626,8 @@ export function DashboardShell({ children }: { children: ReactNode }) {
     pathname === "/dashboard/wallets" ||
     pathname === "/dashboard/custody" ||
     pathname === "/dashboard/payments/counterparty" ||
+    (pathname.startsWith("/dashboard/payments/counterparty/") &&
+      pathname !== "/dashboard/payments/counterparty/create") ||
     isWalletDetailRoute;
   const shouldLockViewportScroll = shouldUseWorkspaceViewport;
   const shouldLockShellViewport = shouldLockViewportScroll || isMobileSidebarOpen;

--- a/apps/sdp-web/src/components/ui/arrow-pagination.tsx
+++ b/apps/sdp-web/src/components/ui/arrow-pagination.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ArrowPaginationProps {
+  page: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+  /** Optional summary of the items shown, e.g. "1–10 of 42". */
+  summary?: string;
+}
+
+export function ArrowPagination({
+  page,
+  pageCount,
+  onPageChange,
+  className,
+  summary,
+}: ArrowPaginationProps) {
+  return (
+    <div className={cn("flex items-center justify-between gap-3", className)}>
+      <span className="text-xs text-text-medium">{summary ?? `Page ${page} of ${pageCount}`}</span>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="Previous page"
+          disabled={page <= 1}
+          onClick={() => onPageChange(page - 1)}
+        >
+          <ChevronLeftIcon />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="Next page"
+          disabled={page >= pageCount}
+          onClick={() => onPageChange(page + 1)}
+        >
+          <ChevronRightIcon />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -104,3 +104,27 @@ export interface CounterpartyAccount {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface CreateCounterpartyAccountRequest {
+  accountKind: CounterpartyAccountKind;
+  label?: string;
+  details?: CounterpartyAccountDetails;
+  providerAccountData?: CounterpartyAccountProviderData;
+}
+
+export interface UpdateCounterpartyAccountRequest {
+  label?: string | null;
+  details?: CounterpartyAccountDetails;
+  providerAccountData?: CounterpartyAccountProviderData;
+}
+
+export interface CounterpartyAccountResponse {
+  account: CounterpartyAccount;
+}
+
+export interface ListCounterpartyAccountsResponse {
+  accounts: CounterpartyAccount[];
+  total: number;
+  page: number;
+  pageSize: number;
+}

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -7,6 +7,7 @@ export * from "./counterparties";
 export * from "./custody";
 export * from "./generated/ramp-support.generated";
 export * from "./organizations";
+export * from "./pagination";
 export * from "./payment-rails";
 export * from "./payments";
 export * from "./permissions";

--- a/packages/sdp-types/src/pagination.ts
+++ b/packages/sdp-types/src/pagination.ts
@@ -1,0 +1,10 @@
+/**
+ * Result of a server-side paginated fetch: the page of items plus the total
+ * count across all pages, with a success flag and optional error message.
+ */
+export interface PaginatedResponse<T> {
+  ok: boolean;
+  data: T[];
+  total: number;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
Phase 1 counterparty management: payment-account CRUD, a Manage Counterparty detail page, and directory pagination.

## Backend (sdp-api / @sdp/types)
- New **`counterparty-accounts` route module** (own context/schemas/handlers/index), mounted under `/counterparties/:counterpartyId/accounts` with full CRUD — parent-scoped and audit-logged. `crypto_wallet` details are validated as base58 Solana addresses.
- Added counterparty-account request/response types and a generic **`PaginatedResponse<T>`** to `@sdp/types`; added `"counterparty_account"` audit resource type.
- Dashboard proxy routes for account list/create and single update/delete; forward `204` with a `null` body.

## Frontend (sdp-web)
- **Manage Counterparty detail page** (`/counterparty/[id]`): two-column Identity / Personal information cards, External accounts list with per-row copy button, and a **Manage** dropdown to delete (shared delete dialog).
- **Shared `CryptoAccountForm`** with best-effort risk screening — confirmation dialog both on a high-risk flag and when screening is unavailable; surfaced via an **Add External Account** dialog and the post-create attach step.
- **Counterparty directory**: server-driven pagination (`page`/`pageSize`) with a reusable `ArrowPagination`, plus a row actions menu (Manage / Delete) with optimistic delete.

```
{
  "id": "counterparty_account_d81e9e5c-abd1-4111-b0c6-9215bf684f48",
  "org_id": "org_a616246f-4823-41c4-9f69-465fd9690302",
  "project_id": "prj_3f578043-f044-49a2-8ddc-d62c218a6007",
  "counterparty_id": "counterparty_960bd74a-b0d3-4e6d-8abd-ef9e74477d4a",
  "type": "crypto_wallet",
  "label": "Contractor Wallet",
  "wallet": {
    "address": "7sudksPevVqyqDw7pBK5ijj4Yg9iEqUDDsLC6xsCKDGS",
    "network": "solana"
  },
  "metadata": {},
  "status": "active",
  "created_at": "2026-06-03T10:54:19.702Z",
  "updated_at": "2026-06-03T10:54:19.702Z"
}
```

<img width="3456" height="2234" alt="CleanShot 2026-06-03 at 19 13 24@2x" src="https://github.com/user-attachments/assets/cdb395de-94b8-4a7a-ae41-6c9c83c71cc8" />
<img width="3456" height="2234" alt="CleanShot 2026-06-03 at 19 15 05@2x" src="https://github.com/user-attachments/assets/e1f2e4b4-79e3-401b-b7c1-439175ff0156" />
<img width="3456" height="2234" alt="CleanShot 2026-06-03 at 19 16 44@2x" src="https://github.com/user-attachments/assets/8dd72dcc-6763-4729-8d54-b0c964c7fb1b" />
<img width="3456" height="2234" alt="CleanShot 2026-06-03 at 19 17 35@2x" src="https://github.com/user-attachments/assets/c2436487-626f-492b-843e-ac9c3d1006e5" />



## Notes
- Risk screening is best-effort: orgs without an enabled compliance provider get a confirm-to-add prompt instead of a hard block.