### PR TITLE
refactor(sdp-api): remove provisioning from on-ramp quotes

### DIFF
--- a/apps/sdp-api/src/lib/errors.ts
+++ b/apps/sdp-api/src/lib/errors.ts
@@ -232,6 +232,6 @@ export function counterpartyNotProvisioned(
   return new AppError(
     "CONFLICT",
     `Counterparty is not provisioned for ${provider} ${direction}. Complete the counterparty requirements (POST /counterparties/:counterpartyId/requirements) before requesting a quote.`,
-    { provider, direction, ...details }
+    { ...details, provider, direction }
   );
 }

--- a/apps/sdp-api/src/lib/errors.ts
+++ b/apps/sdp-api/src/lib/errors.ts
@@ -223,3 +223,15 @@ export function unsupportedCounterparty(
 ): CounterpartyRequirements {
   return { provider, direction, status: "unsupported", reason };
 }
+
+export function counterpartyNotProvisioned(
+  provider: RampProviderId,
+  direction: RampDirection,
+  details?: Record<string, unknown>
+): AppError {
+  return new AppError(
+    "CONFLICT",
+    `Counterparty is not provisioned for ${provider} ${direction}. Complete the counterparty requirements (POST /counterparties/:counterpartyId/requirements) before requesting a quote.`,
+    { provider, direction, ...details }
+  );
+}

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -17,7 +17,14 @@ import { getDb } from "@/db";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
 import type { PaymentTransferStatus } from "@/db/repositories/payments.repository";
 import { requireProjectId } from "@/lib/auth";
-import { AppError, badRequest, badRequestQuery, internalError, notFound } from "@/lib/errors";
+import {
+  AppError,
+  badRequest,
+  badRequestQuery,
+  counterpartyNotProvisioned,
+  internalError,
+  notFound,
+} from "@/lib/errors";
 import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
   buildBvnkPartyDetails,
@@ -27,6 +34,7 @@ import {
   normalizeBvnkCurrencyAndNetwork,
   readBvnkOnrampEntry,
 } from "@/lib/ramps/providers/bvnk";
+import { readLightsparkCustomerId } from "@/lib/ramps/providers/lightspark";
 import { readyCounterparty } from "@/lib/ramps/requirements";
 import type { RampRuntimeContext } from "@/lib/ramps/types";
 import { success } from "@/lib/response";
@@ -516,7 +524,6 @@ export async function createOnrampQuote(c: AppContext) {
   );
 
   let quote: PaymentRampQuote;
-  let persist: boolean;
   switch (input.provider) {
     case "moonpay": {
       quote = await RAMP_PROVIDER_CLIENTS.moonpay.createOnrampQuote(rampRuntime(c), {
@@ -527,11 +534,13 @@ export async function createOnrampQuote(c: AppContext) {
         externalCustomerId: counterparty.external_id ?? counterparty.id,
         redirectUrl: input.redirectUrl,
       });
-      persist = true;
       break;
     }
     case "lightspark": {
-      const { customerId } = await ensureLightsparkCustomer(c, { counterparty, projectId });
+      const customerId = readLightsparkCustomerId(counterparty.provider_data);
+      if (!customerId) {
+        throw counterpartyNotProvisioned("lightspark", "onramp");
+      }
       quote = await RAMP_PROVIDER_CLIENTS.lightspark.createOnrampQuote(rampRuntime(c), {
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
@@ -541,18 +550,15 @@ export async function createOnrampQuote(c: AppContext) {
         customerId,
         redirectUrl: input.redirectUrl,
       });
-      persist = true;
       break;
     }
     case "bvnk": {
-      ({ quote, persist } = await bvnkOnrampQuote(c, {
+      quote = await bvnkOnrampQuote(c, {
         counterparty,
-        projectId,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
         destinationWalletAddress,
-        collectedData: input.collectedData,
-      }));
+      });
       break;
     }
     default: {
@@ -564,21 +570,19 @@ export async function createOnrampQuote(c: AppContext) {
     }
   }
 
-  if (persist) {
-    await persistRampQuoteTransfer(c, {
-      scope,
-      projectId,
-      counterparty,
-      quote,
-      direction: "onramp",
-      wallet: destinationWallet,
-      walletAddress: destinationWalletAddress,
-      cryptoToken: input.cryptoToken,
-      cryptoAmount: null,
-      fiatCurrency: input.fiatCurrency ? input.fiatCurrency : null,
-      fiatAmount: input.fiatAmount,
-    });
-  }
+  await persistRampQuoteTransfer(c, {
+    scope,
+    projectId,
+    counterparty,
+    quote,
+    direction: "onramp",
+    wallet: destinationWallet,
+    walletAddress: destinationWalletAddress,
+    cryptoToken: input.cryptoToken,
+    cryptoAmount: null,
+    fiatCurrency: input.fiatCurrency ? input.fiatCurrency : null,
+    fiatAmount: input.fiatAmount,
+  });
 
   return success(c, { quote });
 }

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
@@ -13,7 +13,6 @@ import {
   buildBvnkRuleEntity,
   bvnkCustomerExternalReference,
   bvnkOnrampKey,
-  bvnkOnrampStatusFromProviderData,
   bvnkRuleReference,
   bvnkUnverifiedOnboardingStatus,
   isBvnkCustomerVerified,
@@ -285,14 +284,12 @@ export async function bvnkOnrampQuote(
   const key = bvnkOnrampKey(fiatCurrency, currency, network, input.destinationWalletAddress);
   const entry = readBvnkOnrampEntry(providerData, key);
 
-  if (!(customer.customerReference && entry.ruleId && entry.bankAccount?.accountNumber)) {
-    throw counterpartyNotProvisioned("bvnk", "onramp", {
-      requirementStatus: bvnkOnrampStatusFromProviderData(providerData, {
-        cryptoToken: input.cryptoToken,
-        fiatCurrency,
-        destinationWalletAddress: input.destinationWalletAddress,
-      }).status,
-    });
+  if (
+    !isBvnkCustomerVerified(customer.status) ||
+    !entry.ruleId ||
+    !entry.bankAccount?.accountNumber
+  ) {
+    throw counterpartyNotProvisioned("bvnk", "onramp", { customerStatus: customer.status });
   }
 
   const instruction = buildBvnkOnrampInstruction(

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
@@ -1,7 +1,7 @@
 import type { BvnkPaymentRampInstruction, PaymentRampQuote } from "@sdp/types";
 import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
-import { badRequest, internalError } from "@/lib/errors";
+import { badRequest, counterpartyNotProvisioned } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
 import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
@@ -13,6 +13,7 @@ import {
   buildBvnkRuleEntity,
   bvnkCustomerExternalReference,
   bvnkOnrampKey,
+  bvnkOnrampStatusFromProviderData,
   bvnkRuleReference,
   bvnkUnverifiedOnboardingStatus,
   isBvnkCustomerVerified,
@@ -33,11 +34,6 @@ type BvnkOnrampQuote = PaymentRampQuote & {
   deliveryMode: "manual_instructions";
   paymentInstructions: BvnkPaymentRampInstruction[];
 };
-
-export interface BvnkOnrampQuoteResult {
-  quote: BvnkOnrampQuote;
-  persist: boolean;
-}
 
 function requesterIpAddress(c: AppContext): string {
   const forwarded = c.req.header("x-forwarded-for");
@@ -270,79 +266,49 @@ export async function ensureBvnkPaymentRule(
   };
 }
 
-async function resolveBvnkOnramp(
-  c: AppContext,
-  input: {
-    counterparty: CounterpartyRow;
-    projectId: string;
-    cryptoToken: string;
-    fiatCurrency?: string;
-    destinationWalletAddress: string;
-    collectedData?: CollectedFieldData;
-  }
-) {
-  if (!input.fiatCurrency) {
-    throw badRequest("fiatCurrency is required for BVNK on-ramp.");
-  }
-  const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
-  const fiatCurrency = input.fiatCurrency;
-  const customer = await ensureBvnkCustomer(c, input.counterparty, input.projectId, {
-    fiatCurrency,
-    collectedData: input.collectedData,
-  });
-  const resolution = await ensureBvnkPaymentRule(
-    c,
-    rampRuntime(c),
-    input.counterparty,
-    input.projectId,
-    customer,
-    {
-      currency,
-      network,
-      destinationWalletAddress: input.destinationWalletAddress,
-      fiatCurrency,
-    }
-  );
-  const instruction = buildBvnkOnrampInstruction(resolution, {
-    network,
-    destinationWalletAddress: input.destinationWalletAddress,
-    fiatCurrency,
-    mode: resolveSdpEnvironment(c),
-  });
-  const reference =
-    resolution.onboardingStatus === "ready"
-      ? resolution.entry.ruleId
-      : resolution.customer.customerReference;
-  if (!reference) {
-    throw internalError(
-      `BVNK on-ramp missing reference at status "${resolution.onboardingStatus}".`
-    );
-  }
-  return { instruction, id: reference, reference };
-}
-
-/**
- * Builds a BVNK on-ramp quote. Only "ready" onboarding states are committable
- * as a transfer row — mid-onboarding quotes must not be persisted.
- */
 export async function bvnkOnrampQuote(
   c: AppContext,
   input: {
     counterparty: CounterpartyRow;
-    projectId: string;
     cryptoToken: string;
     fiatCurrency?: string;
     destinationWalletAddress: string;
-    collectedData?: CollectedFieldData;
   }
-): Promise<BvnkOnrampQuoteResult> {
-  const { instruction, id } = await resolveBvnkOnramp(c, input);
-  const quote: BvnkOnrampQuote = {
+): Promise<BvnkOnrampQuote> {
+  if (!input.fiatCurrency) {
+    throw badRequest("fiatCurrency is required for BVNK on-ramp.");
+  }
+  const fiatCurrency = input.fiatCurrency;
+  const providerData = input.counterparty.provider_data;
+  const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
+  const customer = readBvnkCustomer(providerData);
+  const key = bvnkOnrampKey(fiatCurrency, currency, network, input.destinationWalletAddress);
+  const entry = readBvnkOnrampEntry(providerData, key);
+
+  if (!(customer.customerReference && entry.ruleId && entry.bankAccount?.accountNumber)) {
+    throw counterpartyNotProvisioned("bvnk", "onramp", {
+      requirementStatus: bvnkOnrampStatusFromProviderData(providerData, {
+        cryptoToken: input.cryptoToken,
+        fiatCurrency,
+        destinationWalletAddress: input.destinationWalletAddress,
+      }).status,
+    });
+  }
+
+  const instruction = buildBvnkOnrampInstruction(
+    { customer, entry, onboardingStatus: "ready" },
+    {
+      network,
+      destinationWalletAddress: input.destinationWalletAddress,
+      fiatCurrency,
+      mode: resolveSdpEnvironment(c),
+    }
+  );
+  return {
     provider: "bvnk",
-    id,
+    id: entry.ruleId,
     status: "pending",
     deliveryMode: "manual_instructions",
     paymentInstructions: [instruction],
   };
-  return { quote, persist: instruction.onboardingStatus === "ready" };
 }

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -451,7 +451,6 @@ export const createOnrampQuoteSchema = z.object({
   fiatCurrency: rampFiatCurrencySchema.optional(),
   fiatAmount: paymentAmountSchema,
   redirectUrl: z.string().url().optional(),
-  collectedData: z.record(z.string(), z.string()).optional(),
 });
 
 export const submitCounterpartyRequirementsSchema = z.discriminatedUnion("provider", [


### PR DESCRIPTION
createOnrampQuote is now pure: it reads provisioned state from the counterparty's provider_data instead of running ensure*. Lightspark reads the resolved Grid customerId; BVNK reads the customer + rule entry via bvnkOnrampStatusFromProviderData. When the counterparty isn't fully provisioned, both throw counterpartyNotProvisioned (409) directing the caller to complete POST /counterparties/:id/requirements first.

Provisioning is now owned solely by the requirements advance endpoint. persistRampQuoteTransfer is unconditional since every successful on-ramp quote is fully provisioned.