### PR TITLE
ci(kora): deploy-kora.yml — Cloud Run deploy + Slack notify

### DIFF
--- a/.github/workflows/deploy-kora.yml
+++ b/.github/workflows/deploy-kora.yml
@@ -1,0 +1,110 @@
+# Deploy the Kora paymaster to Cloud Run. Push to main (infra/kora paths) auto-deploys devnet;
+# mainnet is manual via workflow_dispatch (gate with GitHub Environment protection rules).
+# Per-service by path for now (kora only); add a deploy-<svc>.yml for other SDP services.
+#
+# Required per-environment (GitHub Environments: devnet, mainnet):
+#   secrets: DOPPLER_TOKEN
+#   vars:    GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT (kora-<env>-deployer), KORA_GCP_PROJECT
+name: Deploy Kora
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/kora/cloud-run/**'
+      - 'infra/kora/terraform/**'
+      - '.github/workflows/deploy-kora.yml'
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service to deploy"
+        type: choice
+        options: [kora]
+        default: kora
+        required: true
+      environment:
+        description: "Target environment"
+        type: choice
+        options: [devnet, mainnet]
+        default: devnet
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-kora-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'devnet' }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy kora (${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'devnet' }})
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'devnet' }}
+    env:
+      TARGET_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'devnet' }}
+      DOPPLER_PROJECT: solana-developer-platform
+      DOPPLER_CONFIG: prd
+      REGION: us-central1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build + deploy (config baked into image, secrets via Doppler)
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          ENV: ${{ env.TARGET_ENV }}
+          PROJECT: ${{ vars.KORA_GCP_PROJECT }}
+        run: |
+          set -euo pipefail
+          doppler run --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" -- \
+            env ENV="$ENV" PROJECT="$PROJECT" REGION="$REGION" ./infra/kora/cloud-run/deploy.sh
+
+      - name: Notify Slack
+        if: always()
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          STATUS: ${{ job.status }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          SLACK=$(doppler secrets get SLACK_DEPLOY_WEBHOOK_URL --plain --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" 2>/dev/null || true)
+          if [ -z "$SLACK" ]; then echo "::warning::SLACK_DEPLOY_WEBHOOK_URL missing — skipping notification"; exit 0; fi
+          echo "::add-mask::$SLACK"
+          SHA=$(git rev-parse HEAD)
+          MSG=$(git log -1 --format=%s "$SHA" 2>/dev/null | cut -c1-140 || echo "")
+          if [ "$STATUS" = "success" ]; then MARKER="[DONE] Deploy kora ($TARGET_ENV)"; COLOR="#36a64f"; else MARKER="[FAILED] Deploy kora ($TARGET_ENV)"; COLOR="#cc0000"; fi
+          FIELDS=$(jq -n \
+            --arg env "$TARGET_ENV" --arg short_sha "${SHA:0:7}" --arg msg "$MSG" \
+            --arg actor "$ACTOR" --arg run "$RUN_URL" --arg rid "$RUN_ID" \
+            '[
+              {type:"mrkdwn",text:("*Service:*\n`kora` ("+$env+")")},
+              {type:"mrkdwn",text:("*Commit:*\n`"+$short_sha+"` — "+$msg)},
+              {type:"mrkdwn",text:("*Triggered by:*\n"+$actor)},
+              {type:"mrkdwn",text:("*Run:*\n<"+$run+"|workflow #"+$rid+">")}
+            ]')
+          PAYLOAD=$(jq -n --arg marker "$MARKER" --arg color "$COLOR" --argjson fields "$FIELDS" \
+            '{
+              text: ("*" + $marker + "*"),
+              attachments: [{
+                color: $color,
+                blocks: [
+                  {type:"section", text:{type:"mrkdwn", text:("*" + $marker + "*")}},
+                  {type:"section", fields:$fields}
+                ]
+              }]
+            }')
+          curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' --data "$PAYLOAD" "$SLACK"


### PR DESCRIPTION
Stacked on #455. Adds `.github/workflows/deploy-kora.yml`, modeled on `rpc-latency-monitor` (GCP/WIF/Doppler) + the geyser/tokens Slack deploy format.

- **Trigger:** push to `main` on `infra/kora/**` auto-deploys **devnet**; **mainnet** via `workflow_dispatch` (gate with a GitHub Environment protection rule).
- **Deploy:** WIF auth → `doppler run -- infra/kora/cloud-run/deploy.sh` (config baked into image, secrets from Doppler, no Secret Manager).
- **Slack:** posts a deploy DONE/FAILED notification (same `attachments`+color+fields format as the other repos) to `SLACK_DEPLOY_WEBHOOK_URL`.
- **Per-service by path** — kora only for now; add a `deploy-<svc>.yml` for other SDP services.

**Requires per-environment (GitHub Environments `devnet`/`mainnet`):** secret `DOPPLER_TOKEN`; vars `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT` (= `kora-<env>-deployer`), `KORA_GCP_PROJECT`. `SLACK_DEPLOY_WEBHOOK_URL` is in Doppler (`solana-developer-platform/prd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)