### PR TITLE
feat: add recurring payment activation API

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0010_payment_recurring_payment_activation_attempts.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0010_payment_recurring_payment_activation_attempts.sql
@@ -1,0 +1,40 @@
+-- Durable journal for product-level recurring payment activation. These rows
+-- let the API recover from partially completed plan/subscription activation.
+
+CREATE TABLE IF NOT EXISTS payment_recurring_payment_activation_attempts (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    recurring_payment_id TEXT NOT NULL,
+    plan_id TEXT,
+    subscription_id TEXT,
+    status TEXT NOT NULL DEFAULT 'processing',
+    phase TEXT NOT NULL DEFAULT 'claim',
+    plan_creation_signature TEXT,
+    authorization_signature TEXT,
+    error TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (recurring_payment_id) REFERENCES payment_recurring_payments(id) ON DELETE CASCADE,
+    FOREIGN KEY (plan_id) REFERENCES payment_subscription_plans(id) ON DELETE SET NULL,
+    FOREIGN KEY (subscription_id) REFERENCES payment_subscriptions(id) ON DELETE SET NULL,
+    CONSTRAINT payment_recurring_payment_activation_attempts_status_check
+        CHECK (status IN ('processing', 'confirmed', 'failed')),
+    CONSTRAINT payment_recurring_payment_activation_attempts_phase_check
+        CHECK (phase IN ('claim', 'create_plan', 'authorize_subscription', 'finalize')),
+    CONSTRAINT payment_recurring_payment_activation_attempts_metadata_is_object
+        CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_recurring_payment_activation_attempts_payment_created
+    ON payment_recurring_payment_activation_attempts(recurring_payment_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_payment_recurring_payment_activation_attempts_project_status_updated
+    ON payment_recurring_payment_activation_attempts(organization_id, project_id, status, updated_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_recurring_payment_activation_attempts_processing
+    ON payment_recurring_payment_activation_attempts(recurring_payment_id)
+    WHERE status = 'processing';

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -22,11 +22,17 @@ export type {
 } from "./counterparty-account.repository";
 export { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 export type {
+  CreatePaymentRecurringPaymentActivationAttemptInput,
   CreatePaymentRecurringPaymentInput,
   ListPaymentRecurringPaymentsInput,
   ListPaymentRecurringPaymentsResult,
+  PaymentRecurringPaymentActivationAttemptPhase,
+  PaymentRecurringPaymentActivationAttemptRow,
+  PaymentRecurringPaymentActivationAttemptStatus,
   PaymentRecurringPaymentRow,
   PaymentRecurringPaymentsRepository,
+  UpdatePaymentRecurringPaymentActivationAttemptInput,
+  UpdatePaymentRecurringPaymentActivationInput,
 } from "./payment-recurring-payments.repository";
 export { createPostgresPaymentRecurringPaymentsRepository } from "./payment-recurring-payments.repository.postgres";
 export type {

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -1,10 +1,14 @@
 import type { DatabaseExecutor } from "@/db";
 import type {
+  CreatePaymentRecurringPaymentActivationAttemptInput,
   CreatePaymentRecurringPaymentInput,
   ListPaymentRecurringPaymentsInput,
   ListPaymentRecurringPaymentsResult,
+  PaymentRecurringPaymentActivationAttemptRow,
   PaymentRecurringPaymentRow,
   PaymentRecurringPaymentsRepository,
+  UpdatePaymentRecurringPaymentActivationAttemptInput,
+  UpdatePaymentRecurringPaymentActivationInput,
 } from "./payment-recurring-payments.repository";
 
 function buildInClause(length: number): string {
@@ -44,6 +48,44 @@ function mapRecurringPaymentRow(row: Record<string, unknown>): PaymentRecurringP
   };
 }
 
+function parseMetadata(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function mapActivationAttemptRow(
+  row: Record<string, unknown>
+): PaymentRecurringPaymentActivationAttemptRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    recurring_payment_id: row.recurring_payment_id as string,
+    plan_id: (row.plan_id as string | null | undefined) ?? null,
+    subscription_id: (row.subscription_id as string | null | undefined) ?? null,
+    status: row.status as PaymentRecurringPaymentActivationAttemptRow["status"],
+    phase: row.phase as PaymentRecurringPaymentActivationAttemptRow["phase"],
+    plan_creation_signature: (row.plan_creation_signature as string | null | undefined) ?? null,
+    authorization_signature: (row.authorization_signature as string | null | undefined) ?? null,
+    error: (row.error as string | null | undefined) ?? null,
+    metadata: parseMetadata(row.metadata),
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 async function getRecurringPaymentByIdInternal(
   db: DatabaseExecutor,
   params: { recurringPaymentId: string; organizationId: string; projectId: string }
@@ -60,6 +102,24 @@ async function getRecurringPaymentByIdInternal(
     .first<Record<string, unknown>>();
 
   return row ? mapRecurringPaymentRow(row) : null;
+}
+
+async function getActivationAttemptByIdInternal(
+  db: DatabaseExecutor,
+  params: { attemptId: string; organizationId: string; projectId: string }
+): Promise<PaymentRecurringPaymentActivationAttemptRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT *
+         FROM payment_recurring_payment_activation_attempts
+        WHERE id = ?
+          AND organization_id = ?
+          AND project_id = ?`
+    )
+    .bind(params.attemptId, params.organizationId, params.projectId)
+    .first<Record<string, unknown>>();
+
+  return row ? mapActivationAttemptRow(row) : null;
 }
 
 export function createPostgresPaymentRecurringPaymentsRepository(
@@ -110,6 +170,107 @@ export function createPostgresPaymentRecurringPaymentsRepository(
 
       return getRecurringPaymentByIdInternal(db, {
         recurringPaymentId: input.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async claimRecurringPaymentActivation(params) {
+      let reclaimClause = "";
+      const reclaimValues: unknown[] = [];
+
+      if (params.staleBefore) {
+        reclaimClause = " OR (status = 'activating' AND updated_at < ?)";
+        reclaimValues.push(params.staleBefore);
+      }
+
+      const row = await db
+        .prepare(
+          `UPDATE payment_recurring_payments
+              SET status = 'activating',
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND (status = 'pending_activation'${reclaimClause})
+          RETURNING *`
+        )
+        .bind(
+          params.updatedAt,
+          params.recurringPaymentId,
+          params.organizationId,
+          params.projectId,
+          ...reclaimValues
+        )
+        .first<Record<string, unknown>>();
+
+      return row ? mapRecurringPaymentRow(row) : null;
+    },
+
+    async updateRecurringPaymentActivation(input: UpdatePaymentRecurringPaymentActivationInput) {
+      const existing = await getRecurringPaymentByIdInternal(db, {
+        recurringPaymentId: input.recurringPaymentId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+      if (!existing) return null;
+
+      await db
+        .prepare(
+          `UPDATE payment_recurring_payments
+              SET status = COALESCE(?, status),
+                  plan_id = CASE WHEN ?::boolean THEN ? ELSE plan_id END,
+                  subscription_id = CASE WHEN ?::boolean THEN ? ELSE subscription_id END,
+                  plan_pda = CASE WHEN ?::boolean THEN ? ELSE plan_pda END,
+                  plan_created_at = CASE WHEN ?::boolean THEN ? ELSE plan_created_at END,
+                  plan_creation_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE plan_creation_signature END,
+                  subscription_pda =
+                    CASE WHEN ?::boolean THEN ? ELSE subscription_pda END,
+                  subscription_authority_address =
+                    CASE WHEN ?::boolean THEN ? ELSE subscription_authority_address END,
+                  authorization_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE authorization_signature END,
+                  next_collection_due_at =
+                    CASE WHEN ?::boolean THEN ? ELSE next_collection_due_at END,
+                  destination_token_account =
+                    CASE WHEN ?::boolean THEN ? ELSE destination_token_account END,
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?`
+        )
+        .bind(
+          input.status ?? null,
+          input.planId !== undefined,
+          input.planId ?? null,
+          input.subscriptionId !== undefined,
+          input.subscriptionId ?? null,
+          input.planPda !== undefined,
+          input.planPda ?? null,
+          input.planCreatedAt !== undefined,
+          input.planCreatedAt ?? null,
+          input.planCreationSignature !== undefined,
+          input.planCreationSignature ?? null,
+          input.subscriptionPda !== undefined,
+          input.subscriptionPda ?? null,
+          input.subscriptionAuthorityAddress !== undefined,
+          input.subscriptionAuthorityAddress ?? null,
+          input.authorizationSignature !== undefined,
+          input.authorizationSignature ?? null,
+          input.nextCollectionDueAt !== undefined,
+          input.nextCollectionDueAt ?? null,
+          input.destinationTokenAccount !== undefined,
+          input.destinationTokenAccount ?? null,
+          input.updatedAt,
+          input.recurringPaymentId,
+          input.organizationId,
+          input.projectId
+        )
+        .run();
+
+      return getRecurringPaymentByIdInternal(db, {
+        recurringPaymentId: input.recurringPaymentId,
         organizationId: input.organizationId,
         projectId: input.projectId,
       });
@@ -187,6 +348,124 @@ export function createPostgresPaymentRecurringPaymentsRepository(
         rows: rows.results.map(mapRecurringPaymentRow),
         total: countRow?.total ?? 0,
       } satisfies ListPaymentRecurringPaymentsResult;
+    },
+
+    async createActivationAttempt(input: CreatePaymentRecurringPaymentActivationAttemptInput) {
+      await db
+        .prepare(
+          `INSERT INTO payment_recurring_payment_activation_attempts (
+             id,
+             organization_id,
+             project_id,
+             recurring_payment_id,
+             plan_id,
+             subscription_id,
+             status,
+             phase,
+             plan_creation_signature,
+             authorization_signature,
+             error,
+             metadata,
+             created_at,
+             updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT DO NOTHING`
+        )
+        .bind(
+          input.id,
+          input.organizationId,
+          input.projectId,
+          input.recurringPaymentId,
+          input.planId,
+          input.subscriptionId,
+          input.status,
+          input.phase,
+          input.planCreationSignature,
+          input.authorizationSignature,
+          input.error,
+          JSON.stringify(input.metadata),
+          input.createdAt,
+          input.updatedAt
+        )
+        .run();
+
+      return getActivationAttemptByIdInternal(db, {
+        attemptId: input.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async updateActivationAttempt(input: UpdatePaymentRecurringPaymentActivationAttemptInput) {
+      const existing = await getActivationAttemptByIdInternal(db, {
+        attemptId: input.attemptId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+      if (!existing) return null;
+
+      await db
+        .prepare(
+          `UPDATE payment_recurring_payment_activation_attempts
+              SET plan_id = CASE WHEN ?::boolean THEN ? ELSE plan_id END,
+                  subscription_id = CASE WHEN ?::boolean THEN ? ELSE subscription_id END,
+                  status = COALESCE(?, status),
+                  phase = COALESCE(?, phase),
+                  plan_creation_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE plan_creation_signature END,
+                  authorization_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE authorization_signature END,
+                  error = CASE WHEN ?::boolean THEN ? ELSE error END,
+                  metadata = CASE WHEN ?::boolean THEN ?::jsonb ELSE metadata END,
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?`
+        )
+        .bind(
+          input.planId !== undefined,
+          input.planId ?? null,
+          input.subscriptionId !== undefined,
+          input.subscriptionId ?? null,
+          input.status ?? null,
+          input.phase ?? null,
+          input.planCreationSignature !== undefined,
+          input.planCreationSignature ?? null,
+          input.authorizationSignature !== undefined,
+          input.authorizationSignature ?? null,
+          input.error !== undefined,
+          input.error ?? null,
+          input.metadata !== undefined,
+          input.metadata ? JSON.stringify(input.metadata) : null,
+          input.updatedAt,
+          input.attemptId,
+          input.organizationId,
+          input.projectId
+        )
+        .run();
+
+      return getActivationAttemptByIdInternal(db, {
+        attemptId: input.attemptId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async getLatestActivationAttempt(params) {
+      const row = await db
+        .prepare(
+          `SELECT *
+             FROM payment_recurring_payment_activation_attempts
+            WHERE recurring_payment_id = ?
+              AND organization_id = ?
+              AND project_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1`
+        )
+        .bind(params.recurringPaymentId, params.organizationId, params.projectId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapActivationAttemptRow(row) : null;
     },
   };
 }

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -178,10 +178,31 @@ export function createPostgresPaymentRecurringPaymentsRepository(
     async claimRecurringPaymentActivation(params) {
       let reclaimClause = "";
       const reclaimValues: unknown[] = [];
+      let freshAttemptClause = "";
+      const freshAttemptValues: unknown[] = [];
 
       if (params.staleBefore) {
         reclaimClause = " OR (status = 'activating' AND updated_at < ?)";
         reclaimValues.push(params.staleBefore);
+        freshAttemptClause = `AND NOT EXISTS (
+                SELECT 1
+                  FROM payment_recurring_payment_activation_attempts attempts
+                 WHERE attempts.recurring_payment_id = payment_recurring_payments.id
+                   AND attempts.organization_id = payment_recurring_payments.organization_id
+                   AND attempts.project_id = payment_recurring_payments.project_id
+                   AND attempts.status = 'processing'
+                   AND attempts.updated_at >= ?
+              )`;
+        freshAttemptValues.push(params.staleBefore);
+      } else {
+        freshAttemptClause = `AND NOT EXISTS (
+                SELECT 1
+                  FROM payment_recurring_payment_activation_attempts attempts
+                 WHERE attempts.recurring_payment_id = payment_recurring_payments.id
+                   AND attempts.organization_id = payment_recurring_payments.organization_id
+                   AND attempts.project_id = payment_recurring_payments.project_id
+                   AND attempts.status = 'processing'
+              )`;
       }
 
       const row = await db
@@ -193,6 +214,7 @@ export function createPostgresPaymentRecurringPaymentsRepository(
               AND organization_id = ?
               AND project_id = ?
               AND (status = 'pending_activation'${reclaimClause})
+              ${freshAttemptClause}
           RETURNING *`
         )
         .bind(
@@ -200,7 +222,8 @@ export function createPostgresPaymentRecurringPaymentsRepository(
           params.recurringPaymentId,
           params.organizationId,
           params.projectId,
-          ...reclaimValues
+          ...reclaimValues,
+          ...freshAttemptValues
         )
         .first<Record<string, unknown>>();
 
@@ -226,14 +249,8 @@ export function createPostgresPaymentRecurringPaymentsRepository(
     },
 
     async updateRecurringPaymentActivation(input: UpdatePaymentRecurringPaymentActivationInput) {
-      const existing = await getRecurringPaymentByIdInternal(db, {
-        recurringPaymentId: input.recurringPaymentId,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-      });
-      if (!existing) return null;
-
-      await db
+      const allowActiveUpdate = input.status === "active";
+      const row = await db
         .prepare(
           `UPDATE payment_recurring_payments
               SET status = COALESCE(?, status),
@@ -256,7 +273,9 @@ export function createPostgresPaymentRecurringPaymentsRepository(
                   updated_at = ?
             WHERE id = ?
               AND organization_id = ?
-              AND project_id = ?`
+              AND project_id = ?
+              AND (status <> 'active' OR ?::boolean)
+          RETURNING *`
         )
         .bind(
           input.status ?? null,
@@ -283,15 +302,12 @@ export function createPostgresPaymentRecurringPaymentsRepository(
           input.updatedAt,
           input.recurringPaymentId,
           input.organizationId,
-          input.projectId
+          input.projectId,
+          allowActiveUpdate
         )
-        .run();
+        .first<Record<string, unknown>>();
 
-      return getRecurringPaymentByIdInternal(db, {
-        recurringPaymentId: input.recurringPaymentId,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-      });
+      return row ? mapRecurringPaymentRow(row) : null;
     },
 
     async getRecurringPaymentById(params) {
@@ -415,14 +431,7 @@ export function createPostgresPaymentRecurringPaymentsRepository(
     },
 
     async updateActivationAttempt(input: UpdatePaymentRecurringPaymentActivationAttemptInput) {
-      const existing = await getActivationAttemptByIdInternal(db, {
-        attemptId: input.attemptId,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-      });
-      if (!existing) return null;
-
-      await db
+      const row = await db
         .prepare(
           `UPDATE payment_recurring_payment_activation_attempts
               SET plan_id = CASE WHEN ?::boolean THEN ? ELSE plan_id END,
@@ -438,7 +447,8 @@ export function createPostgresPaymentRecurringPaymentsRepository(
                   updated_at = ?
             WHERE id = ?
               AND organization_id = ?
-              AND project_id = ?`
+              AND project_id = ?
+          RETURNING *`
         )
         .bind(
           input.planId !== undefined,
@@ -460,13 +470,9 @@ export function createPostgresPaymentRecurringPaymentsRepository(
           input.organizationId,
           input.projectId
         )
-        .run();
+        .first<Record<string, unknown>>();
 
-      return getActivationAttemptByIdInternal(db, {
-        attemptId: input.attemptId,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-      });
+      return row ? mapActivationAttemptRow(row) : null;
     },
 
     async getLatestActivationAttempt(params) {

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -207,6 +207,24 @@ export function createPostgresPaymentRecurringPaymentsRepository(
       return row ? mapRecurringPaymentRow(row) : null;
     },
 
+    async resetRecurringPaymentActivationIfNotActive(params) {
+      const row = await db
+        .prepare(
+          `UPDATE payment_recurring_payments
+              SET status = 'pending_activation',
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND status <> 'active'
+          RETURNING *`
+        )
+        .bind(params.updatedAt, params.recurringPaymentId, params.organizationId, params.projectId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapRecurringPaymentRow(row) : null;
+    },
+
     async updateRecurringPaymentActivation(input: UpdatePaymentRecurringPaymentActivationInput) {
       const existing = await getRecurringPaymentByIdInternal(db, {
         recurringPaymentId: input.recurringPaymentId,

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -369,7 +369,7 @@ export function createPostgresPaymentRecurringPaymentsRepository(
              created_at,
              updated_at
            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT DO NOTHING`
+           ON CONFLICT (recurring_payment_id) WHERE status = 'processing' DO NOTHING`
         )
         .bind(
           input.id,

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
@@ -30,6 +30,31 @@ export interface PaymentRecurringPaymentRow {
   updated_at: string;
 }
 
+export type PaymentRecurringPaymentActivationAttemptStatus = "processing" | "confirmed" | "failed";
+
+export type PaymentRecurringPaymentActivationAttemptPhase =
+  | "claim"
+  | "create_plan"
+  | "authorize_subscription"
+  | "finalize";
+
+export interface PaymentRecurringPaymentActivationAttemptRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  recurring_payment_id: string;
+  plan_id: string | null;
+  subscription_id: string | null;
+  status: PaymentRecurringPaymentActivationAttemptStatus;
+  phase: PaymentRecurringPaymentActivationAttemptPhase;
+  plan_creation_signature: string | null;
+  authorization_signature: string | null;
+  error: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface CreatePaymentRecurringPaymentInput {
   id: string;
   organizationId: string;
@@ -46,6 +71,56 @@ export interface CreatePaymentRecurringPaymentInput {
   metadataUri: string | null;
   createdBy: string | null;
   createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdatePaymentRecurringPaymentActivationInput {
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  status?: PaymentRecurringPaymentStatus;
+  planId?: string | null;
+  subscriptionId?: string | null;
+  planPda?: string | null;
+  planCreatedAt?: string | null;
+  planCreationSignature?: string | null;
+  subscriptionPda?: string | null;
+  subscriptionAuthorityAddress?: string | null;
+  authorizationSignature?: string | null;
+  nextCollectionDueAt?: string | null;
+  destinationTokenAccount?: string | null;
+  updatedAt: string;
+}
+
+export interface CreatePaymentRecurringPaymentActivationAttemptInput {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  recurringPaymentId: string;
+  planId: string | null;
+  subscriptionId: string | null;
+  status: PaymentRecurringPaymentActivationAttemptStatus;
+  phase: PaymentRecurringPaymentActivationAttemptPhase;
+  planCreationSignature: string | null;
+  authorizationSignature: string | null;
+  error: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdatePaymentRecurringPaymentActivationAttemptInput {
+  attemptId: string;
+  organizationId: string;
+  projectId: string;
+  planId?: string | null;
+  subscriptionId?: string | null;
+  status?: PaymentRecurringPaymentActivationAttemptStatus;
+  phase?: PaymentRecurringPaymentActivationAttemptPhase;
+  planCreationSignature?: string | null;
+  authorizationSignature?: string | null;
+  error?: string | null;
+  metadata?: Record<string, unknown>;
   updatedAt: string;
 }
 
@@ -68,6 +143,16 @@ export interface PaymentRecurringPaymentsRepository {
   createRecurringPayment(
     input: CreatePaymentRecurringPaymentInput
   ): Promise<PaymentRecurringPaymentRow | null>;
+  claimRecurringPaymentActivation(params: {
+    recurringPaymentId: string;
+    organizationId: string;
+    projectId: string;
+    staleBefore?: string;
+    updatedAt: string;
+  }): Promise<PaymentRecurringPaymentRow | null>;
+  updateRecurringPaymentActivation(
+    input: UpdatePaymentRecurringPaymentActivationInput
+  ): Promise<PaymentRecurringPaymentRow | null>;
   getRecurringPaymentById(params: {
     recurringPaymentId: string;
     organizationId: string;
@@ -77,4 +162,15 @@ export interface PaymentRecurringPaymentsRepository {
   listRecurringPayments(
     params: ListPaymentRecurringPaymentsInput
   ): Promise<ListPaymentRecurringPaymentsResult>;
+  createActivationAttempt(
+    input: CreatePaymentRecurringPaymentActivationAttemptInput
+  ): Promise<PaymentRecurringPaymentActivationAttemptRow | null>;
+  updateActivationAttempt(
+    input: UpdatePaymentRecurringPaymentActivationAttemptInput
+  ): Promise<PaymentRecurringPaymentActivationAttemptRow | null>;
+  getLatestActivationAttempt(params: {
+    recurringPaymentId: string;
+    organizationId: string;
+    projectId: string;
+  }): Promise<PaymentRecurringPaymentActivationAttemptRow | null>;
 }

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
@@ -150,6 +150,12 @@ export interface PaymentRecurringPaymentsRepository {
     staleBefore?: string;
     updatedAt: string;
   }): Promise<PaymentRecurringPaymentRow | null>;
+  resetRecurringPaymentActivationIfNotActive(params: {
+    recurringPaymentId: string;
+    organizationId: string;
+    projectId: string;
+    updatedAt: string;
+  }): Promise<PaymentRecurringPaymentRow | null>;
   updateRecurringPaymentActivation(
     input: UpdatePaymentRecurringPaymentActivationInput
   ): Promise<PaymentRecurringPaymentRow | null>;

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -241,7 +241,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     summary: "Create recurring payment",
     operationId: "createPaymentRecurringPayment",
     description:
-      "Creates an SDP-custody outbound recurring payment intent from a custody wallet to a counterparty crypto-wallet account. This stores backend state only; activation and collection are added by follow-up endpoints.",
+      "Creates an SDP-custody outbound recurring payment intent from a custody wallet to a counterparty crypto-wallet account. This stores backend state only; activation creates the on-chain authorization in a follow-up request.",
     security: [{ apiKeyAuth: [] }],
     request: {
       headers: projectScopeHeaders,
@@ -256,6 +256,28 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
         content: jsonContent(paymentRecurringPaymentResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/payments/recurring-payments/{id}/activate",
+    tags: ["Payments"],
+    summary: "Activate recurring payment",
+    operationId: "activatePaymentRecurringPayment",
+    description:
+      "Activates a pending SDP-custody outbound recurring payment by creating the Solana subscriptions plan and subscription authorization with the source custody wallet. The operation is idempotent once active and does not collect funds.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: paymentRecurringPaymentIdParamsSchema,
+    },
+    responses: {
+      200: {
+        description: "Recurring payment activated",
+        content: jsonContent(paymentRecurringPaymentResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 409, 500]),
     },
   });
 

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -15,6 +15,7 @@ import {
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
 } from "@solana/kit";
+import * as subscriptionsProgram from "@solana/subscriptions";
 import { getTransferSolInstruction } from "@solana-program/system";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
@@ -39,6 +40,15 @@ const getSplTokenBalancesMock = vi.spyOn(tokenAccounts, "getSplTokenBalances");
 const getSplTokenAccountAddressesMock = vi.spyOn(tokenAccounts, "getSplTokenAccountAddresses");
 const createFeePaymentAdapterMock = vi.spyOn(feePaymentAdapters, "createFeePaymentAdapter");
 const createOrgSignerMock = vi.spyOn(solanaServices, "createOrgSigner");
+const fetchPlanMock = vi.spyOn(subscriptionsProgram, "fetchPlan");
+const fetchMaybeSubscriptionAuthorityMock = vi.spyOn(
+  subscriptionsProgram,
+  "fetchMaybeSubscriptionAuthority"
+);
+const fetchMaybeSubscriptionDelegationMock = vi.spyOn(
+  subscriptionsProgram,
+  "fetchMaybeSubscriptionDelegation"
+);
 
 const TEST_CONFIG_ID = "cust_cfg_payments_test";
 const TEST_CUSTODY_WALLET_ID = "cwlt_payments_test";
@@ -415,6 +425,37 @@ function mockTokenSupplyDecimalsOnce(decimals = 6): void {
   } as unknown as ReturnType<typeof solanaRpc.createRpc>);
 }
 
+function mockRecurringActivationRpc(decimals = 6): void {
+  createRpcMock.mockReturnValue({
+    getTokenAccountsByOwner: () => ({
+      send: async () => ({
+        value: [
+          {
+            pubkey: TEST_SOLANA_ADDRESSES.wallet3,
+            account: {
+              data: {
+                parsed: {
+                  info: {
+                    mint: DEVNET_USDC_MINT,
+                    tokenAmount: {
+                      amount: "100000000",
+                      decimals,
+                      uiAmountString: "100.00",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    }),
+    getTokenSupply: () => ({
+      send: async () => ({ value: { decimals } }),
+    }),
+  } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+}
+
 function expectPreparedSubscriptionTransaction(
   preparedTransaction: {
     serialized: string;
@@ -478,6 +519,18 @@ describe("Payments routes", () => {
     getSignaturesForAddressMock.mockResolvedValue([]);
     getSplTokenBalancesMock.mockResolvedValue([]);
     getSplTokenAccountAddressesMock.mockResolvedValue([]);
+    fetchPlanMock.mockResolvedValue({
+      data: { data: { terms: { createdAt: 1_770_000_000n } } },
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchPlan>>);
+    fetchMaybeSubscriptionAuthorityMock.mockResolvedValue({
+      exists: false,
+      address: address(TEST_SOLANA_ADDRESSES.wallet3),
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionAuthority>>);
+    fetchMaybeSubscriptionDelegationMock.mockResolvedValue({
+      exists: true,
+      address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      data: {},
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>);
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue("7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv"),
@@ -664,6 +717,312 @@ describe("Payments routes", () => {
     };
     expect(getBody.data.recurringPayment.id).toBe(createBody.data.recurringPayment.id);
     expect(getBody.data.recurringPayment.status).toBe("pending_activation");
+  });
+
+  it("activates recurring payments through SDP API routes and is idempotent once active", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+      )
+      .mockResolvedValueOnce(
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      );
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(200);
+    const activateBody = (await activateRes.json()) as {
+      data: {
+        recurringPayment: {
+          id: string;
+          status: string;
+          planId: string;
+          subscriptionId: string;
+          planPda: string;
+          planCreatedAt: string;
+          planCreationSignature: string;
+          subscriptionPda: string;
+          subscriptionAuthorityAddress: string;
+          authorizationSignature: string;
+          nextCollectionDueAt: string;
+        };
+      };
+    };
+    expect(activateBody.data.recurringPayment).toMatchObject({
+      id: createBody.data.recurringPayment.id,
+      status: "active",
+      planCreatedAt: "1770000000",
+      planCreationSignature:
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy",
+      authorizationSignature:
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV",
+    });
+    expect(activateBody.data.recurringPayment.planId).toMatch(/^psp_/);
+    expect(activateBody.data.recurringPayment.subscriptionId).toMatch(/^psub_/);
+    expect(activateBody.data.recurringPayment.planPda).toBeTruthy();
+    expect(activateBody.data.recurringPayment.subscriptionPda).toBeTruthy();
+    expect(activateBody.data.recurringPayment.subscriptionAuthorityAddress).toBeTruthy();
+    expect(activateBody.data.recurringPayment.nextCollectionDueAt).toBeTruthy();
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+
+    const attempt = await getDb(env)
+      .prepare(
+        `SELECT status, phase
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{ status: string; phase: string }>();
+    expect(attempt).toEqual({ status: "confirmed", phase: "finalize" });
+
+    const idempotentRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+    expect(idempotentRes.status).toBe(200);
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gates recurring payment activation behind PAYMENTS_RECURRING_ENABLED", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_gate_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+    env.PAYMENTS_RECURRING_ENABLED = undefined;
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(403);
+  });
+
+  it("rejects recurring payment activation when the source token account is missing", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    createRpcMock.mockReturnValue({
+      getTokenAccountsByOwner: () => ({
+        send: async () => ({ value: [] }),
+      }),
+      getTokenSupply: () => ({
+        send: async () => ({ value: { decimals: 6 } }),
+      }),
+    } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+    const signAndSendMock = vi.fn();
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_missing_source_token",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(400);
+    expect(signAndSendMock).not.toHaveBeenCalled();
+    const row = await getDb(env)
+      .prepare("SELECT status FROM payment_recurring_payments WHERE id = ?")
+      .bind(createBody.data.recurringPayment.id)
+      .first<{ status: string }>();
+    expect(row?.status).toBe("pending_activation");
+  });
+
+  it("journals failed recurring payment activation attempts", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi.fn().mockRejectedValue(new Error("kora unavailable"));
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_failure_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(500);
+    const attempt = await getDb(env)
+      .prepare(
+        `SELECT status, phase, error
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{ status: string; phase: string; error: string }>();
+    expect(attempt?.status).toBe("failed");
+    expect(attempt?.phase).toBe("create_plan");
+    expect(attempt?.error).toContain("kora unavailable");
+    const row = await getDb(env)
+      .prepare("SELECT status FROM payment_recurring_payments WHERE id = ?")
+      .bind(createBody.data.recurringPayment.id)
+      .first<{ status: string }>();
+    expect(row?.status).toBe("pending_activation");
   });
 
   it("requires owner wallet access when updating subscription plans", async () => {

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1063,6 +1063,16 @@ describe("Payments routes", () => {
         confirmationStatus: "confirmed",
         err: null,
       } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    fetchMaybePlanMock
+      .mockResolvedValueOnce({
+        exists: false,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>>)
+      .mockResolvedValue({
+        exists: true,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+        data: { data: { terms: { createdAt: 1_770_000_000n } } },
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>>);
     const headers = {
       Authorization: `Bearer ${TEST_API_KEY.raw}`,
       "Content-Type": "application/json",
@@ -1246,6 +1256,132 @@ describe("Payments routes", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(3);
   });
 
+  it("recovers an on-chain plan when the plan signature was not persisted", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const authorizationSignature =
+      "3mPvcVSTobARmwhHAzGkXWTLG6hiP1eq84B91g9f2Eczg4xbXn7SQeBHbZdmpWFmxK9MqTzjqJrTgQyXT5wXW1S8" as Signature;
+    const signAndSendMock = vi.fn().mockResolvedValue(authorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_plan_signature_not_persisted_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+    const now = new Date().toISOString();
+    const planId = "psp_recovered_plan_signature_not_persisted";
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_subscription_plans (
+           id,
+           organization_id,
+           project_id,
+           owner_wallet_id,
+           owner_address,
+           token,
+           amount,
+           period_hours,
+           program_plan_id,
+           plan_pda,
+           destination_address,
+           puller_wallet_id,
+           puller_address,
+           metadata_uri,
+           status,
+           created_by,
+           created_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        planId,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_WALLET_ID,
+        sourceSigner.address,
+        DEVNET_USDC_MINT,
+        "25.00",
+        24,
+        "7001",
+        null,
+        TEST_SOLANA_ADDRESSES.wallet2,
+        TEST_WALLET_ID,
+        sourceSigner.address,
+        null,
+        "draft",
+        TEST_USER.id,
+        now,
+        now
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        `UPDATE payment_recurring_payments
+            SET plan_id = ?,
+                plan_creation_signature = NULL
+          WHERE id = ?`
+      )
+      .bind(planId, createBody.data.recurringPayment.id)
+      .run();
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(200);
+    const activateBody = (await activateRes.json()) as {
+      data: {
+        recurringPayment: {
+          planCreationSignature: string | null;
+          authorizationSignature: string;
+          status: string;
+        };
+      };
+    };
+    expect(activateBody.data.recurringPayment.status).toBe("active");
+    expect(activateBody.data.recurringPayment.planCreationSignature).toBeNull();
+    expect(activateBody.data.recurringPayment.authorizationSignature).toBe(authorizationSignature);
+    expect(signAndSendMock).toHaveBeenCalledTimes(1);
+  });
+
   it("clears failed authorization signatures so recurring payment activation can retry", async () => {
     env.PAYMENTS_RECURRING_ENABLED = "true";
     const sourceSigner = await generateKeyPairSigner();
@@ -1288,6 +1424,16 @@ describe("Payments routes", () => {
         confirmationStatus: "confirmed",
         err: null,
       } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    fetchMaybeSubscriptionDelegationMock
+      .mockResolvedValueOnce({
+        exists: false,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>)
+      .mockResolvedValue({
+        exists: true,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+        data: {},
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>);
     const headers = {
       Authorization: `Bearer ${TEST_API_KEY.raw}`,
       "Content-Type": "application/json",
@@ -1384,6 +1530,173 @@ describe("Payments routes", () => {
       retryAuthorizationSignature
     );
     expect(signAndSendMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("recovers an on-chain subscription when the authorization signature was not persisted", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi.fn();
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_authorization_signature_not_persisted_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+    const now = new Date().toISOString();
+    const planId = "psp_recovered_authorization_signature_not_persisted";
+    const subscriptionId = "psub_recovered_authorization_signature_not_persisted";
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_subscription_plans (
+           id,
+           organization_id,
+           project_id,
+           owner_wallet_id,
+           owner_address,
+           token,
+           amount,
+           period_hours,
+           program_plan_id,
+           plan_pda,
+           destination_address,
+           puller_wallet_id,
+           puller_address,
+           metadata_uri,
+           status,
+           created_by,
+           created_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        planId,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_WALLET_ID,
+        sourceSigner.address,
+        DEVNET_USDC_MINT,
+        "25.00",
+        24,
+        "7002",
+        null,
+        TEST_SOLANA_ADDRESSES.wallet2,
+        TEST_WALLET_ID,
+        sourceSigner.address,
+        null,
+        "draft",
+        TEST_USER.id,
+        now,
+        now
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_subscriptions (
+           id,
+           organization_id,
+           project_id,
+           plan_id,
+           counterparty_id,
+           subscriber_address,
+           subscriber_token_account,
+           subscription_pda,
+           subscription_authority_address,
+           authorization_signature,
+           status,
+           current_period_start_at,
+           next_collection_due_at,
+           created_by,
+           created_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        subscriptionId,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        planId,
+        counterpartyId,
+        sourceSigner.address,
+        null,
+        null,
+        null,
+        null,
+        "pending_authorization",
+        null,
+        null,
+        TEST_USER.id,
+        now,
+        now
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        `UPDATE payment_recurring_payments
+            SET plan_id = ?,
+                subscription_id = ?,
+                plan_creation_signature = NULL,
+                authorization_signature = NULL
+          WHERE id = ?`
+      )
+      .bind(planId, subscriptionId, createBody.data.recurringPayment.id)
+      .run();
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(200);
+    const activateBody = (await activateRes.json()) as {
+      data: {
+        recurringPayment: {
+          planCreationSignature: string | null;
+          authorizationSignature: string | null;
+          status: string;
+        };
+      };
+    };
+    expect(activateBody.data.recurringPayment.status).toBe("active");
+    expect(activateBody.data.recurringPayment.planCreationSignature).toBeNull();
+    expect(activateBody.data.recurringPayment.authorizationSignature).toBeNull();
+    expect(signAndSendMock).not.toHaveBeenCalled();
   });
 
   it("resubmits preserved authorization signatures when the subscription account is absent on retry", async () => {

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -40,7 +40,7 @@ const getSplTokenBalancesMock = vi.spyOn(tokenAccounts, "getSplTokenBalances");
 const getSplTokenAccountAddressesMock = vi.spyOn(tokenAccounts, "getSplTokenAccountAddresses");
 const createFeePaymentAdapterMock = vi.spyOn(feePaymentAdapters, "createFeePaymentAdapter");
 const createOrgSignerMock = vi.spyOn(solanaServices, "createOrgSigner");
-const fetchPlanMock = vi.spyOn(subscriptionsProgram, "fetchPlan");
+const fetchMaybePlanMock = vi.spyOn(subscriptionsProgram, "fetchMaybePlan");
 const fetchMaybeSubscriptionAuthorityMock = vi.spyOn(
   subscriptionsProgram,
   "fetchMaybeSubscriptionAuthority"
@@ -519,9 +519,11 @@ describe("Payments routes", () => {
     getSignaturesForAddressMock.mockResolvedValue([]);
     getSplTokenBalancesMock.mockResolvedValue([]);
     getSplTokenAccountAddressesMock.mockResolvedValue([]);
-    fetchPlanMock.mockResolvedValue({
+    fetchMaybePlanMock.mockResolvedValue({
+      exists: true,
+      address: address(TEST_SOLANA_ADDRESSES.wallet3),
       data: { data: { terms: { createdAt: 1_770_000_000n } } },
-    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchPlan>>);
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>>);
     fetchMaybeSubscriptionAuthorityMock.mockResolvedValue({
       exists: false,
       address: address(TEST_SOLANA_ADDRESSES.wallet3),
@@ -1133,6 +1135,117 @@ describe("Payments routes", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(3);
   });
 
+  it("resubmits preserved plan signatures when the plan account is absent on retry", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const failedPlanSignature =
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+    const retryPlanSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const authorizationSignature =
+      "3mPvcVSTobARmwhHAzGkXWTLG6hiP1eq84B91g9f2Eczg4xbXn7SQeBHbZdmpWFmxK9MqTzjqJrTgQyXT5wXW1S8" as Signature;
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(failedPlanSignature)
+      .mockResolvedValueOnce(retryPlanSignature)
+      .mockResolvedValueOnce(authorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock.mockRejectedValueOnce(new Error("RPC timeout")).mockResolvedValue({
+      signature: authorizationSignature,
+      slot: 101n,
+      confirmationStatus: "confirmed",
+      err: null,
+    } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    fetchMaybePlanMock
+      .mockResolvedValueOnce({
+        exists: false,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>>)
+      .mockResolvedValue({
+        exists: true,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+        data: { data: { terms: { createdAt: 1_770_000_000n } } },
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_preserved_plan_retry_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(failedActivateRes.status).toBe(500);
+    const failedRow = await getDb(env)
+      .prepare(
+        `SELECT status, plan_creation_signature
+           FROM payment_recurring_payments
+          WHERE id = ?`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{ status: string; plan_creation_signature: string | null }>();
+    expect(failedRow).toEqual({
+      status: "pending_activation",
+      plan_creation_signature: failedPlanSignature,
+    });
+
+    const retryActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(retryActivateRes.status).toBe(200);
+    const retryActivateBody = (await retryActivateRes.json()) as {
+      data: { recurringPayment: { planCreationSignature: string; status: string } };
+    };
+    expect(retryActivateBody.data.recurringPayment.status).toBe("active");
+    expect(retryActivateBody.data.recurringPayment.planCreationSignature).toBe(retryPlanSignature);
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+  });
+
   it("clears failed authorization signatures so recurring payment activation can retry", async () => {
     env.PAYMENTS_RECURRING_ENABLED = "true";
     const sourceSigner = await generateKeyPairSigner();
@@ -1265,6 +1378,132 @@ describe("Payments routes", () => {
     expect(retryActivateRes.status).toBe(200);
     const retryActivateBody = (await retryActivateRes.json()) as {
       data: { recurringPayment: { status: string; authorizationSignature: string } };
+    };
+    expect(retryActivateBody.data.recurringPayment.status).toBe("active");
+    expect(retryActivateBody.data.recurringPayment.authorizationSignature).toBe(
+      retryAuthorizationSignature
+    );
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("resubmits preserved authorization signatures when the subscription account is absent on retry", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const planSignature =
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+    const failedAuthorizationSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const retryAuthorizationSignature =
+      "3mPvcVSTobARmwhHAzGkXWTLG6hiP1eq84B91g9f2Eczg4xbXn7SQeBHbZdmpWFmxK9MqTzjqJrTgQyXT5wXW1S8" as Signature;
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(planSignature)
+      .mockResolvedValueOnce(failedAuthorizationSignature)
+      .mockResolvedValueOnce(retryAuthorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock
+      .mockResolvedValueOnce({
+        signature: planSignature,
+        slot: 100n,
+        confirmationStatus: "confirmed",
+        err: null,
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>)
+      .mockRejectedValueOnce(new Error("RPC timeout"))
+      .mockResolvedValue({
+        signature: retryAuthorizationSignature,
+        slot: 101n,
+        confirmationStatus: "confirmed",
+        err: null,
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    fetchMaybeSubscriptionDelegationMock
+      .mockResolvedValueOnce({
+        exists: false,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>)
+      .mockResolvedValue({
+        exists: true,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+        data: {},
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_preserved_authorization_retry_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(failedActivateRes.status).toBe(500);
+    const failedRow = await getDb(env)
+      .prepare(
+        `SELECT status, plan_creation_signature, authorization_signature
+           FROM payment_recurring_payments
+          WHERE id = ?`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{
+        status: string;
+        plan_creation_signature: string | null;
+        authorization_signature: string | null;
+      }>();
+    expect(failedRow).toEqual({
+      status: "pending_activation",
+      plan_creation_signature: planSignature,
+      authorization_signature: failedAuthorizationSignature,
+    });
+
+    const retryActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(retryActivateRes.status).toBe(200);
+    const retryActivateBody = (await retryActivateRes.json()) as {
+      data: { recurringPayment: { authorizationSignature: string; status: string } };
     };
     expect(retryActivateBody.data.recurringPayment.status).toBe("active");
     expect(retryActivateBody.data.recurringPayment.authorizationSignature).toBe(

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1025,6 +1025,254 @@ describe("Payments routes", () => {
     expect(row?.status).toBe("pending_activation");
   });
 
+  it("clears failed plan signatures so recurring payment activation can retry", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const failedPlanSignature =
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+    const retryPlanSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const authorizationSignature =
+      "3mPvcVSTobARmwhHAzGkXWTLG6hiP1eq84B91g9f2Eczg4xbXn7SQeBHbZdmpWFmxK9MqTzjqJrTgQyXT5wXW1S8" as Signature;
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(failedPlanSignature)
+      .mockResolvedValueOnce(retryPlanSignature)
+      .mockResolvedValueOnce(authorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock
+      .mockResolvedValueOnce({
+        signature: failedPlanSignature,
+        slot: 100n,
+        confirmationStatus: "confirmed",
+        err: { InstructionError: [0, "Custom"] },
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>)
+      .mockResolvedValue({
+        signature: authorizationSignature,
+        slot: 101n,
+        confirmationStatus: "confirmed",
+        err: null,
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_plan_retry_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(failedActivateRes.status).toBe(400);
+    const failedRow = await getDb(env)
+      .prepare(
+        `SELECT status, plan_creation_signature
+           FROM payment_recurring_payments
+          WHERE id = ?`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{ status: string; plan_creation_signature: string | null }>();
+    expect(failedRow).toEqual({
+      status: "pending_activation",
+      plan_creation_signature: null,
+    });
+
+    const retryActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(retryActivateRes.status).toBe(200);
+    const retryActivateBody = (await retryActivateRes.json()) as {
+      data: { recurringPayment: { planCreationSignature: string; status: string } };
+    };
+    expect(retryActivateBody.data.recurringPayment.status).toBe("active");
+    expect(retryActivateBody.data.recurringPayment.planCreationSignature).toBe(retryPlanSignature);
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears failed authorization signatures so recurring payment activation can retry", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const planSignature =
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+    const failedAuthorizationSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const retryAuthorizationSignature =
+      "3mPvcVSTobARmwhHAzGkXWTLG6hiP1eq84B91g9f2Eczg4xbXn7SQeBHbZdmpWFmxK9MqTzjqJrTgQyXT5wXW1S8" as Signature;
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(planSignature)
+      .mockResolvedValueOnce(failedAuthorizationSignature)
+      .mockResolvedValueOnce(retryAuthorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock
+      .mockResolvedValueOnce({
+        signature: planSignature,
+        slot: 100n,
+        confirmationStatus: "confirmed",
+        err: null,
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>)
+      .mockResolvedValueOnce({
+        signature: failedAuthorizationSignature,
+        slot: 101n,
+        confirmationStatus: "confirmed",
+        err: { InstructionError: [0, "Custom"] },
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>)
+      .mockResolvedValue({
+        signature: retryAuthorizationSignature,
+        slot: 102n,
+        confirmationStatus: "confirmed",
+        err: null,
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_authorization_retry_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(failedActivateRes.status).toBe(400);
+    const failedRow = await getDb(env)
+      .prepare(
+        `SELECT status, plan_creation_signature, authorization_signature
+           FROM payment_recurring_payments
+          WHERE id = ?`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{
+        status: string;
+        plan_creation_signature: string | null;
+        authorization_signature: string | null;
+      }>();
+    expect(failedRow).toEqual({
+      status: "pending_activation",
+      plan_creation_signature: planSignature,
+      authorization_signature: null,
+    });
+    const failedAttempt = await getDb(env)
+      .prepare(
+        `SELECT status, phase, authorization_signature
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?
+          ORDER BY created_at DESC
+          LIMIT 1`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .first<{
+        status: string;
+        phase: string;
+        authorization_signature: string | null;
+      }>();
+    expect(failedAttempt).toEqual({
+      status: "failed",
+      phase: "authorize_subscription",
+      authorization_signature: failedAuthorizationSignature,
+    });
+
+    const retryActivateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(retryActivateRes.status).toBe(200);
+    const retryActivateBody = (await retryActivateRes.json()) as {
+      data: { recurringPayment: { status: string; authorizationSignature: string } };
+    };
+    expect(retryActivateBody.data.recurringPayment.status).toBe("active");
+    expect(retryActivateBody.data.recurringPayment.authorizationSignature).toBe(
+      retryAuthorizationSignature
+    );
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+  });
+
   it("requires owner wallet access when updating subscription plans", async () => {
     env.PAYMENTS_RECURRING_ENABLED = "true";
     const headers = {

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -11,6 +11,7 @@ export {
   simulateSandboxTransfer,
 } from "./handlers/ramps";
 export {
+  activateRecurringPayment,
   createRecurringPayment,
   getRecurringPayment,
   listRecurringPayments,

--- a/apps/sdp-api/src/routes/payments/handlers/recurring-payments.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/recurring-payments.ts
@@ -13,9 +13,13 @@ import {
   assertApiKeyWalletAccess,
   getAllowedApiKeyWalletIdsForPermissions,
 } from "@/services/api-key-scope.service";
-import { createRecurringPayment as createRecurringPaymentRecord } from "@/services/payments/recurring-payments";
+import {
+  activateRecurringPayment as activateRecurringPaymentRecord,
+  createRecurringPayment as createRecurringPaymentRecord,
+} from "@/services/payments/recurring-payments";
 import { type AppContext, getPaymentRecurringPaymentsRepository } from "../context";
 import {
+  activateRecurringPaymentSchema,
   createRecurringPaymentSchema,
   listRecurringPaymentsQuerySchema,
   recurringPaymentIdParamsSchema,
@@ -54,6 +58,19 @@ function mapRecurringPayment(row: PaymentRecurringPaymentRow): PaymentRecurringP
   };
 }
 
+async function readOptionalJsonBody(c: AppContext): Promise<unknown> {
+  const text = await c.req.text();
+  if (!text.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw badRequest("Invalid request body");
+  }
+}
+
 export const createRecurringPayment = async (c: AppContext) => {
   const body = await c.req.json();
   const parsed = createRecurringPaymentSchema.safeParse(body);
@@ -86,6 +103,52 @@ export const createRecurringPayment = async (c: AppContext) => {
     recurringPayment: mapRecurringPayment(recurringPayment),
   };
   return created(c, response);
+};
+
+export const activateRecurringPayment = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = recurringPaymentIdParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const body = await readOptionalJsonBody(c);
+  const parsed = activateRecurringPaymentSchema.safeParse(body);
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", { errors: z.treeifyError(parsed.error) });
+  }
+
+  const allowedWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["payments:write"]);
+  const recurringPayment = await getPaymentRecurringPaymentsRepository(c).getRecurringPaymentById({
+    recurringPaymentId: params.data.id,
+    organizationId: auth.organizationId,
+    projectId,
+    sourceWalletIds: allowedWalletIds ?? undefined,
+  });
+
+  if (!recurringPayment) {
+    throw new AppError("NOT_FOUND", "Recurring payment not found");
+  }
+
+  const scope = await resolveScope(c);
+  const sourceWallet = resolveWallet(scope.wallets, recurringPayment.source_wallet_id);
+  assertApiKeyWalletAccess(scope.auth, sourceWallet.walletId, ["payments:write"]);
+
+  const activated = await activateRecurringPaymentRecord({
+    env: c.env,
+    organizationId: auth.organizationId,
+    projectId,
+    sourceWallet,
+    recurringPayment,
+    createdBy: await resolveCreatorUserId(c),
+  });
+  const response: PaymentRecurringPaymentResponse = {
+    recurringPayment: mapRecurringPayment(activated),
+  };
+
+  return success(c, response);
 };
 
 export const listRecurringPayments = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -6,6 +6,7 @@ import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
+  activateRecurringPayment,
   createOfframpQuote,
   createOnrampQuote,
   createRecurringPayment,
@@ -92,6 +93,11 @@ payments.post(
   createRecurringPayment
 );
 payments.get("/recurring-payments", requirePermissions("payments:read"), listRecurringPayments);
+payments.post(
+  "/recurring-payments/:id/activate",
+  requirePermissions("payments:write", "wallets:read"),
+  activateRecurringPayment
+);
 payments.get("/recurring-payments/:id", requirePermissions("payments:read"), getRecurringPayment);
 payments.get("/subscription-plans", requirePermissions("payments:read"), listSubscriptionPlans);
 payments.post(

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -161,6 +161,8 @@ export const createRecurringPaymentSchema = z.object({
   metadataUri: z.string().url().max(128).optional(),
 });
 
+export const activateRecurringPaymentSchema = z.object({}).strict();
+
 export const listRecurringPaymentsQuerySchema = z.object({
   counterpartyId: z.string().min(1).optional(),
   status: paymentRecurringPaymentStatusSchema.optional(),

--- a/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
+++ b/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
@@ -75,6 +75,7 @@ describe("wallet-scoped route coverage inventory", () => {
       "POST /ramps/onramp/execute",
       "POST /ramps/onramp/quote",
       "POST /recurring-payments",
+      "POST /recurring-payments/:id/activate",
       "POST /subscription-plans",
       "POST /subscription-plans/:planId/prepare-create",
       "POST /subscriptions/:subscriptionId/prepare-collection",

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -177,7 +177,7 @@ async function confirmPersistedSubscriptionSignature(input: {
   }
 }
 
-async function fetchPreservedPlanOrClearSignature(input: {
+async function fetchExistingPlanOrClearFailedSignature(input: {
   rpc: ReturnType<typeof solanaRpc.createRpc>;
   recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
   recurringPaymentId: string;
@@ -185,11 +185,14 @@ async function fetchPreservedPlanOrClearSignature(input: {
   projectId: string;
   planPda: Address;
   planCreationSignature: string | null;
+  probeWithoutSignature: boolean;
 }): Promise<Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>> | null> {
-  if (!input.planCreationSignature) {
+  if (!input.planCreationSignature && !input.probeWithoutSignature) {
     return null;
   }
 
+  // Deterministic PDAs let a retry recover even when the transaction landed but
+  // the DB write that persisted its signature failed.
   const onChainPlan = await subscriptionsProgram.fetchMaybePlan(input.rpc, input.planPda, {
     commitment: "confirmed",
   });
@@ -197,17 +200,19 @@ async function fetchPreservedPlanOrClearSignature(input: {
     return onChainPlan;
   }
 
-  await clearRecurringPaymentFailedSignature({
-    recurringRepo: input.recurringRepo,
-    recurringPaymentId: input.recurringPaymentId,
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    field: "planCreationSignature",
-  });
+  if (input.planCreationSignature) {
+    await clearRecurringPaymentFailedSignature({
+      recurringRepo: input.recurringRepo,
+      recurringPaymentId: input.recurringPaymentId,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      field: "planCreationSignature",
+    });
+  }
   return null;
 }
 
-async function fetchPreservedSubscriptionOrClearSignature(input: {
+async function fetchExistingSubscriptionOrClearFailedSignature(input: {
   rpc: ReturnType<typeof solanaRpc.createRpc>;
   recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
   recurringPaymentId: string;
@@ -215,13 +220,16 @@ async function fetchPreservedSubscriptionOrClearSignature(input: {
   projectId: string;
   subscriptionPda: Address;
   authorizationSignature: string | null;
+  probeWithoutSignature: boolean;
 }): Promise<Awaited<
   ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>
 > | null> {
-  if (!input.authorizationSignature) {
+  if (!input.authorizationSignature && !input.probeWithoutSignature) {
     return null;
   }
 
+  // As with plans, the subscription PDA is the source of truth for retry
+  // recovery when signature persistence did not complete.
   const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
     input.rpc,
     input.subscriptionPda,
@@ -231,13 +239,15 @@ async function fetchPreservedSubscriptionOrClearSignature(input: {
     return onChainSubscription;
   }
 
-  await clearRecurringPaymentFailedSignature({
-    recurringRepo: input.recurringRepo,
-    recurringPaymentId: input.recurringPaymentId,
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    field: "authorizationSignature",
-  });
+  if (input.authorizationSignature) {
+    await clearRecurringPaymentFailedSignature({
+      recurringRepo: input.recurringRepo,
+      recurringPaymentId: input.recurringPaymentId,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      field: "authorizationSignature",
+    });
+  }
   return null;
 }
 
@@ -255,13 +265,15 @@ async function clearActivationSignatureIfPresent(input: {
   await clearRecurringPaymentFailedSignature(input);
 }
 
-async function resetRecurringPaymentActivationIfNotActive(input: {
+async function resetRecurringPaymentActivationUnlessAlreadyActive(input: {
   recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
   recurringPaymentId: string;
   organizationId: string;
   projectId: string;
   updatedAt: string;
 }): Promise<void> {
+  // The repository performs this as one guarded UPDATE so a concurrent success
+  // cannot be reverted from active back to pending_activation.
   await input.recurringRepo.resetRecurringPaymentActivationIfNotActive({
     recurringPaymentId: input.recurringPaymentId,
     organizationId: input.organizationId,
@@ -270,17 +282,20 @@ async function resetRecurringPaymentActivationIfNotActive(input: {
   });
 }
 
-function logFailedActivationCleanup(
+function logActivationAttemptJournalFailures(
   results: PromiseSettledResult<unknown>[],
   context: { recurringPaymentId: string; attemptId: string }
 ): void {
   for (const result of results) {
     if (result.status === "rejected") {
-      console.error("activateRecurringPayment: failed to record activation failure cleanup", {
-        recurringPaymentId: context.recurringPaymentId,
-        attemptId: context.attemptId,
-        error: serializeError(result.reason),
-      });
+      console.error(
+        "activateRecurringPayment: failed to record activation attempt journal update",
+        {
+          recurringPaymentId: context.recurringPaymentId,
+          attemptId: context.attemptId,
+          error: serializeError(result.reason),
+        }
+      );
     }
   }
 }
@@ -444,13 +459,6 @@ export async function activateRecurringPayment(input: {
   });
 
   if (!attempt) {
-    await recurringRepo.updateRecurringPaymentActivation({
-      recurringPaymentId: claimed.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      status: "pending_activation",
-      updatedAt: new Date().toISOString(),
-    });
     throw new AppError("CONFLICT", "Recurring payment activation is already processing");
   }
 
@@ -532,7 +540,7 @@ export async function activateRecurringPayment(input: {
     });
 
     let planCreationSignature = claimed.plan_creation_signature;
-    let onChainPlan = await fetchPreservedPlanOrClearSignature({
+    let onChainPlan = await fetchExistingPlanOrClearFailedSignature({
       rpc,
       recurringRepo,
       recurringPaymentId: claimed.id,
@@ -540,10 +548,10 @@ export async function activateRecurringPayment(input: {
       projectId: input.projectId,
       planPda,
       planCreationSignature,
+      probeWithoutSignature: claimed.plan_id !== null,
     });
-    planCreationSignature = onChainPlan ? planCreationSignature : null;
 
-    if (!planCreationSignature) {
+    if (!onChainPlan) {
       const createPlanInstruction = await subscriptionsProgram.getCreatePlanOverlayInstructionAsync(
         {
           amount: amountBaseUnits,
@@ -699,7 +707,7 @@ export async function activateRecurringPayment(input: {
     let authorizationSignature = claimed.authorization_signature;
     let onChainSubscription: Awaited<
       ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>
-    > | null = await fetchPreservedSubscriptionOrClearSignature({
+    > | null = await fetchExistingSubscriptionOrClearFailedSignature({
       rpc,
       recurringRepo,
       recurringPaymentId: claimed.id,
@@ -707,10 +715,10 @@ export async function activateRecurringPayment(input: {
       projectId: input.projectId,
       subscriptionPda,
       authorizationSignature,
+      probeWithoutSignature: claimed.subscription_id !== null,
     });
-    authorizationSignature = onChainSubscription ? authorizationSignature : null;
 
-    if (!authorizationSignature) {
+    if (!onChainSubscription) {
       const subscriptionAuthority = await subscriptionsProgram.fetchMaybeSubscriptionAuthority(
         rpc,
         subscriptionAuthorityAddress,
@@ -824,27 +832,35 @@ export async function activateRecurringPayment(input: {
       updatedAt: activatedAt,
     });
 
-    await recurringRepo.updateActivationAttempt({
-      attemptId: attempt.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      status: "confirmed",
-      phase: "finalize",
-      planId: plan.id,
-      subscriptionId: subscription.id,
-      planCreationSignature,
-      authorizationSignature,
-      updatedAt: activatedAt,
-    });
-
     if (!finalized) {
       throw new AppError("INTERNAL_ERROR", "Failed to finalize recurring payment activation");
     }
+
+    const confirmedAttemptResults = await Promise.allSettled([
+      recurringRepo.updateActivationAttempt({
+        attemptId: attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        status: "confirmed",
+        phase: "finalize",
+        planId: plan.id,
+        subscriptionId: subscription.id,
+        planCreationSignature,
+        authorizationSignature,
+        updatedAt: activatedAt,
+      }),
+    ]);
+    logActivationAttemptJournalFailures(confirmedAttemptResults, {
+      recurringPaymentId: claimed.id,
+      attemptId: attempt.id,
+    });
 
     return finalized;
   } catch (error) {
     const failedAt = new Date().toISOString();
 
+    // Record failure state best-effort without masking the original activation
+    // error thrown from the chain, signer, RPC, or database path above.
     const cleanupResults = await Promise.allSettled([
       recurringRepo.updateActivationAttempt({
         attemptId: attempt.id,
@@ -854,7 +870,7 @@ export async function activateRecurringPayment(input: {
         error: serializeError(error),
         updatedAt: failedAt,
       }),
-      resetRecurringPaymentActivationIfNotActive({
+      resetRecurringPaymentActivationUnlessAlreadyActive({
         recurringRepo,
         recurringPaymentId: claimed.id,
         organizationId: input.organizationId,
@@ -862,7 +878,7 @@ export async function activateRecurringPayment(input: {
         updatedAt: failedAt,
       }),
     ]);
-    logFailedActivationCleanup(cleanupResults, {
+    logActivationAttemptJournalFailures(cleanupResults, {
       recurringPaymentId: claimed.id,
       attemptId: attempt.id,
     });

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -79,6 +79,15 @@ function staleActivationCutoff(now = new Date()): string {
   return new Date(now.getTime() - ACTIVATION_STALE_MS).toISOString();
 }
 
+function isActivationAttemptStale(
+  attempt: { status: string; updated_at: string } | null,
+  staleBefore: string
+): boolean {
+  return (
+    attempt?.status === "processing" && Date.parse(attempt.updated_at) < Date.parse(staleBefore)
+  );
+}
+
 function serializeError(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -253,20 +262,10 @@ async function resetRecurringPaymentActivationIfNotActive(input: {
   projectId: string;
   updatedAt: string;
 }): Promise<void> {
-  const latest = await input.recurringRepo.getRecurringPaymentById({
+  await input.recurringRepo.resetRecurringPaymentActivationIfNotActive({
     recurringPaymentId: input.recurringPaymentId,
     organizationId: input.organizationId,
     projectId: input.projectId,
-  });
-  if (latest?.status === "active") {
-    return;
-  }
-
-  await input.recurringRepo.updateRecurringPaymentActivation({
-    recurringPaymentId: input.recurringPaymentId,
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    status: "pending_activation",
     updatedAt: input.updatedAt,
   });
 }
@@ -416,7 +415,7 @@ export async function activateRecurringPayment(input: {
     organizationId: input.organizationId,
     projectId: input.projectId,
   });
-  if (staleAttempt?.status === "processing" && staleAttempt.updated_at < staleBefore) {
+  if (staleAttempt && isActivationAttemptStale(staleAttempt, staleBefore)) {
     await recurringRepo.updateActivationAttempt({
       attemptId: staleAttempt.id,
       organizationId: input.organizationId,

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -1,15 +1,43 @@
 import {
+  type Address,
+  addSignersToTransactionMessage,
+  appendTransactionMessageInstructions,
+  createNoopSigner,
+  createTransactionMessage,
+  getTransactionEncoder,
+  type Instruction,
+  pipe,
+  type Signature,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
+import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
+import * as subscriptionsProgram from "@solana/subscriptions";
+import {
   createPaymentRecurringPaymentsRepository,
+  createPaymentSubscriptionsRepository,
   createPaymentsRepository,
 } from "@/db/repositories";
 import type { PaymentRecurringPaymentRow } from "@/db/repositories/payment-recurring-payments.repository";
+import { parseDecimalAmount } from "@/lib/amount";
 import { AppError } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
+import {
+  resolveMintDecimals,
+  resolveMintTokenProgram,
+  resolveSourceTokenAccount,
+} from "@/routes/payments/token-accounts";
+import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { normalizePaymentToken, SOL_MINT } from "@/services/payment-operation.service";
 import { assertWalletPolicyAllowsTransferWithRepository } from "@/services/payments/wallet-policy";
+import * as solanaServices from "@/services/solana";
+import * as solanaRpc from "@/services/solana/rpc";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { resolveSolanaCounterpartyAccount } from "./counterparty-account-resolution";
+
+const U64_MAX = 18_446_744_073_709_551_615n;
+const ACTIVATION_STALE_MS = 5 * 60 * 1000;
 
 function assertRecurringPaymentTokenMint(token: string): string {
   const normalized = normalizePaymentToken(token);
@@ -18,6 +46,89 @@ function assertRecurringPaymentTokenMint(token: string): string {
   }
 
   return assertValidAddress(normalized, "token");
+}
+
+function generateProgramPlanId(): string {
+  const bytes = new Uint8Array(8);
+  let value = 0n;
+
+  while (value === 0n) {
+    crypto.getRandomValues(bytes);
+    value = 0n;
+    for (const byte of bytes) {
+      value = (value << 8n) | BigInt(byte);
+    }
+  }
+
+  return value.toString();
+}
+
+function parseU64String(value: string, fieldName: string): bigint {
+  try {
+    const parsed = BigInt(value);
+    if (parsed < 0n || parsed > U64_MAX) {
+      throw new Error("out of range");
+    }
+    return parsed;
+  } catch {
+    throw new AppError("BAD_REQUEST", `${fieldName} must fit in an unsigned 64-bit integer`);
+  }
+}
+
+function staleActivationCutoff(now = new Date()): string {
+  return new Date(now.getTime() - ACTIVATION_STALE_MS).toISOString();
+}
+
+function serializeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Recurring payment activation failed";
+}
+
+async function sendSubscriptionInstructions(input: {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  sourceWallet: CustodyWallet;
+  instructions: Instruction[];
+}): Promise<Signature> {
+  const signer = await solanaServices.createOrgSigner(
+    input.env,
+    input.organizationId,
+    input.projectId,
+    input.sourceWallet.walletId
+  );
+
+  if (signer.address !== input.sourceWallet.publicKey) {
+    throw new AppError("BAD_REQUEST", "Resolved signing wallet does not match source wallet");
+  }
+
+  const rpc = solanaRpc.createRpc(input.env);
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const feePayment = createFeePaymentAdapter(input.env);
+  const feePayer = await feePayment.getFeePayer();
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(input.instructions, m),
+    (m) => addSignersToTransactionMessage([signer], m)
+  );
+  const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+  const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
+  return feePayment.signAndSend(txBytes);
+}
+
+async function confirmSubscriptionSignature(env: Env, signature: Signature): Promise<void> {
+  const rpc = solanaRpc.createRpc(env);
+  const confirmation = await solanaRpc.confirmTransaction(rpc, signature, {
+    commitment: "confirmed",
+  });
+
+  if (confirmation.err) {
+    throw new AppError("TRANSACTION_FAILED", "Recurring payment activation failed on-chain");
+  }
 }
 
 export async function createRecurringPayment(input: {
@@ -80,4 +191,470 @@ export async function createRecurringPayment(input: {
   }
 
   return recurringPayment;
+}
+
+function assertActivationPreconditions(input: {
+  recurringPayment: PaymentRecurringPaymentRow;
+  sourceWallet: CustodyWallet;
+}): PaymentRecurringPaymentRow | null {
+  if (input.recurringPayment.status === "active") {
+    return input.recurringPayment;
+  }
+  if (
+    input.recurringPayment.status !== "pending_activation" &&
+    input.recurringPayment.status !== "activating"
+  ) {
+    throw new AppError("BAD_REQUEST", "Recurring payment cannot be activated from this status");
+  }
+  if (input.recurringPayment.source_wallet_id !== input.sourceWallet.walletId) {
+    throw new AppError("BAD_REQUEST", "Recurring payment source wallet does not match request");
+  }
+  if (input.recurringPayment.source_address !== input.sourceWallet.publicKey) {
+    throw new AppError("BAD_REQUEST", "Recurring payment source address does not match wallet");
+  }
+
+  return null;
+}
+
+export async function activateRecurringPayment(input: {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  sourceWallet: CustodyWallet;
+  recurringPayment: PaymentRecurringPaymentRow;
+  createdBy: string | null;
+}): Promise<PaymentRecurringPaymentRow> {
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
+  const rpc = solanaRpc.createRpc(input.env);
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const staleBefore = staleActivationCutoff(now);
+
+  const idempotentActive = assertActivationPreconditions(input);
+  if (idempotentActive) {
+    return idempotentActive;
+  }
+
+  const claimed = await recurringRepo.claimRecurringPaymentActivation({
+    recurringPaymentId: input.recurringPayment.id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    staleBefore,
+    updatedAt: nowIso,
+  });
+
+  if (!claimed) {
+    const latest = await recurringRepo.getRecurringPaymentById({
+      recurringPaymentId: input.recurringPayment.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+    });
+    if (latest?.status === "active") {
+      return latest;
+    }
+    throw new AppError("CONFLICT", "Recurring payment activation is already processing");
+  }
+
+  const staleAttempt = await recurringRepo.getLatestActivationAttempt({
+    recurringPaymentId: claimed.id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  if (staleAttempt?.status === "processing" && staleAttempt.updated_at < staleBefore) {
+    await recurringRepo.updateActivationAttempt({
+      attemptId: staleAttempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "failed",
+      error: "Activation attempt was reclaimed after becoming stale",
+      updatedAt: nowIso,
+    });
+  }
+
+  const attempt = await recurringRepo.createActivationAttempt({
+    id: `prpa_${crypto.randomUUID()}`,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    recurringPaymentId: claimed.id,
+    planId: claimed.plan_id,
+    subscriptionId: claimed.subscription_id,
+    status: "processing",
+    phase: "claim",
+    planCreationSignature: claimed.plan_creation_signature,
+    authorizationSignature: claimed.authorization_signature,
+    error: null,
+    metadata: {},
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  if (!attempt) {
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "pending_activation",
+      updatedAt: new Date().toISOString(),
+    });
+    throw new AppError("CONFLICT", "Recurring payment activation is already processing");
+  }
+
+  try {
+    const owner = assertValidAddress(claimed.source_address, "sourceAddress") as Address;
+    const destination = assertValidAddress(claimed.destination_address, "destinationAddress");
+    const mint = assertValidAddress(claimed.token, "token") as Address;
+    const tokenProgram = await resolveMintTokenProgram(rpc, mint);
+    const sourceTokenAccount = await resolveSourceTokenAccount(rpc, owner, mint, tokenProgram);
+    const decimals = await resolveMintDecimals(rpc, mint);
+    const amountBaseUnits = parseDecimalAmount(claimed.amount, decimals);
+
+    if (amountBaseUnits <= 0n) {
+      throw new AppError("BAD_REQUEST", "Subscription amount must be greater than zero");
+    }
+
+    let plan = claimed.plan_id
+      ? await subscriptionsRepo.getPlanById({
+          planId: claimed.plan_id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+        })
+      : null;
+
+    if (!plan) {
+      const createdAt = new Date().toISOString();
+      plan = await subscriptionsRepo.createPlan({
+        id: `psp_${crypto.randomUUID()}`,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        ownerWalletId: input.sourceWallet.walletId,
+        ownerAddress: input.sourceWallet.publicKey,
+        token: claimed.token,
+        amount: claimed.amount,
+        periodHours: claimed.period_hours,
+        programPlanId: generateProgramPlanId(),
+        planPda: null,
+        destinationAddress: destination,
+        pullerWalletId: input.sourceWallet.walletId,
+        pullerAddress: input.sourceWallet.publicKey,
+        metadataUri: claimed.metadata_uri,
+        status: "draft",
+        createdBy: input.createdBy,
+        createdAt,
+        updatedAt: createdAt,
+      });
+
+      if (!plan) {
+        throw new AppError("INTERNAL_ERROR", "Failed to create subscription plan");
+      }
+    }
+
+    const programPlanId = parseU64String(plan.program_plan_id, "programPlanId");
+    const [planPda] = await subscriptionsProgram.findPlanPda({ owner, planId: programPlanId });
+    const planUpdatedAt = new Date().toISOString();
+
+    await subscriptionsRepo.updatePlan({
+      planId: plan.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planPda,
+      updatedAt: planUpdatedAt,
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planId: plan.id,
+      planPda,
+      updatedAt: planUpdatedAt,
+    });
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planId: plan.id,
+      phase: "create_plan",
+      updatedAt: planUpdatedAt,
+    });
+
+    let planCreationSignature = claimed.plan_creation_signature;
+    if (!planCreationSignature) {
+      const createPlanInstruction = await subscriptionsProgram.getCreatePlanOverlayInstructionAsync(
+        {
+          amount: amountBaseUnits,
+          destinations: [destination],
+          endTs: 0n,
+          metadataUri: claimed.metadata_uri ?? "",
+          mint,
+          owner: createNoopSigner(owner),
+          periodHours: BigInt(claimed.period_hours),
+          planId: programPlanId,
+          pullers: [owner],
+          tokenProgram,
+        }
+      );
+
+      const submittedPlanCreationSignature = await sendSubscriptionInstructions({
+        env: input.env,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourceWallet: input.sourceWallet,
+        instructions: [createPlanInstruction],
+      });
+      planCreationSignature = submittedPlanCreationSignature;
+
+      await recurringRepo.updateRecurringPaymentActivation({
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        planCreationSignature,
+        updatedAt: new Date().toISOString(),
+      });
+      await recurringRepo.updateActivationAttempt({
+        attemptId: attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        planCreationSignature,
+        updatedAt: new Date().toISOString(),
+      });
+      await confirmSubscriptionSignature(input.env, submittedPlanCreationSignature);
+    }
+
+    const onChainPlan = await subscriptionsProgram.fetchPlan(rpc, planPda, {
+      commitment: "confirmed",
+    });
+    const planCreatedAt = onChainPlan.data.data.terms.createdAt.toString();
+
+    await subscriptionsRepo.updatePlan({
+      planId: plan.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planPda,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planCreatedAt,
+      updatedAt: new Date().toISOString(),
+    });
+
+    let subscription = claimed.subscription_id
+      ? await subscriptionsRepo.getSubscriptionById({
+          subscriptionId: claimed.subscription_id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+        })
+      : null;
+
+    if (!subscription) {
+      const createdAt = new Date().toISOString();
+      subscription = await subscriptionsRepo.createSubscription({
+        id: `psub_${crypto.randomUUID()}`,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        planId: plan.id,
+        counterpartyId: claimed.counterparty_id,
+        subscriberAddress: input.sourceWallet.publicKey,
+        subscriberTokenAccount: null,
+        subscriptionPda: null,
+        subscriptionAuthorityAddress: null,
+        authorizationSignature: null,
+        status: "pending_authorization",
+        currentPeriodStartAt: null,
+        nextCollectionDueAt: null,
+        createdBy: input.createdBy,
+        createdAt,
+        updatedAt: createdAt,
+      });
+
+      if (!subscription) {
+        throw new AppError("INTERNAL_ERROR", "Failed to create subscription");
+      }
+    }
+
+    const [subscriptionAuthorityAddress] = await subscriptionsProgram.findSubscriptionAuthorityPda({
+      tokenMint: mint,
+      user: owner,
+    });
+    const [subscriptionPda] = await subscriptionsProgram.findSubscriptionDelegationPda({
+      planPda,
+      subscriber: owner,
+    });
+    const authorizationUpdatedAt = new Date().toISOString();
+
+    await subscriptionsRepo.updateSubscription({
+      subscriptionId: subscription.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      subscriberTokenAccount: sourceTokenAccount.tokenAccount,
+      subscriptionPda,
+      subscriptionAuthorityAddress,
+      updatedAt: authorizationUpdatedAt,
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      subscriptionId: subscription.id,
+      subscriptionPda,
+      subscriptionAuthorityAddress,
+      updatedAt: authorizationUpdatedAt,
+    });
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      subscriptionId: subscription.id,
+      phase: "authorize_subscription",
+      updatedAt: authorizationUpdatedAt,
+    });
+
+    let authorizationSignature = claimed.authorization_signature;
+    if (!authorizationSignature) {
+      const subscriptionAuthority = await subscriptionsProgram.fetchMaybeSubscriptionAuthority(
+        rpc,
+        subscriptionAuthorityAddress,
+        { commitment: "confirmed" }
+      );
+      const expectedSubscriptionAuthorityInitId = subscriptionAuthority.exists
+        ? subscriptionAuthority.data.initId
+        : 0n;
+      const feePayer = await createFeePaymentAdapter(input.env).getFeePayer();
+      const payer = createNoopSigner(feePayer);
+      const subscriber = createNoopSigner(owner);
+      const initAuthorityInstruction =
+        await subscriptionsProgram.getInitSubscriptionAuthorityOverlayInstructionAsync({
+          owner: subscriber,
+          payer,
+          tokenMint: mint,
+          tokenProgram,
+          userAta: sourceTokenAccount.tokenAccount,
+        });
+      const subscribeInstruction = await subscriptionsProgram.getSubscribeOverlayInstructionAsync({
+        expectedAmount: amountBaseUnits,
+        expectedCreatedAt: BigInt(planCreatedAt),
+        expectedPeriodHours: BigInt(claimed.period_hours),
+        expectedSubscriptionAuthorityInitId,
+        merchant: owner,
+        payer,
+        planId: programPlanId,
+        subscriber,
+        tokenMint: mint,
+      });
+
+      const submittedAuthorizationSignature = await sendSubscriptionInstructions({
+        env: input.env,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourceWallet: input.sourceWallet,
+        instructions: [initAuthorityInstruction, subscribeInstruction],
+      });
+      authorizationSignature = submittedAuthorizationSignature;
+
+      await recurringRepo.updateRecurringPaymentActivation({
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        authorizationSignature,
+        updatedAt: new Date().toISOString(),
+      });
+      await recurringRepo.updateActivationAttempt({
+        attemptId: attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        authorizationSignature,
+        updatedAt: new Date().toISOString(),
+      });
+      await confirmSubscriptionSignature(input.env, submittedAuthorizationSignature);
+    }
+
+    const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
+      rpc,
+      subscriptionPda,
+      { commitment: "confirmed" }
+    );
+    if (!onChainSubscription.exists) {
+      throw new AppError("TRANSACTION_FAILED", "Subscription authorization was not found on-chain");
+    }
+
+    const activatedAt = new Date().toISOString();
+    const nextCollectionDueAt = claimed.first_collection_at ?? activatedAt;
+
+    await subscriptionsRepo.updateSubscription({
+      subscriptionId: subscription.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      authorizationSignature,
+      status: "active",
+      currentPeriodStartAt: activatedAt,
+      nextCollectionDueAt,
+      updatedAt: activatedAt,
+    });
+
+    const finalized = await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "active",
+      planId: plan.id,
+      subscriptionId: subscription.id,
+      planPda,
+      planCreatedAt,
+      planCreationSignature,
+      subscriptionPda,
+      subscriptionAuthorityAddress,
+      authorizationSignature,
+      nextCollectionDueAt,
+      updatedAt: activatedAt,
+    });
+
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "confirmed",
+      phase: "finalize",
+      planId: plan.id,
+      subscriptionId: subscription.id,
+      planCreationSignature,
+      authorizationSignature,
+      updatedAt: activatedAt,
+    });
+
+    if (!finalized) {
+      throw new AppError("INTERNAL_ERROR", "Failed to finalize recurring payment activation");
+    }
+
+    return finalized;
+  } catch (error) {
+    const failedAt = new Date().toISOString();
+
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "failed",
+      error: serializeError(error),
+      updatedAt: failedAt,
+    });
+    const latest = await recurringRepo.getRecurringPaymentById({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+    });
+    if (latest?.status !== "active") {
+      await recurringRepo.updateRecurringPaymentActivation({
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        status: "pending_activation",
+        updatedAt: failedAt,
+      });
+    }
+
+    throw error;
+  }
 }

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -246,6 +246,46 @@ async function clearActivationSignatureIfPresent(input: {
   await clearRecurringPaymentFailedSignature(input);
 }
 
+async function resetRecurringPaymentActivationIfNotActive(input: {
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  updatedAt: string;
+}): Promise<void> {
+  const latest = await input.recurringRepo.getRecurringPaymentById({
+    recurringPaymentId: input.recurringPaymentId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  if (latest?.status === "active") {
+    return;
+  }
+
+  await input.recurringRepo.updateRecurringPaymentActivation({
+    recurringPaymentId: input.recurringPaymentId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    status: "pending_activation",
+    updatedAt: input.updatedAt,
+  });
+}
+
+function logFailedActivationCleanup(
+  results: PromiseSettledResult<unknown>[],
+  context: { recurringPaymentId: string; attemptId: string }
+): void {
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.error("activateRecurringPayment: failed to record activation failure cleanup", {
+        recurringPaymentId: context.recurringPaymentId,
+        attemptId: context.attemptId,
+        error: serializeError(result.reason),
+      });
+    }
+  }
+}
+
 export async function createRecurringPayment(input: {
   env: Env;
   organizationId: string;
@@ -806,28 +846,27 @@ export async function activateRecurringPayment(input: {
   } catch (error) {
     const failedAt = new Date().toISOString();
 
-    await recurringRepo.updateActivationAttempt({
-      attemptId: attempt.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      status: "failed",
-      error: serializeError(error),
-      updatedAt: failedAt,
-    });
-    const latest = await recurringRepo.getRecurringPaymentById({
-      recurringPaymentId: claimed.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-    });
-    if (latest?.status !== "active") {
-      await recurringRepo.updateRecurringPaymentActivation({
+    const cleanupResults = await Promise.allSettled([
+      recurringRepo.updateActivationAttempt({
+        attemptId: attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        status: "failed",
+        error: serializeError(error),
+        updatedAt: failedAt,
+      }),
+      resetRecurringPaymentActivationIfNotActive({
+        recurringRepo,
         recurringPaymentId: claimed.id,
         organizationId: input.organizationId,
         projectId: input.projectId,
-        status: "pending_activation",
         updatedAt: failedAt,
-      });
-    }
+      }),
+    ]);
+    logFailedActivationCleanup(cleanupResults, {
+      recurringPaymentId: claimed.id,
+      attemptId: attempt.id,
+    });
 
     throw error;
   }

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -168,6 +168,84 @@ async function confirmPersistedSubscriptionSignature(input: {
   }
 }
 
+async function fetchPreservedPlanOrClearSignature(input: {
+  rpc: ReturnType<typeof solanaRpc.createRpc>;
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  planPda: Address;
+  planCreationSignature: string | null;
+}): Promise<Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>> | null> {
+  if (!input.planCreationSignature) {
+    return null;
+  }
+
+  const onChainPlan = await subscriptionsProgram.fetchMaybePlan(input.rpc, input.planPda, {
+    commitment: "confirmed",
+  });
+  if (onChainPlan.exists) {
+    return onChainPlan;
+  }
+
+  await clearRecurringPaymentFailedSignature({
+    recurringRepo: input.recurringRepo,
+    recurringPaymentId: input.recurringPaymentId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    field: "planCreationSignature",
+  });
+  return null;
+}
+
+async function fetchPreservedSubscriptionOrClearSignature(input: {
+  rpc: ReturnType<typeof solanaRpc.createRpc>;
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  subscriptionPda: Address;
+  authorizationSignature: string | null;
+}): Promise<Awaited<
+  ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>
+> | null> {
+  if (!input.authorizationSignature) {
+    return null;
+  }
+
+  const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
+    input.rpc,
+    input.subscriptionPda,
+    { commitment: "confirmed" }
+  );
+  if (onChainSubscription.exists) {
+    return onChainSubscription;
+  }
+
+  await clearRecurringPaymentFailedSignature({
+    recurringRepo: input.recurringRepo,
+    recurringPaymentId: input.recurringPaymentId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    field: "authorizationSignature",
+  });
+  return null;
+}
+
+async function clearActivationSignatureIfPresent(input: {
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  signature: string | null;
+  field: "planCreationSignature" | "authorizationSignature";
+}): Promise<void> {
+  if (!input.signature) {
+    return;
+  }
+  await clearRecurringPaymentFailedSignature(input);
+}
+
 export async function createRecurringPayment(input: {
   env: Env;
   organizationId: string;
@@ -415,6 +493,17 @@ export async function activateRecurringPayment(input: {
     });
 
     let planCreationSignature = claimed.plan_creation_signature;
+    let onChainPlan = await fetchPreservedPlanOrClearSignature({
+      rpc,
+      recurringRepo,
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planPda,
+      planCreationSignature,
+    });
+    planCreationSignature = onChainPlan ? planCreationSignature : null;
+
     if (!planCreationSignature) {
       const createPlanInstruction = await subscriptionsProgram.getCreatePlanOverlayInstructionAsync(
         {
@@ -465,9 +554,20 @@ export async function activateRecurringPayment(input: {
       });
     }
 
-    const onChainPlan = await subscriptionsProgram.fetchPlan(rpc, planPda, {
+    onChainPlan ??= await subscriptionsProgram.fetchMaybePlan(rpc, planPda, {
       commitment: "confirmed",
     });
+    if (!onChainPlan.exists) {
+      await clearActivationSignatureIfPresent({
+        recurringRepo,
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        signature: planCreationSignature,
+        field: "planCreationSignature",
+      });
+      throw new AppError("TRANSACTION_FAILED", "Subscription plan was not found on-chain");
+    }
     const planCreatedAt = onChainPlan.data.data.terms.createdAt.toString();
 
     await subscriptionsRepo.updatePlan({
@@ -558,6 +658,19 @@ export async function activateRecurringPayment(input: {
     });
 
     let authorizationSignature = claimed.authorization_signature;
+    let onChainSubscription: Awaited<
+      ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>
+    > | null = await fetchPreservedSubscriptionOrClearSignature({
+      rpc,
+      recurringRepo,
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      subscriptionPda,
+      authorizationSignature,
+    });
+    authorizationSignature = onChainSubscription ? authorizationSignature : null;
+
     if (!authorizationSignature) {
       const subscriptionAuthority = await subscriptionsProgram.fetchMaybeSubscriptionAuthority(
         rpc,
@@ -624,12 +737,20 @@ export async function activateRecurringPayment(input: {
       });
     }
 
-    const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
+    onChainSubscription ??= await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
       rpc,
       subscriptionPda,
       { commitment: "confirmed" }
     );
     if (!onChainSubscription.exists) {
+      await clearActivationSignatureIfPresent({
+        recurringRepo,
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        signature: authorizationSignature,
+        field: "authorizationSignature",
+      });
       throw new AppError("TRANSACTION_FAILED", "Subscription authorization was not found on-chain");
     }
 

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -131,6 +131,43 @@ async function confirmSubscriptionSignature(env: Env, signature: Signature): Pro
   }
 }
 
+async function clearRecurringPaymentFailedSignature(input: {
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  field: "planCreationSignature" | "authorizationSignature";
+}): Promise<void> {
+  await input.recurringRepo.updateRecurringPaymentActivation({
+    recurringPaymentId: input.recurringPaymentId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    ...(input.field === "planCreationSignature"
+      ? { planCreationSignature: null }
+      : { authorizationSignature: null }),
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+async function confirmPersistedSubscriptionSignature(input: {
+  env: Env;
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  signature: Signature;
+  field: "planCreationSignature" | "authorizationSignature";
+}): Promise<void> {
+  try {
+    await confirmSubscriptionSignature(input.env, input.signature);
+  } catch (error) {
+    if (error instanceof AppError && error.code === "TRANSACTION_FAILED") {
+      await clearRecurringPaymentFailedSignature(input);
+    }
+    throw error;
+  }
+}
+
 export async function createRecurringPayment(input: {
   env: Env;
   organizationId: string;
@@ -417,7 +454,15 @@ export async function activateRecurringPayment(input: {
         planCreationSignature,
         updatedAt: new Date().toISOString(),
       });
-      await confirmSubscriptionSignature(input.env, submittedPlanCreationSignature);
+      await confirmPersistedSubscriptionSignature({
+        env: input.env,
+        recurringRepo,
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        signature: submittedPlanCreationSignature,
+        field: "planCreationSignature",
+      });
     }
 
     const onChainPlan = await subscriptionsProgram.fetchPlan(rpc, planPda, {
@@ -568,7 +613,15 @@ export async function activateRecurringPayment(input: {
         authorizationSignature,
         updatedAt: new Date().toISOString(),
       });
-      await confirmSubscriptionSignature(input.env, submittedAuthorizationSignature);
+      await confirmPersistedSubscriptionSignature({
+        env: input.env,
+        recurringRepo,
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        signature: submittedAuthorizationSignature,
+        field: "authorizationSignature",
+      });
     }
 
     const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -15,6 +15,7 @@ const POSTGRES_TEST_TABLES = [
   "signing_requests",
   "custody_configs",
   "payment_subscription_collection_attempts",
+  "payment_recurring_payment_activation_attempts",
   "payment_recurring_payments",
   "payment_subscriptions",
   "payment_subscription_plans",

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -3717,6 +3717,7 @@ Source: https://platform.solana.com/docs/reference/api/payments
 | `GET` | `/v1/payments/recurring-payments` | List recurring payments |
 | `POST` | `/v1/payments/recurring-payments` | Create recurring payment |
 | `GET` | `/v1/payments/recurring-payments/{id}` | Get recurring payment |
+| `POST` | `/v1/payments/recurring-payments/{id}/activate` | Activate recurring payment |
 | `GET` | `/v1/payments/subscription-plans` | List subscription plans |
 | `POST` | `/v1/payments/subscription-plans` | Create subscription plan |
 | `GET` | `/v1/payments/subscription-plans/{planId}` | Get subscription plan |

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1237,7 +1237,7 @@
               }
             ],
             "url": "{{baseUrl}}/v1/payments/recurring-payments",
-            "description": "Creates an SDP-custody outbound recurring payment intent from a custody wallet to a counterparty crypto-wallet account. This stores backend state only; activation and collection are added by follow-up endpoints.",
+            "description": "Creates an SDP-custody outbound recurring payment intent from a custody wallet to a counterparty crypto-wallet account. This stores backend state only; activation creates the on-chain authorization in a follow-up request.",
             "body": {
               "mode": "raw",
               "raw": "{\n  \"sourceWalletId\": \"wal_source\",\n  \"counterpartyId\": \"cp_example\",\n  \"counterpartyAccountId\": \"cpa_example\",\n  \"token\": \"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\n  \"amount\": \"25.00\",\n  \"periodHours\": 720,\n  \"firstCollectionAt\": \"2099-01-01T00:00:00.000Z\",\n  \"metadataUri\": \"https://example.com/subscriptions/monthly-usdc.json\"\n}",
@@ -1247,6 +1247,15 @@
                 }
               }
             }
+          }
+        },
+        {
+          "name": "Activate recurring payment",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": "{{baseUrl}}/v1/payments/recurring-payments/{{id}}/activate",
+            "description": "Activates a pending SDP-custody outbound recurring payment by creating the Solana subscriptions plan and subscription authorization with the source custody wallet. The operation is idempotent once active and does not collect funds."
           }
         },
         {


### PR DESCRIPTION
## Summary
- Add `POST /v1/payments/recurring-payments/{id}/activate` for SDP-custody outbound recurring payments.
- Add durable activation attempt journaling and recurring payment activation persistence.
- Update OpenAPI/Postman/AI docs and wallet-scope route coverage.

## Tests
- `pnpm --filter @sdp/api typecheck`
- touched-file Biome checks
- `pnpm --filter sdp-docs check:links`
- `pnpm --filter sdp-docs build`
- `git diff --check`
- `pnpm --filter @sdp/api exec vitest run --config vitest.workers.config.ts src/routes/wallet-scope-route-coverage.test.ts`

## Blocked local validation
- DB-backed payments route tests could not run locally because Docker/Postgres is not available: `pnpm db:postgres:up` failed to connect to the Docker daemon.

PRO-1295