### PR TITLE
feat(observability): Kora Grafana dashboards + alerts + sync

### DIFF
--- a/.github/workflows/grafana-push.yml
+++ b/.github/workflows/grafana-push.yml
@@ -1,0 +1,133 @@
+name: Grafana push (dashboards + alert rules)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dashboards/**'
+      - 'alert-rules/**'
+      - 'notification-policies/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: grafana-push
+  cancel-in-progress: false
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_PROJECT: sdp
+      DOPPLER_CONFIG: prd
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
+
+      - name: Fetch secrets from Doppler
+        id: secrets
+        run: |
+          set -euo pipefail
+          for key in GRAFANA_API_URL GRAFANA_API_TOKEN GRAFANA_FOLDER_UID PAGERDUTY_INTEGRATION_KEY SLACK_ALERT_WEBHOOK_URL; do
+            value=$(doppler secrets get "$key" --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG")
+            echo "::add-mask::$value"
+            echo "$key=$value" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Push dashboards
+        if: hashFiles('dashboards/*.json') != ''
+        env:
+          GRAFANA_API_URL: ${{ steps.secrets.outputs.GRAFANA_API_URL }}
+          GRAFANA_API_TOKEN: ${{ steps.secrets.outputs.GRAFANA_API_TOKEN }}
+          GRAFANA_FOLDER_UID: ${{ steps.secrets.outputs.GRAFANA_FOLDER_UID }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for f in dashboards/*.json; do
+            echo "::group::Push $(basename "$f")"
+            payload=$(jq --arg folder "$GRAFANA_FOLDER_UID" \
+              --arg msg "Pushed from $(git rev-parse --short HEAD)" \
+              '{dashboard: ., folderUid: $folder, overwrite: true, message: $msg}' "$f")
+            http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+              -X POST "$GRAFANA_API_URL/api/dashboards/db" \
+              -H "Authorization: Bearer $GRAFANA_API_TOKEN" \
+              -H 'Content-Type: application/json' \
+              --data "$payload")
+            if [ "$http_code" -ge 300 ]; then echo "::error file=$f::Push failed ($http_code)"; cat /tmp/resp.json; exit 1; fi
+            jq -r '"  uid=\(.uid) url=\(.url)"' /tmp/resp.json
+            echo "::endgroup::"
+          done
+
+      - name: Push alert rules
+        if: hashFiles('alert-rules/*.json') != ''
+        env:
+          GRAFANA_API_URL: ${{ steps.secrets.outputs.GRAFANA_API_URL }}
+          GRAFANA_API_TOKEN: ${{ steps.secrets.outputs.GRAFANA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for f in alert-rules/*.json; do
+            echo "::group::Push $(basename "$f")"
+            uid=$(jq -r '.uid // empty' "$f")
+            if [ -z "$uid" ]; then echo "::error file=$f::missing top-level .uid"; exit 1; fi
+            http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+              -X PUT "$GRAFANA_API_URL/api/v1/provisioning/alert-rules/$uid" \
+              -H "Authorization: Bearer $GRAFANA_API_TOKEN" \
+              -H 'Content-Type: application/json' -H 'X-Disable-Provenance: true' \
+              --data "@$f")
+            if [ "$http_code" = "404" ]; then
+              http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+                -X POST "$GRAFANA_API_URL/api/v1/provisioning/alert-rules" \
+                -H "Authorization: Bearer $GRAFANA_API_TOKEN" \
+                -H 'Content-Type: application/json' -H 'X-Disable-Provenance: true' \
+                --data "@$f")
+            fi
+            if [ "$http_code" -ge 300 ]; then echo "::error file=$f::Push failed ($http_code)"; cat /tmp/resp.json; exit 1; fi
+            echo "::endgroup::"
+          done
+
+      - name: Push contact points
+        if: hashFiles('notification-policies/contact-points/*.json') != ''
+        env:
+          GRAFANA_API_URL: ${{ steps.secrets.outputs.GRAFANA_API_URL }}
+          GRAFANA_API_TOKEN: ${{ steps.secrets.outputs.GRAFANA_API_TOKEN }}
+          PAGERDUTY_INTEGRATION_KEY: ${{ steps.secrets.outputs.PAGERDUTY_INTEGRATION_KEY }}
+          SLACK_ALERT_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_ALERT_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          existing=$(curl -sS "$GRAFANA_API_URL/api/v1/provisioning/contact-points" -H "Authorization: Bearer $GRAFANA_API_TOKEN")
+          for f in notification-policies/contact-points/*.json; do
+            name=$(jq -r '.name' "$f")
+            payload=$(envsubst < "$f")
+            uid=$(jq -r --arg name "$name" '.[] | select(.name == $name) | .uid // empty' <<<"$existing" | head -1)
+            if [ -n "$uid" ]; then
+              http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X PUT "$GRAFANA_API_URL/api/v1/provisioning/contact-points/$uid" -H "Authorization: Bearer $GRAFANA_API_TOKEN" -H 'Content-Type: application/json' -H 'X-Disable-Provenance: true' --data "$payload")
+            else
+              http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST "$GRAFANA_API_URL/api/v1/provisioning/contact-points" -H "Authorization: Bearer $GRAFANA_API_TOKEN" -H 'Content-Type: application/json' -H 'X-Disable-Provenance: true' --data "$payload")
+            fi
+            if [ "$http_code" -ge 300 ]; then echo "::error file=$f::Push failed ($http_code)"; cat /tmp/resp.json; exit 1; fi
+            echo "  $(basename "$f"): $http_code"
+          done
+
+      - name: Push notification policy
+        if: hashFiles('notification-policies/policy.json') != ''
+        env:
+          GRAFANA_API_URL: ${{ steps.secrets.outputs.GRAFANA_API_URL }}
+          GRAFANA_API_TOKEN: ${{ steps.secrets.outputs.GRAFANA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+            -X PUT "$GRAFANA_API_URL/api/v1/provisioning/policies" \
+            -H "Authorization: Bearer $GRAFANA_API_TOKEN" \
+            -H 'Content-Type: application/json' -H 'X-Disable-Provenance: true' \
+            --data "$(cat notification-policies/policy.json)")
+          if [ "$http_code" -ge 300 ]; then echo "::error::policy push failed ($http_code)"; cat /tmp/resp.json; exit 1; fi
+          echo "  policy: $http_code"

--- a/.github/workflows/grafana-push.yml
+++ b/.github/workflows/grafana-push.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-      DOPPLER_PROJECT: sdp
+      DOPPLER_PROJECT: solana-developer-platform
       DOPPLER_CONFIG: prd
 
     steps:
@@ -35,10 +35,14 @@ jobs:
         id: secrets
         run: |
           set -euo pipefail
-          for key in GRAFANA_API_URL GRAFANA_API_TOKEN GRAFANA_FOLDER_UID PAGERDUTY_INTEGRATION_KEY SLACK_ALERT_WEBHOOK_URL; do
+          for key in GRAFANA_API_URL GRAFANA_API_TOKEN GRAFANA_FOLDER_UID; do
             value=$(doppler secrets get "$key" --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG")
-            echo "::add-mask::$value"
-            echo "$key=$value" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::$value"; echo "$key=$value" >> "$GITHUB_OUTPUT"
+          done
+          # Optional — contact points + policy are skipped if these aren't set yet.
+          for key in PAGERDUTY_INTEGRATION_KEY SLACK_ALERT_WEBHOOK_URL; do
+            value=$(doppler secrets get "$key" --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" 2>/dev/null || true)
+            echo "::add-mask::$value"; echo "$key=$value" >> "$GITHUB_OUTPUT"
           done
 
       - name: Push dashboards
@@ -102,6 +106,9 @@ jobs:
           SLACK_ALERT_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_ALERT_WEBHOOK_URL }}
         run: |
           set -euo pipefail
+          if [ -z "${PAGERDUTY_INTEGRATION_KEY:-}" ] || [ -z "${SLACK_ALERT_WEBHOOK_URL:-}" ]; then
+            echo "PD/Slack secrets not set — skipping contact points + policy"; exit 0
+          fi
           shopt -s nullglob
           existing=$(curl -sS "$GRAFANA_API_URL/api/v1/provisioning/contact-points" -H "Authorization: Bearer $GRAFANA_API_TOKEN")
           for f in notification-policies/contact-points/*.json; do
@@ -122,8 +129,13 @@ jobs:
         env:
           GRAFANA_API_URL: ${{ steps.secrets.outputs.GRAFANA_API_URL }}
           GRAFANA_API_TOKEN: ${{ steps.secrets.outputs.GRAFANA_API_TOKEN }}
+          PAGERDUTY_INTEGRATION_KEY: ${{ steps.secrets.outputs.PAGERDUTY_INTEGRATION_KEY }}
+          SLACK_ALERT_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_ALERT_WEBHOOK_URL }}
         run: |
           set -euo pipefail
+          if [ -z "${PAGERDUTY_INTEGRATION_KEY:-}" ] || [ -z "${SLACK_ALERT_WEBHOOK_URL:-}" ]; then
+            echo "PD/Slack secrets not set — skipping policy"; exit 0
+          fi
           http_code=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
             -X PUT "$GRAFANA_API_URL/api/v1/provisioning/policies" \
             -H "Authorization: Bearer $GRAFANA_API_TOKEN" \

--- a/alert-rules/kora-5xx-ratio-high.json
+++ b/alert-rules/kora-5xx-ratio-high.json
@@ -1,0 +1,47 @@
+{
+  "uid": "kora-5xx-ratio-high",
+  "title": "kora: 5xx ratio > 1% for 5m",
+  "ruleGroup": "kora-paymaster",
+  "folderUID": "sdp",
+  "condition": "C",
+  "for": "5m",
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-prom",
+      "relativeTimeRange": { "from": 600, "to": 0 },
+      "model": {
+        "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+        "expr": "sum(rate(kora_http_requests_total{status=~\"5..\"}[5m])) / sum(rate(kora_http_requests_total[5m]))",
+        "instant": true,
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "relativeTimeRange": { "from": 0, "to": 0 },
+      "model": { "type": "reduce", "refId": "B", "expression": "A", "reducer": "last", "settings": { "mode": "replaceNN", "replaceWithValue": 0 }, "datasource": { "type": "__expr__", "uid": "__expr__" } }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "relativeTimeRange": { "from": 0, "to": 0 },
+      "model": {
+        "type": "threshold",
+        "refId": "C",
+        "expression": "B",
+        "datasource": { "type": "__expr__", "uid": "__expr__" },
+        "conditions": [ { "evaluator": { "type": "gt", "params": [0.01] }, "operator": { "type": "and" }, "query": { "params": ["B"] }, "reducer": { "type": "last", "params": [] }, "type": "query" } ]
+      }
+    }
+  ],
+  "labels": { "service": "kora", "severity": "critical", "pagerduty": "true", "slack": "true" },
+  "annotations": {
+    "summary": "Kora 5xx ratio > 1%",
+    "description": "Kora is returning 5xx for more than 1% of requests over the last 5 minutes. Check the Kora paymaster dashboard and Cloud Run logs.",
+    "runbook_url": "https://linear.app/solana-fndn/issue/PRO-1323"
+  }
+}

--- a/alert-rules/kora-fee-payer-balance-low.json
+++ b/alert-rules/kora-fee-payer-balance-low.json
@@ -1,0 +1,47 @@
+{
+  "uid": "kora-fee-payer-balance-low",
+  "title": "kora: fee-payer SOL balance low",
+  "ruleGroup": "kora-paymaster",
+  "folderUID": "sdp",
+  "condition": "C",
+  "for": "5m",
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-prom",
+      "relativeTimeRange": { "from": 600, "to": 0 },
+      "model": {
+        "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+        "expr": "max(signer_balance_lamports) / 1e9",
+        "instant": true,
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "relativeTimeRange": { "from": 0, "to": 0 },
+      "model": { "type": "reduce", "refId": "B", "expression": "A", "reducer": "last", "datasource": { "type": "__expr__", "uid": "__expr__" } }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "relativeTimeRange": { "from": 0, "to": 0 },
+      "model": {
+        "type": "threshold",
+        "refId": "C",
+        "expression": "B",
+        "datasource": { "type": "__expr__", "uid": "__expr__" },
+        "conditions": [ { "evaluator": { "type": "lt", "params": [0.5] }, "operator": { "type": "and" }, "query": { "params": ["B"] }, "reducer": { "type": "last", "params": [] }, "type": "query" } ]
+      }
+    }
+  ],
+  "labels": { "service": "kora", "severity": "critical", "pagerduty": "true", "slack": "true" },
+  "annotations": {
+    "summary": "Kora fee-payer SOL balance below 0.5",
+    "description": "max(signer_balance_lamports)/1e9 < 0.5 SOL. The paymaster will stop sponsoring transactions when it runs out — top up the fee-payer.",
+    "runbook_url": "https://linear.app/solana-fndn/issue/PRO-1322"
+  }
+}

--- a/alert-rules/kora-p95-latency-high.json
+++ b/alert-rules/kora-p95-latency-high.json
@@ -1,0 +1,47 @@
+{
+  "uid": "kora-p95-latency-high",
+  "title": "kora: p95 latency > 2s for 10m",
+  "ruleGroup": "kora-paymaster",
+  "folderUID": "sdp",
+  "condition": "C",
+  "for": "10m",
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-prom",
+      "relativeTimeRange": { "from": 600, "to": 0 },
+      "model": {
+        "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+        "expr": "histogram_quantile(0.95, sum by (le) (rate(kora_http_request_duration_seconds_bucket[5m])))",
+        "instant": true,
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "relativeTimeRange": { "from": 0, "to": 0 },
+      "model": { "type": "reduce", "refId": "B", "expression": "A", "reducer": "last", "datasource": { "type": "__expr__", "uid": "__expr__" } }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "relativeTimeRange": { "from": 0, "to": 0 },
+      "model": {
+        "type": "threshold",
+        "refId": "C",
+        "expression": "B",
+        "datasource": { "type": "__expr__", "uid": "__expr__" },
+        "conditions": [ { "evaluator": { "type": "gt", "params": [2] }, "operator": { "type": "and" }, "query": { "params": ["B"] }, "reducer": { "type": "last", "params": [] }, "type": "query" } ]
+      }
+    }
+  ],
+  "labels": { "service": "kora", "severity": "warning", "slack": "true" },
+  "annotations": {
+    "summary": "Kora p95 latency > 2s",
+    "description": "Kora p95 request latency has exceeded 2s for 10 minutes — usually the Solana RPC roundtrip. Check the dashboard and RPC health.",
+    "runbook_url": "https://linear.app/solana-fndn/issue/PRO-1323"
+  }
+}

--- a/alloy/.gcloudignore
+++ b/alloy/.gcloudignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile
+!config.alloy

--- a/alloy/Dockerfile
+++ b/alloy/Dockerfile
@@ -1,0 +1,4 @@
+FROM grafana/alloy:latest
+COPY config.alloy /etc/alloy/config.alloy
+# Cloud Run sets $PORT; Alloy must bind it so the instance passes health checks.
+ENTRYPOINT ["/bin/sh", "-c", "exec /bin/alloy run --server.http.listen-addr=0.0.0.0:${PORT:-8080} /etc/alloy/config.alloy"]

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -7,13 +7,12 @@
 //          alloy run --server.http.listen-addr=0.0.0.0:${PORT:-12345} alloy/config.alloy
 // Deploy: a small always-on Cloud Run service / VM (min 1 instance) with those env vars.
 
-prometheus.scrape "kora" {
-  targets = [{
-    __address__      = "kora-mainnet-562819300243.us-central1.run.app:443",
-    __scheme__       = "https",
-    __metrics_path__ = "/metrics",
-    service          = "kora-mainnet",
-  }]
+// SDP service scrape targets — add more services here as they expose /metrics.
+prometheus.scrape "sdp" {
+  targets = [
+    { __address__ = "kora-mainnet-562819300243.us-central1.run.app:443", __scheme__ = "https", __metrics_path__ = "/metrics", service = "kora-mainnet" },
+    { __address__ = "kora-sdp-654412331372.us-central1.run.app:443", __scheme__ = "https", __metrics_path__ = "/metrics", service = "kora-sdp" },
+  ]
   scrape_interval = "30s"
   forward_to      = [prometheus.remote_write.grafanacloud.receiver]
 }

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -37,12 +37,14 @@ loki.write "grafanacloud" {
   }
 }
 
-// Cloud Run logs -> Loki. Needs a Cloud Logging sink -> Pub/Sub subscription for kora-mainnet.
+// Cloud Run logs -> Loki. Topic `kora-logs` + subscription `kora-logs-alloy` exist in
+// solana-developer-platform; ENABLE once the log sink is created (blocked on logging.sinks.create —
+// needs a logging admin) and the Alloy runtime SA has roles/pubsub.subscriber on the subscription.
 // loki.source.gcplog "kora" {
 //   pull {
-//     project_id   = "trading-prod-494016"
-//     subscription = sys.env("GCP_LOG_SUBSCRIPTION")
-//     labels       = { service = "kora-mainnet" }
+//     project_id   = "solana-developer-platform"
+//     subscription = "kora-logs-alloy"
+//     labels       = { service = "kora-sdp" }
 //   }
 //   forward_to = [loki.write.grafanacloud.receiver]
 // }

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,49 @@
+// Grafana Alloy collector for Kora observability.
+// Scrapes the kora-mainnet /metrics endpoint and remote_writes to Grafana Cloud Mimir,
+// and forwards Cloud Run logs to Loki. Credentials come from Doppler (project
+// solana-developer-platform, config prd) via env — never hardcode tokens here.
+//
+// Run:   doppler run --project solana-developer-platform --config prd -- \
+//          alloy run --server.http.listen-addr=0.0.0.0:${PORT:-12345} alloy/config.alloy
+// Deploy: a small always-on Cloud Run service / VM (min 1 instance) with those env vars.
+
+prometheus.scrape "kora" {
+  targets = [{
+    __address__      = "kora-mainnet-562819300243.us-central1.run.app:443",
+    __scheme__       = "https",
+    __metrics_path__ = "/metrics",
+    service          = "kora-mainnet",
+  }]
+  scrape_interval = "30s"
+  forward_to      = [prometheus.remote_write.grafanacloud.receiver]
+}
+
+prometheus.remote_write "grafanacloud" {
+  endpoint {
+    url = sys.env("GC_PROM_PUSH_URL")
+    basic_auth {
+      username = sys.env("GC_PROM_USER")
+      password = sys.env("GC_PROM_TOKEN")
+    }
+  }
+}
+
+loki.write "grafanacloud" {
+  endpoint {
+    url = sys.env("GC_LOKI_PUSH_URL")
+    basic_auth {
+      username = sys.env("GC_LOKI_USER")
+      password = sys.env("GC_LOKI_TOKEN")
+    }
+  }
+}
+
+// Cloud Run logs -> Loki. Needs a Cloud Logging sink -> Pub/Sub subscription for kora-mainnet.
+// loki.source.gcplog "kora" {
+//   pull {
+//     project_id   = "trading-prod-494016"
+//     subscription = sys.env("GCP_LOG_SUBSCRIPTION")
+//     labels       = { service = "kora-mainnet" }
+//   }
+//   forward_to = [loki.write.grafanacloud.receiver]
+// }

--- a/dashboards/kora.json
+++ b/dashboards/kora.json
@@ -1,0 +1,80 @@
+{
+  "uid": "kora-paymaster",
+  "title": "Kora paymaster",
+  "description": "Kora gasless paymaster — request rate, errors, latency, fee-payer SOL balance, and logs.",
+  "tags": ["kora", "sdp"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    { "id": 1, "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 } },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Request rate by method",
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "sum by (method) (rate(kora_http_requests_total[5m]))", "legendFormat": "{{method}}" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "5xx rate",
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "fixed", "fixedColor": "red" } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "sum (rate(kora_http_requests_total{status=~\"5..\"}[5m]))", "legendFormat": "5xx" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Latency p50 / p95 (s)",
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(kora_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(kora_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p95" }
+      ]
+    },
+    { "id": 5, "type": "row", "title": "Fee payer", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 } },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Fee-payer balance (SOL)",
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 4,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "max(signer_balance_lamports) / 1e9", "legendFormat": "balance" }
+      ]
+    },
+    { "id": 7, "type": "row", "title": "Logs", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 } },
+    {
+      "id": 8,
+      "type": "logs",
+      "title": "Recent logs (kora-mainnet)",
+      "datasource": { "type": "loki", "uid": "grafanacloud-logs" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 25 },
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "grafanacloud-logs" }, "expr": "{service=\"kora-mainnet\"}" }
+      ]
+    }
+  ]
+}

--- a/dashboards/kora.json
+++ b/dashboards/kora.json
@@ -1,14 +1,30 @@
 {
   "uid": "kora-paymaster",
   "title": "Kora paymaster",
-  "description": "Kora gasless paymaster — request rate, errors, latency, fee-payer SOL balance, and logs.",
+  "description": "Kora gasless paymaster — request rate, errors, latency, fee-payer SOL balance, and logs. Toggle service (mainnet/devnet) top-left.",
   "tags": ["kora", "sdp"],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
   "time": { "from": "now-6h", "to": "now" },
-  "templating": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "service",
+        "type": "custom",
+        "query": "mainnet : kora-mainnet, devnet : kora-sdp",
+        "current": { "text": "mainnet", "value": "kora-mainnet", "selected": true },
+        "options": [
+          { "text": "mainnet", "value": "kora-mainnet", "selected": true },
+          { "text": "devnet", "value": "kora-sdp", "selected": false }
+        ],
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
   "panels": [
     { "id": 1, "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 } },
     {
@@ -19,7 +35,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "sum by (method) (rate(kora_http_requests_total[5m]))", "legendFormat": "{{method}}" }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "sum by (method) (rate(kora_http_requests_total{service=\"$service\"}[5m]))", "legendFormat": "{{method}}" }
       ]
     },
     {
@@ -30,7 +46,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "fixed", "fixedColor": "red" } }, "overrides": [] },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "sum (rate(kora_http_requests_total{status=~\"5..\"}[5m]))", "legendFormat": "5xx" }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "sum (rate(kora_http_requests_total{service=\"$service\",status=~\"5..\"}[5m]))", "legendFormat": "5xx" }
       ]
     },
     {
@@ -41,8 +57,8 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
       "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(kora_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p50" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(kora_http_request_duration_seconds_bucket[5m])))", "legendFormat": "p95" }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(kora_http_request_duration_seconds_bucket{service=\"$service\"}[5m])))", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(kora_http_request_duration_seconds_bucket{service=\"$service\"}[5m])))", "legendFormat": "p95" }
       ]
     },
     { "id": 5, "type": "row", "title": "Fee payer", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 } },
@@ -61,19 +77,19 @@
         "overrides": []
       },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "max(signer_balance_lamports) / 1e9", "legendFormat": "balance" }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" }, "expr": "max(signer_balance_lamports{service=\"$service\"}) / 1e9", "legendFormat": "balance" }
       ]
     },
     { "id": 7, "type": "row", "title": "Logs", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 } },
     {
       "id": 8,
       "type": "logs",
-      "title": "Recent logs (kora-mainnet)",
+      "title": "Recent logs ($service)",
       "datasource": { "type": "loki", "uid": "grafanacloud-logs" },
       "gridPos": { "h": 10, "w": 24, "x": 0, "y": 25 },
       "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
       "targets": [
-        { "refId": "A", "datasource": { "type": "loki", "uid": "grafanacloud-logs" }, "expr": "{service=\"kora-mainnet\"}" }
+        { "refId": "A", "datasource": { "type": "loki", "uid": "grafanacloud-logs" }, "expr": "{service=\"$service\"}" }
       ]
     }
   ]

--- a/notification-policies/contact-points/pagerduty.json
+++ b/notification-policies/contact-points/pagerduty.json
@@ -1,0 +1,13 @@
+{
+  "name": "pagerduty",
+  "type": "pagerduty",
+  "settings": {
+    "integrationKey": "${PAGERDUTY_INTEGRATION_KEY}",
+    "severity": "{{ .CommonLabels.severity | default \"critical\" }}",
+    "class": "{{ .CommonLabels.scope | default \"sdp\" }}",
+    "component": "{{ .CommonLabels.service | default \"kora\" }}",
+    "group": "sdp",
+    "summary": "{{ .CommonAnnotations.summary }}{{ if not .CommonAnnotations.summary }}{{ .CommonLabels.alertname }}{{ end }}"
+  },
+  "disableResolveMessage": false
+}

--- a/notification-policies/contact-points/slack.json
+++ b/notification-policies/contact-points/slack.json
@@ -1,0 +1,10 @@
+{
+  "name": "slack",
+  "type": "slack",
+  "settings": {
+    "url": "${SLACK_ALERT_WEBHOOK_URL}",
+    "title": "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}",
+    "text": "{{ range .Alerts }}*{{ .Annotations.summary }}*\n{{ .Annotations.description }}\nlabels: {{ .Labels }}{{ if .Annotations.runbook_url }}\n:book: <{{ .Annotations.runbook_url }}|Runbook>{{ end }}\n{{ end }}"
+  },
+  "disableResolveMessage": false
+}

--- a/notification-policies/policy.json
+++ b/notification-policies/policy.json
@@ -1,0 +1,24 @@
+{
+  "receiver": "slack",
+  "group_by": ["grafana_folder", "alertname"],
+  "group_wait": "30s",
+  "group_interval": "5m",
+  "repeat_interval": "4h",
+  "routes": [
+    {
+      "receiver": "pagerduty",
+      "object_matchers": [["pagerduty", "=", "true"]],
+      "continue": true,
+      "group_wait": "30s",
+      "group_interval": "5m",
+      "repeat_interval": "4h"
+    },
+    {
+      "receiver": "slack",
+      "object_matchers": [["slack", "=", "true"]],
+      "group_wait": "30s",
+      "group_interval": "5m",
+      "repeat_interval": "4h"
+    }
+  ]
+}


### PR DESCRIPTION
Stacked on #455. Adds Grafana-as-code for Kora following the `tokens` / `geyser-data` pattern.

- **`dashboards/kora.json`** — request rate, 5xx, p50/p95 latency, fee-payer SOL balance (Mimir) + recent logs (Loki).
- **`alert-rules/`** — fee-payer balance low, 5xx ratio, p95 latency; label-routed (`pagerduty`/`slack`).
- **`notification-policies/`** — slack + pagerduty contact points + routing policy.
- **`.github/workflows/grafana-push.yml`** — syncs all of the above to Grafana Cloud on push to `main` via the provisioning API; secrets from Doppler (project `sdp`).

**Done live:** created the Grafana `sdp` folder and pushed the dashboard + 3 alert rules into it.

**Needs:** Doppler (`sdp`) secrets — `GRAFANA_API_URL`, `GRAFANA_API_TOKEN`, `GRAFANA_FOLDER_UID=sdp`, `PAGERDUTY_INTEGRATION_KEY`, `SLACK_ALERT_WEBHOOK_URL` — for the workflow + contact points. Metrics scrape + log forwarding (so the panels/alerts get data) tracked in PRO-1323 / PRO-1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)