### PR TITLE
fix(places): harden Google error parsing and session token rotation

### DIFF
--- a/apps/sdp-api/src/lib/places/google.ts
+++ b/apps/sdp-api/src/lib/places/google.ts
@@ -15,16 +15,28 @@ async function googleJson<TSchema extends z.ZodTypeAny>(
   init: RequestInit
 ): Promise<z.output<TSchema>> {
   const response = await fetch(url, init);
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = undefined;
+  }
   if (!response.ok) {
     throw providerUnavailable(
       extractProviderErrorMessage(
-        await response.json(),
+        payload,
         `Google Maps request failed with status ${response.status}`
       ),
       { provider: "google", providerStatus: response.status }
     );
   }
-  return schema.parse(await response.json());
+  if (payload === undefined) {
+    throw providerUnavailable("Google Maps returned an unparseable response", {
+      provider: "google",
+      providerStatus: response.status,
+    });
+  }
+  return schema.parse(payload);
 }
 
 const autocompleteResponseSchema = z.object({

--- a/apps/sdp-api/src/lib/places/google.ts
+++ b/apps/sdp-api/src/lib/places/google.ts
@@ -36,7 +36,14 @@ async function googleJson<TSchema extends z.ZodTypeAny>(
       providerStatus: response.status,
     });
   }
-  return schema.parse(payload);
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw providerUnavailable("Google Maps returned an unexpected response shape", {
+      provider: "google",
+      providerStatus: response.status,
+    });
+  }
+  return parsed.data;
 }
 
 const autocompleteResponseSchema = z.object({

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/components/address-autocomplete.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/components/address-autocomplete.tsx
@@ -64,12 +64,12 @@ export function AddressAutocomplete({ onSelect }: AddressAutocompleteProps) {
     setResolving(true);
     try {
       const place = await fetchPlaceDetails(suggestion.placeId, sessionTokenRef.current);
-      sessionTokenRef.current = newPlacesSessionToken();
       setSelected(place);
       onSelect(place.addressFields);
     } catch (err) {
       setResolveError(err instanceof Error ? err.message : "Failed to load place details");
     } finally {
+      sessionTokenRef.current = newPlacesSessionToken();
       setResolving(false);
     }
   }


### PR DESCRIPTION
Follow-up to #439, addressing review findings on the Google Places integration.

## Changes

**`apps/sdp-api/src/lib/places/google.ts`** — `googleJson` called `response.json()` in the error path without a guard, so any non-JSON Google error body (HTML 503 page, plain-text rate-limit response) escaped as a raw `SyntaxError` to Hono's error handler instead of a typed `AppError(PROVIDER_UNAVAILABLE)`, bypassing the error-classification logic other providers rely on. The body is now parsed defensively (mirroring `providerFetch` in `lib/ramps/fetch.ts`), and an unparseable success body also surfaces as `PROVIDER_UNAVAILABLE` rather than a stray parse error.

**`apps/sdp-web/.../address-autocomplete.tsx`** — the Places session token was only rotated when `fetchPlaceDetails` succeeded, so a failed details call left a consumed token in place for subsequent autocomplete requests. Rotation now happens in `finally`, covering both outcomes.

## Verification

- `turbo run typecheck --filter=@sdp/api --filter=sdp-web` passes
- `biome check` on both files is clean (one pre-existing `<img>` warning)
- Note: `sdp-web`'s eslint currently crashes on any file (`react/display-name` rule incompatibility with ESLint 10, reproduces on unmodified `main`) — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)