### PR TITLE
feat: onchain transfers in payments v2 deposit/pay flows

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -67,6 +67,10 @@ export function isSolBalance(balance: Pick<CustodyWalletTokenBalance, "token" | 
   return balance.token.trim().toUpperCase() === "SOL" || balance.mint.trim() === SOL_MINT;
 }
 
+export function shortenAddress(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+}
+
 export function formatDisplayAmount(value?: string, token?: string): string {
   if (!value) {
     return token ? `- ${token}` : "-";

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -2,8 +2,10 @@
 
 import type {
   Counterparty,
+  CounterpartyAccount,
   CustodyWalletAggregate,
   ListCounterpartiesResponse,
+  ListCounterpartyAccountsResponse,
   PaymentRampExecution,
   PaymentsWalletAggregateEnvelope,
   PaymentTransferEnvelope as TransferEnvelope,
@@ -442,6 +444,22 @@ export async function createTransfer(input: {
   }
 
   return body.data.transfer;
+}
+
+export async function fetchCounterpartyAccounts(
+  counterpartyId: string
+): Promise<CounterpartyAccount[]> {
+  const response = await fetch(
+    `/api/dashboard/counterparty/${encodeURIComponent(counterpartyId)}/accounts?pageSize=100`
+  );
+  const body = (await response.json().catch(() => ({}))) as {
+    data?: ListCounterpartyAccountsResponse;
+    error?: { message?: string };
+  };
+  if (!response.ok) {
+    throw new Error(getApiError(body, `Failed to load accounts (${response.status}).`));
+  }
+  return body.data?.accounts ?? [];
 }
 
 export async function executeRampFlow(

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-account-selector.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-account-selector.tsx
@@ -3,6 +3,7 @@
 import type { CounterpartyAccount } from "@sdp/types";
 import { WalletIcon } from "lucide-react";
 import { useMemo } from "react";
+import { shortenAddress } from "@/app/dashboard/payments/payments-overview.utils";
 import { Combobox } from "@/components/ui/combobox";
 
 interface CounterpartyAccountSelectorProps {
@@ -11,10 +12,6 @@ interface CounterpartyAccountSelectorProps {
   onChange: (accountId: string) => void;
   isLoading?: boolean;
   disabled?: boolean;
-}
-
-function shortenAddress(address: string): string {
-  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
 }
 
 export function CounterpartyAccountSelector({

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-account-selector.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-account-selector.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { CounterpartyAccount } from "@sdp/types";
+import { WalletIcon } from "lucide-react";
+import { useMemo } from "react";
+import { Combobox } from "@/components/ui/combobox";
+
+interface CounterpartyAccountSelectorProps {
+  accounts: CounterpartyAccount[];
+  value: string | null;
+  onChange: (accountId: string) => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
+function shortenAddress(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+}
+
+export function CounterpartyAccountSelector({
+  accounts,
+  value,
+  onChange,
+  isLoading,
+  disabled,
+}: CounterpartyAccountSelectorProps) {
+  const options = useMemo(
+    () =>
+      accounts.map((account) => {
+        const address = typeof account.details.address === "string" ? account.details.address : "";
+        return {
+          value: account.id,
+          label: account.label ?? shortenAddress(address),
+          description: shortenAddress(address),
+        };
+      }),
+    [accounts]
+  );
+
+  return (
+    <Combobox
+      label="Destination account"
+      value={value}
+      onChange={onChange}
+      options={options}
+      placeholder={
+        disabled
+          ? "Select a counterparty first"
+          : options.length === 0
+            ? "No Solana accounts on file"
+            : "Select a destination account"
+      }
+      searchPlaceholder="Search accounts"
+      icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
+      isLoading={isLoading}
+      disabled={disabled || options.length === 0}
+    />
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-picker.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-picker.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { PlusIcon } from "lucide-react";
+import type { CounterpartiesResult } from "../../payments-workspace.data";
+import { CounterpartySelector } from "./counterparty-selector";
+
+interface CounterpartyPickerProps {
+  mode: "send" | "receive";
+  counterpartiesResult: CounterpartiesResult;
+  value: string | null;
+  onChange: (counterpartyId: string) => void;
+  onAddClick: () => void;
+}
+
+export function CounterpartyPicker({
+  mode,
+  counterpartiesResult,
+  value,
+  onChange,
+  onAddClick,
+}: CounterpartyPickerProps) {
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={onAddClick}
+        className="flex w-full items-center gap-3 rounded-2xl border border-dashed border-border-medium px-4 py-4 text-left transition-colors hover:bg-border-extra-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50"
+      >
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-border-extra-light text-text-extra-high">
+          <PlusIcon className="size-4" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-medium text-text-extra-high">Add counterparty</span>
+          <span className="block text-sm text-text-low">
+            {mode === "send"
+              ? "Create a new payee if they aren't in the list yet."
+              : "Create a new buyer if they aren't in the list yet."}
+          </span>
+        </span>
+      </button>
+      <CounterpartySelector
+        counterpartiesResult={counterpartiesResult}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PlusIcon, WalletIcon } from "lucide-react";
+import { WalletIcon } from "lucide-react";
 import { useMemo } from "react";
 import {
   formatCurrencyAmount,
@@ -9,7 +9,6 @@ import {
 import { Combobox } from "@/components/ui/combobox";
 import { OFFRAMP_PAIRS, RAMP_PROVIDER_OPTIONS } from "@/lib/ramps";
 import type { OfframpWizard } from "../hooks/use-offramp-wizard";
-import { CounterpartySelector } from "./counterparty-selector";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
 import { RampStepPlaceholder } from "./ramp-step-placeholder";
 
@@ -17,7 +16,6 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
   const {
     currentStepId,
     enabledRampProviders,
-    liveCounterpartiesResult,
     liveWallets,
     walletsLoading,
     selectedWallet,
@@ -25,7 +23,6 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     fields,
     quote,
     setField,
-    setCounterpartyDialogOpen,
     handlePairChange,
   } = wizard;
 
@@ -42,40 +39,18 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     [liveWallets]
   );
 
-  if (currentStepId === "COUNTERPARTY") {
+  if (currentStepId === "WALLET") {
     return (
-      <div className="space-y-3">
-        <button
-          type="button"
-          onClick={() => setCounterpartyDialogOpen(true)}
-          className="flex w-full items-center gap-3 rounded-2xl border border-dashed border-border-light px-4 py-3.5 text-left transition-colors hover:border-border-medium hover:bg-border-extra-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50"
-        >
-          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-border-extra-light text-text-extra-high">
-            <PlusIcon className="size-4" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block text-sm font-medium text-text-extra-high">Add counterparty</span>
-            <span className="block text-sm text-text-low">
-              Create a new payee to pay out to if they aren&apos;t in the list yet.
-            </span>
-          </span>
-        </button>
-        <CounterpartySelector
-          counterpartiesResult={liveCounterpartiesResult}
-          value={fields.counterpartyId || null}
-          onChange={(id) => setField("counterpartyId", id)}
-        />
-        <Combobox
-          label="Source wallet"
-          value={fields.walletId || null}
-          onChange={(walletId) => setField("walletId", walletId)}
-          options={walletOptions}
-          placeholder="Select a source wallet"
-          searchPlaceholder="Search wallets"
-          icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
-          isLoading={walletsLoading}
-        />
-      </div>
+      <Combobox
+        label="Source wallet"
+        value={fields.walletId || null}
+        onChange={(walletId) => setField("walletId", walletId)}
+        options={walletOptions}
+        placeholder="Select a source wallet"
+        searchPlaceholder="Search wallets"
+        icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
+        isLoading={walletsLoading}
+      />
     );
   }
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-receive-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-receive-step-content.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { WalletIcon } from "lucide-react";
+import { useMemo } from "react";
+import {
+  formatCurrencyAmount,
+  resolveTotalBalance,
+} from "@/app/dashboard/payments/payments-overview.utils";
+import { Combobox } from "@/components/ui/combobox";
+import type { OnchainReceiveWizard } from "../hooks/use-onchain-receive-wizard";
+import { WalletReceiveCard } from "./wallet-receive-card";
+
+export function OnchainReceiveStepContent({ wizard }: { wizard: OnchainReceiveWizard }) {
+  const { currentStepId, liveWallets, walletsLoading, selectedWallet, walletId, setWalletId } =
+    wizard;
+
+  const walletOptions = useMemo(
+    () =>
+      liveWallets.map((wallet) => {
+        const total = wallet.balances ? resolveTotalBalance(wallet.balances) : null;
+        return {
+          value: wallet.walletId,
+          label: wallet.label ?? wallet.walletId,
+          description: total !== null ? formatCurrencyAmount(total) : undefined,
+        };
+      }),
+    [liveWallets]
+  );
+
+  if (currentStepId === "WALLET") {
+    return (
+      <Combobox
+        label="Destination wallet"
+        value={walletId || null}
+        onChange={setWalletId}
+        options={walletOptions}
+        placeholder="Select a wallet"
+        searchPlaceholder="Search wallets"
+        icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
+        isLoading={walletsLoading}
+      />
+    );
+  }
+
+  return <WalletReceiveCard address={selectedWallet?.publicKey ?? ""} />;
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -63,6 +63,7 @@ export function OnchainSendStepContent({
     counterpartyId,
     fields,
     setField,
+    selectWallet,
     addAccountOpen,
     setAddAccountOpen,
     handleAccountAdded,
@@ -126,7 +127,7 @@ export function OnchainSendStepContent({
         <Combobox
           label="Source wallet"
           value={fields.walletId || null}
-          onChange={(id) => setField("walletId", id)}
+          onChange={selectWallet}
           options={walletOptions}
           placeholder="Select a source wallet"
           searchPlaceholder="Search wallets"

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -61,16 +61,8 @@ export function OnchainSendStepContent({
     availableAmount,
     exceedsBalance,
     counterpartyId,
-    accountId,
-    setAccountId,
-    walletId,
-    setWalletId,
-    asset,
-    setAsset,
-    amount,
-    setAmount,
-    memo,
-    setMemo,
+    fields,
+    setField,
     addAccountOpen,
     setAddAccountOpen,
     handleAccountAdded,
@@ -95,8 +87,8 @@ export function OnchainSendStepContent({
       <div className="space-y-3">
         <CounterpartyAccountSelector
           accounts={cryptoAccounts}
-          value={accountId || null}
-          onChange={setAccountId}
+          value={fields.accountId || null}
+          onChange={(id) => setField("accountId", id)}
           isLoading={accountsLoading}
         />
         <button
@@ -133,8 +125,8 @@ export function OnchainSendStepContent({
       <div className="space-y-4">
         <Combobox
           label="Source wallet"
-          value={walletId || null}
-          onChange={setWalletId}
+          value={fields.walletId || null}
+          onChange={(id) => setField("walletId", id)}
           options={walletOptions}
           placeholder="Select a source wallet"
           searchPlaceholder="Search wallets"
@@ -143,8 +135,8 @@ export function OnchainSendStepContent({
         />
         <Combobox
           label="Asset"
-          value={asset || null}
-          onChange={setAsset}
+          value={fields.asset || null}
+          onChange={(value) => setField("asset", value)}
           options={assetOptions.map((value) => ({ value, label: value }))}
           placeholder="Select an asset"
           searchable={false}
@@ -159,8 +151,8 @@ export function OnchainSendStepContent({
             inputMode="decimal"
             min="0"
             step="any"
-            value={amount}
-            onChange={(event) => setAmount(event.currentTarget.value)}
+            value={fields.amount}
+            onChange={(event) => setField("amount", event.currentTarget.value)}
             placeholder="1.0"
             size="xl"
             className="shadow-none ring-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [&>span:first-child]:border-0 [&>span:first-child]:bg-border-extra-light"
@@ -172,8 +164,8 @@ export function OnchainSendStepContent({
               }
             >
               {exceedsBalance
-                ? `Amount exceeds the available ${asset} balance (${availableAmount}).`
-                : `Available: ${availableAmount} ${asset}`}
+                ? `Amount exceeds the available ${fields.asset} balance (${availableAmount}).`
+                : `Available: ${availableAmount} ${fields.asset}`}
             </p>
           ) : null}
         </div>
@@ -183,8 +175,8 @@ export function OnchainSendStepContent({
           </Label>
           <Input
             id="onchain-send-memo"
-            value={memo}
-            onChange={(event) => setMemo(event.currentTarget.value)}
+            value={fields.memo}
+            onChange={(event) => setField("memo", event.currentTarget.value)}
             placeholder="Add a note for this transfer"
             size="xl"
             className="shadow-none ring-0 [&>span:first-child]:border-0 [&>span:first-child]:bg-border-extra-light"
@@ -211,11 +203,11 @@ export function OnchainSendStepContent({
         label="Source wallet"
         value={selectedWallet?.label ?? selectedWallet?.walletId ?? "—"}
       />
-      {memo.trim() ? (
+      {fields.memo.trim() ? (
         <DetailRow
           icon={<StickyNoteIcon className="size-3.5" />}
           label="Memo"
-          value={memo.trim()}
+          value={fields.memo.trim()}
         />
       ) : null}
     </div>
@@ -224,7 +216,7 @@ export function OnchainSendStepContent({
   const amountHero = (
     <div className="flex flex-col items-center gap-0.5 border-b border-border-light pb-4">
       <p className="text-3xl font-semibold tracking-tight text-text-extra-high">
-        {amount || "0"} {asset}
+        {fields.amount || "0"} {fields.asset}
       </p>
       <p className="text-sm text-text-low">to {counterpartyName || "counterparty"}</p>
     </div>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCircle2Icon, CoinsIcon, ExternalLink, PlusIcon, WalletIcon } from "lucide-react";
+import { CheckCircle2Icon, ExternalLink, PlusIcon, WalletIcon } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 import { AddExternalAccountDialog } from "@/app/dashboard/payments/counterparty/add-external-account-dialog";
 import {
@@ -133,18 +133,23 @@ export function OnchainSendStepContent({
           onChange={setAsset}
           options={assetOptions.map((value) => ({ value, label: value }))}
           placeholder="Select an asset"
-          searchPlaceholder="Search assets"
-          icon={<CoinsIcon className="size-5 shrink-0 text-text-low" />}
+          searchable={false}
         />
-        <div className="space-y-2">
-          <Label htmlFor="onchain-send-amount">Amount</Label>
+        <div className="flex flex-col gap-2">
+          <Label className="text-sm font-medium text-text-low" htmlFor="onchain-send-amount">
+            Amount
+          </Label>
           <Input
             id="onchain-send-amount"
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="any"
             value={amount}
             onChange={(event) => setAmount(event.currentTarget.value)}
-            inputMode="decimal"
-            placeholder="0.00"
-            className="h-12 rounded-2xl border-border-light bg-white px-4 shadow-none"
+            placeholder="1.0"
+            size="xl"
+            className="shadow-none ring-0 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [&>span:first-child]:border-0 [&>span:first-child]:bg-border-extra-light"
           />
           {availableAmount !== null ? (
             <p
@@ -158,14 +163,17 @@ export function OnchainSendStepContent({
             </p>
           ) : null}
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="onchain-send-memo">Memo (optional)</Label>
+        <div className="flex flex-col gap-2">
+          <Label className="text-sm font-medium text-text-low" htmlFor="onchain-send-memo">
+            Memo (optional)
+          </Label>
           <Input
             id="onchain-send-memo"
             value={memo}
             onChange={(event) => setMemo(event.currentTarget.value)}
             placeholder="Add a note for this transfer"
-            className="h-12 rounded-2xl border-border-light bg-white px-4 shadow-none"
+            size="xl"
+            className="shadow-none ring-0 [&>span:first-child]:border-0 [&>span:first-child]:bg-border-extra-light"
           />
         </div>
       </div>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { CheckCircle2Icon, CoinsIcon, ExternalLink, PlusIcon, WalletIcon } from "lucide-react";
+import { type ReactNode, useMemo } from "react";
+import { AddExternalAccountDialog } from "@/app/dashboard/payments/counterparty/add-external-account-dialog";
+import {
+  formatCurrencyAmount,
+  resolveTotalBalance,
+} from "@/app/dashboard/payments/payments-overview.utils";
+import { getDevnetExplorerUrl } from "@/app/dashboard/payments/payments-workspace.data";
+import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { OnchainSendWizard } from "../hooks/use-onchain-send-wizard";
+import { CounterpartyAccountSelector } from "./counterparty-account-selector";
+
+function SummaryRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+      <p className="text-sm text-text-low">{label}</p>
+      <div className="text-right text-sm font-medium text-text-extra-high">{value}</div>
+    </div>
+  );
+}
+
+function shortenAddress(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+}
+
+export function OnchainSendStepContent({
+  wizard,
+  counterpartyName,
+}: {
+  wizard: OnchainSendWizard;
+  counterpartyName: string;
+}) {
+  const {
+    currentStepId,
+    cryptoAccounts,
+    accountsLoading,
+    liveWallets,
+    walletsLoading,
+    selectedWallet,
+    destinationAddress,
+    assetOptions,
+    availableAmount,
+    exceedsBalance,
+    counterpartyId,
+    accountId,
+    setAccountId,
+    walletId,
+    setWalletId,
+    asset,
+    setAsset,
+    amount,
+    setAmount,
+    memo,
+    setMemo,
+    addAccountOpen,
+    setAddAccountOpen,
+    handleAccountAdded,
+    transferResult,
+  } = wizard;
+
+  const walletOptions = useMemo(
+    () =>
+      liveWallets.map((wallet) => {
+        const total = wallet.balances ? resolveTotalBalance(wallet.balances) : null;
+        return {
+          value: wallet.walletId,
+          label: wallet.label ?? wallet.walletId,
+          description: total !== null ? formatCurrencyAmount(total) : undefined,
+        };
+      }),
+    [liveWallets]
+  );
+
+  if (currentStepId === "DESTINATION") {
+    return (
+      <div className="space-y-3">
+        <CounterpartyAccountSelector
+          accounts={cryptoAccounts}
+          value={accountId || null}
+          onChange={setAccountId}
+          isLoading={accountsLoading}
+        />
+        <button
+          type="button"
+          onClick={() => setAddAccountOpen(true)}
+          className="flex w-full items-center gap-3 rounded-2xl border border-dashed border-border-medium px-4 py-4 text-left transition-colors hover:bg-border-extra-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50"
+        >
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-border-extra-light text-text-extra-high">
+            <PlusIcon className="size-4" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium text-text-extra-high">
+              Add Solana address
+            </span>
+            <span className="block text-sm text-text-low">
+              {cryptoAccounts.length === 0
+                ? `${counterpartyName || "This counterparty"} has no Solana address on file yet.`
+                : "Attach another destination address for this counterparty."}
+            </span>
+          </span>
+        </button>
+        <AddExternalAccountDialog
+          isOpen={addAccountOpen}
+          counterpartyId={counterpartyId}
+          onAdded={handleAccountAdded}
+          onClose={() => setAddAccountOpen(false)}
+        />
+      </div>
+    );
+  }
+
+  if (currentStepId === "DETAILS") {
+    return (
+      <div className="space-y-4">
+        <Combobox
+          label="Source wallet"
+          value={walletId || null}
+          onChange={setWalletId}
+          options={walletOptions}
+          placeholder="Select a source wallet"
+          searchPlaceholder="Search wallets"
+          icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
+          isLoading={walletsLoading}
+        />
+        <Combobox
+          label="Asset"
+          value={asset || null}
+          onChange={setAsset}
+          options={assetOptions.map((value) => ({ value, label: value }))}
+          placeholder="Select an asset"
+          searchPlaceholder="Search assets"
+          icon={<CoinsIcon className="size-5 shrink-0 text-text-low" />}
+        />
+        <div className="space-y-2">
+          <Label htmlFor="onchain-send-amount">Amount</Label>
+          <Input
+            id="onchain-send-amount"
+            value={amount}
+            onChange={(event) => setAmount(event.currentTarget.value)}
+            inputMode="decimal"
+            placeholder="0.00"
+            className="h-12 rounded-2xl border-border-light bg-white px-4 shadow-none"
+          />
+          {availableAmount !== null ? (
+            <p
+              className={
+                exceedsBalance ? "text-sm text-status-error-text" : "text-sm text-text-low"
+              }
+            >
+              {exceedsBalance
+                ? `Amount exceeds the available ${asset} balance (${availableAmount}).`
+                : `Available: ${availableAmount} ${asset}`}
+            </p>
+          ) : null}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="onchain-send-memo">Memo (optional)</Label>
+          <Input
+            id="onchain-send-memo"
+            value={memo}
+            onChange={(event) => setMemo(event.currentTarget.value)}
+            placeholder="Add a note for this transfer"
+            className="h-12 rounded-2xl border-border-light bg-white px-4 shadow-none"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (transferResult) {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-2xl border border-status-success-border bg-status-success-bg p-5">
+          <p className="flex items-center gap-2 text-[20px] font-medium text-status-success-text">
+            <CheckCircle2Icon className="size-5" /> Transfer submitted
+          </p>
+          <p className="mt-2 text-sm text-status-success-text">
+            {transferResult.signature
+              ? "Transaction sent successfully."
+              : `Status: ${transferResult.status}`}
+          </p>
+        </div>
+        {transferResult.signature ? (
+          <div className="rounded-2xl border border-border-light bg-border-extra-light p-5">
+            <p className="text-sm font-medium text-text-extra-high">Signature</p>
+            <p className="mt-3 break-all font-mono text-xs text-text-medium">
+              {transferResult.signature}
+            </p>
+            <div className="mt-4 flex justify-end">
+              <Button
+                type="button"
+                variant="secondary"
+                iconLeft={<ExternalLink />}
+                onClick={() =>
+                  window.open(getDevnetExplorerUrl(transferResult.signature ?? ""), "_blank")
+                }
+              >
+                View on explorer
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-border-light bg-border-extra-light p-5">
+      <div className="divide-y divide-border-extra-light">
+        <SummaryRow label="Flow" value="Onchain transfer" />
+        <SummaryRow label="To" value={counterpartyName || "—"} />
+        <SummaryRow
+          label="Destination"
+          value={<span className="font-mono text-xs">{shortenAddress(destinationAddress)}</span>}
+        />
+        <SummaryRow
+          label="Source wallet"
+          value={selectedWallet?.label ?? selectedWallet?.walletId ?? "—"}
+        />
+        <SummaryRow label="Asset" value={asset || "—"} />
+        <SummaryRow label="Amount" value={amount || "—"} />
+        {memo.trim() ? <SummaryRow label="Memo" value={memo.trim()} /> : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -13,6 +13,7 @@ import { AddExternalAccountDialog } from "@/app/dashboard/payments/counterparty/
 import {
   formatCurrencyAmount,
   resolveTotalBalance,
+  shortenAddress,
 } from "@/app/dashboard/payments/payments-overview.utils";
 import { getDevnetExplorerUrl } from "@/app/dashboard/payments/payments-workspace.data";
 import { Button } from "@/components/ui/button";
@@ -36,10 +37,6 @@ function DetailRow({ icon, label, value }: { icon: ReactNode; label: string; val
       </div>
     </div>
   );
-}
-
-function shortenAddress(address: string): string {
-  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
 }
 
 export function OnchainSendStepContent({

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { CheckCircle2Icon, ExternalLink, PlusIcon, WalletIcon } from "lucide-react";
+import {
+  CheckCircle2Icon,
+  ExternalLink,
+  PlusIcon,
+  StickyNoteIcon,
+  UserRoundIcon,
+  WalletIcon,
+} from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 import { AddExternalAccountDialog } from "@/app/dashboard/payments/counterparty/add-external-account-dialog";
 import {
@@ -15,11 +22,18 @@ import { Label } from "@/components/ui/label";
 import type { OnchainSendWizard } from "../hooks/use-onchain-send-wizard";
 import { CounterpartyAccountSelector } from "./counterparty-account-selector";
 
-function SummaryRow({ label, value }: { label: string; value: ReactNode }) {
+function DetailRow({ icon, label, value }: { icon: ReactNode; label: string; value: ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
-      <p className="text-sm text-text-low">{label}</p>
-      <div className="text-right text-sm font-medium text-text-extra-high">{value}</div>
+      <span className="flex items-center gap-2.5 text-sm text-text-low">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-white text-text-medium">
+          {icon}
+        </span>
+        {label}
+      </span>
+      <div className="min-w-0 truncate text-right text-sm font-medium text-text-extra-high">
+        {value}
+      </div>
     </div>
   );
 }
@@ -180,60 +194,83 @@ export function OnchainSendStepContent({
     );
   }
 
+  const detailRows = (
+    <div className="divide-y divide-border-light">
+      <DetailRow
+        icon={<UserRoundIcon className="size-3.5" />}
+        label="To"
+        value={counterpartyName || "—"}
+      />
+      <DetailRow
+        icon={<WalletIcon className="size-3.5" />}
+        label="Destination"
+        value={<span className="font-mono text-xs">{shortenAddress(destinationAddress)}</span>}
+      />
+      <DetailRow
+        icon={<WalletIcon className="size-3.5" />}
+        label="Source wallet"
+        value={selectedWallet?.label ?? selectedWallet?.walletId ?? "—"}
+      />
+      {memo.trim() ? (
+        <DetailRow
+          icon={<StickyNoteIcon className="size-3.5" />}
+          label="Memo"
+          value={memo.trim()}
+        />
+      ) : null}
+    </div>
+  );
+
+  const amountHero = (
+    <div className="flex flex-col items-center gap-0.5 border-b border-border-light pb-4">
+      <p className="text-3xl font-semibold tracking-tight text-text-extra-high">
+        {amount || "0"} {asset}
+      </p>
+      <p className="text-sm text-text-low">to {counterpartyName || "counterparty"}</p>
+    </div>
+  );
+
   if (transferResult) {
     return (
-      <div className="space-y-6">
-        <div className="rounded-2xl border border-status-success-border bg-status-success-bg p-5">
-          <p className="flex items-center gap-2 text-[20px] font-medium text-status-success-text">
-            <CheckCircle2Icon className="size-5" /> Transfer submitted
+      <div className="flex flex-col items-center gap-6">
+        <div className="flex size-16 items-center justify-center rounded-full bg-status-success-bg text-status-success-text">
+          <CheckCircle2Icon className="size-8" />
+        </div>
+        <div className="space-y-1 text-center">
+          <p className="text-2xl font-medium tracking-tight text-text-extra-high">
+            Transfer submitted
           </p>
-          <p className="mt-2 text-sm text-status-success-text">
+          <p className="text-sm text-text-low">
             {transferResult.signature
-              ? "Transaction sent successfully."
+              ? "Your transfer was sent successfully."
               : `Status: ${transferResult.status}`}
           </p>
         </div>
+        <section className="w-full space-y-4 rounded-2xl bg-border-extra-light p-5">
+          {amountHero}
+          {detailRows}
+        </section>
         {transferResult.signature ? (
-          <div className="rounded-2xl border border-border-light bg-border-extra-light p-5">
-            <p className="text-sm font-medium text-text-extra-high">Signature</p>
-            <p className="mt-3 break-all font-mono text-xs text-text-medium">
-              {transferResult.signature}
-            </p>
-            <div className="mt-4 flex justify-end">
-              <Button
-                type="button"
-                variant="secondary"
-                iconLeft={<ExternalLink />}
-                onClick={() =>
-                  window.open(getDevnetExplorerUrl(transferResult.signature ?? ""), "_blank")
-                }
-              >
-                View on explorer
-              </Button>
-            </div>
-          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            className="w-full"
+            iconLeft={<ExternalLink />}
+            onClick={() =>
+              window.open(getDevnetExplorerUrl(transferResult.signature ?? ""), "_blank")
+            }
+          >
+            View on explorer
+          </Button>
         ) : null}
       </div>
     );
   }
 
   return (
-    <section className="rounded-2xl border border-border-light bg-border-extra-light p-5">
-      <div className="divide-y divide-border-extra-light">
-        <SummaryRow label="Flow" value="Onchain transfer" />
-        <SummaryRow label="To" value={counterpartyName || "—"} />
-        <SummaryRow
-          label="Destination"
-          value={<span className="font-mono text-xs">{shortenAddress(destinationAddress)}</span>}
-        />
-        <SummaryRow
-          label="Source wallet"
-          value={selectedWallet?.label ?? selectedWallet?.walletId ?? "—"}
-        />
-        <SummaryRow label="Asset" value={asset || "—"} />
-        <SummaryRow label="Amount" value={amount || "—"} />
-        {memo.trim() ? <SummaryRow label="Memo" value={memo.trim()} /> : null}
-      </div>
+    <section className="space-y-4 rounded-2xl bg-border-extra-light p-5">
+      {amountHero}
+      {detailRows}
     </section>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { PlusIcon } from "lucide-react";
 import { ONRAMP_PAIRS, RAMP_PROVIDER_OPTIONS, toRampCryptoToken } from "@/lib/ramps";
 import type { OnrampWizard } from "../hooks/use-onramp-wizard";
-import { CounterpartySelector } from "./counterparty-selector";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
 import { RampStepPlaceholder } from "./ramp-step-placeholder";
@@ -12,10 +10,8 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
   const {
     currentStepId,
     enabledRampProviders,
-    liveCounterpartiesResult,
     fields,
     setField,
-    setCounterpartyDialogOpen,
     liveWallets,
     walletsLoading,
     selectedWallet,
@@ -26,33 +22,6 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     simulateCurrentQuote,
     handlePairChange,
   } = wizard;
-
-  if (currentStepId === "COUNTERPARTY") {
-    return (
-      <div className="space-y-3">
-        <button
-          type="button"
-          onClick={() => setCounterpartyDialogOpen(true)}
-          className="flex w-full items-center gap-3 rounded-2xl border border-dashed border-border-light px-4 py-3.5 text-left transition-colors hover:border-border-medium hover:bg-border-extra-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50"
-        >
-          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-border-extra-light text-text-extra-high">
-            <PlusIcon className="size-4" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block text-sm font-medium text-text-extra-high">Add counterparty</span>
-            <span className="block text-sm text-text-low">
-              Create a new buyer to deposit for if they aren&apos;t in the list yet.
-            </span>
-          </span>
-        </button>
-        <CounterpartySelector
-          counterpartiesResult={liveCounterpartiesResult}
-          value={fields.counterpartyId || null}
-          onChange={(id) => setField("counterpartyId", id)}
-        />
-      </div>
-    );
-  }
 
   if (currentStepId === "DEPOSIT") {
     if (enabledRampProviders.length === 0) {

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/payment-method-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/payment-method-step.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { ArrowLeftRight, Banknote } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type PaymentMethod = "onchain" | "ramp";
+
+interface PaymentMethodStepProps {
+  mode: "send" | "receive";
+  value: PaymentMethod | null;
+  onChange: (method: PaymentMethod) => void;
+}
+
+type MethodOption = {
+  id: PaymentMethod;
+  title: string;
+  description: string;
+  icon: ReactNode;
+};
+
+function buildOptions(mode: "send" | "receive"): MethodOption[] {
+  if (mode === "send") {
+    return [
+      {
+        id: "onchain",
+        title: "Onchain transfer",
+        description: "Send crypto from an SDP wallet to a counterparty's Solana address.",
+        icon: <ArrowLeftRight className="size-5" />,
+      },
+      {
+        id: "ramp",
+        title: "Off-ramp to fiat",
+        description: "Convert crypto to fiat and pay out through a provider.",
+        icon: <Banknote className="size-5" />,
+      },
+    ];
+  }
+  return [
+    {
+      id: "onchain",
+      title: "Onchain deposit",
+      description: "Receive crypto directly to an SDP wallet address.",
+      icon: <ArrowLeftRight className="size-5" />,
+    },
+    {
+      id: "ramp",
+      title: "On-ramp from fiat",
+      description: "Buy crypto with fiat through a provider and deposit it into a wallet.",
+      icon: <Banknote className="size-5" />,
+    },
+  ];
+}
+
+export function PaymentMethodStep({ mode, value, onChange }: PaymentMethodStepProps) {
+  return (
+    <div className="space-y-3">
+      {buildOptions(mode).map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          onClick={() => onChange(option.id)}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-2xl bg-border-extra-light px-4 py-4 text-left outline outline-2 -outline-offset-2 transition-colors focus-visible:ring-2 focus-visible:ring-black/50 dark:focus-visible:ring-white/50",
+            value === option.id
+              ? "outline-border-medium ring-2 ring-text-low ring-offset-2 ring-offset-white"
+              : "outline-transparent hover:bg-border-light"
+          )}
+        >
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-white text-text-extra-high">
+            {option.icon}
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-base font-medium text-text-extra-high">{option.title}</span>
+            <span className="block text-sm text-text-low">{option.description}</span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/provider-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/provider-card.tsx
@@ -26,8 +26,10 @@ export function ProviderCard({ option, active, onSelect }: ProviderCardProps) {
         scale: { duration: 0.15 },
       }}
       className={cn(
-        "flex w-full items-center gap-3 rounded-xl border bg-border-extra-light px-4 py-3 text-left transition-colors",
-        active ? "border-border-medium" : "border-transparent hover:bg-border-light"
+        "flex w-full items-center gap-3 rounded-xl bg-border-extra-light px-4 py-3 text-left outline outline-2 -outline-offset-2 transition-colors",
+        active
+          ? "outline-border-medium ring-2 ring-text-low ring-offset-2 ring-offset-white"
+          : "outline-transparent hover:bg-border-light"
       )}
     >
       <Image

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
@@ -79,7 +79,7 @@ export function RampWizardShell({
               Step {stepIndex + 1} of {steps.length}
             </span>
           </div>
-          <p className="text-2xl font-medium leading-tight text-text-extra-high">
+          <p className="text-3xl font-medium leading-tight tracking-tight text-text-extra-high">
             {steps[stepIndex]?.title}
           </p>
         </div>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/wallet-receive-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/wallet-receive-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { CopyIcon } from "lucide-react";
+import Image from "next/image";
+import QRCode from "qrcode";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+export function WalletReceiveCard({ address }: { address: string }) {
+  const [qrCodeUrl, setQrCodeUrl] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!address) {
+      setQrCodeUrl("");
+      return;
+    }
+
+    void QRCode.toDataURL(address, {
+      margin: 1,
+      width: 240,
+      color: { dark: "#1c1c1d", light: "#ffffff" },
+    })
+      .then((url) => {
+        if (!cancelled) {
+          setQrCodeUrl(url);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setQrCodeUrl("");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  if (!address) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-2xl border border-border-light bg-border-extra-light p-6">
+      <div className="flex flex-col items-center gap-5 sm:flex-row sm:items-start">
+        <div className="flex size-[180px] items-center justify-center rounded-2xl bg-white p-4 ring-1 ring-border-extra-light">
+          {qrCodeUrl ? (
+            <Image
+              src={qrCodeUrl}
+              alt="Wallet address QR code"
+              width={148}
+              height={148}
+              unoptimized
+              className="size-full"
+            />
+          ) : (
+            <div className="size-full animate-pulse rounded-xl bg-border-light" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <p className="text-sm text-text-low">
+            Scan this QR code or copy the address to receive USDC or any SPL token on Solana into
+            the selected wallet.
+          </p>
+          <div className="rounded-2xl border border-border-extra-light bg-white px-4 py-3">
+            <p className="break-all font-mono text-xs text-text-medium">{address}</p>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              iconLeft={<CopyIcon />}
+              onClick={() => {
+                void navigator.clipboard.writeText(address);
+                toast.success("Address copied.", { position: "bottom-right" });
+              }}
+            >
+              Copy address
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
@@ -1,11 +1,11 @@
 "use client";
 
 import { OFFRAMP_PAIRS } from "@/lib/ramps";
-import { payoutCounterpartySchema, withdrawAmountSchema, withdrawSelectionSchema } from "../schema";
+import { sourceWalletSchema, withdrawAmountSchema, withdrawSelectionSchema } from "../schema";
 import { type RampWizardStep, type UseRampWizardProps, useRampWizard } from "./use-ramp-wizard";
 
 export const OFFRAMP_STEPS = [
-  { id: "COUNTERPARTY", label: "Counterparty", title: "Who are you paying out to?" },
+  { id: "WALLET", label: "Wallet", title: "Which wallet are you withdrawing from?" },
   { id: "WITHDRAW", label: "Withdraw", title: "How much would you like to withdraw?" },
   { id: "COMPLETE", label: "Complete", title: "Complete your payout" },
 ] as const satisfies readonly RampWizardStep[];
@@ -16,7 +16,7 @@ export function useOfframpWizard(props: UseRampWizardProps) {
   return useRampWizard(props, {
     pairs: OFFRAMP_PAIRS,
     steps: OFFRAMP_STEPS,
-    stepSchemas: { COUNTERPARTY: payoutCounterpartySchema, WITHDRAW: withdrawAmountSchema },
+    stepSchemas: { WALLET: sourceWalletSchema, WITHDRAW: withdrawAmountSchema },
     quoteStepId: "WITHDRAW",
     selectionSchema: withdrawSelectionSchema,
     quoteEndpoint: "/api/dashboard/payments/ramps/offramp/quote",

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-receive-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-receive-wizard.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import type { PaymentsDashboardWallet } from "@sdp/types";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { fetchWallets } from "@/app/dashboard/payments/payments-workspace.data";
+import type { RampWizardStep } from "./use-ramp-wizard";
+
+export const ONCHAIN_RECEIVE_STEPS = [
+  { id: "WALLET", label: "Wallet", title: "Which wallet should receive funds?" },
+  { id: "RECEIVE", label: "Receive", title: "Receive funds onchain" },
+] as const satisfies readonly RampWizardStep[];
+
+export type OnchainReceiveStepId = (typeof ONCHAIN_RECEIVE_STEPS)[number]["id"];
+
+const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
+
+export interface UseOnchainReceiveWizardProps {
+  wallets: PaymentsDashboardWallet[];
+  walletsError: string | null;
+  counterpartyId: string;
+  onExit: () => void;
+}
+
+export function useOnchainReceiveWizard({
+  wallets,
+  walletsError,
+  counterpartyId,
+  onExit,
+}: UseOnchainReceiveWizardProps) {
+  const router = useRouter();
+  const [stepIndex, setStepIndex] = useState(0);
+  const [walletId, setWalletId] = useState("");
+
+  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
+    PAYMENTS_ACTION_WALLETS_KEY,
+    () => fetchWallets({ includeBalances: true }),
+    {
+      fallbackData: wallets.length > 0 ? wallets : undefined,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const liveWallets = swrWallets ?? wallets;
+  const walletsLoading = swrWallets === undefined && !walletsFetchError;
+  const liveWalletsError = walletsFetchError
+    ? walletsFetchError instanceof Error
+      ? walletsFetchError.message
+      : "Request failed."
+    : swrWallets === undefined
+      ? walletsError
+      : null;
+
+  const selectedWallet = useMemo(
+    () => liveWallets.find((wallet) => wallet.walletId === walletId) ?? null,
+    [liveWallets, walletId]
+  );
+
+  const currentStepId = ONCHAIN_RECEIVE_STEPS[stepIndex].id;
+  const isLastStep = stepIndex === ONCHAIN_RECEIVE_STEPS.length - 1;
+  const canProceed = currentStepId === "WALLET" ? !!walletId : true;
+
+  const handlePrimary = () => {
+    if (!canProceed) {
+      return;
+    }
+    if (isLastStep) {
+      router.push("/dashboard/payments");
+      return;
+    }
+    setStepIndex((current) => current + 1);
+  };
+
+  const handleSecondary = () => {
+    if (stepIndex === 0) {
+      onExit();
+      return;
+    }
+    setStepIndex((current) => Math.max(0, current - 1));
+  };
+
+  return {
+    counterpartyId,
+    stepIndex,
+    currentStepId,
+    isLastStep,
+    canProceed,
+    liveWallets,
+    walletsLoading,
+    liveWalletsError,
+    selectedWallet,
+    walletId,
+    setWalletId,
+    handlePrimary,
+    handleSecondary,
+  };
+}
+
+export type OnchainReceiveWizard = ReturnType<typeof useOnchainReceiveWizard>;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
@@ -1,0 +1,269 @@
+"use client";
+
+import type {
+  CounterpartyAccount,
+  PaymentsDashboardWallet,
+  PaymentTransferSummary,
+} from "@sdp/types";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import useSWR from "swr";
+import { isSolBalance } from "@/app/dashboard/payments/payments-overview.utils";
+import {
+  createTransfer,
+  fetchCounterpartyAccounts,
+  fetchWallets,
+} from "@/app/dashboard/payments/payments-workspace.data";
+import type { RampWizardStep } from "./use-ramp-wizard";
+
+export const ONCHAIN_SEND_STEPS = [
+  { id: "DESTINATION", label: "Destination", title: "Where should the funds go?" },
+  { id: "DETAILS", label: "Details", title: "What would you like to send?" },
+  { id: "REVIEW", label: "Review", title: "Review transfer" },
+] as const satisfies readonly RampWizardStep[];
+
+export type OnchainSendStepId = (typeof ONCHAIN_SEND_STEPS)[number]["id"];
+
+const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
+
+function resolveAccountAddress(account: CounterpartyAccount | null): string {
+  if (!account) {
+    return "";
+  }
+  const address = account.details.address;
+  return typeof address === "string" ? address : "";
+}
+
+export interface UseOnchainSendWizardProps {
+  wallets: PaymentsDashboardWallet[];
+  walletsError: string | null;
+  counterpartyId: string;
+  onExit: () => void;
+}
+
+export function useOnchainSendWizard({
+  wallets,
+  walletsError,
+  counterpartyId,
+  onExit,
+}: UseOnchainSendWizardProps) {
+  const router = useRouter();
+  const [stepIndex, setStepIndex] = useState(0);
+  const [accountId, setAccountId] = useState("");
+  const [walletId, setWalletId] = useState("");
+  const [asset, setAsset] = useState("USDC");
+  const [amount, setAmount] = useState("");
+  const [memo, setMemo] = useState("");
+  const [addAccountOpen, setAddAccountOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [transferResult, setTransferResult] = useState<PaymentTransferSummary | null>(null);
+
+  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
+    PAYMENTS_ACTION_WALLETS_KEY,
+    () => fetchWallets({ includeBalances: true }),
+    {
+      fallbackData: wallets.length > 0 ? wallets : undefined,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const liveWallets = swrWallets ?? wallets;
+  const walletsLoading = swrWallets === undefined && !walletsFetchError;
+  const liveWalletsError = walletsFetchError
+    ? walletsFetchError instanceof Error
+      ? walletsFetchError.message
+      : "Request failed."
+    : swrWallets === undefined
+      ? walletsError
+      : null;
+
+  const {
+    data: accounts,
+    isLoading: accountsLoading,
+    mutate: mutateAccounts,
+  } = useSWR(
+    counterpartyId ? ["counterparty-accounts", counterpartyId] : null,
+    ([, id]: readonly [string, string]) => fetchCounterpartyAccounts(id),
+    { revalidateOnFocus: false }
+  );
+  const cryptoAccounts = useMemo(
+    () =>
+      (accounts ?? []).filter(
+        (account) =>
+          account.accountKind === "crypto_wallet" &&
+          account.status === "active" &&
+          resolveAccountAddress(account).length > 0
+      ),
+    [accounts]
+  );
+
+  const selectedWallet = useMemo(
+    () => liveWallets.find((wallet) => wallet.walletId === walletId) ?? null,
+    [liveWallets, walletId]
+  );
+  const selectedAccount = useMemo(
+    () => cryptoAccounts.find((account) => account.id === accountId) ?? null,
+    [cryptoAccounts, accountId]
+  );
+  const destinationAddress = resolveAccountAddress(selectedAccount);
+
+  const assetOptions = useMemo(() => {
+    const assetSet = new Set<string>(["USDC"]);
+    for (const balance of selectedWallet?.balances ?? []) {
+      if (!isSolBalance(balance) && balance.token) {
+        assetSet.add(balance.token.trim().toUpperCase());
+      }
+    }
+    return [...assetSet];
+  }, [selectedWallet]);
+
+  const selectedAssetBalance = useMemo(
+    () =>
+      selectedWallet?.balances?.find(
+        (balance) => balance.token.trim().toUpperCase() === asset.trim().toUpperCase()
+      ) ?? null,
+    [selectedWallet, asset]
+  );
+
+  const numericAmount = Number.parseFloat(amount);
+  const availableAmount = selectedAssetBalance ? Number(selectedAssetBalance.uiAmount) : null;
+  const exceedsBalance =
+    amount.trim().length > 0 &&
+    Number.isFinite(numericAmount) &&
+    availableAmount !== null &&
+    numericAmount > availableAmount;
+
+  const currentStepId = ONCHAIN_SEND_STEPS[stepIndex].id;
+  const isLastStep = stepIndex === ONCHAIN_SEND_STEPS.length - 1;
+
+  const canProceed = useMemo(() => {
+    if (currentStepId === "DESTINATION") {
+      return !!accountId && !!destinationAddress;
+    }
+    if (currentStepId === "DETAILS") {
+      return (
+        !!walletId &&
+        !!asset &&
+        amount.trim().length > 0 &&
+        Number.isFinite(numericAmount) &&
+        numericAmount > 0 &&
+        !exceedsBalance
+      );
+    }
+    return true;
+  }, [
+    currentStepId,
+    accountId,
+    destinationAddress,
+    walletId,
+    asset,
+    amount,
+    numericAmount,
+    exceedsBalance,
+  ]);
+
+  const handleAccountAdded = (account: CounterpartyAccount) => {
+    setAccountId(account.id);
+    void mutateAccounts();
+    setAddAccountOpen(false);
+  };
+
+  const submitTransfer = async () => {
+    if (!walletId || !destinationAddress) {
+      return;
+    }
+    setSubmitting(true);
+    const toastId = toast.loading("Submitting transfer.", { position: "bottom-right" });
+    try {
+      const transfer = await createTransfer({
+        source: walletId,
+        destination: destinationAddress,
+        token:
+          selectedAssetBalance?.mint?.trim() ||
+          (asset.trim().toUpperCase() === "SOL" ? "SOL" : asset.trim()) ||
+          "SOL",
+        amount: amount.trim(),
+        ...(memo.trim() ? { memo: memo.trim() } : {}),
+      });
+      setTransferResult(transfer);
+      toast.success("Transfer submitted.", {
+        id: toastId,
+        description: transfer.signature
+          ? "Transaction sent successfully."
+          : `Status: ${transfer.status}`,
+        position: "bottom-right",
+      });
+    } catch (error) {
+      toast.error("Transfer failed.", {
+        id: toastId,
+        description: error instanceof Error ? error.message : "Transfer failed.",
+        position: "bottom-right",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handlePrimary = async () => {
+    if (!canProceed) {
+      return;
+    }
+    if (isLastStep) {
+      if (transferResult) {
+        router.push("/dashboard/payments");
+        return;
+      }
+      await submitTransfer();
+      return;
+    }
+    setStepIndex((current) => current + 1);
+  };
+
+  const handleSecondary = () => {
+    if (stepIndex === 0) {
+      onExit();
+      return;
+    }
+    setStepIndex((current) => Math.max(0, current - 1));
+  };
+
+  return {
+    stepIndex,
+    currentStepId,
+    isLastStep,
+    canProceed,
+    liveWallets,
+    walletsLoading,
+    liveWalletsError,
+    cryptoAccounts,
+    accountsLoading,
+    counterpartyId,
+    selectedWallet,
+    selectedAccount,
+    destinationAddress,
+    assetOptions,
+    selectedAssetBalance,
+    availableAmount,
+    exceedsBalance,
+    accountId,
+    setAccountId,
+    walletId,
+    setWalletId,
+    asset,
+    setAsset,
+    amount,
+    setAmount,
+    memo,
+    setMemo,
+    addAccountOpen,
+    setAddAccountOpen,
+    handleAccountAdded,
+    submitting,
+    transferResult,
+    handlePrimary,
+    handleSecondary,
+  };
+}
+
+export type OnchainSendWizard = ReturnType<typeof useOnchainSendWizard>;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
@@ -15,6 +15,8 @@ import {
   fetchCounterpartyAccounts,
   fetchWallets,
 } from "@/app/dashboard/payments/payments-workspace.data";
+import { useZodForm } from "@/lib/use-zod-form";
+import { onchainDestinationSchema, onchainDetailsSchema, onchainSendSchema } from "../schema";
 import type { RampWizardStep } from "./use-ramp-wizard";
 
 export const ONCHAIN_SEND_STEPS = [
@@ -50,11 +52,13 @@ export function useOnchainSendWizard({
 }: UseOnchainSendWizardProps) {
   const router = useRouter();
   const [stepIndex, setStepIndex] = useState(0);
-  const [accountId, setAccountId] = useState("");
-  const [walletId, setWalletId] = useState("");
-  const [asset, setAsset] = useState("USDC");
-  const [amount, setAmount] = useState("");
-  const [memo, setMemo] = useState("");
+  const { values: fields, setField } = useZodForm(onchainSendSchema, {
+    accountId: "",
+    walletId: "",
+    asset: "USDC",
+    amount: "",
+    memo: "",
+  });
   const [addAccountOpen, setAddAccountOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [transferResult, setTransferResult] = useState<PaymentTransferSummary | null>(null);
@@ -99,12 +103,12 @@ export function useOnchainSendWizard({
   );
 
   const selectedWallet = useMemo(
-    () => liveWallets.find((wallet) => wallet.walletId === walletId) ?? null,
-    [liveWallets, walletId]
+    () => liveWallets.find((wallet) => wallet.walletId === fields.walletId) ?? null,
+    [liveWallets, fields.walletId]
   );
   const selectedAccount = useMemo(
-    () => cryptoAccounts.find((account) => account.id === accountId) ?? null,
-    [cryptoAccounts, accountId]
+    () => cryptoAccounts.find((account) => account.id === fields.accountId) ?? null,
+    [cryptoAccounts, fields.accountId]
   );
   const destinationAddress = resolveAccountAddress(selectedAccount);
 
@@ -112,59 +116,37 @@ export function useOnchainSendWizard({
     const assetSet = new Set<string>(["USDC"]);
     for (const balance of selectedWallet?.balances ?? []) {
       if (!isSolBalance(balance) && balance.token) {
-        assetSet.add(balance.token.trim().toUpperCase());
+        assetSet.add(balance.token);
       }
     }
     return [...assetSet];
   }, [selectedWallet]);
 
   const selectedAssetBalance = useMemo(
-    () =>
-      selectedWallet?.balances?.find(
-        (balance) => balance.token.trim().toUpperCase() === asset.trim().toUpperCase()
-      ) ?? null,
-    [selectedWallet, asset]
+    () => selectedWallet?.balances?.find((balance) => balance.token === fields.asset) ?? null,
+    [selectedWallet, fields.asset]
   );
 
-  const numericAmount = Number.parseFloat(amount);
   const availableAmount = selectedAssetBalance ? Number(selectedAssetBalance.uiAmount) : null;
+  const numericAmount = Number(fields.amount);
   const exceedsBalance =
-    amount.trim().length > 0 &&
-    Number.isFinite(numericAmount) &&
-    availableAmount !== null &&
-    numericAmount > availableAmount;
+    fields.amount.length > 0 && availableAmount !== null && numericAmount > availableAmount;
 
   const currentStepId = ONCHAIN_SEND_STEPS[stepIndex].id;
   const isLastStep = stepIndex === ONCHAIN_SEND_STEPS.length - 1;
 
   const canProceed = useMemo(() => {
     if (currentStepId === "DESTINATION") {
-      return !!accountId && !!destinationAddress;
+      return onchainDestinationSchema.safeParse(fields).success && !!destinationAddress;
     }
     if (currentStepId === "DETAILS") {
-      return (
-        !!walletId &&
-        !!asset &&
-        amount.trim().length > 0 &&
-        Number.isFinite(numericAmount) &&
-        numericAmount > 0 &&
-        !exceedsBalance
-      );
+      return onchainDetailsSchema.safeParse(fields).success && !exceedsBalance;
     }
     return true;
-  }, [
-    currentStepId,
-    accountId,
-    destinationAddress,
-    walletId,
-    asset,
-    amount,
-    numericAmount,
-    exceedsBalance,
-  ]);
+  }, [currentStepId, fields, destinationAddress, exceedsBalance]);
 
   const handleAccountAdded = (account: CounterpartyAccount) => {
-    setAccountId(account.id);
+    setField("accountId", account.id);
     void mutateAccounts(
       (prev) => [account, ...(prev ?? []).filter((existing) => existing.id !== account.id)],
       { revalidate: true }
@@ -173,21 +155,18 @@ export function useOnchainSendWizard({
   };
 
   const submitTransfer = async () => {
-    if (!walletId || !destinationAddress) {
+    if (!fields.walletId || !destinationAddress) {
       return;
     }
     setSubmitting(true);
     const toastId = toast.loading("Submitting transfer.", { position: "bottom-right" });
     try {
       const transfer = await createTransfer({
-        source: walletId,
+        source: fields.walletId,
         destination: destinationAddress,
-        token:
-          selectedAssetBalance?.mint?.trim() ||
-          (asset.trim().toUpperCase() === "SOL" ? "SOL" : asset.trim()) ||
-          "SOL",
-        amount: amount.trim(),
-        ...(memo.trim() ? { memo: memo.trim() } : {}),
+        token: selectedAssetBalance?.mint ?? (fields.asset === "SOL" ? "SOL" : fields.asset),
+        amount: fields.amount,
+        ...(fields.memo.trim() ? { memo: fields.memo.trim() } : {}),
       });
       setTransferResult(transfer);
       toast.success("Transfer submitted.", {
@@ -252,16 +231,8 @@ export function useOnchainSendWizard({
     selectedAssetBalance,
     availableAmount,
     exceedsBalance,
-    accountId,
-    setAccountId,
-    walletId,
-    setWalletId,
-    asset,
-    setAsset,
-    amount,
-    setAmount,
-    memo,
-    setMemo,
+    fields,
+    setField,
     addAccountOpen,
     setAddAccountOpen,
     handleAccountAdded,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
@@ -165,7 +165,10 @@ export function useOnchainSendWizard({
 
   const handleAccountAdded = (account: CounterpartyAccount) => {
     setAccountId(account.id);
-    void mutateAccounts();
+    void mutateAccounts(
+      (prev) => [account, ...(prev ?? []).filter((existing) => existing.id !== account.id)],
+      { revalidate: true }
+    );
     setAddAccountOpen(false);
   };
 
@@ -221,6 +224,9 @@ export function useOnchainSendWizard({
   };
 
   const handleSecondary = () => {
+    if (submitting || transferResult) {
+      return;
+    }
     if (stepIndex === 0) {
       onExit();
       return;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
@@ -151,10 +151,15 @@ export function useOnchainSendWizard({
       return onchainDestinationSchema.safeParse(fields).success && !!destinationAddress;
     }
     if (currentStepId === "DETAILS") {
-      return onchainDetailsSchema.safeParse(fields).success && !exceedsBalance;
+      const schemaOk = onchainDetailsSchema.safeParse(fields).success;
+      // When a wallet is selected, require a matching balance entry so that
+      // submitTransfer always has a mint address rather than falling back to
+      // the raw asset string (e.g. "USDC"), which the API would reject.
+      const hasMint = !fields.walletId || selectedAssetBalance !== null;
+      return schemaOk && !exceedsBalance && hasMint;
     }
     return true;
-  }, [currentStepId, fields, destinationAddress, exceedsBalance]);
+  }, [currentStepId, fields, destinationAddress, exceedsBalance, selectedAssetBalance]);
 
   const handleAccountAdded = (account: CounterpartyAccount) => {
     setField("accountId", account.id);

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
@@ -37,6 +37,16 @@ function resolveAccountAddress(account: CounterpartyAccount | null): string {
   return typeof address === "string" ? address : "";
 }
 
+function resolveWalletAssets(wallet: PaymentsDashboardWallet | null): string[] {
+  const assetSet = new Set<string>(["USDC"]);
+  for (const balance of wallet?.balances ?? []) {
+    if (!isSolBalance(balance) && balance.token) {
+      assetSet.add(balance.token);
+    }
+  }
+  return [...assetSet];
+}
+
 export interface UseOnchainSendWizardProps {
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
@@ -112,15 +122,16 @@ export function useOnchainSendWizard({
   );
   const destinationAddress = resolveAccountAddress(selectedAccount);
 
-  const assetOptions = useMemo(() => {
-    const assetSet = new Set<string>(["USDC"]);
-    for (const balance of selectedWallet?.balances ?? []) {
-      if (!isSolBalance(balance) && balance.token) {
-        assetSet.add(balance.token);
-      }
+  const assetOptions = useMemo(() => resolveWalletAssets(selectedWallet), [selectedWallet]);
+
+  const selectWallet = (walletId: string) => {
+    setField("walletId", walletId);
+    const nextWallet = liveWallets.find((wallet) => wallet.walletId === walletId) ?? null;
+    const nextAssets = resolveWalletAssets(nextWallet);
+    if (!nextAssets.includes(fields.asset)) {
+      setField("asset", nextAssets[0] ?? "");
     }
-    return [...assetSet];
-  }, [selectedWallet]);
+  };
 
   const selectedAssetBalance = useMemo(
     () => selectedWallet?.balances?.find((balance) => balance.token === fields.asset) ?? null,
@@ -233,6 +244,7 @@ export function useOnchainSendWizard({
     exceedsBalance,
     fields,
     setField,
+    selectWallet,
     addAccountOpen,
     setAddAccountOpen,
     handleAccountAdded,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onramp-wizard.ts
@@ -4,15 +4,10 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { simulateSandboxTransfer } from "@/app/dashboard/payments/payments-workspace.data";
 import { ONRAMP_PAIRS } from "@/lib/ramps";
-import {
-  counterpartySelectionSchema,
-  depositAmountSchema,
-  depositSelectionSchema,
-} from "../schema";
+import { depositAmountSchema, depositSelectionSchema } from "../schema";
 import { type RampWizardStep, type UseRampWizardProps, useRampWizard } from "./use-ramp-wizard";
 
 export const ONRAMP_STEPS = [
-  { id: "COUNTERPARTY", label: "Counterparty", title: "Who is this deposit for?" },
   { id: "DEPOSIT", label: "Deposit", title: "How much would you like to deposit?" },
   { id: "PROVIDER", label: "Provider", title: "Complete your deposit" },
   { id: "DONE", label: "Step 4", title: "Coming soon" },
@@ -27,7 +22,7 @@ export function useOnrampWizard(props: UseRampWizardProps) {
   const wizard = useRampWizard(props, {
     pairs: ONRAMP_PAIRS,
     steps: ONRAMP_STEPS,
-    stepSchemas: { COUNTERPARTY: counterpartySelectionSchema, DEPOSIT: depositAmountSchema },
+    stepSchemas: { DEPOSIT: depositAmountSchema },
     quoteStepId: "DEPOSIT",
     selectionSchema: depositSelectionSchema,
     quoteEndpoint: "/api/dashboard/payments/ramps/onramp/quote",

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -86,10 +86,21 @@ export interface UseRampWizardProps {
   walletsError: string | null;
   enabledRampProviders: RampProviderId[];
   counterpartiesResult: CounterpartiesResult;
+  /** Counterparty chosen upstream; seeds the form and is no longer picked in-wizard. */
+  initialCounterpartyId?: string;
+  /** Invoked when the user goes back from the first step. */
+  onExit?: () => void;
 }
 
 export function useRampWizard<TId extends string>(
-  { wallets, walletsError, enabledRampProviders, counterpartiesResult }: UseRampWizardProps,
+  {
+    wallets,
+    walletsError,
+    enabledRampProviders,
+    counterpartiesResult,
+    initialCounterpartyId = "",
+    onExit,
+  }: UseRampWizardProps,
   config: RampWizardConfig<TId>
 ) {
   const router = useRouter();
@@ -103,7 +114,7 @@ export function useRampWizard<TId extends string>(
     walletId: "",
     amount: "",
     provider: null,
-    counterpartyId: "",
+    counterpartyId: initialCounterpartyId,
   });
 
   const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
@@ -203,6 +214,10 @@ export function useRampWizard<TId extends string>(
 
   const handleSecondary = () => {
     if (stepIndex === 0) {
+      if (onExit) {
+        onExit();
+        return;
+      }
       router.push("/dashboard/payments");
       return;
     }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -1,11 +1,28 @@
 "use client";
 
-import type { ComplianceProviderId, PaymentsDashboardWallet, RampProviderId } from "@sdp/types";
-import type { CounterpartiesResult } from "@/app/dashboard/payments/payments-workspace.data";
+import type {
+  ComplianceProviderId,
+  Counterparty,
+  PaymentsDashboardWallet,
+  RampProviderId,
+} from "@sdp/types";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import {
+  type CounterpartiesResult,
+  fetchAllCounterparties,
+} from "@/app/dashboard/payments/payments-workspace.data";
+import { CounterpartyPicker } from "./components/counterparty-picker";
 import { OfframpStepContent } from "./components/offramp-step-content";
+import { OnchainReceiveStepContent } from "./components/onchain-receive-step-content";
+import { OnchainSendStepContent } from "./components/onchain-send-step-content";
 import { OnrampStepContent } from "./components/onramp-step-content";
+import { type PaymentMethod, PaymentMethodStep } from "./components/payment-method-step";
 import { PoweredByRampProvider, RampWizardShell } from "./components/ramp-wizard-shell";
 import { OFFRAMP_STEPS, useOfframpWizard } from "./hooks/use-offramp-wizard";
+import { ONCHAIN_RECEIVE_STEPS, useOnchainReceiveWizard } from "./hooks/use-onchain-receive-wizard";
+import { ONCHAIN_SEND_STEPS, useOnchainSendWizard } from "./hooks/use-onchain-send-wizard";
 import { ONRAMP_STEPS, useOnrampWizard } from "./hooks/use-onramp-wizard";
 
 interface PaymentsActionPageProps {
@@ -19,84 +36,95 @@ interface PaymentsActionPageProps {
   counterpartiesResult: CounterpartiesResult;
 }
 
-function OnrampFlow(props: PaymentsActionPageProps) {
-  const wizard = useOnrampWizard(props);
-  const {
-    stepIndex,
-    currentStepId,
-    isLastStep,
-    canProceed,
-    liveWalletsError,
-    walletsLoading,
-    quote,
-    hostedQuoteLoading,
-    counterpartyDialogOpen,
-    setCounterpartyDialogOpen,
-    handlePrimary,
-    handleSecondary,
-    handleCounterpartyCreated,
-  } = wizard;
+type WizardStep = { label: string; title: string };
+
+const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
+
+// ---- Rail children (mounted once the counterparty + method are known) ----
+
+interface RailProps {
+  wallets: PaymentsDashboardWallet[];
+  walletsError: string | null;
+  enabledRampProviders: RampProviderId[];
+  counterpartiesResult: CounterpartiesResult;
+  counterpartyId: string;
+  counterpartyName: string;
+  preSteps: WizardStep[];
+  onExit: () => void;
+}
+
+function OnchainSendRail({
+  wallets,
+  walletsError,
+  counterpartyId,
+  counterpartyName,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOnchainSendWizard({ wallets, walletsError, counterpartyId, onExit });
+  const primaryLabel = wizard.submitting
+    ? "Submitting..."
+    : wizard.isLastStep
+      ? wizard.transferResult
+        ? "Done"
+        : "Send transfer"
+      : "Next";
 
   return (
     <RampWizardShell
-      steps={ONRAMP_STEPS}
-      stepIndex={stepIndex}
-      primaryDisabled={
-        hostedQuoteLoading || !canProceed || (currentStepId === "DEPOSIT" && walletsLoading)
-      }
-      primaryLabel={hostedQuoteLoading ? "Opening..." : isLastStep ? "Done" : "Next"}
-      walletsError={liveWalletsError}
-      onPrimary={() => void handlePrimary()}
-      onSecondary={handleSecondary}
-      counterpartyDialogOpen={counterpartyDialogOpen}
-      setCounterpartyDialogOpen={setCounterpartyDialogOpen}
-      onCounterpartyCreated={handleCounterpartyCreated}
-      footer={
-        currentStepId === "PROVIDER" && quote ? (
-          <PoweredByRampProvider provider={quote.provider} />
-        ) : null
-      }
+      steps={[...preSteps, ...ONCHAIN_SEND_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={wizard.submitting || !wizard.canProceed}
+      primaryLabel={primaryLabel}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={() => void wizard.handlePrimary()}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
     >
-      <OnrampStepContent wizard={wizard} />
+      <OnchainSendStepContent wizard={wizard} counterpartyName={counterpartyName} />
     </RampWizardShell>
   );
 }
 
-function OfframpFlow(props: PaymentsActionPageProps) {
-  const wizard = useOfframpWizard(props);
-  const {
-    stepIndex,
-    currentStepId,
-    isLastStep,
-    canProceed,
-    liveWalletsError,
-    walletsLoading,
-    quote,
-    hostedQuoteLoading,
-    counterpartyDialogOpen,
-    setCounterpartyDialogOpen,
-    handlePrimary,
-    handleSecondary,
-    handleCounterpartyCreated,
-  } = wizard;
+function OfframpRail({
+  wallets,
+  walletsError,
+  enabledRampProviders,
+  counterpartiesResult,
+  counterpartyId,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOfframpWizard({
+    wallets,
+    walletsError,
+    enabledRampProviders,
+    counterpartiesResult,
+    initialCounterpartyId: counterpartyId,
+    onExit,
+  });
 
   return (
     <RampWizardShell
-      steps={OFFRAMP_STEPS}
-      stepIndex={stepIndex}
+      steps={[...preSteps, ...OFFRAMP_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
       primaryDisabled={
-        hostedQuoteLoading || !canProceed || (currentStepId === "WITHDRAW" && walletsLoading)
+        wizard.hostedQuoteLoading ||
+        !wizard.canProceed ||
+        (wizard.currentStepId === "WALLET" && wizard.walletsLoading)
       }
-      primaryLabel={hostedQuoteLoading ? "Opening..." : isLastStep ? "Done" : "Next"}
-      walletsError={liveWalletsError}
-      onPrimary={() => void handlePrimary()}
-      onSecondary={handleSecondary}
-      counterpartyDialogOpen={counterpartyDialogOpen}
-      setCounterpartyDialogOpen={setCounterpartyDialogOpen}
-      onCounterpartyCreated={handleCounterpartyCreated}
+      primaryLabel={wizard.hostedQuoteLoading ? "Opening..." : wizard.isLastStep ? "Done" : "Next"}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={() => void wizard.handlePrimary()}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
       footer={
-        currentStepId === "COMPLETE" && quote ? (
-          <PoweredByRampProvider provider={quote.provider} />
+        wizard.currentStepId === "COMPLETE" && wizard.quote ? (
+          <PoweredByRampProvider provider={wizard.quote.provider} />
         ) : null
       }
     >
@@ -105,9 +133,210 @@ function OfframpFlow(props: PaymentsActionPageProps) {
   );
 }
 
+function OnchainReceiveRail({
+  wallets,
+  walletsError,
+  counterpartyId,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOnchainReceiveWizard({ wallets, walletsError, counterpartyId, onExit });
+
+  return (
+    <RampWizardShell
+      steps={[...preSteps, ...ONCHAIN_RECEIVE_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={
+        !wizard.canProceed || (wizard.currentStepId === "WALLET" && wizard.walletsLoading)
+      }
+      primaryLabel={wizard.isLastStep ? "Done" : "Next"}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={wizard.handlePrimary}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
+    >
+      <OnchainReceiveStepContent wizard={wizard} />
+    </RampWizardShell>
+  );
+}
+
+function OnrampRail({
+  wallets,
+  walletsError,
+  enabledRampProviders,
+  counterpartiesResult,
+  counterpartyId,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOnrampWizard({
+    wallets,
+    walletsError,
+    enabledRampProviders,
+    counterpartiesResult,
+    initialCounterpartyId: counterpartyId,
+    onExit,
+  });
+
+  return (
+    <RampWizardShell
+      steps={[...preSteps, ...ONRAMP_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={
+        wizard.hostedQuoteLoading ||
+        !wizard.canProceed ||
+        (wizard.currentStepId === "DEPOSIT" && wizard.walletsLoading)
+      }
+      primaryLabel={wizard.hostedQuoteLoading ? "Opening..." : wizard.isLastStep ? "Done" : "Next"}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={() => void wizard.handlePrimary()}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
+      footer={
+        wizard.currentStepId === "PROVIDER" && wizard.quote ? (
+          <PoweredByRampProvider provider={wizard.quote.provider} />
+        ) : null
+      }
+    >
+      <OnrampStepContent wizard={wizard} />
+    </RampWizardShell>
+  );
+}
+
+// ---- Orchestrator: counterparty -> method -> rail ----
+
+type Phase = "counterparty" | "method" | "rail";
+
 export function PaymentsActionPage(props: PaymentsActionPageProps) {
-  if (props.mode === "send") {
-    return <OfframpFlow {...props} />;
+  const { mode, enabledRampProviders } = props;
+  const router = useRouter();
+
+  const [phase, setPhase] = useState<Phase>("counterparty");
+  const [counterpartyId, setCounterpartyId] = useState("");
+  const [method, setMethod] = useState<PaymentMethod | null>(null);
+  const [counterpartyDialogOpen, setCounterpartyDialogOpen] = useState(false);
+
+  const { data: counterpartiesResult, mutate: mutateCounterparties } = useSWR(
+    PAYMENTS_ACTION_COUNTERPARTIES_KEY,
+    fetchAllCounterparties,
+    {
+      fallbackData: props.counterpartiesResult,
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+    }
+  );
+  const liveCounterparties = counterpartiesResult ?? props.counterpartiesResult;
+
+  // Fiat is gated on org ramp-provider access; onchain is always offerable
+  // (a missing Solana address can be added inline).
+  const fiatEnabled = enabledRampProviders.length > 0;
+  const availableMethods: PaymentMethod[] = fiatEnabled ? ["onchain", "ramp"] : ["onchain"];
+  const showMethodStep = availableMethods.length > 1;
+
+  const counterpartyTitle = mode === "send" ? "Who are you paying?" : "Who is this deposit from?";
+  const methodTitle =
+    mode === "send" ? "How would you like to pay?" : "How would you like to deposit?";
+
+  const preSteps = useMemo<WizardStep[]>(
+    () => [
+      { label: "Counterparty", title: counterpartyTitle },
+      ...(showMethodStep ? [{ label: "Method", title: methodTitle }] : []),
+    ],
+    [counterpartyTitle, methodTitle, showMethodStep]
+  );
+
+  const effectiveMethod: PaymentMethod = showMethodStep ? (method ?? "onchain") : "onchain";
+  const counterpartyName =
+    liveCounterparties.data.find((cp) => cp.id === counterpartyId)?.displayName ?? "";
+
+  const handleCounterpartyCreated = (created: Counterparty) => {
+    setCounterpartyId(created.id);
+    void mutateCounterparties(
+      (prev) => (prev ? { ...prev, data: [created, ...prev.data] } : { ok: true, data: [created] }),
+      { revalidate: true }
+    );
+    setCounterpartyDialogOpen(false);
+  };
+
+  const railOnExit = () => setPhase(showMethodStep ? "method" : "counterparty");
+
+  if (phase === "rail") {
+    const railProps: RailProps = {
+      wallets: props.wallets,
+      walletsError: props.walletsError,
+      enabledRampProviders,
+      counterpartiesResult: liveCounterparties,
+      counterpartyId,
+      counterpartyName,
+      preSteps,
+      onExit: railOnExit,
+    };
+
+    if (mode === "send") {
+      return effectiveMethod === "onchain" ? (
+        <OnchainSendRail {...railProps} />
+      ) : (
+        <OfframpRail {...railProps} />
+      );
+    }
+    return effectiveMethod === "onchain" ? (
+      <OnchainReceiveRail {...railProps} />
+    ) : (
+      <OnrampRail {...railProps} />
+    );
   }
-  return <OnrampFlow {...props} />;
+
+  const stepIndex = phase === "counterparty" ? 0 : 1;
+  const primaryDisabled = phase === "counterparty" ? !counterpartyId : !method;
+  const onPrimary = () => {
+    if (phase === "counterparty") {
+      if (!counterpartyId) {
+        return;
+      }
+      setPhase(showMethodStep ? "method" : "rail");
+      return;
+    }
+    if (!method) {
+      return;
+    }
+    setPhase("rail");
+  };
+  const onSecondary = () => {
+    if (phase === "counterparty") {
+      router.push("/dashboard/payments");
+      return;
+    }
+    setPhase("counterparty");
+  };
+
+  return (
+    <RampWizardShell
+      steps={preSteps}
+      stepIndex={stepIndex}
+      primaryDisabled={primaryDisabled}
+      primaryLabel="Next"
+      walletsError={null}
+      onPrimary={onPrimary}
+      onSecondary={onSecondary}
+      counterpartyDialogOpen={counterpartyDialogOpen}
+      setCounterpartyDialogOpen={setCounterpartyDialogOpen}
+      onCounterpartyCreated={handleCounterpartyCreated}
+    >
+      {phase === "counterparty" ? (
+        <CounterpartyPicker
+          mode={mode}
+          counterpartiesResult={liveCounterparties}
+          value={counterpartyId || null}
+          onChange={setCounterpartyId}
+          onAddClick={() => setCounterpartyDialogOpen(true)}
+        />
+      ) : (
+        <PaymentMethodStep mode={mode} value={method} onChange={setMethod} />
+      )}
+    </RampWizardShell>
+  );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -8,10 +8,12 @@ import type {
 } from "@sdp/types";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
-import useSWR from "swr";
+import useSWR, { preload } from "swr";
 import {
   type CounterpartiesResult,
   fetchAllCounterparties,
+  fetchCounterpartyAccounts,
+  fetchWallets,
 } from "@/app/dashboard/payments/payments-workspace.data";
 import { CounterpartyPicker } from "./components/counterparty-picker";
 import { OfframpStepContent } from "./components/offramp-step-content";
@@ -39,6 +41,7 @@ interface PaymentsActionPageProps {
 type WizardStep = { label: string; title: string };
 
 const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
+const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 
 // ---- Rail children (mounted once the counterparty + method are known) ----
 
@@ -231,8 +234,15 @@ export function PaymentsActionPage(props: PaymentsActionPageProps) {
   );
   const liveCounterparties = counterpartiesResult ?? props.counterpartiesResult;
 
-  // Fiat is gated on org ramp-provider access; onchain is always offerable
-  // (a missing Solana address can be added inline).
+  const selectCounterparty = (id: string) => {
+    setCounterpartyId(id);
+    if (!id) {
+      return;
+    }
+    void preload(PAYMENTS_ACTION_WALLETS_KEY, () => fetchWallets({ includeBalances: true }));
+    void preload(["counterparty-accounts", id], () => fetchCounterpartyAccounts(id));
+  };
+
   const fiatEnabled = enabledRampProviders.length > 0;
   const availableMethods: PaymentMethod[] = fiatEnabled ? ["onchain", "ramp"] : ["onchain"];
   const showMethodStep = availableMethods.length > 1;
@@ -254,7 +264,7 @@ export function PaymentsActionPage(props: PaymentsActionPageProps) {
     liveCounterparties.data.find((cp) => cp.id === counterpartyId)?.displayName ?? "";
 
   const handleCounterpartyCreated = (created: Counterparty) => {
-    setCounterpartyId(created.id);
+    selectCounterparty(created.id);
     void mutateCounterparties(
       (prev) => (prev ? { ...prev, data: [created, ...prev.data] } : { ok: true, data: [created] }),
       { revalidate: true }
@@ -331,7 +341,7 @@ export function PaymentsActionPage(props: PaymentsActionPageProps) {
           mode={mode}
           counterpartiesResult={liveCounterparties}
           value={counterpartyId || null}
-          onChange={setCounterpartyId}
+          onChange={selectCounterparty}
           onAddClick={() => setCounterpartyDialogOpen(true)}
         />
       ) : (

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/schema.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/schema.ts
@@ -46,16 +46,12 @@ export const withdrawSelectionSchema = makeRampSelectionSchema(
 );
 
 // Per-step gating schemas.
-export const counterpartySelectionSchema = depositSelectionSchema.pick({ counterpartyId: true });
 export const depositAmountSchema = depositSelectionSchema.pick({
   walletId: true,
   amount: true,
   provider: true,
 });
-export const payoutCounterpartySchema = withdrawSelectionSchema.pick({
-  counterpartyId: true,
-  walletId: true,
-});
+export const sourceWalletSchema = withdrawSelectionSchema.pick({ walletId: true });
 export const withdrawAmountSchema = withdrawSelectionSchema.pick({
   amount: true,
   provider: true,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/schema.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/schema.ts
@@ -70,3 +70,34 @@ export const rampSelectionSchema = z.object({
 });
 
 export type RampFields = z.input<typeof rampSelectionSchema>;
+
+const onchainAmount = z
+  .string()
+  .trim()
+  .refine((value) => /^\d+(\.\d{1,9})?$/.test(value), "Enter a valid amount.")
+  .transform(Number)
+  .refine((value) => value > 0, "Enter an amount greater than 0.");
+
+export const onchainSendSelectionSchema = z.object({
+  accountId: z.string().min(1, "Select a destination account."),
+  walletId: z.string().min(1, "Select a source wallet."),
+  asset: z.string().min(1, "Select an asset."),
+  amount: onchainAmount,
+});
+
+export const onchainDestinationSchema = onchainSendSelectionSchema.pick({ accountId: true });
+export const onchainDetailsSchema = onchainSendSelectionSchema.pick({
+  walletId: true,
+  asset: true,
+  amount: true,
+});
+
+export const onchainSendSchema = z.object({
+  accountId: z.string(),
+  walletId: z.string(),
+  asset: z.string(),
+  amount: z.string(),
+  memo: z.string(),
+});
+
+export type OnchainSendFields = z.input<typeof onchainSendSchema>;


### PR DESCRIPTION
## Summary

Adds **onchain (crypto) transfers** to the payments v2 `/deposit` and `/pay` flows (previously fiat-only). Both flows now go:

```
Counterparty  →  Method (onchain vs fiat, auto-skipped if only one)  →  rail steps
```
Step 1: select who you're paying to - deposit also mirrors this
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 31 01@2x" src="https://github.com/user-attachments/assets/933fdb24-b817-4264-ad80-3d59e1029725" />

Step 2: Select how you're paying, either onchain or offchain
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 30 51@2x" src="https://github.com/user-attachments/assets/574703d1-1717-46c7-9ba8-e9b333644420" />

Step 3: Each counterparty can now add in "addresses" so u can select which address here
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 31 09@2x" src="https://github.com/user-attachments/assets/9c289337-50f6-4132-a6c6-974b9a46cf91" />

Step 3.5: Or make a new one if none exists yet
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 32 21@2x" src="https://github.com/user-attachments/assets/c0e94c45-9b9f-4e1c-aaec-f8ab7bcde11e" />

Step 4: Select source wallet and amount
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 42 36@2x" src="https://github.com/user-attachments/assets/15db0c53-9ba9-4ef5-992a-49fe83aabd18" />

Step 5: Review and send
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 43 10@2x" src="https://github.com/user-attachments/assets/b5a5c01b-49d1-4bb7-baac-f20b9672b48f" />

Step 6: Verify on explorer - [Explorer link](https://explorer.solana.com/tx/5PJepEcayZc7J7oWTZ21YD91HGz2KGicYQarYq4UYt16gZAS59mHHss3XpyyAHH4wJ7pad2vtcRqcgUCtet4QXVQ?cluster=devnet)
<img width="3456" height="2234" alt="CleanShot 2026-06-04 at 11 43 45@2x" src="https://github.com/user-attachments/assets/fa8d8e6e-3a0f-420e-8394-becabb06bceb" />

Deposit goes through the same selection

## What changed
- **Onchain send** (`/pay`): pick the counterparty's saved Solana account (or add one inline via the screened dialog) → source wallet, asset, amount, memo → review → submit via existing transfers endpoint (shows signature + explorer link).
- **Onchain receive** (`/deposit`): pick wallet → show address + QR.
- **Refactor:** counterparty selection hoisted into a shared first step, seeded into the rail wizards via `initialCounterpartyId`; off-ramp keeps its source-wallet picker as its own step.
- **Polish:** larger step titles, secondary-background option cards, layered selected outline with no layout shift.

Frontend only (`apps/sdp-web/.../payments/ramps/` + a `fetchCounterpartyAccounts` helper). No API changes.

## Follow-up (not in this PR)
Gate the receive "Done" on detecting the inbound deposit by reference memo — needs the API to surface the SPL memo on observed inbound transfers.