### PR TITLE
feat: HOO-520 rework the self-hosted .env configurator

### DIFF
--- a/apps/sdp-api/scripts/configure.ts
+++ b/apps/sdp-api/scripts/configure.ts
@@ -23,8 +23,10 @@ import {
   FIELDS,
   generateEnv,
   isFieldVisible,
+  parseList,
   randomHex32,
   SECTIONS,
+  type SelectOption,
   type Values,
   validateValues,
 } from "@sdp/env-config";
@@ -47,7 +49,18 @@ export function collectFromEnv(env: Record<string, string | undefined>): Values 
   if (typeof env.DATABASE_URL === "string" && env.DATABASE_URL !== "") {
     values.DATABASE_MODE = "external";
   }
-  for (const key of autoSecretKeys()) {
+  // Keep SIGNING_PROVIDERS and the default SIGNING_PROVIDER consistent for the
+  // non-interactive path: derive the list from a bare provider, or pick the
+  // first listed provider as the default when only the list was given.
+  if (env.SIGNING_PROVIDERS === undefined) {
+    values.SIGNING_PROVIDERS = values.SIGNING_PROVIDER || "local";
+  } else if (env.SIGNING_PROVIDER === undefined) {
+    const list = parseList(values.SIGNING_PROVIDERS);
+    if (list.length > 0 && !list.includes(values.SIGNING_PROVIDER)) {
+      values.SIGNING_PROVIDER = list[0];
+    }
+  }
+  for (const key of autoSecretKeys(values)) {
     if (!values[key]) values[key] = randomHex32();
   }
   return values;
@@ -78,17 +91,27 @@ class PromptAbortError extends Error {
 }
 
 /** Resolve a select answer (1-based index or option value) to a stored value. */
-async function promptSelect(field: EnvField, current: string, ask: Asker): Promise<string> {
-  const options = field.options ?? [];
+async function promptSelect(
+  field: EnvField,
+  current: string,
+  ask: Asker,
+  values: Values
+): Promise<string> {
+  const options = (field.optionsWhen ? field.optionsWhen(values) : field.options) ?? [];
+  // If the carried default is no longer a valid option, fall back to the first.
+  const safeCurrent = options.some((o) => o.value === current)
+    ? current
+    : (options[0]?.value ?? current);
   note(field.label);
+  if (field.help) note(field.help);
   options.forEach((opt, i) => {
-    const marker = opt.value === current ? " (default)" : "";
+    const marker = opt.value === safeCurrent ? " (default)" : "";
     note(`  ${i + 1}) ${opt.label}${marker}`);
   });
 
   for (;;) {
     const answer = (await ask("> ")).trim();
-    if (answer === "") return current;
+    if (answer === "") return safeCurrent;
 
     if (/^\d+$/.test(answer)) {
       const byIndex = Number.parseInt(answer, 10);
@@ -103,6 +126,80 @@ async function promptSelect(field: EnvField, current: string, ask: Asker): Promi
     note(
       `Unknown option: ${answer} — enter a number 1-${options.length}, an option value, or blank.`
     );
+  }
+}
+
+/**
+ * Resolve raw multiselect tokens (1-based indices or option values) to option
+ * values, preserving order and dropping duplicates. Returns the first
+ * unrecognized token as an error rather than silently dropping it.
+ */
+export function resolveMultiSelectTokens(
+  tokens: string[],
+  options: SelectOption[]
+): { values: string[] } | { error: string } {
+  const resolved: string[] = [];
+  for (const tok of tokens) {
+    if (/^\d+$/.test(tok)) {
+      const idx = Number.parseInt(tok, 10);
+      if (idx >= 1 && idx <= options.length) {
+        resolved.push(options[idx - 1].value);
+        continue;
+      }
+    } else if (options.some((o) => o.value === tok)) {
+      resolved.push(tok);
+      continue;
+    }
+    return { error: tok };
+  }
+  return { values: [...new Set(resolved)] };
+}
+
+/** Resolve a multiselect answer (comma-separated indices or values) to a stored list. */
+async function promptMultiSelect(
+  field: EnvField,
+  current: string,
+  ask: Asker,
+  values: Values
+): Promise<string> {
+  const options = (field.optionsWhen ? field.optionsWhen(values) : field.options) ?? [];
+  const currentList = current
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  note(`${field.label}${field.required ? " *" : ""}`);
+  if (field.help) note(field.help);
+  options.forEach((opt, i) => {
+    const marker = currentList.includes(opt.value) ? " (selected)" : "";
+    note(`  ${i + 1}) ${opt.label}${marker}`);
+  });
+  note("Enter comma-separated numbers or values (blank keeps current).");
+
+  for (;;) {
+    const answer = (await ask("> ")).trim();
+    if (answer === "") {
+      if (field.required && currentList.length === 0) {
+        note(`${field.label} is required.`);
+        continue;
+      }
+      return currentList.join(",");
+    }
+
+    const tokens = answer
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const result = resolveMultiSelectTokens(tokens, options);
+    if ("error" in result) {
+      note(`Unknown option: ${result.error} — enter numbers 1-${options.length} or option values.`);
+      continue;
+    }
+    const unique = result.values;
+    if (field.required && unique.length === 0) {
+      note(`${field.label} is required.`);
+      continue;
+    }
+    return unique.join(",");
   }
 }
 
@@ -141,13 +238,15 @@ async function promptField(
   field: EnvField,
   current: string,
   ask: Asker,
-  askMasked: MaskedAsker
+  askMasked: MaskedAsker,
+  values: Values
 ): Promise<string> {
-  if (field.kind === "secret") {
+  if (field.kind === "secret" || (field.secretWhen?.(values) ?? false)) {
     note(`${field.label}: generated`);
     return randomHex32();
   }
-  if (field.kind === "select") return promptSelect(field, current, ask);
+  if (field.kind === "multiselect") return promptMultiSelect(field, current, ask, values);
+  if (field.kind === "select") return promptSelect(field, current, ask, values);
   return promptText(field, current, ask, askMasked);
 }
 
@@ -222,7 +321,7 @@ async function collectInteractively(): Promise<Values> {
         if (meta) note(`\n# ${meta.title}`);
       }
 
-      values[field.key] = await promptField(field, values[field.key] ?? "", ask, askMasked);
+      values[field.key] = await promptField(field, values[field.key] ?? "", ask, askMasked, values);
     }
   } finally {
     rl.close();

--- a/apps/sdp-api/src/configure.node.test.ts
+++ b/apps/sdp-api/src/configure.node.test.ts
@@ -1,8 +1,34 @@
 import { FIELDS, generateEnv } from "@sdp/env-config";
 import { describe, expect, it } from "vitest";
-import { collectFromEnv, getOutPath } from "../scripts/configure";
+import { collectFromEnv, getOutPath, resolveMultiSelectTokens } from "../scripts/configure";
 
 const HEX_64 = /^[0-9a-f]{64}$/;
+
+describe("resolveMultiSelectTokens", () => {
+  const opts = [
+    { value: "local", label: "local" },
+    { value: "fireblocks", label: "Fireblocks" },
+    { value: "privy", label: "Privy" },
+  ];
+
+  it("resolves 1-based indices and option values, preserving order", () => {
+    expect(resolveMultiSelectTokens(["2", "privy"], opts)).toEqual({
+      values: ["fireblocks", "privy"],
+    });
+  });
+
+  it("dedupes repeated selections", () => {
+    expect(resolveMultiSelectTokens(["local", "1", "local"], opts)).toEqual({ values: ["local"] });
+  });
+
+  it("returns the first unknown token as an error", () => {
+    expect(resolveMultiSelectTokens(["local", "bogus"], opts)).toEqual({ error: "bogus" });
+  });
+
+  it("treats an out-of-range index as an error", () => {
+    expect(resolveMultiSelectTokens(["9"], opts)).toEqual({ error: "9" });
+  });
+});
 
 describe("getOutPath", () => {
   it("returns the path after --out", () => {
@@ -54,6 +80,28 @@ describe("collectFromEnv", () => {
     ]) {
       expect(env).toContain(`${key}=`);
     }
+  });
+
+  it("auto-fills the Postgres password by default", () => {
+    expect(collectFromEnv({}).POSTGRES_PASSWORD).toMatch(HEX_64);
+  });
+
+  it("does not auto-fill the Postgres password in manual mode", () => {
+    const values = collectFromEnv({ POSTGRES_PASSWORD_MODE: "manual" });
+    expect(values.POSTGRES_PASSWORD).toBe("");
+  });
+
+  it("derives SIGNING_PROVIDERS from a bare SIGNING_PROVIDER", () => {
+    expect(collectFromEnv({ SIGNING_PROVIDER: "fireblocks" }).SIGNING_PROVIDERS).toBe("fireblocks");
+  });
+
+  it("picks the first listed provider as the default when only SIGNING_PROVIDERS is given", () => {
+    const values = collectFromEnv({ SIGNING_PROVIDERS: "fireblocks,privy" });
+    expect(values.SIGNING_PROVIDER).toBe("fireblocks");
+  });
+
+  it("emits the self_hosted deployment mode constant", () => {
+    expect(generateEnv(collectFromEnv({}))).toContain("SDP_DEPLOYMENT_MODE=self_hosted");
   });
 
   it("emits derived fields without taking them from input", () => {

--- a/apps/sdp-docs/src/components/EnvConfigurator/FieldRenderer.tsx
+++ b/apps/sdp-docs/src/components/EnvConfigurator/FieldRenderer.tsx
@@ -1,37 +1,68 @@
 "use client";
 
-import type { EnvField } from "@sdp/env-config";
+import { type EnvField, parseList, type Values } from "@sdp/env-config";
 
 export interface FieldRowProps {
   field: EnvField;
   value: string;
+  values: Values;
   error?: string;
   onChange: (key: string, value: string) => void;
   onRegenerate: (key: string) => void;
 }
 
-export function FieldRow({ field, value, error, onChange, onRegenerate }: FieldRowProps) {
+export function FieldRow({ field, value, values, error, onChange, onRegenerate }: FieldRowProps) {
   const id = `sdp-cfg-${field.key}`;
   const errorId = error ? `${id}-error` : undefined;
   const helpId = field.help ? `${id}-help` : undefined;
   const describedBy = [helpId, errorId].filter(Boolean).join(" ") || undefined;
 
-  const isSecret = field.kind === "secret";
+  const isSecret = field.kind === "secret" || (field.secretWhen?.(values) ?? false);
   const inputType = field.kind === "password" || field.kind === "secret" ? "password" : "text";
+  const options = field.optionsWhen ? field.optionsWhen(values) : (field.options ?? []);
+  const selected = field.kind === "multiselect" ? parseList(value) : [];
 
   return (
     <div className="sdp-cfg-field">
-      <label className="sdp-cfg-label" htmlFor={id}>
-        {field.label}
-        {field.required ? (
-          <span aria-hidden="true" className="sdp-cfg-required">
-            {" *"}
-          </span>
-        ) : null}
-      </label>
+      {field.kind !== "multiselect" ? (
+        <label className="sdp-cfg-label" htmlFor={id}>
+          {field.label}
+          {field.required ? (
+            <span aria-hidden="true" className="sdp-cfg-required">
+              {" *"}
+            </span>
+          ) : null}
+        </label>
+      ) : null}
 
       <div className="sdp-cfg-control">
-        {field.kind === "select" ? (
+        {field.kind === "multiselect" ? (
+          <fieldset aria-describedby={describedBy} className="sdp-cfg-checks">
+            <legend className="sdp-cfg-label">
+              {field.label}
+              {field.required ? (
+                <span aria-hidden="true" className="sdp-cfg-required">
+                  {" *"}
+                </span>
+              ) : null}
+            </legend>
+            {options.map((opt) => (
+              <label className="sdp-cfg-check" key={opt.value}>
+                <input
+                  checked={selected.includes(opt.value)}
+                  onChange={(e) => {
+                    const next = e.target.checked
+                      ? [...selected, opt.value]
+                      : selected.filter((s) => s !== opt.value);
+                    onChange(field.key, next.join(","));
+                  }}
+                  type="checkbox"
+                />
+                {opt.label}
+              </label>
+            ))}
+          </fieldset>
+        ) : field.kind === "select" ? (
           <select
             aria-describedby={describedBy}
             aria-invalid={error ? true : undefined}
@@ -40,7 +71,7 @@ export function FieldRow({ field, value, error, onChange, onRegenerate }: FieldR
             onChange={(e) => onChange(field.key, e.target.value)}
             value={value}
           >
-            {field.options?.map((opt) => (
+            {options.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
@@ -114,6 +145,7 @@ export function SectionBlock({
       onChange={onChange}
       onRegenerate={onRegenerate}
       value={values[field.key] ?? ""}
+      values={values}
     />
   ));
 

--- a/apps/sdp-docs/src/components/EnvConfigurator/index.tsx
+++ b/apps/sdp-docs/src/components/EnvConfigurator/index.tsx
@@ -6,6 +6,7 @@ import {
   FIELDS,
   generateEnv,
   isFieldVisible,
+  parseList,
   randomHex32,
   SECTIONS,
   type Values,
@@ -13,9 +14,6 @@ import {
 } from "@sdp/env-config";
 import { useEffect, useMemo, useState } from "react";
 import { FieldRow, SectionBlock } from "./FieldRenderer";
-
-const SOURCE_URL =
-  "https://github.com/solana-foundation/solana-developer-platform/tree/main/apps/sdp-docs/src/components/EnvConfigurator";
 
 /**
  * Seed defaults only. Secrets are filled on the client after mount (see useEffect)
@@ -44,29 +42,6 @@ const STYLES = `
 }
 .sdp-cfg * {
   box-sizing: border-box;
-}
-.sdp-cfg-banner {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px 14px;
-  padding: 12px 16px;
-  margin-bottom: 20px;
-  border: 1px solid var(--cfg-border);
-  border-radius: 10px;
-  background: var(--cfg-surface);
-  font-size: 13px;
-  color: var(--cfg-text);
-}
-.sdp-cfg-banner strong {
-  color: var(--cfg-ink);
-}
-.sdp-cfg-banner a {
-  color: var(--cfg-ink);
-  font-weight: 650;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  white-space: nowrap;
 }
 .sdp-cfg-layout {
   display: grid;
@@ -131,6 +106,30 @@ const STYLES = `
   display: flex;
   gap: 8px;
   align-items: stretch;
+}
+.sdp-cfg-checks {
+  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+.sdp-cfg-checks legend {
+  padding: 0;
+  margin-bottom: 6px;
+}
+.sdp-cfg-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--cfg-ink);
+}
+.sdp-cfg-check input {
+  accent-color: var(--cfg-accent);
 }
 .sdp-cfg-input {
   flex: 1 1 auto;
@@ -252,7 +251,7 @@ export function EnvConfigurator() {
   useEffect(() => {
     setValues((prev) => {
       const next = { ...prev };
-      for (const key of autoSecretKeys()) {
+      for (const key of autoSecretKeys(prev)) {
         next[key] = randomHex32();
       }
       return next;
@@ -268,7 +267,23 @@ export function EnvConfigurator() {
   useEffect(() => setCopied(false), [env]);
 
   function setValue(key: string, value: string) {
-    setValues((prev) => ({ ...prev, [key]: value }));
+    setValues((prev) => {
+      const next = { ...prev, [key]: value };
+      // Switching the Postgres password mode resets the value: manual clears it
+      // for typed entry; auto fills a fresh generated secret.
+      if (key === "POSTGRES_PASSWORD_MODE") {
+        next.POSTGRES_PASSWORD = value === "manual" ? "" : randomHex32();
+      }
+      // Keep the default provider valid: if it drops out of the selected set,
+      // fall back to the first selected provider.
+      if (key === "SIGNING_PROVIDERS") {
+        const selected = parseList(value);
+        if (!selected.includes(next.SIGNING_PROVIDER)) {
+          next.SIGNING_PROVIDER = selected[0] ?? "";
+        }
+      }
+      return next;
+    });
   }
 
   function regenerate(key: string) {
@@ -298,16 +313,6 @@ export function EnvConfigurator() {
     <div className="sdp-cfg">
       {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static, component-scoped stylesheet with no user input */}
       <style dangerouslySetInnerHTML={{ __html: STYLES }} />
-
-      <div className="sdp-cfg-banner">
-        <span>
-          <strong>Zero outbound.</strong> Don't trust us? Disconnect your network — this form still
-          generates the .env locally.
-        </span>
-        <a href={SOURCE_URL} rel="noreferrer" target="_blank">
-          View source
-        </a>
-      </div>
 
       <div className="sdp-cfg-layout">
         <div className="sdp-cfg-form">

--- a/packages/sdp-env-config/src/fields.test.ts
+++ b/packages/sdp-env-config/src/fields.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { FIELDS, SECTIONS } from "./fields";
+import { defaultValues } from "./generate";
 import type { SectionId } from "./types";
 
 test("no duplicate field keys", () => {
@@ -13,16 +14,30 @@ test("every field references a declared section", () => {
   for (const f of FIELDS) assert.ok(ids.has(f.section), `unknown section: ${f.section}`);
 });
 
-test("every select field has options", () => {
-  for (const f of FIELDS.filter((f) => f.kind === "select")) {
-    assert.ok(f.options && f.options.length > 0, `${f.key} missing options`);
+test("every select/multiselect field has static or dynamic options", () => {
+  for (const f of FIELDS.filter((f) => f.kind === "select" || f.kind === "multiselect")) {
+    const hasStatic = Boolean(f.options && f.options.length > 0);
+    assert.ok(hasStatic || f.optionsWhen, `${f.key} missing options`);
   }
 });
 
-test("every select field's default value is one of its options", () => {
+test("every select field's default value is one of its (resolved) options", () => {
+  const base = defaultValues();
   for (const f of FIELDS.filter((f) => f.kind === "select")) {
     if (f.defaultValue === undefined) continue;
-    const values = f.options?.map((o) => o.value) ?? [];
+    const opts = f.optionsWhen ? f.optionsWhen(base) : f.options;
+    const values = opts?.map((o) => o.value) ?? [];
     assert.ok(values.includes(f.defaultValue), `${f.key} default ${f.defaultValue} not in options`);
+  }
+});
+
+test("multiselect default values are a subset of options", () => {
+  const base = defaultValues();
+  for (const f of FIELDS.filter((f) => f.kind === "multiselect")) {
+    const opts = (f.optionsWhen ? f.optionsWhen(base) : f.options) ?? [];
+    const allowed = new Set(opts.map((o) => o.value));
+    for (const v of (f.defaultValue ?? "").split(",").filter(Boolean)) {
+      assert.ok(allowed.has(v), `${f.key} default ${v} not in options`);
+    }
   }
 });

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -1,4 +1,4 @@
-import type { EnvField, SectionMeta, Values } from "./types";
+import type { EnvField, SectionMeta, SelectOption, Values } from "./types";
 
 export const SECTIONS: SectionMeta[] = [
   { id: "basic", title: "Basic", comment: "Core runtime" },
@@ -23,6 +23,30 @@ export const SECTIONS: SectionMeta[] = [
 
 const isProvider = (key: string, value: string) => (v: Values) => v[key] === value;
 
+/** Split a comma-separated list value (e.g. SIGNING_PROVIDERS) into trimmed entries. */
+export const parseList = (value: string | undefined): string[] =>
+  value
+    ? value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+/** Predicate: the comma-separated list at `key` includes `value`. */
+const listIncludes = (key: string, value: string) => (v: Values) =>
+  parseList(v[key]).includes(value);
+
+/** Curated provider set the configurator collects full env for. */
+const SIGNING_PROVIDER_OPTIONS: SelectOption[] = [
+  { value: "local", label: "local" },
+  { value: "fireblocks", label: "Fireblocks" },
+  { value: "privy", label: "Privy" },
+  { value: "coinbase_cdp", label: "Coinbase CDP" },
+  { value: "para", label: "Para" },
+  { value: "turnkey", label: "Turnkey" },
+  { value: "utila", label: "Utila" },
+];
+
 export const FIELDS: EnvField[] = [
   // Basic
   {
@@ -35,17 +59,15 @@ export const FIELDS: EnvField[] = [
       { value: "production", label: "production" },
       { value: "development", label: "development" },
     ],
+    help: "App runtime mode: production hardens logging and error handling; development is for local testing.",
   },
   {
+    // Always self-hosted for this configurator; emitted as a constant, not shown.
     key: "SDP_DEPLOYMENT_MODE",
     section: "basic",
-    kind: "select",
+    kind: "text",
     label: "Deployment mode",
-    defaultValue: "self_hosted",
-    options: [
-      { value: "self_hosted", label: "self_hosted" },
-      { value: "managed", label: "managed" },
-    ],
+    derive: () => "self_hosted",
   },
   {
     key: "EMAIL_FROM",
@@ -82,6 +104,28 @@ export const FIELDS: EnvField[] = [
     label: "Postgres user",
     defaultValue: "sdp",
     visibleWhen: isProvider("DATABASE_MODE", "bundled"),
+  },
+  {
+    key: "POSTGRES_PASSWORD_MODE",
+    section: "database",
+    kind: "select",
+    label: "Postgres password",
+    defaultValue: "auto",
+    visibleWhen: isProvider("DATABASE_MODE", "bundled"),
+    options: [
+      { value: "auto", label: "Auto-generate" },
+      { value: "manual", label: "Set manually" },
+    ],
+    help: "Auto-generate a strong password, or set your own.",
+  },
+  {
+    key: "POSTGRES_PASSWORD",
+    section: "database",
+    kind: "password",
+    label: "Password",
+    required: true,
+    visibleWhen: isProvider("DATABASE_MODE", "bundled"),
+    secretWhen: (v) => v.POSTGRES_PASSWORD_MODE !== "manual",
   },
   {
     key: "DATABASE_URL",
@@ -190,23 +234,26 @@ export const FIELDS: EnvField[] = [
 
   // Signing
   {
+    key: "SIGNING_PROVIDERS",
+    section: "signing",
+    kind: "multiselect",
+    label: "Signing providers",
+    defaultValue: "local",
+    required: true,
+    options: SIGNING_PROVIDER_OPTIONS,
+    help: "Providers to prepare credentials for in this .env. The runtime default is chosen below; orgs/projects can later activate any configured provider from the dashboard.",
+  },
+  {
     key: "SIGNING_PROVIDER",
     section: "signing",
     kind: "select",
-    label: "Signing provider",
+    label: "Default signing provider",
     defaultValue: "local",
-    // Curated set this configurator supports: managed backends whose full env
-    // surface the form collects. Other adapters the API ships (e.g. dfns,
-    // anchorage) are intentionally not offered here.
-    options: [
-      { value: "local", label: "local" },
-      { value: "fireblocks", label: "Fireblocks" },
-      { value: "privy", label: "Privy" },
-      { value: "coinbase_cdp", label: "Coinbase CDP" },
-      { value: "para", label: "Para" },
-      { value: "turnkey", label: "Turnkey" },
-      { value: "utila", label: "Utila" },
-    ],
+    optionsWhen: (v) =>
+      parseList(v.SIGNING_PROVIDERS).map(
+        (p) => SIGNING_PROVIDER_OPTIONS.find((o) => o.value === p) ?? { value: p, label: p }
+      ),
+    help: "Global fallback provider, used when an org/project has no custody config of its own.",
   },
   {
     key: "CUSTODY_PRIVATE_KEY",
@@ -214,7 +261,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Signing key (base58)",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "local"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "local"),
     help: "Base58 private key the local signer uses. Generate one and fund it on your network.",
   },
   {
@@ -223,7 +270,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Fireblocks API key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "fireblocks"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "fireblocks"),
   },
   {
     key: "FIREBLOCKS_API_SECRET",
@@ -231,7 +278,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Fireblocks API secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "fireblocks"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "fireblocks"),
   },
   {
     key: "FIREBLOCKS_VAULT_ID",
@@ -239,7 +286,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Fireblocks vault ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "fireblocks"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "fireblocks"),
   },
   {
     key: "PRIVY_APP_ID",
@@ -247,7 +294,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Privy app ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "privy"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "privy"),
   },
   {
     key: "PRIVY_APP_SECRET",
@@ -255,7 +302,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Privy app secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "privy"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "privy"),
   },
   {
     key: "PRIVY_WALLET_ID",
@@ -263,7 +310,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Privy wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "privy"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "privy"),
   },
   {
     key: "COINBASE_CDP_API_KEY_ID",
@@ -271,7 +318,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Coinbase CDP API key ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "COINBASE_CDP_API_KEY_SECRET",
@@ -279,7 +326,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Coinbase CDP API key secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "COINBASE_CDP_WALLET_SECRET",
@@ -287,7 +334,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Coinbase CDP wallet secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "COINBASE_CDP_WALLET_ID",
@@ -295,7 +342,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Coinbase CDP wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "PARA_API_KEY",
@@ -303,7 +350,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Para API key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "para"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "para"),
   },
   {
     key: "PARA_WALLET_ID",
@@ -311,7 +358,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Para wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "para"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "para"),
   },
   {
     key: "TURNKEY_API_PUBLIC_KEY",
@@ -319,7 +366,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey API public key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_API_PRIVATE_KEY",
@@ -327,7 +374,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Turnkey API private key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_ORGANIZATION_ID",
@@ -335,7 +382,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey organization ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_PRIVATE_KEY_ID",
@@ -343,7 +390,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey private key ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_PUBLIC_KEY",
@@ -351,7 +398,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey public key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "UTILA_SERVICE_ACCOUNT_EMAIL",
@@ -359,7 +406,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila service account email",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^[^@\s]+@vault\.[^@\s]+\.utilaserviceaccount\.io$/,
   },
   {
@@ -368,7 +415,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Utila service account private key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     help: "PKCS#8 private key PEM for the Utila service account. Use escaped newlines when storing in .env.",
   },
   {
@@ -377,7 +424,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila vault ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
   },
   {
     key: "UTILA_WALLET_ID",
@@ -385,7 +432,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
   },
   {
     key: "UTILA_NETWORK",
@@ -394,7 +441,7 @@ export const FIELDS: EnvField[] = [
     label: "Utila network",
     defaultValue: "networks/solana-devnet",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     options: [
       { value: "networks/solana-devnet", label: "Solana devnet" },
       { value: "networks/solana-mainnet", label: "Solana mainnet" },
@@ -406,7 +453,7 @@ export const FIELDS: EnvField[] = [
     kind: "url",
     label: "Utila API base URL",
     defaultValue: "https://api.utila.io",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^https:\/\//,
   },
   {
@@ -415,7 +462,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila poll interval (ms)",
     defaultValue: "1000",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^[1-9]\d*$/,
   },
   {
@@ -424,7 +471,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila max poll attempts",
     defaultValue: "60",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^[1-9]\d*$/,
   },
   {
@@ -432,7 +479,7 @@ export const FIELDS: EnvField[] = [
     section: "signing",
     kind: "text",
     label: "Utila designated signers",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     help: "Comma-separated Utila user resources. Leave empty to default to users/$UTILA_SERVICE_ACCOUNT_EMAIL.",
   },
 
@@ -479,13 +526,6 @@ export const FIELDS: EnvField[] = [
     section: "secrets",
     kind: "secret",
     label: "Custody encryption key",
-    required: true,
-  },
-  {
-    key: "POSTGRES_PASSWORD",
-    section: "secrets",
-    kind: "secret",
-    label: "Postgres password",
     required: true,
   },
 
@@ -570,7 +610,12 @@ export const FIELDS: EnvField[] = [
 ];
 
 /** Keys that hold compose-only UI state and must NOT be emitted into the .env. */
-export const UI_ONLY_KEYS = new Set(["DATABASE_MODE", "CACHE_MODE"]);
+export const UI_ONLY_KEYS = new Set([
+  "DATABASE_MODE",
+  "CACHE_MODE",
+  "SIGNING_PROVIDERS",
+  "POSTGRES_PASSWORD_MODE",
+]);
 
 /** A field is visible unless its visibleWhen predicate returns false. */
 export function isFieldVisible(field: EnvField, values: Values): boolean {

--- a/packages/sdp-env-config/src/generate.test.ts
+++ b/packages/sdp-env-config/src/generate.test.ts
@@ -28,6 +28,13 @@ test("UI-only selector keys are never emitted", () => {
   const env = generateEnv(defaultValues());
   assert.doesNotMatch(env, /^DATABASE_MODE=/m);
   assert.doesNotMatch(env, /^CACHE_MODE=/m);
+  assert.doesNotMatch(env, /^SIGNING_PROVIDERS=/m);
+  assert.doesNotMatch(env, /^POSTGRES_PASSWORD_MODE=/m);
+});
+
+test("deployment mode is emitted as the self_hosted constant", () => {
+  const env = generateEnv(defaultValues());
+  assert.match(env, /^SDP_DEPLOYMENT_MODE=self_hosted$/m);
 });
 
 test("invisible conditional fields are skipped", () => {

--- a/packages/sdp-env-config/src/secrets.test.ts
+++ b/packages/sdp-env-config/src/secrets.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { defaultValues } from "./generate";
 import { autoSecretKeys, randomHex32 } from "./secrets";
 
 test("randomHex32 returns 64 lowercase hex chars", () => {
@@ -11,10 +12,17 @@ test("successive calls differ", () => {
   assert.notEqual(randomHex32(), randomHex32());
 });
 
-test("autoSecretKeys lists the secret-kind field keys", () => {
-  assert.deepEqual([...autoSecretKeys()].sort(), [
-    "API_KEY_PEPPER",
-    "CUSTODY_ENCRYPTION_KEY",
-    "POSTGRES_PASSWORD",
-  ]);
+test("autoSecretKeys without values lists only secret-kind fields", () => {
+  assert.deepEqual([...autoSecretKeys()].sort(), ["API_KEY_PEPPER", "CUSTODY_ENCRYPTION_KEY"]);
+});
+
+test("autoSecretKeys with default values includes the auto-mode Postgres password", () => {
+  const keys = autoSecretKeys(defaultValues());
+  assert.ok(keys.has("POSTGRES_PASSWORD"));
+  assert.ok(keys.has("API_KEY_PEPPER"));
+});
+
+test("autoSecretKeys excludes the Postgres password in manual mode", () => {
+  const keys = autoSecretKeys({ ...defaultValues(), POSTGRES_PASSWORD_MODE: "manual" });
+  assert.ok(!keys.has("POSTGRES_PASSWORD"));
 });

--- a/packages/sdp-env-config/src/secrets.ts
+++ b/packages/sdp-env-config/src/secrets.ts
@@ -1,4 +1,5 @@
 import { FIELDS } from "./fields";
+import type { Values } from "./types";
 
 /** 32 random bytes as lowercase hex — equivalent to `openssl rand -hex 32`. */
 export function randomHex32(): string {
@@ -8,7 +9,15 @@ export function randomHex32(): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-/** Keys whose field kind is "secret". */
-export function autoSecretKeys(): Set<string> {
-  return new Set(FIELDS.filter((f) => f.kind === "secret").map((f) => f.key));
+/**
+ * Keys to auto-generate as secrets. Always includes `kind: "secret"` fields;
+ * when `values` are supplied, also includes fields whose `secretWhen(values)`
+ * holds (e.g. an auto-mode Postgres password).
+ */
+export function autoSecretKeys(values?: Values): Set<string> {
+  return new Set(
+    FIELDS.filter(
+      (f) => f.kind === "secret" || (values ? (f.secretWhen?.(values) ?? false) : false)
+    ).map((f) => f.key)
+  );
 }

--- a/packages/sdp-env-config/src/types.ts
+++ b/packages/sdp-env-config/src/types.ts
@@ -9,7 +9,7 @@ export type SectionId =
   | "secrets"
   | "advanced";
 
-export type FieldKind = "text" | "url" | "password" | "secret" | "select";
+export type FieldKind = "text" | "url" | "password" | "secret" | "select" | "multiselect";
 
 export type Values = Record<string, string>;
 
@@ -30,10 +30,21 @@ export interface EnvField {
   required?: boolean;
   /** Options for kind: "select". */
   options?: SelectOption[];
+  /**
+   * Dynamic options for "select"/"multiselect", computed from current values.
+   * When present it overrides `options` for both rendering and validation.
+   */
+  optionsWhen?: (v: Values) => SelectOption[];
   /** Validation pattern source; tested in validate.ts. */
   pattern?: RegExp;
   /** Visibility predicate over current values; absent ⇒ always visible. */
   visibleWhen?: (v: Values) => boolean;
+  /**
+   * When this predicate holds, `autoSecretKeys(values)` includes this field's key
+   * so callers can fill it with a generated secret; otherwise it is treated as a
+   * normal required input. Lets one field switch between generated and manual entry.
+   */
+  secretWhen?: (v: Values) => boolean;
   /** Computed from other values; hidden from the form, always emitted. */
   derive?: (values: Values) => string;
 }

--- a/packages/sdp-env-config/src/validate.test.ts
+++ b/packages/sdp-env-config/src/validate.test.ts
@@ -19,11 +19,15 @@ test("valid value has no error", () => {
 });
 
 test("invisible required field is not validated", () => {
-  // CUSTODY_PRIVATE_KEY is required but hidden unless SIGNING_PROVIDER=local
+  // CUSTODY_PRIVATE_KEY is required but hidden unless "local" is in SIGNING_PROVIDERS.
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "fireblocks",
     SIGNING_PROVIDER: "fireblocks",
     CUSTODY_PRIVATE_KEY: "",
+    FIREBLOCKS_API_KEY: "k",
+    FIREBLOCKS_API_SECRET: "s",
+    FIREBLOCKS_VAULT_ID: "0",
   });
   assert.equal(errors.CUSTODY_PRIVATE_KEY, undefined);
 });
@@ -41,6 +45,7 @@ test("a valid select value has no error", () => {
 test("managed signing with native fees requires a fee payer key", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "fireblocks",
     SIGNING_PROVIDER: "fireblocks",
     FEE_PAYMENT_PROVIDER: "native",
     FEE_PAYER_PRIVATE_KEY: "",
@@ -51,7 +56,9 @@ test("managed signing with native fees requires a fee payer key", () => {
 test("local signing with native fees does not require a fee payer key", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "local",
     SIGNING_PROVIDER: "local",
+    CUSTODY_PRIVATE_KEY: "k",
     FEE_PAYMENT_PROVIDER: "native",
     FEE_PAYER_PRIVATE_KEY: "",
   });
@@ -61,6 +68,7 @@ test("local signing with native fees does not require a fee payer key", () => {
 test("utila signing requires Utila credentials", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "utila",
     SIGNING_PROVIDER: "utila",
     FEE_PAYMENT_PROVIDER: "kora",
     UTILA_SERVICE_ACCOUNT_EMAIL: "",
@@ -78,6 +86,7 @@ test("utila signing requires Utila credentials", () => {
 test("valid utila signing config has no Utila field errors", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "utila",
     SIGNING_PROVIDER: "utila",
     FEE_PAYMENT_PROVIDER: "kora",
     UTILA_SERVICE_ACCOUNT_EMAIL: "service@vault.example.utilaserviceaccount.io",
@@ -105,6 +114,29 @@ test("valid utila signing config has no Utila field errors", () => {
   ]) {
     assert.equal(errors[key], undefined, `${key}: ${errors[key]}`);
   }
+});
+
+test("an unknown provider in SIGNING_PROVIDERS reports an error", () => {
+  const errors = validateValues({ ...defaultValues(), SIGNING_PROVIDERS: "local,bogus" });
+  assert.match(errors.SIGNING_PROVIDERS ?? "", /must be one of/);
+});
+
+test("a default provider outside the selected set reports an error", () => {
+  const errors = validateValues({
+    ...defaultValues(),
+    SIGNING_PROVIDERS: "local",
+    SIGNING_PROVIDER: "fireblocks",
+  });
+  assert.match(errors.SIGNING_PROVIDER ?? "", /must be one of: local/);
+});
+
+test("manual Postgres password is required when empty", () => {
+  const errors = validateValues({
+    ...defaultValues(),
+    POSTGRES_PASSWORD_MODE: "manual",
+    POSTGRES_PASSWORD: "",
+  });
+  assert.ok(errors.POSTGRES_PASSWORD);
 });
 
 test("a value with a newline is rejected as multi-line", () => {

--- a/packages/sdp-env-config/src/validate.ts
+++ b/packages/sdp-env-config/src/validate.ts
@@ -1,38 +1,63 @@
-import { FIELDS, isFieldVisible } from "./fields";
-import type { Values } from "./types";
+import { FIELDS, isFieldVisible, parseList } from "./fields";
+import type { EnvField, Values } from "./types";
 
 export type Errors = Record<string, string>;
 
-/** Validate only visible fields: required-but-empty and pattern mismatches. */
+/** Resolve a field's options, preferring the dynamic `optionsWhen` when present. */
+function resolveOptions(field: EnvField, values: Values) {
+  return field.optionsWhen ? field.optionsWhen(values) : field.options;
+}
+
+/**
+ * A select/multiselect must hold values drawn from its (possibly dynamic)
+ * options; this also catches a bad value injected via the environment.
+ * Returns an error message, or undefined when the values are acceptable.
+ */
+function optionMembershipError(
+  field: EnvField,
+  values: Values,
+  selected: string[]
+): string | undefined {
+  if (field.kind !== "select" && field.kind !== "multiselect") return undefined;
+  const opts = resolveOptions(field, values);
+  // Skip membership when there are no resolvable options yet (e.g. a default
+  // select whose options depend on a not-yet-chosen list): let the upstream
+  // field's own error stand instead of an empty "must be one of: " message.
+  if (!opts || opts.length === 0) return undefined;
+  const allowed = opts.map((o) => o.value);
+  if (selected.some((s) => !allowed.includes(s))) {
+    return `${field.label} must be one of: ${allowed.join(", ")}`;
+  }
+  return undefined;
+}
+
+/** Validate a single visible field; returns an error message or undefined. */
+function validateField(f: EnvField, values: Values): string | undefined {
+  const value = (values[f.key] ?? "").trim();
+  const isMultiselect = f.kind === "multiselect";
+  // A multiselect's emptiness is about its parsed entries, not the raw string,
+  // so a value like ",," counts as empty rather than satisfying `required`.
+  const selected = isMultiselect ? parseList(value) : value === "" ? [] : [value];
+
+  if (f.required && (isMultiselect ? selected.length === 0 : value === "")) {
+    return `${f.label} is required`;
+  }
+  if (value === "") return undefined;
+  // Reject control characters that could inject additional .env lines.
+  if (/[\r\n\0]/.test(value)) return `${f.label} must be a single line`;
+  if (f.pattern && !f.pattern.test(value)) return `${f.label} has an invalid format`;
+  return optionMembershipError(f, values, selected);
+}
+
+/** Validate only visible fields: required-but-empty, pattern, and option membership. */
 export function validateValues(values: Values): Errors {
   const errors: Errors = {};
   for (const f of FIELDS) {
     // Derived fields are computed, not user input — nothing to validate.
     if (f.derive) continue;
     if (!isFieldVisible(f, values)) continue;
-    const value = (values[f.key] ?? "").trim();
-
-    if (f.required && value === "") {
-      errors[f.key] = `${f.label} is required`;
-      continue;
-    }
-    // Reject control characters that could inject additional .env lines.
-    if (value !== "" && /[\r\n\0]/.test(value)) {
-      errors[f.key] = `${f.label} must be a single line`;
-      continue;
-    }
-    if (value !== "" && f.pattern && !f.pattern.test(value)) {
-      errors[f.key] = `${f.label} has an invalid format`;
-      continue;
-    }
-    // A select must hold one of its declared options; this catches a bad value
-    // injected through the environment in the non-interactive path.
-    if (value !== "" && f.kind === "select" && f.options) {
-      const allowed = f.options.map((o) => o.value);
-      if (!allowed.includes(value)) {
-        errors[f.key] = `${f.label} must be one of: ${allowed.join(", ")}`;
-      }
-    }
+    const error = validateField(f, values);
+    if (error) errors[f.key] = error;
   }
   return errors;
 }

--- a/scripts/check-env-configurator-drift.mjs
+++ b/scripts/check-env-configurator-drift.mjs
@@ -9,7 +9,12 @@ const ENV_EXAMPLE = path.join(repoRoot, "infra/self-hosted/.env.example");
 const FIELDS_FILE = path.join(repoRoot, "packages/sdp-env-config/src/fields.ts");
 
 // UI-only selectors that are not real env vars (see fields.ts UI_ONLY_KEYS).
-const IGNORE = new Set(["DATABASE_MODE", "CACHE_MODE"]);
+const IGNORE = new Set([
+  "DATABASE_MODE",
+  "CACHE_MODE",
+  "SIGNING_PROVIDERS",
+  "POSTGRES_PASSWORD_MODE",
+]);
 
 /** Keys declared in .env.example, including commented optionals (`# KEY=`). */
 function readExampleKeys() {

--- a/scripts/check-env-contract.mjs
+++ b/scripts/check-env-contract.mjs
@@ -41,6 +41,8 @@ const API_ENV_IGNORE = new Set([
   "SDP_CACHE",
   "SDP_RATE_LIMITS",
   "SDP_SESSIONS",
+  // Configurator-only input key (UI-only in @sdp/env-config); not an sdp-api runtime binding.
+  "SIGNING_PROVIDERS",
   "TRITON_API_KEY",
 ]);
 


### PR DESCRIPTION
## HOO-520 — Self-hosted .env configurator rework

Reworks the self-hosted configurator end-to-end across the shared core (`@sdp/env-config`), the CLI (`apps/sdp-api/scripts/configure.ts`), and the web form (`apps/sdp-docs/.../EnvConfigurator`). **No backend changes.**

### Requirements closed

| # | Requirement | How |
|---|---|---|
| 1 | Environment vs deployment | `ENVIRONMENT` gains help text; `SDP_DEPLOYMENT_MODE` leaves the form and is emitted as the derived `self_hosted` constant |
| 2 | Postgres password auto/manual | `POSTGRES_PASSWORD_MODE` (auto/manual) drives generate-vs-enter via a new `secretWhen` field hook |
| 3 | "Zero outbound" banner | Removed (JSX + source link + CSS) |
| 4 | Multiple signing providers | `SIGNING_PROVIDERS` (UI-only multiselect) controls which credential blocks show; `SIGNING_PROVIDER` is the default, with options derived from the selected set |

### Core (`@sdp/env-config`)

- New `multiselect` field kind
- `optionsWhen` / `secretWhen` field hooks
- values-aware `autoSecretKeys`
- extracted + unit-tested `resolveMultiSelectTokens` parser
- env-drift and env-contract guards exclude the new UI-only keys

### Verification

- `@sdp/env-config` tests: **33/33**
- `configure.node` tests: **17/17**
- typecheck (env-config + sdp-api + sdp-docs): clean
- biome lint: clean
- `check:env-configurator-drift`: ok
