### PR TITLE
feat(self-hosted): publish env template as default.env.example

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -21,7 +21,8 @@ jobs:
         working-directory: infra/self-hosted
         run: |
           set -euo pipefail
-          sha256sum install.sh compose.yml .env.example > SHA256SUMS
+          cp .env.example default.env.example
+          sha256sum install.sh compose.yml default.env.example > SHA256SUMS
           cat SHA256SUMS
 
       - name: Install Cosign
@@ -42,5 +43,5 @@ jobs:
             infra/self-hosted/SHA256SUMS.cosign.bundle \
             infra/self-hosted/install.sh \
             infra/self-hosted/compose.yml \
-            infra/self-hosted/.env.example \
+            infra/self-hosted/default.env.example \
             --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pnpm-debug.log*
 # Kora keypairs and secrets (never commit)
 infra/kora/.keypair.json
 infra/kora/.env
+infra/self-hosted/default.env.example
 
 # Local secrets (API keys, private keys)
 .secrets/

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -131,7 +131,7 @@ verify() {
 # behind; the temp is cleaned up on any exit.
 fetch_verified() {
   local tmp="$2.tmp.$$"
-  trap 'rm -f "${tmp:-}"' EXIT
+  trap '[ -z "${tmp:-}" ] || rm -f "$tmp"' EXIT
   fetch "$1" "$tmp"
   verify "$1" "$tmp"
   mv -f "$tmp" "$2"

--- a/infra/self-hosted/install.sh
+++ b/infra/self-hosted/install.sh
@@ -131,7 +131,7 @@ verify() {
 # behind; the temp is cleaned up on any exit.
 fetch_verified() {
   local tmp="$2.tmp.$$"
-  trap 'rm -f "$tmp"' EXIT
+  trap 'rm -f "${tmp:-}"' EXIT
   fetch "$1" "$tmp"
   verify "$1" "$tmp"
   mv -f "$tmp" "$2"
@@ -167,9 +167,9 @@ main() {
     printf '\nReplaced the existing compose.yml with the %s release.\n' "$VERSION"
   fi
   if [ ! -f "$INSTALL_DIR/.env.example" ]; then
-    fetch_verified .env.example "$INSTALL_DIR/.env.example"
+    fetch_verified default.env.example "$INSTALL_DIR/.env.example"
   else
-    printf '\nKept your existing .env.example. Review the %s template for new variables:\n  %s/%s/.env.example\n' \
+    printf '\nKept your existing .env.example. Review the %s template for new variables:\n  %s/%s/default.env.example\n' \
       "$VERSION" "$RELEASE_BASE_URL" "$VERSION"
   fi
 

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -167,5 +167,17 @@ if scenario "no-corrupt-env-example" -- "
 "; then check "leaves no .env.example behind when its download fails verification" 0
 else check "leaves no .env.example behind when its download fails verification" 1; fi
 
+# 11. A missing template asset (fetch failure) aborts cleanly, without the cleanup
+#     trap surfacing an unbound-variable error in place of the real cause.
+if scenario "missing-env-template" -- "
+  $DOCKER_OK
+  rm -f /release/default.env.example
+  out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
+  [ \$rc -ne 0 ] \
+    && ! echo \"\$out\" | grep -qi 'unbound variable' \
+    && [ ! -f /root/sdp/.env.example ]
+"; then check "aborts cleanly without unbound-variable when the template asset is missing" 0
+else check "aborts cleanly without unbound-variable when the template asset is missing" 1; fi
+
 echo "----"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ]

--- a/infra/self-hosted/install.test.sh
+++ b/infra/self-hosted/install.test.sh
@@ -28,9 +28,9 @@ scenario() { # scenario <name> <docker-run-flags...> -- <in-container-bash>
       apt-get update -qq >/dev/null 2>&1
       apt-get install -y -qq curl >/dev/null 2>&1
       mkdir -p /release
-      cp /src/infra/self-hosted/compose.yml /src/infra/self-hosted/.env.example \
-         /src/infra/self-hosted/install.sh /release/
-      ( cd /release && sha256sum install.sh compose.yml .env.example > SHA256SUMS )
+      cp /src/infra/self-hosted/compose.yml /src/infra/self-hosted/install.sh /release/
+      cp /src/infra/self-hosted/.env.example /release/default.env.example
+      ( cd /release && sha256sum install.sh compose.yml default.env.example > SHA256SUMS )
       set +e
       $1
     "
@@ -159,7 +159,7 @@ else check "preserves the existing compose.yml when the new download fails verif
 #     instead of treating the corrupt download as a kept existing file.
 if scenario "no-corrupt-env-example" -- "
   $DOCKER_OK
-  echo 'TAMPERED=true' >> /release/.env.example
+  echo 'TAMPERED=true' >> /release/default.env.example
   out=\$(bash /src/infra/self-hosted/install.sh 2>&1); rc=\$?
   [ \$rc -ne 0 ] \
     && echo \"\$out\" | grep -qi 'checksum verification failed' \


### PR DESCRIPTION
## Summary

Make the self-hosted release asset naming explicit and harden `install.sh` around template download and cleanup.

GitHub serves a release asset uploaded as `.env.example` under the name `default.env.example` (the leading dot is dropped). This change publishes and references the env template under that explicit name end-to-end, so the served asset, `SHA256SUMS`, and `install.sh` stay consistent.

## Changes

- **release-checksums**: publish and checksum the env template as `default.env.example`, matching the served asset name.
- **install.sh**: fetch `default.env.example` and write it locally as `.env.example` — the filename operators use is unchanged.
- **install.sh**: harden the `fetch_verified` cleanup trap (`${tmp:-}`) so a failed download reports its underlying cause rather than an unbound-variable error from cleanup.
- **install.test.sh**: cover the explicit asset name across the setup and the tampered-download path.

## Verification

- `infra/self-hosted/install.test.sh` — **10/10** in clean `ubuntu:24.04` containers, including the download-failure and tampered-asset scenarios.
- End-to-end run of the install flow completes: template fetched, verified, written as `.env.example`, configurator handoff printed.
- `actionlint` + `shellcheck` clean.

