### PR TITLE
chore: refactor ramps to use correct utils and have cleaner code separation for requirements for api

### DIFF
--- a/apps/sdp-api/src/lib/auth.ts
+++ b/apps/sdp-api/src/lib/auth.ts
@@ -8,7 +8,7 @@
 import type { ApiKeyWalletBinding, Permission } from "@sdp/types";
 import type { Context } from "hono";
 import type { Env } from "@/types/env";
-import { AppError } from "./errors";
+import { AppError, badRequest } from "./errors";
 
 export type AuthType = "api_key" | "clerk" | "session";
 
@@ -130,7 +130,7 @@ export function getAuth(c: Context<{ Bindings: Env }>): ApiKeyContext {
 export function requireProjectId(c: Context<{ Bindings: Env }>): string {
   const projectId = c.get("projectId");
   if (!projectId) {
-    throw new AppError("BAD_REQUEST", "Project scope is required");
+    throw badRequest("Project scope is required");
   }
   return projectId;
 }

--- a/apps/sdp-api/src/lib/ramps/fetch.ts
+++ b/apps/sdp-api/src/lib/ramps/fetch.ts
@@ -2,9 +2,15 @@ import type { RampProviderId } from "@sdp/types/provider-access";
 import { AppError, type ErrorCode } from "@/lib/errors";
 
 export interface ProviderRequestInit<TBody> {
-  method: "GET" | "POST";
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   headers?: HeadersInit;
   body?: TBody;
+}
+
+export interface ProviderResponse {
+  response: Response;
+  raw: string;
+  parsed: unknown;
 }
 
 export function classifyProviderStatus(status: number): ErrorCode {
@@ -21,16 +27,16 @@ export function extractProviderErrorMessage(payload: unknown, fallback: string):
   return typeof message === "string" && message.trim() ? message : fallback;
 }
 
-export async function providerFetchJson<TResponse, TBody = never>(
+export async function providerFetch<TBody = never>(
   provider: RampProviderId,
   url: string,
   init: ProviderRequestInit<TBody>
-): Promise<TResponse> {
+): Promise<ProviderResponse> {
   let response: Response;
   try {
     response = await fetch(url, {
       method: init.method,
-      headers: { "Content-Type": "application/json", ...init.headers },
+      headers: { "Content-Type": "application/json", Accept: "application/json", ...init.headers },
       body: init.body === undefined ? undefined : JSON.stringify(init.body),
     });
   } catch {
@@ -44,6 +50,16 @@ export async function providerFetchJson<TResponse, TBody = never>(
   } catch {
     parsed = undefined;
   }
+
+  return { response, raw, parsed };
+}
+
+export async function providerFetchJson<TResponse, TBody = never>(
+  provider: RampProviderId,
+  url: string,
+  init: ProviderRequestInit<TBody>
+): Promise<TResponse> {
+  const { response, parsed } = await providerFetch(provider, url, init);
 
   if (!response.ok) {
     throw new AppError(

--- a/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
@@ -1,22 +1,26 @@
 import type {
   BvnkBankFundingDetails,
   BvnkOnboardingStatus,
+  BvnkPaymentRampExecution,
   BvnkPaymentRampInstruction,
   Counterparty,
+  CounterpartyEntityType,
   PaymentRampEstimate,
   PaymentRampEstimateFees,
   PaymentRampExecution,
   PaymentRampQuote,
   SdpEnvironment,
 } from "@sdp/types";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import { RAMP_FIAT_CURRENCIES } from "@sdp/types/generated/ramp-support";
 import { getCryptoRailAssetLabel, parseFiatCurrency } from "@sdp/types/payment-rails";
 import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { z } from "zod";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
 import { formatDecimalAmount, isDecimalString, parseDecimalAmount } from "@/lib/amount";
-import { AppError, providerNotConfigured } from "@/lib/errors";
+import { AppError, badRequest, internalError, providerNotConfigured } from "@/lib/errors";
 import { hashString, hmacSha256Base64, verifyHmacSha256Base64 } from "@/lib/hash";
+import { type ProviderRequestInit, providerFetch } from "../fetch";
 import {
   createProviderRampSupport,
   isSolanaCryptoAsset,
@@ -29,7 +33,6 @@ import type {
   RampDumpReader,
   RampEstimateOfframpInput,
   RampEstimateOnrampInput,
-  RampExecuteOfframpInput,
   RampOfframpQuoteInput,
   RampProvider,
   RampRuntimeContext,
@@ -43,20 +46,26 @@ const BVNK_PRODUCTION_API_URL = "https://api.bvnk.com";
 const BVNK_SANDBOX_API_URL = "https://api.sandbox.bvnk.com";
 const bvnkEstimateFiatCurrencySchema = z.enum(RAMP_FIAT_CURRENCIES);
 
+interface BvnkSandboxBankAccount {
+  accountNumber: string;
+  accountNumberFormat: string;
+  bankCode?: string;
+}
+
 // SANDBOX ONLY: synthetic originator (fiat sender) bank accounts for pay-in
 // simulations. The real buyer's funding bank is never stored; BVNK just needs
 // a format-valid account to accept the simulated deposit. Never used in prod.
-const SANDBOX_ORIGINATOR_BANK_ACCOUNTS: Record<string, Record<string, string>> = {
+const SANDBOX_ORIGINATOR_BANK_ACCOUNTS: Record<string, BvnkSandboxBankAccount> = {
   // biome-ignore lint/security/noSecrets: synthetic sandbox account, not a credential
   USD: { accountNumber: "000123456789", accountNumberFormat: "ABA", bankCode: "021000021" },
 };
-const SANDBOX_ORIGINATOR_BANK_ACCOUNT_FALLBACK = {
+const SANDBOX_ORIGINATOR_BANK_ACCOUNT_FALLBACK: BvnkSandboxBankAccount = {
   // biome-ignore lint/security/noSecrets: synthetic sandbox account, not a credential
   accountNumber: "GB29NWBK60161331926819",
   accountNumberFormat: "IBAN",
 };
 
-function sandboxOriginatorBankAccount(currency: string): Record<string, string> {
+function sandboxOriginatorBankAccount(currency: string): BvnkSandboxBankAccount {
   return SANDBOX_ORIGINATOR_BANK_ACCOUNTS[currency] ?? SANDBOX_ORIGINATOR_BANK_ACCOUNT_FALLBACK;
 }
 
@@ -72,12 +81,19 @@ export interface BvnkRuleEntityAddress {
   stateCode?: string;
 }
 
+type BvnkEntityType = "INDIVIDUAL" | "COMPANY";
+
+const BVNK_ENTITY_TYPE = {
+  individual: "INDIVIDUAL",
+  business: "COMPANY",
+} as const satisfies Record<CounterpartyEntityType, BvnkEntityType>;
+
 /**
  * Beneficiary entity for a BVNK on-ramp payment rule. The handler builds this
  * from the counterparty identity; the provider only serializes it.
  */
 export interface BvnkRuleEntity {
-  type: "INDIVIDUAL" | "COMPANY";
+  type: BvnkEntityType;
   customerIdentifier: string;
   relationshipType: "SELF_OWNED" | "THIRD_PARTY";
   firstName?: string;
@@ -127,7 +143,21 @@ function readBvnkConfig(env: Record<string, string | undefined>, mode: SdpEnviro
   return { auth: { authId, secretKey }, walletId, apiBaseUrl };
 }
 
-const BVNK_NETWORK_ALIASES: Record<string, string> = {
+type BvnkNetwork =
+  | "ALGORAND"
+  | "CARDANO"
+  | "BITCOIN_CASH"
+  | "BINANCE"
+  | "BITCOIN"
+  | "DOGECOIN"
+  | "ETHEREUM"
+  | "LITECOIN"
+  | "POLYGON"
+  | "SOLANA"
+  | "TRON"
+  | "RIPPLE";
+
+const BVNK_NETWORK_ALIASES: Record<string, BvnkNetwork> = {
   algo: "ALGORAND",
   algorand: "ALGORAND",
   ada: "CARDANO",
@@ -157,19 +187,19 @@ const BVNK_NETWORK_ALIASES: Record<string, string> = {
 
 interface BvnkCurrencyNetwork {
   currency: string;
-  network: string;
+  network: BvnkNetwork;
 }
 
 export function normalizeBvnkCurrencyAndNetwork(value: string): BvnkCurrencyNetwork {
   const normalized = value.trim().toUpperCase();
   if (!/^[A-Z0-9_]+$/.test(normalized)) {
-    throw new AppError("BAD_REQUEST", "cryptoToken must be a valid BVNK currency code");
+    throw badRequest("cryptoToken must be a valid BVNK currency code");
   }
 
   const tokenParts = normalized.split("_").filter((part) => part.length > 0);
   const currency = tokenParts[0];
   if (!currency) {
-    throw new AppError("BAD_REQUEST", "cryptoToken must include a BVNK currency code");
+    throw badRequest("cryptoToken must include a BVNK currency code");
   }
 
   const networkHint = tokenParts.length > 1 ? tokenParts[tokenParts.length - 1]?.toLowerCase() : "";
@@ -182,8 +212,7 @@ export function normalizeBvnkCurrencyAndNetwork(value: string): BvnkCurrencyNetw
     return { currency, network: "SOLANA" };
   }
 
-  throw new AppError(
-    "BAD_REQUEST",
+  throw badRequest(
     `Unsupported BVNK cryptoToken '${value}'. Provide token with network (for example: BTC, ETH, SOL, USDC_SOLANA).`
   );
 }
@@ -231,17 +260,9 @@ function buildBvnkComplianceDetails(
   return { partyDetails };
 }
 
-function safeParseJson(value: string): unknown | null {
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return null;
-  }
-}
-
 async function buildBvnkHawkAuthorizationHeader(
   url: URL,
-  method: "GET" | "POST" | "PUT",
+  method: ProviderRequestInit<unknown>["method"],
   authId: string,
   secretKey: string
 ): Promise<string> {
@@ -254,7 +275,7 @@ async function buildBvnkHawkAuthorizationHeader(
     "hawk.1.header",
     ts,
     nonce,
-    method.toUpperCase(),
+    method,
     resource,
     url.hostname.toLowerCase(),
     port,
@@ -265,44 +286,6 @@ async function buildBvnkHawkAuthorizationHeader(
 
   const mac = await hmacSha256Base64(normalized, secretKey);
   return `Hawk id="${authId}", ts="${ts}", nonce="${nonce}", mac="${mac}"`;
-}
-
-async function bvnkRequest(
-  config: BvnkConfig,
-  path: string,
-  init: { method: "GET" | "POST" | "PUT"; body?: unknown; headers?: Record<string, string> }
-): Promise<unknown> {
-  const apiBaseUrl = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
-  const url = new URL(path.replace(/^\//, ""), apiBaseUrl);
-  const authorization = await buildBvnkHawkAuthorizationHeader(
-    url,
-    init.method,
-    config.auth.authId,
-    config.auth.secretKey
-  );
-  const response = await fetch(url.toString(), {
-    method: init.method,
-    headers: {
-      Authorization: authorization,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      ...init.headers,
-    },
-    body: init.body === undefined ? undefined : JSON.stringify(init.body),
-  });
-
-  const raw = await response.text();
-  const parsed = safeParseJson(raw);
-
-  if (!response.ok) {
-    console.warn(`[bvnk] ${init.method} ${path} -> ${response.status}: ${raw.slice(0, 600)}`);
-    const message = raw.trim() || `BVNK request failed with status ${response.status}`;
-    throw mapBvnkErrorStatus(response.status, message, {
-      edgeBlocked: isEdgeBlockBody(parsed, raw),
-    });
-  }
-
-  return parsed ?? {};
 }
 
 /**
@@ -344,7 +327,7 @@ function mapBvnkErrorStatus(
   if (status >= 500) {
     return new AppError("INTERNAL_ERROR", `BVNK request failed with status ${status}.`);
   }
-  return new AppError("BAD_REQUEST", message);
+  return badRequest(message);
 }
 
 interface BvnkEstimateResponse {
@@ -356,13 +339,6 @@ interface BvnkPaymentSummary {
   status?: string;
   redirectUrl?: string;
   reference?: string;
-}
-
-function parseBvnkEstimateResponse(payload: unknown): BvnkEstimateResponse {
-  if (typeof payload !== "object" || payload === null) {
-    throw new AppError("BAD_REQUEST", "BVNK estimate response payload is invalid");
-  }
-  return payload as BvnkEstimateResponse;
 }
 
 interface BvnkPayoutEstimateResponse {
@@ -378,20 +354,6 @@ interface BvnkPayoutEstimateResponse {
   exchangeRate: number;
 }
 
-function parseBvnkPayoutEstimateResponse(payload: unknown): BvnkPayoutEstimateResponse {
-  if (typeof payload !== "object" || payload === null) {
-    throw new AppError("BAD_REQUEST", "BVNK estimate response payload is invalid");
-  }
-  return payload as BvnkPayoutEstimateResponse;
-}
-
-function parseBvnkPaymentSummary(payload: unknown): BvnkPaymentSummary {
-  if (typeof payload !== "object" || payload === null) {
-    throw new AppError("BAD_REQUEST", "BVNK payment response payload is invalid");
-  }
-  return payload as BvnkPaymentSummary;
-}
-
 interface BvnkRuleResponse {
   id?: string;
   reference?: string;
@@ -399,17 +361,10 @@ interface BvnkRuleResponse {
   originator?: { currency?: string; walletId?: string };
 }
 
-function parseBvnkRuleResponse(payload: unknown): BvnkRuleResponse {
-  if (typeof payload !== "object" || payload === null) {
-    throw new AppError("BAD_REQUEST", "BVNK rule response payload is invalid");
-  }
-  return payload as BvnkRuleResponse;
-}
-
 function toPositiveAmount(value: string, fieldName: string): number {
   const amount = Number.parseFloat(value);
   if (!Number.isFinite(amount) || amount <= 0) {
-    throw new AppError("BAD_REQUEST", `${fieldName} must be a positive amount`);
+    throw badRequest(`${fieldName} must be a positive amount`);
   }
   return amount;
 }
@@ -546,22 +501,14 @@ export interface BvnkCustomerState {
   verificationUrl?: string;
 }
 
-export interface BvnkBankAccount {
-  accountNumber?: string;
-  code?: string;
-  accountNumberFormat?: string;
-  paymentReference?: string;
-  bankName?: string;
-}
-
 export interface BvnkFiatWallet {
   id: string;
   status?: string;
-  bankAccount?: BvnkBankAccount;
+  bankAccount?: BvnkBankFundingDetails;
 }
 
 export interface CreateBvnkAgreementSessionInput {
-  customerType: "INDIVIDUAL" | "COMPANY";
+  customerType: BvnkEntityType;
   countryCode: string;
   useCase: string;
 }
@@ -624,6 +571,13 @@ export type BvnkWebhookEvent =
       customerStatus?: string;
       verificationUrl?: string;
     }
+  | {
+      kind: "payment";
+      event: string;
+      customerId?: string;
+      walletId?: string;
+      status?: string;
+    }
   | { kind: "ignore"; event: string };
 
 export interface CreateBvnkOnrampRuleInput {
@@ -647,7 +601,7 @@ function parseBvnkAgreementSession(payload: unknown): BvnkAgreementSession {
   const data = asRecord(payload);
   const reference = readString(data.reference);
   if (!reference) {
-    throw new AppError("BAD_REQUEST", "BVNK agreement session response is missing a reference");
+    throw badRequest("BVNK agreement session response is missing a reference");
   }
   const agreements = Array.isArray(data.agreements)
     ? data.agreements.map((entry): BvnkAgreement => {
@@ -692,7 +646,7 @@ function parseBvnkCustomerState(payload: unknown): BvnkCustomerState {
   const data = asRecord(payload);
   const reference = readString(data.reference);
   if (!reference) {
-    throw new AppError("BAD_REQUEST", "BVNK customer response is missing a reference");
+    throw badRequest("BVNK customer response is missing a reference");
   }
   const verification = asRecord(data.verification);
   return {
@@ -725,7 +679,7 @@ function parseBvnkFiatWallet(payload: unknown): BvnkFiatWallet {
   const data = asRecord(payload);
   const id = readString(data.id);
   if (!id) {
-    throw new AppError("BAD_REQUEST", "BVNK wallet response is missing an id");
+    throw badRequest("BVNK wallet response is missing an id");
   }
   const status = readString(data.status);
   const instruments = Array.isArray(data.paymentInstruments) ? data.paymentInstruments : [];
@@ -749,6 +703,39 @@ function parseBvnkFiatWallet(payload: unknown): BvnkFiatWallet {
 
 export class BvnkRampClient implements RampProvider {
   readonly id = "bvnk";
+
+  private async request<T = unknown>(
+    config: BvnkConfig,
+    path: string,
+    init: {
+      method: ProviderRequestInit<unknown>["method"];
+      body?: unknown;
+      headers?: Record<string, string>;
+    }
+  ): Promise<T> {
+    const url = new URL(path, config.apiBaseUrl);
+    const authorization = await buildBvnkHawkAuthorizationHeader(
+      url,
+      init.method,
+      config.auth.authId,
+      config.auth.secretKey
+    );
+
+    const { response, raw, parsed } = await providerFetch(this.id, url.toString(), {
+      ...init,
+      headers: { Authorization: authorization, ...init.headers },
+    });
+
+    if (!response.ok) {
+      console.warn(`[bvnk] ${init.method} ${path} -> ${response.status}: ${raw.slice(0, 600)}`);
+      const message = raw.trim() || `BVNK request failed with status ${response.status}`;
+      throw mapBvnkErrorStatus(response.status, message, {
+        edgeBlocked: isEdgeBlockBody(parsed, raw),
+      });
+    }
+
+    return (parsed ?? {}) as T;
+  }
 
   validateCounterparty(
     counterparty: Counterparty,
@@ -829,7 +816,7 @@ export class BvnkRampClient implements RampProvider {
     try {
       payload = JSON.parse(rawBody);
     } catch {
-      throw new AppError("BAD_REQUEST", "BVNK webhook body must be valid JSON", {
+      throw badRequest("BVNK webhook body must be valid JSON", {
         provider: this.id,
       });
     }
@@ -882,6 +869,14 @@ export class BvnkRampClient implements RampProvider {
           walletStatus: readString(data.status),
           bankAccount: parseBvnkLedgersBankAccount(data),
         };
+      case "bvnk:payment:crypto:status-change":
+        return {
+          kind: "payment",
+          event,
+          customerId: readString(data.customerId),
+          walletId: readString(data.walletId),
+          status: readString(data.status),
+        };
       default:
         return { kind: "ignore", event };
     }
@@ -892,7 +887,7 @@ export class BvnkRampClient implements RampProvider {
     input: CreateBvnkAgreementSessionInput
   ): Promise<BvnkAgreementSession> {
     const config = readBvnkConfig(env, mode);
-    const response = await bvnkRequest(config, "/platform/v1/customers/agreement/sessions", {
+    const response = await this.request(config, "/platform/v1/customers/agreement/sessions", {
       method: "POST",
       body: {
         customerType: input.customerType,
@@ -908,7 +903,7 @@ export class BvnkRampClient implements RampProvider {
     input: { reference: string; ipAddress: string }
   ): Promise<void> {
     const config = readBvnkConfig(env, mode);
-    await bvnkRequest(
+    await this.request(
       config,
       `/platform/v1/customers/agreement/sessions/${encodeURIComponent(input.reference)}`,
       { method: "PUT", body: { status: "SIGNED", ipAddress: input.ipAddress } }
@@ -920,7 +915,7 @@ export class BvnkRampClient implements RampProvider {
     input: CreateBvnkCustomerInput
   ): Promise<BvnkCustomerState> {
     const config = readBvnkConfig(env, mode);
-    const response = await bvnkRequest(config, "/platform/v1/customers", {
+    const response = await this.request(config, "/platform/v1/customers", {
       method: "POST",
       body: {
         type: "individual",
@@ -937,7 +932,7 @@ export class BvnkRampClient implements RampProvider {
     input: { reference: string }
   ): Promise<BvnkCustomerState> {
     const config = readBvnkConfig(env, mode);
-    const response = await bvnkRequest(
+    const response = await this.request(
       config,
       `/platform/v1/customers/${encodeURIComponent(input.reference)}`,
       { method: "GET" }
@@ -955,7 +950,7 @@ export class BvnkRampClient implements RampProvider {
   ): Promise<string> {
     const config = readBvnkConfig(env, mode);
     const query = `customerId:${input.customerReference} AND currency:${input.currency}`;
-    const response = await bvnkRequest(
+    const response = await this.request(
       config,
       `/ledger/v2/wallets/profiles?q=${encodeURIComponent(query)}`,
       { method: "GET" }
@@ -975,7 +970,7 @@ export class BvnkRampClient implements RampProvider {
     input: { walletId: string }
   ): Promise<BvnkFiatWallet> {
     const config = readBvnkConfig(env, mode);
-    const response = await bvnkRequest(
+    const response = await this.request(
       config,
       `/ledger/v2/wallets/${encodeURIComponent(input.walletId)}`,
       { method: "GET" }
@@ -988,7 +983,7 @@ export class BvnkRampClient implements RampProvider {
     input: CreateBvnkFiatWalletInput
   ): Promise<BvnkFiatWallet> {
     const config = readBvnkConfig(env, mode);
-    const response = await bvnkRequest(config, "/ledger/v2/wallets", {
+    const response = await this.request(config, "/ledger/v2/wallets", {
       method: "POST",
       headers: { "Idempotency-Key": input.idempotencyKey },
       body: {
@@ -1006,7 +1001,7 @@ export class BvnkRampClient implements RampProvider {
     input: CreateBvnkOnrampRuleInput
   ): Promise<BvnkRuleResponse> {
     const config = readBvnkConfig(env, mode);
-    const response = await bvnkRequest(config, "/payment/v1/rules", {
+    return this.request<BvnkRuleResponse>(config, "/payment/v1/rules", {
       method: "POST",
       body: {
         reference: input.reference,
@@ -1019,7 +1014,6 @@ export class BvnkRampClient implements RampProvider {
         },
       },
     });
-    return parseBvnkRuleResponse(response);
   }
 
   async simulatePayin(
@@ -1035,7 +1029,7 @@ export class BvnkRampClient implements RampProvider {
     const config = readBvnkConfig(env, mode);
     const remittanceInformation =
       input.remittanceInformation ?? `SDP ${crypto.randomUUID().replace(/-/g, "").slice(0, 20)}`;
-    return bvnkRequest(config, "/payment/v2/payins/simulation", {
+    return this.request(config, "/payment/v2/payins/simulation", {
       method: "POST",
       body: {
         walletId: input.walletId,
@@ -1051,10 +1045,12 @@ export class BvnkRampClient implements RampProvider {
   }
 
   /**
-   * BVNK on-ramp is stateful (per-counterparty KYC customer + virtual wallet +
-   * rule) and is orchestrated in the payments handler via `ensureBvnkOnramp`,
-   * which owns the DB-cached state. The stateless provider contract can't model
-   * it, so these interface methods are unreachable for BVNK.
+   * BVNK quotes its on-ramp rate only at quote time, so an upfront estimate is
+   * unavailable; ESTIMATE_NOT_AVAILABLE lets the cross-provider estimate sweep
+   * surface BVNK as "unsupported" for the pair. The rest of the on-ramp (KYC
+   * customer + virtual wallet + rule) is stateful and orchestrated in the
+   * payments handler via `ensureBvnkOnramp`, so BVNK omits the on-ramp
+   * quote/execute methods entirely.
    */
   async estimateOnramp(
     _ctx: RampRuntimeContext,
@@ -1074,8 +1070,10 @@ export class BvnkRampClient implements RampProvider {
       getCryptoRailAssetLabel(input.assetRail)
     );
     const paidRequiredAmount = toPositiveAmount(input.cryptoAmount, "cryptoAmount");
-    const estimate = parseBvnkPayoutEstimateResponse(
-      await bvnkRequest(config, "/api/v1/pay/estimate", {
+    const estimate = await this.request<BvnkPayoutEstimateResponse>(
+      config,
+      "/api/v1/pay/estimate",
+      {
         method: "POST",
         body: {
           walletId: config.walletId,
@@ -1085,7 +1083,7 @@ export class BvnkRampClient implements RampProvider {
           reference: rampId("sdp_offramp_est"),
           network,
         },
-      })
+      }
     );
     if (
       estimate.feePredictedAmount > 0 &&
@@ -1133,19 +1131,12 @@ export class BvnkRampClient implements RampProvider {
     };
   }
 
-  async createOnrampQuote(): Promise<PaymentRampQuote> {
-    throw new AppError(
-      "INTERNAL_ERROR",
-      "BVNK on-ramp is orchestrated by the payments handler, not the provider quote method."
-    );
-  }
-
   async createOfframpQuote(
     { env, mode }: RampRuntimeContext,
     input: RampOfframpQuoteInput
   ): Promise<PaymentRampQuote> {
     if (!input.fiatCurrency) {
-      throw new AppError("BAD_REQUEST", "fiatCurrency is required for BVNK off-ramp.");
+      throw badRequest("fiatCurrency is required for BVNK off-ramp.");
     }
     const config = readBvnkConfig(env, mode);
     const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
@@ -1156,72 +1147,88 @@ export class BvnkRampClient implements RampProvider {
       requirePartyDetails: true,
     });
 
-    const estimate = parseBvnkEstimateResponse(
-      await bvnkRequest(config, "/api/v1/pay/estimate", {
-        method: "POST",
-        body: {
-          walletId: config.walletId,
-          walletCurrency: fiatCurrency,
-          paidCurrency: currency,
-          paidRequiredAmount,
-          reference,
-          network,
-          complianceDetails,
-        },
-      })
-    );
+    const estimate = await this.request<BvnkEstimateResponse>(config, "/api/v1/pay/estimate", {
+      method: "POST",
+      body: {
+        walletId: config.walletId,
+        walletCurrency: fiatCurrency,
+        paidCurrency: currency,
+        paidRequiredAmount,
+        reference,
+        network,
+        complianceDetails,
+      },
+    });
     if (!estimate.externalId) {
-      throw new AppError("BAD_REQUEST", "BVNK estimate response is missing externalId");
+      throw badRequest("BVNK estimate response is missing externalId");
     }
 
-    const summary = parseBvnkPaymentSummary(
-      await bvnkRequest(
-        config,
-        `/api/v1/pay/estimate/${encodeURIComponent(estimate.externalId)}/accept`,
-        {
-          method: "POST",
-          body: {
-            customerId: input.customerId ?? input.externalCustomerId,
-            payOutDetails: { currency, address: input.sourceWalletAddress, network },
-            complianceDetails,
-          },
-        }
-      )
+    const summary = await this.request<BvnkPaymentSummary>(
+      config,
+      `/api/v1/pay/estimate/${encodeURIComponent(estimate.externalId)}/accept`,
+      {
+        method: "POST",
+        body: {
+          customerId: input.customerId ?? input.externalCustomerId,
+          payOutDetails: { currency, address: input.sourceWalletAddress, network },
+          complianceDetails,
+        },
+      }
     );
+    if (!summary.uuid) {
+      throw badRequest("BVNK off-ramp did not return a payment uuid");
+    }
     if (!summary.redirectUrl) {
-      throw new AppError("BAD_REQUEST", "BVNK off-ramp did not return a redirect URL");
+      throw badRequest("BVNK off-ramp did not return a redirect URL");
     }
     return {
       provider: "bvnk",
-      id: typeof summary.uuid === "string" ? summary.uuid : estimate.externalId,
+      id: summary.uuid,
       status: mapBvnkPaymentStatus(summary.status),
       deliveryMode: "hosted",
       hostedUrl: summary.redirectUrl,
     };
   }
 
-  async executeOnramp(): Promise<PaymentRampExecution> {
-    throw new AppError(
-      "INTERNAL_ERROR",
-      "BVNK on-ramp is orchestrated by the payments handler, not the provider execute method."
-    );
+  async executeOnramp(
+    { mode }: RampRuntimeContext,
+    input: BvnkExecuteOnrampInput
+  ): Promise<BvnkPaymentRampExecution> {
+    const resolution = input.bvnkPaymentRule;
+    const { network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
+    const fiatCurrency = input.fiatCurrency;
+    const instruction = buildBvnkOnrampInstruction(resolution, {
+      network,
+      destinationWalletAddress: input.destinationWalletAddress,
+      fiatCurrency,
+      mode,
+    });
+    const reference =
+      resolution.onboardingStatus === "ready"
+        ? resolution.entry.ruleId
+        : resolution.customer.customerReference;
+    if (!reference)
+      throw internalError(
+        `BVNK on-ramp missing reference at status "${resolution.onboardingStatus}".`
+      );
+    return {
+      id: reference,
+      provider: "bvnk",
+      status: "pending",
+      reference,
+      paymentInstructions: [instruction],
+    };
   }
 
   async executeOfframp(
     { env, mode }: RampRuntimeContext,
-    input: RampExecuteOfframpInput
-  ): Promise<PaymentRampExecution> {
-    const customerId = input.kycReference?.trim();
+    input: BvnkExecuteOfframpInput
+  ): Promise<BvnkPaymentRampExecution> {
+    const customerId = input.providerCustomer.customerReference;
     if (!customerId) {
-      throw new AppError(
-        "BAD_REQUEST",
-        "kycReference is required for BVNK offramp and must contain a BVNK customer id"
-      );
+      throw badRequest("providerCustomer.customerReference is required for BVNK off-ramp.");
     }
 
-    if (!input.fiatCurrency) {
-      throw new AppError("BAD_REQUEST", "fiatCurrency is required for BVNK off-ramp.");
-    }
     const config = readBvnkConfig(env, mode);
     const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
     const fiatCurrency = input.fiatCurrency;
@@ -1231,7 +1238,7 @@ export class BvnkRampClient implements RampProvider {
       requirePartyDetails: true,
     });
 
-    const estimateResponse = await bvnkRequest(config, "/api/v1/pay/estimate", {
+    const estimate = await this.request<BvnkEstimateResponse>(config, "/api/v1/pay/estimate", {
       method: "POST",
       body: {
         walletId: config.walletId,
@@ -1243,13 +1250,11 @@ export class BvnkRampClient implements RampProvider {
         complianceDetails,
       },
     });
-
-    const estimate = parseBvnkEstimateResponse(estimateResponse);
     if (!estimate.externalId) {
-      throw new AppError("BAD_REQUEST", "BVNK estimate response is missing externalId");
+      throw badRequest("BVNK estimate response is missing externalId");
     }
 
-    const summaryResponse = await bvnkRequest(
+    const summary = await this.request<BvnkPaymentSummary>(
       config,
       `/api/v1/pay/estimate/${encodeURIComponent(estimate.externalId)}/accept`,
       {
@@ -1261,25 +1266,22 @@ export class BvnkRampClient implements RampProvider {
         },
       }
     );
+    if (!summary.uuid) {
+      throw badRequest("BVNK off-ramp did not return a payment uuid");
+    }
 
-    const summary = parseBvnkPaymentSummary(summaryResponse);
     return {
       id: rampId("ramp"),
       provider: "bvnk",
       status: mapBvnkPaymentStatus(summary.status),
-      redirectUrl: typeof summary.redirectUrl === "string" ? summary.redirectUrl : undefined,
-      reference:
-        typeof summary.uuid === "string"
-          ? summary.uuid
-          : typeof summary.reference === "string"
-            ? summary.reference
-            : estimate.externalId,
+      redirectUrl: summary.redirectUrl,
+      reference: summary.uuid,
     };
   }
 }
 
 /** Shared, one-per-counterparty BVNK customer (KYC) state. */
-export interface BvnkCustomerData {
+export interface BvnkCustomerResolution {
   externalReference?: string;
   customerReference?: string;
   status?: string;
@@ -1302,10 +1304,26 @@ export function isBvnkWalletActive(status: string | undefined): boolean {
   return status !== undefined && BVNK_WALLET_ACTIVE_STATUSES.has(status.toUpperCase());
 }
 
-export interface BvnkOnrampResolution {
-  customer: BvnkCustomerData;
+export interface BvnkPaymentRuleResolution {
+  customer: BvnkCustomerResolution;
   entry: BvnkOnrampEntry;
   onboardingStatus: BvnkOnboardingStatus;
+}
+
+export interface BvnkExecuteOnrampInput {
+  destinationWalletAddress: string;
+  cryptoToken: string;
+  fiatCurrency: RampFiatCurrency;
+  bvnkPaymentRule: BvnkPaymentRuleResolution;
+}
+
+export interface BvnkExecuteOfframpInput {
+  sourceWalletAddress: string;
+  cryptoToken: string;
+  fiatCurrency: RampFiatCurrency;
+  cryptoAmount: string;
+  providerCustomer: BvnkCustomerResolution;
+  bvnkCompliance?: BvnkComplianceInput;
 }
 
 export function readBvnkData(
@@ -1315,9 +1333,11 @@ export function readBvnkData(
   return bvnk && typeof bvnk === "object" ? (bvnk as Record<string, unknown>) : {};
 }
 
-export function readBvnkCustomer(providerData: CounterpartyRow["provider_data"]): BvnkCustomerData {
+export function readBvnkCustomer(
+  providerData: CounterpartyRow["provider_data"]
+): BvnkCustomerResolution {
   const customer = readBvnkData(providerData).customer;
-  return customer && typeof customer === "object" ? (customer as BvnkCustomerData) : {};
+  return customer && typeof customer === "object" ? (customer as BvnkCustomerResolution) : {};
 }
 
 export function readBvnkWallets(
@@ -1376,7 +1396,7 @@ export function buildBvnkRuleEntity(counterparty: CounterpartyRow): BvnkRuleEnti
   const isCompany = counterparty.entity_type === "business";
 
   return {
-    type: isCompany ? "COMPANY" : "INDIVIDUAL",
+    type: BVNK_ENTITY_TYPE[counterparty.entity_type],
     customerIdentifier: counterparty.external_id ?? counterparty.id,
     relationshipType: "SELF_OWNED",
     ...(isCompany
@@ -1409,7 +1429,7 @@ export function buildBvnkPartyDetails(
     partyDetails: [
       {
         type: role,
-        entityType: counterparty.entity_type === "business" ? "COMPANY" : "INDIVIDUAL",
+        entityType: BVNK_ENTITY_TYPE[counterparty.entity_type],
         relationshipType: "SELF_OWNED",
         firstName: identity.firstName,
         lastName: identity.lastName,
@@ -1421,7 +1441,7 @@ export function buildBvnkPartyDetails(
 }
 
 export function buildBvnkOnrampInstruction(
-  resolution: BvnkOnrampResolution,
+  resolution: BvnkPaymentRuleResolution,
   params: {
     network: string;
     destinationWalletAddress: string;

--- a/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
@@ -295,7 +295,7 @@ async function buildBvnkHawkAuthorizationHeader(
  * credential problem — and must not be reported as a Hawk misconfiguration.
  */
 function isEdgeBlockBody(parsed: unknown, raw: string): boolean {
-  if (parsed !== null) return false;
+  if (parsed !== undefined) return false;
   return /cloudfront|request could not be satisfied|request blocked/i.test(raw);
 }
 

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -1,6 +1,7 @@
 import { createVerify } from "node:crypto";
 import type {
   Counterparty,
+  LightsparkPaymentRampExecution,
   LightsparkPaymentRampInstruction,
   PaymentRampEstimate,
   PaymentRampExecution,
@@ -8,6 +9,7 @@ import type {
   PaymentRampQuoteCurrency,
   SdpEnvironment,
 } from "@sdp/types";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import {
   CRYPTO_ASSET_DECIMALS,
   type CryptoAssetSymbol,
@@ -16,7 +18,7 @@ import {
 } from "@sdp/types/payment-rails";
 import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
-import { AppError, providerNotConfigured } from "@/lib/errors";
+import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
 import { isAddress } from "@/lib/solana";
 import { type ProviderRequestInit, providerFetchJson } from "../fetch";
 import { readyCounterparty } from "../requirements";
@@ -34,8 +36,6 @@ import type {
   RampDumpReader,
   RampEstimateOfframpInput,
   RampEstimateOnrampInput,
-  RampExecuteOfframpInput,
-  RampExecuteOnrampInput,
   RampOfframpQuoteInput,
   RampOnrampQuoteInput,
   RampProvider,
@@ -76,7 +76,7 @@ function readLightsparkConfig(
 function normalizeLightsparkCurrencyCode(value: string): string {
   const normalized = value.trim().toUpperCase();
   if (!/^[A-Z0-9_]+$/.test(normalized)) {
-    throw new AppError("BAD_REQUEST", "cryptoToken must be a valid Lightspark currency code");
+    throw badRequest("cryptoToken must be a valid Lightspark currency code");
   }
   return normalized;
 }
@@ -98,7 +98,7 @@ function getLightsparkCurrencyDecimals(currencyCode: string): number {
 function assertLightsparkAccountId(value: string, fieldName: string): string {
   const normalized = value.trim();
   if (normalized.length === 0) {
-    throw new AppError("BAD_REQUEST", `${fieldName} is required for lightspark`);
+    throw badRequest(`${fieldName} is required for lightspark`);
   }
   if (!normalized.includes(":")) {
     throw new AppError(
@@ -111,7 +111,7 @@ function assertLightsparkAccountId(value: string, fieldName: string): string {
 
 function toLightsparkMinorUnitsInteger(value: bigint, fieldName: string): number {
   if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new AppError("BAD_REQUEST", `${fieldName} is too large for Lightspark quote minor units`);
+    throw badRequest(`${fieldName} is too large for Lightspark quote minor units`);
   }
   return Number(value);
 }
@@ -159,7 +159,7 @@ function readRequiredGridString(
 ): string {
   const value = record[field];
   if (typeof value !== "string" || value.trim().length === 0) {
-    throw new AppError("BAD_REQUEST", `${payloadName} is missing ${field}`);
+    throw badRequest(`${payloadName} is missing ${field}`);
   }
   return value.trim();
 }
@@ -186,7 +186,7 @@ function readRequiredGridObject(
 ): Record<string, unknown> {
   const value = record[field];
   if (!isGridRecord(value)) {
-    throw new AppError("BAD_REQUEST", `${payloadName} is missing ${field}`);
+    throw badRequest(`${payloadName} is missing ${field}`);
   }
   return value;
 }
@@ -201,7 +201,7 @@ function parseLightsparkOutgoingPaymentWebhook(
   payload: unknown
 ): LightsparkOutgoingPaymentWebhook | null {
   if (!isGridRecord(payload)) {
-    throw new AppError("BAD_REQUEST", "Lightspark webhook body must be an object");
+    throw badRequest("Lightspark webhook body must be an object");
   }
 
   const type = readRequiredGridString(payload, "type", "Lightspark webhook");
@@ -268,6 +268,26 @@ export interface CreateLightsparkCustomerInput {
 
 export interface LightsparkCustomer {
   id: string;
+}
+
+export interface LightsparkCustomerResolution {
+  customerId: string;
+}
+
+export interface LightsparkExecuteOnrampInput {
+  destinationWalletAddress: string;
+  cryptoToken: string;
+  fiatCurrency?: RampFiatCurrency;
+  fiatAmount: string;
+  providerCustomer: LightsparkCustomerResolution;
+}
+
+export interface LightsparkExecuteOfframpInput {
+  sourceWalletAddress: string;
+  cryptoToken: string;
+  fiatCurrency?: RampFiatCurrency;
+  cryptoAmount: string;
+  providerCustomer: LightsparkCustomerResolution;
 }
 
 interface GridCreateCustomerBody {
@@ -563,7 +583,7 @@ export class LightsparkRampClient implements RampProvider {
     try {
       payload = JSON.parse(rawBody);
     } catch {
-      throw new AppError("BAD_REQUEST", "Lightspark webhook body must be valid JSON", {
+      throw badRequest("Lightspark webhook body must be valid JSON", {
         provider: this.id,
       });
     }
@@ -737,7 +757,7 @@ export class LightsparkRampClient implements RampProvider {
   ): Promise<string> {
     const normalized = destinationWallet.trim();
     if (normalized.length === 0) {
-      throw new AppError("BAD_REQUEST", "destinationWallet is required for lightspark");
+      throw badRequest("destinationWallet is required for lightspark");
     }
     if (normalized.includes(":")) {
       return assertLightsparkAccountId(normalized, "destinationWallet");
@@ -774,7 +794,7 @@ export class LightsparkRampClient implements RampProvider {
     );
     const created = parseLightsparkExternalAccount(createResponse);
     if (!created.id) {
-      throw new AppError("BAD_REQUEST", "Lightspark external account response is missing id");
+      throw badRequest("Lightspark external account response is missing id");
     }
     return created.id;
   }
@@ -847,7 +867,7 @@ export class LightsparkRampClient implements RampProvider {
     input: RampOnrampQuoteInput
   ): Promise<PaymentRampQuote> {
     if (!input.customerId) {
-      throw new AppError("BAD_REQUEST", "Lightspark on-ramp requires a resolved customerId");
+      throw badRequest("Lightspark on-ramp requires a resolved customerId");
     }
     const config = readLightsparkConfig(env, mode);
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
@@ -900,15 +920,9 @@ export class LightsparkRampClient implements RampProvider {
 
   async executeOnramp(
     { env, mode }: RampRuntimeContext,
-    input: RampExecuteOnrampInput
-  ): Promise<PaymentRampExecution> {
-    const customerId = input.kycReference?.trim();
-    if (!customerId) {
-      throw new AppError(
-        "BAD_REQUEST",
-        "kycReference is required for lightspark onramp and must contain a Lightspark customer id"
-      );
-    }
+    input: LightsparkExecuteOnrampInput
+  ): Promise<LightsparkPaymentRampExecution> {
+    const customerId = input.providerCustomer.customerId;
     const config = readLightsparkConfig(env, mode);
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
     const fiatCurrency = input.fiatCurrency ?? "USD";
@@ -942,12 +956,12 @@ export class LightsparkRampClient implements RampProvider {
 
   async executeOfframp(
     { env, mode }: RampRuntimeContext,
-    input: RampExecuteOfframpInput
-  ): Promise<PaymentRampExecution> {
+    input: LightsparkExecuteOfframpInput
+  ): Promise<LightsparkPaymentRampExecution> {
     const sourceAccountId = assertLightsparkAccountId(input.sourceWalletAddress, "sourceWallet");
     const destinationAccountId = assertLightsparkAccountId(
-      input.kycReference ?? "",
-      "kycReference"
+      input.providerCustomer.customerId,
+      "providerCustomer.customerId"
     );
     const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
     const fiatCurrency = input.fiatCurrency ?? "USD";

--- a/apps/sdp-api/src/lib/ramps/providers/moonpay.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/moonpay.ts
@@ -1,18 +1,19 @@
 import { timingSafeEqual } from "node:crypto";
 import type {
   Counterparty,
+  MoonpayPaymentRampExecution,
   PaymentRampEstimate,
-  PaymentRampExecution,
   PaymentRampQuote,
   SdpEnvironment,
 } from "@sdp/types";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import {
   type CryptoRailId,
   getCryptoRailAssetLabel,
   parseFiatCurrency,
 } from "@sdp/types/payment-rails";
 import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
-import { AppError, providerNotConfigured } from "@/lib/errors";
+import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
 import { providerFetchJson } from "../fetch";
 import { readyCounterparty } from "../requirements";
@@ -23,8 +24,6 @@ import type {
   RampDumpReader,
   RampEstimateOfframpInput,
   RampEstimateOnrampInput,
-  RampExecuteOfframpInput,
-  RampExecuteOnrampInput,
   RampOfframpQuoteInput,
   RampOnrampQuoteInput,
   RampProvider,
@@ -277,6 +276,22 @@ interface MoonpayTransactionWebhook {
   };
 }
 
+export interface MoonpayExecuteOnrampInput {
+  destinationWalletAddress: string;
+  cryptoToken: string;
+  fiatCurrency?: RampFiatCurrency;
+  fiatAmount: string;
+  redirectUrl?: string;
+}
+
+export interface MoonpayExecuteOfframpInput {
+  sourceWalletAddress: string;
+  cryptoToken: string;
+  fiatCurrency?: RampFiatCurrency;
+  cryptoAmount: string;
+  redirectUrl?: string;
+}
+
 export class MoonpayRampClient implements RampProvider {
   readonly id = "moonpay";
 
@@ -355,7 +370,7 @@ export class MoonpayRampClient implements RampProvider {
     try {
       payload = JSON.parse(rawBody);
     } catch {
-      throw new AppError("BAD_REQUEST", "MoonPay webhook body must be valid JSON", {
+      throw badRequest("MoonPay webhook body must be valid JSON", {
         provider: this.id,
       });
     }
@@ -509,8 +524,8 @@ export class MoonpayRampClient implements RampProvider {
 
   async executeOnramp(
     { env, mode }: RampRuntimeContext,
-    input: RampExecuteOnrampInput
-  ): Promise<PaymentRampExecution> {
+    input: MoonpayExecuteOnrampInput
+  ): Promise<MoonpayPaymentRampExecution> {
     const amount = Number.parseFloat(input.fiatAmount);
     if (!Number.isFinite(amount) || amount < MOONPAY_ONRAMP_MIN_USD) {
       throw new AppError(
@@ -527,7 +542,6 @@ export class MoonpayRampClient implements RampProvider {
       currencyCode: normalizeMoonpayCurrencyCode(input.cryptoToken),
       walletAddress: input.destinationWalletAddress,
       redirectURL: input.redirectUrl,
-      externalCustomerId: input.kycReference,
       externalTransactionId: rampId("sdp_onramp"),
     });
 
@@ -536,8 +550,8 @@ export class MoonpayRampClient implements RampProvider {
 
   async executeOfframp(
     { env, mode }: RampRuntimeContext,
-    input: RampExecuteOfframpInput
-  ): Promise<PaymentRampExecution> {
+    input: MoonpayExecuteOfframpInput
+  ): Promise<MoonpayPaymentRampExecution> {
     const config = readMoonpayConfig(env, mode);
     const externalTransactionId = rampId("sdp_offramp");
     const redirectUrl = await buildSignedMoonpayWidgetUrl(config.offrampUrl, config.secretKey, {
@@ -547,7 +561,6 @@ export class MoonpayRampClient implements RampProvider {
       quoteCurrencyCode: (input.fiatCurrency ?? "USD").toLowerCase(),
       refundWalletAddress: input.sourceWalletAddress,
       redirectURL: input.redirectUrl,
-      externalCustomerId: input.kycReference,
       externalTransactionId,
     });
 

--- a/apps/sdp-api/src/lib/ramps/types.ts
+++ b/apps/sdp-api/src/lib/ramps/types.ts
@@ -2,7 +2,6 @@ import type {
   Counterparty,
   CounterpartyProviderData,
   PaymentRampEstimate,
-  PaymentRampExecution,
   PaymentRampQuote,
   SdpEnvironment,
 } from "@sdp/types";
@@ -12,7 +11,13 @@ import type { RampProviderId } from "@sdp/types/provider-access";
 import type { CounterpartyRequirements, RampDirection } from "@sdp/types/ramp-requirements";
 import type { BvnkComplianceInput } from "./providers/bvnk";
 
-export type { BvnkComplianceInput, BvnkRuleEntity } from "./providers/bvnk";
+export type {
+  BvnkComplianceInput,
+  BvnkCustomerResolution,
+  BvnkPaymentRuleResolution,
+  BvnkRuleEntity,
+} from "./providers/bvnk";
+export type { LightsparkCustomerResolution } from "./providers/lightspark";
 
 export interface ProviderRampSupport {
   onrampFiats: ReadonlySet<FiatCurrencyCode>;
@@ -121,26 +126,6 @@ export interface RampOfframpQuoteInput {
   bvnkCompliance?: BvnkComplianceInput;
 }
 
-export interface RampExecuteOnrampInput {
-  destinationWalletAddress: string;
-  cryptoToken: string;
-  fiatCurrency?: RampFiatCurrency;
-  fiatAmount: string;
-  kycReference?: string;
-  redirectUrl?: string;
-  bvnkCompliance?: BvnkComplianceInput;
-}
-
-export interface RampExecuteOfframpInput {
-  sourceWalletAddress: string;
-  cryptoToken: string;
-  fiatCurrency?: RampFiatCurrency;
-  cryptoAmount: string;
-  kycReference?: string;
-  redirectUrl?: string;
-  bvnkCompliance?: BvnkComplianceInput;
-}
-
 export interface ValidateCounterpartyOptions {
   direction: RampDirection;
   providerData: CounterpartyProviderData;
@@ -167,7 +152,7 @@ export interface RampProvider extends RampProviderClient {
     ctx: RampRuntimeContext,
     input: RampEstimateOfframpInput
   ): Promise<PaymentRampEstimate>;
-  createOnrampQuote(
+  createOnrampQuote?(
     ctx: RampRuntimeContext,
     input: RampOnrampQuoteInput
   ): Promise<PaymentRampQuote>;
@@ -175,14 +160,6 @@ export interface RampProvider extends RampProviderClient {
     ctx: RampRuntimeContext,
     input: RampOfframpQuoteInput
   ): Promise<PaymentRampQuote>;
-  executeOnramp(
-    ctx: RampRuntimeContext,
-    input: RampExecuteOnrampInput
-  ): Promise<PaymentRampExecution>;
-  executeOfframp(
-    ctx: RampRuntimeContext,
-    input: RampExecuteOfframpInput
-  ): Promise<PaymentRampExecution>;
   validateCounterparty(
     counterparty: Counterparty,
     options: ValidateCounterpartyOptions

--- a/apps/sdp-api/src/lib/ramps/validation/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/bvnk.ts
@@ -16,7 +16,7 @@ import type {
 } from "@sdp/types/ramp-requirements";
 import { z } from "zod";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
-import { AppError, unsupportedCounterparty } from "@/lib/errors";
+import { AppError, badRequest, unsupportedCounterparty } from "@/lib/errors";
 import { readBvnkCustomer } from "../providers/bvnk";
 import {
   buildRequirementSchema,
@@ -245,7 +245,7 @@ export function buildBvnkIndividualPayload(
     }
     const collected = supplied[key];
     if (typeof collected !== "string") {
-      throw new AppError("BAD_REQUEST", `Missing required field "${key}" for BVNK on-ramp.`);
+      throw badRequest(`Missing required field "${key}" for BVNK on-ramp.`);
     }
     return collected;
   };

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -1134,9 +1134,6 @@ export const executeOnrampRequestSchema = executeOnrampSchemaBase
         "Fiat amount to purchase crypto with. MoonPay on-ramp requires at least 20 units of the selected fiat currency.",
       example: "100.00",
     }),
-    kycReference: withOpenApi(executeOnrampSchemaBase.shape.kycReference, {
-      description: "Optional KYC reference identifier.",
-    }),
     redirectUrl: withOpenApi(executeOnrampSchemaBase.shape.redirectUrl, {
       description: "Optional redirect URL after provider flow completes.",
     }),
@@ -1151,11 +1148,11 @@ export const executeOnrampRequestSchema = executeOnrampSchemaBase
       'Execute on-ramp request payload. Note: BVNK on-ramp requires additional provider-side account enablement and compliance setup beyond API credentials. The default example is shaped for `provider: "moonpay"`; switch `provider` to `bvnk` to attach `bvnkCompliance.partyDetails`.',
     example: {
       provider: "moonpay",
+      counterpartyId: "cp_example",
       destinationWallet: "wal_example",
       cryptoToken: "USDC",
       fiatCurrency: "USD",
       fiatAmount: "100.00",
-      kycReference: "",
       redirectUrl: "https://example.com",
     },
   });
@@ -1231,9 +1228,6 @@ export const executeOfframpRequestSchema = executeOfframpSchemaBase
       description: "Crypto amount to sell for fiat.",
       example: "50.00",
     }),
-    kycReference: withOpenApi(executeOfframpSchemaBase.shape.kycReference, {
-      description: "Optional KYC reference identifier.",
-    }),
     redirectUrl: withOpenApi(executeOfframpSchemaBase.shape.redirectUrl, {
       description: "Optional redirect URL after provider flow completes.",
     }),
@@ -1248,11 +1242,11 @@ export const executeOfframpRequestSchema = executeOfframpSchemaBase
       'Execute off-ramp request payload. The default example is shaped for `provider: "moonpay"`; switch `provider` to `bvnk` to attach `bvnkCompliance.partyDetails`.',
     example: {
       provider: "moonpay",
+      counterpartyId: "cp_example",
       sourceWallet: "wal_example",
       cryptoToken: "USDC",
       fiatCurrency: "USD",
       cryptoAmount: "50.00",
-      kycReference: "",
       redirectUrl: "https://example.com",
     },
   });

--- a/apps/sdp-api/src/routes/allowlist/handlers.ts
+++ b/apps/sdp-api/src/routes/allowlist/handlers.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, noContent, success } from "@/lib/response";
 import { createAllowlistService } from "@/services/allowlist.service";
 import { AuditService } from "@/services/audit.service";
@@ -25,8 +26,8 @@ export const addEntry = async (c: AppContext) => {
   const parsed = addEntrySchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -6,9 +6,10 @@ import type {
   RotateApiKeyResponse,
 } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { requireProjectId } from "@/lib/auth";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import { ApiKeyService } from "@/services/api-key.service";
 import {
@@ -100,8 +101,8 @@ export const createApiKey = async (c: AppContext) => {
   const parsed = apiKeyCreateSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -159,7 +160,7 @@ export const createApiKey = async (c: AppContext) => {
         if (error.code === "NOT_FOUND") {
           throw new AppError("CONFLICT", error.message);
         }
-        throw new AppError("BAD_REQUEST", error.message);
+        throw badRequest(error.message);
       }
       throw error;
     }
@@ -308,8 +309,8 @@ export const updateApiKey = async (c: AppContext) => {
   const parsed = apiKeyUpdateSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -379,7 +380,7 @@ export const updateApiKey = async (c: AppContext) => {
   }
 
   if (updates.length === 0) {
-    throw new AppError("BAD_REQUEST", "No fields to update");
+    throw badRequest("No fields to update");
   }
 
   values.push(keyId);
@@ -420,15 +421,15 @@ export const rotateApiKey = async (c: AppContext) => {
 
   // Prevent rotating the key being used
   if (actor.apiKeyId && keyId === actor.apiKeyId) {
-    throw new AppError("BAD_REQUEST", "Cannot rotate the API key being used for this request");
+    throw badRequest("Cannot rotate the API key being used for this request");
   }
 
   const body = await c.req.json().catch(() => ({}));
   const parsed = apiKeyRotateSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -474,7 +475,7 @@ export const revokeApiKey = async (c: AppContext) => {
 
   // Prevent revoking your own key
   if (actor.apiKeyId && keyId === actor.apiKeyId) {
-    throw new AppError("BAD_REQUEST", "Cannot revoke the API key being used for this request");
+    throw badRequest("Cannot revoke the API key being used for this request");
   }
 
   const body = await c.req.json().catch(() => ({}));
@@ -504,11 +505,11 @@ export const revokeApiKey = async (c: AppContext) => {
   }
 
   if (!confirmation) {
-    throw new AppError("BAD_REQUEST", "Confirmation is required to deactivate an API key");
+    throw badRequest("Confirmation is required to deactivate an API key");
   }
 
   if (confirmation !== existing.name) {
-    throw new AppError("BAD_REQUEST", "Confirmation did not match the key name");
+    throw badRequest("Confirmation did not match the key name");
   }
 
   const apiKeyService = new ApiKeyService(getDb(c.env));

--- a/apps/sdp-api/src/routes/compliance/handlers.ts
+++ b/apps/sdp-api/src/routes/compliance/handlers.ts
@@ -1,7 +1,8 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { isSelfHostedDeployment } from "@/lib/runtime-env";
 import { assertValidAddress } from "@/lib/solana";
@@ -17,8 +18,8 @@ export async function screenAddress(c: AppContext) {
   const parsed = screenAddressSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -29,7 +30,7 @@ export async function screenAddress(c: AppContext) {
     try {
       assertValidAddress(address, "address");
     } catch {
-      throw new AppError("BAD_REQUEST", "Invalid Solana address");
+      throw badRequest("Invalid Solana address");
     }
   }
 

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -1,5 +1,6 @@
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import { clearWalletCaches } from "@/routes/custody/handlers/wallets";
 import { AuditService } from "@/services/audit.service";
@@ -41,8 +42,8 @@ export const initializeSigning = async (c: AppContext) => {
   const parsed = initializeSigningSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -94,8 +95,8 @@ export const switchSigning = async (c: AppContext) => {
   const parsed = switchSigningSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -258,7 +259,7 @@ async function initializeProviderConnection(
       });
     case "fireblocks": {
       if (!env.FIREBLOCKS_API_KEY || !env.FIREBLOCKS_API_SECRET) {
-        throw new AppError("BAD_REQUEST", "Fireblocks backend credentials are not configured");
+        throw badRequest("Fireblocks backend credentials are not configured");
       }
 
       const resolvedApiKey = env.FIREBLOCKS_API_KEY;
@@ -339,7 +340,7 @@ async function initializeProviderConnection(
         walletLabel: request.walletLabel,
       });
     default:
-      throw new AppError("BAD_REQUEST", "Unsupported provider");
+      throw badRequest("Unsupported provider");
   }
 }
 
@@ -483,7 +484,7 @@ function handleSigningInitializationError(error: unknown): never {
     if (error.code === "ALREADY_INITIALIZED") {
       throw new AppError("CONFLICT", error.message);
     }
-    throw new AppError("BAD_REQUEST", error.message);
+    throw badRequest(error.message);
   }
 
   throw error;

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -10,9 +10,10 @@ import {
   setTransactionMessageLifetimeUsingBlockhash,
 } from "@solana/kit";
 import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
@@ -46,8 +47,8 @@ export const signerCheck = async (c: AppContext) => {
   const parsed = signerCheckSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -57,7 +58,7 @@ export const signerCheck = async (c: AppContext) => {
   ]);
 
   if (!resolvedWalletId) {
-    throw new AppError("BAD_REQUEST", "API key is not bound to a signing wallet");
+    throw badRequest("API key is not bound to a signing wallet");
   }
 
   try {
@@ -149,7 +150,7 @@ export const signerCheck = async (c: AppContext) => {
     }
 
     if (error instanceof SigningError) {
-      throw new AppError("BAD_REQUEST", error.message);
+      throw badRequest(error.message);
     }
 
     if (error instanceof Error) {

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -4,10 +4,11 @@ import type {
   CustodyWalletTokenBalance,
 } from "@sdp/types";
 import type { Address } from "@solana/kit";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { formatDecimalAmount } from "@/lib/amount";
 import { getAuth } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import * as tokenAccounts from "@/routes/payments/token-accounts";
 import {
@@ -356,7 +357,7 @@ function resolveWalletFilters(
       : undefined;
 
   if (providerQuery && !provider) {
-    throw new AppError("BAD_REQUEST", "Invalid provider query parameter");
+    throw badRequest("Invalid provider query parameter");
   }
 
   return {
@@ -453,8 +454,8 @@ export const createWallet = async (c: AppContext) => {
   const parsed = createWalletSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -488,7 +489,7 @@ export const createWallet = async (c: AppContext) => {
       if (error.code === "NOT_FOUND") {
         throw new AppError("NOT_FOUND", error.message);
       }
-      throw new AppError("BAD_REQUEST", error.message);
+      throw badRequest(error.message);
     }
     throw error;
   }
@@ -501,8 +502,8 @@ export const deleteWallet = async (c: AppContext) => {
   const parsed = deleteWalletSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -541,7 +542,7 @@ export const deleteWallet = async (c: AppContext) => {
       if (error.code === "NOT_FOUND" || error.code === "WALLET_NOT_FOUND") {
         throw new AppError("NOT_FOUND", error.message);
       }
-      throw new AppError("BAD_REQUEST", error.message);
+      throw badRequest(error.message);
     }
     throw error;
   }
@@ -554,8 +555,8 @@ export const setDefaultWallet = async (c: AppContext) => {
   const parsed = setDefaultWalletSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -592,7 +593,7 @@ export const setDefaultWallet = async (c: AppContext) => {
     .first<{ id: string }>();
 
   if (!wallet) {
-    throw new AppError("BAD_REQUEST", "Unknown walletId for this wallet signing configuration");
+    throw badRequest("Unknown walletId for this wallet signing configuration");
   }
 
   await getDb(c.env)
@@ -629,15 +630,15 @@ export const updateWallet = async (c: AppContext) => {
   const walletId = c.req.param("walletId")?.trim();
 
   if (!walletId) {
-    throw new AppError("BAD_REQUEST", "Invalid wallet ID");
+    throw badRequest("Invalid wallet ID");
   }
 
   const body = await c.req.json();
   const parsed = updateWalletSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -808,7 +809,7 @@ export const getWalletById = async (c: AppContext) => {
   const walletId = c.req.param("walletId")?.trim();
 
   if (!walletId) {
-    throw new AppError("BAD_REQUEST", "Invalid wallet ID");
+    throw badRequest("Invalid wallet ID");
   }
 
   const signingService = signingServiceModule.createSigningService(c.env);

--- a/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
@@ -1,7 +1,8 @@
 import type { TokenAllowlistResponse } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, noContent, paginated } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { AuditService } from "@/services/audit.service";
@@ -111,8 +112,8 @@ export const addAllowlistEntry = async (c: AppContext) => {
   const parsed = addAllowlistSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.ts
@@ -1,7 +1,7 @@
 import type { Address, TransactionSigner } from "@solana/kit";
 import { getDb } from "@/db";
 import type { ApiKeyContext } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { getSolanaConfig } from "@/lib/solana";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
 import { getTemplateInfo } from "@/services/issuance/templates";
@@ -227,7 +227,7 @@ export async function resolveAuthoritySigner(params: {
   );
 
   if (!authorityWallet) {
-    throw new AppError("BAD_REQUEST", "Current authority is not controlled by custody");
+    throw badRequest("Current authority is not controlled by custody");
   }
 
   assertApiKeyWalletAccess(auth, authorityWallet.walletId, ["tokens:admin"]);
@@ -239,7 +239,7 @@ export async function resolveAuthoritySigner(params: {
   );
 
   if (signer.address !== (currentAuthority as Address)) {
-    throw new AppError("BAD_REQUEST", "Current authority is not controlled by custody");
+    throw badRequest("Current authority is not controlled by custody");
   }
 
   return { signer, walletId: authorityWallet.walletId };

--- a/apps/sdp-api/src/routes/issuance/handlers/authority.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority.ts
@@ -1,7 +1,8 @@
 import { AuthorityType } from "@solana-program/token-2022";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { AuditService } from "@/services/audit.service";
@@ -50,8 +51,8 @@ export const prepareUpdateAuthority = async (c: AppContext) => {
   const parsed = updateAuthoritySchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -80,7 +81,7 @@ export const prepareUpdateAuthority = async (c: AppContext) => {
   );
 
   if (!currentAuthorityRaw) {
-    throw new AppError("BAD_REQUEST", "Current authority is not available for this token");
+    throw badRequest("Current authority is not available for this token");
   }
 
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
@@ -159,8 +160,8 @@ export const executeUpdateAuthority = async (c: AppContext) => {
   const parsed = updateAuthoritySchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -189,7 +190,7 @@ export const executeUpdateAuthority = async (c: AppContext) => {
   );
 
   if (!currentAuthorityRaw) {
-    throw new AppError("BAD_REQUEST", "Current authority is not available for this token");
+    throw badRequest("Current authority is not available for this token");
   }
 
   const { signer } = await resolveAuthoritySigner({

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -1,7 +1,8 @@
 import { resolveTokenAccount } from "@solana/mosaic-sdk";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { type Address, assertValidAddress } from "@/lib/solana";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
@@ -127,8 +128,8 @@ export const prepareBurn = async (c: AppContext) => {
   const parsed = burnSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -238,8 +239,8 @@ export const executeBurn = async (c: AppContext) => {
   const parsed = burnSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
@@ -1,8 +1,9 @@
 import type { TokenResponse } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
@@ -26,8 +27,8 @@ export const deployToken = async (c: AppContext) => {
   const parsed = deployTokenSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -51,7 +52,7 @@ export const deployToken = async (c: AppContext) => {
   }
 
   if (token.mintAddress) {
-    throw new AppError("BAD_REQUEST", "Token already has a mint address");
+    throw badRequest("Token already has a mint address");
   }
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
@@ -194,8 +195,8 @@ export const prepareDeploy = async (c: AppContext) => {
   const parsed = deployTokenSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -218,7 +219,7 @@ export const prepareDeploy = async (c: AppContext) => {
   }
 
   if (token.mintAddress) {
-    throw new AppError("BAD_REQUEST", "Token already has a mint address");
+    throw badRequest("Token already has a mint address");
   }
 
   const signingWalletId = resolveApiKeySigningWalletId(

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { AuditService } from "@/services/audit.service";
@@ -28,8 +29,8 @@ export const prepareForceBurn = async (c: AppContext) => {
   const parsed = forceBurnSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -53,7 +54,7 @@ export const prepareForceBurn = async (c: AppContext) => {
     parsed.data.forceBurn.delegateAuthority ??
     (await resolvePermanentDelegateAuthority(c.env, tokenService, token));
   if (!permanentDelegateRaw) {
-    throw new AppError("BAD_REQUEST", "Permanent delegate is not configured for this token");
+    throw badRequest("Permanent delegate is not configured for this token");
   }
 
   const { signer } = await resolveAuthoritySigner({
@@ -130,8 +131,8 @@ export const executeForceBurn = async (c: AppContext) => {
   const parsed = forceBurnSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -155,7 +156,7 @@ export const executeForceBurn = async (c: AppContext) => {
     parsed.data.forceBurn.delegateAuthority ??
     (await resolvePermanentDelegateAuthority(c.env, tokenService, token));
   if (!permanentDelegateRaw) {
-    throw new AppError("BAD_REQUEST", "Permanent delegate is not configured for this token");
+    throw badRequest("Permanent delegate is not configured for this token");
   }
 
   const { signer } = await resolveAuthoritySigner({

--- a/apps/sdp-api/src/routes/issuance/handlers/freeze.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/freeze.ts
@@ -1,8 +1,9 @@
 import type { FrozenAccountResponse } from "@sdp/types";
 import { resolveTokenAccount } from "@solana/mosaic-sdk";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, paginated, success } from "@/lib/response";
 import { type Address, assertValidAddress } from "@/lib/solana";
 import { AuditService } from "@/services/audit.service";
@@ -133,8 +134,8 @@ export const freezeAccount = async (c: AppContext) => {
   const parsed = freezeSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -150,7 +151,7 @@ export const freezeAccount = async (c: AppContext) => {
   }
 
   if (!token.isFreezable) {
-    throw new AppError("BAD_REQUEST", "Token does not support freeze operations");
+    throw badRequest("Token does not support freeze operations");
   }
 
   if (!token.mintAddress) {
@@ -167,7 +168,7 @@ export const freezeAccount = async (c: AppContext) => {
   );
 
   if (!currentAuthorityRaw) {
-    throw new AppError("BAD_REQUEST", "Current freeze authority is not available for this token");
+    throw badRequest("Current freeze authority is not available for this token");
   }
 
   const { signer } = await resolveAuthoritySigner({
@@ -210,7 +211,7 @@ export const freezeAccount = async (c: AppContext) => {
 
   if (replayed) {
     if (tx.status === "failed") {
-      throw new AppError("BAD_REQUEST", tx.error ?? "Previous freeze request failed");
+      throw badRequest(tx.error ?? "Previous freeze request failed");
     }
 
     const latestRecord = await tokenService.getFrozenAccount(tokenId, tokenAccount, true);
@@ -336,8 +337,8 @@ export const unfreezeAccount = async (c: AppContext) => {
   const parsed = unfreezeSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -366,7 +367,7 @@ export const unfreezeAccount = async (c: AppContext) => {
   );
 
   if (!currentAuthorityRaw) {
-    throw new AppError("BAD_REQUEST", "Current freeze authority is not available for this token");
+    throw badRequest("Current freeze authority is not available for this token");
   }
 
   const requestedAddress = assertValidAddress(parsed.data.accountAddress, "accountAddress");
@@ -414,7 +415,7 @@ export const unfreezeAccount = async (c: AppContext) => {
 
   if (replayed) {
     if (tx.status === "failed") {
-      throw new AppError("BAD_REQUEST", tx.error ?? "Previous unfreeze request failed");
+      throw badRequest(tx.error ?? "Previous unfreeze request failed");
     }
 
     const latestRecord = await tokenService.getFrozenAccount(tokenId, tokenAccount, true);

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
@@ -188,8 +189,8 @@ export const prepareMint = async (c: AppContext) => {
   const parsed = mintSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -317,8 +318,8 @@ export const executeMint = async (c: AppContext) => {
   const parsed = mintSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/issuance/handlers/pause.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/pause.ts
@@ -1,7 +1,8 @@
 import { MINT_ALREADY_PAUSED_ERROR, MINT_NOT_PAUSED_ERROR } from "@solana/mosaic-sdk";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
@@ -32,8 +33,8 @@ export const pauseToken = async (c: AppContext) => {
   const parsed = pauseTokenSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -58,7 +59,7 @@ export const pauseToken = async (c: AppContext) => {
 
   const pauseAuthorityRaw = resolvePauseAuthority(token);
   if (!pauseAuthorityRaw) {
-    throw new AppError("BAD_REQUEST", "Pause authority is not configured for this token");
+    throw badRequest("Pause authority is not configured for this token");
   }
 
   const signingWalletId = resolveApiKeySigningWalletId(auth, token.signingWalletId, [
@@ -98,7 +99,7 @@ export const pauseToken = async (c: AppContext) => {
       signingWalletId
     );
     if (pauseAuthorityRaw !== signer.address) {
-      throw new AppError("BAD_REQUEST", "Pause authority is not controlled by custody");
+      throw badRequest("Pause authority is not controlled by custody");
     }
 
     const mosaic = createMosaicService(c.env, signer);
@@ -135,7 +136,7 @@ export const pauseToken = async (c: AppContext) => {
         status: "failed",
         error: error.message,
       });
-      throw new AppError("BAD_REQUEST", "Token is already paused");
+      throw badRequest("Token is already paused");
     }
     await tokenService.updateTransaction(tx.id, {
       status: "failed",
@@ -153,8 +154,8 @@ export const unpauseToken = async (c: AppContext) => {
   const parsed = pauseTokenSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -170,7 +171,7 @@ export const unpauseToken = async (c: AppContext) => {
   }
 
   if (token.status !== "paused") {
-    throw new AppError("BAD_REQUEST", "Token is not paused");
+    throw badRequest("Token is not paused");
   }
 
   if (!token.mintAddress) {
@@ -179,7 +180,7 @@ export const unpauseToken = async (c: AppContext) => {
 
   const pauseAuthorityRaw = resolvePauseAuthority(token);
   if (!pauseAuthorityRaw) {
-    throw new AppError("BAD_REQUEST", "Pause authority is not configured for this token");
+    throw badRequest("Pause authority is not configured for this token");
   }
 
   const signingWalletId = resolveApiKeySigningWalletId(auth, token.signingWalletId, [
@@ -219,7 +220,7 @@ export const unpauseToken = async (c: AppContext) => {
       signingWalletId
     );
     if (pauseAuthorityRaw !== signer.address) {
-      throw new AppError("BAD_REQUEST", "Pause authority is not controlled by custody");
+      throw badRequest("Pause authority is not controlled by custody");
     }
 
     const mosaic = createMosaicService(c.env, signer);
@@ -256,7 +257,7 @@ export const unpauseToken = async (c: AppContext) => {
         status: "failed",
         error: error.message,
       });
-      throw new AppError("BAD_REQUEST", "Token is not paused");
+      throw badRequest("Token is not paused");
     }
     await tokenService.updateTransaction(tx.id, {
       status: "failed",

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { AuditService } from "@/services/audit.service";
@@ -29,8 +30,8 @@ export const prepareSeize = async (c: AppContext) => {
   const parsed = seizeSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -64,7 +65,7 @@ export const prepareSeize = async (c: AppContext) => {
     parsed.data.seize.delegateAuthority ??
     (await resolvePermanentDelegateAuthority(c.env, tokenService, token));
   if (!permanentDelegateRaw) {
-    throw new AppError("BAD_REQUEST", "Permanent delegate is not configured for this token");
+    throw badRequest("Permanent delegate is not configured for this token");
   }
 
   const { signer } = await resolveAuthoritySigner({
@@ -145,8 +146,8 @@ export const executeSeize = async (c: AppContext) => {
   const parsed = seizeSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -180,7 +181,7 @@ export const executeSeize = async (c: AppContext) => {
     parsed.data.seize.delegateAuthority ??
     (await resolvePermanentDelegateAuthority(c.env, tokenService, token));
   if (!permanentDelegateRaw) {
-    throw new AppError("BAD_REQUEST", "Permanent delegate is not configured for this token");
+    throw badRequest("Permanent delegate is not configured for this token");
   }
 
   const { signer } = await resolveAuthoritySigner({

--- a/apps/sdp-api/src/routes/issuance/handlers/tokens.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/tokens.ts
@@ -1,7 +1,8 @@
 import type { TokenResponse } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { badRequest, notFound } from "@/lib/errors";
 import { created, paginated, success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
@@ -53,8 +54,8 @@ export const createToken = async (c: AppContext) => {
   const parsed = createTokenSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -67,7 +68,7 @@ export const createToken = async (c: AppContext) => {
   );
 
   if (resolved.errors.length > 0) {
-    throw new AppError("BAD_REQUEST", "Invalid template overrides", {
+    throw badRequest("Invalid template overrides", {
       errors: resolved.errors,
     });
   }
@@ -162,8 +163,8 @@ export const updateToken = async (c: AppContext) => {
   const parsed = updateTokenSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -197,7 +198,7 @@ export const updateToken = async (c: AppContext) => {
       );
 
       if (!currentAuthorityRaw) {
-        throw new AppError("BAD_REQUEST", "Metadata authority is not available for this token");
+        throw badRequest("Metadata authority is not available for this token");
       }
 
       const { signer } = await resolveAuthoritySigner({

--- a/apps/sdp-api/src/routes/issuance/handlers/transactions.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/transactions.ts
@@ -10,7 +10,7 @@ import { findAssociatedTokenPda, TOKEN_2022_PROGRAM_ADDRESS } from "@solana-prog
 import type { Context } from "hono";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, notFound } from "@/lib/errors";
+import { badRequest, notFound } from "@/lib/errors";
 import { paginated } from "@/lib/response";
 import { type Address, assertValidAddress } from "@/lib/solana";
 import {
@@ -36,7 +36,7 @@ function parsePositiveInteger(value: string | undefined, fallback: number, name:
 
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new AppError("BAD_REQUEST", `Invalid ${name} query parameter`);
+    throw badRequest(`Invalid ${name} query parameter`);
   }
 
   return parsed;
@@ -50,14 +50,14 @@ function parseTransactionTypes(c: AppContext): TokenTransactionType[] | undefine
 
   const normalized = values.map((value) => value.trim()).filter(Boolean);
   if (normalized.length !== values.length) {
-    throw new AppError("BAD_REQUEST", "Invalid type query parameter");
+    throw badRequest("Invalid type query parameter");
   }
 
   const invalid = normalized.filter(
     (value): value is string => !TOKEN_TRANSACTION_TYPES.includes(value as TokenTransactionType)
   );
   if (invalid.length > 0) {
-    throw new AppError("BAD_REQUEST", "Invalid type query parameter", {
+    throw badRequest("Invalid type query parameter", {
       invalidTypes: invalid,
       allowedTypes: TOKEN_TRANSACTION_TYPES,
     });
@@ -72,7 +72,7 @@ function parseTransactionStatus(value: string | undefined): TokenTransactionStat
   }
 
   if (!TOKEN_TRANSACTION_STATUSES.includes(value as TokenTransactionStatus)) {
-    throw new AppError("BAD_REQUEST", "Invalid status query parameter", {
+    throw badRequest("Invalid status query parameter", {
       allowedStatuses: TOKEN_TRANSACTION_STATUSES,
     });
   }
@@ -262,7 +262,7 @@ export const listTransactions = async (c: AppContext) => {
   const walletIdRaw = c.req.query("walletId");
   const walletId = walletIdRaw?.trim();
   if (walletIdRaw !== undefined && !walletId) {
-    throw new AppError("BAD_REQUEST", "Invalid walletId query parameter");
+    throw badRequest("Invalid walletId query parameter");
   }
 
   const walletScope = await resolveWalletTransactionScope(c, tokenService, walletId);

--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -1,7 +1,8 @@
 import { normalizeOrganizationRole, type OrganizationRole } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
 import { created, noContent, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
@@ -138,8 +139,8 @@ export const inviteMember = async (c: AppContext) => {
   const parsed = inviteSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -181,7 +182,7 @@ export const inviteMember = async (c: AppContext) => {
 
   const clerkOrgId = await getClerkOrgId(getDb(c.env), organizationId);
   if (!clerkOrgId) {
-    throw new AppError("BAD_REQUEST", "Organization is not linked to Clerk");
+    throw badRequest("Organization is not linked to Clerk");
   }
 
   const inviterKey =
@@ -266,8 +267,8 @@ export const acceptInvitation = async (c: AppContext) => {
   const parsed = acceptSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/organizations/handlers.ts
+++ b/apps/sdp-api/src/routes/organizations/handlers.ts
@@ -7,9 +7,10 @@ import {
   type OrganizationTier,
 } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { noContent, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import {
@@ -115,8 +116,8 @@ export const updateOrganization = async (c: AppContext) => {
   const parsed = updateOrgSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -160,7 +161,7 @@ export const updateOrganization = async (c: AppContext) => {
   }
 
   if (updates.length === 0) {
-    throw new AppError("BAD_REQUEST", "No valid updates provided");
+    throw badRequest("No valid updates provided");
   }
 
   updates.push("updated_at = datetime('now')");

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -331,6 +331,7 @@ async function seedCounterparty(params?: {
   id?: string;
   externalId?: string | null;
   identity?: Record<string, unknown>;
+  providerData?: Record<string, unknown>;
 }): Promise<string> {
   const id = params?.id ?? `counterparty_${crypto.randomUUID()}`;
   await getDb(env)
@@ -358,7 +359,7 @@ async function seedCounterparty(params?: {
       "MoonPay Test Counterparty",
       "moonpay-counterparty@example.com",
       params?.identity ?? {},
-      {},
+      params?.providerData ?? {},
       TEST_USER.id
     )
     .run();
@@ -1633,6 +1634,8 @@ describe("Payments routes", () => {
   });
 
   it("creates a signed MoonPay on-ramp session URL", async () => {
+    const counterpartyId = await seedCounterparty();
+
     const res = await app.request(
       "/v1/payments/ramps/onramp/execute",
       {
@@ -1644,11 +1647,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId,
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           fiatAmount: "120.50",
-          kycReference: "kyc_ref_123",
           redirectUrl: "https://example.com/onramp-done",
         }),
       },
@@ -1671,7 +1674,7 @@ describe("Payments routes", () => {
     expect(redirect.searchParams.get("currencyCode")).toBe("usdc_sol");
     expect(redirect.searchParams.get("walletAddress")).toBe(TEST_SOLANA_ADDRESSES.wallet1);
     expect(redirect.searchParams.get("redirectURL")).toBe("https://example.com/onramp-done");
-    expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("kyc_ref_123");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBeNull();
     assertMoonPaySignature(redirect);
   });
 
@@ -1731,6 +1734,8 @@ describe("Payments routes", () => {
   });
 
   it("creates a signed MoonPay off-ramp session URL", async () => {
+    const counterpartyId = await seedCounterparty();
+
     const res = await app.request(
       "/v1/payments/ramps/offramp/execute",
       {
@@ -1741,11 +1746,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId,
           sourceWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           cryptoAmount: "75.25",
-          kycReference: "kyc_ref_456",
           redirectUrl: "https://example.com/offramp-done",
         }),
       },
@@ -1771,11 +1776,12 @@ describe("Payments routes", () => {
       TEST_SOLANA_ADDRESSES.wallet1
     );
     expect(redirect.searchParams.get("redirectURL")).toBe("https://example.com/offramp-done");
-    expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBe("kyc_ref_456");
+    expect(redirect.searchParams.get(MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID)).toBeNull();
     assertMoonPaySignature(redirect);
   });
 
   it("blocks MoonPay off-ramp when the wallet policy maxTransferAmount is exceeded", async () => {
+    const counterpartyId = await seedCounterparty();
     await seedWalletPolicy({
       destinationAllowlist: [],
       maxTransferAmount: "50.00",
@@ -1791,6 +1797,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId,
           sourceWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -1806,6 +1813,7 @@ describe("Payments routes", () => {
   });
 
   it("does not apply outbound wallet policy checks to MoonPay on-ramp", async () => {
+    const counterpartyId = await seedCounterparty();
     await seedWalletPolicy({
       destinationAllowlist: [],
       maxTransferAmount: "10.00",
@@ -1821,6 +1829,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId,
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -1834,6 +1843,7 @@ describe("Payments routes", () => {
   });
 
   it("checks wallet bindings when a custody wallet public key is used for MoonPay off-ramp", async () => {
+    const counterpartyId = await seedCounterparty();
     await seedCachedKey({
       walletBindings: [{ walletId: "wal_other_wallet", permissions: ["payments:write"] }],
     });
@@ -1848,6 +1858,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId,
           sourceWallet: TEST_SOLANA_ADDRESSES.wallet1,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -1861,6 +1872,8 @@ describe("Payments routes", () => {
   });
 
   it("returns bad request when MoonPay on-ramp amount is below the minimum", async () => {
+    const counterpartyId = await seedCounterparty();
+
     const res = await app.request(
       "/v1/payments/ramps/onramp/execute",
       {
@@ -1871,6 +1884,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId,
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -1887,6 +1901,9 @@ describe("Payments routes", () => {
   });
 
   it("creates a Lightspark on-ramp quote through the execute endpoint", async () => {
+    const counterpartyId = await seedCounterparty({
+      providerData: { lightspark: { customerId: "Customer:cus_123" } },
+    });
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -1943,11 +1960,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          counterpartyId,
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           fiatAmount: "12.34",
-          kycReference: "Customer:cus_123",
         }),
       },
       env
@@ -2001,6 +2018,9 @@ describe("Payments routes", () => {
   });
 
   it("reuses an existing Lightspark external account for Solana wallet on-ramp destinations", async () => {
+    const counterpartyId = await seedCounterparty({
+      providerData: { lightspark: { customerId: "Customer:cus_123" } },
+    });
     const destinationSolanaWallet = TEST_SOLANA_ADDRESSES.wallet2;
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -2047,11 +2067,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          counterpartyId,
           destinationWallet: destinationSolanaWallet,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           fiatAmount: "5.00",
-          kycReference: "Customer:cus_123",
         }),
       },
       env
@@ -2079,6 +2099,9 @@ describe("Payments routes", () => {
   });
 
   it("resolves SDP wallet ids for Lightspark on-ramp destinations", async () => {
+    const counterpartyId = await seedCounterparty({
+      providerData: { lightspark: { customerId: "Customer:cus_123" } },
+    });
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -2124,11 +2147,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          counterpartyId,
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           fiatAmount: "5.00",
-          kycReference: "Customer:cus_123",
         }),
       },
       env
@@ -2150,6 +2173,9 @@ describe("Payments routes", () => {
   });
 
   it("creates a Lightspark external account when Solana wallet destination is not found", async () => {
+    const counterpartyId = await seedCounterparty({
+      providerData: { lightspark: { customerId: "Customer:cus_123" } },
+    });
     const destinationSolanaWallet = TEST_SOLANA_ADDRESSES.wallet3;
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -2203,11 +2229,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          counterpartyId,
           destinationWallet: destinationSolanaWallet,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           fiatAmount: "5.00",
-          kycReference: "Customer:cus_123",
         }),
       },
       env
@@ -2241,6 +2267,9 @@ describe("Payments routes", () => {
   });
 
   it("creates and executes a Lightspark off-ramp quote through the execute endpoint", async () => {
+    const counterpartyId = await seedCounterparty({
+      providerData: { lightspark: { customerId: "ExternalAccount:acc_destination_456" } },
+    });
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -2278,11 +2307,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          counterpartyId,
           sourceWallet: "InternalAccount:acc_source_123",
           cryptoToken: "BTC",
           fiatCurrency: "USD",
           cryptoAmount: "0.015",
-          kycReference: "ExternalAccount:acc_destination_456",
         }),
       },
       env
@@ -2497,6 +2526,12 @@ describe("Payments routes", () => {
   });
 
   it("creates and accepts a BVNK off-ramp estimate through the execute endpoint", async () => {
+    const counterpartyId = await seedCounterparty({
+      identity: { address: { countryCode: "US" } },
+      providerData: {
+        bvnk: { customer: { customerReference: "customer_456", status: "VERIFIED" } },
+      },
+    });
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -2534,11 +2569,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "bvnk",
+          counterpartyId,
           sourceWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           cryptoAmount: "75.25",
-          kycReference: "customer_456",
           bvnkCompliance: {
             partyDetails: [
               {
@@ -2609,6 +2644,13 @@ describe("Payments routes", () => {
   });
 
   it("returns bad request when BVNK off-ramp is missing compliance party details", async () => {
+    const counterpartyId = await seedCounterparty({
+      identity: { address: { countryCode: "US" } },
+      providerData: {
+        bvnk: { customer: { customerReference: "customer_456", status: "VERIFIED" } },
+      },
+    });
+
     const res = await app.request(
       "/v1/payments/ramps/offramp/execute",
       {
@@ -2620,11 +2662,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "bvnk",
+          counterpartyId,
           sourceWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           cryptoAmount: "75.25",
-          kycReference: "customer_456",
         }),
       },
       env
@@ -2647,6 +2689,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "unsupported_provider",
+          counterpartyId: "cp_test",
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -2673,6 +2716,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId: "cp_test",
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -2704,6 +2748,7 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "moonpay",
+          counterpartyId: "cp_test",
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
@@ -2732,11 +2777,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "lightspark",
+          counterpartyId: "cp_test",
           destinationWallet: "ExternalAccount:acc_destination_123",
           cryptoToken: "BTC",
           fiatCurrency: "USD",
           fiatAmount: "10",
-          kycReference: "Customer:cus_123",
         }),
       },
       env
@@ -2762,11 +2807,11 @@ describe("Payments routes", () => {
         },
         body: JSON.stringify({
           provider: "bvnk",
+          counterpartyId: "cp_test",
           destinationWallet: TEST_WALLET_ID,
           cryptoToken: "USDC",
           fiatCurrency: "USD",
           fiatAmount: "10",
-          kycReference: "customer_123",
         }),
       },
       env

--- a/apps/sdp-api/src/routes/payments/context.ts
+++ b/apps/sdp-api/src/routes/payments/context.ts
@@ -1,3 +1,4 @@
+import type { SdpEnvironment } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import type { Context } from "hono";
 import {
@@ -5,10 +6,31 @@ import {
   createPaymentSubscriptionsRepository,
   createPaymentsRepository,
 } from "@/db/repositories";
+import type { RampRuntimeContext } from "@/lib/ramps/types";
 import * as feePaymentAdapters from "@/services/adapters/fee-payment";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
+
+/**
+ * Resolves the product environment for provider credentials.
+ * API-key callers are scoped by the key. Dashboard/session callers default to
+ * sandbox while that is the only supported dashboard mode.
+ */
+export function resolveSdpEnvironment(c: AppContext): SdpEnvironment {
+  const apiKey = c.get("apiKey");
+  if (apiKey) {
+    return apiKey.environment;
+  }
+  return "sandbox";
+}
+
+export function rampRuntime(c: AppContext): RampRuntimeContext {
+  return {
+    env: c.env as unknown as Record<string, string | undefined>,
+    mode: resolveSdpEnvironment(c),
+  };
+}
 
 export function getPaymentsRepository(c: AppContext) {
   return createPaymentsRepository(c.env);

--- a/apps/sdp-api/src/routes/payments/handlers/balances.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/balances.ts
@@ -1,6 +1,7 @@
 import type { Address } from "@solana/kit";
+import { z } from "zod";
 import { formatDecimalAmount } from "@/lib/amount";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { attachUsdValuesToBalances } from "@/services/helius-das.service";
 import * as solanaRpc from "@/services/solana/rpc";
@@ -83,8 +84,8 @@ export async function updateWalletPolicy(c: AppContext) {
   const parsed = updateWalletPolicySchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -3,7 +3,6 @@ import type {
   PaymentRampExecution,
   PaymentRampQuote,
   RampProviderEstimateResult,
-  SdpEnvironment,
 } from "@sdp/types";
 import {
   OFFRAMP_SUPPORT,
@@ -30,7 +29,12 @@ import type { LightsparkCustomerResolution, RampRuntimeContext } from "@/lib/ram
 import { success } from "@/lib/response";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { assertProviderAvailable } from "@/services/provider-availability.service";
-import { type AppContext, getPaymentsRepository } from "../context";
+import {
+  type AppContext,
+  getPaymentsRepository,
+  rampRuntime,
+  resolveSdpEnvironment,
+} from "../context";
 import { assertWalletPolicyAllowsTransfer } from "../policy";
 import {
   createOfframpQuoteSchema,
@@ -74,26 +78,6 @@ function filterProviders(
 
 function uniqueSorted<T extends string>(values: readonly T[]): T[] {
   return [...new Set(values)].sort();
-}
-
-/**
- * Resolves the product environment for provider credentials.
- * API-key callers are scoped by the key. Dashboard/session callers default to
- * sandbox while that is the only supported dashboard mode.
- */
-function resolveSdpEnvironment(c: AppContext): SdpEnvironment {
-  const apiKey = c.get("apiKey");
-  if (apiKey) {
-    return apiKey.environment;
-  }
-  return "sandbox";
-}
-
-function rampRuntime(c: AppContext): RampRuntimeContext {
-  return {
-    env: c.env as unknown as Record<string, string | undefined>,
-    mode: resolveSdpEnvironment(c),
-  };
 }
 
 /** Enriches BVNK compliance with the requester IP from request headers. */

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -221,7 +221,7 @@ async function executeOnrampWithProvider(
 
   switch (input.provider) {
     case "moonpay":
-      return RAMP_PROVIDER_CLIENTS.moonpay.executeOnramp(ctx, {
+      return await RAMP_PROVIDER_CLIENTS.moonpay.executeOnramp(ctx, {
         destinationWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -230,7 +230,7 @@ async function executeOnrampWithProvider(
       });
     case "lightspark": {
       const providerCustomer = await ensureLightsparkCustomer(c, { counterparty, projectId });
-      return RAMP_PROVIDER_CLIENTS.lightspark.executeOnramp(ctx, {
+      return await RAMP_PROVIDER_CLIENTS.lightspark.executeOnramp(ctx, {
         destinationWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -250,7 +250,7 @@ async function executeOnrampWithProvider(
         destinationWalletAddress,
         fiatCurrency: input.fiatCurrency,
       });
-      return RAMP_PROVIDER_CLIENTS.bvnk.executeOnramp(ctx, {
+      return await RAMP_PROVIDER_CLIENTS.bvnk.executeOnramp(ctx, {
         destinationWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -305,7 +305,7 @@ async function executeOfframpWithProvider(
 
   switch (input.provider) {
     case "moonpay":
-      return RAMP_PROVIDER_CLIENTS.moonpay.executeOfframp(ctx, {
+      return await RAMP_PROVIDER_CLIENTS.moonpay.executeOfframp(ctx, {
         sourceWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -314,7 +314,7 @@ async function executeOfframpWithProvider(
       });
     case "lightspark": {
       const providerCustomer = await ensureLightsparkCustomer(c, { counterparty, projectId });
-      return RAMP_PROVIDER_CLIENTS.lightspark.executeOfframp(ctx, {
+      return await RAMP_PROVIDER_CLIENTS.lightspark.executeOfframp(ctx, {
         sourceWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -327,7 +327,7 @@ async function executeOfframpWithProvider(
       const providerCustomer = await ensureBvnkCustomer(c, counterparty, projectId, {
         fiatCurrency: input.fiatCurrency,
       });
-      return RAMP_PROVIDER_CLIENTS.bvnk.executeOfframp(ctx, {
+      return await RAMP_PROVIDER_CLIENTS.bvnk.executeOfframp(ctx, {
         sourceWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -1,5 +1,4 @@
 import type {
-  BvnkPaymentRampInstruction,
   PaymentRampEstimate,
   PaymentRampExecution,
   PaymentRampQuote,
@@ -13,36 +12,21 @@ import {
   type RampFiatCurrency,
 } from "@sdp/types/generated/ramp-support";
 import type { RampProviderId } from "@sdp/types/provider-access";
-import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
+import { z } from "zod";
 import { getDb } from "@/db";
-import type {
-  CounterpartiesRepository,
-  CounterpartyRow,
-} from "@/db/repositories/counterparty.repository";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
 import type { PaymentTransferStatus } from "@/db/repositories/payments.repository";
 import { requireProjectId } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
-import { hashString } from "@/lib/hash";
+import { AppError, badRequest, badRequestQuery, internalError, notFound } from "@/lib/errors";
 import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
-  type BvnkOnrampEntry,
-  type BvnkOnrampResolution,
-  buildBvnkOnrampInstruction,
   buildBvnkPartyDetails,
-  buildBvnkRuleEntity,
-  bvnkCustomerExternalReference,
   bvnkOnrampKey,
-  bvnkRuleReference,
-  isBvnkCustomerVerified,
   isBvnkWalletActive,
   normalizeBvnkCurrencyAndNetwork,
-  readBvnkCustomer,
-  readBvnkData,
   readBvnkOnrampEntry,
-  readBvnkWallets,
 } from "@/lib/ramps/providers/bvnk";
-import type { BvnkComplianceInput, RampRuntimeContext } from "@/lib/ramps/types";
-import { buildBvnkIndividualPayload } from "@/lib/ramps/validation/bvnk";
+import type { LightsparkCustomerResolution, RampRuntimeContext } from "@/lib/ramps/types";
 import { success } from "@/lib/response";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { assertProviderAvailable } from "@/services/provider-availability.service";
@@ -60,6 +44,7 @@ import {
   simulateSandboxTransferSchema,
 } from "../schemas";
 import { type ResolvedScope, resolveScope, resolveWalletAddress } from "../wallets";
+import { bvnkOnrampQuote, ensureBvnkCustomer, ensureBvnkPaymentRule } from "./ramps/bvnk";
 
 type OnrampCurrencyPair = {
   source: (typeof ONRAMP_SUPPORT)[number]["source"];
@@ -73,33 +58,9 @@ type OfframpCurrencyPair = {
   providers: RampProviderId[];
 };
 
-type ExecuteOnrampInput = {
-  provider: RampProviderId;
-  counterpartyId?: string;
-  destinationWallet: string;
-  cryptoToken: string;
-  fiatCurrency?: RampFiatCurrency;
-  fiatAmount: string;
-  kycReference?: string;
-  redirectUrl?: string;
-  bvnkCompliance?: BvnkComplianceInput;
-};
+type ExecuteOnrampInput = z.infer<typeof executeOnrampSchema>;
 
-type ExecuteOfframpInput = {
-  provider: RampProviderId;
-  counterpartyId?: string;
-  sourceWallet: string;
-  cryptoToken: string;
-  fiatCurrency?: RampFiatCurrency;
-  cryptoAmount: string;
-  kycReference?: string;
-  redirectUrl?: string;
-  bvnkCompliance?: BvnkComplianceInput;
-};
-
-type ExecuteRampInput =
-  | ({ direction: "onramp" } & ExecuteOnrampInput)
-  | ({ direction: "offramp" } & ExecuteOfframpInput);
+type ExecuteOfframpInput = z.infer<typeof executeOfframpSchema>;
 
 function filterProviders(
   providers: readonly RampProviderId[],
@@ -153,11 +114,6 @@ async function assertRampProviderAvailable(
 
 type RampQuoteDirection = "onramp" | "offramp";
 type ScopedRampWallet = ResolvedScope["wallets"][number];
-type BvnkOnrampQuote = PaymentRampQuote & {
-  provider: "bvnk";
-  deliveryMode: "manual_instructions";
-  paymentInstructions: BvnkPaymentRampInstruction[];
-};
 
 interface PersistRampQuoteTransferInput {
   scope: ResolvedScope;
@@ -187,7 +143,7 @@ function requireRampTransferWallet(
     (entry) => entry.walletId === walletIdOrAddress || entry.publicKey === walletAddress
   );
   if (!wallet) {
-    throw new AppError("BAD_REQUEST", `${fieldName} must reference an SDP wallet.`);
+    throw badRequest(`${fieldName} must reference an SDP wallet.`);
   }
   return wallet;
 }
@@ -255,73 +211,82 @@ async function persistRampQuoteTransfer(
   }
 }
 
-async function executeRampWithProvider(
+async function executeOnrampWithProvider(
   c: AppContext,
-  input: ExecuteRampInput
+  input: ExecuteOnrampInput
 ): Promise<PaymentRampExecution> {
   const scope = await resolveScope(c);
   await assertRampProviderAvailable(c, input.provider, scope.auth.organizationId);
   const ctx = rampRuntime(c);
 
-  if (input.direction === "onramp") {
-    const destinationWalletAddress = resolveWalletAddress(
-      scope.wallets,
-      input.destinationWallet,
-      "destinationWallet",
-      scope.auth,
-      ["payments:write"]
-    );
-    if (input.provider === "bvnk") {
-      if (!input.counterpartyId) {
-        throw new AppError("BAD_REQUEST", "counterpartyId is required for BVNK on-ramp.");
-      }
-      const projectId = requireProjectId(c);
-      const repo = getCounterpartiesRepository(c);
-      const counterparty = await repo.getCounterpartyById({
-        counterpartyId: input.counterpartyId,
-        organizationId: scope.auth.organizationId,
-        projectId,
-      });
-      if (!counterparty) {
-        throw new AppError("NOT_FOUND", "Counterparty not found");
-      }
-      const { instruction, id, reference } = await resolveBvnkOnramp(
-        c,
-        repo,
-        counterparty,
-        projectId,
-        {
-          cryptoToken: input.cryptoToken,
-          fiatCurrency: input.fiatCurrency,
-          destinationWalletAddress,
-        }
-      );
-      return {
-        id,
-        provider: "bvnk",
-        status: "pending",
-        reference,
-        paymentInstructions: [instruction],
-      };
-    }
+  const destinationWalletAddress = resolveWalletAddress(
+    scope.wallets,
+    input.destinationWallet,
+    "destinationWallet",
+    scope.auth,
+    ["payments:write"]
+  );
 
-    const kycReference = await resolveRampKycReference(
-      c,
-      scope,
-      input.provider,
-      input.counterpartyId,
-      input.kycReference
-    );
-    return await RAMP_PROVIDER_CLIENTS[input.provider].executeOnramp(ctx, {
-      destinationWalletAddress,
-      cryptoToken: input.cryptoToken,
-      fiatCurrency: input.fiatCurrency,
-      fiatAmount: input.fiatAmount,
-      kycReference,
-      redirectUrl: input.redirectUrl,
-      bvnkCompliance: input.bvnkCompliance,
-    });
+  const projectId = requireProjectId(c);
+  const counterparty = await getCounterpartiesRepository(c).getCounterpartyById({
+    counterpartyId: input.counterpartyId,
+    organizationId: scope.auth.organizationId,
+    projectId,
+  });
+  if (!counterparty) throw notFound("Counterparty");
+
+  switch (input.provider) {
+    case "moonpay":
+      return RAMP_PROVIDER_CLIENTS.moonpay.executeOnramp(ctx, {
+        destinationWalletAddress,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        fiatAmount: input.fiatAmount,
+        redirectUrl: input.redirectUrl,
+      });
+    case "lightspark": {
+      const providerCustomer = await ensureLightsparkCustomer(c, { counterparty, projectId });
+      return RAMP_PROVIDER_CLIENTS.lightspark.executeOnramp(ctx, {
+        destinationWalletAddress,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        fiatAmount: input.fiatAmount,
+        providerCustomer,
+      });
+    }
+    case "bvnk": {
+      if (!input.fiatCurrency) throw badRequest("fiatCurrency is required for BVNK on-ramp.");
+      const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
+      const customer = await ensureBvnkCustomer(c, counterparty, projectId, {
+        fiatCurrency: input.fiatCurrency,
+      });
+      const bvnkPaymentRule = await ensureBvnkPaymentRule(c, counterparty, projectId, customer, {
+        currency,
+        network,
+        destinationWalletAddress,
+        fiatCurrency: input.fiatCurrency,
+      });
+      return RAMP_PROVIDER_CLIENTS.bvnk.executeOnramp(ctx, {
+        destinationWalletAddress,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        bvnkPaymentRule,
+      });
+    }
+    default: {
+      const _exhaustive: never = input.provider;
+      throw internalError(`Unhandled ramp provider: ${_exhaustive}`);
+    }
   }
+}
+
+async function executeOfframpWithProvider(
+  c: AppContext,
+  input: ExecuteOfframpInput
+): Promise<PaymentRampExecution> {
+  const scope = await resolveScope(c);
+  await assertRampProviderAvailable(c, input.provider, scope.auth.organizationId);
+  const ctx = rampRuntime(c);
 
   const sourceWallet = scope.wallets.find(
     (wallet) => wallet.walletId === input.sourceWallet || wallet.publicKey === input.sourceWallet
@@ -346,23 +311,52 @@ async function executeRampWithProvider(
           "payments:write",
         ]);
 
-  const kycReference = await resolveRampKycReference(
-    c,
-    scope,
-    input.provider,
-    input.counterpartyId,
-    input.kycReference
-  );
-
-  return await RAMP_PROVIDER_CLIENTS[input.provider].executeOfframp(ctx, {
-    sourceWalletAddress,
-    cryptoToken: input.cryptoToken,
-    fiatCurrency: input.fiatCurrency,
-    cryptoAmount: input.cryptoAmount,
-    kycReference,
-    redirectUrl: input.redirectUrl,
-    bvnkCompliance: input.bvnkCompliance,
+  const projectId = requireProjectId(c);
+  const counterparty = await getCounterpartiesRepository(c).getCounterpartyById({
+    counterpartyId: input.counterpartyId,
+    organizationId: scope.auth.organizationId,
+    projectId,
   });
+  if (!counterparty) throw notFound("Counterparty");
+
+  switch (input.provider) {
+    case "moonpay":
+      return RAMP_PROVIDER_CLIENTS.moonpay.executeOfframp(ctx, {
+        sourceWalletAddress,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        cryptoAmount: input.cryptoAmount,
+        redirectUrl: input.redirectUrl,
+      });
+    case "lightspark": {
+      const providerCustomer = await ensureLightsparkCustomer(c, { counterparty, projectId });
+      return RAMP_PROVIDER_CLIENTS.lightspark.executeOfframp(ctx, {
+        sourceWalletAddress,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        cryptoAmount: input.cryptoAmount,
+        providerCustomer,
+      });
+    }
+    case "bvnk": {
+      if (!input.fiatCurrency) throw badRequest("fiatCurrency is required for BVNK off-ramp.");
+      const providerCustomer = await ensureBvnkCustomer(c, counterparty, projectId, {
+        fiatCurrency: input.fiatCurrency,
+      });
+      return RAMP_PROVIDER_CLIENTS.bvnk.executeOfframp(ctx, {
+        sourceWalletAddress,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        cryptoAmount: input.cryptoAmount,
+        providerCustomer,
+        bvnkCompliance: input.bvnkCompliance,
+      });
+    }
+    default: {
+      const _exhaustive: never = input.provider;
+      throw internalError(`Unhandled ramp provider: ${_exhaustive}`);
+    }
+  }
 }
 
 function readLightsparkData(
@@ -386,13 +380,12 @@ function readLightsparkCustomerId(providerData: CounterpartyRow["provider_data"]
  */
 async function ensureLightsparkCustomer(
   c: AppContext,
-  repo: CounterpartiesRepository,
-  counterparty: CounterpartyRow,
-  projectId: string
-): Promise<string> {
+  { counterparty, projectId }: { counterparty: CounterpartyRow; projectId: string }
+): Promise<LightsparkCustomerResolution> {
+  const repo = getCounterpartiesRepository(c);
   const existing = readLightsparkCustomerId(counterparty.provider_data);
   if (existing) {
-    return existing;
+    return { customerId: existing };
   }
 
   const customer = await RAMP_PROVIDER_CLIENTS.lightspark.getOrCreateCustomer(rampRuntime(c), {
@@ -414,266 +407,7 @@ async function ensureLightsparkCustomer(
     },
   });
 
-  return customer.id;
-}
-
-function requesterIpAddress(c: AppContext): string {
-  const forwarded = c.req.header("x-forwarded-for");
-  return c.req.header("cf-connecting-ip") ?? forwarded?.split(",")[0]?.trim() ?? "0.0.0.0";
-}
-
-async function ensureBvnkOnramp(
-  c: AppContext,
-  repo: CounterpartiesRepository,
-  counterparty: CounterpartyRow,
-  projectId: string,
-  params: {
-    currency: string;
-    network: string;
-    destinationWalletAddress: string;
-    fiatCurrency: string;
-    collectedData?: CollectedFieldData;
-  }
-): Promise<BvnkOnrampResolution> {
-  if (counterparty.entity_type === "business") {
-    throw new AppError("BAD_REQUEST", "BVNK on-ramp supports individual counterparties only.");
-  }
-  const countryCode = counterparty.identity.address?.countryCode;
-  if (!countryCode) {
-    throw new AppError("BAD_REQUEST", "Counterparty address country is required for BVNK on-ramp.");
-  }
-
-  const ctx = rampRuntime(c);
-  const client = RAMP_PROVIDER_CLIENTS.bvnk;
-  const key = bvnkOnrampKey(
-    params.fiatCurrency,
-    params.currency,
-    params.network,
-    params.destinationWalletAddress
-  );
-
-  let customer = readBvnkCustomer(counterparty.provider_data);
-  let entry: BvnkOnrampEntry = readBvnkOnrampEntry(counterparty.provider_data, key);
-
-  const persist = async () => {
-    const latest =
-      (await repo.getCounterpartyById({
-        counterpartyId: counterparty.id,
-        organizationId: counterparty.organization_id,
-        projectId,
-      })) ?? counterparty;
-    const bvnk = readBvnkData(latest.provider_data);
-    const wallets = readBvnkWallets(latest.provider_data);
-    await repo.updateCounterparty({
-      counterpartyId: counterparty.id,
-      organizationId: counterparty.organization_id,
-      projectId,
-      providerData: {
-        ...latest.provider_data,
-        bvnk: {
-          ...bvnk,
-          customer: { ...readBvnkCustomer(latest.provider_data), ...customer },
-          wallets: { ...wallets, [key]: { ...wallets[key], ...entry } },
-        },
-      },
-    });
-  };
-
-  if (!customer.customerReference) {
-    const individual = buildBvnkIndividualPayload(
-      counterparty,
-      params.collectedData,
-      params.fiatCurrency
-    );
-    const session = await client.createAgreementSession(ctx, {
-      customerType: "INDIVIDUAL",
-      countryCode,
-      useCase: "EMBEDDED_FIAT_ACCOUNTS",
-    });
-    await client.signAgreement(ctx, {
-      reference: session.reference,
-      ipAddress: requesterIpAddress(c),
-    });
-    const externalReference =
-      customer.externalReference ?? bvnkCustomerExternalReference(counterparty.id);
-    const created = await client.createBvnkCustomer(ctx, {
-      externalReference,
-      signedAgreementSessionReference: session.reference,
-      individual,
-    });
-    customer = {
-      externalReference,
-      customerReference: created.reference,
-      status: created.status,
-      verificationStatus: created.verificationStatus,
-      verificationUrl: created.verificationUrl,
-    };
-    await persist();
-  }
-
-  if (entry.walletId && entry.bankAccount?.accountNumber && entry.ruleId) {
-    return { customer, entry, onboardingStatus: "ready" };
-  }
-
-  if (customer.customerReference && !isBvnkCustomerVerified(customer.status)) {
-    const latest = await client.getBvnkCustomer(ctx, { reference: customer.customerReference });
-    customer = {
-      ...customer,
-      status: latest.status,
-      verificationStatus: latest.verificationStatus,
-      verificationUrl: latest.verificationUrl ?? customer.verificationUrl,
-    };
-    await persist();
-  }
-
-  if (!isBvnkCustomerVerified(customer.status) || !customer.customerReference) {
-    return {
-      customer,
-      entry,
-      onboardingStatus: customer.verificationUrl ? "verification_required" : "verifying",
-    };
-  }
-
-  if (!entry.walletId) {
-    const walletProfile = await client.getFiatWalletProfile(ctx, {
-      customerReference: customer.customerReference,
-      currency: params.fiatCurrency,
-    });
-    const wallet = await client.createFiatWallet(ctx, {
-      customerReference: customer.customerReference,
-      name: `SDP onramp ${customer.externalReference}`,
-      currencyCode: params.fiatCurrency,
-      walletProfile,
-      idempotencyKey: (await hashString(`bvnk-wallet:${counterparty.id}:${key}`)).slice(0, 36),
-    });
-    entry = {
-      ...entry,
-      walletId: wallet.id,
-      walletStatus: wallet.status,
-      bankAccount: wallet.bankAccount,
-    };
-    await persist();
-  }
-
-  if (entry.walletId && !isBvnkWalletActive(entry.walletStatus)) {
-    try {
-      const wallet = await client.getFiatWallet(ctx, { walletId: entry.walletId });
-      entry = {
-        ...entry,
-        walletStatus: wallet.status ?? entry.walletStatus,
-        bankAccount: wallet.bankAccount ?? entry.bankAccount,
-      };
-      await persist();
-    } catch (error) {
-      console.warn(
-        `[bvnk onramp] wallet ${entry.walletId} status refresh failed; relying on webhook: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
-  }
-
-  if (!entry.ruleId && entry.walletId && isBvnkWalletActive(entry.walletStatus)) {
-    const rule = await client.createOnrampRule(ctx, {
-      reference: await bvnkRuleReference(counterparty.id, key),
-      walletId: entry.walletId,
-      currency: params.currency,
-      network: params.network,
-      beneficiaryAddress: params.destinationWalletAddress,
-      entity: {
-        ...buildBvnkRuleEntity(counterparty),
-        customerIdentifier: customer.customerReference,
-      },
-    });
-    entry = { ...entry, ruleId: rule.id ?? entry.ruleId, ruleStatus: rule.status };
-    await persist();
-  }
-
-  return {
-    customer,
-    entry,
-    onboardingStatus: entry.ruleId && entry.bankAccount?.accountNumber ? "ready" : "provisioning",
-  };
-}
-
-async function resolveBvnkOnramp(
-  c: AppContext,
-  repo: CounterpartiesRepository,
-  counterparty: CounterpartyRow,
-  projectId: string,
-  input: {
-    cryptoToken: string;
-    fiatCurrency?: string;
-    destinationWalletAddress: string;
-    collectedData?: CollectedFieldData;
-  }
-) {
-  if (!input.fiatCurrency) {
-    throw new AppError("BAD_REQUEST", "fiatCurrency is required for BVNK on-ramp.");
-  }
-  const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
-  const fiatCurrency = input.fiatCurrency;
-  const resolution = await ensureBvnkOnramp(c, repo, counterparty, projectId, {
-    currency,
-    network,
-    destinationWalletAddress: input.destinationWalletAddress,
-    fiatCurrency,
-    collectedData: input.collectedData,
-  });
-  const instruction = buildBvnkOnrampInstruction(resolution, {
-    network,
-    destinationWalletAddress: input.destinationWalletAddress,
-    fiatCurrency,
-    mode: resolveSdpEnvironment(c),
-  });
-  const reference = resolution.entry.ruleId ?? resolution.customer.customerReference;
-  if (!reference) {
-    throw new AppError("INTERNAL_ERROR", "BVNK on-ramp resolution is missing a reference.");
-  }
-  return { instruction, id: reference, reference };
-}
-
-async function createBvnkOnrampQuote(
-  c: AppContext,
-  repo: CounterpartiesRepository,
-  counterparty: CounterpartyRow,
-  projectId: string,
-  input: {
-    cryptoToken: string;
-    fiatCurrency?: string;
-    destinationWalletAddress: string;
-    collectedData?: CollectedFieldData;
-  }
-): Promise<BvnkOnrampQuote> {
-  const { instruction, id } = await resolveBvnkOnramp(c, repo, counterparty, projectId, input);
-  return {
-    provider: "bvnk",
-    id,
-    status: "pending",
-    deliveryMode: "manual_instructions",
-    paymentInstructions: [instruction],
-  };
-}
-
-async function resolveRampKycReference(
-  c: AppContext,
-  scope: Awaited<ReturnType<typeof resolveScope>>,
-  provider: RampProviderId,
-  counterpartyId: string | undefined,
-  fallback: string | undefined
-): Promise<string | undefined> {
-  if (!counterpartyId || provider !== "lightspark") {
-    return fallback;
-  }
-  const projectId = requireProjectId(c);
-  const repo = getCounterpartiesRepository(c);
-  const counterparty = await repo.getCounterpartyById({
-    counterpartyId,
-    organizationId: scope.auth.organizationId,
-    projectId,
-  });
-  if (!counterparty) {
-    throw new AppError("NOT_FOUND", "Counterparty not found");
-  }
-  return ensureLightsparkCustomer(c, repo, counterparty, projectId);
+  return { customerId: customer.id };
 }
 
 async function estimateAcrossProviders(
@@ -709,8 +443,8 @@ export async function estimateOnramp(c: AppContext) {
   const parsed = estimateOnrampSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -736,8 +470,8 @@ export async function estimateOfframp(c: AppContext) {
   const parsed = estimateOfframpSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -763,8 +497,8 @@ export async function createOnrampQuote(c: AppContext) {
   const parsed = createOnrampQuoteSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -813,7 +547,7 @@ export async function createOnrampQuote(c: AppContext) {
       break;
     }
     case "lightspark": {
-      const customerId = await ensureLightsparkCustomer(c, repo, counterparty, projectId);
+      const { customerId } = await ensureLightsparkCustomer(c, { counterparty, projectId });
       quote = await RAMP_PROVIDER_CLIENTS.lightspark.createOnrampQuote(rampRuntime(c), {
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -827,18 +561,14 @@ export async function createOnrampQuote(c: AppContext) {
       break;
     }
     case "bvnk": {
-      const bvnkQuote = await createBvnkOnrampQuote(c, repo, counterparty, projectId, {
+      ({ quote, persist } = await bvnkOnrampQuote(c, {
+        counterparty,
+        projectId,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
         destinationWalletAddress,
         collectedData: input.collectedData,
-      });
-      const instruction = bvnkQuote.paymentInstructions[0];
-      if (!instruction) {
-        throw new AppError("INTERNAL_ERROR", "BVNK on-ramp quote is missing instructions.");
-      }
-      quote = bvnkQuote;
-      persist = instruction.onboardingStatus === "ready";
+      }));
       break;
     }
     default: {
@@ -874,8 +604,8 @@ export async function createOfframpQuote(c: AppContext) {
   const parsed = createOfframpQuoteSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -974,12 +704,12 @@ export async function executeOnramp(c: AppContext) {
   const parsed = executeOnrampSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
-  const ramp = await executeRampWithProvider(c, { ...parsed.data, direction: "onramp" });
+  const ramp = await executeOnrampWithProvider(c, parsed.data);
   return success(c, { ramp });
 }
 
@@ -988,12 +718,12 @@ export async function executeOfframp(c: AppContext) {
   const parsed = executeOfframpSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
-  const ramp = await executeRampWithProvider(c, { ...parsed.data, direction: "offramp" });
+  const ramp = await executeOfframpWithProvider(c, parsed.data);
   return success(c, { ramp });
 }
 
@@ -1001,8 +731,8 @@ export async function listOnrampCurrencies(c: AppContext) {
   const parsed = listOnrampCurrenciesQuerySchema.safeParse(c.req.query());
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid query parameters", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequestQuery({
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -1029,8 +759,8 @@ export async function listOfframpCurrencies(c: AppContext) {
   const parsed = listOfframpCurrenciesQuerySchema.safeParse(c.req.query());
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid query parameters", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequestQuery({
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -1065,8 +795,8 @@ export async function simulateSandboxTransfer(c: AppContext) {
   const parsed = simulateSandboxTransferSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
@@ -1,4 +1,4 @@
-import type { BvnkPaymentRampInstruction, PaymentRampQuote, SdpEnvironment } from "@sdp/types";
+import type { BvnkPaymentRampInstruction, PaymentRampQuote } from "@sdp/types";
 import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
 import { badRequest, internalError } from "@/lib/errors";
@@ -21,10 +21,9 @@ import {
   readBvnkOnrampEntry,
   readBvnkWallets,
 } from "@/lib/ramps/providers/bvnk";
-import type { RampRuntimeContext } from "@/lib/ramps/types";
 import { buildBvnkIndividualPayload } from "@/lib/ramps/validation/bvnk";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
-import type { AppContext } from "../../context";
+import { type AppContext, rampRuntime, resolveSdpEnvironment } from "../../context";
 
 type BvnkOnrampQuote = PaymentRampQuote & {
   provider: "bvnk";
@@ -35,18 +34,6 @@ type BvnkOnrampQuote = PaymentRampQuote & {
 export interface BvnkOnrampQuoteResult {
   quote: BvnkOnrampQuote;
   persist: boolean;
-}
-
-function resolveSdpEnvironment(c: AppContext): SdpEnvironment {
-  const apiKey = c.get("apiKey");
-  return apiKey ? apiKey.environment : "sandbox";
-}
-
-function rampRuntime(c: AppContext): RampRuntimeContext {
-  return {
-    env: c.env as unknown as Record<string, string | undefined>,
-    mode: resolveSdpEnvironment(c),
-  };
 }
 
 function requesterIpAddress(c: AppContext): string {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
@@ -1,0 +1,347 @@
+import type { BvnkPaymentRampInstruction, PaymentRampQuote, SdpEnvironment } from "@sdp/types";
+import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import { badRequest, internalError } from "@/lib/errors";
+import { hashString } from "@/lib/hash";
+import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
+import {
+  type BvnkCustomerResolution,
+  type BvnkOnrampEntry,
+  type BvnkPaymentRuleResolution,
+  buildBvnkOnrampInstruction,
+  buildBvnkRuleEntity,
+  bvnkCustomerExternalReference,
+  bvnkOnrampKey,
+  bvnkRuleReference,
+  isBvnkCustomerVerified,
+  isBvnkWalletActive,
+  normalizeBvnkCurrencyAndNetwork,
+  readBvnkCustomer,
+  readBvnkData,
+  readBvnkOnrampEntry,
+  readBvnkWallets,
+} from "@/lib/ramps/providers/bvnk";
+import type { RampRuntimeContext } from "@/lib/ramps/types";
+import { buildBvnkIndividualPayload } from "@/lib/ramps/validation/bvnk";
+import { getCounterpartiesRepository } from "@/routes/counterparties/context";
+import type { AppContext } from "../../context";
+
+type BvnkOnrampQuote = PaymentRampQuote & {
+  provider: "bvnk";
+  deliveryMode: "manual_instructions";
+  paymentInstructions: BvnkPaymentRampInstruction[];
+};
+
+export interface BvnkOnrampQuoteResult {
+  quote: BvnkOnrampQuote;
+  persist: boolean;
+}
+
+function resolveSdpEnvironment(c: AppContext): SdpEnvironment {
+  const apiKey = c.get("apiKey");
+  return apiKey ? apiKey.environment : "sandbox";
+}
+
+function rampRuntime(c: AppContext): RampRuntimeContext {
+  return {
+    env: c.env as unknown as Record<string, string | undefined>,
+    mode: resolveSdpEnvironment(c),
+  };
+}
+
+function requesterIpAddress(c: AppContext): string {
+  const forwarded = c.req.header("x-forwarded-for");
+  return c.req.header("cf-connecting-ip") ?? forwarded?.split(",")[0]?.trim() ?? "0.0.0.0";
+}
+
+/** Merges customer + wallet entry state into counterparty.provider_data.bvnk. */
+async function persistBvnkCustomerState(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  customer: BvnkCustomerResolution
+): Promise<void> {
+  const repo = getCounterpartiesRepository(c);
+  const bvnk = readBvnkData(counterparty.provider_data);
+  await repo.updateCounterparty({
+    counterpartyId: counterparty.id,
+    organizationId: counterparty.organization_id,
+    projectId,
+    providerData: {
+      ...counterparty.provider_data,
+      bvnk: {
+        ...bvnk,
+        customer: { ...readBvnkCustomer(counterparty.provider_data), ...customer },
+      },
+    },
+  });
+}
+
+async function persistBvnkOnrampState(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  key: string,
+  customer: BvnkCustomerResolution,
+  entry: BvnkOnrampEntry
+): Promise<void> {
+  const repo = getCounterpartiesRepository(c);
+  const bvnk = readBvnkData(counterparty.provider_data);
+  const wallets = readBvnkWallets(counterparty.provider_data);
+  await repo.updateCounterparty({
+    counterpartyId: counterparty.id,
+    organizationId: counterparty.organization_id,
+    projectId,
+    providerData: {
+      ...counterparty.provider_data,
+      bvnk: {
+        ...bvnk,
+        customer: { ...readBvnkCustomer(counterparty.provider_data), ...customer },
+        wallets: { ...wallets, [key]: { ...wallets[key], ...entry } },
+      },
+    },
+  });
+}
+
+/**
+ * Ensures the counterparty has a BVNK customer (agreement → sign → create) and
+ * refreshes verification status when pending. Persists customer state to
+ * counterparty.provider_data.bvnk.customer after each completed step.
+ */
+export async function ensureBvnkCustomer(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  params: {
+    fiatCurrency: string;
+    collectedData?: CollectedFieldData;
+  }
+): Promise<BvnkCustomerResolution> {
+  if (counterparty.entity_type === "business") {
+    throw badRequest("BVNK supports individual counterparties only.");
+  }
+  const countryCode = counterparty.identity.address?.countryCode;
+  if (!countryCode) {
+    throw badRequest("Counterparty address country is required for BVNK.");
+  }
+
+  const ctx = rampRuntime(c);
+  const client = RAMP_PROVIDER_CLIENTS.bvnk;
+
+  let customer = readBvnkCustomer(counterparty.provider_data);
+
+  if (!customer.customerReference) {
+    const individual = buildBvnkIndividualPayload(
+      counterparty,
+      params.collectedData,
+      params.fiatCurrency
+    );
+    const session = await client.createAgreementSession(ctx, {
+      customerType: "INDIVIDUAL",
+      countryCode,
+      useCase: "EMBEDDED_FIAT_ACCOUNTS",
+    });
+    await client.signAgreement(ctx, {
+      reference: session.reference,
+      ipAddress: requesterIpAddress(c),
+    });
+    const externalReference =
+      customer.externalReference ?? bvnkCustomerExternalReference(counterparty.id);
+    const created = await client.createBvnkCustomer(ctx, {
+      externalReference,
+      signedAgreementSessionReference: session.reference,
+      individual,
+    });
+    customer = {
+      externalReference,
+      customerReference: created.reference,
+      status: created.status,
+      verificationStatus: created.verificationStatus,
+      verificationUrl: created.verificationUrl,
+    };
+    await persistBvnkCustomerState(c, counterparty, projectId, customer);
+  }
+
+  if (customer.customerReference && !isBvnkCustomerVerified(customer.status)) {
+    const latest = await client.getBvnkCustomer(ctx, { reference: customer.customerReference });
+    customer = {
+      ...customer,
+      status: latest.status,
+      verificationStatus: latest.verificationStatus,
+      verificationUrl: latest.verificationUrl ?? customer.verificationUrl,
+    };
+    await persistBvnkCustomerState(c, counterparty, projectId, customer);
+  }
+
+  return customer;
+}
+
+/**
+ * Advances on-ramp provisioning (wallet profile → create/get wallet → create
+ * rule) for a verified customer + funding spec. Persists entry state to
+ * counterparty.provider_data.bvnk.wallets[key] after each completed step.
+ */
+export async function ensureBvnkPaymentRule(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  customer: BvnkCustomerResolution,
+  params: {
+    currency: string;
+    network: string;
+    destinationWalletAddress: string;
+    fiatCurrency: string;
+  }
+): Promise<BvnkPaymentRuleResolution> {
+  const ctx = rampRuntime(c);
+  const client = RAMP_PROVIDER_CLIENTS.bvnk;
+  const key = bvnkOnrampKey(
+    params.fiatCurrency,
+    params.currency,
+    params.network,
+    params.destinationWalletAddress
+  );
+
+  let entry: BvnkOnrampEntry = readBvnkOnrampEntry(counterparty.provider_data, key);
+
+  if (entry.walletId && entry.bankAccount?.accountNumber && entry.ruleId) {
+    return { customer, entry, onboardingStatus: "ready" };
+  }
+
+  if (!isBvnkCustomerVerified(customer.status) || !customer.customerReference) {
+    return {
+      customer,
+      entry,
+      onboardingStatus: customer.verificationUrl ? "verification_required" : "verifying",
+    };
+  }
+
+  if (!entry.walletId) {
+    const walletProfile = await client.getFiatWalletProfile(ctx, {
+      customerReference: customer.customerReference,
+      currency: params.fiatCurrency,
+    });
+    const wallet = await client.createFiatWallet(ctx, {
+      customerReference: customer.customerReference,
+      name: `SDP onramp ${customer.externalReference}`,
+      currencyCode: params.fiatCurrency,
+      walletProfile,
+      idempotencyKey: (await hashString(`bvnk-wallet:${counterparty.id}:${key}`)).slice(0, 36),
+    });
+    entry = {
+      ...entry,
+      walletId: wallet.id,
+      walletStatus: wallet.status,
+      bankAccount: wallet.bankAccount,
+    };
+    await persistBvnkOnrampState(c, counterparty, projectId, key, customer, entry);
+  }
+
+  if (entry.walletId && !isBvnkWalletActive(entry.walletStatus)) {
+    try {
+      const wallet = await client.getFiatWallet(ctx, { walletId: entry.walletId });
+      entry = {
+        ...entry,
+        walletStatus: wallet.status ?? entry.walletStatus,
+        bankAccount: wallet.bankAccount ?? entry.bankAccount,
+      };
+      await persistBvnkOnrampState(c, counterparty, projectId, key, customer, entry);
+    } catch (error) {
+      console.warn(
+        `[bvnk onramp] wallet ${entry.walletId} status refresh failed; relying on webhook: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  if (!entry.ruleId && entry.walletId && isBvnkWalletActive(entry.walletStatus)) {
+    const rule = await client.createOnrampRule(ctx, {
+      reference: await bvnkRuleReference(counterparty.id, key),
+      walletId: entry.walletId,
+      currency: params.currency,
+      network: params.network,
+      beneficiaryAddress: params.destinationWalletAddress,
+      entity: {
+        ...buildBvnkRuleEntity(counterparty),
+        customerIdentifier: customer.customerReference,
+      },
+    });
+    entry = { ...entry, ruleId: rule.id ?? entry.ruleId, ruleStatus: rule.status };
+    await persistBvnkOnrampState(c, counterparty, projectId, key, customer, entry);
+  }
+
+  return {
+    customer,
+    entry,
+    onboardingStatus: entry.ruleId && entry.bankAccount?.accountNumber ? "ready" : "provisioning",
+  };
+}
+
+async function resolveBvnkOnramp(
+  c: AppContext,
+  input: {
+    counterparty: CounterpartyRow;
+    projectId: string;
+    cryptoToken: string;
+    fiatCurrency?: string;
+    destinationWalletAddress: string;
+    collectedData?: CollectedFieldData;
+  }
+) {
+  if (!input.fiatCurrency) {
+    throw badRequest("fiatCurrency is required for BVNK on-ramp.");
+  }
+  const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
+  const fiatCurrency = input.fiatCurrency;
+  const customer = await ensureBvnkCustomer(c, input.counterparty, input.projectId, {
+    fiatCurrency,
+    collectedData: input.collectedData,
+  });
+  const resolution = await ensureBvnkPaymentRule(c, input.counterparty, input.projectId, customer, {
+    currency,
+    network,
+    destinationWalletAddress: input.destinationWalletAddress,
+    fiatCurrency,
+  });
+  const instruction = buildBvnkOnrampInstruction(resolution, {
+    network,
+    destinationWalletAddress: input.destinationWalletAddress,
+    fiatCurrency,
+    mode: resolveSdpEnvironment(c),
+  });
+  const reference =
+    resolution.onboardingStatus === "ready"
+      ? resolution.entry.ruleId
+      : resolution.customer.customerReference;
+  if (!reference) {
+    throw internalError(
+      `BVNK on-ramp missing reference at status "${resolution.onboardingStatus}".`
+    );
+  }
+  return { instruction, id: reference, reference };
+}
+
+/**
+ * Builds a BVNK on-ramp quote. Only "ready" onboarding states are committable
+ * as a transfer row — mid-onboarding quotes must not be persisted.
+ */
+export async function bvnkOnrampQuote(
+  c: AppContext,
+  input: {
+    counterparty: CounterpartyRow;
+    projectId: string;
+    cryptoToken: string;
+    fiatCurrency?: string;
+    destinationWalletAddress: string;
+    collectedData?: CollectedFieldData;
+  }
+): Promise<BvnkOnrampQuoteResult> {
+  const { instruction, id } = await resolveBvnkOnramp(c, input);
+  const quote: BvnkOnrampQuote = {
+    provider: "bvnk",
+    id,
+    status: "pending",
+    deliveryMode: "manual_instructions",
+    paymentInstructions: [instruction],
+  };
+  return { quote, persist: instruction.onboardingStatus === "ready" };
+}

--- a/apps/sdp-api/src/routes/payments/handlers/subscriptions.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/subscriptions.ts
@@ -187,7 +187,7 @@ function parseU64String(value: string, fieldName: string): bigint {
     }
     return parsed;
   } catch {
-    throw new AppError("BAD_REQUEST", `${fieldName} must fit in an unsigned 64-bit integer`);
+    throw badRequest(`${fieldName} must fit in an unsigned 64-bit integer`);
   }
 }
 
@@ -199,13 +199,13 @@ function parseI64String(value: string, fieldName: string): bigint {
     }
     return parsed;
   } catch {
-    throw new AppError("BAD_REQUEST", `${fieldName} must fit in a signed 64-bit integer`);
+    throw badRequest(`${fieldName} must fit in a signed 64-bit integer`);
   }
 }
 
 function assertSubscriptionTokenMint(token: string): Address {
   if (token === "SOL" || token === SOL_MINT) {
-    throw new AppError("BAD_REQUEST", "Subscription plans require an SPL token mint");
+    throw badRequest("Subscription plans require an SPL token mint");
   }
 
   return assertValidAddress(token, "token");
@@ -252,7 +252,7 @@ async function resolvePlanRuntime(
   const amountBaseUnits = parseDecimalAmount(amount, decimals);
 
   if (amountBaseUnits <= 0n) {
-    throw new AppError("BAD_REQUEST", "Subscription amount must be greater than zero");
+    throw badRequest("Subscription amount must be greater than zero");
   }
 
   return { amountBaseUnits, mint, tokenProgram };
@@ -362,7 +362,7 @@ async function requireActiveCounterparty(c: AppContext, counterpartyId: string):
     throw new AppError("NOT_FOUND", "Counterparty not found");
   }
   if (counterparty.status !== "active") {
-    throw new AppError("BAD_REQUEST", "Counterparty must be active before creating a subscription");
+    throw badRequest("Counterparty must be active before creating a subscription");
   }
 }
 
@@ -525,7 +525,7 @@ export const prepareCreateSubscriptionPlan = async (c: AppContext) => {
     throw new AppError("NOT_FOUND", "Subscription plan not found");
   }
   if (plan.status === "archived") {
-    throw new AppError("BAD_REQUEST", "Cannot prepare an archived subscription plan");
+    throw badRequest("Cannot prepare an archived subscription plan");
   }
 
   const scope = await resolveScope(c);
@@ -652,7 +652,7 @@ export const createSubscription = async (c: AppContext) => {
     throw new AppError("NOT_FOUND", "Subscription plan not found");
   }
   if (plan.status === "archived") {
-    throw new AppError("BAD_REQUEST", "Cannot create a subscription for an archived plan");
+    throw badRequest("Cannot create a subscription for an archived plan");
   }
 
   await requireActiveCounterparty(c, parsed.data.counterpartyId);
@@ -721,7 +721,7 @@ export const prepareSubscriptionAuthorization = async (c: AppContext) => {
 
   const { plan, subscription } = await getSubscriptionWithPlan(c, params.data.subscriptionId);
   if (plan.status !== "active") {
-    throw new AppError("BAD_REQUEST", "Subscription plan must be active before authorization");
+    throw badRequest("Subscription plan must be active before authorization");
   }
   if (subscription.status !== "pending_authorization") {
     throw new AppError(
@@ -963,10 +963,10 @@ export const prepareSubscriptionCollection = async (c: AppContext) => {
 
   const { plan, subscription } = await getSubscriptionWithPlan(c, params.data.subscriptionId);
   if (subscription.status !== "active") {
-    throw new AppError("BAD_REQUEST", "Subscription must be active before collection");
+    throw badRequest("Subscription must be active before collection");
   }
   if (plan.status !== "active") {
-    throw new AppError("BAD_REQUEST", "Subscription plan must be active before collection");
+    throw badRequest("Subscription plan must be active before collection");
   }
 
   const callerWallet = await resolvePlanWriteWallet(
@@ -1038,7 +1038,7 @@ export const createSubscriptionCollectionAttempt = async (c: AppContext) => {
     throw new AppError("NOT_FOUND", "Subscription not found");
   }
   if (subscription.status !== "active") {
-    throw new AppError("BAD_REQUEST", "Subscription must be active before collection");
+    throw badRequest("Subscription must be active before collection");
   }
 
   const plan = await repo.getPlanById({
@@ -1050,7 +1050,7 @@ export const createSubscriptionCollectionAttempt = async (c: AppContext) => {
     throw new AppError("NOT_FOUND", "Subscription plan not found");
   }
   if (plan.status !== "active") {
-    throw new AppError("BAD_REQUEST", "Subscription plan must be active before collection");
+    throw badRequest("Subscription plan must be active before collection");
   }
 
   await resolvePlanWriteWallet(c, plan, plan.puller_wallet_id ?? plan.owner_wallet_id);

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -26,6 +26,7 @@ import {
   getCreateAssociatedTokenIdempotentInstruction,
   getTransferCheckedInstruction,
 } from "@solana-program/token-2022";
+import { z } from "zod";
 import { getDb } from "@/db";
 import {
   isRampTransferType,
@@ -38,7 +39,7 @@ import {
 } from "@/db/repositories/payments.repository";
 import { formatDecimalAmount, MAX_SAFE_BASE_UNITS, parseDecimalAmount } from "@/lib/amount";
 import { getAuth } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest, badRequestQuery } from "@/lib/errors";
 import { paginated, success } from "@/lib/response";
 import { assertValidAddress, getSolanaConfig } from "@/lib/solana";
 import {
@@ -190,7 +191,7 @@ export async function resolveWalletFromParams(
 ) {
   const params = walletIdParamsSchema.safeParse(c.req.param());
   if (!params.success) {
-    throw new AppError("BAD_REQUEST", "Invalid wallet ID");
+    throw badRequest("Invalid wallet ID");
   }
 
   const scope = await resolveScope(c);
@@ -301,7 +302,7 @@ async function prepareSolTransfer(
 ): Promise<PreparedTransferPayload> {
   const lamports = parseDecimalAmount(amount, 9);
   if (lamports <= 0n) {
-    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+    throw badRequest("Transfer amount must be greater than zero");
   }
 
   const rpc = solanaRpc.createRpc(c.env);
@@ -338,7 +339,7 @@ async function executeSolTransfer(
 ): Promise<{ signature: string; slot: number | null; blockTime: string | null }> {
   const lamports = parseDecimalAmount(amount, 9);
   if (lamports <= 0n) {
-    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+    throw badRequest("Transfer amount must be greater than zero");
   }
 
   const auth = getAuth(c);
@@ -350,7 +351,7 @@ async function executeSolTransfer(
   );
 
   if (signer.address !== sourceWallet.publicKey) {
-    throw new AppError("BAD_REQUEST", "Resolved signing wallet does not match source wallet");
+    throw badRequest("Resolved signing wallet does not match source wallet");
   }
 
   const rpc = solanaRpc.createRpc(c.env);
@@ -410,7 +411,7 @@ async function prepareSplTransfer(
   const transferAmount = parseDecimalAmount(amount, sourceTokenAccount.decimals);
 
   if (transferAmount <= 0n) {
-    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+    throw badRequest("Transfer amount must be greater than zero");
   }
 
   const [destinationTokenAccount] = await findAssociatedTokenPda({
@@ -539,7 +540,7 @@ async function prepareMagicBlockPrivateTransferForOperation(params: {
   const amountBaseUnits = parseDecimalAmount(operation.amount, decimals);
 
   if (amountBaseUnits <= 0n) {
-    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+    throw badRequest("Transfer amount must be greater than zero");
   }
 
   if (amountBaseUnits > MAX_SAFE_BASE_UNITS) {
@@ -760,7 +761,7 @@ async function executePreparedPrivateTransfer(
       );
 
       if (signer.address !== wallet.publicKey) {
-        throw new AppError("BAD_REQUEST", "Resolved signing wallet does not match required signer");
+        throw badRequest("Resolved signing wallet does not match required signer");
       }
       assertIsTransactionPartialSigner(signer);
       return signer;
@@ -816,7 +817,7 @@ async function executeSplTransfer(
   );
 
   if (signer.address !== sourceWallet.publicKey) {
-    throw new AppError("BAD_REQUEST", "Resolved signing wallet does not match source wallet");
+    throw badRequest("Resolved signing wallet does not match source wallet");
   }
 
   const rpc = solanaRpc.createRpc(c.env);
@@ -830,7 +831,7 @@ async function executeSplTransfer(
   const transferAmount = parseDecimalAmount(amount, sourceTokenAccount.decimals);
 
   if (transferAmount <= 0n) {
-    throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+    throw badRequest("Transfer amount must be greater than zero");
   }
 
   const [destinationTokenAccount] = await findAssociatedTokenPda({
@@ -899,8 +900,8 @@ export async function prepareTransfer(c: AppContext) {
   const parsed = prepareTransferSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -1626,8 +1627,8 @@ export async function createTransfer(c: AppContext) {
   const parsed = createTransferSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -1784,7 +1785,7 @@ export async function createTransfer(c: AppContext) {
 export async function listTransfers(c: AppContext) {
   const auth = getAuth(c);
   const query = listTransfersQuerySchema.safeParse(c.req.query());
-  if (!query.success) throw new AppError("BAD_REQUEST", "Invalid query parameters");
+  if (!query.success) throw badRequestQuery();
   const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
 
   const {
@@ -2057,7 +2058,7 @@ export async function getTransfer(c: AppContext) {
   const params = transferIdParamsSchema.safeParse(c.req.param());
   const repo = getPaymentsRepository(c);
 
-  if (!params.success) throw new AppError("BAD_REQUEST", "Transfer ID is required");
+  if (!params.success) throw badRequest("Transfer ID is required");
 
   const row = await repo.getTransferById({
     transferId: params.data.transferId,

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -418,12 +418,11 @@ export const prepareTransferSchema = createTransferSchema.extend({
 
 export const executeOnrampSchema = z.object({
   provider: rampProviderSchema,
-  counterpartyId: z.string().min(1).optional(),
+  counterpartyId: z.string().min(1),
   destinationWallet: z.string().min(1),
   cryptoToken: rampCurrencyCodeSchema,
   fiatCurrency: rampFiatCurrencySchema.optional(),
   fiatAmount: paymentAmountSchema,
-  kycReference: z.string().max(128).optional(),
   redirectUrl: z.string().url().optional(),
   bvnkCompliance: bvnkComplianceSchema.optional(),
 });
@@ -463,12 +462,11 @@ export const createOfframpQuoteSchema = z.object({
 
 export const executeOfframpSchema = z.object({
   provider: rampProviderSchema,
-  counterpartyId: z.string().min(1).optional(),
+  counterpartyId: z.string().min(1),
   sourceWallet: z.string().min(1),
   cryptoToken: rampCurrencyCodeSchema,
   fiatCurrency: rampFiatCurrencySchema.optional(),
   cryptoAmount: paymentAmountSchema,
-  kycReference: z.string().max(128).optional(),
   redirectUrl: z.string().url().optional(),
   bvnkCompliance: bvnkComplianceSchema.optional(),
 });

--- a/apps/sdp-api/src/routes/payments/token-accounts.ts
+++ b/apps/sdp-api/src/routes/payments/token-accounts.ts
@@ -1,6 +1,6 @@
 import type { Address } from "@solana/kit";
 import { formatDecimalAmount } from "@/lib/amount";
-import { AppError } from "@/lib/errors";
+import { badRequest } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
 import { SOL_MINT } from "@/services/payment-operation.service";
 import { type createRpc, getAccountInfo } from "@/services/solana/rpc";
@@ -84,7 +84,7 @@ export async function resolveMintDecimals(
   const decimals = response.value?.decimals;
 
   if (typeof decimals !== "number" || !Number.isInteger(decimals) || decimals < 0) {
-    throw new AppError("BAD_REQUEST", "Token mint decimals could not be resolved");
+    throw badRequest("Token mint decimals could not be resolved");
   }
 
   return decimals;
@@ -212,7 +212,7 @@ function assertSupportedTokenProgram(program: string): Address {
   if (program === SPL_TOKEN_PROGRAM_ID || program === SPL_TOKEN_2022_PROGRAM_ID) {
     return program as Address;
   }
-  throw new AppError("BAD_REQUEST", "Unsupported token program for mint");
+  throw badRequest("Unsupported token program for mint");
 }
 
 export async function resolveMintTokenProgram(
@@ -221,7 +221,7 @@ export async function resolveMintTokenProgram(
 ): Promise<Address> {
   const mintAccountInfo = await getAccountInfo(rpc, mint);
   if (!mintAccountInfo) {
-    throw new AppError("BAD_REQUEST", "Token mint account does not exist");
+    throw badRequest("Token mint account does not exist");
   }
   return assertSupportedTokenProgram(mintAccountInfo.owner);
 }
@@ -256,7 +256,7 @@ export async function resolveSourceTokenAccount(
   }
 
   if (!selected) {
-    throw new AppError("BAD_REQUEST", "Source wallet has no token account for this mint");
+    throw badRequest("Source wallet has no token account for this mint");
   }
 
   return {

--- a/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
@@ -1,8 +1,9 @@
 import type { ApiKeyRole, CreateApiKeyResponse } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, notFound } from "@/lib/errors";
+import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import { apiKeyCreateSchema } from "@/routes/api-keys/schemas";
 import { ApiKeyService } from "@/services/api-key.service";
@@ -84,8 +85,8 @@ export const createProjectApiKey = async (c: AppContext) => {
   const parsed = apiKeyCreateSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -143,7 +144,7 @@ export const createProjectApiKey = async (c: AppContext) => {
         if (error.code === "NOT_FOUND") {
           throw new AppError("CONFLICT", error.message);
         }
-        throw new AppError("BAD_REQUEST", error.message);
+        throw badRequest(error.message);
       }
       throw error;
     }

--- a/apps/sdp-api/src/routes/projects/handlers/members.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/members.ts
@@ -1,8 +1,9 @@
 import type { ListProjectMembersResponse, ProjectMemberResponse, ProjectRole } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, notFound } from "@/lib/errors";
+import { badRequest, notFound } from "@/lib/errors";
 import { created, noContent, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { ProjectService, ProjectServiceError } from "@/services/project.service";
@@ -37,8 +38,8 @@ export const addProjectMember = async (c: AppContext) => {
   const parsed = addMemberSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -59,7 +60,7 @@ export const addProjectMember = async (c: AppContext) => {
     .first();
 
   if (!orgMember) {
-    throw new AppError("BAD_REQUEST", "User is not a member of this organization");
+    throw badRequest("User is not a member of this organization");
   }
 
   try {
@@ -93,7 +94,7 @@ export const addProjectMember = async (c: AppContext) => {
     return created(c, response);
   } catch (error) {
     if (error instanceof ProjectServiceError && error.code === "ALREADY_MEMBER") {
-      throw new AppError("BAD_REQUEST", "User is already a member of this project");
+      throw badRequest("User is already a member of this project");
     }
     throw error;
   }
@@ -107,8 +108,8 @@ export const updateProjectMember = async (c: AppContext) => {
   const parsed = updateMemberSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/projects/handlers/projects.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/projects.ts
@@ -1,8 +1,9 @@
 import type { ListProjectsResponse, ProjectResponse, UpdateProjectRequest } from "@sdp/types";
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, forbidden, notFound } from "@/lib/errors";
+import { AppError, badRequest, forbidden, notFound } from "@/lib/errors";
 import { created, noContent, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { ProjectService, ProjectServiceError } from "@/services/project.service";
@@ -19,8 +20,8 @@ export const createProject = async (c: AppContext) => {
   const parsed = createProjectSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
@@ -87,7 +88,7 @@ export const createProject = async (c: AppContext) => {
     return created(c, response);
   } catch (error) {
     if (error instanceof ProjectServiceError && error.code === "DUPLICATE_SLUG") {
-      throw new AppError("BAD_REQUEST", "A project with this slug already exists");
+      throw badRequest("A project with this slug already exists");
     }
     throw error;
   }
@@ -127,8 +128,8 @@ export const updateProject = async (c: AppContext) => {
   const parsed = updateProjectSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new AppError("BAD_REQUEST", "Invalid request body", {
-      errors: parsed.error.flatten().fieldErrors,
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/rpc/handlers.ts
+++ b/apps/sdp-api/src/routes/rpc/handlers.ts
@@ -1,7 +1,8 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest, badRequestQuery } from "@/lib/errors";
 import { success } from "@/lib/response";
 import {
   listRpcProviders,
@@ -114,8 +115,8 @@ export const getRpcProviders = async (c: AppContext) => {
   const queryParse = rpcProjectQuerySchema.safeParse(c.req.query());
 
   if (!queryParse.success) {
-    throw new AppError("BAD_REQUEST", "Invalid query parameters", {
-      errors: queryParse.error.flatten().fieldErrors,
+    throw badRequestQuery({
+      errors: z.flattenError(queryParse.error).fieldErrors,
     });
   }
 
@@ -136,8 +137,8 @@ export const relayRpcRequest = async (c: AppContext) => {
   const queryParse = rpcProjectQuerySchema.safeParse(c.req.query());
 
   if (!queryParse.success) {
-    throw new AppError("BAD_REQUEST", "Invalid query parameters", {
-      errors: queryParse.error.flatten().fieldErrors,
+    throw badRequestQuery({
+      errors: z.flattenError(queryParse.error).fieldErrors,
     });
   }
 
@@ -145,13 +146,13 @@ export const relayRpcRequest = async (c: AppContext) => {
   try {
     requestBody = await c.req.json();
   } catch {
-    throw new AppError("BAD_REQUEST", "Invalid JSON body");
+    throw badRequest("Invalid JSON body");
   }
 
   const payloadParse = rpcRelayPayloadSchema.safeParse(requestBody);
   if (!payloadParse.success) {
-    throw new AppError("BAD_REQUEST", "Invalid JSON-RPC payload", {
-      errors: payloadParse.error.flatten().fieldErrors,
+    throw badRequest("Invalid JSON-RPC payload", {
+      errors: z.flattenError(payloadParse.error).fieldErrors,
     });
   }
 
@@ -248,8 +249,8 @@ export const testRpcConnection = async (c: AppContext) => {
   const queryParse = rpcProjectQuerySchema.safeParse(c.req.query());
 
   if (!queryParse.success) {
-    throw new AppError("BAD_REQUEST", "Invalid query parameters", {
-      errors: queryParse.error.flatten().fieldErrors,
+    throw badRequestQuery({
+      errors: z.flattenError(queryParse.error).fieldErrors,
     });
   }
 

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -397,7 +397,7 @@ async function resolveUserEmail(env: Env, userId: string, fallbackEmail?: string
   const email = primaryEmailFromClerkUser(user);
 
   if (!email) {
-    throw new AppError("BAD_REQUEST", "Clerk user missing email");
+    throw badRequest("Clerk user missing email");
   }
 
   return email;

--- a/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
@@ -1,74 +1,95 @@
 import type { SdpEnvironment } from "@sdp/types";
 import type { Context } from "hono";
-import { createCounterpartiesRepository } from "@/db/repositories";
+import { createCounterpartiesRepository, createPaymentsRepository } from "@/db/repositories";
+import type {
+  CounterpartiesRepository,
+  CounterpartyRow,
+} from "@/db/repositories/counterparty.repository";
 import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
+  type BvnkWebhookEvent,
   findBvnkWalletEntryKey,
   isBvnkCustomerVerified,
   readBvnkCustomer,
+  readBvnkOnrampEntry,
 } from "@/lib/ramps/providers/bvnk";
 import type { Env } from "@/types/env";
 
 type AppContext = Context<{ Bindings: Env }>;
 
-async function processBvnkCustomerWebhook(
+async function completeBvnkOnrampTransfer(
   c: AppContext,
-  environment: SdpEnvironment,
-  payload: unknown
+  event: Extract<BvnkWebhookEvent, { kind: "payment" }>
 ): Promise<void> {
-  const event = RAMP_PROVIDER_CLIENTS.bvnk.parseBvnkWebhookEvent(payload);
-  if (event.kind === "ignore") {
-    console.log(`[bvnk webhook] unmapped event "${event.event}": ${JSON.stringify(payload)}`);
+  if (event.status !== "COMPLETE" || !event.customerId || !event.walletId) {
     return;
   }
-  if (!event.customerReference) {
-    console.log(
-      `[bvnk webhook] "${event.event}" has no customer reference: ${JSON.stringify(payload)}`
-    );
-    return;
-  }
-
   const repo = createCounterpartiesRepository(c.env);
-  const counterparty = await repo.findCounterpartyByBvnkCustomerReference(event.customerReference);
+  const counterparty = await repo.findCounterpartyByBvnkCustomerReference(event.customerId);
   if (!counterparty) {
     return;
   }
-
-  const providerData = counterparty.provider_data;
-
-  if (event.kind === "customer") {
-    const current = readBvnkCustomer(providerData);
-    const customer: Record<string, unknown> = {};
-    if (event.customerStatus) customer.status = event.customerStatus.toUpperCase();
-    if (event.verificationUrl) customer.verificationUrl = event.verificationUrl;
-    const nextStatus = typeof customer.status === "string" ? customer.status : current.status;
-    const nextUrl =
-      typeof customer.verificationUrl === "string"
-        ? customer.verificationUrl
-        : current.verificationUrl;
-    if (!nextUrl && !isBvnkCustomerVerified(nextStatus)) {
-      const latest = await RAMP_PROVIDER_CLIENTS.bvnk.getBvnkCustomer(
-        { env: c.env as unknown as Record<string, string | undefined>, mode: environment },
-        { reference: event.customerReference }
-      );
-      customer.status = latest.status.toUpperCase();
-      customer.verificationStatus = latest.verificationStatus;
-      if (latest.verificationUrl) customer.verificationUrl = latest.verificationUrl;
-    }
-    if (Object.keys(customer).length === 0) {
-      return;
-    }
-    await repo.patchBvnkCustomerByReference({
-      customerReference: event.customerReference,
-      customer,
-    });
+  const entryKey = findBvnkWalletEntryKey(counterparty.provider_data, event.walletId);
+  if (!entryKey) {
     return;
   }
-
-  if (event.kind !== "wallet") {
+  const ruleId = readBvnkOnrampEntry(counterparty.provider_data, entryKey).ruleId;
+  if (!ruleId) {
     return;
   }
+  const paymentsRepo = createPaymentsRepository(c.env);
+  const transfer = await paymentsRepo.getTransferByProviderReference({
+    provider: "bvnk",
+    providerReference: ruleId,
+  });
+  if (!transfer) {
+    return;
+  }
+  await paymentsRepo.updateTransfer({
+    transferId: transfer.id,
+    status: "completed",
+    updatedAt: new Date().toISOString(),
+  });
+}
 
+async function patchBvnkCustomerFromWebhook(
+  c: AppContext,
+  environment: SdpEnvironment,
+  repo: CounterpartiesRepository,
+  counterparty: CounterpartyRow,
+  customerReference: string,
+  event: Extract<BvnkWebhookEvent, { kind: "customer" }>
+): Promise<void> {
+  const current = readBvnkCustomer(counterparty.provider_data);
+  const customer: Record<string, unknown> = {};
+  if (event.customerStatus) customer.status = event.customerStatus.toUpperCase();
+  if (event.verificationUrl) customer.verificationUrl = event.verificationUrl;
+  const nextStatus = typeof customer.status === "string" ? customer.status : current.status;
+  const nextUrl =
+    typeof customer.verificationUrl === "string"
+      ? customer.verificationUrl
+      : current.verificationUrl;
+  if (!nextUrl && !isBvnkCustomerVerified(nextStatus)) {
+    const latest = await RAMP_PROVIDER_CLIENTS.bvnk.getBvnkCustomer(
+      { env: c.env as unknown as Record<string, string | undefined>, mode: environment },
+      { reference: customerReference }
+    );
+    customer.status = latest.status.toUpperCase();
+    customer.verificationStatus = latest.verificationStatus;
+    if (latest.verificationUrl) customer.verificationUrl = latest.verificationUrl;
+  }
+  if (Object.keys(customer).length === 0) {
+    return;
+  }
+  await repo.patchBvnkCustomerByReference({ customerReference, customer });
+}
+
+async function patchBvnkWalletFromWebhook(
+  repo: CounterpartiesRepository,
+  counterparty: CounterpartyRow,
+  customerReference: string,
+  event: Extract<BvnkWebhookEvent, { kind: "wallet" }>
+): Promise<void> {
   if (!event.walletId) {
     return;
   }
@@ -82,18 +103,56 @@ async function processBvnkCustomerWebhook(
     return;
   }
 
-  const key = findBvnkWalletEntryKey(providerData, event.walletId);
+  const key = findBvnkWalletEntryKey(counterparty.provider_data, event.walletId);
   if (!key) {
     return;
   }
   const wallet: Record<string, unknown> = {};
   if (event.walletStatus) wallet.walletStatus = event.walletStatus;
   if (hasBankAccountNumber) wallet.bankAccount = bankAccount;
-  await repo.patchBvnkWalletByReference({
-    customerReference: event.customerReference,
-    walletKey: key,
-    wallet,
-  });
+  await repo.patchBvnkWalletByReference({ customerReference, walletKey: key, wallet });
+}
+
+async function processBvnkCustomerWebhook(
+  c: AppContext,
+  environment: SdpEnvironment,
+  payload: unknown
+): Promise<void> {
+  const event = RAMP_PROVIDER_CLIENTS.bvnk.parseBvnkWebhookEvent(payload);
+  if (event.kind === "ignore") {
+    console.log(`[bvnk webhook] unmapped event "${event.event}": ${JSON.stringify(payload)}`);
+    return;
+  }
+
+  if (event.kind === "payment") {
+    return completeBvnkOnrampTransfer(c, event);
+  }
+
+  if (!event.customerReference) {
+    console.log(
+      `[bvnk webhook] "${event.event}" has no customer reference: ${JSON.stringify(payload)}`
+    );
+    return;
+  }
+
+  const repo = createCounterpartiesRepository(c.env);
+  const counterparty = await repo.findCounterpartyByBvnkCustomerReference(event.customerReference);
+  if (!counterparty) {
+    return;
+  }
+
+  if (event.kind === "customer") {
+    return patchBvnkCustomerFromWebhook(
+      c,
+      environment,
+      repo,
+      counterparty,
+      event.customerReference,
+      event
+    );
+  }
+
+  return patchBvnkWalletFromWebhook(repo, counterparty, event.customerReference, event);
 }
 
 export async function handleBvnkRampWebhook(

--- a/apps/sdp-api/src/services/api-key-scope.service.ts
+++ b/apps/sdp-api/src/services/api-key-scope.service.ts
@@ -1,6 +1,6 @@
 import type { ApiKeyWalletBinding, ApiKeyWalletScope, Permission } from "@sdp/types";
 import type { ApiKeyContext } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { normalizeApiKeyWalletPermissions } from "@/services/api-key-wallets.service";
 
 type WalletBindingInput = {
@@ -28,7 +28,7 @@ type WalletScopeInput = WalletBindingPatchInput & {
 function trimWalletId(walletId: string): string {
   const normalized = walletId.trim();
   if (!normalized) {
-    throw new AppError("BAD_REQUEST", "Wallet IDs must be non-empty strings");
+    throw badRequest("Wallet IDs must be non-empty strings");
   }
   return normalized;
 }
@@ -171,7 +171,7 @@ export function resolveCreateWalletScope(input: WalletScopeInput): {
 } {
   const walletScope = input.walletScope;
   if (!walletScope) {
-    throw new AppError("BAD_REQUEST", "walletScope is required");
+    throw badRequest("walletScope is required");
   }
 
   const walletBindingPatch = parseWalletBindingPatch(input);
@@ -259,7 +259,7 @@ export function resolveUpdateWalletScope(input: WalletScopeInput): {
   }
 
   if (input.provisionWallet) {
-    throw new AppError("BAD_REQUEST", "provisionWallet is only supported during API key creation");
+    throw badRequest("provisionWallet is only supported during API key creation");
   }
 
   if (!walletBindingPatch.touched || walletBindingPatch.bindings.length === 0) {
@@ -312,7 +312,7 @@ export async function assertWalletBindingsInScope(
 
   const missingWalletIds = walletIds.filter((walletId) => !walletScope.has(walletId));
   if (missingWalletIds.length > 0) {
-    throw new AppError("BAD_REQUEST", `Unknown signing wallet IDs: ${missingWalletIds.join(", ")}`);
+    throw badRequest(`Unknown signing wallet IDs: ${missingWalletIds.join(", ")}`);
   }
 
   for (const walletId of walletIds) {

--- a/apps/sdp-api/src/services/payment-operation.service.ts
+++ b/apps/sdp-api/src/services/payment-operation.service.ts
@@ -2,7 +2,7 @@ import type { Permission } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import { isDecimalString } from "@/lib/amount";
 import type { ApiKeyContext } from "@/lib/auth";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -34,7 +34,7 @@ export function assertPaymentProjectScope(
   }
 
   if (bodyProjectId !== authProjectId) {
-    throw new AppError("BAD_REQUEST", "projectId does not match the authenticated API key scope");
+    throw badRequest("projectId does not match the authenticated API key scope");
   }
 }
 
@@ -42,7 +42,7 @@ export function assertPositivePaymentAmount(amount: string): string {
   const normalized = amount.trim();
 
   if (!isDecimalString(normalized)) {
-    throw new AppError("BAD_REQUEST", "Invalid amount format");
+    throw badRequest("Invalid amount format");
   }
 
   // isDecimalString guarantees only digits and "." are present, so any non-zero digit
@@ -53,7 +53,7 @@ export function assertPositivePaymentAmount(amount: string): string {
     }
   }
 
-  throw new AppError("BAD_REQUEST", "Transfer amount must be greater than zero");
+  throw badRequest("Transfer amount must be greater than zero");
 }
 
 export function isNativePaymentToken(token: string): boolean {

--- a/apps/sdp-api/src/services/payments/decimal.ts
+++ b/apps/sdp-api/src/services/payments/decimal.ts
@@ -1,10 +1,10 @@
 import { isDecimalString } from "@/lib/amount";
-import { AppError } from "@/lib/errors";
+import { badRequest } from "@/lib/errors";
 
 function parseDecimalParts(value: string): { whole: string; fraction: string } {
   const normalized = value.trim();
   if (!isDecimalString(normalized)) {
-    throw new AppError("BAD_REQUEST", "Invalid amount format");
+    throw badRequest("Invalid amount format");
   }
 
   const [wholeRaw = "", fractionRaw = ""] = normalized.split(".");

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -3,7 +3,7 @@ import {
   createPaymentsRepository,
 } from "@/db/repositories";
 import type { PaymentRecurringPaymentRow } from "@/db/repositories/payment-recurring-payments.repository";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
 import { normalizePaymentToken, SOL_MINT } from "@/services/payment-operation.service";
 import { assertWalletPolicyAllowsTransferWithRepository } from "@/services/payments/wallet-policy";
@@ -14,7 +14,7 @@ import { resolveSolanaCounterpartyAccount } from "./counterparty-account-resolut
 function assertRecurringPaymentTokenMint(token: string): string {
   const normalized = normalizePaymentToken(token);
   if (normalized === "SOL" || normalized === SOL_MINT) {
-    throw new AppError("BAD_REQUEST", "Recurring payments require an SPL token mint");
+    throw badRequest("Recurring payments require an SPL token mint");
   }
 
   return assertValidAddress(normalized, "token");

--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -19,7 +19,7 @@ import type {
   TokenTransactionType,
 } from "@sdp/types";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
-import { AppError } from "@/lib/errors";
+import { AppError, badRequest } from "@/lib/errors";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Input Types
@@ -743,7 +743,7 @@ export class TokenService {
    */
   async createTransaction(input: CreateTokenTransactionInput): Promise<CreateTransactionResult> {
     if (input.idempotencyKey && !input.idempotencyFingerprint) {
-      throw new AppError("BAD_REQUEST", "Missing idempotency fingerprint for idempotency key");
+      throw badRequest("Missing idempotency fingerprint for idempotency key");
     }
 
     if (input.idempotencyKey) {

--- a/apps/sdp-web/src/app/dashboard/payments/payments-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-playground-config.ts
@@ -296,6 +296,12 @@ export function buildPaymentsPlaygroundEndpointConfigs({
           defaultValue: "moonpay",
           required: true,
         },
+        {
+          key: "counterpartyId",
+          label: "counterpartyId",
+          placeholder: "Counterparty ID (e.g. cpty_abc123)",
+          required: true,
+        },
         destinationWalletField,
         {
           key: "cryptoToken",
@@ -318,11 +324,6 @@ export function buildPaymentsPlaygroundEndpointConfigs({
           placeholder: "250.00",
           defaultValue: "250.00",
           required: true,
-        },
-        {
-          key: "kycReference",
-          label: "kycReference",
-          placeholder: "Optional KYC reference",
         },
         {
           key: "redirectUrl",
@@ -354,6 +355,12 @@ export function buildPaymentsPlaygroundEndpointConfigs({
           defaultValue: "moonpay",
           required: true,
         },
+        {
+          key: "counterpartyId",
+          label: "counterpartyId",
+          placeholder: "Counterparty ID (e.g. cpty_abc123)",
+          required: true,
+        },
         sourceWalletField,
         {
           key: "cryptoToken",
@@ -376,11 +383,6 @@ export function buildPaymentsPlaygroundEndpointConfigs({
           placeholder: "250.00",
           defaultValue: "250.00",
           required: true,
-        },
-        {
-          key: "kycReference",
-          label: "kycReference",
-          placeholder: "Optional KYC reference",
         },
         {
           key: "redirectUrl",

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -501,19 +501,25 @@ interface BasePaymentRampExecution {
   reference?: string;
 }
 
+export type LightsparkPaymentRampExecution = BasePaymentRampExecution & {
+  provider: "lightspark";
+  paymentInstructions?: LightsparkPaymentRampInstruction[];
+};
+
+export type BvnkPaymentRampExecution = BasePaymentRampExecution & {
+  provider: "bvnk";
+  paymentInstructions?: BvnkPaymentRampInstruction[];
+};
+
+export type MoonpayPaymentRampExecution = BasePaymentRampExecution & {
+  provider: "moonpay";
+  paymentInstructions?: never;
+};
+
 export type PaymentRampExecution =
-  | (BasePaymentRampExecution & {
-      provider: "lightspark";
-      paymentInstructions?: LightsparkPaymentRampInstruction[];
-    })
-  | (BasePaymentRampExecution & {
-      provider: "bvnk";
-      paymentInstructions?: BvnkPaymentRampInstruction[];
-    })
-  | (BasePaymentRampExecution & {
-      provider: Exclude<RampProviderId, "lightspark" | "bvnk">;
-      paymentInstructions?: never;
-    });
+  | LightsparkPaymentRampExecution
+  | BvnkPaymentRampExecution
+  | MoonpayPaymentRampExecution;
 
 interface BasePaymentRampQuote {
   id: string;


### PR DESCRIPTION
## What changed

### Error-handling cleanup (sdp-api)
- Migrated deprecated zod `error.flatten().fieldErrors` → `z.flattenError()`
- Replaced inline `new AppError("BAD_REQUEST", ...)` with the `badRequest` / `badRequestQuery` / `badRequestParams` helpers from `lib/errors` across handlers and services

### Ramps refactor
- **Per-provider execute contracts**: `executeOnramp`/`executeOfframp` moved off the generic `RampProvider` interface; each client (MoonPay / Lightspark / BVNK) declares its own input type and returns its narrow `PaymentRampExecution` member (now named types in `@sdp/types`). Removes the runtime "X is required for Y" checks and provider-side casts — invalid inputs are unrepresentable
- **BVNK onboarding split**: `ensureBvnkCustomer` (KYC: agreement → sign → create → verify, shared by on/offramp) and `ensureBvnkPaymentRule` (fiat wallet + payment rule provisioning, onramp only)
- Provider customers resolve from the counterparty: Lightspark → `LightsparkCustomerResolution`, BVNK → `BvnkCustomerResolution`; BVNK onramp passes `BvnkPaymentRuleResolution` into `executeOnramp` to build payment instructions
- Handler dispatch is an exhaustive per-provider switch in `executeOnrampWithProvider` / `executeOfframpWithProvider`
- BVNK payment webhooks now complete matching ramp transfers by rule id; `providerFetch` extracted for non-JSON provider responses

### API contract change (ramp execute endpoints only)
`POST /v1/payments/ramps/{onramp,offramp}/execute`:
- `counterpartyId` is now **required**
- `kycReference` is **removed** — provider customer identity is resolved server-side from the counterparty

Quote/estimate endpoints are unchanged. Blast radius is effectively zero: nothing calls the execute endpoints today — the v2 ramp wizards use the quote endpoints (and already send `counterpartyId`), and the API playground field configs are updated in this PR.

### Tests
- Payments tests updated to the new contract (counterparties seeded with provider customer state)
- Full suite green: 591 workers + 51 node
