### PR TITLE
feat(ramps): lightspark off-ramp via payout requirements and realtime-funded quotes

### DIFF
--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -192,6 +192,7 @@ export function createPostgresPaymentsRepository(db: AppDb): PaymentsRepository 
                slot = ?,
                block_time = ?,
                fee = ?,
+               fiat_amount = ?,
                error = ?,
                updated_at = ?
            WHERE id = ?`
@@ -203,6 +204,7 @@ export function createPostgresPaymentsRepository(db: AppDb): PaymentsRepository 
           input.slot ?? existing.slot,
           input.blockTime ?? existing.block_time,
           input.fee ?? existing.fee,
+          input.fiatAmount ?? existing.fiat_amount,
           input.error ?? existing.error,
           input.updatedAt,
           input.transferId

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -102,6 +102,7 @@ export interface UpdatePaymentTransferInput {
   slot?: number | null;
   blockTime?: string | null;
   fee?: number | null;
+  fiatAmount?: string | null;
   error?: string | null;
   updatedAt: string;
 }

--- a/apps/sdp-api/src/lib/ramps/fetch.ts
+++ b/apps/sdp-api/src/lib/ramps/fetch.ts
@@ -54,11 +54,13 @@ export async function providerFetch<TBody = never>(
   return { response, raw, parsed };
 }
 
-function assertProviderResponseOk(
+export async function providerFetchJson<TResponse, TBody = never>(
   provider: RampProviderId,
-  response: Response,
-  parsed: unknown
-): void {
+  url: string,
+  init: ProviderRequestInit<TBody>
+): Promise<TResponse> {
+  const { response, parsed } = await providerFetch(provider, url, init);
+
   if (!response.ok) {
     throw new AppError(
       classifyProviderStatus(response.status),
@@ -69,16 +71,6 @@ function assertProviderResponseOk(
       { provider, providerStatus: response.status }
     );
   }
-}
-
-export async function providerFetchJson<TResponse, TBody = never>(
-  provider: RampProviderId,
-  url: string,
-  init: ProviderRequestInit<TBody>
-): Promise<TResponse> {
-  const { response, parsed } = await providerFetch(provider, url, init);
-
-  assertProviderResponseOk(provider, response, parsed);
 
   if (parsed === undefined) {
     throw new AppError("PROVIDER_UNAVAILABLE", `${provider} returned an unparseable response`, {
@@ -87,14 +79,4 @@ export async function providerFetchJson<TResponse, TBody = never>(
   }
 
   return parsed as TResponse;
-}
-
-/** For endpoints that succeed with no body (e.g. 204 deletes), which providerFetchJson rejects. */
-export async function providerFetchNoContent<TBody = never>(
-  provider: RampProviderId,
-  url: string,
-  init: ProviderRequestInit<TBody>
-): Promise<void> {
-  const { response, parsed } = await providerFetch(provider, url, init);
-  assertProviderResponseOk(provider, response, parsed);
 }

--- a/apps/sdp-api/src/lib/ramps/fetch.ts
+++ b/apps/sdp-api/src/lib/ramps/fetch.ts
@@ -54,13 +54,11 @@ export async function providerFetch<TBody = never>(
   return { response, raw, parsed };
 }
 
-export async function providerFetchJson<TResponse, TBody = never>(
+function assertProviderResponseOk(
   provider: RampProviderId,
-  url: string,
-  init: ProviderRequestInit<TBody>
-): Promise<TResponse> {
-  const { response, parsed } = await providerFetch(provider, url, init);
-
+  response: Response,
+  parsed: unknown
+): void {
   if (!response.ok) {
     throw new AppError(
       classifyProviderStatus(response.status),
@@ -71,6 +69,16 @@ export async function providerFetchJson<TResponse, TBody = never>(
       { provider, providerStatus: response.status }
     );
   }
+}
+
+export async function providerFetchJson<TResponse, TBody = never>(
+  provider: RampProviderId,
+  url: string,
+  init: ProviderRequestInit<TBody>
+): Promise<TResponse> {
+  const { response, parsed } = await providerFetch(provider, url, init);
+
+  assertProviderResponseOk(provider, response, parsed);
 
   if (parsed === undefined) {
     throw new AppError("PROVIDER_UNAVAILABLE", `${provider} returned an unparseable response`, {
@@ -79,4 +87,14 @@ export async function providerFetchJson<TResponse, TBody = never>(
   }
 
   return parsed as TResponse;
+}
+
+/** For endpoints that succeed with no body (e.g. 204 deletes), which providerFetchJson rejects. */
+export async function providerFetchNoContent<TBody = never>(
+  provider: RampProviderId,
+  url: string,
+  init: ProviderRequestInit<TBody>
+): Promise<void> {
+  const { response, parsed } = await providerFetch(provider, url, init);
+  assertProviderResponseOk(provider, response, parsed);
 }

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LightsparkRampClient } from "./lightspark";
+import { LightsparkRampClient, lightsparkPayoutAccountKey } from "./lightspark";
 
 const LIGHTSPARK_GRID_API_BASE_URL = "https://api.lightspark.com/grid/2025-10-13";
 const LIGHTSPARK_CONTEXT = {
@@ -260,5 +260,27 @@ describe("LightsparkRampClient", () => {
       `${LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts`
     );
     expect(account).toEqual({ id: "ExternalAccount:acc_payout_123", status: "ACTIVE" });
+  });
+
+  it("derives content-addressed payout account keys", async () => {
+    const key = await lightsparkPayoutAccountKey("USD", {
+      paymentRails: "ACH",
+      routingNumber: "021000021",
+      accountNumber: "12345678901",
+    });
+    const reordered = await lightsparkPayoutAccountKey("USD", {
+      accountNumber: " 12345678901 ",
+      routingNumber: "021000021",
+      paymentRails: "ACH",
+    });
+    const differentDetails = await lightsparkPayoutAccountKey("USD", {
+      paymentRails: "ACH",
+      routingNumber: "021000021",
+      accountNumber: "99999999999",
+    });
+
+    expect(key.startsWith("USD:")).toBe(true);
+    expect(reordered).toBe(key);
+    expect(differentDetails).not.toBe(key);
   });
 });

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -261,4 +261,19 @@ describe("LightsparkRampClient", () => {
     );
     expect(account).toEqual({ id: "ExternalAccount:acc_payout_123", status: "ACTIVE" });
   });
+
+  it("deletes external accounts and accepts the empty 204 body", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await new LightsparkRampClient().deleteExternalAccount(LIGHTSPARK_CONTEXT, {
+      accountId: "ExternalAccount:acc_payout_123",
+    });
+
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      `${LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts/ExternalAccount%3Aacc_payout_123`
+    );
+    expect(fetchSpy.mock.calls[0]?.[1]?.method).toBe("DELETE");
+  });
 });

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -261,19 +261,4 @@ describe("LightsparkRampClient", () => {
     );
     expect(account).toEqual({ id: "ExternalAccount:acc_payout_123", status: "ACTIVE" });
   });
-
-  it("deletes external accounts and accepts the empty 204 body", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(null, { status: 204 }));
-
-    await new LightsparkRampClient().deleteExternalAccount(LIGHTSPARK_CONTEXT, {
-      accountId: "ExternalAccount:acc_payout_123",
-    });
-
-    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
-      `${LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts/ExternalAccount%3Aacc_payout_123`
-    );
-    expect(fetchSpy.mock.calls[0]?.[1]?.method).toBe("DELETE");
-  });
 });

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -165,4 +165,100 @@ describe("LightsparkRampClient", () => {
       symbol: "$",
     });
   });
+
+  it("creates realtime-funded off-ramp quotes against the payout account", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "Quote:ls_offramp_123",
+          quoteStatus: "PENDING",
+          paymentInstructions: [
+            {
+              accountOrWalletInfo: {
+                infoType: "CRYPTO_WALLET_INFO",
+                accountType: "SOLANA_WALLET",
+                address: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+              },
+            },
+          ],
+          exchangeRate: 1,
+          totalSendingAmount: 25000000,
+          sendingCurrency: { code: "USDC", decimals: 6, name: "USD Coin", symbol: "$" },
+          totalReceivingAmount: 2490,
+          receivingCurrency: { code: "USD", decimals: 2, name: "US Dollar", symbol: "$" },
+          feesIncluded: 10,
+          expiresAt: "2026-06-11T09:45:00.000Z",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    const quote = await new LightsparkRampClient().createOfframpQuote(LIGHTSPARK_CONTEXT, {
+      customerId: "Customer:cus_123",
+      externalCustomerId: "counterparty_123",
+      payoutAccountId: "ExternalAccount:acc_payout_123",
+      sourceWalletAddress: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+      cryptoToken: "USDC",
+      fiatCurrency: "USD",
+      cryptoAmount: "25",
+    });
+
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(`${LIGHTSPARK_GRID_API_BASE_URL}/quotes`);
+    const body = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body));
+    expect(body).toEqual({
+      source: {
+        sourceType: "REALTIME_FUNDING",
+        customerId: "Customer:cus_123",
+        currency: "USDC",
+        cryptoNetwork: "SOLANA",
+      },
+      destination: {
+        destinationType: "ACCOUNT",
+        accountId: "ExternalAccount:acc_payout_123",
+        currency: "USD",
+      },
+      lockedCurrencySide: "SENDING",
+      lockedCurrencyAmount: 25000000,
+      description: "SDP offramp",
+    });
+
+    expect(quote.provider).toBe("lightspark");
+    if (quote.provider !== "lightspark") {
+      throw new Error("Expected Lightspark quote");
+    }
+    expect(quote.id).toBe("Quote:ls_offramp_123");
+    expect(quote.status).toBe("pending");
+    expect(quote.deliveryMode).toBe("manual_instructions");
+    expect(quote.paymentInstructions).toHaveLength(1);
+    expect(quote.totalReceivingAmount).toBe(2490);
+  });
+
+  it("creates fiat external payout accounts and parses id + status", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "ExternalAccount:acc_payout_123", status: "ACTIVE" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const account = await new LightsparkRampClient().createFiatExternalAccount(LIGHTSPARK_CONTEXT, {
+      customerId: "Customer:cus_123",
+      currency: "USD",
+      accountInfo: {
+        accountType: "USD_ACCOUNT",
+        paymentRails: ["ACH"],
+        routingNumber: "021000021",
+        accountNumber: "12345678901",
+        beneficiary: { beneficiaryType: "INDIVIDUAL", fullName: "Ada Lovelace" },
+      },
+    });
+
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      `${LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts`
+    );
+    expect(account).toEqual({ id: "ExternalAccount:acc_payout_123", status: "ACTIVE" });
+  });
 });

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -247,6 +247,7 @@ describe("LightsparkRampClient", () => {
     const account = await new LightsparkRampClient().createFiatExternalAccount(LIGHTSPARK_CONTEXT, {
       customerId: "Customer:cus_123",
       currency: "USD",
+      platformAccountId: "cp_123:USD:ab12cd34ef56ab12",
       accountInfo: {
         accountType: "USD_ACCOUNT",
         paymentRails: ["ACH"],
@@ -259,7 +260,59 @@ describe("LightsparkRampClient", () => {
     expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
       `${LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts`
     );
+    const body = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body));
+    expect(body.platformAccountId).toBe("cp_123:USD:ab12cd34ef56ab12");
     expect(account).toEqual({ id: "ExternalAccount:acc_payout_123", status: "ACTIVE" });
+  });
+
+  it("converges on the existing payout account when Grid returns 409", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "External account already exists" }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "ExternalAccount:acc_existing_123",
+                status: "ACTIVE",
+                platformAccountId: "cp_123:USD:ab12cd34ef56ab12",
+                accountInfo: { accountType: "USD_ACCOUNT" },
+              },
+            ],
+            hasMore: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+    const account = await new LightsparkRampClient().getOrCreateFiatExternalAccount(
+      LIGHTSPARK_CONTEXT,
+      {
+        customerId: "Customer:cus_123",
+        currency: "USD",
+        platformAccountId: "cp_123:USD:ab12cd34ef56ab12",
+        accountInfo: {
+          accountType: "USD_ACCOUNT",
+          paymentRails: ["ACH"],
+          routingNumber: "021000021",
+          accountNumber: "12345678901",
+          beneficiary: { beneficiaryType: "INDIVIDUAL", fullName: "Ada Lovelace" },
+        },
+      }
+    );
+
+    const listUrl = new URL(String(fetchSpy.mock.calls[1]?.[0]));
+    expect(`${listUrl.origin}${listUrl.pathname}`).toBe(
+      `${LIGHTSPARK_GRID_API_BASE_URL}/customers/external-accounts`
+    );
+    expect(listUrl.searchParams.get("customerId")).toBe("Customer:cus_123");
+    expect(account).toEqual({ id: "ExternalAccount:acc_existing_123", status: "ACTIVE" });
   });
 
   it("derives content-addressed payout account keys", async () => {

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -21,7 +21,7 @@ import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
 import { isAddress } from "@/lib/solana";
-import { type ProviderRequestInit, providerFetchJson, providerFetchNoContent } from "../fetch";
+import { type ProviderRequestInit, providerFetchJson } from "../fetch";
 import {
   basicAuthHeader,
   createProviderRampSupport,
@@ -676,17 +676,15 @@ export class LightsparkRampClient implements RampProvider {
     return { provider: this.id, kind, reference };
   }
 
-  private requestUrl(config: LightsparkConfig, path: string): string {
-    const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
-    return new URL(path, base).toString();
-  }
-
   private async request<TResponse, TBody = never>(
     config: LightsparkConfig,
     path: string,
     init: ProviderRequestInit<TBody>
   ): Promise<TResponse> {
-    return providerFetchJson<TResponse, TBody>(this.id, this.requestUrl(config, path), {
+    const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
+    const url = new URL(path, base);
+
+    return providerFetchJson<TResponse, TBody>(this.id, url.toString(), {
       ...init,
       headers: {
         Authorization: basicAuthHeader(config.tokenId, config.clientSecret),
@@ -1013,22 +1011,6 @@ export class LightsparkRampClient implements RampProvider {
       { method: "GET" }
     );
     return parseLightsparkExternalAccountResolution(response);
-  }
-
-  /** Deletes a payout account that lost a concurrent-creation race, so it is not orphaned at Grid. */
-  async deleteExternalAccount(
-    { env, mode }: RampRuntimeContext,
-    input: { accountId: string }
-  ): Promise<void> {
-    const config = readLightsparkConfig(env, mode);
-    await providerFetchNoContent(
-      this.id,
-      this.requestUrl(config, `customers/external-accounts/${encodeURIComponent(input.accountId)}`),
-      {
-        method: "DELETE",
-        headers: { Authorization: basicAuthHeader(config.tokenId, config.clientSecret) },
-      }
-    );
   }
 
   /**

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -143,6 +143,27 @@ interface LightsparkOutgoingPaymentData {
   status: string;
   quoteId: string;
   failureReason?: string;
+  receivedAmount?: { amount: number; decimals: number };
+}
+
+function readOptionalGridAmount(
+  record: Record<string, unknown>,
+  field: string
+): { amount: number; decimals: number } | undefined {
+  const value = record[field];
+  if (!isGridRecord(value)) {
+    return undefined;
+  }
+  const amount = value.amount;
+  const currency = value.currency;
+  if (!Number.isInteger(amount) || typeof amount !== "number" || !isGridRecord(currency)) {
+    return undefined;
+  }
+  const decimals = currency.decimals;
+  if (!Number.isInteger(decimals) || typeof decimals !== "number") {
+    return undefined;
+  }
+  return { amount, decimals };
 }
 
 interface LightsparkOutgoingPaymentWebhook {
@@ -219,6 +240,7 @@ function parseLightsparkOutgoingPaymentWebhook(
       status: readRequiredGridString(data, "status", "Lightspark outgoing payment webhook data"),
       quoteId: readRequiredGridString(data, "quoteId", "Lightspark outgoing payment webhook data"),
       failureReason: readOptionalGridString(data, "failureReason"),
+      receivedAmount: readOptionalGridAmount(data, "receivedAmount"),
     },
   };
 }
@@ -728,6 +750,17 @@ export class LightsparkRampClient implements RampProvider {
     const kind = LIGHTSPARK_OUTGOING_PAYMENT_WEBHOOK_TYPES[webhook.type];
     if (kind === "failed" || kind === "expired") {
       return { provider: this.id, kind, reference, error: webhook.data.failureReason };
+    }
+    if (kind === "settled" && webhook.data.receivedAmount) {
+      return {
+        provider: this.id,
+        kind,
+        reference,
+        receivedAmount: formatDecimalAmount(
+          BigInt(webhook.data.receivedAmount.amount),
+          webhook.data.receivedAmount.decimals
+        ),
+      };
     }
     return { provider: this.id, kind, reference };
   }

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -17,9 +17,10 @@ import {
   getCryptoRailAssetLabel,
   parseFiatCurrency,
 } from "@sdp/types/payment-rails";
-import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
+import type { CollectedFieldData, CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
+import { hashString } from "@/lib/hash";
 import { isAddress } from "@/lib/solana";
 import { type ProviderRequestInit, providerFetchJson } from "../fetch";
 import {
@@ -280,8 +281,26 @@ export interface LightsparkPayoutAccount {
   status: string;
 }
 
+export interface LightsparkPayoutAccountEntry extends LightsparkPayoutAccount {
+  /** `${fiatCurrency}:${hash(accountInfo)}` — content-addressed so distinct bank details map to distinct Grid accounts. */
+  key: string;
+  createdAt: string;
+}
+
 export function isLightsparkExternalAccountActive(status: string): boolean {
   return status.trim().toUpperCase() === "ACTIVE";
+}
+
+/** Cache key for a payout account: same collected details always map to the same key, distinct details never collide. */
+export async function lightsparkPayoutAccountKey(
+  fiatCurrency: string,
+  collectedData: CollectedFieldData
+): Promise<string> {
+  const fields = Object.entries(collectedData)
+    .map(([key, value]) => `${key}=${value.trim()}`)
+    .sort()
+    .join("&");
+  return `${fiatCurrency}:${(await hashString(fields)).slice(0, 16)}`;
 }
 
 export function readLightsparkData(
@@ -307,19 +326,49 @@ export function readLightsparkPayoutAccounts(
     : {};
 }
 
-export function readLightsparkPayoutAccount(
+function parseLightsparkPayoutAccountEntry(
+  key: string,
+  value: unknown
+): LightsparkPayoutAccountEntry {
+  const { accountId, status, createdAt } = value as {
+    accountId?: unknown;
+    status?: unknown;
+    createdAt?: unknown;
+  };
+  if (
+    typeof accountId !== "string" ||
+    accountId.length === 0 ||
+    typeof status !== "string" ||
+    typeof createdAt !== "string"
+  ) {
+    throw new AppError(
+      "INTERNAL_ERROR",
+      `Malformed lightspark payout account entry "${key}" in provider_data`
+    );
+  }
+  return { key, accountId, status, createdAt };
+}
+
+export function readLightsparkPayoutAccountByKey(
+  providerData: CounterpartyProviderData,
+  key: string
+): LightsparkPayoutAccountEntry | null {
+  const value = readLightsparkPayoutAccounts(providerData)[key];
+  if (value === undefined) {
+    return null;
+  }
+  return parseLightsparkPayoutAccountEntry(key, value);
+}
+
+export function latestLightsparkPayoutAccount(
   providerData: CounterpartyProviderData,
   fiatCurrency: string
-): LightsparkPayoutAccount | null {
-  const entry = readLightsparkPayoutAccounts(providerData)[fiatCurrency];
-  if (!entry || typeof entry !== "object") {
-    return null;
-  }
-  const { accountId, status } = entry as { accountId?: unknown; status?: unknown };
-  if (typeof accountId !== "string" || accountId.length === 0 || typeof status !== "string") {
-    return null;
-  }
-  return { accountId, status };
+): LightsparkPayoutAccountEntry | null {
+  const entries = Object.entries(readLightsparkPayoutAccounts(providerData))
+    .filter(([key]) => key.startsWith(`${fiatCurrency}:`))
+    .map(([key, value]) => parseLightsparkPayoutAccountEntry(key, value))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return entries[0] ?? null;
 }
 
 export type LightsparkCustomerType = "INDIVIDUAL" | "BUSINESS";

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -21,7 +21,7 @@ import type { CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
 import { isAddress } from "@/lib/solana";
-import { type ProviderRequestInit, providerFetchJson } from "../fetch";
+import { type ProviderRequestInit, providerFetchJson, providerFetchNoContent } from "../fetch";
 import {
   basicAuthHeader,
   createProviderRampSupport,
@@ -676,15 +676,17 @@ export class LightsparkRampClient implements RampProvider {
     return { provider: this.id, kind, reference };
   }
 
+  private requestUrl(config: LightsparkConfig, path: string): string {
+    const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
+    return new URL(path, base).toString();
+  }
+
   private async request<TResponse, TBody = never>(
     config: LightsparkConfig,
     path: string,
     init: ProviderRequestInit<TBody>
   ): Promise<TResponse> {
-    const base = config.apiBaseUrl.endsWith("/") ? config.apiBaseUrl : `${config.apiBaseUrl}/`;
-    const url = new URL(path, base);
-
-    return providerFetchJson<TResponse, TBody>(this.id, url.toString(), {
+    return providerFetchJson<TResponse, TBody>(this.id, this.requestUrl(config, path), {
       ...init,
       headers: {
         Authorization: basicAuthHeader(config.tokenId, config.clientSecret),
@@ -1011,6 +1013,22 @@ export class LightsparkRampClient implements RampProvider {
       { method: "GET" }
     );
     return parseLightsparkExternalAccountResolution(response);
+  }
+
+  /** Deletes a payout account that lost a concurrent-creation race, so it is not orphaned at Grid. */
+  async deleteExternalAccount(
+    { env, mode }: RampRuntimeContext,
+    input: { accountId: string }
+  ): Promise<void> {
+    const config = readLightsparkConfig(env, mode);
+    await providerFetchNoContent(
+      this.id,
+      this.requestUrl(config, `customers/external-accounts/${encodeURIComponent(input.accountId)}`),
+      {
+        method: "DELETE",
+        headers: { Authorization: basicAuthHeader(config.tokenId, config.clientSecret) },
+      }
+    );
   }
 
   /**

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -225,6 +225,8 @@ function parseLightsparkOutgoingPaymentWebhook(
 
 interface LightsparkExternalAccount {
   id?: string;
+  status?: string;
+  platformAccountId?: string;
   accountInfo?: { accountType?: string; address?: string };
 }
 
@@ -251,10 +253,15 @@ function parseLightsparkExternalAccount(payload: unknown): LightsparkExternalAcc
   }
   const raw = payload as {
     id?: unknown;
+    status?: unknown;
+    platformAccountId?: unknown;
     accountInfo?: { accountType?: unknown; address?: unknown };
   };
   return {
     id: typeof raw.id === "string" ? raw.id : undefined,
+    status: typeof raw.status === "string" ? raw.status : undefined,
+    platformAccountId:
+      typeof raw.platformAccountId === "string" ? raw.platformAccountId : undefined,
     accountInfo:
       raw.accountInfo && typeof raw.accountInfo === "object"
         ? {
@@ -1031,7 +1038,12 @@ export class LightsparkRampClient implements RampProvider {
   /** Creates a fiat external payout account for a Grid customer. */
   async createFiatExternalAccount(
     { env, mode }: RampRuntimeContext,
-    input: { customerId: string; currency: string; accountInfo: Record<string, unknown> }
+    input: {
+      customerId: string;
+      currency: string;
+      platformAccountId: string;
+      accountInfo: Record<string, unknown>;
+    }
   ): Promise<LightsparkExternalAccountResolution> {
     const config = readLightsparkConfig(env, mode);
     const response = await this.request<unknown, Record<string, unknown>>(
@@ -1042,11 +1054,46 @@ export class LightsparkRampClient implements RampProvider {
         body: {
           customerId: input.customerId,
           currency: input.currency,
+          platformAccountId: input.platformAccountId,
           accountInfo: input.accountInfo,
         },
       }
     );
     return parseLightsparkExternalAccountResolution(response);
+  }
+
+  /**
+   * Idempotent payout-account creation keyed on platformAccountId. Grid rejects
+   * a duplicate with 409 ("External account already exists"); we recover by
+   * returning the account that already carries our id, so concurrent callers
+   * converge instead of orphaning one.
+   */
+  async getOrCreateFiatExternalAccount(
+    ctx: RampRuntimeContext,
+    input: {
+      customerId: string;
+      currency: string;
+      platformAccountId: string;
+      accountInfo: Record<string, unknown>;
+    }
+  ): Promise<LightsparkExternalAccountResolution> {
+    try {
+      return await this.createFiatExternalAccount(ctx, input);
+    } catch (error) {
+      if (error instanceof AppError && error.code === "CONFLICT") {
+        const config = readLightsparkConfig(ctx.env, ctx.mode);
+        const existing = await this.findCustomerExternalAccount(
+          config,
+          input.customerId,
+          input.currency,
+          (account) => account.platformAccountId === input.platformAccountId
+        );
+        if (existing?.id && existing.status) {
+          return { id: existing.id, status: existing.status };
+        }
+      }
+      throw error;
+    }
   }
 
   async getExternalAccount(

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -1,6 +1,7 @@
 import { createVerify } from "node:crypto";
 import type {
   Counterparty,
+  CounterpartyProviderData,
   LightsparkPaymentRampExecution,
   LightsparkPaymentRampInstruction,
   PaymentRampEstimate,
@@ -21,7 +22,6 @@ import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
 import { isAddress } from "@/lib/solana";
 import { type ProviderRequestInit, providerFetchJson } from "../fetch";
-import { readyCounterparty } from "../requirements";
 import {
   basicAuthHeader,
   createProviderRampSupport,
@@ -45,6 +45,7 @@ import type {
   RampWebhookValidationResult,
   ValidateCounterpartyOptions,
 } from "../types";
+import { lightsparkCounterpartyRequirements } from "../validation/lightspark";
 
 const LIGHTSPARK_DEFAULT_GRID_API_URL = "https://api.lightspark.com/grid/2025-10-13";
 const GRID_EXCHANGE_RATE_DEFAULT_REQUEST_SENDING_AMOUNT = 10_000n;
@@ -226,6 +227,23 @@ interface LightsparkExternalAccount {
   accountInfo?: { accountType?: string; address?: string };
 }
 
+export interface LightsparkExternalAccountResolution {
+  id: string;
+  status: string;
+}
+
+function parseLightsparkExternalAccountResolution(
+  payload: unknown
+): LightsparkExternalAccountResolution {
+  if (!isGridRecord(payload)) {
+    throw badRequest("Lightspark external account response must be an object");
+  }
+  return {
+    id: readRequiredGridString(payload, "id", "Lightspark external account"),
+    status: readRequiredGridString(payload, "status", "Lightspark external account"),
+  };
+}
+
 function parseLightsparkExternalAccount(payload: unknown): LightsparkExternalAccount {
   if (typeof payload !== "object" || payload === null) {
     return {};
@@ -255,6 +273,53 @@ export interface LightsparkConfig {
   tokenId: string;
   clientSecret: string;
   apiBaseUrl: string;
+}
+
+export interface LightsparkPayoutAccount {
+  accountId: string;
+  status: string;
+}
+
+export function isLightsparkExternalAccountActive(status: string): boolean {
+  return status.trim().toUpperCase() === "ACTIVE";
+}
+
+export function readLightsparkData(
+  providerData: CounterpartyProviderData
+): Record<string, unknown> {
+  const lightspark = providerData.lightspark;
+  return lightspark && typeof lightspark === "object"
+    ? (lightspark as Record<string, unknown>)
+    : {};
+}
+
+export function readLightsparkCustomerId(providerData: CounterpartyProviderData): string | null {
+  const customerId = readLightsparkData(providerData).customerId;
+  return typeof customerId === "string" && customerId.length > 0 ? customerId : null;
+}
+
+export function readLightsparkPayoutAccounts(
+  providerData: CounterpartyProviderData
+): Record<string, unknown> {
+  const payoutAccounts = readLightsparkData(providerData).payoutAccounts;
+  return payoutAccounts && typeof payoutAccounts === "object"
+    ? (payoutAccounts as Record<string, unknown>)
+    : {};
+}
+
+export function readLightsparkPayoutAccount(
+  providerData: CounterpartyProviderData,
+  fiatCurrency: string
+): LightsparkPayoutAccount | null {
+  const entry = readLightsparkPayoutAccounts(providerData)[fiatCurrency];
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+  const { accountId, status } = entry as { accountId?: unknown; status?: unknown };
+  if (typeof accountId !== "string" || accountId.length === 0 || typeof status !== "string") {
+    return null;
+  }
+  return { accountId, status };
 }
 
 export type LightsparkCustomerType = "INDIVIDUAL" | "BUSINESS";
@@ -310,6 +375,8 @@ interface GridCreateQuoteBody {
     sourceType: "REALTIME_FUNDING";
     customerId: string;
     currency: string;
+    /** Required by Grid when `currency` is a stablecoin — which deposit network to generate. */
+    cryptoNetwork?: "SOLANA";
   };
   destination: {
     destinationType: "ACCOUNT";
@@ -499,10 +566,10 @@ export class LightsparkRampClient implements RampProvider {
   readonly id = "lightspark";
 
   validateCounterparty(
-    _counterparty: Counterparty,
+    counterparty: Counterparty,
     options: ValidateCounterpartyOptions
   ): CounterpartyRequirements {
-    return readyCounterparty(this.id, options.direction);
+    return lightsparkCounterpartyRequirements(counterparty, options);
   }
 
   async _discoverRails({
@@ -891,6 +958,10 @@ export class LightsparkRampClient implements RampProvider {
       fiatAmountMinorUnits,
     });
 
+    return this.toRampQuote(quote);
+  }
+
+  private toRampQuote(quote: LightsparkQuote): PaymentRampQuote {
     return {
       provider: "lightspark",
       id: quote.id,
@@ -908,14 +979,91 @@ export class LightsparkRampClient implements RampProvider {
     };
   }
 
-  async createOfframpQuote(
-    _ctx: RampRuntimeContext,
-    _input: RampOfframpQuoteInput
-  ): Promise<PaymentRampQuote> {
-    throw new AppError(
-      "BAD_REQUEST",
-      "Lightspark off-ramp quotes require payout bank details, which aren't collected yet."
+  /** Creates a fiat external payout account for a Grid customer. */
+  async createFiatExternalAccount(
+    { env, mode }: RampRuntimeContext,
+    input: { customerId: string; currency: string; accountInfo: Record<string, unknown> }
+  ): Promise<LightsparkExternalAccountResolution> {
+    const config = readLightsparkConfig(env, mode);
+    const response = await this.request<unknown, Record<string, unknown>>(
+      config,
+      "customers/external-accounts",
+      {
+        method: "POST",
+        body: {
+          customerId: input.customerId,
+          currency: input.currency,
+          accountInfo: input.accountInfo,
+        },
+      }
     );
+    return parseLightsparkExternalAccountResolution(response);
+  }
+
+  async getExternalAccount(
+    { env, mode }: RampRuntimeContext,
+    input: { accountId: string }
+  ): Promise<LightsparkExternalAccountResolution> {
+    const config = readLightsparkConfig(env, mode);
+    const response = await this.request<unknown>(
+      config,
+      `customers/external-accounts/${encodeURIComponent(input.accountId)}`,
+      { method: "GET" }
+    );
+    return parseLightsparkExternalAccountResolution(response);
+  }
+
+  /**
+   * Creates a just-in-time (real-time funded) off-ramp quote: the customer
+   * funds it by sending crypto to the returned payment instructions, and Grid
+   * auto-executes into the fiat payout account at the locked rate.
+   */
+  async createOfframpQuote(
+    { env, mode }: RampRuntimeContext,
+    input: RampOfframpQuoteInput
+  ): Promise<PaymentRampQuote> {
+    if (!input.customerId) {
+      throw badRequest("Lightspark off-ramp requires a resolved customerId");
+    }
+    if (!input.payoutAccountId) {
+      throw badRequest("Lightspark off-ramp requires a resolved payoutAccountId");
+    }
+    if (!input.fiatCurrency) {
+      throw badRequest("fiatCurrency is required for Lightspark off-ramp.");
+    }
+    const config = readLightsparkConfig(env, mode);
+    const cryptoCurrency = normalizeLightsparkCurrencyCode(input.cryptoToken);
+    if (!isSolanaCryptoAsset(cryptoCurrency)) {
+      throw badRequest(
+        `Lightspark off-ramp from an SDP wallet supports Solana assets only; got ${cryptoCurrency}.`
+      );
+    }
+    const cryptoAmountMinorUnits = toLightsparkMinorUnitsInteger(
+      parseDecimalAmount(input.cryptoAmount, getLightsparkCurrencyDecimals(cryptoCurrency)),
+      "cryptoAmount"
+    );
+
+    const response = await this.request<GridQuoteResponse, GridCreateQuoteBody>(config, "quotes", {
+      method: "POST",
+      body: {
+        source: {
+          sourceType: "REALTIME_FUNDING",
+          customerId: input.customerId,
+          currency: cryptoCurrency,
+          cryptoNetwork: "SOLANA",
+        },
+        destination: {
+          destinationType: "ACCOUNT",
+          accountId: input.payoutAccountId,
+          currency: input.fiatCurrency,
+        },
+        lockedCurrencySide: "SENDING",
+        lockedCurrencyAmount: cryptoAmountMinorUnits,
+        description: "SDP offramp",
+      },
+    });
+
+    return this.toRampQuote(parseLightsparkQuote(response));
   }
 
   async executeOnramp(

--- a/apps/sdp-api/src/lib/ramps/types.ts
+++ b/apps/sdp-api/src/lib/ramps/types.ts
@@ -75,7 +75,11 @@ interface BaseRampSettlementEvent {
 export type RampSettlementEvent =
   | (BaseRampSettlementEvent & { kind: "awaiting_payment" })
   | (BaseRampSettlementEvent & { kind: "settling" })
-  | (BaseRampSettlementEvent & { kind: "settled" })
+  | (BaseRampSettlementEvent & {
+      kind: "settled";
+      /** Amount the receiving side settled for, in display units — fiat for off-ramp, crypto for on-ramp. */
+      receivedAmount?: string;
+    })
   | (BaseRampSettlementEvent & { kind: "failed"; error?: string })
   | (BaseRampSettlementEvent & { kind: "expired"; error?: string })
   | { provider: RampProviderId; kind: "ignore"; reason: string };

--- a/apps/sdp-api/src/lib/ramps/types.ts
+++ b/apps/sdp-api/src/lib/ramps/types.ts
@@ -122,6 +122,8 @@ export interface RampOfframpQuoteInput {
   sourceWalletAddress: string;
   externalCustomerId: string;
   customerId?: string;
+  /** Handler-resolved Grid external payout account id (Lightspark). */
+  payoutAccountId?: string;
   redirectUrl?: string;
   bvnkCompliance?: BvnkComplianceInput;
 }
@@ -129,6 +131,7 @@ export interface RampOfframpQuoteInput {
 export interface ValidateCounterpartyOptions {
   direction: RampDirection;
   providerData: CounterpartyProviderData;
+  fiatCurrency?: RampFiatCurrency;
 }
 
 export interface RampProviderClient {

--- a/apps/sdp-api/src/lib/ramps/validation/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/lightspark.test.ts
@@ -108,7 +108,11 @@ describe("lightsparkCounterpartyRequirements", () => {
         lightspark: {
           customerId: "Customer:cus_123",
           payoutAccounts: {
-            USD: { accountId: "ExternalAccount:acc_payout_123", status: "ACTIVE" },
+            "USD:ab12cd34ef56ab12": {
+              accountId: "ExternalAccount:acc_payout_123",
+              status: "ACTIVE",
+              createdAt: "2026-06-11T00:00:00.000Z",
+            },
           },
         },
       },

--- a/apps/sdp-api/src/lib/ramps/validation/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/lightspark.test.ts
@@ -1,0 +1,202 @@
+import type { Counterparty } from "@sdp/types";
+import { describe, expect, it } from "vitest";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import { AppError } from "@/lib/errors";
+import { buildLightsparkAccountInfo, lightsparkCounterpartyRequirements } from "./lightspark";
+
+function counterparty(overrides?: Partial<Counterparty>): Counterparty {
+  return {
+    id: "cp_123",
+    organizationId: "org_123",
+    projectId: "proj_123",
+    externalId: null,
+    entityType: "individual",
+    displayName: "Ada Lovelace",
+    email: "ada@example.com",
+    identity: {},
+    status: "active",
+    createdBy: null,
+    createdAt: "2026-06-11T00:00:00.000Z",
+    updatedAt: "2026-06-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function counterpartyRow(overrides?: Partial<CounterpartyRow>): CounterpartyRow {
+  return {
+    id: "cp_123",
+    organization_id: "org_123",
+    project_id: "proj_123",
+    external_id: null,
+    entity_type: "individual",
+    display_name: "Ada Lovelace",
+    email: "ada@example.com",
+    identity: {},
+    provider_data: {},
+    status: "active",
+    created_by: null,
+    created_at: "2026-06-11T00:00:00.000Z",
+    updated_at: "2026-06-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("lightsparkCounterpartyRequirements", () => {
+  it("returns ready for onramp", () => {
+    expect(
+      lightsparkCounterpartyRequirements(counterparty(), {
+        direction: "onramp",
+        providerData: {},
+      })
+    ).toEqual({ provider: "lightspark", direction: "onramp", status: "ready" });
+  });
+
+  it("requires fiatCurrency for offramp", () => {
+    expect(() =>
+      lightsparkCounterpartyRequirements(counterparty(), {
+        direction: "offramp",
+        providerData: {},
+      })
+    ).toThrowError(AppError);
+  });
+
+  it("collects USD payout bank fields including the rail select", () => {
+    const requirements = lightsparkCounterpartyRequirements(counterparty(), {
+      direction: "offramp",
+      providerData: {},
+      fiatCurrency: "USD",
+    });
+
+    expect(requirements.status).toBe("collect");
+    if (requirements.status !== "collect") {
+      throw new Error("Expected collect requirements");
+    }
+    expect(requirements.fields.map((field) => field.key)).toEqual([
+      "paymentRails",
+      "routingNumber",
+      "accountNumber",
+    ]);
+    const railField = requirements.fields[0];
+    if (railField?.kind !== "select") {
+      throw new Error("Expected paymentRails select field");
+    }
+    expect(railField.options.map((option) => option.value)).toEqual([
+      "ACH",
+      "WIRE",
+      "RTP",
+      "FEDNOW",
+    ]);
+  });
+
+  it("omits the rail select for single-rail currencies", () => {
+    const requirements = lightsparkCounterpartyRequirements(counterparty(), {
+      direction: "offramp",
+      providerData: {},
+      fiatCurrency: "GBP",
+    });
+
+    if (requirements.status !== "collect") {
+      throw new Error("Expected collect requirements");
+    }
+    expect(requirements.fields.map((field) => field.key)).toEqual(["sortCode", "accountNumber"]);
+  });
+
+  it("returns ready once a payout account is stored for the currency", () => {
+    const requirements = lightsparkCounterpartyRequirements(counterparty(), {
+      direction: "offramp",
+      providerData: {
+        lightspark: {
+          customerId: "Customer:cus_123",
+          payoutAccounts: {
+            USD: { accountId: "ExternalAccount:acc_payout_123", status: "ACTIVE" },
+          },
+        },
+      },
+      fiatCurrency: "USD",
+    });
+
+    expect(requirements).toEqual({ provider: "lightspark", direction: "offramp", status: "ready" });
+  });
+
+  it("returns unsupported for currencies without a Grid payout account type", () => {
+    const requirements = lightsparkCounterpartyRequirements(counterparty(), {
+      direction: "offramp",
+      providerData: {},
+      fiatCurrency: "TRY",
+    });
+
+    expect(requirements.status).toBe("unsupported");
+  });
+});
+
+describe("buildLightsparkAccountInfo", () => {
+  it("builds USD accountInfo with the selected rail and beneficiary", () => {
+    const accountInfo = buildLightsparkAccountInfo(
+      counterpartyRow({ identity: { dateOfBirth: "1990-01-15" } }),
+      "USD",
+      {
+        paymentRails: "ACH",
+        routingNumber: "021000021",
+        accountNumber: "12345678901",
+      }
+    );
+
+    expect(accountInfo).toEqual({
+      accountType: "USD_ACCOUNT",
+      paymentRails: ["ACH"],
+      routingNumber: "021000021",
+      accountNumber: "12345678901",
+      beneficiary: {
+        beneficiaryType: "INDIVIDUAL",
+        fullName: "Ada Lovelace",
+        birthDate: "1990-01-15",
+      },
+    });
+  });
+
+  it("hardcodes the rail and wraps countries for XOF mobile money", () => {
+    const accountInfo = buildLightsparkAccountInfo(counterpartyRow(), "XOF", {
+      phoneNumber: "+221770000000",
+      provider: "Orange Money",
+      countries: "SN",
+    });
+
+    expect(accountInfo).toEqual({
+      accountType: "XOF_ACCOUNT",
+      paymentRails: ["MOBILE_MONEY"],
+      phoneNumber: "+221770000000",
+      provider: "Orange Money",
+      countries: ["SN"],
+      beneficiary: { beneficiaryType: "INDIVIDUAL", fullName: "Ada Lovelace" },
+    });
+  });
+
+  it("uses a business legal name for business counterparties", () => {
+    const accountInfo = buildLightsparkAccountInfo(
+      counterpartyRow({ entity_type: "business", display_name: "Acme Corp" }),
+      "GBP",
+      { sortCode: "12-34-56", accountNumber: "12345678" }
+    );
+
+    expect(accountInfo.beneficiary).toEqual({
+      beneficiaryType: "BUSINESS",
+      legalName: "Acme Corp",
+    });
+  });
+
+  it("throws when collectedData is missing", () => {
+    expect(() => buildLightsparkAccountInfo(counterpartyRow(), "USD", undefined)).toThrowError(
+      AppError
+    );
+  });
+
+  it("throws when collected fields fail validation", () => {
+    expect(() =>
+      buildLightsparkAccountInfo(counterpartyRow(), "USD", {
+        paymentRails: "ACH",
+        routingNumber: "not-a-routing-number",
+        accountNumber: "12345678901",
+      })
+    ).toThrowError(AppError);
+  });
+});

--- a/apps/sdp-api/src/lib/ramps/validation/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/lightspark.ts
@@ -1,0 +1,455 @@
+import type { Counterparty } from "@sdp/types";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
+import type {
+  CollectedFieldData,
+  CounterpartyRequirements,
+  RequirementField,
+  RequirementOption,
+} from "@sdp/types/ramp-requirements";
+import { z } from "zod";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import { AppError, badRequest, unsupportedCounterparty } from "@/lib/errors";
+import { readLightsparkPayoutAccount } from "../providers/lightspark";
+import { buildRequirementSchema, readyCounterparty, selectField, textField } from "../requirements";
+import type { ValidateCounterpartyOptions } from "../types";
+
+const SWIFT_BIC_PATTERN = "^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$";
+const INTERNATIONAL_PHONE_PATTERN = "^\\+[0-9]{6,14}$";
+
+const LIGHTSPARK_RAIL_LABELS = {
+  ACH: "ACH",
+  WIRE: "Wire",
+  RTP: "RTP",
+  FEDNOW: "FedNow",
+  SEPA: "SEPA",
+  SEPA_INSTANT: "SEPA Instant",
+  PAYNOW: "PayNow",
+  FAST: "FAST",
+  BANK_TRANSFER: "Bank transfer",
+  FASTER_PAYMENTS: "Faster Payments",
+  SPEI: "SPEI",
+  PIX: "PIX",
+  UPI: "UPI",
+  MOBILE_MONEY: "Mobile money",
+} as const satisfies Record<string, string>;
+
+export type LightsparkPaymentRail = keyof typeof LIGHTSPARK_RAIL_LABELS;
+
+function railOption(value: LightsparkPaymentRail): RequirementOption {
+  return { value, label: LIGHTSPARK_RAIL_LABELS[value] };
+}
+
+function bankNameField(): RequirementField {
+  return textField({ key: "bankName", label: "Bank name", required: true, maxLength: 256 });
+}
+
+function swiftCodeField(required: boolean): RequirementField {
+  return textField({
+    key: "swiftCode",
+    label: "SWIFT / BIC code",
+    required,
+    pattern: SWIFT_BIC_PATTERN,
+  });
+}
+
+function accountNumberField(pattern?: string): RequirementField {
+  return textField({
+    key: "accountNumber",
+    label: "Account number",
+    required: true,
+    maxLength: 64,
+    ...(pattern ? { pattern } : {}),
+  });
+}
+
+function ibanField(pattern?: string): RequirementField {
+  return textField({
+    key: "iban",
+    label: "IBAN",
+    required: true,
+    minLength: 15,
+    maxLength: 34,
+    ...(pattern ? { pattern } : {}),
+  });
+}
+
+function phoneNumberField(pattern: string): RequirementField {
+  return textField({
+    key: "phoneNumber",
+    label: "Phone number",
+    required: true,
+    pattern,
+    placeholder: "+254700000000",
+  });
+}
+
+function mobileMoneyProviderField(): RequirementField {
+  return textField({
+    key: "provider",
+    label: "Mobile money provider",
+    required: true,
+    maxLength: 128,
+    placeholder: "M-Pesa",
+  });
+}
+
+export interface LightsparkPayoutSpec {
+  accountType: string;
+  rails: readonly [LightsparkPaymentRail, ...LightsparkPaymentRail[]];
+  fields: readonly RequirementField[];
+}
+
+export const LIGHTSPARK_PAYOUT_CURRENCIES = [
+  "AED",
+  "BRL",
+  "BWP",
+  "CAD",
+  "DKK",
+  "EUR",
+  "GBP",
+  "HKD",
+  "IDR",
+  "INR",
+  "KES",
+  "MWK",
+  "MXN",
+  "MYR",
+  "NGN",
+  "PHP",
+  "RWF",
+  "SGD",
+  "THB",
+  "TZS",
+  "UGX",
+  "USD",
+  "VND",
+  "XAF",
+  "XOF",
+  "ZAR",
+] as const satisfies readonly RampFiatCurrency[];
+
+export type LightsparkPayoutCurrency = (typeof LIGHTSPARK_PAYOUT_CURRENCIES)[number];
+
+const LIGHTSPARK_PAYOUT_SPECS = {
+  AED: {
+    accountType: "AED_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [ibanField("^AE[0-9]{21}$"), swiftCodeField(false)],
+  },
+  BRL: {
+    accountType: "BRL_ACCOUNT",
+    rails: ["PIX"],
+    fields: [
+      textField({ key: "pixKey", label: "PIX key", required: true, maxLength: 128 }),
+      selectField({
+        key: "pixKeyType",
+        label: "PIX key type",
+        required: true,
+        options: [
+          { value: "CPF", label: "CPF" },
+          { value: "CNPJ", label: "CNPJ" },
+          { value: "EMAIL", label: "Email" },
+          { value: "PHONE", label: "Phone" },
+          { value: "RANDOM", label: "Random (EVP)" },
+        ],
+      }),
+      textField({ key: "taxId", label: "Tax ID", required: true, maxLength: 32 }),
+    ],
+  },
+  BWP: {
+    accountType: "BWP_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [phoneNumberField(INTERNATIONAL_PHONE_PATTERN), mobileMoneyProviderField()],
+  },
+  CAD: {
+    accountType: "CAD_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [
+      textField({ key: "bankCode", label: "Bank code", required: true, pattern: "^[0-9]{3}$" }),
+      textField({
+        key: "branchCode",
+        label: "Branch transit number",
+        required: true,
+        pattern: "^[0-9]{5}$",
+      }),
+      accountNumberField("^[0-9]{7,12}$"),
+    ],
+  },
+  DKK: {
+    accountType: "DKK_ACCOUNT",
+    rails: ["SEPA", "SEPA_INSTANT"],
+    fields: [ibanField(), swiftCodeField(false)],
+  },
+  EUR: {
+    accountType: "EUR_ACCOUNT",
+    rails: ["SEPA", "SEPA_INSTANT"],
+    fields: [ibanField(), swiftCodeField(false)],
+  },
+  GBP: {
+    accountType: "GBP_ACCOUNT",
+    rails: ["FASTER_PAYMENTS"],
+    fields: [
+      textField({
+        key: "sortCode",
+        label: "Sort code",
+        required: true,
+        pattern: "^[0-9]{2}-?[0-9]{2}-?[0-9]{2}$",
+        placeholder: "12-34-56",
+      }),
+      accountNumberField("^[0-9]{8}$"),
+    ],
+  },
+  HKD: {
+    accountType: "HKD_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [bankNameField(), swiftCodeField(true), accountNumberField()],
+  },
+  IDR: {
+    accountType: "IDR_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [
+      bankNameField(),
+      swiftCodeField(true),
+      accountNumberField(),
+      phoneNumberField("^\\+62[0-9]{9,12}$"),
+    ],
+  },
+  INR: {
+    accountType: "INR_ACCOUNT",
+    rails: ["UPI"],
+    fields: [
+      textField({
+        key: "vpa",
+        label: "UPI ID (VPA)",
+        required: true,
+        maxLength: 256,
+        placeholder: "user@okbank",
+      }),
+    ],
+  },
+  KES: {
+    accountType: "KES_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [phoneNumberField(INTERNATIONAL_PHONE_PATTERN), mobileMoneyProviderField()],
+  },
+  MWK: {
+    accountType: "MWK_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [phoneNumberField("^\\+265[0-9]{9}$"), mobileMoneyProviderField()],
+  },
+  MXN: {
+    accountType: "MXN_ACCOUNT",
+    rails: ["SPEI"],
+    fields: [
+      textField({
+        key: "clabeNumber",
+        label: "CLABE number",
+        required: true,
+        pattern: "^[0-9]{18}$",
+      }),
+    ],
+  },
+  MYR: {
+    accountType: "MYR_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [bankNameField(), swiftCodeField(true), accountNumberField()],
+  },
+  NGN: {
+    accountType: "NGN_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [accountNumberField("^[0-9]{10}$"), bankNameField()],
+  },
+  PHP: {
+    accountType: "PHP_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [bankNameField(), accountNumberField()],
+  },
+  RWF: {
+    accountType: "RWF_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [phoneNumberField("^\\+250[0-9]{9}$"), mobileMoneyProviderField()],
+  },
+  SGD: {
+    accountType: "SGD_ACCOUNT",
+    rails: ["PAYNOW", "FAST", "BANK_TRANSFER"],
+    fields: [bankNameField(), swiftCodeField(true), accountNumberField()],
+  },
+  THB: {
+    accountType: "THB_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [bankNameField(), swiftCodeField(true), accountNumberField()],
+  },
+  TZS: {
+    accountType: "TZS_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [phoneNumberField("^\\+255[0-9]{9}$"), mobileMoneyProviderField()],
+  },
+  UGX: {
+    accountType: "UGX_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [phoneNumberField("^\\+256[0-9]{9}$"), mobileMoneyProviderField()],
+  },
+  USD: {
+    accountType: "USD_ACCOUNT",
+    rails: ["ACH", "WIRE", "RTP", "FEDNOW"],
+    fields: [
+      textField({
+        key: "routingNumber",
+        label: "Routing number",
+        required: true,
+        pattern: "^[0-9]{9}$",
+        placeholder: "021000021",
+      }),
+      accountNumberField(),
+    ],
+  },
+  VND: {
+    accountType: "VND_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [bankNameField(), swiftCodeField(true), accountNumberField()],
+  },
+  XAF: {
+    accountType: "XAF_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [
+      phoneNumberField(INTERNATIONAL_PHONE_PATTERN),
+      mobileMoneyProviderField(),
+      selectField({
+        key: "region",
+        label: "Region",
+        required: true,
+        options: [
+          { value: "CM", label: "Cameroon" },
+          { value: "CG", label: "Congo" },
+        ],
+      }),
+    ],
+  },
+  XOF: {
+    accountType: "XOF_ACCOUNT",
+    rails: ["MOBILE_MONEY"],
+    fields: [
+      phoneNumberField(INTERNATIONAL_PHONE_PATTERN),
+      mobileMoneyProviderField(),
+      selectField({
+        key: "countries",
+        label: "Country",
+        required: true,
+        options: [
+          { value: "SN", label: "Senegal" },
+          { value: "BJ", label: "Benin" },
+          { value: "CI", label: "Ivory Coast" },
+        ],
+      }),
+    ],
+  },
+  ZAR: {
+    accountType: "ZAR_ACCOUNT",
+    rails: ["BANK_TRANSFER"],
+    fields: [bankNameField(), accountNumberField("^[0-9]{9,13}$")],
+  },
+} as const satisfies Record<LightsparkPayoutCurrency, LightsparkPayoutSpec>;
+
+export function isLightsparkPayoutCurrency(value: string): value is LightsparkPayoutCurrency {
+  return Object.hasOwn(LIGHTSPARK_PAYOUT_SPECS, value);
+}
+
+export function lightsparkPayoutSpec(fiatCurrency: string): LightsparkPayoutSpec {
+  if (!isLightsparkPayoutCurrency(fiatCurrency)) {
+    throw badRequest(`Lightspark off-ramp does not support payouts in ${fiatCurrency}.`);
+  }
+  return LIGHTSPARK_PAYOUT_SPECS[fiatCurrency];
+}
+
+export function lightsparkPayoutFields(spec: LightsparkPayoutSpec): RequirementField[] {
+  const railField =
+    spec.rails.length > 1
+      ? [
+          selectField({
+            key: "paymentRails",
+            label: "Payment rail",
+            required: true,
+            options: spec.rails.map(railOption),
+          }),
+        ]
+      : [];
+  return [...railField, ...spec.fields];
+}
+
+export function lightsparkCounterpartyRequirements(
+  _counterparty: Counterparty,
+  { direction, providerData, fiatCurrency }: ValidateCounterpartyOptions
+): CounterpartyRequirements {
+  if (direction === "onramp") {
+    return readyCounterparty("lightspark", direction);
+  }
+  if (!fiatCurrency) {
+    throw badRequest("fiatCurrency is required for Lightspark off-ramp requirements.");
+  }
+  if (!isLightsparkPayoutCurrency(fiatCurrency)) {
+    return unsupportedCounterparty(
+      "lightspark",
+      direction,
+      `Lightspark off-ramp does not support payouts in ${fiatCurrency}.`
+    );
+  }
+  if (readLightsparkPayoutAccount(providerData, fiatCurrency)) {
+    return readyCounterparty("lightspark", direction);
+  }
+  return {
+    provider: "lightspark",
+    direction,
+    status: "collect",
+    fields: lightsparkPayoutFields(LIGHTSPARK_PAYOUT_SPECS[fiatCurrency]),
+  };
+}
+
+function lightsparkBeneficiary(counterparty: CounterpartyRow): Record<string, unknown> {
+  if (counterparty.entity_type === "business") {
+    return { beneficiaryType: "BUSINESS", legalName: counterparty.display_name };
+  }
+  const identity = counterparty.identity;
+  return {
+    beneficiaryType: "INDIVIDUAL",
+    fullName: counterparty.display_name,
+    ...(identity.dateOfBirth ? { birthDate: identity.dateOfBirth } : {}),
+    ...(identity.compliance?.nationality ? { nationality: identity.compliance.nationality } : {}),
+  };
+}
+
+export function buildLightsparkAccountInfo(
+  counterparty: CounterpartyRow,
+  fiatCurrency: RampFiatCurrency,
+  collectedData: CollectedFieldData | undefined
+): Record<string, unknown> {
+  const spec = lightsparkPayoutSpec(fiatCurrency);
+  if (!collectedData) {
+    throw badRequest("collectedData with payout bank details is required for Lightspark off-ramp.");
+  }
+  const result = buildRequirementSchema(lightsparkPayoutFields(spec)).safeParse(collectedData);
+  if (!result.success) {
+    throw new AppError(
+      "BAD_REQUEST",
+      "Missing or invalid payout bank details for Lightspark off-ramp.",
+      { errors: z.treeifyError(result.error) }
+    );
+  }
+  const supplied: Record<string, unknown> = result.data;
+
+  const rail = spec.rails.length > 1 ? supplied.paymentRails : spec.rails[0];
+  if (typeof rail !== "string") {
+    throw badRequest('Missing required field "paymentRails" for Lightspark off-ramp.');
+  }
+
+  const accountInfo: Record<string, unknown> = {
+    accountType: spec.accountType,
+    paymentRails: [rail],
+  };
+  for (const field of spec.fields) {
+    const value = supplied[field.key];
+    if (value === undefined) continue;
+    accountInfo[field.key] = field.key === "countries" ? [value] : value;
+  }
+  accountInfo.beneficiary = lightsparkBeneficiary(counterparty);
+  return accountInfo;
+}

--- a/apps/sdp-api/src/lib/ramps/validation/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/lightspark.ts
@@ -9,7 +9,7 @@ import type {
 import { z } from "zod";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
 import { AppError, badRequest, unsupportedCounterparty } from "@/lib/errors";
-import { readLightsparkPayoutAccount } from "../providers/lightspark";
+import { latestLightsparkPayoutAccount } from "../providers/lightspark";
 import { buildRequirementSchema, readyCounterparty, selectField, textField } from "../requirements";
 import type { ValidateCounterpartyOptions } from "../types";
 
@@ -393,7 +393,7 @@ export function lightsparkCounterpartyRequirements(
       `Lightspark off-ramp does not support payouts in ${fiatCurrency}.`
     );
   }
-  if (readLightsparkPayoutAccount(providerData, fiatCurrency)) {
+  if (latestLightsparkPayoutAccount(providerData, fiatCurrency)) {
     return readyCounterparty("lightspark", direction);
   }
   return {

--- a/apps/sdp-api/src/routes/counterparties/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparties/handlers.ts
@@ -158,7 +158,11 @@ export const getCounterpartyRequirements = async (c: AppContext) => {
 
   const requirements = RAMP_PROVIDER_CLIENTS[query.data.provider].validateCounterparty(
     mapToCounterparty(counterparty),
-    { direction: query.data.direction, providerData: counterparty.provider_data }
+    {
+      direction: query.data.direction,
+      providerData: counterparty.provider_data,
+      ...("fiatCurrency" in query.data ? { fiatCurrency: query.data.fiatCurrency } : {}),
+    }
   );
   return success(c, requirements);
 };

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -8,9 +8,9 @@ import {
   COUNTERPARTY_SOURCE_OF_FUNDS,
   COUNTERPARTY_YEARLY_INCOME,
   COUNTRY_CODES,
-  RAMP_PROVIDERS,
 } from "@sdp/types";
 import { z } from "zod";
+import { LIGHTSPARK_PAYOUT_CURRENCIES } from "@/lib/ramps/validation/lightspark";
 
 const countryCodeSchema = z.enum(COUNTRY_CODES);
 const currencyCodeSchema = z.string().trim().toUpperCase().length(3);
@@ -87,10 +87,25 @@ export const counterpartyIdParamsSchema = z.object({
   counterpartyId: counterpartyIdSchema,
 });
 
-export const counterpartyRequirementsQuerySchema = z.object({
-  provider: z.enum(RAMP_PROVIDERS),
-  direction: z.enum(["onramp", "offramp"]),
-});
+const rampDirectionSchema = z.enum(["onramp", "offramp"]);
+
+const lightsparkPayoutCurrencySchema = z.preprocess(
+  (value) => (typeof value === "string" ? value.trim().toUpperCase() : value),
+  z.enum(LIGHTSPARK_PAYOUT_CURRENCIES)
+);
+
+export const counterpartyRequirementsQuerySchema = z.discriminatedUnion("provider", [
+  z.object({ provider: z.literal("moonpay"), direction: rampDirectionSchema }),
+  z.object({ provider: z.literal("bvnk"), direction: rampDirectionSchema }),
+  z.discriminatedUnion("direction", [
+    z.object({ provider: z.literal("lightspark"), direction: z.literal("onramp") }),
+    z.object({
+      provider: z.literal("lightspark"),
+      direction: z.literal("offramp"),
+      fiatCurrency: lightsparkPayoutCurrencySchema,
+    }),
+  ]),
+]);
 
 export const createCounterpartySchema = z.object({
   externalId: z.string().min(1).max(256).optional(),

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -25,7 +25,7 @@ import {
   normalizeBvnkCurrencyAndNetwork,
   readBvnkOnrampEntry,
 } from "@/lib/ramps/providers/bvnk";
-import type { LightsparkCustomerResolution, RampRuntimeContext } from "@/lib/ramps/types";
+import type { RampRuntimeContext } from "@/lib/ramps/types";
 import { success } from "@/lib/response";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { assertProviderAvailable } from "@/services/provider-availability.service";
@@ -49,6 +49,7 @@ import {
 } from "../schemas";
 import { type ResolvedScope, resolveScope, resolveWalletAddress } from "../wallets";
 import { bvnkOnrampQuote, ensureBvnkCustomer, ensureBvnkPaymentRule } from "./ramps/bvnk";
+import { ensureLightsparkCustomer, lightsparkOfframpQuote } from "./ramps/lightspark";
 
 type OnrampCurrencyPair = {
   source: (typeof ONRAMP_SUPPORT)[number]["source"];
@@ -132,15 +133,8 @@ function requireRampTransferWallet(
   return wallet;
 }
 
-function rampQuoteTransferStatus(
-  direction: RampQuoteDirection,
-  quote: PaymentRampQuote
-): PaymentTransferStatus {
-  if (
-    direction === "onramp" &&
-    quote.deliveryMode === "manual_instructions" &&
-    quote.status === "pending"
-  ) {
+function rampQuoteTransferStatus(quote: PaymentRampQuote): PaymentTransferStatus {
+  if (quote.deliveryMode === "manual_instructions" && quote.status === "pending") {
     return "awaiting_payment";
   }
   return quote.status;
@@ -177,7 +171,7 @@ async function persistRampQuoteTransfer(
     memo: null,
     type: input.direction,
     direction: isOnramp ? "inbound" : "outbound",
-    status: rampQuoteTransferStatus(input.direction, input.quote),
+    status: rampQuoteTransferStatus(input.quote),
     provider: input.quote.provider,
     providerReference: input.quote.id,
     deliveryMode: input.quote.deliveryMode,
@@ -341,57 +335,6 @@ async function executeOfframpWithProvider(
       throw internalError(`Unhandled ramp provider: ${_exhaustive}`);
     }
   }
-}
-
-function readLightsparkData(
-  providerData: CounterpartyRow["provider_data"]
-): Record<string, unknown> {
-  const lightspark = providerData.lightspark;
-  return lightspark && typeof lightspark === "object"
-    ? (lightspark as Record<string, unknown>)
-    : {};
-}
-
-function readLightsparkCustomerId(providerData: CounterpartyRow["provider_data"]): string | null {
-  const customerId = readLightsparkData(providerData).customerId;
-  return typeof customerId === "string" && customerId.length > 0 ? customerId : null;
-}
-
-/**
- * Returns the Grid customer id for a counterparty, lazily creating the native
- * Lightspark customer (via the provider) and persisting it into provider_data
- * on first use.
- */
-async function ensureLightsparkCustomer(
-  c: AppContext,
-  { counterparty, projectId }: { counterparty: CounterpartyRow; projectId: string }
-): Promise<LightsparkCustomerResolution> {
-  const repo = getCounterpartiesRepository(c);
-  const existing = readLightsparkCustomerId(counterparty.provider_data);
-  if (existing) {
-    return { customerId: existing };
-  }
-
-  const customer = await RAMP_PROVIDER_CLIENTS.lightspark.getOrCreateCustomer(rampRuntime(c), {
-    platformCustomerId: counterparty.id,
-    customerType: counterparty.entity_type === "business" ? "BUSINESS" : "INDIVIDUAL",
-    fullName: counterparty.display_name,
-    email: counterparty.email,
-  });
-
-  const existingLightspark = readLightsparkData(counterparty.provider_data);
-
-  await repo.updateCounterparty({
-    counterpartyId: counterparty.id,
-    organizationId: counterparty.organization_id,
-    projectId,
-    providerData: {
-      ...counterparty.provider_data,
-      lightspark: { ...existingLightspark, customerId: customer.id },
-    },
-  });
-
-  return { customerId: customer.id };
 }
 
 async function estimateAcrossProviders(
@@ -608,15 +551,6 @@ export async function createOfframpQuote(c: AppContext) {
     throw new AppError("NOT_FOUND", "Counterparty not found");
   }
 
-  if (input.provider === "lightspark") {
-    // Lightspark off-ramp is account-funded and requires a destination fiat payout
-    // account created from bank details. That collection step is not wired yet.
-    throw new AppError(
-      "BAD_REQUEST",
-      "Lightspark off-ramp quotes require payout bank details, which aren't collected yet."
-    );
-  }
-
   const sourceWalletAddress = resolveWalletAddress(
     scope.wallets,
     input.sourceWallet,
@@ -641,6 +575,18 @@ export async function createOfframpQuote(c: AppContext) {
         sourceWalletAddress,
         externalCustomerId: counterparty.external_id ?? counterparty.id,
         redirectUrl: input.redirectUrl,
+      });
+      break;
+    }
+    case "lightspark": {
+      quote = await lightsparkOfframpQuote(c, {
+        counterparty,
+        projectId,
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        cryptoAmount: input.cryptoAmount,
+        sourceWalletAddress,
+        collectedData: input.collectedData,
       });
       break;
     }

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -7,9 +7,12 @@ import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
   isLightsparkExternalAccountActive,
   type LightsparkPayoutAccount,
+  type LightsparkPayoutAccountEntry,
+  latestLightsparkPayoutAccount,
+  lightsparkPayoutAccountKey,
   readLightsparkCustomerId,
   readLightsparkData,
-  readLightsparkPayoutAccount,
+  readLightsparkPayoutAccountByKey,
   readLightsparkPayoutAccounts,
 } from "@/lib/ramps/providers/lightspark";
 import type { LightsparkCustomerResolution } from "@/lib/ramps/types";
@@ -88,60 +91,117 @@ async function persistLightsparkPayoutAccount(
   row: CounterpartyRow,
   projectId: string,
   customerId: string,
-  fiatCurrency: RampFiatCurrency,
-  account: LightsparkPayoutAccount
+  entry: LightsparkPayoutAccountEntry
 ): Promise<void> {
   await persistLightsparkData(c, row, projectId, {
     customerId,
     payoutAccounts: {
       ...readLightsparkPayoutAccounts(row.provider_data),
-      [fiatCurrency]: account,
+      [entry.key]: { accountId: entry.accountId, status: entry.status, createdAt: entry.createdAt },
     },
   });
 }
 
+interface PayoutAccountContext {
+  counterparty: CounterpartyRow;
+  projectId: string;
+  customer: LightsparkCustomerResolution;
+  fiatCurrency: RampFiatCurrency;
+}
+
+async function refreshPayoutAccount(
+  c: AppContext,
+  input: PayoutAccountContext,
+  entry: LightsparkPayoutAccountEntry
+): Promise<LightsparkPayoutAccount> {
+  if (isLightsparkExternalAccountActive(entry.status)) {
+    return entry;
+  }
+
+  const latest = await RAMP_PROVIDER_CLIENTS.lightspark.getExternalAccount(rampRuntime(c), {
+    accountId: entry.accountId,
+  });
+  const refreshed: LightsparkPayoutAccountEntry = { ...entry, status: latest.status };
+  if (latest.status !== entry.status) {
+    const row = await freshCounterpartyRow(c, input.counterparty, input.projectId);
+    await persistLightsparkPayoutAccount(
+      c,
+      row,
+      input.projectId,
+      input.customer.customerId,
+      refreshed
+    );
+  }
+  if (!isLightsparkExternalAccountActive(latest.status)) {
+    throw badRequest(
+      `Lightspark payout account is not active yet (status: ${latest.status}). Retry once it is verified.`
+    );
+  }
+  return refreshed;
+}
+
 /**
- * Resolves the Grid external payout account for (counterparty, fiatCurrency).
- * Creates it from collected bank details on first use, persisting only the
- * resulting account id + status into provider_data — raw bank details are
- * passed through to Grid and never stored. Grid customers can hold several
- * external accounts, so the stored entry is a reuse cache: concurrent
- * first-time quotes each quote against the account they created (last write
- * wins the cache) rather than risking a quote against someone else's details.
+ * Resolves the Grid external payout account for the quote. Entries are cached
+ * in provider_data keyed by `${fiat}:${hash(collectedData)}`, so re-submitting
+ * the same bank details reuses the same Grid account while different details
+ * create (and keep) a distinct one — Grid customers can hold several external
+ * accounts. Raw bank details pass through to Grid and are never stored. A
+ * quote without collected details uses the most recently created account for
+ * the currency.
  */
 export async function ensureLightsparkPayoutAccount(
   c: AppContext,
-  input: {
-    counterparty: CounterpartyRow;
-    projectId: string;
-    customer: LightsparkCustomerResolution;
-    fiatCurrency: RampFiatCurrency;
-    collectedData?: CollectedFieldData;
-  }
+  input: PayoutAccountContext & { collectedData?: CollectedFieldData }
 ): Promise<LightsparkPayoutAccount> {
-  const client = RAMP_PROVIDER_CLIENTS.lightspark;
+  // The wizard always sends collectedData; an empty object means nothing was collected.
+  const collected =
+    input.collectedData !== undefined && Object.keys(input.collectedData).length > 0
+      ? input.collectedData
+      : undefined;
 
-  let stored = readLightsparkPayoutAccount(input.counterparty.provider_data, input.fiatCurrency);
-  if (!stored) {
+  if (!collected) {
+    let entry = latestLightsparkPayoutAccount(input.counterparty.provider_data, input.fiatCurrency);
+    if (!entry) {
+      const row = await freshCounterpartyRow(c, input.counterparty, input.projectId);
+      entry = latestLightsparkPayoutAccount(row.provider_data, input.fiatCurrency);
+    }
+    if (!entry) {
+      throw badRequest(
+        "collectedData with payout bank details is required for Lightspark off-ramp."
+      );
+    }
+    return refreshPayoutAccount(c, input, entry);
+  }
+
+  const key = await lightsparkPayoutAccountKey(input.fiatCurrency, collected);
+  let entry = readLightsparkPayoutAccountByKey(input.counterparty.provider_data, key);
+  if (!entry) {
     const row = await freshCounterpartyRow(c, input.counterparty, input.projectId);
-    stored = readLightsparkPayoutAccount(row.provider_data, input.fiatCurrency);
+    entry = readLightsparkPayoutAccountByKey(row.provider_data, key);
 
-    if (!stored) {
-      const accountInfo = buildLightsparkAccountInfo(row, input.fiatCurrency, input.collectedData);
-      const created = await client.createFiatExternalAccount(rampRuntime(c), {
-        customerId: input.customer.customerId,
-        currency: input.fiatCurrency,
-        accountInfo,
-      });
+    if (!entry) {
+      const accountInfo = buildLightsparkAccountInfo(row, input.fiatCurrency, collected);
+      const created = await RAMP_PROVIDER_CLIENTS.lightspark.createFiatExternalAccount(
+        rampRuntime(c),
+        {
+          customerId: input.customer.customerId,
+          currency: input.fiatCurrency,
+          accountInfo,
+        }
+      );
 
-      const account: LightsparkPayoutAccount = { accountId: created.id, status: created.status };
+      const account: LightsparkPayoutAccountEntry = {
+        key,
+        accountId: created.id,
+        status: created.status,
+        createdAt: new Date().toISOString(),
+      };
       const latestRow = await freshCounterpartyRow(c, input.counterparty, input.projectId);
       await persistLightsparkPayoutAccount(
         c,
         latestRow,
         input.projectId,
         input.customer.customerId,
-        input.fiatCurrency,
         account
       );
       if (!isLightsparkExternalAccountActive(created.status)) {
@@ -153,29 +213,7 @@ export async function ensureLightsparkPayoutAccount(
     }
   }
 
-  if (isLightsparkExternalAccountActive(stored.status)) {
-    return stored;
-  }
-
-  const latest = await client.getExternalAccount(rampRuntime(c), { accountId: stored.accountId });
-  const refreshed: LightsparkPayoutAccount = { accountId: latest.id, status: latest.status };
-  if (latest.status !== stored.status) {
-    const row = await freshCounterpartyRow(c, input.counterparty, input.projectId);
-    await persistLightsparkPayoutAccount(
-      c,
-      row,
-      input.projectId,
-      input.customer.customerId,
-      input.fiatCurrency,
-      refreshed
-    );
-  }
-  if (!isLightsparkExternalAccountActive(latest.status)) {
-    throw badRequest(
-      `Lightspark payout account is not active yet (status: ${latest.status}). Retry once it is verified.`
-    );
-  }
-  return refreshed;
+  return refreshPayoutAccount(c, input, entry);
 }
 
 export async function lightsparkOfframpQuote(

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -181,11 +181,12 @@ export async function ensureLightsparkPayoutAccount(
 
     if (!entry) {
       const accountInfo = buildLightsparkAccountInfo(row, input.fiatCurrency, collected);
-      const created = await RAMP_PROVIDER_CLIENTS.lightspark.createFiatExternalAccount(
+      const created = await RAMP_PROVIDER_CLIENTS.lightspark.getOrCreateFiatExternalAccount(
         rampRuntime(c),
         {
           customerId: input.customer.customerId,
           currency: input.fiatCurrency,
+          platformAccountId: `${input.counterparty.id}:${key}`,
           accountInfo,
         }
       );

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -2,7 +2,7 @@ import type { PaymentRampQuote } from "@sdp/types";
 import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
-import { badRequest } from "@/lib/errors";
+import { badRequest, notFound } from "@/lib/errors";
 import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
   isLightsparkExternalAccountActive,
@@ -17,20 +17,41 @@ import { buildLightsparkAccountInfo } from "@/lib/ramps/validation/lightspark";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { type AppContext, rampRuntime } from "../../context";
 
-async function persistLightsparkData(
+/**
+ * Re-reads the counterparty row so provider_data merges happen against the
+ * latest state instead of the request's snapshot — concurrent requests for the
+ * same counterparty would otherwise clobber each other's writes.
+ */
+async function freshCounterpartyRow(
   c: AppContext,
   counterparty: CounterpartyRow,
+  projectId: string
+): Promise<CounterpartyRow> {
+  const row = await getCounterpartiesRepository(c).getCounterpartyById({
+    counterpartyId: counterparty.id,
+    organizationId: counterparty.organization_id,
+    projectId,
+  });
+  if (!row) {
+    throw notFound("Counterparty");
+  }
+  return row;
+}
+
+async function persistLightsparkData(
+  c: AppContext,
+  row: CounterpartyRow,
   projectId: string,
   patch: Record<string, unknown>
 ): Promise<void> {
   const repo = getCounterpartiesRepository(c);
   await repo.updateCounterparty({
-    counterpartyId: counterparty.id,
-    organizationId: counterparty.organization_id,
+    counterpartyId: row.id,
+    organizationId: row.organization_id,
     projectId,
     providerData: {
-      ...counterparty.provider_data,
-      lightspark: { ...readLightsparkData(counterparty.provider_data), ...patch },
+      ...row.provider_data,
+      lightspark: { ...readLightsparkData(row.provider_data), ...patch },
     },
   });
 }
@@ -56,23 +77,24 @@ export async function ensureLightsparkCustomer(
     email: counterparty.email,
   });
 
-  await persistLightsparkData(c, counterparty, projectId, { customerId: customer.id });
+  const row = await freshCounterpartyRow(c, counterparty, projectId);
+  await persistLightsparkData(c, row, projectId, { customerId: customer.id });
 
   return { customerId: customer.id };
 }
 
 async function persistLightsparkPayoutAccount(
   c: AppContext,
-  counterparty: CounterpartyRow,
+  row: CounterpartyRow,
   projectId: string,
   customerId: string,
   fiatCurrency: RampFiatCurrency,
   account: LightsparkPayoutAccount
 ): Promise<void> {
-  await persistLightsparkData(c, counterparty, projectId, {
+  await persistLightsparkData(c, row, projectId, {
     customerId,
     payoutAccounts: {
-      ...readLightsparkPayoutAccounts(counterparty.provider_data),
+      ...readLightsparkPayoutAccounts(row.provider_data),
       [fiatCurrency]: account,
     },
   });
@@ -82,7 +104,9 @@ async function persistLightsparkPayoutAccount(
  * Resolves the Grid external payout account for (counterparty, fiatCurrency).
  * Creates it from collected bank details on first use, persisting only the
  * resulting account id + status into provider_data — raw bank details are
- * passed through to Grid and never stored.
+ * passed through to Grid and never stored. Concurrent first-time quotes are
+ * converged first-writer-wins: a loser deletes its duplicate account at Grid
+ * and adopts the persisted one.
  */
 export async function ensureLightsparkPayoutAccount(
   c: AppContext,
@@ -95,59 +119,68 @@ export async function ensureLightsparkPayoutAccount(
   }
 ): Promise<LightsparkPayoutAccount> {
   const client = RAMP_PROVIDER_CLIENTS.lightspark;
-  const stored = readLightsparkPayoutAccount(input.counterparty.provider_data, input.fiatCurrency);
 
-  if (stored) {
-    if (isLightsparkExternalAccountActive(stored.status)) {
-      return stored;
+  let stored = readLightsparkPayoutAccount(input.counterparty.provider_data, input.fiatCurrency);
+  if (!stored) {
+    const row = await freshCounterpartyRow(c, input.counterparty, input.projectId);
+    stored = readLightsparkPayoutAccount(row.provider_data, input.fiatCurrency);
+
+    if (!stored) {
+      const accountInfo = buildLightsparkAccountInfo(row, input.fiatCurrency, input.collectedData);
+      const created = await client.createFiatExternalAccount(rampRuntime(c), {
+        customerId: input.customer.customerId,
+        currency: input.fiatCurrency,
+        accountInfo,
+      });
+
+      const latestRow = await freshCounterpartyRow(c, input.counterparty, input.projectId);
+      const concurrent = readLightsparkPayoutAccount(latestRow.provider_data, input.fiatCurrency);
+      if (concurrent) {
+        await client.deleteExternalAccount(rampRuntime(c), { accountId: created.id });
+        stored = concurrent;
+      } else {
+        const account: LightsparkPayoutAccount = { accountId: created.id, status: created.status };
+        await persistLightsparkPayoutAccount(
+          c,
+          latestRow,
+          input.projectId,
+          input.customer.customerId,
+          input.fiatCurrency,
+          account
+        );
+        if (!isLightsparkExternalAccountActive(created.status)) {
+          throw badRequest(
+            `Lightspark payout account was created but is not active yet (status: ${created.status}). Retry once it is verified.`
+          );
+        }
+        return account;
+      }
     }
-    const latest = await client.getExternalAccount(rampRuntime(c), {
-      accountId: stored.accountId,
-    });
-    const refreshed: LightsparkPayoutAccount = { accountId: latest.id, status: latest.status };
-    if (latest.status !== stored.status) {
-      await persistLightsparkPayoutAccount(
-        c,
-        input.counterparty,
-        input.projectId,
-        input.customer.customerId,
-        input.fiatCurrency,
-        refreshed
-      );
-    }
-    if (!isLightsparkExternalAccountActive(latest.status)) {
-      throw badRequest(
-        `Lightspark payout account is not active yet (status: ${latest.status}). Retry once it is verified.`
-      );
-    }
-    return refreshed;
   }
 
-  const accountInfo = buildLightsparkAccountInfo(
-    input.counterparty,
-    input.fiatCurrency,
-    input.collectedData
-  );
-  const created = await client.createFiatExternalAccount(rampRuntime(c), {
-    customerId: input.customer.customerId,
-    currency: input.fiatCurrency,
-    accountInfo,
-  });
-  const account: LightsparkPayoutAccount = { accountId: created.id, status: created.status };
-  await persistLightsparkPayoutAccount(
-    c,
-    input.counterparty,
-    input.projectId,
-    input.customer.customerId,
-    input.fiatCurrency,
-    account
-  );
-  if (!isLightsparkExternalAccountActive(created.status)) {
-    throw badRequest(
-      `Lightspark payout account was created but is not active yet (status: ${created.status}). Retry once it is verified.`
+  if (isLightsparkExternalAccountActive(stored.status)) {
+    return stored;
+  }
+
+  const latest = await client.getExternalAccount(rampRuntime(c), { accountId: stored.accountId });
+  const refreshed: LightsparkPayoutAccount = { accountId: latest.id, status: latest.status };
+  if (latest.status !== stored.status) {
+    const row = await freshCounterpartyRow(c, input.counterparty, input.projectId);
+    await persistLightsparkPayoutAccount(
+      c,
+      row,
+      input.projectId,
+      input.customer.customerId,
+      input.fiatCurrency,
+      refreshed
     );
   }
-  return account;
+  if (!isLightsparkExternalAccountActive(latest.status)) {
+    throw badRequest(
+      `Lightspark payout account is not active yet (status: ${latest.status}). Retry once it is verified.`
+    );
+  }
+  return refreshed;
 }
 
 export async function lightsparkOfframpQuote(

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -1,0 +1,190 @@
+import type { PaymentRampQuote } from "@sdp/types";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
+import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import { badRequest } from "@/lib/errors";
+import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
+import {
+  isLightsparkExternalAccountActive,
+  type LightsparkPayoutAccount,
+  readLightsparkCustomerId,
+  readLightsparkData,
+  readLightsparkPayoutAccount,
+  readLightsparkPayoutAccounts,
+} from "@/lib/ramps/providers/lightspark";
+import type { LightsparkCustomerResolution } from "@/lib/ramps/types";
+import { buildLightsparkAccountInfo } from "@/lib/ramps/validation/lightspark";
+import { getCounterpartiesRepository } from "@/routes/counterparties/context";
+import { type AppContext, rampRuntime } from "../../context";
+
+async function persistLightsparkData(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  patch: Record<string, unknown>
+): Promise<void> {
+  const repo = getCounterpartiesRepository(c);
+  await repo.updateCounterparty({
+    counterpartyId: counterparty.id,
+    organizationId: counterparty.organization_id,
+    projectId,
+    providerData: {
+      ...counterparty.provider_data,
+      lightspark: { ...readLightsparkData(counterparty.provider_data), ...patch },
+    },
+  });
+}
+
+/**
+ * Returns the Grid customer id for a counterparty, lazily creating the native
+ * Lightspark customer (via the provider) and persisting it into provider_data
+ * on first use.
+ */
+export async function ensureLightsparkCustomer(
+  c: AppContext,
+  { counterparty, projectId }: { counterparty: CounterpartyRow; projectId: string }
+): Promise<LightsparkCustomerResolution> {
+  const existing = readLightsparkCustomerId(counterparty.provider_data);
+  if (existing) {
+    return { customerId: existing };
+  }
+
+  const customer = await RAMP_PROVIDER_CLIENTS.lightspark.getOrCreateCustomer(rampRuntime(c), {
+    platformCustomerId: counterparty.id,
+    customerType: counterparty.entity_type === "business" ? "BUSINESS" : "INDIVIDUAL",
+    fullName: counterparty.display_name,
+    email: counterparty.email,
+  });
+
+  await persistLightsparkData(c, counterparty, projectId, { customerId: customer.id });
+
+  return { customerId: customer.id };
+}
+
+async function persistLightsparkPayoutAccount(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  customerId: string,
+  fiatCurrency: RampFiatCurrency,
+  account: LightsparkPayoutAccount
+): Promise<void> {
+  await persistLightsparkData(c, counterparty, projectId, {
+    customerId,
+    payoutAccounts: {
+      ...readLightsparkPayoutAccounts(counterparty.provider_data),
+      [fiatCurrency]: account,
+    },
+  });
+}
+
+/**
+ * Resolves the Grid external payout account for (counterparty, fiatCurrency).
+ * Creates it from collected bank details on first use, persisting only the
+ * resulting account id + status into provider_data — raw bank details are
+ * passed through to Grid and never stored.
+ */
+export async function ensureLightsparkPayoutAccount(
+  c: AppContext,
+  input: {
+    counterparty: CounterpartyRow;
+    projectId: string;
+    customer: LightsparkCustomerResolution;
+    fiatCurrency: RampFiatCurrency;
+    collectedData?: CollectedFieldData;
+  }
+): Promise<LightsparkPayoutAccount> {
+  const client = RAMP_PROVIDER_CLIENTS.lightspark;
+  const stored = readLightsparkPayoutAccount(input.counterparty.provider_data, input.fiatCurrency);
+
+  if (stored) {
+    if (isLightsparkExternalAccountActive(stored.status)) {
+      return stored;
+    }
+    const latest = await client.getExternalAccount(rampRuntime(c), {
+      accountId: stored.accountId,
+    });
+    const refreshed: LightsparkPayoutAccount = { accountId: latest.id, status: latest.status };
+    if (latest.status !== stored.status) {
+      await persistLightsparkPayoutAccount(
+        c,
+        input.counterparty,
+        input.projectId,
+        input.customer.customerId,
+        input.fiatCurrency,
+        refreshed
+      );
+    }
+    if (!isLightsparkExternalAccountActive(latest.status)) {
+      throw badRequest(
+        `Lightspark payout account is not active yet (status: ${latest.status}). Retry once it is verified.`
+      );
+    }
+    return refreshed;
+  }
+
+  const accountInfo = buildLightsparkAccountInfo(
+    input.counterparty,
+    input.fiatCurrency,
+    input.collectedData
+  );
+  const created = await client.createFiatExternalAccount(rampRuntime(c), {
+    customerId: input.customer.customerId,
+    currency: input.fiatCurrency,
+    accountInfo,
+  });
+  const account: LightsparkPayoutAccount = { accountId: created.id, status: created.status };
+  await persistLightsparkPayoutAccount(
+    c,
+    input.counterparty,
+    input.projectId,
+    input.customer.customerId,
+    input.fiatCurrency,
+    account
+  );
+  if (!isLightsparkExternalAccountActive(created.status)) {
+    throw badRequest(
+      `Lightspark payout account was created but is not active yet (status: ${created.status}). Retry once it is verified.`
+    );
+  }
+  return account;
+}
+
+export async function lightsparkOfframpQuote(
+  c: AppContext,
+  input: {
+    counterparty: CounterpartyRow;
+    projectId: string;
+    cryptoToken: string;
+    fiatCurrency?: RampFiatCurrency;
+    cryptoAmount: string;
+    sourceWalletAddress: string;
+    collectedData?: CollectedFieldData;
+  }
+): Promise<PaymentRampQuote> {
+  if (!input.fiatCurrency) {
+    throw badRequest("fiatCurrency is required for Lightspark off-ramp.");
+  }
+
+  const customer = await ensureLightsparkCustomer(c, {
+    counterparty: input.counterparty,
+    projectId: input.projectId,
+  });
+  const payoutAccount = await ensureLightsparkPayoutAccount(c, {
+    counterparty: input.counterparty,
+    projectId: input.projectId,
+    customer,
+    fiatCurrency: input.fiatCurrency,
+    collectedData: input.collectedData,
+  });
+
+  return RAMP_PROVIDER_CLIENTS.lightspark.createOfframpQuote(rampRuntime(c), {
+    cryptoToken: input.cryptoToken,
+    fiatCurrency: input.fiatCurrency,
+    cryptoAmount: input.cryptoAmount,
+    sourceWalletAddress: input.sourceWalletAddress,
+    externalCustomerId: input.counterparty.external_id ?? input.counterparty.id,
+    customerId: customer.customerId,
+    payoutAccountId: payoutAccount.accountId,
+  });
+}

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -104,9 +104,10 @@ async function persistLightsparkPayoutAccount(
  * Resolves the Grid external payout account for (counterparty, fiatCurrency).
  * Creates it from collected bank details on first use, persisting only the
  * resulting account id + status into provider_data — raw bank details are
- * passed through to Grid and never stored. Concurrent first-time quotes are
- * converged first-writer-wins: a loser deletes its duplicate account at Grid
- * and adopts the persisted one.
+ * passed through to Grid and never stored. Grid customers can hold several
+ * external accounts, so the stored entry is a reuse cache: concurrent
+ * first-time quotes each quote against the account they created (last write
+ * wins the cache) rather than risking a quote against someone else's details.
  */
 export async function ensureLightsparkPayoutAccount(
   c: AppContext,
@@ -133,28 +134,22 @@ export async function ensureLightsparkPayoutAccount(
         accountInfo,
       });
 
+      const account: LightsparkPayoutAccount = { accountId: created.id, status: created.status };
       const latestRow = await freshCounterpartyRow(c, input.counterparty, input.projectId);
-      const concurrent = readLightsparkPayoutAccount(latestRow.provider_data, input.fiatCurrency);
-      if (concurrent) {
-        await client.deleteExternalAccount(rampRuntime(c), { accountId: created.id });
-        stored = concurrent;
-      } else {
-        const account: LightsparkPayoutAccount = { accountId: created.id, status: created.status };
-        await persistLightsparkPayoutAccount(
-          c,
-          latestRow,
-          input.projectId,
-          input.customer.customerId,
-          input.fiatCurrency,
-          account
+      await persistLightsparkPayoutAccount(
+        c,
+        latestRow,
+        input.projectId,
+        input.customer.customerId,
+        input.fiatCurrency,
+        account
+      );
+      if (!isLightsparkExternalAccountActive(created.status)) {
+        throw badRequest(
+          `Lightspark payout account was created but is not active yet (status: ${created.status}). Retry once it is verified.`
         );
-        if (!isLightsparkExternalAccountActive(created.status)) {
-          throw badRequest(
-            `Lightspark payout account was created but is not active yet (status: ${created.status}). Retry once it is verified.`
-          );
-        }
-        return account;
       }
+      return account;
     }
   }
 

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -458,6 +458,7 @@ export const createOfframpQuoteSchema = z.object({
   fiatCurrency: rampFiatCurrencySchema.optional(),
   cryptoAmount: paymentAmountSchema,
   redirectUrl: z.string().url().optional(),
+  collectedData: z.record(z.string(), z.string()).optional(),
 });
 
 export const executeOfframpSchema = z.object({
@@ -473,7 +474,7 @@ export const executeOfframpSchema = z.object({
 
 const simulateLightsparkSandboxTransferPayloadSchema = z.object({
   quoteId: z.string().min(1),
-  currencyCode: z.literal("USD").default("USD"),
+  currencyCode: z.enum(["USD", "USDC"]).default("USD"),
   currencyAmount: z.number().int().positive().optional(),
 });
 

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -959,4 +959,113 @@ describe("Lightspark ramp webhook", () => {
       .first<{ status: string }>();
     expect(transfer).toEqual({ status: "completed" });
   });
+
+  const OFFRAMP_TRANSFER_ID = "pt_lightspark_offramp_webhook";
+  const OFFRAMP_QUOTE_ID = "Quote:019eb56d-f06c-5246-0000-c18574f65f2a";
+
+  async function seedLightsparkOfframpTransfer() {
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers (
+           id, organization_id, project_id, wallet_id, source_address, destination_address,
+           token, amount, memo, type, direction, status, provider, provider_reference,
+           delivery_mode, fiat_currency, fiat_amount, provider_data, signature, serialized_tx,
+           initiated_by_key_id, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        OFFRAMP_TRANSFER_ID,
+        ORG_ID,
+        PROJECT_ID,
+        "wallet_lightspark_webhook",
+        "SourceSolanaWallet1111111111111111111111111111",
+        null,
+        "USDC",
+        "10",
+        null,
+        "offramp",
+        "outbound",
+        "awaiting_payment",
+        "lightspark",
+        OFFRAMP_QUOTE_ID,
+        "manual_instructions",
+        "USD",
+        null,
+        {},
+        null,
+        null,
+        null,
+        "2026-06-11T00:00:00.000Z",
+        "2026-06-11T00:00:00.000Z"
+      )
+      .run();
+  }
+
+  function offrampCompletedWebhook(): LightsparkOnrampWebhookPayload {
+    return {
+      id: "Webhook:019eb56e-ea4e-52c1-0000-36fa5542e7e6",
+      type: "OUTGOING_PAYMENT.COMPLETED",
+      timestamp: "2026-06-11T06:46:45.582432Z",
+      data: {
+        ...LIGHTSPARK_ONRAMP_PAYMENT_DATA,
+        quoteId: OFFRAMP_QUOTE_ID,
+        description: "SDP offramp",
+        source: {
+          sourceType: "REALTIME_FUNDING",
+          currency: "USDC",
+          customerId: "Customer:019eb1a0-8aa2-938e-0000-36f4d5ac29d2",
+        },
+        sentAmount: {
+          amount: 10000000,
+          currency: { code: "USDC", name: "USD Coin", symbol: "usdc", decimals: 6 },
+        },
+        receivedAmount: {
+          amount: 999,
+          currency: { code: "USD", name: "US Dollar", symbol: "$", decimals: 2 },
+        },
+        status: "COMPLETED",
+        updatedAt: "2026-06-11T06:46:45.550956Z",
+        settledAt: "2026-06-11T06:46:45.552374Z",
+      },
+    };
+  }
+
+  it("persists the settled fiat amount on a lightspark offramp COMPLETED webhook", async () => {
+    await seedLightsparkOfframpTransfer();
+
+    const res = await sendLightsparkWebhook(offrampCompletedWebhook());
+    expect(res.status).toBe(200);
+
+    const transfer = await getDb(env)
+      .prepare("SELECT status, fiat_amount FROM payment_transfers WHERE id = ?")
+      .bind(OFFRAMP_TRANSFER_ID)
+      .first<{ status: string; fiat_amount: string }>();
+    expect(transfer).toEqual({ status: "completed", fiat_amount: "9.99" });
+  });
+
+  it("does not regress a settled transfer when a stale webhook is redelivered", async () => {
+    await seedLightsparkOfframpTransfer();
+
+    const completed = await sendLightsparkWebhook(offrampCompletedWebhook());
+    expect(completed.status).toBe(200);
+
+    const stale = await sendLightsparkWebhook({
+      id: "Webhook:019eb56d-f08b-52c1-0000-90f1e68dc8f8",
+      type: "OUTGOING_PAYMENT.PENDING",
+      timestamp: "2026-06-11T06:45:41.643544Z",
+      data: {
+        ...LIGHTSPARK_ONRAMP_PAYMENT_DATA,
+        quoteId: OFFRAMP_QUOTE_ID,
+        status: "PENDING",
+        updatedAt: "2026-06-11T06:45:41.629605Z",
+      },
+    });
+    expect(stale.status).toBe(200);
+
+    const transfer = await getDb(env)
+      .prepare("SELECT status, fiat_amount FROM payment_transfers WHERE id = ?")
+      .bind(OFFRAMP_TRANSFER_ID)
+      .first<{ status: string; fiat_amount: string }>();
+    expect(transfer).toEqual({ status: "completed", fiat_amount: "9.99" });
+  });
 });

--- a/apps/sdp-api/src/routes/webhooks/ramps/settlements.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/settlements.ts
@@ -14,6 +14,16 @@ const RAMP_SETTLEMENT_STATUS = {
   expired: "expired",
 } as const satisfies Record<Exclude<RampSettlementEvent["kind"], "ignore">, PaymentTransferStatus>;
 
+const TERMINAL_RAMP_TRANSFER_STATUSES = [
+  "completed",
+  "failed",
+  "expired",
+] as const satisfies readonly PaymentTransferStatus[];
+
+function isTerminalRampTransferStatus(status: PaymentTransferStatus): boolean {
+  return (TERMINAL_RAMP_TRANSFER_STATUSES as readonly PaymentTransferStatus[]).includes(status);
+}
+
 export async function applyRampSettlementEvent(c: AppContext, event: RampSettlementEvent) {
   if (event.kind === "ignore") {
     return;
@@ -30,12 +40,22 @@ export async function applyRampSettlementEvent(c: AppContext, event: RampSettlem
   if (!isRampTransferType(transfer.type)) {
     return;
   }
+  // Out-of-order or redelivered events must not regress a settled transfer
+  // (e.g. a retried PENDING arriving after COMPLETED).
+  if (isTerminalRampTransferStatus(transfer.status)) {
+    return;
+  }
 
   const update: UpdatePaymentTransferInput = {
     transferId: transfer.id,
     status: RAMP_SETTLEMENT_STATUS[event.kind],
     updatedAt: new Date().toISOString(),
   };
+  // For off-ramp the received side is the fiat payout; for on-ramp it is the
+  // crypto leg, which the transfer row already records as its amount.
+  if (event.kind === "settled" && event.receivedAmount && transfer.type === "offramp") {
+    update.fiatAmount = event.receivedAmount;
+  }
   if (event.kind === "failed" && event.error) {
     update.error = event.error;
   }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -544,7 +544,7 @@ type SandboxTransferSimulationInput =
       provider: "lightspark";
       payload: {
         quoteId: string;
-        currencyCode?: "USD";
+        currencyCode?: "USD" | "USDC";
         currencyAmount?: number;
       };
     }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/manual-instructions-quote.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/manual-instructions-quote.tsx
@@ -23,6 +23,7 @@ import {
   formatRampQuoteTimeRemaining,
 } from "@/app/dashboard/payments/payments-overview.utils";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type ManualQuote = Extract<PaymentRampQuote, { deliveryMode: "manual_instructions" }>;
 type LightsparkQuote = Extract<ManualQuote, { provider: "lightspark" }>;
@@ -36,13 +37,21 @@ async function copyPaymentInstruction(label: string, value: string) {
   }
 }
 
-function PaymentInstructionField({ label, value }: { label: string; value?: string }) {
+function PaymentInstructionField({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value?: string;
+  className?: string;
+}) {
   if (!value) {
     return null;
   }
 
   return (
-    <div className="rounded-xl bg-border-extra-light px-4 py-3">
+    <div className={cn("rounded-xl bg-border-extra-light px-4 py-3", className)}>
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
           <p className="text-xs font-medium uppercase tracking-[0.08em] text-text-low">{label}</p>
@@ -184,27 +193,28 @@ function ManualQuoteSummary({
 type LightsparkInstructionType = Extract<PaymentRampInstruction, { provider: "lightspark" }>;
 type BvnkInstructionType = Extract<PaymentRampInstruction, { provider: "bvnk" }>;
 
-type SimulateQuote = { loading: boolean; succeeded: boolean; onClick: () => void };
-
-function SimulateButton({
-  simulateQuote,
-  idleLabel,
-  doneLabel,
-}: {
-  simulateQuote: SimulateQuote;
+export interface InstructionAction {
+  loading: boolean;
+  succeeded: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  icon: ReactNode;
   idleLabel: string;
+  busyLabel: string;
   doneLabel: string;
-}) {
+}
+
+function InstructionActionButton({ action }: { action: InstructionAction }) {
   return (
     <Button
       type="button"
       variant="secondary"
       size="xs"
-      iconLeft={simulateQuote.succeeded ? <CheckCircle2Icon /> : <DollarSignIcon />}
-      onClick={simulateQuote.onClick}
-      disabled={simulateQuote.loading || simulateQuote.succeeded}
+      iconLeft={action.succeeded ? <CheckCircle2Icon /> : action.icon}
+      onClick={action.onClick}
+      disabled={action.disabled || action.loading || action.succeeded}
     >
-      {simulateQuote.succeeded ? doneLabel : simulateQuote.loading ? "Simulating..." : idleLabel}
+      {action.succeeded ? action.doneLabel : action.loading ? action.busyLabel : action.idleLabel}
     </Button>
   );
 }
@@ -223,12 +233,12 @@ function InstructionBadge({ children }: { children: ReactNode }) {
 
 function LightsparkInstruction({
   instruction,
-  showSimulate,
-  simulateQuote,
+  showAction,
+  action,
 }: {
   instruction: LightsparkInstructionType;
-  showSimulate: boolean;
-  simulateQuote?: SimulateQuote;
+  showAction: boolean;
+  action?: InstructionAction;
 }) {
   const info = instruction.accountOrWalletInfo;
   return (
@@ -238,19 +248,17 @@ function LightsparkInstruction({
           <InstructionBadge>{info.accountType.replaceAll("_", " ")}</InstructionBadge>
           {info.assetType ? <InstructionBadge>{info.assetType}</InstructionBadge> : null}
         </InstructionBadges>
-        {showSimulate && simulateQuote ? (
-          <SimulateButton
-            simulateQuote={simulateQuote}
-            idleLabel="Simulate Quote"
-            doneLabel="Quote Simulated"
-          />
-        ) : null}
+        {showAction && action ? <InstructionActionButton action={action} /> : null}
       </div>
       <div className="grid gap-3 lg:grid-cols-2">
         <PaymentInstructionField label="Bank name" value={info.bankName} />
         <PaymentInstructionField label="Routing number" value={info.routingNumber} />
         <PaymentInstructionField label="Account number" value={info.accountNumber} />
-        <PaymentInstructionField label="Wallet address" value={info.address} />
+        <PaymentInstructionField
+          label="Wallet address"
+          value={info.address}
+          className="lg:col-span-2"
+        />
       </div>
       <PaymentInstructionField label="Reference" value={info.reference} />
       {info.paymentRails?.length ? (
@@ -273,10 +281,10 @@ function LightsparkInstruction({
 
 function BvnkInstruction({
   instruction,
-  simulateQuote,
+  action,
 }: {
   instruction: BvnkInstructionType;
-  simulateQuote?: SimulateQuote;
+  action?: InstructionAction;
 }) {
   const isReady = instruction.onboardingStatus === "ready";
   const needsVerification = instruction.onboardingStatus === "verification_required";
@@ -291,13 +299,7 @@ function BvnkInstruction({
           <InstructionBadge>{instruction.fiatCurrency} virtual account</InstructionBadge>
           <InstructionBadge>{instruction.network}</InstructionBadge>
         </InstructionBadges>
-        {isReady && simulateQuote ? (
-          <SimulateButton
-            simulateQuote={simulateQuote}
-            idleLabel="Simulate Deposit"
-            doneLabel="Deposit Simulated"
-          />
-        ) : null}
+        {isReady && action ? <InstructionActionButton action={action} /> : null}
       </div>
 
       {needsVerification ? (
@@ -377,18 +379,18 @@ export function ManualInstructionsQuote({
   fiatCurrency,
   cryptoToken,
   instructions,
-  simulateQuote,
+  action,
+  description,
 }: {
   amount: string;
   quote: ManualQuote;
   fiatCurrency: string;
   cryptoToken: string;
   instructions: PaymentRampInstruction[];
-  simulateQuote?: {
-    loading: boolean;
-    succeeded: boolean;
-    onClick: () => void;
-  };
+  /** Button rendered in the instruction header (e.g. simulate for onramp, send for offramp). */
+  action?: InstructionAction;
+  /** Overrides the default fiat-deposit copy (e.g. for crypto-funded off-ramp quotes). */
+  description?: string;
 }) {
   const [activeTab, setActiveTab] = useState<"instructions" | "summary">("instructions");
 
@@ -397,7 +399,7 @@ export function ManualInstructionsQuote({
       <BvnkInstruction
         key={instruction.ruleId ?? instruction.beneficiaryAddress}
         instruction={instruction}
-        simulateQuote={simulateQuote}
+        action={action}
       />
     ) : (
       <LightsparkInstruction
@@ -407,8 +409,8 @@ export function ManualInstructionsQuote({
           "lightspark"
         }
         instruction={instruction}
-        showSimulate={index === 0}
-        simulateQuote={simulateQuote}
+        showAction={index === 0}
+        action={action}
       />
     )
   );
@@ -422,8 +424,8 @@ export function ManualInstructionsQuote({
         <div>
           <p className="text-sm font-medium text-text-extra-high">Manual Funding Instructions</p>
           <p className="mt-2 text-sm text-text-low">
-            Send {amount ? `$${amount}` : "the quoted amount"} using one of the supported rails.
-            Include the reference exactly so the provider can match the deposit to this quote.
+            {description ??
+              `Send ${amount ? `$${amount}` : "the quoted amount"} using one of the supported rails. Include the reference exactly so the provider can match the deposit to this quote.`}
           </p>
         </div>
       </div>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { CheckCircle2Icon, Loader2Icon, WalletIcon, XCircleIcon } from "lucide-react";
-import { useMemo } from "react";
-import {
-  formatCurrencyAmount,
-  resolveTotalBalance,
-} from "@/app/dashboard/payments/payments-overview.utils";
+import { CheckCircle2Icon, SendIcon, WalletIcon, XCircleIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { Combobox } from "@/components/ui/combobox";
-import { OFFRAMP_PAIRS, RAMP_PROVIDER_OPTIONS } from "@/lib/ramps";
+import { OFFRAMP_PAIRS, RAMP_PROVIDER_OPTIONS, toRampCryptoToken } from "@/lib/ramps";
 import type { OfframpWizard } from "../hooks/use-offramp-wizard";
+import { walletComboboxOptions } from "../wallet-options";
 import { HostedRampFrame } from "./hosted-ramp-frame";
+import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
 import { RampStepPlaceholder } from "./ramp-step-placeholder";
+import { RequirementsFields } from "./requirements-fields";
+import { WalletAssetBreakdown } from "./wallet-asset-breakdown";
 
 function getOfframpTransferStatusCopy(status: string) {
   switch (status) {
@@ -20,7 +20,7 @@ function getOfframpTransferStatusCopy(status: string) {
       return {
         title: "Waiting to send",
         description:
-          "Complete the payout in the widget above. We will update this outgoing transfer automatically once the provider receives your crypto.",
+          "Complete the payout using the instructions above. We will update this outgoing transfer automatically once the provider receives your crypto.",
         state: "loading" as const,
       };
     case "processing":
@@ -61,6 +61,17 @@ function getOfframpTransferStatusCopy(status: string) {
   }
 }
 
+function AnimatedDots() {
+  const [count, setCount] = useState(1);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setCount((current) => (current % 3) + 1), 500);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return <span aria-hidden>{".".repeat(count)}</span>;
+}
+
 function OfframpTransferStatusPanel({ transfer }: { transfer: OfframpWizard["transferStatus"] }) {
   const copy = transfer
     ? getOfframpTransferStatusCopy(transfer.status)
@@ -74,18 +85,74 @@ function OfframpTransferStatusPanel({ transfer }: { transfer: OfframpWizard["tra
       <CheckCircle2Icon className="size-5 text-status-success-text" />
     ) : copy.state === "error" ? (
       <XCircleIcon className="size-5 text-status-error-text" />
-    ) : (
-      <Loader2Icon className="size-5 animate-spin text-text-medium" />
-    );
+    ) : null;
   return (
     <div className="flex items-start gap-3">
-      <span className="mt-0.5 shrink-0">{icon}</span>
+      {icon ? <span className="mt-0.5 shrink-0">{icon}</span> : null}
       <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-text-extra-high">{copy.title}</p>
-        <p className="mt-1 text-sm leading-relaxed text-text-low">
-          {copy.description}
-          {copy.state === "loading" ? " Checking transfer status…" : null}
+        <p className="text-sm font-medium text-text-extra-high">
+          {copy.title}
+          {copy.state === "loading" ? <AnimatedDots /> : null}
         </p>
+        <p className="mt-1 text-sm leading-relaxed text-text-low">{copy.description}</p>
+      </div>
+    </div>
+  );
+}
+
+function OfframpManualQuoteStep({
+  wizard,
+  quote,
+}: {
+  wizard: OfframpWizard;
+  quote: Extract<NonNullable<OfframpWizard["quote"]>, { deliveryMode: "manual_instructions" }>;
+}) {
+  const {
+    selectedRampPair,
+    fields,
+    transferStatus,
+    canSendOnchain,
+    onchainSendLoading,
+    onchainSendResult,
+    sendCryptoToDeposit,
+  } = wizard;
+
+  if (!quote.paymentInstructions) {
+    return (
+      <div className="rounded-2xl border border-status-error-border bg-status-error-bg px-5 py-5 text-sm text-status-error-text">
+        Ramp quote is missing payment instructions.
+      </div>
+    );
+  }
+
+  const cryptoToken = toRampCryptoToken(selectedRampPair.assetRail);
+  const sendLabel = `Send ${fields.amount.trim()} ${cryptoToken.toUpperCase()}`;
+  return (
+    <div className="space-y-6">
+      <ManualInstructionsQuote
+        amount={fields.amount.trim()}
+        quote={quote}
+        fiatCurrency={selectedRampPair.fiatCurrency}
+        cryptoToken={cryptoToken}
+        instructions={quote.paymentInstructions}
+        description={`Send ${fields.amount.trim()} ${cryptoToken.toUpperCase()} to the deposit address below before the quote expires. The provider converts it at the locked rate and pays out to the saved bank account automatically.`}
+        action={
+          quote.provider === "lightspark"
+            ? {
+                loading: onchainSendLoading,
+                succeeded: onchainSendResult !== null,
+                disabled: !canSendOnchain,
+                onClick: () => void sendCryptoToDeposit(),
+                icon: <SendIcon />,
+                idleLabel: sendLabel,
+                busyLabel: "Sending...",
+                doneLabel: "Transfer submitted",
+              }
+            : undefined
+        }
+      />
+      <div className="border-t border-border-light pt-5">
+        <OfframpTransferStatusPanel transfer={transferStatus} />
       </div>
     </div>
   );
@@ -104,33 +171,29 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     transferStatus,
     setField,
     handlePairChange,
+    requirementFields,
+    collectedData,
+    setCollectedField,
+    requirementsBlocker,
   } = wizard;
 
-  const walletOptions = useMemo(
-    () =>
-      liveWallets.map((wallet) => {
-        const total = wallet.balances ? resolveTotalBalance(wallet.balances) : null;
-        return {
-          value: wallet.walletId,
-          label: wallet.label ?? wallet.walletId,
-          description: total !== null ? formatCurrencyAmount(total) : undefined,
-        };
-      }),
-    [liveWallets]
-  );
+  const walletOptions = useMemo(() => walletComboboxOptions(liveWallets), [liveWallets]);
 
   if (currentStepId === "WALLET") {
     return (
-      <Combobox
-        label="Source wallet"
-        value={fields.walletId || null}
-        onChange={(walletId) => setField("walletId", walletId)}
-        options={walletOptions}
-        placeholder="Select a source wallet"
-        searchPlaceholder="Search wallets"
-        icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
-        isLoading={walletsLoading}
-      />
+      <div className="space-y-4">
+        <Combobox
+          label="Source wallet"
+          value={fields.walletId || null}
+          onChange={(walletId) => setField("walletId", walletId)}
+          options={walletOptions}
+          placeholder="Select a source wallet"
+          searchPlaceholder="Search wallets"
+          icon={<WalletIcon className="size-5 shrink-0 text-text-low" />}
+          isLoading={walletsLoading}
+        />
+        {selectedWallet ? <WalletAssetBreakdown wallet={selectedWallet} /> : null}
+      </div>
     );
   }
 
@@ -144,23 +207,40 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     }
 
     return (
-      <RampPairProviderSelector
-        direction="offramp"
-        pairs={OFFRAMP_PAIRS}
-        enabledRampProviders={enabledRampProviders}
-        providerOptions={RAMP_PROVIDER_OPTIONS}
-        wallets={liveWallets}
-        walletsLoading={walletsLoading}
-        selectedWallet={selectedWallet}
-        showWallet={false}
-        selectedPair={selectedRampPair}
-        selectedProvider={fields.provider}
-        amount={fields.amount}
-        onAmountChange={(value) => setField("amount", value)}
-        onAmountBlur={() => {}}
-        onWalletChange={(walletId) => setField("walletId", walletId)}
-        onPairChange={handlePairChange}
-        onProviderSelect={(nextProvider) => setField("provider", nextProvider)}
+      <div className="space-y-4">
+        <RampPairProviderSelector
+          direction="offramp"
+          pairs={OFFRAMP_PAIRS}
+          enabledRampProviders={enabledRampProviders}
+          providerOptions={RAMP_PROVIDER_OPTIONS}
+          wallets={liveWallets}
+          walletsLoading={walletsLoading}
+          selectedWallet={selectedWallet}
+          showWallet={false}
+          selectedPair={selectedRampPair}
+          selectedProvider={fields.provider}
+          amount={fields.amount}
+          onAmountChange={(value) => setField("amount", value)}
+          onAmountBlur={() => {}}
+          onWalletChange={(walletId) => setField("walletId", walletId)}
+          onPairChange={handlePairChange}
+          onProviderSelect={(nextProvider) => setField("provider", nextProvider)}
+        />
+        {requirementsBlocker ? (
+          <div className="rounded-2xl border border-status-error-border bg-status-error-bg px-4 py-3 text-sm text-status-error-text">
+            {requirementsBlocker}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (currentStepId === "REQUIREMENTS") {
+    return (
+      <RequirementsFields
+        fields={requirementFields}
+        values={collectedData}
+        onChange={setCollectedField}
       />
     );
   }
@@ -174,6 +254,10 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
         </div>
       </div>
     );
+  }
+
+  if (currentStepId === "COMPLETE" && quote?.deliveryMode === "manual_instructions") {
+    return <OfframpManualQuoteStep wizard={wizard} quote={quote} />;
   }
 
   return <RampStepPlaceholder />;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -115,6 +115,7 @@ function OfframpManualQuoteStep({
     onchainSendLoading,
     onchainSendResult,
     sendCryptoToDeposit,
+    quoteExpired,
   } = wizard;
 
   if (!quote.paymentInstructions) {
@@ -141,10 +142,10 @@ function OfframpManualQuoteStep({
             ? {
                 loading: onchainSendLoading,
                 succeeded: onchainSendResult !== null,
-                disabled: !canSendOnchain,
+                disabled: !canSendOnchain || quoteExpired,
                 onClick: () => void sendCryptoToDeposit(),
                 icon: <SendIcon />,
-                idleLabel: sendLabel,
+                idleLabel: quoteExpired ? "Quote expired" : sendLabel,
                 busyLabel: "Sending...",
                 doneLabel: "Transfer submitted",
               }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-receive-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-receive-step-content.tsx
@@ -2,30 +2,16 @@
 
 import { WalletIcon } from "lucide-react";
 import { useMemo } from "react";
-import {
-  formatCurrencyAmount,
-  resolveTotalBalance,
-} from "@/app/dashboard/payments/payments-overview.utils";
 import { Combobox } from "@/components/ui/combobox";
 import type { OnchainReceiveWizard } from "../hooks/use-onchain-receive-wizard";
+import { walletComboboxOptions } from "../wallet-options";
 import { WalletReceiveCard } from "./wallet-receive-card";
 
 export function OnchainReceiveStepContent({ wizard }: { wizard: OnchainReceiveWizard }) {
   const { currentStepId, liveWallets, walletsLoading, selectedWallet, walletId, setWalletId } =
     wizard;
 
-  const walletOptions = useMemo(
-    () =>
-      liveWallets.map((wallet) => {
-        const total = wallet.balances ? resolveTotalBalance(wallet.balances) : null;
-        return {
-          value: wallet.walletId,
-          label: wallet.label ?? wallet.walletId,
-          description: total !== null ? formatCurrencyAmount(total) : undefined,
-        };
-      }),
-    [liveWallets]
-  );
+  const walletOptions = useMemo(() => walletComboboxOptions(liveWallets), [liveWallets]);
 
   if (currentStepId === "WALLET") {
     return (

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -10,17 +10,14 @@ import {
 } from "lucide-react";
 import { type ReactNode, useMemo } from "react";
 import { AddExternalAccountDialog } from "@/app/dashboard/payments/counterparty/add-external-account-dialog";
-import {
-  formatCurrencyAmount,
-  resolveTotalBalance,
-  shortenAddress,
-} from "@/app/dashboard/payments/payments-overview.utils";
+import { shortenAddress } from "@/app/dashboard/payments/payments-overview.utils";
 import { getDevnetExplorerUrl } from "@/app/dashboard/payments/payments-workspace.data";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { OnchainSendWizard } from "../hooks/use-onchain-send-wizard";
+import { walletComboboxOptions } from "../wallet-options";
 import { CounterpartyAccountSelector } from "./counterparty-account-selector";
 
 function DetailRow({ icon, label, value }: { icon: ReactNode; label: string; value: ReactNode }) {
@@ -67,18 +64,7 @@ export function OnchainSendStepContent({
     transferResult,
   } = wizard;
 
-  const walletOptions = useMemo(
-    () =>
-      liveWallets.map((wallet) => {
-        const total = wallet.balances ? resolveTotalBalance(wallet.balances) : null;
-        return {
-          value: wallet.walletId,
-          label: wallet.label ?? wallet.walletId,
-          description: total !== null ? formatCurrencyAmount(total) : undefined,
-        };
-      }),
-    [liveWallets]
-  );
+  const walletOptions = useMemo(() => walletComboboxOptions(liveWallets), [liveWallets]);
 
   if (currentStepId === "DESTINATION") {
     return (

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCircle2Icon, Loader2Icon, XCircleIcon } from "lucide-react";
+import { CheckCircle2Icon, DollarSignIcon, Loader2Icon, XCircleIcon } from "lucide-react";
 import {
   formatMinorCurrencyAmount,
   formatTimestamp,
@@ -288,12 +288,16 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
           fiatCurrency={selectedRampPair.fiatCurrency}
           cryptoToken={toRampCryptoToken(selectedRampPair.assetRail)}
           instructions={quote.paymentInstructions}
-          simulateQuote={
+          action={
             quote.provider === "lightspark" || quote.provider === "bvnk"
               ? {
                   loading: quoteSimulationLoading,
                   succeeded: quoteSimulationSucceeded,
                   onClick: () => void simulateCurrentQuote(),
+                  icon: <DollarSignIcon />,
+                  idleLabel: quote.provider === "bvnk" ? "Simulate Deposit" : "Simulate Quote",
+                  busyLabel: "Simulating...",
+                  doneLabel: quote.provider === "bvnk" ? "Deposit Simulated" : "Quote Simulated",
                 }
               : undefined
           }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
@@ -38,7 +38,8 @@ interface RampWizardShellProps {
   setCounterpartyDialogOpen: (open: boolean) => void;
   onCounterpartyCreated: (created: Counterparty) => void;
   children: ReactNode;
-  footer?: ReactNode;
+  /** Rendered top-right, next to the step title (e.g. the "Powered by" badge). */
+  header?: ReactNode;
   footerActions?: ReactNode;
   hidePrimary?: boolean;
 }
@@ -55,7 +56,7 @@ export function RampWizardShell({
   setCounterpartyDialogOpen,
   onCounterpartyCreated,
   children,
-  footer,
+  header,
   footerActions,
   hidePrimary,
 }: RampWizardShellProps) {
@@ -87,7 +88,7 @@ export function RampWizardShell({
             <p className="text-3xl font-medium leading-tight tracking-tight text-text-extra-high">
               {steps[stepIndex]?.title}
             </p>
-            {footer}
+            {header}
           </div>
         </div>
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
@@ -31,6 +31,8 @@ interface RampWizardShellProps {
   stepIndex: number;
   primaryDisabled: boolean;
   primaryLabel: string;
+  /** Overrides the default Cancel/Previous secondary label. */
+  secondaryLabel?: string;
   walletsError: string | null;
   onPrimary: () => void;
   onSecondary: () => void;
@@ -49,6 +51,7 @@ export function RampWizardShell({
   stepIndex,
   primaryDisabled,
   primaryLabel,
+  secondaryLabel,
   walletsError,
   onPrimary,
   onSecondary,
@@ -108,7 +111,7 @@ export function RampWizardShell({
           className="h-14 rounded-full text-base"
           onClick={onSecondary}
         >
-          {stepIndex === 0 ? "Cancel" : "Previous"}
+          {secondaryLabel ?? (stepIndex === 0 ? "Cancel" : "Previous")}
         </Button>
         <div className="flex flex-col gap-3 sm:flex-row">
           {footerActions}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/wallet-asset-breakdown.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/wallet-asset-breakdown.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { PaymentsDashboardWallet } from "@sdp/types";
+import { motion } from "motion/react";
+import {
+  formatCurrencyAmount,
+  resolveUsdBalanceValue,
+} from "@/app/dashboard/payments/payments-overview.utils";
+
+interface BreakdownRow {
+  token: string;
+  amount: number;
+  usdValue: number | null;
+}
+
+function breakdownRows(wallet: PaymentsDashboardWallet): BreakdownRow[] {
+  const rows = (wallet.balances ?? []).flatMap((balance) => {
+    const amount = Number(balance.uiAmount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return [];
+    }
+    return [
+      {
+        token: balance.token.trim().toUpperCase(),
+        amount,
+        usdValue: resolveUsdBalanceValue(balance),
+      },
+    ];
+  });
+  return rows.sort((a, b) => (b.usdValue ?? -1) - (a.usdValue ?? -1));
+}
+
+function formatTwoDecimals(value: number): string {
+  return value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
+export function WalletAssetBreakdown({ wallet }: { wallet: PaymentsDashboardWallet }) {
+  const rows = breakdownRows(wallet);
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const totalUsd = rows.reduce((sum, row) => sum + (row.usdValue ?? 0), 0);
+
+  return (
+    <motion.div
+      key={wallet.walletId}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className="space-y-5 pt-4"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-medium tracking-tight text-text-extra-high">Asset breakdown</h2>
+        {totalUsd > 0 ? (
+          <p className="text-sm text-text-low">{formatCurrencyAmount(totalUsd)} total</p>
+        ) : null}
+      </div>
+      <div className="space-y-6">
+        {rows.map((row, index) => {
+          const shareValue =
+            row.usdValue !== null && totalUsd > 0 ? (row.usdValue / totalUsd) * 100 : null;
+          return (
+            <motion.div
+              key={row.token}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.25, ease: "easeOut", delay: index * 0.06 }}
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex min-w-0 items-baseline gap-2">
+                  <p className="text-base font-medium text-text-extra-high">{row.token}</p>
+                  {row.usdValue !== null ? (
+                    <p className="text-sm text-text-low">{formatCurrencyAmount(row.usdValue)}</p>
+                  ) : null}
+                </div>
+                <p className="shrink-0 text-sm text-text-medium">
+                  {formatTwoDecimals(row.amount)}
+                  {shareValue !== null ? ` · ${formatTwoDecimals(shareValue)}%` : ""}
+                </p>
+              </div>
+              {shareValue !== null ? (
+                <div className="mt-3 h-1.5 w-full rounded-full bg-border-light">
+                  <motion.div
+                    initial={{ width: 0 }}
+                    animate={{ width: `${shareValue}%` }}
+                    transition={{ duration: 0.5, ease: "easeOut", delay: 0.1 + index * 0.06 }}
+                    className="h-1.5 rounded-full bg-gray-1400"
+                  />
+                </div>
+              ) : null}
+            </motion.div>
+          );
+        })}
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { RampProviderId } from "@sdp/types";
+import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import type {
   CollectedFieldData,
   CounterpartyRequirements,
@@ -14,9 +15,13 @@ import { getApiError } from "@/app/dashboard/payments/payments-workspace.data";
 async function fetchCounterpartyRequirements(
   counterpartyId: string,
   provider: RampProviderId,
-  direction: RampDirection
+  direction: RampDirection,
+  fiatCurrency: RampFiatCurrency | undefined
 ): Promise<CounterpartyRequirements> {
   const params = new URLSearchParams({ provider, direction });
+  if (fiatCurrency !== undefined) {
+    params.set("fiatCurrency", fiatCurrency);
+  }
   const response = await fetch(
     `/api/dashboard/counterparty/${encodeURIComponent(counterpartyId)}/requirements?${params.toString()}`
   );
@@ -36,6 +41,8 @@ export interface CounterpartyRequirementsParams {
   counterpartyId: string;
   provider: RampProviderId | null;
   direction: RampDirection;
+  /** Payout currency — required by lightspark offramp requirements; ignored by other providers. */
+  fiatCurrency?: RampFiatCurrency;
 }
 
 export interface CounterpartyRequirementsState {
@@ -67,10 +74,11 @@ export function useCounterpartyRequirements(
     setCollectedData((prev) => ({ ...prev, [key]: value }));
   };
 
-  // Reset collected answers when the counterparty/provider changes by comparing the
-  // previous value during render (React's no-effect way to reset state on a change),
-  // so stale KYC never leaks into a different provider's payload.
-  const subjectKey = params === null ? "" : `${params.counterpartyId}:${params.provider}`;
+  // Reset collected answers when the counterparty/provider/currency changes by comparing
+  // the previous value during render (React's no-effect way to reset state on a change),
+  // so stale KYC or bank details never leak into a different provider's payload.
+  const subjectKey =
+    params === null ? "" : `${params.counterpartyId}:${params.provider}:${params.fiatCurrency}`;
   const [trackedSubject, setTrackedSubject] = useState(subjectKey);
   if (subjectKey !== trackedSubject) {
     setTrackedSubject(subjectKey);
@@ -84,15 +92,16 @@ export function useCounterpartyRequirements(
           params.counterpartyId,
           params.provider,
           params.direction,
+          params.fiatCurrency,
         ] as const)
       : null;
-  // Requirements are deterministic for a (counterparty, provider) for the wizard's
-  // lifetime — never revalidate, so `needsCollection` (and thus the wizard's step
-  // list) can't flip out from under the user mid-flow.
+  // Requirements are deterministic for a (counterparty, provider, currency) for the
+  // wizard's lifetime — never revalidate, so `needsCollection` (and thus the wizard's
+  // step list) can't flip out from under the user mid-flow.
   const { data, error } = useSWR(
     key,
-    ([, counterpartyId, provider, direction]) =>
-      fetchCounterpartyRequirements(counterpartyId, provider, direction),
+    ([, counterpartyId, provider, direction, fiatCurrency]) =>
+      fetchCounterpartyRequirements(counterpartyId, provider, direction, fiatCurrency),
     { revalidateOnFocus: false, revalidateOnReconnect: false, revalidateIfStale: false }
   );
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
@@ -1,9 +1,14 @@
 "use client";
 
 import type { PaymentTransferSummary } from "@sdp/types";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import useSWR from "swr";
-import { fetchTransferByProviderReference } from "@/app/dashboard/payments/payments-workspace.data";
-import { OFFRAMP_PAIRS } from "@/lib/ramps";
+import {
+  createTransfer,
+  fetchTransferByProviderReference,
+} from "@/app/dashboard/payments/payments-workspace.data";
+import { OFFRAMP_PAIRS, toRampCryptoToken } from "@/lib/ramps";
 import { sourceWalletSchema, withdrawAmountSchema, withdrawSelectionSchema } from "../schema";
 import {
   isTerminalRampTransferStatus,
@@ -18,17 +23,33 @@ export const OFFRAMP_STEPS = [
   { id: "COMPLETE", label: "Complete", title: "Complete your payout" },
 ] as const satisfies readonly RampWizardStep[];
 
-export type OfframpStepId = (typeof OFFRAMP_STEPS)[number]["id"];
+const OFFRAMP_REQUIREMENTS_STEP = {
+  id: "REQUIREMENTS",
+  label: "Payout details",
+  title: "Where should we send the payout?",
+} as const satisfies RampWizardStep;
+
+export type OfframpStepId =
+  | (typeof OFFRAMP_STEPS)[number]["id"]
+  | typeof OFFRAMP_REQUIREMENTS_STEP.id;
 
 export function useOfframpWizard(props: UseRampWizardProps) {
-  const wizard = useRampWizard(props, {
+  const [onchainSendLoading, setOnchainSendLoading] = useState(false);
+  const [onchainSendResult, setOnchainSendResult] = useState<PaymentTransferSummary | null>(null);
+
+  const wizard = useRampWizard<OfframpStepId>(props, {
     pairs: OFFRAMP_PAIRS,
     steps: OFFRAMP_STEPS,
     stepSchemas: { WALLET: sourceWalletSchema, WITHDRAW: withdrawAmountSchema },
     quoteStepId: "WITHDRAW",
+    requirements: {
+      step: OFFRAMP_REQUIREMENTS_STEP,
+      insertAfter: "WITHDRAW",
+      direction: "offramp",
+    },
     selectionSchema: withdrawSelectionSchema,
     quoteEndpoint: "/api/dashboard/payments/ramps/offramp/quote",
-    buildQuotePayload: ({ fields, provider, selectedRampPair, cryptoToken }) => ({
+    buildQuotePayload: ({ fields, provider, selectedRampPair, cryptoToken, collectedData }) => ({
       provider,
       counterpartyId: fields.counterpartyId,
       sourceWallet: fields.walletId,
@@ -36,8 +57,76 @@ export function useOfframpWizard(props: UseRampWizardProps) {
       fiatCurrency: selectedRampPair.fiatCurrency,
       cryptoAmount: fields.amount.trim(),
       redirectUrl: `${window.location.origin}/dashboard/payments`,
+      collectedData,
     }),
+    onQuoteCreated: () => {
+      setOnchainSendLoading(false);
+      setOnchainSendResult(null);
+    },
   });
+
+  // The Solana deposit address Grid generated for this realtime-funded quote.
+  const depositAddress = useMemo(() => {
+    const quote = wizard.quote;
+    if (quote?.provider !== "lightspark" || quote.deliveryMode !== "manual_instructions") {
+      return null;
+    }
+    const instruction = quote.paymentInstructions?.find(
+      (entry) =>
+        entry.accountOrWalletInfo.accountType.toUpperCase() === "SOLANA_WALLET" &&
+        entry.accountOrWalletInfo.address
+    );
+    return instruction?.accountOrWalletInfo.address ?? null;
+  }, [wizard.quote]);
+
+  const offrampCryptoToken = toRampCryptoToken(wizard.selectedRampPair.assetRail);
+  // The transfers API requires the mint address, not the token symbol.
+  const sourceTokenMint = useMemo(() => {
+    const balance = wizard.selectedWallet?.balances?.find(
+      (entry) => entry.token === offrampCryptoToken
+    );
+    return balance?.mint ?? null;
+  }, [wizard.selectedWallet, offrampCryptoToken]);
+
+  const canSendOnchain =
+    depositAddress !== null && sourceTokenMint !== null && wizard.fields.walletId.length > 0;
+
+  const sendCryptoToDeposit = async () => {
+    if (!depositAddress || !sourceTokenMint || !wizard.fields.walletId) {
+      return;
+    }
+    if (onchainSendLoading || onchainSendResult) {
+      return;
+    }
+
+    setOnchainSendLoading(true);
+    const toastId = toast.loading("Submitting on-chain transfer.", { position: "bottom-right" });
+
+    try {
+      const transfer = await createTransfer({
+        source: wizard.fields.walletId,
+        destination: depositAddress,
+        token: sourceTokenMint,
+        amount: wizard.fields.amount.trim(),
+      });
+      setOnchainSendResult(transfer);
+      toast.success("Transfer submitted.", {
+        id: toastId,
+        description: transfer.signature
+          ? "Transaction sent successfully."
+          : `Status: ${transfer.status}`,
+        position: "bottom-right",
+      });
+    } catch (error) {
+      toast.error("Transfer failed.", {
+        id: toastId,
+        description: error instanceof Error ? error.message : "Transfer failed.",
+        position: "bottom-right",
+      });
+    } finally {
+      setOnchainSendLoading(false);
+    }
+  };
 
   const transferStatusKey = wizard.quote
     ? (["offramp-transfer-status", wizard.quote.provider, wizard.quote.id] as const)
@@ -58,6 +147,10 @@ export function useOfframpWizard(props: UseRampWizardProps) {
     ...wizard,
     transferStatus,
     transferStatusLoading,
+    canSendOnchain,
+    onchainSendLoading,
+    onchainSendResult,
+    sendCryptoToDeposit,
   };
 }
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PaymentTransferSummary } from "@sdp/types";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import useSWR from "swr";
 import {
@@ -36,6 +36,7 @@ export type OfframpStepId =
 export function useOfframpWizard(props: UseRampWizardProps) {
   const [onchainSendLoading, setOnchainSendLoading] = useState(false);
   const [onchainSendResult, setOnchainSendResult] = useState<PaymentTransferSummary | null>(null);
+  const [quoteExpired, setQuoteExpired] = useState(false);
 
   const wizard = useRampWizard<OfframpStepId>(props, {
     pairs: OFFRAMP_PAIRS,
@@ -62,8 +63,30 @@ export function useOfframpWizard(props: UseRampWizardProps) {
     onQuoteCreated: () => {
       setOnchainSendLoading(false);
       setOnchainSendResult(null);
+      setQuoteExpired(false);
     },
   });
+
+  const quoteExpiresAt =
+    wizard.quote?.provider === "lightspark" && wizard.quote.deliveryMode === "manual_instructions"
+      ? wizard.quote.expiresAt
+      : undefined;
+
+  useEffect(() => {
+    if (!quoteExpiresAt) {
+      return;
+    }
+    const remainingMs = Date.parse(quoteExpiresAt) - Date.now();
+    if (!Number.isFinite(remainingMs)) {
+      return;
+    }
+    if (remainingMs <= 0) {
+      setQuoteExpired(true);
+      return;
+    }
+    const timeoutId = window.setTimeout(() => setQuoteExpired(true), remainingMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [quoteExpiresAt]);
 
   // The Solana deposit address Grid generated for this realtime-funded quote.
   const depositAddress = useMemo(() => {
@@ -96,6 +119,15 @@ export function useOfframpWizard(props: UseRampWizardProps) {
       return;
     }
     if (onchainSendLoading || onchainSendResult) {
+      return;
+    }
+    // Re-check the timestamp at call time — the armed timeout only covers renders.
+    if (quoteExpiresAt && Date.parse(quoteExpiresAt) <= Date.now()) {
+      setQuoteExpired(true);
+      toast.error("Quote expired.", {
+        description: "Create a new quote to continue the withdrawal.",
+        position: "bottom-right",
+      });
       return;
     }
 
@@ -151,6 +183,7 @@ export function useOfframpWizard(props: UseRampWizardProps) {
     onchainSendLoading,
     onchainSendResult,
     sendCryptoToDeposit,
+    quoteExpired,
   };
 }
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -309,24 +309,24 @@ export function useRampWizard<TId extends string>(
     setStepIndex((current) => current + 1);
   };
 
-  const handleSecondary = () => {
-    if (stepIndex === 0) {
-      if (onExit) {
-        onExit();
-        return;
-      }
-      router.push("/dashboard/payments");
-      return;
-    }
-    setStepIndex((current) => Math.max(0, current - 1));
-  };
-
   const finish = () => {
     if (onExit) {
       onExit();
       return;
     }
     router.push("/dashboard/payments");
+  };
+
+  // Once the quote exists the wizard is on the transaction stage — stepping back
+  // into amount/details would orphan the live quote, so back becomes an explicit exit.
+  const onTransactionStage = isLastStep && quote !== null;
+
+  const handleSecondary = () => {
+    if (stepIndex === 0 || onTransactionStage) {
+      finish();
+      return;
+    }
+    setStepIndex((current) => Math.max(0, current - 1));
   };
 
   const handlePairChange = (nextPair: SelectedRampPair) => {
@@ -352,6 +352,7 @@ export function useRampWizard<TId extends string>(
     steps,
     currentStepId,
     isLastStep,
+    onTransactionStage,
     canProceed,
     collectedData: requirements.collectedData,
     setCollectedField: requirements.setField,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -141,6 +141,11 @@ export function useRampWizard<TId extends string>(
           counterpartyId: fields.counterpartyId,
           provider: fields.provider,
           direction: requirementsConfig.direction,
+          // Off-ramp requirements are payout-currency specific (e.g. lightspark bank
+          // fields); on-ramp requirements are not, so the key stays currency-free there.
+          ...(requirementsConfig.direction === "offramp"
+            ? { fiatCurrency: selectedRampPair.fiatCurrency }
+            : {}),
         }
       : null
   );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -138,9 +138,10 @@ function OfframpRail({
           <PoweredByRampProvider provider={wizard.fields.provider} />
         ) : null
       }
+      secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       footerActions={
         transferTerminal ? (
-          <Button asChild type="button" variant="secondary" className="h-14 rounded-full text-base">
+          <Button asChild type="button" variant="secondary" className="self-center rounded-full">
             <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
               Go to transaction
             </Link>
@@ -251,9 +252,10 @@ function OnrampRail({
           <PoweredByRampProvider provider={wizard.fields.provider} />
         ) : null
       }
+      secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       footerActions={
         transferTerminal ? (
-          <Button asChild type="button" variant="secondary" className="h-14 rounded-full text-base">
+          <Button asChild type="button" variant="secondary" className="self-center rounded-full">
             <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
               Go to transaction
             </Link>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -132,9 +132,10 @@ function OfframpRail({
       counterpartyDialogOpen={false}
       setCounterpartyDialogOpen={() => {}}
       onCounterpartyCreated={() => {}}
-      footer={
-        wizard.currentStepId === "COMPLETE" && wizard.quote ? (
-          <PoweredByRampProvider provider={wizard.quote.provider} />
+      header={
+        wizard.fields.provider &&
+        (wizard.currentStepId === "REQUIREMENTS" || wizard.currentStepId === "COMPLETE") ? (
+          <PoweredByRampProvider provider={wizard.fields.provider} />
         ) : null
       }
       footerActions={
@@ -244,9 +245,10 @@ function OnrampRail({
       counterpartyDialogOpen={false}
       setCounterpartyDialogOpen={() => {}}
       onCounterpartyCreated={() => {}}
-      footer={
-        wizard.currentStepId === "PROVIDER" && wizard.quote ? (
-          <PoweredByRampProvider provider={wizard.quote.provider} />
+      header={
+        wizard.fields.provider &&
+        (wizard.currentStepId === "REQUIREMENTS" || wizard.currentStepId === "PROVIDER") ? (
+          <PoweredByRampProvider provider={wizard.fields.provider} />
         ) : null
       }
       footerActions={

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/wallet-options.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/wallet-options.ts
@@ -1,0 +1,17 @@
+import type { PaymentsDashboardWallet } from "@sdp/types";
+import {
+  formatCurrencyAmount,
+  resolveTotalBalance,
+} from "@/app/dashboard/payments/payments-overview.utils";
+import type { ComboboxOption } from "@/components/ui/combobox";
+
+export function walletComboboxOptions(wallets: PaymentsDashboardWallet[]): ComboboxOption[] {
+  return wallets.map((wallet) => {
+    const total = resolveTotalBalance(wallet.balances ?? []);
+    return {
+      value: wallet.walletId,
+      label: wallet.label ?? wallet.walletId,
+      description: total !== null ? formatCurrencyAmount(total) : undefined,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

Lightspark off-ramp end to end: USDC from an SDP wallet to a fiat bank payout via Grid, using the counterparty-requirements pattern shipped in #423 for collecting the payout bank details.

Change 1 - show asset distribution on wallet selection
<img width="3452" height="1996" alt="CleanShot 2026-06-11 at 13 49 53@2x" src="https://github.com/user-attachments/assets/b91b9501-4a61-4e63-a1bc-3b0926a7b67a" />

Change 2 - ask for lightspark specific counterparty requirements, in this case banking details 
<img width="3450" height="1998" alt="CleanShot 2026-06-11 at 13 52 14@2x" src="https://github.com/user-attachments/assets/4ba77500-949a-4655-a5f3-0579399b34ef" />

Change 3 - have payment instructions for sending 50 usdc to this account 
<img width="3452" height="2004" alt="CleanShot 2026-06-11 at 13 53 20@2x" src="https://github.com/user-attachments/assets/4a997c1a-9db3-4cbf-a4f0-770a8ed02f32" />

Lightspark transaction done 
<img width="1338" height="1266" alt="CleanShot 2026-06-11 at 13 54 23@2x" src="https://github.com/user-attachments/assets/c657284c-cb89-4da8-a6fe-4ea58466ab33" />

Lightspark specifically stores this and not us
<img width="3015" height="1451" alt="CleanShot 2026-06-11 at 13 55 51@2x" src="https://github.com/user-attachments/assets/253fc750-f91a-4744-9a18-5b60cf766dec" />





### API (sdp-api)

- `GET /v1/counterparties/:id/requirements?provider=lightspark&direction=offramp&fiatCurrency=USD` returns the Grid payout bank fields for the currency (`collect`), `ready` once a payout account exists, or `unsupported`. `fiatCurrency` is mandatory for this combination via a nested discriminated union; field specs are encoded for all 26 supported Grid payout currencies (routing/account, IBAN, CLABE, PIX, sort code, mobile money, etc.).
- `POST /v1/payments/ramps/offramp/quote` accepts `collectedData`, creates the Grid external payout account just-in-time, then creates a `REALTIME_FUNDING` quote (Grid customer funding in USDC on Solana → payout account). The quote returns a Solana deposit address; Grid auto-executes at the locked rate on deposit and settlement flows through the existing `OUTGOING_PAYMENT.*` webhooks.
- **No sensitive data persisted**: raw bank details pass through to Grid; only the resulting `ExternalAccount` id + status are stored in `provider_data.lightspark.payoutAccounts[fiat]`.
- Grid has no external-account status webhook, so non-ACTIVE accounts are refreshed at quote time via `GET /customers/external-accounts/:id` and the quote fails loudly with the status until verified.
- Sandbox simulate (`/sandbox/send`) now accepts `currencyCode: USDC` to fund off-ramp quotes.

### Web (sdp-web)

- Off-ramp wizard inserts a payout-details step (rendered by the existing requirements form machinery) when the provider reports `collect`, and sends `collectedData` with the quote. Requirements fetches carry the payout currency and reset collected answers when it changes.
- Completion step shows the deposit instructions with a `Send {amount} USDC` action that submits the on-chain transfer from the selected wallet to the deposit address, plus live transfer-status polling.
- Wallet selection shows an animated per-token asset breakdown; the wallet picker options builder is deduplicated across the three step contents.
- "Powered by {provider}" shows on every step after provider selection so users know who is requesting the payout details.

## Test plan

- `vitest`: new coverage for requirements shapes (collect/ready/unsupported, rail select, single-rail currencies), Grid `accountInfo` building (rail mapping, XOF countries array, business beneficiary, validation failures), `REALTIME_FUNDING` quote body incl. `cryptoNetwork`, and external-account parsing — plus payments/counterparties/webhooks suites green.
- `tsc --noEmit` + `biome check` clean in both apps.
- Manual: full sandbox loop in the dashboard — wallet → amount/provider → bank form (first quote only) → quote → deposit address → settlement statuses via webhooks.