### PR TITLE
feat: add counterparty crypto-wallet accounts

### DIFF
--- a/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty-account.repository.postgres.ts
@@ -125,7 +125,7 @@ export function createPostgresCounterpartyAccountsRepository(
     },
 
     async archiveCounterpartyAccount(input: ArchiveCounterpartyAccountInput) {
-      const result = await db
+      const row = await db
         .prepare(
           `UPDATE counterparty_accounts
              SET status = 'archived',
@@ -134,7 +134,8 @@ export function createPostgresCounterpartyAccountsRepository(
              AND id = ?
              AND organization_id = ?
              AND project_id = ?
-             AND status = 'active'`
+             AND status = 'active'
+           RETURNING *`
         )
         .bind(
           input.counterpartyId,
@@ -142,17 +143,9 @@ export function createPostgresCounterpartyAccountsRepository(
           input.organizationId,
           input.projectId
         )
-        .run();
+        .first<Record<string, unknown>>();
 
-      if (result === 0) {
-        return null;
-      }
-
-      return getCounterpartyAccountByIdInternal(db, {
-        counterpartyAccountId: input.counterpartyAccountId,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-      });
+      return row ? mapCounterpartyAccountRow(row) : null;
     },
 
     async getCounterpartyAccountById(params) {

--- a/apps/sdp-api/src/openapi/paths/counterparties.ts
+++ b/apps/sdp-api/src/openapi/paths/counterparties.ts
@@ -2,17 +2,23 @@ import type { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
 import {
+  counterpartyAccountPathParamsSchema,
   counterpartyIdParamSchema,
+  createCounterpartyAccountRequestSchema,
   createCounterpartyRequestSchema,
   errorResponseSchema,
   listCounterpartiesQuerySchema,
+  listCounterpartyAccountsQuerySchema,
+  updateCounterpartyAccountRequestSchema,
   updateCounterpartyRequestSchema,
 } from "../schemas";
 import { errorResponses, jsonContent, projectScopeHeaders } from "./helpers";
 import {
+  counterpartyAccountResponse,
   counterpartyFieldOptionsResponse,
   counterpartyResponse,
   listCounterpartiesResponse,
+  listCounterpartyAccountsResponse,
 } from "./responses";
 
 export function registerCounterpartyPaths(registry: OpenAPIRegistry) {
@@ -151,6 +157,126 @@ export function registerCounterpartyPaths(registry: OpenAPIRegistry) {
     responses: {
       204: {
         description: "Counterparty archived",
+      },
+      ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/counterparties/{counterpartyId}/accounts",
+    tags: ["Counterparties"],
+    summary: "List counterparty accounts",
+    operationId: "listCounterpartyAccounts",
+    description:
+      "Lists payment accounts for a counterparty. Crypto-wallet accounts can be used by payment flows that send funds to a counterparty wallet.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({
+        counterpartyId: counterpartyIdParamSchema,
+      }),
+      query: listCounterpartyAccountsQuerySchema,
+    },
+    responses: {
+      200: {
+        description: "Counterparty account list",
+        content: jsonContent(listCounterpartyAccountsResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/counterparties/{counterpartyId}/accounts",
+    tags: ["Counterparties"],
+    summary: "Create counterparty account",
+    operationId: "createCounterpartyAccount",
+    description:
+      'Creates a payment account for a counterparty. For accountKind "crypto_wallet", details.network must be "solana" and details.address must be a Solana wallet address.',
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({
+        counterpartyId: counterpartyIdParamSchema,
+      }),
+      body: {
+        required: true,
+        content: jsonContent(createCounterpartyAccountRequestSchema),
+      },
+    },
+    responses: {
+      201: {
+        description: "Counterparty account created",
+        content: jsonContent(counterpartyAccountResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/v1/counterparties/{counterpartyId}/accounts/{counterpartyAccountId}",
+    tags: ["Counterparties"],
+    summary: "Get counterparty account",
+    operationId: "getCounterpartyAccount",
+    description: "Gets a counterparty payment account by id.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: counterpartyAccountPathParamsSchema,
+    },
+    responses: {
+      200: {
+        description: "Counterparty account",
+        content: jsonContent(counterpartyAccountResponse),
+      },
+      ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/v1/counterparties/{counterpartyId}/accounts/{counterpartyAccountId}",
+    tags: ["Counterparties"],
+    summary: "Update counterparty account",
+    operationId: "updateCounterpartyAccount",
+    description: "Updates a counterparty payment account. At least one field must be provided.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: counterpartyAccountPathParamsSchema,
+      body: {
+        required: true,
+        content: jsonContent(updateCounterpartyAccountRequestSchema),
+      },
+    },
+    responses: {
+      200: {
+        description: "Counterparty account updated",
+        content: jsonContent(counterpartyAccountResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/counterparties/{counterpartyId}/accounts/{counterpartyAccountId}",
+    tags: ["Counterparties"],
+    summary: "Archive counterparty account",
+    operationId: "archiveCounterpartyAccount",
+    description:
+      "Archives a counterparty payment account. Archived accounts are hidden from default lists.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: counterpartyAccountPathParamsSchema,
+    },
+    responses: {
+      204: {
+        description: "Counterparty account archived",
       },
       ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
     },

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -7,6 +7,7 @@ import {
   allowlistEntrySchema,
   apiKeyDetailSchema,
   apiKeyResponseSchema,
+  counterpartyAccountResponseSchema,
   counterpartyFieldOptionsResponseSchema,
   counterpartyResponseSchema,
   currentUserResponseSchema,
@@ -29,6 +30,7 @@ import {
   inviteMemberResponseSchema,
   listApiKeysResponseSchema,
   listCounterpartiesResponseSchema,
+  listCounterpartyAccountsResponseSchema,
   listMembersResponseSchema,
   listProjectApiKeysResponseSchema,
   listProjectMembersResponseSchema,
@@ -90,6 +92,10 @@ export const counterpartyFieldOptionsResponse = successResponseSchema(
   counterpartyFieldOptionsResponseSchema
 );
 export const listCounterpartiesResponse = successResponseSchema(listCounterpartiesResponseSchema);
+export const counterpartyAccountResponse = successResponseSchema(counterpartyAccountResponseSchema);
+export const listCounterpartyAccountsResponse = successResponseSchema(
+  listCounterpartyAccountsResponseSchema
+);
 
 export const projectResponse = successResponseSchema(projectResponseSchema);
 export const listProjectsResponse = successResponseSchema(listProjectsResponseSchema);

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -21,6 +21,13 @@ import {
   updateCounterpartyObjectSchema as updateCounterpartyObjectSchemaBase,
 } from "../../routes/counterparties/schemas";
 import {
+  counterpartyAccountKindSchema as counterpartyAccountKindSchemaBase,
+  counterpartyAccountParamsSchema as counterpartyAccountParamsSchemaBase,
+  createCounterpartyAccountSchema as createCounterpartyAccountSchemaBase,
+  listCounterpartyAccountsQuerySchema as listCounterpartyAccountsQuerySchemaBase,
+  updateCounterpartyAccountObjectSchema as updateCounterpartyAccountSchemaBase,
+} from "../../routes/counterparty-accounts/schemas";
+import {
   isoDateSchema,
   isoDateTimeSchema,
   orgIdParamSchema,
@@ -44,6 +51,15 @@ export const counterpartyStatusSchema = withOpenApi(counterpartyStatusSchemaBase
   description: "Counterparty status.",
   example: "active",
 });
+
+export const counterpartyAccountKindSchema = withOpenApi(counterpartyAccountKindSchemaBase, {
+  description: "Counterparty account kind.",
+  example: "crypto_wallet",
+});
+
+export const counterpartyAccountStatusSchema = z
+  .enum(["active", "archived"])
+  .openapi({ description: "Counterparty account status.", example: "active" });
 
 export const counterpartyIdTypeSchema = withOpenApi(counterpartyIdTypeSchemaBase, {
   description:
@@ -202,6 +218,93 @@ export const counterpartyResponseSchema = withOpenApi(
   { description: "Counterparty response payload." }
 );
 
+export const counterpartyAccountPathParamsSchema = counterpartyAccountParamsSchemaBase
+  .extend({
+    counterpartyId: withOpenApi(counterpartyAccountParamsSchemaBase.shape.counterpartyId, {
+      description: "Counterparty identifier.",
+      example: "cp_example",
+    }),
+    counterpartyAccountId: withOpenApi(
+      counterpartyAccountParamsSchemaBase.shape.counterpartyAccountId,
+      {
+        description: "Counterparty account identifier.",
+        example: "cpa_example",
+      }
+    ),
+  })
+  .openapi({ description: "Counterparty account path parameters." });
+
+export const counterpartyAccountDetailsSchema = z.record(z.string(), z.unknown()).openapi({
+  description:
+    'Account details. For crypto_wallet accounts, include network: "solana" and address as a Solana wallet address.',
+  example: {
+    network: "solana",
+    address: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  },
+});
+
+export const counterpartyAccountProviderDataSchema = z.record(z.string(), z.unknown()).openapi({
+  description: "Provider-specific account metadata preserved by SDP.",
+  example: {},
+});
+
+export const counterpartyAccountSchema = withOpenApi(
+  z.object({
+    id: withOpenApi(z.string(), {
+      description: "Counterparty account identifier.",
+      example: "cpa_example",
+    }),
+    organizationId: orgIdParamSchema,
+    projectId: projectIdParamSchema,
+    counterpartyId: counterpartyIdParamSchema,
+    accountKind: counterpartyAccountKindSchema,
+    label: withOpenApi(z.string().nullable(), {
+      description: "Optional human-readable account label.",
+      example: "USDC wallet",
+    }),
+    details: counterpartyAccountDetailsSchema,
+    providerAccountData: counterpartyAccountProviderDataSchema,
+    status: counterpartyAccountStatusSchema,
+    createdAt: withOpenApi(isoDateTimeSchema, {
+      description: "Creation timestamp.",
+      example: "2025-01-01T00:00:00.000Z",
+    }),
+    updatedAt: withOpenApi(isoDateTimeSchema, {
+      description: "Last update timestamp.",
+      example: "2025-01-02T00:00:00.000Z",
+    }),
+  }),
+  { description: "Counterparty payment account record." }
+);
+
+export const counterpartyAccountResponseSchema = withOpenApi(
+  z.object({
+    account: counterpartyAccountSchema,
+  }),
+  { description: "Counterparty account response payload." }
+);
+
+export const listCounterpartyAccountsResponseSchema = withOpenApi(
+  z.object({
+    accounts: withOpenApi(z.array(counterpartyAccountSchema), {
+      description: "Counterparty accounts.",
+    }),
+    total: withOpenApi(z.number().int().nonnegative(), {
+      description: "Total counterparty accounts matching the query.",
+      example: 2,
+    }),
+    page: withOpenApi(z.number().int().positive(), {
+      description: "Current page number.",
+      example: 1,
+    }),
+    pageSize: withOpenApi(z.number().int().positive(), {
+      description: "Items per page.",
+      example: 20,
+    }),
+  }),
+  { description: "Paginated list of counterparty accounts." }
+);
+
 export const listCounterpartiesResponseSchema = withOpenApi(
   z.object({
     counterparties: withOpenApi(z.array(counterpartySchema), {
@@ -272,6 +375,27 @@ export const listCounterpartiesQuerySchema = listCounterpartiesQuerySchemaBase.e
   }),
 });
 
+export const listCounterpartyAccountsQuerySchema = listCounterpartyAccountsQuerySchemaBase
+  .extend({
+    accountKind: withOpenApi(listCounterpartyAccountsQuerySchemaBase.shape.accountKind, {
+      description: "Filter accounts by account kind.",
+      example: "crypto_wallet",
+    }),
+    page: withOpenApi(listCounterpartyAccountsQuerySchemaBase.shape.page, {
+      description: "Page number (1-based).",
+      example: 1,
+    }),
+    pageSize: withOpenApi(listCounterpartyAccountsQuerySchemaBase.shape.pageSize, {
+      description: "Items per page (max 100).",
+      example: 20,
+    }),
+    includeArchived: withOpenApi(listCounterpartyAccountsQuerySchemaBase.shape.includeArchived, {
+      description: "Include archived counterparty accounts in results.",
+      example: false,
+    }),
+  })
+  .openapi({ description: "Counterparty account list filters." });
+
 export const createCounterpartyRequestSchema = withOpenApi(
   createCounterpartySchemaBase.extend({
     externalId: withOpenApi(createCounterpartySchemaBase.shape.externalId, {
@@ -295,6 +419,35 @@ export const createCounterpartyRequestSchema = withOpenApi(
     }),
   }),
   { description: "Create counterparty request body." }
+);
+
+export const createCounterpartyAccountRequestSchema = withOpenApi(
+  createCounterpartyAccountSchemaBase.safeExtend({
+    accountKind: withOpenApi(createCounterpartyAccountSchemaBase.shape.accountKind, {
+      description: "Counterparty account kind.",
+      example: "crypto_wallet",
+    }),
+    label: withOpenApi(createCounterpartyAccountSchemaBase.shape.label, {
+      description: "Optional account label.",
+      example: "USDC wallet",
+    }),
+    details: withOpenApi(createCounterpartyAccountSchemaBase.shape.details, {
+      description:
+        'For crypto_wallet accounts, must include network: "solana" and address as a Solana wallet address.',
+      example: {
+        network: "solana",
+        address: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+      },
+    }),
+    providerAccountData: withOpenApi(
+      createCounterpartyAccountSchemaBase.shape.providerAccountData,
+      {
+        description: "Provider-specific metadata to preserve with the account.",
+        example: {},
+      }
+    ),
+  }),
+  { description: "Create counterparty account request body." }
 );
 
 export const updateCounterpartyRequestSchema = withOpenApi(
@@ -321,6 +474,34 @@ export const updateCounterpartyRequestSchema = withOpenApi(
   }),
   {
     description: "Update counterparty request body. At least one field must be provided.",
+    minProperties: 1,
+  }
+);
+
+export const updateCounterpartyAccountRequestSchema = withOpenApi(
+  updateCounterpartyAccountSchemaBase.safeExtend({
+    label: withOpenApi(updateCounterpartyAccountSchemaBase.shape.label, {
+      description: "Updated account label. Use null to clear.",
+      example: "Primary USDC wallet",
+    }),
+    details: withOpenApi(updateCounterpartyAccountSchemaBase.shape.details, {
+      description:
+        'Updated account details. Crypto-wallet accounts must retain network: "solana" and a valid Solana wallet address.',
+      example: {
+        network: "solana",
+        address: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+      },
+    }),
+    providerAccountData: withOpenApi(
+      updateCounterpartyAccountSchemaBase.shape.providerAccountData,
+      {
+        description: "Updated provider-specific metadata.",
+        example: {},
+      }
+    ),
+  }),
+  {
+    description: "Update counterparty account request body. At least one field must be provided.",
     minProperties: 1,
   }
 );

--- a/apps/sdp-api/src/routes/counterparties.test.ts
+++ b/apps/sdp-api/src/routes/counterparties.test.ts
@@ -288,6 +288,94 @@ describe("Counterparties Routes", () => {
     });
   });
 
+  describe("counterparty accounts", () => {
+    it("creates, lists, updates, gets, and archives a crypto wallet account", async () => {
+      const created = await createCounterparty({ externalId: "account_parent_1" });
+      const cp = (await created.json()).data.counterparty;
+
+      const createAccountRes = await app.request(
+        `/v1/counterparties/${cp.id}/accounts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: authHeader },
+          body: JSON.stringify({
+            accountKind: "crypto_wallet",
+            label: "Primary wallet",
+            details: {
+              network: "solana",
+              address: "8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ",
+            },
+          }),
+        },
+        env
+      );
+      expect(createAccountRes.status).toBe(201);
+      const account = (await createAccountRes.json()).data.account;
+      expect(account.accountKind).toBe("crypto_wallet");
+      expect(account.details.network).toBe("solana");
+
+      const listRes = await app.request(
+        `/v1/counterparties/${cp.id}/accounts?accountKind=crypto_wallet`,
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(listRes.status).toBe(200);
+      const listBody = await listRes.json();
+      expect(listBody.data.total).toBe(1);
+
+      const updateRes = await app.request(
+        `/v1/counterparties/${cp.id}/accounts/${account.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json", Authorization: authHeader },
+          body: JSON.stringify({ label: "Updated wallet" }),
+        },
+        env
+      );
+      expect(updateRes.status).toBe(200);
+      const updated = (await updateRes.json()).data.account;
+      expect(updated.label).toBe("Updated wallet");
+
+      const getRes = await app.request(
+        `/v1/counterparties/${cp.id}/accounts/${account.id}`,
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(getRes.status).toBe(200);
+
+      const deleteRes = await app.request(
+        `/v1/counterparties/${cp.id}/accounts/${account.id}`,
+        { method: "DELETE", headers: { Authorization: authHeader } },
+        env
+      );
+      expect(deleteRes.status).toBe(204);
+    });
+
+    it("rejects crypto wallet accounts without a Solana wallet address", async () => {
+      const created = await createCounterparty({ externalId: "account_parent_invalid" });
+      const cp = (await created.json()).data.counterparty;
+
+      const res = await app.request(
+        `/v1/counterparties/${cp.id}/accounts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: authHeader },
+          body: JSON.stringify({
+            accountKind: "crypto_wallet",
+            details: {
+              network: "ethereum",
+              address: "not-a-solana-address",
+            },
+          }),
+        },
+        env
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error.code).toBe("BAD_REQUEST");
+    });
+  });
+
   describe("PATCH /v1/counterparties/:counterpartyId", () => {
     it("updates displayName", async () => {
       const created = await createCounterparty({ externalId: "patch_1", displayName: "Old" });

--- a/apps/sdp-api/src/routes/counterparties.test.ts
+++ b/apps/sdp-api/src/routes/counterparties.test.ts
@@ -336,6 +336,22 @@ describe("Counterparties Routes", () => {
       const updated = (await updateRes.json()).data.account;
       expect(updated.label).toBe("Updated wallet");
 
+      const invalidPatchRes = await app.request(
+        `/v1/counterparties/${cp.id}/accounts/${account.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json", Authorization: authHeader },
+          body: JSON.stringify({
+            details: {
+              network: "solana",
+              address: "not-a-solana-address",
+            },
+          }),
+        },
+        env
+      );
+      expect(invalidPatchRes.status).toBe(400);
+
       const getRes = await app.request(
         `/v1/counterparties/${cp.id}/accounts/${account.id}`,
         { headers: { Authorization: authHeader } },

--- a/apps/sdp-api/src/routes/counterparties/context.ts
+++ b/apps/sdp-api/src/routes/counterparties/context.ts
@@ -1,9 +1,16 @@
 import type { Context } from "hono";
-import { createCounterpartiesRepository } from "@/db/repositories";
+import {
+  createCounterpartiesRepository,
+  createCounterpartyAccountsRepository,
+} from "@/db/repositories";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
 
 export function getCounterpartiesRepository(c: AppContext) {
   return createCounterpartiesRepository(c.env);
+}
+
+export function getCounterpartyAccountsRepository(c: AppContext) {
+  return createCounterpartyAccountsRepository(c.env);
 }

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -86,6 +86,10 @@ export const counterpartyIdParamsSchema = z.object({
   counterpartyId: counterpartyIdSchema,
 });
 
+export const counterpartyAccountIdParamsSchema = counterpartyIdParamsSchema.extend({
+  accountId: z.string().min(1),
+});
+
 export const createCounterpartySchema = z.object({
   externalId: z.string().min(1).max(256).optional(),
   entityType: counterpartyEntityTypeSchema,

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -86,10 +86,6 @@ export const counterpartyIdParamsSchema = z.object({
   counterpartyId: counterpartyIdSchema,
 });
 
-export const counterpartyAccountIdParamsSchema = counterpartyIdParamsSchema.extend({
-  accountId: z.string().min(1),
-});
-
 export const createCounterpartySchema = z.object({
   externalId: z.string().min(1).max(256).optional(),
   entityType: counterpartyEntityTypeSchema,

--- a/apps/sdp-api/src/routes/counterparty-accounts/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/handlers.ts
@@ -222,6 +222,7 @@ export const updateCounterpartyAccount = async (c: AppContext) => {
   });
 
   if (!updated) {
+    await assertCounterpartyExists(c, params.data.counterpartyId, auth.organizationId, projectId);
     throw notFound("Counterparty account");
   }
 
@@ -257,6 +258,7 @@ export const archiveCounterpartyAccount = async (c: AppContext) => {
   });
 
   if (!archived) {
+    await assertCounterpartyExists(c, params.data.counterpartyId, auth.organizationId, projectId);
     throw notFound("Counterparty account");
   }
 

--- a/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
@@ -8,14 +8,11 @@ const jsonObjectSchema = z.record(z.string(), z.unknown());
 
 export const cryptoWalletDetailsSchema = z
   .object({
-    network: z.string().min(1).max(64),
+    network: z.literal("solana"),
     address: z.string().min(1).max(256),
   })
   .superRefine((value, ctx) => {
-    if (
-      value.network === "solana" &&
-      !(value.address.length >= 32 && value.address.length <= 44 && isAddress(value.address))
-    ) {
+    if (!(value.address.length >= 32 && value.address.length <= 44 && isAddress(value.address))) {
       ctx.addIssue({
         code: "custom",
         path: ["address"],

--- a/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/schemas.ts
@@ -32,11 +32,12 @@ export const createCounterpartyAccountSchema = z
     if (value.accountKind === "crypto_wallet") {
       const result = cryptoWalletDetailsSchema.safeParse(value.details);
       if (!result.success) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["details"],
-          message: "crypto_wallet accounts require details.network and details.address",
-        });
+        for (const issue of result.error.issues) {
+          ctx.addIssue({
+            ...issue,
+            path: ["details", ...issue.path],
+          });
+        }
       }
     }
   });

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > Full public documentation for Solana Developer Platform — all page content for AI and agent ingestion.
 
 ## Canonical URLs
-- Docs: https://platform.solana.com
+- Docs: https://platform.solana.com/docs
 - API: https://api.solana.com
 - Interactive API docs: https://api.solana.com/docs
 - OpenAPI: https://api.solana.com/openapi.json

--- a/apps/sdp-docs/public/llms.txt
+++ b/apps/sdp-docs/public/llms.txt
@@ -3,7 +3,7 @@
 > Public documentation and API discovery resources for Solana Developer Platform.
 
 ## Canonical URLs
-- Docs: https://platform.solana.com
+- Docs: https://platform.solana.com/docs
 - API: https://api.solana.com
 - Interactive API docs: https://api.solana.com/docs
 - OpenAPI: https://api.solana.com/openapi.json


### PR DESCRIPTION
## Summary
- split from the closed recurring payments PR #398
- add public counterparty account endpoints for crypto-wallet accounts
- require crypto-wallet accounts to use Solana network and a valid Solana wallet address
- update OpenAPI and AI discovery artifacts

## Validation
- pnpm --filter @sdp/api typecheck
- pnpm -C apps/sdp-docs generate:api
- pnpm -C apps/sdp-docs generate:ai
- git diff --check

## Notes
This is the first PR in the recurring payments split. It does not add subscription primitives or managed recurring payments.