### PR TITLE
feat: HOO-520 self-hosting docs section + .env configurator optimization

### DIFF
--- a/apps/sdp-api/scripts/configure.ts
+++ b/apps/sdp-api/scripts/configure.ts
@@ -23,8 +23,10 @@ import {
   FIELDS,
   generateEnv,
   isFieldVisible,
+  parseList,
   randomHex32,
   SECTIONS,
+  type SelectOption,
   type Values,
   validateValues,
 } from "@sdp/env-config";
@@ -47,7 +49,18 @@ export function collectFromEnv(env: Record<string, string | undefined>): Values 
   if (typeof env.DATABASE_URL === "string" && env.DATABASE_URL !== "") {
     values.DATABASE_MODE = "external";
   }
-  for (const key of autoSecretKeys()) {
+  // Keep SIGNING_PROVIDERS and the default SIGNING_PROVIDER consistent for the
+  // non-interactive path: derive the list from a bare provider, or pick the
+  // first listed provider as the default when only the list was given.
+  if (env.SIGNING_PROVIDERS === undefined) {
+    values.SIGNING_PROVIDERS = values.SIGNING_PROVIDER || "local";
+  } else if (env.SIGNING_PROVIDER === undefined) {
+    const list = parseList(values.SIGNING_PROVIDERS);
+    if (list.length > 0) {
+      values.SIGNING_PROVIDER = list[0];
+    }
+  }
+  for (const key of autoSecretKeys(values)) {
     if (!values[key]) values[key] = randomHex32();
   }
   return values;
@@ -78,17 +91,27 @@ class PromptAbortError extends Error {
 }
 
 /** Resolve a select answer (1-based index or option value) to a stored value. */
-async function promptSelect(field: EnvField, current: string, ask: Asker): Promise<string> {
-  const options = field.options ?? [];
+async function promptSelect(
+  field: EnvField,
+  current: string,
+  ask: Asker,
+  values: Values
+): Promise<string> {
+  const options = (field.optionsWhen ? field.optionsWhen(values) : field.options) ?? [];
+  // If the carried default is no longer a valid option, fall back to the first.
+  const safeCurrent = options.some((o) => o.value === current)
+    ? current
+    : (options[0]?.value ?? current);
   note(field.label);
+  if (field.help) note(field.help);
   options.forEach((opt, i) => {
-    const marker = opt.value === current ? " (default)" : "";
+    const marker = opt.value === safeCurrent ? " (default)" : "";
     note(`  ${i + 1}) ${opt.label}${marker}`);
   });
 
   for (;;) {
     const answer = (await ask("> ")).trim();
-    if (answer === "") return current;
+    if (answer === "") return safeCurrent;
 
     if (/^\d+$/.test(answer)) {
       const byIndex = Number.parseInt(answer, 10);
@@ -103,6 +126,77 @@ async function promptSelect(field: EnvField, current: string, ask: Asker): Promi
     note(
       `Unknown option: ${answer} — enter a number 1-${options.length}, an option value, or blank.`
     );
+  }
+}
+
+/**
+ * Resolve raw multiselect tokens (1-based indices or option values) to option
+ * values, preserving order and dropping duplicates. Returns the first
+ * unrecognized token as an error rather than silently dropping it.
+ */
+export function resolveMultiSelectTokens(
+  tokens: string[],
+  options: SelectOption[]
+): { values: string[] } | { error: string } {
+  const resolved: string[] = [];
+  for (const tok of tokens) {
+    if (/^\d+$/.test(tok)) {
+      const idx = Number.parseInt(tok, 10);
+      if (idx >= 1 && idx <= options.length) {
+        resolved.push(options[idx - 1].value);
+        continue;
+      }
+    } else if (options.some((o) => o.value === tok)) {
+      resolved.push(tok);
+      continue;
+    }
+    return { error: tok };
+  }
+  return { values: [...new Set(resolved)] };
+}
+
+/** Resolve a multiselect answer (comma-separated indices or values) to a stored list. */
+async function promptMultiSelect(
+  field: EnvField,
+  current: string,
+  ask: Asker,
+  values: Values
+): Promise<string> {
+  const options = (field.optionsWhen ? field.optionsWhen(values) : field.options) ?? [];
+  const currentList = parseList(current);
+  note(`${field.label}${field.required ? " *" : ""}`);
+  if (field.help) note(field.help);
+  options.forEach((opt, i) => {
+    const marker = currentList.includes(opt.value) ? " (selected)" : "";
+    note(`  ${i + 1}) ${opt.label}${marker}`);
+  });
+  note("Enter comma-separated numbers or values (blank keeps current).");
+
+  for (;;) {
+    const answer = (await ask("> ")).trim();
+    if (answer === "") {
+      if (field.required && currentList.length === 0) {
+        note(`${field.label} is required.`);
+        continue;
+      }
+      return currentList.join(",");
+    }
+
+    const tokens = answer
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const result = resolveMultiSelectTokens(tokens, options);
+    if ("error" in result) {
+      note(`Unknown option: ${result.error} — enter numbers 1-${options.length} or option values.`);
+      continue;
+    }
+    const unique = result.values;
+    if (field.required && unique.length === 0) {
+      note(`${field.label} is required.`);
+      continue;
+    }
+    return unique.join(",");
   }
 }
 
@@ -141,13 +235,15 @@ async function promptField(
   field: EnvField,
   current: string,
   ask: Asker,
-  askMasked: MaskedAsker
+  askMasked: MaskedAsker,
+  values: Values
 ): Promise<string> {
-  if (field.kind === "secret") {
+  if (field.kind === "secret" || (field.secretWhen?.(values) ?? false)) {
     note(`${field.label}: generated`);
     return randomHex32();
   }
-  if (field.kind === "select") return promptSelect(field, current, ask);
+  if (field.kind === "multiselect") return promptMultiSelect(field, current, ask, values);
+  if (field.kind === "select") return promptSelect(field, current, ask, values);
   return promptText(field, current, ask, askMasked);
 }
 
@@ -222,7 +318,7 @@ async function collectInteractively(): Promise<Values> {
         if (meta) note(`\n# ${meta.title}`);
       }
 
-      values[field.key] = await promptField(field, values[field.key] ?? "", ask, askMasked);
+      values[field.key] = await promptField(field, values[field.key] ?? "", ask, askMasked, values);
     }
   } finally {
     rl.close();

--- a/apps/sdp-api/scripts/configure.ts
+++ b/apps/sdp-api/scripts/configure.ts
@@ -324,6 +324,12 @@ async function collectInteractively(): Promise<Values> {
     rl.close();
   }
 
+  // Fill any auto-secret the prompt loop skipped, including an always-emitted
+  // field hidden by the current answers (e.g. POSTGRES_PASSWORD with an external
+  // database), which compose still requires.
+  for (const key of autoSecretKeys(values)) {
+    if (!values[key]) values[key] = randomHex32();
+  }
   return values;
 }
 

--- a/apps/sdp-api/src/configure.node.test.ts
+++ b/apps/sdp-api/src/configure.node.test.ts
@@ -60,6 +60,24 @@ describe("collectFromEnv", () => {
     expect(env).toContain("DATABASE_URL=postgresql://u@h:5432/d");
   });
 
+  it("still emits POSTGRES_PASSWORD with an external database", () => {
+    // External mode hides the field, but compose's bundled Postgres still needs it.
+    const env = generateEnv(collectFromEnv({ DATABASE_URL: "postgresql://u@h:5432/d" }));
+    expect(env).toMatch(/^POSTGRES_PASSWORD=[0-9a-f]{64}$/m);
+  });
+
+  it("emits POSTGRES_PASSWORD for an external DB even when manual mode is set", () => {
+    // Manual mode is a bundled-DB choice; it must not suppress the password the
+    // bundled container still requires under an external database.
+    const env = generateEnv(
+      collectFromEnv({
+        DATABASE_URL: "postgresql://u@h:5432/d",
+        POSTGRES_PASSWORD_MODE: "manual",
+      })
+    );
+    expect(env).toMatch(/^POSTGRES_PASSWORD=[0-9a-f]{64}$/m);
+  });
+
   it("generates a non-empty .env containing the required keys", () => {
     const env = generateEnv(
       collectFromEnv({

--- a/apps/sdp-api/src/configure.node.test.ts
+++ b/apps/sdp-api/src/configure.node.test.ts
@@ -1,8 +1,34 @@
 import { FIELDS, generateEnv } from "@sdp/env-config";
 import { describe, expect, it } from "vitest";
-import { collectFromEnv, getOutPath } from "../scripts/configure";
+import { collectFromEnv, getOutPath, resolveMultiSelectTokens } from "../scripts/configure";
 
 const HEX_64 = /^[0-9a-f]{64}$/;
+
+describe("resolveMultiSelectTokens", () => {
+  const opts = [
+    { value: "local", label: "local" },
+    { value: "fireblocks", label: "Fireblocks" },
+    { value: "privy", label: "Privy" },
+  ];
+
+  it("resolves 1-based indices and option values, preserving order", () => {
+    expect(resolveMultiSelectTokens(["2", "privy"], opts)).toEqual({
+      values: ["fireblocks", "privy"],
+    });
+  });
+
+  it("dedupes repeated selections", () => {
+    expect(resolveMultiSelectTokens(["local", "1", "local"], opts)).toEqual({ values: ["local"] });
+  });
+
+  it("returns the first unknown token as an error", () => {
+    expect(resolveMultiSelectTokens(["local", "bogus"], opts)).toEqual({ error: "bogus" });
+  });
+
+  it("treats an out-of-range index as an error", () => {
+    expect(resolveMultiSelectTokens(["9"], opts)).toEqual({ error: "9" });
+  });
+});
 
 describe("getOutPath", () => {
   it("returns the path after --out", () => {
@@ -54,6 +80,33 @@ describe("collectFromEnv", () => {
     ]) {
       expect(env).toContain(`${key}=`);
     }
+  });
+
+  it("auto-fills the Postgres password by default", () => {
+    expect(collectFromEnv({}).POSTGRES_PASSWORD).toMatch(HEX_64);
+  });
+
+  it("does not auto-fill the Postgres password in manual mode", () => {
+    const values = collectFromEnv({ POSTGRES_PASSWORD_MODE: "manual" });
+    expect(values.POSTGRES_PASSWORD).toBe("");
+  });
+
+  it("derives SIGNING_PROVIDERS from a bare SIGNING_PROVIDER", () => {
+    expect(collectFromEnv({ SIGNING_PROVIDER: "fireblocks" }).SIGNING_PROVIDERS).toBe("fireblocks");
+  });
+
+  it("picks the first listed provider as the default when only SIGNING_PROVIDERS is given", () => {
+    const values = collectFromEnv({ SIGNING_PROVIDERS: "fireblocks,privy" });
+    expect(values.SIGNING_PROVIDER).toBe("fireblocks");
+  });
+
+  it("picks the first listed provider even when the field default is also listed", () => {
+    const values = collectFromEnv({ SIGNING_PROVIDERS: "fireblocks,local" });
+    expect(values.SIGNING_PROVIDER).toBe("fireblocks");
+  });
+
+  it("emits the self_hosted deployment mode constant", () => {
+    expect(generateEnv(collectFromEnv({}))).toContain("SDP_DEPLOYMENT_MODE=self_hosted");
   });
 
   it("emits derived fields without taking them from input", () => {

--- a/apps/sdp-docs/content/docs/self-hosting/env-reference.mdx
+++ b/apps/sdp-docs/content/docs/self-hosting/env-reference.mdx
@@ -1,0 +1,93 @@
+---
+title: Environment Reference
+description: The configuration variables a self-hosted Solana Developer Platform reads from .env.
+---
+
+The self-hosted stack reads its configuration from a single `.env` file next to
+`compose.yml`. The [configurator](/docs/self-hosting/configurator) is the
+authoritative source of the field list, defaults, and validation — it always
+matches the release you installed. This page explains how the configuration is
+organized and the variables you are most likely to set by hand.
+
+The configurator groups variables into sections:
+
+| Section | What it covers |
+|---|---|
+| Basic | Core runtime — environment, deployment mode, sender email. |
+| Database | Bundled Postgres or an external database. |
+| Cache | Bundled Redis or an external cache. |
+| Solana RPC | Network and RPC endpoint. |
+| Authentication (Clerk) | Required Clerk keys and JWT settings. |
+| Signing provider | Which signer(s) to enable and their credentials. |
+| Fee payment | How transaction fees are paid. |
+| Secrets | App secrets, generated locally. |
+| Advanced | Image source, ports, and internal service URLs. |
+
+## Required variables
+
+These must be set or the stack will refuse to start:
+
+| Variable | Description |
+|---|---|
+| `POSTGRES_PASSWORD` | Password for the bundled Postgres. Always required — the bundled `postgres` service starts even when the API points at an external `DATABASE_URL`. |
+| `API_KEY_PEPPER` | Server-side pepper for API key hashing. Generate with `openssl rand -hex 32`. |
+| `CUSTODY_ENCRYPTION_KEY` | Encryption key for custody material at rest. Generate with `openssl rand -hex 32`. |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk publishable key for the web app. |
+| `CLERK_SECRET_KEY` | Clerk secret key for the API. |
+| `CLERK_ISSUER` | Clerk issuer URL used to validate tokens. |
+| `SOLANA_RPC_URL` | Solana RPC endpoint the API calls. |
+| `SIGNING_PROVIDER` | The default signing provider. Each non-local provider adds its own required credentials. |
+
+The configurator generates `API_KEY_PEPPER` and `CUSTODY_ENCRYPTION_KEY` for you
+and can auto-generate `POSTGRES_PASSWORD`.
+
+## Database
+
+In the configurator, `DATABASE_MODE` chooses between the bundled Postgres and an
+external database. It is a generation-time selector and is not written to `.env`.
+
+For the bundled database, set `POSTGRES_DB`, `POSTGRES_USER`, and
+`POSTGRES_PASSWORD`; the API and migration services build their connection string
+from them. To use an external database, set `DATABASE_URL` to your own
+`postgresql://…` string and the API and migrations connect there instead. Note
+that `compose.yml` always starts the bundled `postgres` container — with an
+external `DATABASE_URL` it simply goes unused, and `POSTGRES_PASSWORD` is still
+required for it to start.
+
+The configurator hides `POSTGRES_PASSWORD` once you select an external database
+but still emits an auto-generated value for it, since the bundled `postgres`
+container needs one to start even when nothing connects to it.
+
+## Cache
+
+Like `DATABASE_MODE`, `CACHE_MODE` is a configurator-only selector and is not
+written to `.env`. To use an external cache, set `REDIS_URL` to your own
+`redis://…` endpoint; the bundled `redis` container still starts but goes unused.
+
+## Signing providers
+
+`SIGNING_PROVIDER` is the default signer written to `.env`. Supported values are
+`local`, `fireblocks`, `privy`, `coinbase_cdp`, `para`, `turnkey`, and `utila`.
+The configurator also tracks a `SIGNING_PROVIDERS` selection to decide which
+fields to show, but that key is configurator-only and is not written to `.env`.
+Each non-local provider requires its own credentials — for example Fireblocks
+needs an API key, secret, and vault ID — and the configurator only prompts for
+the providers you enable.
+
+For provider-managed co-signer runtimes that live outside the default stack, see
+[External co-signers](/docs/self-hosting/external-co-signers).
+
+## Advanced
+
+| Variable | Default | Description |
+|---|---|---|
+| `SDP_IMAGE_REGISTRY` | `ghcr.io/solana-foundation/sdp` | Registry the service images are pulled from. |
+| `SDP_VERSION` | `latest` | Image tag for every SDP service. Pin this to a release tag in production. |
+| `SDP_API_PORT` | `8787` | Host port for the API. |
+| `SDP_WEB_PORT` | `3000` | Host port for the dashboard. |
+| `SDP_DOCS_PORT` | `3001` | Host port for these docs. |
+
+`SDP_API_BASE_URL` defaults to the in-network service name `http://sdp-api:8787`
+for server-to-server calls. The browser-facing `NEXT_PUBLIC_*` URLs default to
+`localhost` (for example `http://localhost:8787` and `http://localhost:3000`) and
+need changing when you put the services behind your own domains or ingress.

--- a/apps/sdp-docs/content/docs/self-hosting/index.mdx
+++ b/apps/sdp-docs/content/docs/self-hosting/index.mdx
@@ -1,0 +1,52 @@
+---
+title: Self-Hosting
+description: Run the Solana Developer Platform on your own infrastructure with Docker Compose.
+---
+
+Self-hosting runs the full Solana Developer Platform — API, web dashboard, docs,
+database, and cache — on infrastructure you control, from prebuilt container
+images. You bring your own authentication, Solana RPC, and signing provider; SDP
+stays the same product you'd use as a managed service.
+
+This section covers installing the stack, generating its configuration, and
+keeping it running.
+
+## What you run
+
+`infra/self-hosted/compose.yml` starts six services:
+
+| Service | Image | Purpose |
+|---|---|---|
+| `sdp-api` | `sdp-api` | The core API (default port `8787`). |
+| `sdp-web` | `sdp-web` | The dashboard web app (default port `3000`). |
+| `sdp-docs` | `sdp-docs` | This documentation site (default port `3001`). |
+| `sdp-migrate` | `sdp-api` | Runs database migrations once on startup, then exits. |
+| `postgres` | `postgres:16-alpine` | Bundled database (or point at an external one). |
+| `redis` | `redis:7-alpine` | Bundled cache (or point at an external one). |
+
+## Start here
+
+- **[Quickstart](/docs/self-hosting/quickstart)** — install the stack and bring it
+  up for the first time.
+- **[Configurator](/docs/self-hosting/configurator)** — generate a complete `.env`
+  in your browser or terminal.
+- **[Environment reference](/docs/self-hosting/env-reference)** — what every
+  configuration variable does and which ones are required.
+
+## Operate
+
+- **[Upgrade & backup](/docs/self-hosting/upgrade-and-backup)** — move to a new
+  release and protect your data.
+- **[Troubleshooting](/docs/self-hosting/troubleshooting)** — common startup and
+  configuration failures.
+- **[External co-signers](/docs/self-hosting/external-co-signers)** — host
+  provider-specific signing automation alongside the stack.
+
+## Requirements
+
+- A 64-bit Linux or macOS host with **Docker Engine** and **Docker Compose v2**.
+- Outbound network access to pull images and reach your Solana RPC and
+  authentication providers.
+- A [Clerk](https://clerk.com) application for authentication and a Solana RPC
+  endpoint. See the [environment reference](/docs/self-hosting/env-reference) for
+  the full list.

--- a/apps/sdp-docs/content/docs/self-hosting/meta.json
+++ b/apps/sdp-docs/content/docs/self-hosting/meta.json
@@ -1,4 +1,12 @@
 {
   "title": "Self-Hosting",
-  "pages": ["configurator", "external-co-signers"]
+  "pages": [
+    "index",
+    "quickstart",
+    "configurator",
+    "env-reference",
+    "upgrade-and-backup",
+    "troubleshooting",
+    "external-co-signers"
+  ]
 }

--- a/apps/sdp-docs/content/docs/self-hosting/quickstart.mdx
+++ b/apps/sdp-docs/content/docs/self-hosting/quickstart.mdx
@@ -1,0 +1,81 @@
+---
+title: Quickstart
+description: Install the self-hosted stack, generate a .env, and bring it up with Docker Compose.
+---
+
+This guide takes you from an empty host to a running Solana Developer Platform.
+It assumes **Docker Engine** and **Docker Compose v2** are installed and the
+Docker daemon is running.
+
+## 1. Install
+
+The install script downloads `compose.yml` and `.env.example` for the latest
+release into `~/sdp` and verifies them against the release checksums.
+
+```bash
+curl -fsSL https://github.com/solana-foundation/solana-developer-platform/releases/latest/download/install.sh | bash
+```
+
+The script is open source — you can read it before running it, and verify the
+checksums and signature out of band. The commented header of `install.sh`
+documents the full verified-install flow and the environment variables you can
+override (`SDP_INSTALL_DIR`, `INSTALL_VERSION`, and others).
+
+Prefer to do it by hand? Download `compose.yml` and `.env.example` from the
+[latest release](https://github.com/solana-foundation/solana-developer-platform/releases/latest)
+into a working directory instead.
+
+## 2. Generate your `.env`
+
+The stack reads its configuration from a `.env` file next to `compose.yml`. The
+[configurator](/docs/self-hosting/configurator) fills it in for you, generates
+the app secrets, and validates your answers.
+
+- **In your browser** — open the [configurator](/docs/self-hosting/configurator),
+  answer the prompts, and download the `.env` into `~/sdp`.
+- **In your terminal** — run the configurator from the API image:
+
+  ```bash
+  docker run --rm -it -v "$HOME/sdp:/out" \
+    ghcr.io/solana-foundation/sdp/sdp-api:latest \
+    node configure.js --out /out/.env
+  ```
+
+  Use the same release tag you installed in place of `latest` so the configurator
+  matches your `compose.yml`.
+
+See the [environment reference](/docs/self-hosting/env-reference) for what each
+variable means and which are required.
+
+## 3. Bring up the stack
+
+```bash
+cd ~/sdp
+docker compose up -d
+```
+
+On startup, `sdp-migrate` runs the database migrations once, then the API, web,
+and docs services start. The first run pulls the images, so it may take a few
+minutes.
+
+## 4. Verify
+
+```bash
+docker compose ps
+docker compose logs -f sdp-api
+```
+
+When the services report healthy, the dashboard is at `http://localhost:3000`,
+the API at `http://localhost:8787`, and these docs at `http://localhost:3001`.
+The API exposes a [health endpoint](/docs/reference/api/health) you can poll from
+a load balancer or uptime check.
+
+If a service fails to start or a required variable is missing, see
+[Troubleshooting](/docs/self-hosting/troubleshooting).
+
+## Next steps
+
+- [Upgrade & backup](/docs/self-hosting/upgrade-and-backup) — keep the stack
+  current and protect your data.
+- [Environment reference](/docs/self-hosting/env-reference) — tune ports, RPC,
+  signing, and authentication.

--- a/apps/sdp-docs/content/docs/self-hosting/troubleshooting.mdx
+++ b/apps/sdp-docs/content/docs/self-hosting/troubleshooting.mdx
@@ -1,0 +1,78 @@
+---
+title: Troubleshooting
+description: Diagnose common startup and configuration failures on a self-hosted stack.
+---
+
+Most self-hosting problems surface at startup. Start by looking at the service
+state and logs:
+
+```bash
+cd ~/sdp
+docker compose ps
+docker compose logs -f sdp-api
+```
+
+## Docker is not ready
+
+The install script checks for Docker up front. If you see that Docker is not
+installed, that Compose v2 is unavailable, or that the daemon is unreachable,
+install or start Docker and retry — see the
+[Docker Engine](https://docs.docker.com/engine/install/) and
+[Compose](https://docs.docker.com/compose/install/) docs.
+
+## A required variable is missing
+
+`compose.yml` fails fast when a required variable is unset, with a message such
+as `set POSTGRES_PASSWORD in .env`. Make sure a `.env` exists next to
+`compose.yml` and fills in every required variable. The
+[configurator](/docs/self-hosting/configurator) produces a complete file; the
+[environment reference](/docs/self-hosting/env-reference) lists what is required.
+
+## Images won't pull
+
+If `docker compose pull` reports access denied or a missing manifest:
+
+- Confirm `SDP_IMAGE_REGISTRY` and `SDP_VERSION` point at a registry and tag you
+  can reach.
+- Pull a single image directly to see the underlying error, e.g.
+  `docker pull ghcr.io/solana-foundation/sdp/sdp-api:latest`.
+- If the registry is private, run `docker login` for it first.
+
+## Port already in use
+
+The API, web, and docs default to ports `8787`, `3000`, and `3001`. If another
+process holds one of them, the service won't bind. Override the host port in
+`.env` with `SDP_API_PORT`, `SDP_WEB_PORT`, or `SDP_DOCS_PORT` and run
+`docker compose up -d` again.
+
+## Migrations failed
+
+`sdp-migrate` runs once before the API starts; if it fails, the API stays down.
+Inspect it with:
+
+```bash
+docker compose logs sdp-migrate
+```
+
+A failure here is usually a database connection problem — check `POSTGRES_*` (or
+`DATABASE_URL`) and that the `postgres` service is healthy in `docker compose ps`.
+
+## Database connection refused
+
+The API and migration services wait for Postgres to report healthy before
+starting. If they still can't connect, verify the credentials in `.env`, and for
+an external database (`DATABASE_URL` set) that it is reachable from inside the
+Docker network.
+
+## Authentication errors in the dashboard
+
+Sign-in problems point at the Clerk configuration. Re-check
+`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, and `CLERK_ISSUER`
+against your Clerk application, and confirm the keys match the environment
+(development vs production) you intend to run.
+
+## Still stuck?
+
+Capture the failing service's logs and your (secret-redacted) `.env` settings,
+then open an issue on the
+[project repository](https://github.com/solana-foundation/solana-developer-platform).

--- a/apps/sdp-docs/content/docs/self-hosting/upgrade-and-backup.mdx
+++ b/apps/sdp-docs/content/docs/self-hosting/upgrade-and-backup.mdx
@@ -1,0 +1,102 @@
+---
+title: Upgrade & Backup
+description: Move a self-hosted Solana Developer Platform to a new release and protect its data.
+---
+
+This page covers upgrading to a new release and backing up the data that matters
+on a self-hosted stack.
+
+## Upgrade
+
+A release ships new container images plus an updated `compose.yml`. To upgrade:
+
+1. **Refresh the install files.** Re-run the install script. It replaces
+   `compose.yml` with the new release's version (verified against the release
+   checksums) and leaves any existing `.env` and `.env.example` in place, printing
+   a link to the new release's `.env.example` so you can check for new variables.
+
+   ```bash
+   curl -fsSL https://github.com/solana-foundation/solana-developer-platform/releases/latest/download/install.sh | bash
+   ```
+
+2. **Pin the version.** Set `SDP_VERSION` in `.env` to the release tag you are
+   upgrading to (rather than `latest`) so every service runs the same, known
+   build.
+
+3. **Pull and restart.**
+
+   ```bash
+   cd ~/sdp
+   docker compose pull
+   docker compose up -d
+   ```
+
+   `sdp-migrate` runs any new database migrations once before the API starts.
+
+4. **Verify** the services are healthy, as in the
+   [Quickstart](/docs/self-hosting/quickstart#4-verify).
+
+To upgrade to a specific release instead of the latest, set `INSTALL_VERSION`
+when running the script and the matching `SDP_VERSION` in `.env`.
+
+### Roll back
+
+Set `SDP_VERSION` back to the previous tag and run `docker compose up -d`. Note
+that migrations are not automatically reversed; if a release applied a migration,
+restore from a backup taken before the upgrade rather than relying on a
+version downgrade alone.
+
+## Backup
+
+Two things hold your state:
+
+- **The Postgres database** — all platform data. With the bundled database it
+  lives in the `sdp-postgres-data` Docker volume; with an external `DATABASE_URL`,
+  back it up with your database provider's tooling instead.
+- **Your `.env`** — secrets and configuration. Store it somewhere safe (a secret
+  manager); it cannot be regenerated identically.
+
+Redis is a cache and does not need backing up.
+
+### Back up the database
+
+Take a logical dump with `pg_dump` from the running container. Running it through
+`sh -c` lets `pg_dump` read `POSTGRES_USER` and `POSTGRES_DB` from inside the
+container, so custom values are honored:
+
+```bash
+cd ~/sdp
+docker compose exec -T postgres \
+  sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > sdp-backup.sql
+```
+
+Keep these dumps off-host and on a schedule that matches your recovery needs.
+
+### Restore the database
+
+A plain `pg_dump` includes the full schema and the migration history, so restore
+into an **empty** database and let the stack start on top of it. Do not restore
+over an already-migrated database, or the dump's schema collides with the one
+`sdp-migrate` created on the previous `up`.
+
+```bash
+cd ~/sdp
+docker compose down                       # stop every service
+docker volume rm sdp_sdp-postgres-data    # discard the current database (destructive)
+docker compose up -d postgres             # start a fresh, empty Postgres
+until docker compose exec -T postgres \
+  sh -c 'pg_isready -U "$POSTGRES_USER"' >/dev/null 2>&1; do sleep 1; done
+docker compose exec -T postgres \
+  sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' < sdp-backup.sql
+docker compose up -d                      # start the rest
+```
+
+On that final `up`, `sdp-migrate` skips every migration already recorded in the
+restored dump. Restoring a dump taken at the same release leaves it with nothing
+to do; restoring an older dump before an upgrade lets it apply only the newer
+migrations.
+
+Restore the matching `.env` alongside it so secrets such as
+`CUSTODY_ENCRYPTION_KEY` line up with the data they protect. For an external
+`DATABASE_URL`, restore through your database provider rather than the bundled
+`postgres` service.

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -3331,6 +3331,145 @@ Use the [Payments API reference](/docs/reference/api/payments), [Wallets API ref
 
 ## Self-Hosting
 
+### Self-Hosting
+Source: https://platform.solana.com/docs/self-hosting
+
+> Run the Solana Developer Platform on your own infrastructure with Docker Compose.
+
+Self-hosting runs the full Solana Developer Platform — API, web dashboard, docs,
+database, and cache — on infrastructure you control, from prebuilt container
+images. You bring your own authentication, Solana RPC, and signing provider; SDP
+stays the same product you'd use as a managed service.
+
+This section covers installing the stack, generating its configuration, and
+keeping it running.
+
+## What you run
+
+`infra/self-hosted/compose.yml` starts six services:
+
+| Service | Image | Purpose |
+|---|---|---|
+| `sdp-api` | `sdp-api` | The core API (default port `8787`). |
+| `sdp-web` | `sdp-web` | The dashboard web app (default port `3000`). |
+| `sdp-docs` | `sdp-docs` | This documentation site (default port `3001`). |
+| `sdp-migrate` | `sdp-api` | Runs database migrations once on startup, then exits. |
+| `postgres` | `postgres:16-alpine` | Bundled database (or point at an external one). |
+| `redis` | `redis:7-alpine` | Bundled cache (or point at an external one). |
+
+## Start here
+
+- **[Quickstart](/docs/self-hosting/quickstart)** — install the stack and bring it
+  up for the first time.
+- **[Configurator](/docs/self-hosting/configurator)** — generate a complete `.env`
+  in your browser or terminal.
+- **[Environment reference](/docs/self-hosting/env-reference)** — what every
+  configuration variable does and which ones are required.
+
+## Operate
+
+- **[Upgrade & backup](/docs/self-hosting/upgrade-and-backup)** — move to a new
+  release and protect your data.
+- **[Troubleshooting](/docs/self-hosting/troubleshooting)** — common startup and
+  configuration failures.
+- **[External co-signers](/docs/self-hosting/external-co-signers)** — host
+  provider-specific signing automation alongside the stack.
+
+## Requirements
+
+- A 64-bit Linux or macOS host with **Docker Engine** and **Docker Compose v2**.
+- Outbound network access to pull images and reach your Solana RPC and
+  authentication providers.
+- A [Clerk](https://clerk.com) application for authentication and a Solana RPC
+  endpoint. See the [environment reference](/docs/self-hosting/env-reference) for
+  the full list.
+
+---
+
+### Quickstart
+Source: https://platform.solana.com/docs/self-hosting/quickstart
+
+> Install the self-hosted stack, generate a .env, and bring it up with Docker Compose.
+
+This guide takes you from an empty host to a running Solana Developer Platform.
+It assumes **Docker Engine** and **Docker Compose v2** are installed and the
+Docker daemon is running.
+
+## 1. Install
+
+The install script downloads `compose.yml` and `.env.example` for the latest
+release into `~/sdp` and verifies them against the release checksums.
+
+```bash
+curl -fsSL https://github.com/solana-foundation/solana-developer-platform/releases/latest/download/install.sh | bash
+```
+
+The script is open source — you can read it before running it, and verify the
+checksums and signature out of band. The commented header of `install.sh`
+documents the full verified-install flow and the environment variables you can
+override (`SDP_INSTALL_DIR`, `INSTALL_VERSION`, and others).
+
+Prefer to do it by hand? Download `compose.yml` and `.env.example` from the
+[latest release](https://github.com/solana-foundation/solana-developer-platform/releases/latest)
+into a working directory instead.
+
+## 2. Generate your `.env`
+
+The stack reads its configuration from a `.env` file next to `compose.yml`. The
+[configurator](/docs/self-hosting/configurator) fills it in for you, generates
+the app secrets, and validates your answers.
+
+- **In your browser** — open the [configurator](/docs/self-hosting/configurator),
+  answer the prompts, and download the `.env` into `~/sdp`.
+- **In your terminal** — run the configurator from the API image:
+
+  ```bash
+  docker run --rm -it -v "$HOME/sdp:/out" \
+    ghcr.io/solana-foundation/sdp/sdp-api:latest \
+    node configure.js --out /out/.env
+  ```
+
+  Use the same release tag you installed in place of `latest` so the configurator
+  matches your `compose.yml`.
+
+See the [environment reference](/docs/self-hosting/env-reference) for what each
+variable means and which are required.
+
+## 3. Bring up the stack
+
+```bash
+cd ~/sdp
+docker compose up -d
+```
+
+On startup, `sdp-migrate` runs the database migrations once, then the API, web,
+and docs services start. The first run pulls the images, so it may take a few
+minutes.
+
+## 4. Verify
+
+```bash
+docker compose ps
+docker compose logs -f sdp-api
+```
+
+When the services report healthy, the dashboard is at `http://localhost:3000`,
+the API at `http://localhost:8787`, and these docs at `http://localhost:3001`.
+The API exposes a [health endpoint](/docs/reference/api/health) you can poll from
+a load balancer or uptime check.
+
+If a service fails to start or a required variable is missing, see
+[Troubleshooting](/docs/self-hosting/troubleshooting).
+
+## Next steps
+
+- [Upgrade & backup](/docs/self-hosting/upgrade-and-backup) — keep the stack
+  current and protect your data.
+- [Environment reference](/docs/self-hosting/env-reference) — tune ports, RPC,
+  signing, and authentication.
+
+---
+
 ### Configurator
 Source: https://platform.solana.com/docs/self-hosting/configurator
 
@@ -3341,6 +3480,288 @@ your browser — nothing is sent anywhere. Drop the file next to `compose.yml`, 
 run `docker compose up -d`.
 
 <EnvConfigurator />
+
+---
+
+### Environment Reference
+Source: https://platform.solana.com/docs/self-hosting/env-reference
+
+> The configuration variables a self-hosted Solana Developer Platform reads from .env.
+
+The self-hosted stack reads its configuration from a single `.env` file next to
+`compose.yml`. The [configurator](/docs/self-hosting/configurator) is the
+authoritative source of the field list, defaults, and validation — it always
+matches the release you installed. This page explains how the configuration is
+organized and the variables you are most likely to set by hand.
+
+The configurator groups variables into sections:
+
+| Section | What it covers |
+|---|---|
+| Basic | Core runtime — environment, deployment mode, sender email. |
+| Database | Bundled Postgres or an external database. |
+| Cache | Bundled Redis or an external cache. |
+| Solana RPC | Network and RPC endpoint. |
+| Authentication (Clerk) | Required Clerk keys and JWT settings. |
+| Signing provider | Which signer(s) to enable and their credentials. |
+| Fee payment | How transaction fees are paid. |
+| Secrets | App secrets, generated locally. |
+| Advanced | Image source, ports, and internal service URLs. |
+
+## Required variables
+
+These must be set or the stack will refuse to start:
+
+| Variable | Description |
+|---|---|
+| `POSTGRES_PASSWORD` | Password for the bundled Postgres. Always required — the bundled `postgres` service starts even when the API points at an external `DATABASE_URL`. |
+| `API_KEY_PEPPER` | Server-side pepper for API key hashing. Generate with `openssl rand -hex 32`. |
+| `CUSTODY_ENCRYPTION_KEY` | Encryption key for custody material at rest. Generate with `openssl rand -hex 32`. |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk publishable key for the web app. |
+| `CLERK_SECRET_KEY` | Clerk secret key for the API. |
+| `CLERK_ISSUER` | Clerk issuer URL used to validate tokens. |
+| `SOLANA_RPC_URL` | Solana RPC endpoint the API calls. |
+| `SIGNING_PROVIDER` | The default signing provider. Each non-local provider adds its own required credentials. |
+
+The configurator generates `API_KEY_PEPPER` and `CUSTODY_ENCRYPTION_KEY` for you
+and can auto-generate `POSTGRES_PASSWORD`.
+
+## Database
+
+In the configurator, `DATABASE_MODE` chooses between the bundled Postgres and an
+external database. It is a generation-time selector and is not written to `.env`.
+
+For the bundled database, set `POSTGRES_DB`, `POSTGRES_USER`, and
+`POSTGRES_PASSWORD`; the API and migration services build their connection string
+from them. To use an external database, set `DATABASE_URL` to your own
+`postgresql://…` string and the API and migrations connect there instead. Note
+that `compose.yml` always starts the bundled `postgres` container — with an
+external `DATABASE_URL` it simply goes unused, and `POSTGRES_PASSWORD` is still
+required for it to start.
+
+The configurator hides `POSTGRES_PASSWORD` once you select an external database
+but still emits an auto-generated value for it, since the bundled `postgres`
+container needs one to start even when nothing connects to it.
+
+## Cache
+
+Like `DATABASE_MODE`, `CACHE_MODE` is a configurator-only selector and is not
+written to `.env`. To use an external cache, set `REDIS_URL` to your own
+`redis://…` endpoint; the bundled `redis` container still starts but goes unused.
+
+## Signing providers
+
+`SIGNING_PROVIDER` is the default signer written to `.env`. Supported values are
+`local`, `fireblocks`, `privy`, `coinbase_cdp`, `para`, `turnkey`, and `utila`.
+The configurator also tracks a `SIGNING_PROVIDERS` selection to decide which
+fields to show, but that key is configurator-only and is not written to `.env`.
+Each non-local provider requires its own credentials — for example Fireblocks
+needs an API key, secret, and vault ID — and the configurator only prompts for
+the providers you enable.
+
+For provider-managed co-signer runtimes that live outside the default stack, see
+[External co-signers](/docs/self-hosting/external-co-signers).
+
+## Advanced
+
+| Variable | Default | Description |
+|---|---|---|
+| `SDP_IMAGE_REGISTRY` | `ghcr.io/solana-foundation/sdp` | Registry the service images are pulled from. |
+| `SDP_VERSION` | `latest` | Image tag for every SDP service. Pin this to a release tag in production. |
+| `SDP_API_PORT` | `8787` | Host port for the API. |
+| `SDP_WEB_PORT` | `3000` | Host port for the dashboard. |
+| `SDP_DOCS_PORT` | `3001` | Host port for these docs. |
+
+`SDP_API_BASE_URL` defaults to the in-network service name `http://sdp-api:8787`
+for server-to-server calls. The browser-facing `NEXT_PUBLIC_*` URLs default to
+`localhost` (for example `http://localhost:8787` and `http://localhost:3000`) and
+need changing when you put the services behind your own domains or ingress.
+
+---
+
+### Upgrade & Backup
+Source: https://platform.solana.com/docs/self-hosting/upgrade-and-backup
+
+> Move a self-hosted Solana Developer Platform to a new release and protect its data.
+
+This page covers upgrading to a new release and backing up the data that matters
+on a self-hosted stack.
+
+## Upgrade
+
+A release ships new container images plus an updated `compose.yml`. To upgrade:
+
+1. **Refresh the install files.** Re-run the install script. It replaces
+   `compose.yml` with the new release's version (verified against the release
+   checksums) and leaves any existing `.env` and `.env.example` in place, printing
+   a link to the new release's `.env.example` so you can check for new variables.
+
+   ```bash
+   curl -fsSL https://github.com/solana-foundation/solana-developer-platform/releases/latest/download/install.sh | bash
+   ```
+
+2. **Pin the version.** Set `SDP_VERSION` in `.env` to the release tag you are
+   upgrading to (rather than `latest`) so every service runs the same, known
+   build.
+
+3. **Pull and restart.**
+
+   ```bash
+   cd ~/sdp
+   docker compose pull
+   docker compose up -d
+   ```
+
+   `sdp-migrate` runs any new database migrations once before the API starts.
+
+4. **Verify** the services are healthy, as in the
+   [Quickstart](/docs/self-hosting/quickstart#4-verify).
+
+To upgrade to a specific release instead of the latest, set `INSTALL_VERSION`
+when running the script and the matching `SDP_VERSION` in `.env`.
+
+### Roll back
+
+Set `SDP_VERSION` back to the previous tag and run `docker compose up -d`. Note
+that migrations are not automatically reversed; if a release applied a migration,
+restore from a backup taken before the upgrade rather than relying on a
+version downgrade alone.
+
+## Backup
+
+Two things hold your state:
+
+- **The Postgres database** — all platform data. With the bundled database it
+  lives in the `sdp-postgres-data` Docker volume; with an external `DATABASE_URL`,
+  back it up with your database provider's tooling instead.
+- **Your `.env`** — secrets and configuration. Store it somewhere safe (a secret
+  manager); it cannot be regenerated identically.
+
+Redis is a cache and does not need backing up.
+
+### Back up the database
+
+Take a logical dump with `pg_dump` from the running container. Running it through
+`sh -c` lets `pg_dump` read `POSTGRES_USER` and `POSTGRES_DB` from inside the
+container, so custom values are honored:
+
+```bash
+cd ~/sdp
+docker compose exec -T postgres \
+  sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > sdp-backup.sql
+```
+
+Keep these dumps off-host and on a schedule that matches your recovery needs.
+
+### Restore the database
+
+A plain `pg_dump` includes the full schema and the migration history, so restore
+into an **empty** database and let the stack start on top of it. Do not restore
+over an already-migrated database, or the dump's schema collides with the one
+`sdp-migrate` created on the previous `up`.
+
+```bash
+cd ~/sdp
+docker compose down                       # stop every service
+docker volume rm sdp_sdp-postgres-data    # discard the current database (destructive)
+docker compose up -d postgres             # start a fresh, empty Postgres
+until docker compose exec -T postgres \
+  sh -c 'pg_isready -U "$POSTGRES_USER"' >/dev/null 2>&1; do sleep 1; done
+docker compose exec -T postgres \
+  sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' < sdp-backup.sql
+docker compose up -d                      # start the rest
+```
+
+On that final `up`, `sdp-migrate` skips every migration already recorded in the
+restored dump. Restoring a dump taken at the same release leaves it with nothing
+to do; restoring an older dump before an upgrade lets it apply only the newer
+migrations.
+
+Restore the matching `.env` alongside it so secrets such as
+`CUSTODY_ENCRYPTION_KEY` line up with the data they protect. For an external
+`DATABASE_URL`, restore through your database provider rather than the bundled
+`postgres` service.
+
+---
+
+### Troubleshooting
+Source: https://platform.solana.com/docs/self-hosting/troubleshooting
+
+> Diagnose common startup and configuration failures on a self-hosted stack.
+
+Most self-hosting problems surface at startup. Start by looking at the service
+state and logs:
+
+```bash
+cd ~/sdp
+docker compose ps
+docker compose logs -f sdp-api
+```
+
+## Docker is not ready
+
+The install script checks for Docker up front. If you see that Docker is not
+installed, that Compose v2 is unavailable, or that the daemon is unreachable,
+install or start Docker and retry — see the
+[Docker Engine](https://docs.docker.com/engine/install/) and
+[Compose](https://docs.docker.com/compose/install/) docs.
+
+## A required variable is missing
+
+`compose.yml` fails fast when a required variable is unset, with a message such
+as `set POSTGRES_PASSWORD in .env`. Make sure a `.env` exists next to
+`compose.yml` and fills in every required variable. The
+[configurator](/docs/self-hosting/configurator) produces a complete file; the
+[environment reference](/docs/self-hosting/env-reference) lists what is required.
+
+## Images won't pull
+
+If `docker compose pull` reports access denied or a missing manifest:
+
+- Confirm `SDP_IMAGE_REGISTRY` and `SDP_VERSION` point at a registry and tag you
+  can reach.
+- Pull a single image directly to see the underlying error, e.g.
+  `docker pull ghcr.io/solana-foundation/sdp/sdp-api:latest`.
+- If the registry is private, run `docker login` for it first.
+
+## Port already in use
+
+The API, web, and docs default to ports `8787`, `3000`, and `3001`. If another
+process holds one of them, the service won't bind. Override the host port in
+`.env` with `SDP_API_PORT`, `SDP_WEB_PORT`, or `SDP_DOCS_PORT` and run
+`docker compose up -d` again.
+
+## Migrations failed
+
+`sdp-migrate` runs once before the API starts; if it fails, the API stays down.
+Inspect it with:
+
+```bash
+docker compose logs sdp-migrate
+```
+
+A failure here is usually a database connection problem — check `POSTGRES_*` (or
+`DATABASE_URL`) and that the `postgres` service is healthy in `docker compose ps`.
+
+## Database connection refused
+
+The API and migration services wait for Postgres to report healthy before
+starting. If they still can't connect, verify the credentials in `.env`, and for
+an external database (`DATABASE_URL` set) that it is reachable from inside the
+Docker network.
+
+## Authentication errors in the dashboard
+
+Sign-in problems point at the Clerk configuration. Re-check
+`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, and `CLERK_ISSUER`
+against your Clerk application, and confirm the keys match the environment
+(development vs production) you intend to run.
+
+## Still stuck?
+
+Capture the failing service's logs and your (secret-redacted) `.env` settings,
+then open an issue on the
+[project repository](https://github.com/solana-foundation/solana-developer-platform).
 
 ---
 

--- a/apps/sdp-docs/src/components/EnvConfigurator/FieldRenderer.tsx
+++ b/apps/sdp-docs/src/components/EnvConfigurator/FieldRenderer.tsx
@@ -1,37 +1,72 @@
 "use client";
 
-import type { EnvField } from "@sdp/env-config";
+import { type EnvField, parseList, type Values } from "@sdp/env-config";
 
 export interface FieldRowProps {
   field: EnvField;
   value: string;
+  values: Values;
   error?: string;
   onChange: (key: string, value: string) => void;
   onRegenerate: (key: string) => void;
 }
 
-export function FieldRow({ field, value, error, onChange, onRegenerate }: FieldRowProps) {
+export function FieldRow({ field, value, values, error, onChange, onRegenerate }: FieldRowProps) {
   const id = `sdp-cfg-${field.key}`;
   const errorId = error ? `${id}-error` : undefined;
   const helpId = field.help ? `${id}-help` : undefined;
   const describedBy = [helpId, errorId].filter(Boolean).join(" ") || undefined;
 
-  const isSecret = field.kind === "secret";
+  // A field is auto-managed when `secretWhen` resolves true: the value is
+  // generated for the operator (e.g. POSTGRES_PASSWORD in auto-mode), so the
+  // input is display-only and is changed via Regenerate, not typing.
+  const isAutoManaged = field.secretWhen?.(values) ?? false;
+  const isSecret = field.kind === "secret" || isAutoManaged;
   const inputType = field.kind === "password" || field.kind === "secret" ? "password" : "text";
+  const options = field.optionsWhen ? field.optionsWhen(values) : (field.options ?? []);
+  const selected = field.kind === "multiselect" ? parseList(value) : [];
 
   return (
     <div className="sdp-cfg-field">
-      <label className="sdp-cfg-label" htmlFor={id}>
-        {field.label}
-        {field.required ? (
-          <span aria-hidden="true" className="sdp-cfg-required">
-            {" *"}
-          </span>
-        ) : null}
-      </label>
+      {field.kind !== "multiselect" ? (
+        <label className="sdp-cfg-label" htmlFor={id}>
+          {field.label}
+          {field.required ? (
+            <span aria-hidden="true" className="sdp-cfg-required">
+              {" *"}
+            </span>
+          ) : null}
+        </label>
+      ) : null}
 
       <div className="sdp-cfg-control">
-        {field.kind === "select" ? (
+        {field.kind === "multiselect" ? (
+          <fieldset aria-describedby={describedBy} className="sdp-cfg-checks">
+            <legend className="sdp-cfg-label">
+              {field.label}
+              {field.required ? (
+                <span aria-hidden="true" className="sdp-cfg-required">
+                  {" *"}
+                </span>
+              ) : null}
+            </legend>
+            {options.map((opt) => (
+              <label className="sdp-cfg-check" key={opt.value}>
+                <input
+                  checked={selected.includes(opt.value)}
+                  onChange={(e) => {
+                    const next = e.target.checked
+                      ? [...selected, opt.value]
+                      : selected.filter((s) => s !== opt.value);
+                    onChange(field.key, next.join(","));
+                  }}
+                  type="checkbox"
+                />
+                {opt.label}
+              </label>
+            ))}
+          </fieldset>
+        ) : field.kind === "select" ? (
           <select
             aria-describedby={describedBy}
             aria-invalid={error ? true : undefined}
@@ -40,7 +75,7 @@ export function FieldRow({ field, value, error, onChange, onRegenerate }: FieldR
             onChange={(e) => onChange(field.key, e.target.value)}
             value={value}
           >
-            {field.options?.map((opt) => (
+            {options.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
@@ -54,6 +89,7 @@ export function FieldRow({ field, value, error, onChange, onRegenerate }: FieldR
             id={id}
             onChange={(e) => onChange(field.key, e.target.value)}
             placeholder={field.defaultValue}
+            readOnly={isAutoManaged}
             type={inputType}
             value={value}
           />
@@ -114,6 +150,7 @@ export function SectionBlock({
       onChange={onChange}
       onRegenerate={onRegenerate}
       value={values[field.key] ?? ""}
+      values={values}
     />
   ));
 

--- a/apps/sdp-docs/src/components/EnvConfigurator/index.tsx
+++ b/apps/sdp-docs/src/components/EnvConfigurator/index.tsx
@@ -274,6 +274,12 @@ export function EnvConfigurator() {
       if (key === "POSTGRES_PASSWORD_MODE") {
         next.POSTGRES_PASSWORD = value === "manual" ? "" : randomHex32();
       }
+      // An external database hides the bundled-Postgres password fields, but
+      // compose still requires POSTGRES_PASSWORD. Ensure one exists so the .env
+      // stays bootable even if manual mode had cleared it before the switch.
+      if (key === "DATABASE_MODE" && value !== "bundled" && !next.POSTGRES_PASSWORD) {
+        next.POSTGRES_PASSWORD = randomHex32();
+      }
       // Keep the default provider valid: if it drops out of the selected set,
       // fall back to the first selected provider.
       if (key === "SIGNING_PROVIDERS") {

--- a/apps/sdp-docs/src/components/EnvConfigurator/index.tsx
+++ b/apps/sdp-docs/src/components/EnvConfigurator/index.tsx
@@ -6,6 +6,7 @@ import {
   FIELDS,
   generateEnv,
   isFieldVisible,
+  parseList,
   randomHex32,
   SECTIONS,
   type Values,
@@ -13,9 +14,6 @@ import {
 } from "@sdp/env-config";
 import { useEffect, useMemo, useState } from "react";
 import { FieldRow, SectionBlock } from "./FieldRenderer";
-
-const SOURCE_URL =
-  "https://github.com/solana-foundation/solana-developer-platform/tree/main/apps/sdp-docs/src/components/EnvConfigurator";
 
 /**
  * Seed defaults only. Secrets are filled on the client after mount (see useEffect)
@@ -44,29 +42,6 @@ const STYLES = `
 }
 .sdp-cfg * {
   box-sizing: border-box;
-}
-.sdp-cfg-banner {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px 14px;
-  padding: 12px 16px;
-  margin-bottom: 20px;
-  border: 1px solid var(--cfg-border);
-  border-radius: 10px;
-  background: var(--cfg-surface);
-  font-size: 13px;
-  color: var(--cfg-text);
-}
-.sdp-cfg-banner strong {
-  color: var(--cfg-ink);
-}
-.sdp-cfg-banner a {
-  color: var(--cfg-ink);
-  font-weight: 650;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  white-space: nowrap;
 }
 .sdp-cfg-layout {
   display: grid;
@@ -131,6 +106,30 @@ const STYLES = `
   display: flex;
   gap: 8px;
   align-items: stretch;
+}
+.sdp-cfg-checks {
+  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-width: 0;
+}
+.sdp-cfg-checks legend {
+  padding: 0;
+  margin-bottom: 6px;
+}
+.sdp-cfg-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--cfg-ink);
+}
+.sdp-cfg-check input {
+  accent-color: var(--cfg-accent);
 }
 .sdp-cfg-input {
   flex: 1 1 auto;
@@ -252,7 +251,7 @@ export function EnvConfigurator() {
   useEffect(() => {
     setValues((prev) => {
       const next = { ...prev };
-      for (const key of autoSecretKeys()) {
+      for (const key of autoSecretKeys(prev)) {
         next[key] = randomHex32();
       }
       return next;
@@ -268,7 +267,23 @@ export function EnvConfigurator() {
   useEffect(() => setCopied(false), [env]);
 
   function setValue(key: string, value: string) {
-    setValues((prev) => ({ ...prev, [key]: value }));
+    setValues((prev) => {
+      const next = { ...prev, [key]: value };
+      // Switching the Postgres password mode resets the value: manual clears it
+      // for typed entry; auto fills a fresh generated secret.
+      if (key === "POSTGRES_PASSWORD_MODE") {
+        next.POSTGRES_PASSWORD = value === "manual" ? "" : randomHex32();
+      }
+      // Keep the default provider valid: if it drops out of the selected set,
+      // fall back to the first selected provider.
+      if (key === "SIGNING_PROVIDERS") {
+        const selected = parseList(value);
+        if (!selected.includes(next.SIGNING_PROVIDER)) {
+          next.SIGNING_PROVIDER = selected[0] ?? "";
+        }
+      }
+      return next;
+    });
   }
 
   function regenerate(key: string) {
@@ -298,16 +313,6 @@ export function EnvConfigurator() {
     <div className="sdp-cfg">
       {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static, component-scoped stylesheet with no user input */}
       <style dangerouslySetInnerHTML={{ __html: STYLES }} />
-
-      <div className="sdp-cfg-banner">
-        <span>
-          <strong>Zero outbound.</strong> Don't trust us? Disconnect your network — this form still
-          generates the .env locally.
-        </span>
-        <a href={SOURCE_URL} rel="noreferrer" target="_blank">
-          View source
-        </a>
-      </div>
 
       <div className="sdp-cfg-layout">
         <div className="sdp-cfg-form">

--- a/packages/sdp-env-config/src/fields.test.ts
+++ b/packages/sdp-env-config/src/fields.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { FIELDS, SECTIONS } from "./fields";
+import { defaultValues } from "./generate";
 import type { SectionId } from "./types";
 
 test("no duplicate field keys", () => {
@@ -13,16 +14,30 @@ test("every field references a declared section", () => {
   for (const f of FIELDS) assert.ok(ids.has(f.section), `unknown section: ${f.section}`);
 });
 
-test("every select field has options", () => {
-  for (const f of FIELDS.filter((f) => f.kind === "select")) {
-    assert.ok(f.options && f.options.length > 0, `${f.key} missing options`);
+test("every select/multiselect field has static or dynamic options", () => {
+  for (const f of FIELDS.filter((f) => f.kind === "select" || f.kind === "multiselect")) {
+    const hasStatic = Boolean(f.options && f.options.length > 0);
+    assert.ok(hasStatic || f.optionsWhen, `${f.key} missing options`);
   }
 });
 
-test("every select field's default value is one of its options", () => {
+test("every select field's default value is one of its (resolved) options", () => {
+  const base = defaultValues();
   for (const f of FIELDS.filter((f) => f.kind === "select")) {
     if (f.defaultValue === undefined) continue;
-    const values = f.options?.map((o) => o.value) ?? [];
+    const opts = f.optionsWhen ? f.optionsWhen(base) : f.options;
+    const values = opts?.map((o) => o.value) ?? [];
     assert.ok(values.includes(f.defaultValue), `${f.key} default ${f.defaultValue} not in options`);
+  }
+});
+
+test("multiselect default values are a subset of options", () => {
+  const base = defaultValues();
+  for (const f of FIELDS.filter((f) => f.kind === "multiselect")) {
+    const opts = (f.optionsWhen ? f.optionsWhen(base) : f.options) ?? [];
+    const allowed = new Set(opts.map((o) => o.value));
+    for (const v of (f.defaultValue ?? "").split(",").filter(Boolean)) {
+      assert.ok(allowed.has(v), `${f.key} default ${v} not in options`);
+    }
   }
 });

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -1,4 +1,4 @@
-import type { EnvField, SectionMeta, Values } from "./types";
+import type { EnvField, SectionMeta, SelectOption, Values } from "./types";
 
 export const SECTIONS: SectionMeta[] = [
   { id: "basic", title: "Basic", comment: "Core runtime" },
@@ -23,6 +23,30 @@ export const SECTIONS: SectionMeta[] = [
 
 const isProvider = (key: string, value: string) => (v: Values) => v[key] === value;
 
+/** Split a comma-separated list value (e.g. SIGNING_PROVIDERS) into trimmed entries. */
+export const parseList = (value: string | undefined): string[] =>
+  value
+    ? value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+/** Predicate: the comma-separated list at `key` includes `value`. */
+const listIncludes = (key: string, value: string) => (v: Values) =>
+  parseList(v[key]).includes(value);
+
+/** Curated provider set the configurator collects full env for. */
+const SIGNING_PROVIDER_OPTIONS: SelectOption[] = [
+  { value: "local", label: "local" },
+  { value: "fireblocks", label: "Fireblocks" },
+  { value: "privy", label: "Privy" },
+  { value: "coinbase_cdp", label: "Coinbase CDP" },
+  { value: "para", label: "Para" },
+  { value: "turnkey", label: "Turnkey" },
+  { value: "utila", label: "Utila" },
+];
+
 export const FIELDS: EnvField[] = [
   // Basic
   {
@@ -35,17 +59,15 @@ export const FIELDS: EnvField[] = [
       { value: "production", label: "production" },
       { value: "development", label: "development" },
     ],
+    help: "App runtime mode: production hardens logging and error handling; development is for local testing.",
   },
   {
+    // Always self-hosted for this configurator; emitted as a constant, not shown.
     key: "SDP_DEPLOYMENT_MODE",
     section: "basic",
-    kind: "select",
+    kind: "text",
     label: "Deployment mode",
-    defaultValue: "self_hosted",
-    options: [
-      { value: "self_hosted", label: "self_hosted" },
-      { value: "managed", label: "managed" },
-    ],
+    derive: () => "self_hosted",
   },
   {
     key: "EMAIL_FROM",
@@ -82,6 +104,28 @@ export const FIELDS: EnvField[] = [
     label: "Postgres user",
     defaultValue: "sdp",
     visibleWhen: isProvider("DATABASE_MODE", "bundled"),
+  },
+  {
+    key: "POSTGRES_PASSWORD_MODE",
+    section: "database",
+    kind: "select",
+    label: "Postgres password",
+    defaultValue: "auto",
+    visibleWhen: isProvider("DATABASE_MODE", "bundled"),
+    options: [
+      { value: "auto", label: "Auto-generate" },
+      { value: "manual", label: "Set manually" },
+    ],
+    help: "Auto-generate a strong password, or set your own.",
+  },
+  {
+    key: "POSTGRES_PASSWORD",
+    section: "database",
+    kind: "password",
+    label: "Password",
+    required: true,
+    visibleWhen: isProvider("DATABASE_MODE", "bundled"),
+    secretWhen: (v) => v.POSTGRES_PASSWORD_MODE !== "manual",
   },
   {
     key: "DATABASE_URL",
@@ -190,23 +234,27 @@ export const FIELDS: EnvField[] = [
 
   // Signing
   {
+    key: "SIGNING_PROVIDERS",
+    section: "signing",
+    kind: "multiselect",
+    label: "Signing providers",
+    defaultValue: "local",
+    required: true,
+    options: SIGNING_PROVIDER_OPTIONS,
+    help: "Providers to prepare credentials for in this .env. The runtime default is chosen below; orgs/projects can later activate any configured provider from the dashboard.",
+  },
+  {
     key: "SIGNING_PROVIDER",
     section: "signing",
     kind: "select",
-    label: "Signing provider",
+    label: "Default signing provider",
     defaultValue: "local",
-    // Curated set this configurator supports: managed backends whose full env
-    // surface the form collects. Other adapters the API ships (e.g. dfns,
-    // anchorage) are intentionally not offered here.
-    options: [
-      { value: "local", label: "local" },
-      { value: "fireblocks", label: "Fireblocks" },
-      { value: "privy", label: "Privy" },
-      { value: "coinbase_cdp", label: "Coinbase CDP" },
-      { value: "para", label: "Para" },
-      { value: "turnkey", label: "Turnkey" },
-      { value: "utila", label: "Utila" },
-    ],
+    required: true,
+    optionsWhen: (v) =>
+      parseList(v.SIGNING_PROVIDERS).map(
+        (p) => SIGNING_PROVIDER_OPTIONS.find((o) => o.value === p) ?? { value: p, label: p }
+      ),
+    help: "Global fallback provider, used when an org/project has no custody config of its own.",
   },
   {
     key: "CUSTODY_PRIVATE_KEY",
@@ -214,7 +262,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Signing key (base58)",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "local"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "local"),
     help: "Base58 private key the local signer uses. Generate one and fund it on your network.",
   },
   {
@@ -223,7 +271,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Fireblocks API key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "fireblocks"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "fireblocks"),
   },
   {
     key: "FIREBLOCKS_API_SECRET",
@@ -231,7 +279,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Fireblocks API secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "fireblocks"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "fireblocks"),
   },
   {
     key: "FIREBLOCKS_VAULT_ID",
@@ -239,7 +287,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Fireblocks vault ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "fireblocks"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "fireblocks"),
   },
   {
     key: "PRIVY_APP_ID",
@@ -247,7 +295,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Privy app ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "privy"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "privy"),
   },
   {
     key: "PRIVY_APP_SECRET",
@@ -255,7 +303,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Privy app secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "privy"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "privy"),
   },
   {
     key: "PRIVY_WALLET_ID",
@@ -263,7 +311,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Privy wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "privy"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "privy"),
   },
   {
     key: "COINBASE_CDP_API_KEY_ID",
@@ -271,7 +319,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Coinbase CDP API key ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "COINBASE_CDP_API_KEY_SECRET",
@@ -279,7 +327,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Coinbase CDP API key secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "COINBASE_CDP_WALLET_SECRET",
@@ -287,7 +335,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Coinbase CDP wallet secret",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "COINBASE_CDP_WALLET_ID",
@@ -295,7 +343,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Coinbase CDP wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "coinbase_cdp"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "coinbase_cdp"),
   },
   {
     key: "PARA_API_KEY",
@@ -303,7 +351,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Para API key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "para"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "para"),
   },
   {
     key: "PARA_WALLET_ID",
@@ -311,7 +359,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Para wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "para"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "para"),
   },
   {
     key: "TURNKEY_API_PUBLIC_KEY",
@@ -319,7 +367,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey API public key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_API_PRIVATE_KEY",
@@ -327,7 +375,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Turnkey API private key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_ORGANIZATION_ID",
@@ -335,7 +383,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey organization ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_PRIVATE_KEY_ID",
@@ -343,7 +391,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey private key ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "TURNKEY_PUBLIC_KEY",
@@ -351,7 +399,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Turnkey public key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "turnkey"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "turnkey"),
   },
   {
     key: "UTILA_SERVICE_ACCOUNT_EMAIL",
@@ -359,7 +407,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila service account email",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^[^@\s]+@vault\.[^@\s]+\.utilaserviceaccount\.io$/,
   },
   {
@@ -368,7 +416,7 @@ export const FIELDS: EnvField[] = [
     kind: "password",
     label: "Utila service account private key",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     help: "PKCS#8 private key PEM for the Utila service account. Use escaped newlines when storing in .env.",
   },
   {
@@ -377,7 +425,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila vault ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
   },
   {
     key: "UTILA_WALLET_ID",
@@ -385,7 +433,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila wallet ID",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
   },
   {
     key: "UTILA_NETWORK",
@@ -394,7 +442,7 @@ export const FIELDS: EnvField[] = [
     label: "Utila network",
     defaultValue: "networks/solana-devnet",
     required: true,
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     options: [
       { value: "networks/solana-devnet", label: "Solana devnet" },
       { value: "networks/solana-mainnet", label: "Solana mainnet" },
@@ -406,7 +454,7 @@ export const FIELDS: EnvField[] = [
     kind: "url",
     label: "Utila API base URL",
     defaultValue: "https://api.utila.io",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^https:\/\//,
   },
   {
@@ -415,7 +463,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila poll interval (ms)",
     defaultValue: "1000",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^[1-9]\d*$/,
   },
   {
@@ -424,7 +472,7 @@ export const FIELDS: EnvField[] = [
     kind: "text",
     label: "Utila max poll attempts",
     defaultValue: "60",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     pattern: /^[1-9]\d*$/,
   },
   {
@@ -432,7 +480,7 @@ export const FIELDS: EnvField[] = [
     section: "signing",
     kind: "text",
     label: "Utila designated signers",
-    visibleWhen: isProvider("SIGNING_PROVIDER", "utila"),
+    visibleWhen: listIncludes("SIGNING_PROVIDERS", "utila"),
     help: "Comma-separated Utila user resources. Leave empty to default to users/$UTILA_SERVICE_ACCOUNT_EMAIL.",
   },
 
@@ -479,13 +527,6 @@ export const FIELDS: EnvField[] = [
     section: "secrets",
     kind: "secret",
     label: "Custody encryption key",
-    required: true,
-  },
-  {
-    key: "POSTGRES_PASSWORD",
-    section: "secrets",
-    kind: "secret",
-    label: "Postgres password",
     required: true,
   },
 
@@ -577,7 +618,12 @@ export const FIELDS: EnvField[] = [
 ];
 
 /** Keys that hold compose-only UI state and must NOT be emitted into the .env. */
-export const UI_ONLY_KEYS = new Set(["DATABASE_MODE", "CACHE_MODE"]);
+export const UI_ONLY_KEYS = new Set([
+  "DATABASE_MODE",
+  "CACHE_MODE",
+  "SIGNING_PROVIDERS",
+  "POSTGRES_PASSWORD_MODE",
+]);
 
 /** A field is visible unless its visibleWhen predicate returns false. */
 export function isFieldVisible(field: EnvField, values: Values): boolean {

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -125,7 +125,14 @@ export const FIELDS: EnvField[] = [
     label: "Password",
     required: true,
     visibleWhen: isProvider("DATABASE_MODE", "bundled"),
-    secretWhen: (v) => v.POSTGRES_PASSWORD_MODE !== "manual",
+    // Auto-generate unless the operator chose manual entry for the bundled DB.
+    // With an external database the field is hidden and manual mode unreachable,
+    // so always auto-generate — compose still needs a value and the form offers
+    // no way to type one.
+    secretWhen: (v) => v.DATABASE_MODE !== "bundled" || v.POSTGRES_PASSWORD_MODE !== "manual",
+    // The bundled Postgres container always starts and requires this, even with
+    // an external database, so emit an auto-generated value while hiding the field.
+    alwaysEmit: true,
   },
   {
     key: "DATABASE_URL",

--- a/packages/sdp-env-config/src/generate.test.ts
+++ b/packages/sdp-env-config/src/generate.test.ts
@@ -47,6 +47,20 @@ test("invisible conditional fields are skipped", () => {
   assert.match(env, /^CUSTODY_PRIVATE_KEY=k$/m); // local selected → visible + filled
 });
 
+test("POSTGRES_PASSWORD is emitted even when the database is external", () => {
+  // The bundled Postgres container always starts and requires the password, so
+  // it is emitted (hidden from the form) alongside the external DATABASE_URL.
+  const env = generateEnv({
+    ...defaultValues(),
+    DATABASE_MODE: "external",
+    DATABASE_URL: "postgresql://u:p@db:5432/app",
+    POSTGRES_PASSWORD: "generated-pw",
+  });
+  assert.match(env, /^POSTGRES_PASSWORD=generated-pw$/m);
+  assert.match(env, /^DATABASE_URL=postgresql:\/\/u:p@db:5432\/app$/m);
+  assert.doesNotMatch(env, /^DATABASE_MODE=/m);
+});
+
 test("empty optional fields are omitted so runtime fallbacks apply", () => {
   // local + native default: FEE_PAYER_PRIVATE_KEY is optional and blank here, so it
   // must NOT be emitted (an empty value would defeat the native adapter's fallback).

--- a/packages/sdp-env-config/src/generate.test.ts
+++ b/packages/sdp-env-config/src/generate.test.ts
@@ -28,6 +28,13 @@ test("UI-only selector keys are never emitted", () => {
   const env = generateEnv(defaultValues());
   assert.doesNotMatch(env, /^DATABASE_MODE=/m);
   assert.doesNotMatch(env, /^CACHE_MODE=/m);
+  assert.doesNotMatch(env, /^SIGNING_PROVIDERS=/m);
+  assert.doesNotMatch(env, /^POSTGRES_PASSWORD_MODE=/m);
+});
+
+test("deployment mode is emitted as the self_hosted constant", () => {
+  const env = generateEnv(defaultValues());
+  assert.match(env, /^SDP_DEPLOYMENT_MODE=self_hosted$/m);
 });
 
 test("invisible conditional fields are skipped", () => {

--- a/packages/sdp-env-config/src/generate.ts
+++ b/packages/sdp-env-config/src/generate.ts
@@ -23,7 +23,7 @@ export function generateEnv(values: Values): string {
       (f) =>
         f.section === section.id &&
         !UI_ONLY_KEYS.has(f.key) &&
-        (f.derive ? true : isFieldVisible(f, values))
+        (f.derive || f.alwaysEmit ? true : isFieldVisible(f, values))
     );
 
     const sectionLines: string[] = [];

--- a/packages/sdp-env-config/src/secrets.test.ts
+++ b/packages/sdp-env-config/src/secrets.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { defaultValues } from "./generate";
 import { autoSecretKeys, randomHex32 } from "./secrets";
 
 test("randomHex32 returns 64 lowercase hex chars", () => {
@@ -11,10 +12,25 @@ test("successive calls differ", () => {
   assert.notEqual(randomHex32(), randomHex32());
 });
 
-test("autoSecretKeys lists the secret-kind field keys", () => {
-  assert.deepEqual([...autoSecretKeys()].sort(), [
-    "API_KEY_PEPPER",
-    "CUSTODY_ENCRYPTION_KEY",
-    "POSTGRES_PASSWORD",
-  ]);
+test("autoSecretKeys without values lists only secret-kind fields", () => {
+  assert.deepEqual([...autoSecretKeys()].sort(), ["API_KEY_PEPPER", "CUSTODY_ENCRYPTION_KEY"]);
+});
+
+test("autoSecretKeys with default values includes the auto-mode Postgres password", () => {
+  const keys = autoSecretKeys(defaultValues());
+  assert.ok(keys.has("POSTGRES_PASSWORD"));
+  assert.ok(keys.has("API_KEY_PEPPER"));
+});
+
+test("autoSecretKeys excludes the Postgres password in manual mode", () => {
+  const keys = autoSecretKeys({ ...defaultValues(), POSTGRES_PASSWORD_MODE: "manual" });
+  assert.ok(!keys.has("POSTGRES_PASSWORD"));
+});
+
+test("autoSecretKeys excludes invisible fields", () => {
+  // An external database hides POSTGRES_PASSWORD, so no secret should be
+  // generated for it even though auto-mode is still selected.
+  const keys = autoSecretKeys({ ...defaultValues(), DATABASE_MODE: "external" });
+  assert.ok(!keys.has("POSTGRES_PASSWORD"));
+  assert.ok(keys.has("API_KEY_PEPPER"));
 });

--- a/packages/sdp-env-config/src/secrets.test.ts
+++ b/packages/sdp-env-config/src/secrets.test.ts
@@ -27,10 +27,22 @@ test("autoSecretKeys excludes the Postgres password in manual mode", () => {
   assert.ok(!keys.has("POSTGRES_PASSWORD"));
 });
 
-test("autoSecretKeys excludes invisible fields", () => {
-  // An external database hides POSTGRES_PASSWORD, so no secret should be
-  // generated for it even though auto-mode is still selected.
+test("autoSecretKeys still generates POSTGRES_PASSWORD with an external database", () => {
+  // An external database hides POSTGRES_PASSWORD from the form, but the bundled
+  // Postgres container still starts and requires it, so it is always emitted —
+  // and therefore still needs an auto-generated secret.
   const keys = autoSecretKeys({ ...defaultValues(), DATABASE_MODE: "external" });
-  assert.ok(!keys.has("POSTGRES_PASSWORD"));
+  assert.ok(keys.has("POSTGRES_PASSWORD"));
   assert.ok(keys.has("API_KEY_PEPPER"));
+});
+
+test("autoSecretKeys generates POSTGRES_PASSWORD for external DB even in manual mode", () => {
+  // Manual mode only applies to the bundled database. With an external database
+  // the field is hidden and unreachable, so the password must still be generated.
+  const keys = autoSecretKeys({
+    ...defaultValues(),
+    DATABASE_MODE: "external",
+    POSTGRES_PASSWORD_MODE: "manual",
+  });
+  assert.ok(keys.has("POSTGRES_PASSWORD"));
 });

--- a/packages/sdp-env-config/src/secrets.ts
+++ b/packages/sdp-env-config/src/secrets.ts
@@ -1,4 +1,5 @@
-import { FIELDS } from "./fields";
+import { FIELDS, isFieldVisible } from "./fields";
+import type { Values } from "./types";
 
 /** 32 random bytes as lowercase hex — equivalent to `openssl rand -hex 32`. */
 export function randomHex32(): string {
@@ -8,7 +9,18 @@ export function randomHex32(): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-/** Keys whose field kind is "secret". */
-export function autoSecretKeys(): Set<string> {
-  return new Set(FIELDS.filter((f) => f.kind === "secret").map((f) => f.key));
+/**
+ * Keys to auto-generate as secrets. Always includes `kind: "secret"` fields;
+ * when `values` are supplied, also includes fields whose `secretWhen(values)`
+ * holds (e.g. an auto-mode Postgres password) and, conversely, drops any field
+ * that is currently invisible — an invisible field is never emitted, so
+ * generating a secret for it would only be discarded.
+ */
+export function autoSecretKeys(values?: Values): Set<string> {
+  return new Set(
+    FIELDS.filter((f) => {
+      if (values && !isFieldVisible(f, values)) return false;
+      return f.kind === "secret" || (values ? (f.secretWhen?.(values) ?? false) : false);
+    }).map((f) => f.key)
+  );
 }

--- a/packages/sdp-env-config/src/secrets.ts
+++ b/packages/sdp-env-config/src/secrets.ts
@@ -14,12 +14,14 @@ export function randomHex32(): string {
  * when `values` are supplied, also includes fields whose `secretWhen(values)`
  * holds (e.g. an auto-mode Postgres password) and, conversely, drops any field
  * that is currently invisible — an invisible field is never emitted, so
- * generating a secret for it would only be discarded.
+ * generating a secret for it would only be discarded. The exception is an
+ * `alwaysEmit` field, which is emitted even when hidden and so still needs its
+ * secret generated.
  */
 export function autoSecretKeys(values?: Values): Set<string> {
   return new Set(
     FIELDS.filter((f) => {
-      if (values && !isFieldVisible(f, values)) return false;
+      if (values && !isFieldVisible(f, values) && !f.alwaysEmit) return false;
       return f.kind === "secret" || (values ? (f.secretWhen?.(values) ?? false) : false);
     }).map((f) => f.key)
   );

--- a/packages/sdp-env-config/src/types.ts
+++ b/packages/sdp-env-config/src/types.ts
@@ -9,7 +9,7 @@ export type SectionId =
   | "secrets"
   | "advanced";
 
-export type FieldKind = "text" | "url" | "password" | "secret" | "select";
+export type FieldKind = "text" | "url" | "password" | "secret" | "select" | "multiselect";
 
 export type Values = Record<string, string>;
 
@@ -30,10 +30,21 @@ export interface EnvField {
   required?: boolean;
   /** Options for kind: "select". */
   options?: SelectOption[];
+  /**
+   * Dynamic options for "select"/"multiselect", computed from current values.
+   * When present it overrides `options` for both rendering and validation.
+   */
+  optionsWhen?: (v: Values) => SelectOption[];
   /** Validation pattern source; tested in validate.ts. */
   pattern?: RegExp;
   /** Visibility predicate over current values; absent ⇒ always visible. */
   visibleWhen?: (v: Values) => boolean;
+  /**
+   * When this predicate holds, `autoSecretKeys(values)` includes this field's key
+   * so callers can fill it with a generated secret; otherwise it is treated as a
+   * normal required input. Lets one field switch between generated and manual entry.
+   */
+  secretWhen?: (v: Values) => boolean;
   /** Computed from other values; hidden from the form, always emitted. */
   derive?: (values: Values) => string;
 }

--- a/packages/sdp-env-config/src/types.ts
+++ b/packages/sdp-env-config/src/types.ts
@@ -47,6 +47,12 @@ export interface EnvField {
   secretWhen?: (v: Values) => boolean;
   /** Computed from other values; hidden from the form, always emitted. */
   derive?: (values: Values) => string;
+  /**
+   * Emit this field even when `visibleWhen` hides it, for a setting the runtime
+   * needs regardless of the choice that hides it from the form. Unlike `derive`,
+   * the value still comes from input or an auto-generated secret.
+   */
+  alwaysEmit?: boolean;
 }
 
 export interface SectionMeta {

--- a/packages/sdp-env-config/src/validate.test.ts
+++ b/packages/sdp-env-config/src/validate.test.ts
@@ -19,11 +19,15 @@ test("valid value has no error", () => {
 });
 
 test("invisible required field is not validated", () => {
-  // CUSTODY_PRIVATE_KEY is required but hidden unless SIGNING_PROVIDER=local
+  // CUSTODY_PRIVATE_KEY is required but hidden unless "local" is in SIGNING_PROVIDERS.
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "fireblocks",
     SIGNING_PROVIDER: "fireblocks",
     CUSTODY_PRIVATE_KEY: "",
+    FIREBLOCKS_API_KEY: "k",
+    FIREBLOCKS_API_SECRET: "s",
+    FIREBLOCKS_VAULT_ID: "0",
   });
   assert.equal(errors.CUSTODY_PRIVATE_KEY, undefined);
 });
@@ -41,6 +45,7 @@ test("a valid select value has no error", () => {
 test("managed signing with native fees requires a fee payer key", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "fireblocks",
     SIGNING_PROVIDER: "fireblocks",
     FEE_PAYMENT_PROVIDER: "native",
     FEE_PAYER_PRIVATE_KEY: "",
@@ -51,7 +56,9 @@ test("managed signing with native fees requires a fee payer key", () => {
 test("local signing with native fees does not require a fee payer key", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "local",
     SIGNING_PROVIDER: "local",
+    CUSTODY_PRIVATE_KEY: "k",
     FEE_PAYMENT_PROVIDER: "native",
     FEE_PAYER_PRIVATE_KEY: "",
   });
@@ -61,6 +68,7 @@ test("local signing with native fees does not require a fee payer key", () => {
 test("utila signing requires Utila credentials", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "utila",
     SIGNING_PROVIDER: "utila",
     FEE_PAYMENT_PROVIDER: "kora",
     UTILA_SERVICE_ACCOUNT_EMAIL: "",
@@ -78,6 +86,7 @@ test("utila signing requires Utila credentials", () => {
 test("valid utila signing config has no Utila field errors", () => {
   const errors = validateValues({
     ...defaultValues(),
+    SIGNING_PROVIDERS: "utila",
     SIGNING_PROVIDER: "utila",
     FEE_PAYMENT_PROVIDER: "kora",
     UTILA_SERVICE_ACCOUNT_EMAIL: "service@vault.example.utilaserviceaccount.io",
@@ -105,6 +114,29 @@ test("valid utila signing config has no Utila field errors", () => {
   ]) {
     assert.equal(errors[key], undefined, `${key}: ${errors[key]}`);
   }
+});
+
+test("an unknown provider in SIGNING_PROVIDERS reports an error", () => {
+  const errors = validateValues({ ...defaultValues(), SIGNING_PROVIDERS: "local,bogus" });
+  assert.match(errors.SIGNING_PROVIDERS ?? "", /must be one of/);
+});
+
+test("a default provider outside the selected set reports an error", () => {
+  const errors = validateValues({
+    ...defaultValues(),
+    SIGNING_PROVIDERS: "local",
+    SIGNING_PROVIDER: "fireblocks",
+  });
+  assert.match(errors.SIGNING_PROVIDER ?? "", /must be one of: local/);
+});
+
+test("manual Postgres password is required when empty", () => {
+  const errors = validateValues({
+    ...defaultValues(),
+    POSTGRES_PASSWORD_MODE: "manual",
+    POSTGRES_PASSWORD: "",
+  });
+  assert.ok(errors.POSTGRES_PASSWORD);
 });
 
 test("a value with a newline is rejected as multi-line", () => {

--- a/packages/sdp-env-config/src/validate.test.ts
+++ b/packages/sdp-env-config/src/validate.test.ts
@@ -139,6 +139,18 @@ test("manual Postgres password is required when empty", () => {
   assert.ok(errors.POSTGRES_PASSWORD);
 });
 
+test("an always-emitted password is validated even when hidden by external DB", () => {
+  // POSTGRES_PASSWORD is hidden under an external database but still emitted and
+  // required, so an empty value must be caught rather than silently omitted.
+  const errors = validateValues({
+    ...defaultValues(),
+    DATABASE_MODE: "external",
+    DATABASE_URL: "postgresql://u@h:5432/d",
+    POSTGRES_PASSWORD: "",
+  });
+  assert.ok(errors.POSTGRES_PASSWORD);
+});
+
 test("a value with a newline is rejected as multi-line", () => {
   const errors = validateValues({
     ...defaultValues(),

--- a/packages/sdp-env-config/src/validate.ts
+++ b/packages/sdp-env-config/src/validate.ts
@@ -55,7 +55,9 @@ export function validateValues(values: Values): Errors {
   for (const f of FIELDS) {
     // Derived fields are computed, not user input — nothing to validate.
     if (f.derive) continue;
-    if (!isFieldVisible(f, values)) continue;
+    // Skip hidden fields, except `alwaysEmit` ones: those are emitted even when
+    // hidden, so a required-but-empty value must still be caught.
+    if (!isFieldVisible(f, values) && !f.alwaysEmit) continue;
     const error = validateField(f, values);
     if (error) errors[f.key] = error;
   }

--- a/packages/sdp-env-config/src/validate.ts
+++ b/packages/sdp-env-config/src/validate.ts
@@ -1,38 +1,63 @@
-import { FIELDS, isFieldVisible } from "./fields";
-import type { Values } from "./types";
+import { FIELDS, isFieldVisible, parseList } from "./fields";
+import type { EnvField, Values } from "./types";
 
 export type Errors = Record<string, string>;
 
-/** Validate only visible fields: required-but-empty and pattern mismatches. */
+/** Resolve a field's options, preferring the dynamic `optionsWhen` when present. */
+function resolveOptions(field: EnvField, values: Values) {
+  return field.optionsWhen ? field.optionsWhen(values) : field.options;
+}
+
+/**
+ * A select/multiselect must hold values drawn from its (possibly dynamic)
+ * options; this also catches a bad value injected via the environment.
+ * Returns an error message, or undefined when the values are acceptable.
+ */
+function optionMembershipError(
+  field: EnvField,
+  values: Values,
+  selected: string[]
+): string | undefined {
+  if (field.kind !== "select" && field.kind !== "multiselect") return undefined;
+  const opts = resolveOptions(field, values);
+  // Skip membership when there are no resolvable options yet (e.g. a default
+  // select whose options depend on a not-yet-chosen list): let the upstream
+  // field's own error stand instead of an empty "must be one of: " message.
+  if (!opts || opts.length === 0) return undefined;
+  const allowed = opts.map((o) => o.value);
+  if (selected.some((s) => !allowed.includes(s))) {
+    return `${field.label} must be one of: ${allowed.join(", ")}`;
+  }
+  return undefined;
+}
+
+/** Validate a single visible field; returns an error message or undefined. */
+function validateField(f: EnvField, values: Values): string | undefined {
+  const value = (values[f.key] ?? "").trim();
+  const isMultiselect = f.kind === "multiselect";
+  // A multiselect's emptiness is about its parsed entries, not the raw string,
+  // so a value like ",," counts as empty rather than satisfying `required`.
+  const selected = isMultiselect ? parseList(value) : value === "" ? [] : [value];
+
+  if (f.required && (isMultiselect ? selected.length === 0 : value === "")) {
+    return `${f.label} is required`;
+  }
+  if (value === "") return undefined;
+  // Reject control characters that could inject additional .env lines.
+  if (/[\r\n\0]/.test(value)) return `${f.label} must be a single line`;
+  if (f.pattern && !f.pattern.test(value)) return `${f.label} has an invalid format`;
+  return optionMembershipError(f, values, selected);
+}
+
+/** Validate only visible fields: required-but-empty, pattern, and option membership. */
 export function validateValues(values: Values): Errors {
   const errors: Errors = {};
   for (const f of FIELDS) {
     // Derived fields are computed, not user input — nothing to validate.
     if (f.derive) continue;
     if (!isFieldVisible(f, values)) continue;
-    const value = (values[f.key] ?? "").trim();
-
-    if (f.required && value === "") {
-      errors[f.key] = `${f.label} is required`;
-      continue;
-    }
-    // Reject control characters that could inject additional .env lines.
-    if (value !== "" && /[\r\n\0]/.test(value)) {
-      errors[f.key] = `${f.label} must be a single line`;
-      continue;
-    }
-    if (value !== "" && f.pattern && !f.pattern.test(value)) {
-      errors[f.key] = `${f.label} has an invalid format`;
-      continue;
-    }
-    // A select must hold one of its declared options; this catches a bad value
-    // injected through the environment in the non-interactive path.
-    if (value !== "" && f.kind === "select" && f.options) {
-      const allowed = f.options.map((o) => o.value);
-      if (!allowed.includes(value)) {
-        errors[f.key] = `${f.label} must be one of: ${allowed.join(", ")}`;
-      }
-    }
+    const error = validateField(f, values);
+    if (error) errors[f.key] = error;
   }
   return errors;
 }

--- a/scripts/check-env-configurator-drift.mjs
+++ b/scripts/check-env-configurator-drift.mjs
@@ -9,7 +9,12 @@ const ENV_EXAMPLE = path.join(repoRoot, "infra/self-hosted/.env.example");
 const FIELDS_FILE = path.join(repoRoot, "packages/sdp-env-config/src/fields.ts");
 
 // UI-only selectors that are not real env vars (see fields.ts UI_ONLY_KEYS).
-const IGNORE = new Set(["DATABASE_MODE", "CACHE_MODE"]);
+const IGNORE = new Set([
+  "DATABASE_MODE",
+  "CACHE_MODE",
+  "SIGNING_PROVIDERS",
+  "POSTGRES_PASSWORD_MODE",
+]);
 
 /** Keys declared in .env.example, including commented optionals (`# KEY=`). */
 function readExampleKeys() {

--- a/scripts/check-env-contract.mjs
+++ b/scripts/check-env-contract.mjs
@@ -41,6 +41,8 @@ const API_ENV_IGNORE = new Set([
   "SDP_CACHE",
   "SDP_RATE_LIMITS",
   "SDP_SESSIONS",
+  // Configurator-only input key (UI-only in @sdp/env-config); not an sdp-api runtime binding.
+  "SIGNING_PROVIDERS",
   "TRITON_API_KEY",
 ]);
 


### PR DESCRIPTION
## HOO-520 — Self-hosting docs section + .env configurator optimization

Adds the `docs/self-hosting` documentation section and optimizes the self-hosted `.env` configurator end-to-end across the shared core (`@sdp/env-config`), the CLI (`apps/sdp-api/scripts/configure.ts`), and the web form (`apps/sdp-docs/.../EnvConfigurator`).

### Self-hosting documentation

New Fumadocs pages under `apps/sdp-docs/content/docs/self-hosting/`, alongside the existing configurator and external-co-signers pages:

- **Landing** — overview of the stack and the section index
- **Quickstart** — install script, generating `.env`, `docker compose up`
- **Environment reference** — configuration sections and required variables
- **Upgrade & backup** — moving to a new release; `pg_dump` / restore
- **Troubleshooting** — common startup and configuration failures

### Configurator optimization

| # | Requirement | How |
|---|---|---|
| 1 | Environment vs deployment | `ENVIRONMENT` gains help text; `SDP_DEPLOYMENT_MODE` leaves the form and is emitted as the derived `self_hosted` constant |
| 2 | Postgres password auto/manual | `POSTGRES_PASSWORD_MODE` (auto/manual) drives generate-vs-enter via a `secretWhen` field hook |
| 4 | Multiple signing providers | `SIGNING_PROVIDERS` (UI-only multiselect) controls which credential blocks show; `SIGNING_PROVIDER` is the default, with options derived from the selected set |

Core (`@sdp/env-config`): new `multiselect` field kind; `optionsWhen` / `secretWhen` field hooks; values-aware `autoSecretKeys`; extracted + unit-tested `resolveMultiSelectTokens` parser; env-drift and env-contract guards exclude the new UI-only keys.

### External-database .env fix

The bundled Postgres container in `compose.yml` always starts and requires `POSTGRES_PASSWORD`, but the configurator hid and omitted that field when an external database was selected — producing an `.env` that failed `docker compose up`. Fixed with a new `alwaysEmit` field flag:

- `POSTGRES_PASSWORD` is auto-generated and emitted even when hidden, and generated regardless of password mode under an external database
- the interactive CLI path fills auto-secrets (matching the non-interactive path)
- the web form regenerates the password when switching to an external database
- validation now covers `alwaysEmit` fields even when hidden

### Verification

- `@sdp/env-config` tests: **37/37**
- `configure.node` tests: **20/20**
- typecheck (env-config + sdp-api): clean
- biome lint: clean
- `check:env-configurator-drift`: ok
- `sdp-docs` build: clean (65 pages)
