### PR TITLE
fix(api): avoid reusing DFNS signing key for new wallets

### DIFF
--- a/apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.node.test.ts
+++ b/apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.node.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createProviderWallet } from "@/services/domain/signing/provider-wallet-lifecycle";
+import type { Env } from "@/types/env";
+
+const createWalletMock = vi.hoisted(() => vi.fn());
+const createDfnsApiClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/dfns/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/dfns/client")>();
+
+  return {
+    ...actual,
+    createDfnsApiClient: createDfnsApiClientMock,
+  };
+});
+
+describe("createProviderWallet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createWalletMock.mockResolvedValue({
+      id: "wa-12345-abcde-newdfnswallet",
+      address: "DfnsNewWalletPublicKey111111111111111111111",
+    });
+    createDfnsApiClientMock.mockResolvedValue({
+      wallets: {
+        createWallet: createWalletMock,
+      },
+    });
+  });
+
+  it("creates additional DFNS wallets without reusing the configured signing key", async () => {
+    const env = {} as Env;
+
+    const wallet = await createProviderWallet({
+      env,
+      orgId: "org_dfns",
+      projectId: "project_dfns",
+      params: {
+        label: "DFNS treasury",
+      },
+      parsed: {
+        provider: "dfns",
+        apiBaseUrl: "https://api.dfns.test",
+        network: "SolanaDevnet",
+        walletId: "wa-12345-abcde-rootwallet",
+        signingKeyId: "key-12345-abcde-rootwallet",
+      },
+    });
+
+    expect(createDfnsApiClientMock).toHaveBeenCalledWith(env, {
+      apiBaseUrl: "https://api.dfns.test",
+    });
+    expect(createWalletMock).toHaveBeenCalledWith({
+      body: {
+        network: "SolanaDevnet",
+        name: "DFNS treasury",
+      },
+    });
+    expect(wallet).toEqual({
+      walletId: "dfns_wa-12345-abcde-newdfnswallet",
+      publicKey: "DfnsNewWalletPublicKey111111111111111111111",
+    });
+  });
+});

--- a/apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.ts
+++ b/apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.ts
@@ -164,7 +164,6 @@ const providerWalletLifecycleRegistry = {
           body: {
             network: resolveDfnsNetwork(parsed.network),
             ...(params.label ? { name: params.label } : {}),
-            ...(parsed.signingKeyId ? { signingKey: { id: parsed.signingKeyId } } : {}),
           },
         });
       });


### PR DESCRIPTION
## Summary

- Stop sending the configured DFNS `signingKeyId` when provisioning additional DFNS wallets.
- Add a focused regression test that verifies the DFNS wallet creation payload omits `signingKey` even when the stored provider config has a root signin

<img width="1611" height="1028" alt="Screenshot 2026-06-15 at 2 39 49 PM" src="https://github.com/user-attachments/assets/cefa7079-f680-4a9f-a4e0-7f463bd22f14" />
g key.




## Root Cause

The additional-wallet path reused the root DFNS `signingKeyId` in `POST /wallets`. DFNS permits a key to back only one wallet per network, so creating a second `SolanaDevnet` wallet with the same key failed with `key already used for network`.

## Impact

Creating additional DFNS wallets now lets DFNS create a fresh signing key for the new wallet, avoiding the provider-side uniqueness error while keeping existing root-wallet signing behavior unchanged.

## Validation

- `pnpm --filter @sdp/api typecheck`
- Focused Vitest regression for `provider-wallet-lifecycle.node.test.ts` via a temporary no-global-setup unit config, because the repo Node Vitest config requires Testcontainers/Docker in global setup.
