### PR TITLE
feat(payments): PRO-1371 gate off-ramp quote on counterparty requirements

### DIFF
--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -1,3 +1,4 @@
+import type { PaymentTransferStatus } from "@sdp/types";
 import type { RampProviderId } from "@sdp/types/provider-access";
 import type { RepositoryDbClient } from "./base";
 
@@ -16,16 +17,7 @@ export function isRampTransferType(type: PaymentTransferType): type is RampTrans
   return type === "onramp" || type === "offramp";
 }
 export type PaymentTransferDeliveryMode = "hosted" | "manual_instructions";
-export type PaymentTransferStatus =
-  | "pending"
-  | "processing"
-  | "confirmed"
-  | "finalized"
-  | "failed"
-  | "awaiting_payment"
-  | "settling"
-  | "completed"
-  | "expired";
+export type { PaymentTransferStatus };
 export type PaymentWalletPolicyType = string;
 
 export interface PaymentWalletPolicyRow {

--- a/apps/sdp-api/src/lib/ramps/requirements.ts
+++ b/apps/sdp-api/src/lib/ramps/requirements.ts
@@ -31,6 +31,7 @@ export function textField(args: {
   minLength?: number;
   maxLength?: number;
   placeholder?: string;
+  mask?: string;
 }): RequirementField {
   return { kind: "text", ...args };
 }

--- a/apps/sdp-api/src/lib/ramps/validation/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/bvnk.ts
@@ -37,12 +37,14 @@ const US_STATE_OPTIONS = US_STATES.map((state) => ({ value: state.code, label: s
 
 const BVNK_ONRAMP_BASE_FIELDS: BvnkOnrampField[] = [
   {
+    // TODO: US-centric SSN/ITIN mask + format; branch per-country for non-US tax IDs.
     descriptor: textField({
       key: "taxIdentification.number",
       label: "Tax identification number (SSN / ITIN)",
       required: true,
       maxLength: 64,
       placeholder: "123-45-6789",
+      mask: "###-##-####",
     }),
     read: (id) => id.compliance?.taxIdentification?.number,
   },
@@ -262,7 +264,7 @@ export function buildBvnkIndividualPayload(
     nationality: resolveField("nationality"),
     birthCountryCode: resolveField("birthCountryCode"),
     taxIdentification: {
-      number: resolveField("taxIdentification.number"),
+      number: resolveField("taxIdentification.number").replace(/\D/g, ""),
       taxResidenceCountryCode: resolveField("taxIdentification.taxResidenceCountryCode"),
     },
     ...(address

--- a/apps/sdp-api/src/lib/ramps/validation/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/lightspark.ts
@@ -40,7 +40,13 @@ function railOption(value: LightsparkPaymentRail): RequirementOption {
 }
 
 function bankNameField(): RequirementField {
-  return textField({ key: "bankName", label: "Bank name", required: true, maxLength: 256 });
+  return textField({
+    key: "bankName",
+    label: "Bank name",
+    required: true,
+    maxLength: 256,
+    placeholder: "Chase",
+  });
 }
 
 function swiftCodeField(required: boolean): RequirementField {
@@ -49,6 +55,7 @@ function swiftCodeField(required: boolean): RequirementField {
     label: "SWIFT / BIC code",
     required,
     pattern: SWIFT_BIC_PATTERN,
+    placeholder: "DEUTDEFF",
   });
 }
 
@@ -58,6 +65,7 @@ function accountNumberField(pattern?: string): RequirementField {
     label: "Account number",
     required: true,
     maxLength: 64,
+    placeholder: "12345678",
     ...(pattern ? { pattern } : {}),
   });
 }
@@ -69,6 +77,7 @@ function ibanField(pattern?: string): RequirementField {
     required: true,
     minLength: 15,
     maxLength: 34,
+    placeholder: "DE89370400440532013000",
     ...(pattern ? { pattern } : {}),
   });
 }
@@ -195,6 +204,7 @@ const LIGHTSPARK_PAYOUT_SPECS = {
         required: true,
         pattern: "^[0-9]{2}-?[0-9]{2}-?[0-9]{2}$",
         placeholder: "12-34-56",
+        mask: "##-##-##",
       }),
       accountNumberField("^[0-9]{8}$"),
     ],
@@ -300,7 +310,7 @@ const LIGHTSPARK_PAYOUT_SPECS = {
         pattern: "^[0-9]{9}$",
         placeholder: "021000021",
       }),
-      accountNumberField(),
+      accountNumberField("^[0-9]{4,17}$"),
     ],
   },
   VND: {

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -11,7 +11,11 @@ import {
 } from "@sdp/types";
 import { z } from "zod";
 import { LIGHTSPARK_PAYOUT_CURRENCIES } from "@/lib/ramps/validation/lightspark";
-import { rampCurrencyCodeSchema, rampFiatCurrencySchema } from "@/routes/payments/schemas";
+import {
+  rampCurrencyCodeSchema,
+  rampDirectionSchema,
+  rampFiatCurrencySchema,
+} from "@/routes/payments/schemas";
 
 const countryCodeSchema = z.enum(COUNTRY_CODES);
 const currencyCodeSchema = z.string().trim().toUpperCase().length(3);
@@ -87,8 +91,6 @@ export const counterpartyIdSchema = z.string().min(1);
 export const counterpartyIdParamsSchema = z.object({
   counterpartyId: counterpartyIdSchema,
 });
-
-const rampDirectionSchema = z.enum(["onramp", "offramp"]);
 
 const lightsparkPayoutCurrencySchema = z.preprocess(
   (value) => (typeof value === "string" ? value.trim().toUpperCase() : value),

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -34,7 +34,11 @@ import {
   normalizeBvnkCurrencyAndNetwork,
   readBvnkOnrampEntry,
 } from "@/lib/ramps/providers/bvnk";
-import { readLightsparkCustomerId } from "@/lib/ramps/providers/lightspark";
+import {
+  isLightsparkExternalAccountActive,
+  latestLightsparkPayoutAccount,
+  readLightsparkCustomerId,
+} from "@/lib/ramps/providers/lightspark";
 import { readyCounterparty } from "@/lib/ramps/requirements";
 import type { RampRuntimeContext } from "@/lib/ramps/types";
 import { success } from "@/lib/response";
@@ -61,7 +65,7 @@ import {
 } from "../schemas";
 import { type ResolvedScope, resolveScope, resolveWalletAddress } from "../wallets";
 import { bvnkOnrampQuote, ensureBvnkCustomer, ensureBvnkPaymentRule } from "./ramps/bvnk";
-import { ensureLightsparkCustomer, lightsparkOfframpQuote } from "./ramps/lightspark";
+import { ensureLightsparkCustomer, ensureLightsparkPayoutAccount } from "./ramps/lightspark";
 
 type OnrampCurrencyPair = {
   source: (typeof ONRAMP_SUPPORT)[number]["source"];
@@ -287,13 +291,25 @@ export async function advanceCounterpartyRequirements(
     case "moonpay":
       return readyCounterparty("moonpay", input.direction);
     case "lightspark": {
-      await ensureLightsparkCustomer(c, {
+      const customer = await ensureLightsparkCustomer(c, {
         counterparty: input.counterparty,
         projectId: input.projectId,
       });
+      if (input.direction === "offramp") {
+        await ensureLightsparkPayoutAccount(c, {
+          counterparty: input.counterparty,
+          projectId: input.projectId,
+          customer,
+          fiatCurrency: input.fiatCurrency,
+          collectedData: input.collectedData,
+        });
+      }
       return readyCounterparty("lightspark", input.direction);
     }
     case "bvnk": {
+      if (input.direction === "offramp") {
+        return readyCounterparty("bvnk", input.direction);
+      }
       const customer = await ensureBvnkCustomer(c, input.counterparty, input.projectId, {
         fiatCurrency: input.fiatCurrency,
         collectedData: input.collectedData,
@@ -640,14 +656,29 @@ export async function createOfframpQuote(c: AppContext) {
       break;
     }
     case "lightspark": {
-      quote = await lightsparkOfframpQuote(c, {
-        counterparty,
-        projectId,
+      if (!input.fiatCurrency) {
+        throw badRequest("fiatCurrency is required for Lightspark off-ramp.");
+      }
+      const customerId = readLightsparkCustomerId(counterparty.provider_data);
+      const payoutAccount = latestLightsparkPayoutAccount(
+        counterparty.provider_data,
+        input.fiatCurrency
+      );
+      if (
+        !customerId ||
+        !payoutAccount ||
+        !isLightsparkExternalAccountActive(payoutAccount.status)
+      ) {
+        throw counterpartyNotProvisioned("lightspark", "offramp");
+      }
+      quote = await RAMP_PROVIDER_CLIENTS.lightspark.createOfframpQuote(rampRuntime(c), {
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
         cryptoAmount: input.cryptoAmount,
         sourceWalletAddress,
-        collectedData: input.collectedData,
+        externalCustomerId: counterparty.external_id ?? counterparty.id,
+        customerId,
+        payoutAccountId: payoutAccount.accountId,
       });
       break;
     }

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -1,4 +1,3 @@
-import type { PaymentRampQuote } from "@sdp/types";
 import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
@@ -215,43 +214,4 @@ export async function ensureLightsparkPayoutAccount(
   }
 
   return refreshPayoutAccount(c, input, entry);
-}
-
-export async function lightsparkOfframpQuote(
-  c: AppContext,
-  input: {
-    counterparty: CounterpartyRow;
-    projectId: string;
-    cryptoToken: string;
-    fiatCurrency?: RampFiatCurrency;
-    cryptoAmount: string;
-    sourceWalletAddress: string;
-    collectedData?: CollectedFieldData;
-  }
-): Promise<PaymentRampQuote> {
-  if (!input.fiatCurrency) {
-    throw badRequest("fiatCurrency is required for Lightspark off-ramp.");
-  }
-
-  const customer = await ensureLightsparkCustomer(c, {
-    counterparty: input.counterparty,
-    projectId: input.projectId,
-  });
-  const payoutAccount = await ensureLightsparkPayoutAccount(c, {
-    counterparty: input.counterparty,
-    projectId: input.projectId,
-    customer,
-    fiatCurrency: input.fiatCurrency,
-    collectedData: input.collectedData,
-  });
-
-  return RAMP_PROVIDER_CLIENTS.lightspark.createOfframpQuote(rampRuntime(c), {
-    cryptoToken: input.cryptoToken,
-    fiatCurrency: input.fiatCurrency,
-    cryptoAmount: input.cryptoAmount,
-    sourceWalletAddress: input.sourceWalletAddress,
-    externalCustomerId: input.counterparty.external_id ?? input.counterparty.id,
-    customerId: customer.customerId,
-    payoutAccountId: payoutAccount.accountId,
-  });
 }

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -311,6 +311,7 @@ export const privateTransferSchema: z.ZodType<PrivateTransferRequest> = z.object
 });
 
 const rampProviderSchema = z.enum(RAMP_PROVIDERS);
+export const rampDirectionSchema = z.enum(["onramp", "offramp"]);
 const onrampCryptoRailSchema = z.enum(ONRAMP_CRYPTO_RAILS);
 const offrampCryptoRailSchema = z.enum(OFFRAMP_CRYPTO_RAILS);
 
@@ -454,16 +455,27 @@ export const createOnrampQuoteSchema = z.object({
 });
 
 export const submitCounterpartyRequirementsSchema = z.discriminatedUnion("provider", [
-  z.object({ provider: z.literal("moonpay"), direction: z.literal("onramp") }),
-  z.object({
-    provider: z.literal("bvnk"),
-    direction: z.literal("onramp"),
-    cryptoToken: rampCurrencyCodeSchema,
-    destinationWallet: z.string().min(1),
-    fiatCurrency: rampFiatCurrencySchema,
-    collectedData: z.record(z.string(), z.string()).optional(),
-  }),
-  z.object({ provider: z.literal("lightspark"), direction: z.literal("onramp") }),
+  z.object({ provider: z.literal("moonpay"), direction: rampDirectionSchema }),
+  z.discriminatedUnion("direction", [
+    z.object({
+      provider: z.literal("bvnk"),
+      direction: z.literal("onramp"),
+      cryptoToken: rampCurrencyCodeSchema,
+      destinationWallet: z.string().min(1),
+      fiatCurrency: rampFiatCurrencySchema,
+      collectedData: z.record(z.string(), z.string()).optional(),
+    }),
+    z.object({ provider: z.literal("bvnk"), direction: z.literal("offramp") }),
+  ]),
+  z.discriminatedUnion("direction", [
+    z.object({ provider: z.literal("lightspark"), direction: z.literal("onramp") }),
+    z.object({
+      provider: z.literal("lightspark"),
+      direction: z.literal("offramp"),
+      fiatCurrency: rampFiatCurrencySchema,
+      collectedData: z.record(z.string(), z.string()).optional(),
+    }),
+  ]),
 ]);
 
 export const createOfframpQuoteSchema = z.object({
@@ -474,7 +486,6 @@ export const createOfframpQuoteSchema = z.object({
   fiatCurrency: rampFiatCurrencySchema.optional(),
   cryptoAmount: paymentAmountSchema,
   redirectUrl: z.string().url().optional(),
-  collectedData: z.record(z.string(), z.string()).optional(),
 });
 
 export const executeOfframpSchema = z.object({

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail-workspace.tsx
@@ -4,7 +4,6 @@ import type {
   Counterparty,
   CounterpartyAccount,
   PaymentTransferSummary,
-  RampDirection,
   RampProviderId,
 } from "@sdp/types";
 import {
@@ -51,7 +50,12 @@ import { getRampProviderLabel, RAMP_PROVIDER_LOGOS } from "@/lib/ramps";
 import { useCopy } from "@/lib/use-copy";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime, toTitleCase } from "../../activity-format-utils";
-import { formatDisplayAmount, formatTimestamp, shortenAddress } from "../payments-overview.utils";
+import {
+  formatTimestamp,
+  resolveTransferFlow,
+  resolveTransferTypeLabel,
+  shortenAddress,
+} from "../payments-overview.utils";
 import { getDevnetExplorerUrl } from "../payments-workspace.data";
 import { AddExternalAccountDialog } from "./add-external-account-dialog";
 import { DeleteCounterpartyDialog } from "./delete-counterparty-dialog";
@@ -95,35 +99,6 @@ function TransferStatusBadge({ status }: { status: string }) {
       {toTitleCase(status)}
     </span>
   );
-}
-
-const RAMP_TYPE_LABELS = {
-  onramp: "Deposit",
-  offramp: "Pay",
-} as const satisfies Record<RampDirection, string>;
-
-function resolveTransferTypeLabel(type: string | undefined): string {
-  if (type === "onramp" || type === "offramp") {
-    return RAMP_TYPE_LABELS[type];
-  }
-  return type ? toTitleCase(type) : "Transfer";
-}
-
-/** Source → destination amounts, Wise-style: what's sent vs. what's received. */
-function resolveTransferFlow(transfer: PaymentTransferSummary): {
-  send: string | null;
-  receive: string | null;
-} {
-  const isInbound = transfer.type === "onramp" || transfer.direction === "inbound";
-  const cryptoLabel =
-    transfer.amount && transfer.token ? formatDisplayAmount(transfer.amount, transfer.token) : null;
-  const fiatLabel =
-    transfer.fiatAmount && transfer.fiatCurrency
-      ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
-      : null;
-  return isInbound
-    ? { send: fiatLabel, receive: cryptoLabel }
-    : { send: cryptoLabel, receive: fiatLabel };
 }
 
 function TransferProviderCell({ provider }: { provider?: RampProviderId }) {

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -1,9 +1,11 @@
 import type {
   CustodyWalletAggregate,
   CustodyWalletTokenBalance,
+  RampDirection,
   PaymentTransferSummary as TransferRecord,
   PaymentsDashboardWallet as WalletRecord,
 } from "@sdp/types";
+import { toTitleCase } from "../activity-format-utils";
 
 // biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
 const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
@@ -196,6 +198,35 @@ export function resolveCounterparty(transfer: TransferRecord): string {
   }
 
   return transfer.destination ?? transfer.source ?? "Unavailable";
+}
+
+const RAMP_TYPE_LABELS = {
+  onramp: "Deposit",
+  offramp: "Pay",
+} as const satisfies Record<RampDirection, string>;
+
+export function resolveTransferTypeLabel(type: string | undefined): string {
+  if (type === "onramp" || type === "offramp") {
+    return RAMP_TYPE_LABELS[type];
+  }
+  return type ? toTitleCase(type) : "Transfer";
+}
+
+/** Source → destination amounts, Wise-style: what's sent vs. what's received. */
+export function resolveTransferFlow(transfer: TransferRecord): {
+  send: string | null;
+  receive: string | null;
+} {
+  const isInbound = transfer.type === "onramp" || transfer.direction === "inbound";
+  const cryptoLabel =
+    transfer.amount && transfer.token ? formatDisplayAmount(transfer.amount, transfer.token) : null;
+  const fiatLabel =
+    transfer.fiatAmount && transfer.fiatCurrency
+      ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
+      : null;
+  return isInbound
+    ? { send: fiatLabel, receive: cryptoLabel }
+    : { send: cryptoLabel, receive: fiatLabel };
 }
 
 export function resolveTotalBalance(balances: CustodyWalletTokenBalance[]): number | null {

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-recent-transfers.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/counterparty-recent-transfers.tsx
@@ -1,16 +1,16 @@
 "use client";
 
+import { SUCCESSFUL_PAYMENT_TRANSFER_STATUSES } from "@sdp/types";
 import { ArrowRightIcon } from "lucide-react";
 import Image from "next/image";
 import useSWR from "swr";
 import { SkeletonBlock } from "@/components/ui/skeleton-block";
 import { getRampProviderLabel, RAMP_PROVIDER_LOGOS } from "@/lib/ramps";
-import { formatRelativeTime, toTitleCase } from "../../../activity-format-utils";
-import { formatDisplayAmount } from "../../payments-overview.utils";
+import { formatRelativeTime } from "../../../activity-format-utils";
+import { resolveTransferFlow, resolveTransferTypeLabel } from "../../payments-overview.utils";
 import { fetchTransfers } from "../../payments-workspace.data";
 
 const RECENT_TRANSFERS_MAX_ROWS = 5;
-const SUCCESSFUL_TRANSFER_STATUSES: readonly string[] = ["completed", "confirmed", "finalized"];
 
 const SKELETON_ROWS = [
   { key: "row-1", provider: "w-24", type: "w-16", amount: "w-36", time: "w-16" },
@@ -25,7 +25,7 @@ export function CounterpartyRecentTransfers({ counterpartyId }: { counterpartyId
       fetchTransfers({
         pageSize: RECENT_TRANSFERS_MAX_ROWS,
         counterpartyId,
-        statuses: SUCCESSFUL_TRANSFER_STATUSES,
+        statuses: SUCCESSFUL_PAYMENT_TRANSFER_STATUSES,
       }),
     { revalidateOnFocus: false, revalidateIfStale: false, keepPreviousData: false }
   );
@@ -73,17 +73,7 @@ export function CounterpartyRecentTransfers({ counterpartyId }: { counterpartyId
       <h2 className="text-2xl font-medium text-text-extra-high">Recent Transfers</h2>
       <div>
         {data.map((transfer) => {
-          const cryptoLabel =
-            transfer.amount && transfer.token
-              ? formatDisplayAmount(transfer.amount, transfer.token)
-              : null;
-          const fiatLabel =
-            transfer.fiatAmount && transfer.fiatCurrency
-              ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
-              : null;
-          const orderedAmounts =
-            transfer.type === "onramp" ? [fiatLabel, cryptoLabel] : [cryptoLabel, fiatLabel];
-          const amounts = orderedAmounts.filter((label): label is string => label !== null);
+          const flow = resolveTransferFlow(transfer);
 
           return (
             <div key={transfer.id} className="flex items-center gap-3 py-3">
@@ -102,16 +92,16 @@ export function CounterpartyRecentTransfers({ counterpartyId }: { counterpartyId
                 </>
               ) : null}
               <span className="min-w-0 flex-1 truncate text-sm text-text-medium">
-                {transfer.type ? toTitleCase(transfer.type) : "Transfer"}
+                {resolveTransferTypeLabel(transfer.type)}
               </span>
-              {amounts.length > 0 ? (
-                <span className="flex shrink-0 items-center gap-1.5 text-sm text-text-medium">
-                  {amounts[0]}
-                  {amounts.length === 2 ? (
-                    <>
-                      <ArrowRightIcon className="size-3.5" />
-                      {amounts[1]}
-                    </>
+              {flow.send || flow.receive ? (
+                <span className="flex shrink-0 items-center gap-1.5 text-sm">
+                  {flow.send ? <span className="text-text-medium">{flow.send}</span> : null}
+                  {flow.send && flow.receive ? (
+                    <ArrowRightIcon className="size-3.5 text-text-low" />
+                  ) : null}
+                  {flow.receive ? (
+                    <span className="font-medium text-text-extra-high">{flow.receive}</span>
                   ) : null}
                 </span>
               ) : null}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -9,7 +9,7 @@ import { walletComboboxOptions } from "../wallet-options";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
-import { RampStepPlaceholder } from "./ramp-step-placeholder";
+import { RampQuoteSkeleton } from "./ramp-quote-skeleton";
 import { RequirementsFields } from "./requirements-fields";
 import { WalletAssetBreakdown } from "./wallet-asset-breakdown";
 
@@ -261,5 +261,5 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     return <OfframpManualQuoteStep wizard={wizard} quote={quote} />;
   }
 
-  return <RampStepPlaceholder />;
+  return <RampQuoteSkeleton />;
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -17,7 +17,7 @@ import type { OnrampWizard } from "../hooks/use-onramp-wizard";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
-import { RampStepPlaceholder } from "./ramp-step-placeholder";
+import { RampQuoteSkeleton } from "./ramp-quote-skeleton";
 import { RequirementsFields } from "./requirements-fields";
 
 function getOnrampTransferStatusCopy(status: string) {
@@ -401,5 +401,5 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     );
   }
 
-  return <RampStepPlaceholder />;
+  return <RampQuoteSkeleton />;
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/provider-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/provider-card.tsx
@@ -28,7 +28,7 @@ function formatEstimateDecimal(value: string): string {
   }).format(parsed);
 }
 
-function buildFeeLabel(fees: PaymentRampEstimateFees): string | null {
+function buildFeeLabel(fees: PaymentRampEstimateFees): string {
   const networkFee = fees.network;
   const providerFee = fees.provider;
   const network = networkFee !== undefined ? Number(networkFee) : undefined;
@@ -50,9 +50,8 @@ function buildFeeLabel(fees: PaymentRampEstimateFees): string | null {
     return `Fees ${formatEstimateDecimal(providerFee)} ${providerCurrency} + ${formatEstimateDecimal(networkFee)} ${networkCurrency}`;
   }
 
-  const total = Number(fees.total);
-  if (total <= 0) {
-    return null;
+  if (Number(fees.total) === 0) {
+    return "No fees";
   }
 
   return `Fee ${formatEstimateDecimal(fees.total)} ${fees.currency}`;
@@ -84,11 +83,9 @@ function ProviderCardEstimate({
         </p>
         <div className="flex items-center justify-end gap-2 whitespace-nowrap">
           <span className="text-sm leading-none font-semibold text-text-extra-high">{`≈ ${amount} ${unit}`}</span>
-          {feeLabel ? (
-            <span className="rounded-full bg-border-extra-light px-2 py-0.5 text-xs leading-none font-medium text-text-low">
-              {feeLabel}
-            </span>
-          ) : null}
+          <span className="rounded-full bg-border-extra-light px-2 py-0.5 text-xs leading-none font-medium text-text-low">
+            {feeLabel}
+          </span>
         </div>
       </div>
     );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-quote-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-quote-skeleton.tsx
@@ -1,0 +1,22 @@
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
+
+export function RampQuoteSkeleton() {
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-start gap-3">
+        <SkeletonBlock className="size-10 shrink-0 rounded-xl" />
+        <div className="flex-1 space-y-2 pt-1">
+          <SkeletonBlock className="h-4 w-48" />
+          <SkeletonBlock className="h-3.5 w-full max-w-md" />
+        </div>
+      </div>
+      <div className="mt-6 space-y-3">
+        <SkeletonBlock className="h-16 rounded-xl" />
+        <SkeletonBlock className="h-16 rounded-xl" />
+      </div>
+      <div className="mt-6 border-t border-border-light pt-5">
+        <SkeletonBlock className="h-4 w-40" />
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-step-placeholder.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-step-placeholder.tsx
@@ -1,8 +1,0 @@
-export function RampStepPlaceholder() {
-  return (
-    <div className="grid place-items-center rounded-2xl border border-dashed border-border-light bg-border-extra-light px-6 py-16 text-center">
-      <p className="text-lg font-medium text-text-extra-high">Coming soon</p>
-      <p className="mt-1 text-sm text-text-low">This step isn&apos;t built yet.</p>
-    </div>
-  );
-}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/requirements-fields.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/requirements-fields.tsx
@@ -4,6 +4,7 @@ import type { CollectedFieldData, RequirementField } from "@sdp/types/ramp-requi
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { applyRequirementMask, requirementFieldError } from "../schema";
 
 function RequirementFieldInput({
   field,
@@ -26,7 +27,8 @@ function RequirementFieldInput({
           searchPlaceholder="Search…"
         />
       );
-    case "text":
+    case "text": {
+      const error = value.trim().length > 0 ? requirementFieldError(field, value) : null;
       return (
         <div className="space-y-2">
           <Label htmlFor={field.key}>{field.label}</Label>
@@ -35,10 +37,18 @@ function RequirementFieldInput({
             id={field.key}
             placeholder={field.placeholder}
             value={value}
-            onChange={(event) => onChange(event.target.value)}
+            onChange={(event) =>
+              onChange(
+                field.mask
+                  ? applyRequirementMask(field.mask, event.target.value)
+                  : event.target.value
+              )
+            }
           />
+          {error ? <p className="text-sm text-status-error-text">{error}</p> : null}
         </div>
       );
+    }
     default: {
       const exhaustive: never = field;
       throw new Error(`Unhandled requirement field kind: ${JSON.stringify(exhaustive)}`);

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
@@ -52,6 +52,7 @@ export interface AdvanceRequirementsPayload {
 async function advanceCounterpartyRequirements(
   counterpartyId: string,
   provider: RampProviderId,
+  direction: RampDirection,
   payload: AdvanceRequirementsPayload & { collectedData: CollectedFieldData }
 ): Promise<CounterpartyRequirements> {
   const response = await fetch(
@@ -59,7 +60,7 @@ async function advanceCounterpartyRequirements(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ provider, direction: "onramp", ...payload }),
+      body: JSON.stringify({ provider, direction, ...payload }),
     }
   );
   const body = (await response.json().catch(() => ({}))) as {
@@ -173,10 +174,12 @@ export function useCounterpartyRequirements(
     }
     setIsAdvancing(true);
     try {
-      const result = await advanceCounterpartyRequirements(params.counterpartyId, params.provider, {
-        ...payload,
-        collectedData,
-      });
+      const result = await advanceCounterpartyRequirements(
+        params.counterpartyId,
+        params.provider,
+        params.direction,
+        { ...payload, collectedData }
+      );
       setOnboarding(result);
       setLastAdvancePayload(payload);
       return result;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-counterparty-requirements.ts
@@ -11,6 +11,7 @@ import type {
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 import { getApiError } from "@/app/dashboard/payments/payments-workspace.data";
+import { requirementFieldError } from "../schema";
 
 async function fetchCounterpartyRequirements(
   counterpartyId: string,
@@ -220,14 +221,7 @@ export function useCounterpartyRequirements(
   );
 
   const isComplete = useMemo(
-    () =>
-      fields.every((field) => {
-        if (!field.required) {
-          return true;
-        }
-        const value = collectedData[field.key];
-        return value !== undefined && value.trim().length > 0;
-      }),
+    () => fields.every((field) => requirementFieldError(field, collectedData[field.key]) === null),
     [fields, collectedData]
   );
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-offramp-wizard.ts
@@ -48,9 +48,10 @@ export function useOfframpWizard(props: UseRampWizardProps) {
       insertAfter: "WITHDRAW",
       direction: "offramp",
     },
+    advanceRequirementsBeforeQuote: true,
     selectionSchema: withdrawSelectionSchema,
     quoteEndpoint: "/api/dashboard/payments/ramps/offramp/quote",
-    buildQuotePayload: ({ fields, provider, selectedRampPair, cryptoToken, collectedData }) => ({
+    buildQuotePayload: ({ fields, provider, selectedRampPair, cryptoToken }) => ({
       provider,
       counterpartyId: fields.counterpartyId,
       sourceWallet: fields.walletId,
@@ -58,7 +59,6 @@ export function useOfframpWizard(props: UseRampWizardProps) {
       fiatCurrency: selectedRampPair.fiatCurrency,
       cryptoAmount: fields.amount.trim(),
       redirectUrl: `${window.location.origin}/dashboard/payments`,
-      collectedData,
     }),
     onQuoteCreated: () => {
       setOnchainSendLoading(false);

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onramp-wizard.ts
@@ -63,13 +63,6 @@ export function useOnrampWizard(props: UseRampWizardProps) {
     },
   });
 
-  const onboardingReady = wizard.onboarding?.status === "ready";
-  useSWR(
-    onboardingReady && !wizard.quote ? "onramp-ready-quote" : null,
-    () => wizard.refreshQuote(),
-    { refreshInterval: 4000, revalidateOnFocus: false, dedupingInterval: 0 }
-  );
-
   const transferStatusKey = wizard.quote
     ? (["onramp-transfer-status", wizard.quote.provider, wizard.quote.id] as const)
     : null;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -72,8 +72,9 @@ export interface RampWizardConfig<TId extends string = string> {
   };
   /**
    * When set, the quote step advances provider onboarding via POST /requirements
-   * (provisioning) instead of firing the quote; the caller fires the quote once
-   * the lifecycle reaches `ready`. Used by on-ramp; off-ramp leaves this unset.
+   * (provisioning) instead of firing the quote; this hook then fires the
+   * provisioning-free quote once the lifecycle reaches `ready`. Used by on-ramp
+   * and off-ramp.
    */
   advanceRequirementsBeforeQuote?: boolean;
   onQuoteCreated?: (quote: PaymentRampQuote) => void;
@@ -299,6 +300,16 @@ export function useRampWizard<TId extends string>(
       setQuote(created);
     } catch {}
   };
+
+  useSWR(
+    config.advanceRequirementsBeforeQuote &&
+      requirements.onboarding?.status === "ready" &&
+      quote === null
+      ? ([requirementsConfig?.direction ?? "ramp", "ready-quote"] as const)
+      : null,
+    () => refreshQuote(),
+    { refreshInterval: 4000, revalidateOnFocus: false, dedupingInterval: 0 }
+  );
 
   const advanceRequirementsAndProceed = async () => {
     if (!config.selectionSchema.safeParse(fields).success || !fields.provider) {

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { OfframpStepContent } from "./components/offramp-step-content";
 import { PoweredByRampProvider, RampWizardShell } from "./components/ramp-wizard-shell";
-import { OFFRAMP_STEPS, type OfframpWizard, useOfframpWizard } from "./hooks/use-offramp-wizard";
+import { type OfframpWizard, useOfframpWizard } from "./hooks/use-offramp-wizard";
 import { isTerminalRampTransferStatus } from "./hooks/use-ramp-wizard";
 import type { RailProps } from "./ramp-action-page";
 
@@ -43,7 +43,7 @@ export function OfframpRail({
 
   return (
     <RampWizardShell
-      steps={[...preSteps, ...OFFRAMP_STEPS]}
+      steps={[...preSteps, ...wizard.steps]}
       stepIndex={preSteps.length + wizard.stepIndex}
       primaryDisabled={
         wizard.hostedQuoteLoading ||
@@ -66,7 +66,7 @@ export function OfframpRail({
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       footerActions={
         transferTerminal ? (
-          <Button asChild type="button" variant="secondary" className="self-center rounded-full">
+          <Button asChild type="button" className="h-14 rounded-full text-base">
             <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
               Go to transaction
             </Link>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
@@ -66,7 +66,7 @@ export function OfframpRail({
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       footerActions={
         transferTerminal ? (
-          <Button asChild type="button" className="h-14 rounded-full text-base">
+          <Button asChild type="button">
             <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
               Go to transaction
             </Link>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { OfframpStepContent } from "./components/offramp-step-content";
+import { PoweredByRampProvider, RampWizardShell } from "./components/ramp-wizard-shell";
+import { OFFRAMP_STEPS, type OfframpWizard, useOfframpWizard } from "./hooks/use-offramp-wizard";
+import { isTerminalRampTransferStatus } from "./hooks/use-ramp-wizard";
+import type { RailProps } from "./ramp-action-page";
+
+function offrampPrimaryLabel(wizard: OfframpWizard): string {
+  switch (true) {
+    case wizard.hostedQuoteLoading:
+      return "Processing";
+    case wizard.isLastStep:
+      return "Done";
+    default:
+      return "Next";
+  }
+}
+
+export function OfframpRail({
+  wallets,
+  walletsError,
+  enabledRampProviders,
+  counterpartiesResult,
+  counterpartyId,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOfframpWizard({
+    wallets,
+    walletsError,
+    enabledRampProviders,
+    counterpartiesResult,
+    initialCounterpartyId: counterpartyId,
+    onExit,
+  });
+
+  const transferTerminal = wizard.transferStatus
+    ? isTerminalRampTransferStatus(wizard.transferStatus.status)
+    : false;
+
+  return (
+    <RampWizardShell
+      steps={[...preSteps, ...OFFRAMP_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={
+        wizard.hostedQuoteLoading ||
+        !wizard.canProceed ||
+        (wizard.currentStepId === "WALLET" && wizard.walletsLoading)
+      }
+      primaryLabel={offrampPrimaryLabel(wizard)}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={() => void wizard.handlePrimary()}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
+      header={
+        wizard.fields.provider &&
+        (wizard.currentStepId === "REQUIREMENTS" || wizard.currentStepId === "COMPLETE") ? (
+          <PoweredByRampProvider provider={wizard.fields.provider} />
+        ) : null
+      }
+      secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
+      footerActions={
+        transferTerminal ? (
+          <Button asChild type="button" variant="secondary" className="self-center rounded-full">
+            <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
+              Go to transaction
+            </Link>
+          </Button>
+        ) : null
+      }
+      hidePrimary={wizard.currentStepId === "COMPLETE"}
+    >
+      <OfframpStepContent wizard={wizard} />
+    </RampWizardShell>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onchain-receive-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onchain-receive-rail.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { OnchainReceiveStepContent } from "./components/onchain-receive-step-content";
+import { RampWizardShell } from "./components/ramp-wizard-shell";
+import { ONCHAIN_RECEIVE_STEPS, useOnchainReceiveWizard } from "./hooks/use-onchain-receive-wizard";
+import type { RailProps } from "./ramp-action-page";
+
+export function OnchainReceiveRail({
+  wallets,
+  walletsError,
+  counterpartyId,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOnchainReceiveWizard({ wallets, walletsError, counterpartyId, onExit });
+
+  return (
+    <RampWizardShell
+      steps={[...preSteps, ...ONCHAIN_RECEIVE_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={
+        !wizard.canProceed || (wizard.currentStepId === "WALLET" && wizard.walletsLoading)
+      }
+      primaryLabel={wizard.isLastStep ? "Done" : "Next"}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={wizard.handlePrimary}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
+    >
+      <OnchainReceiveStepContent wizard={wizard} />
+    </RampWizardShell>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onchain-send-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onchain-send-rail.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { OnchainSendStepContent } from "./components/onchain-send-step-content";
+import { RampWizardShell } from "./components/ramp-wizard-shell";
+import {
+  ONCHAIN_SEND_STEPS,
+  type OnchainSendWizard,
+  useOnchainSendWizard,
+} from "./hooks/use-onchain-send-wizard";
+import type { RailProps } from "./ramp-action-page";
+
+function sendPrimaryLabel(wizard: OnchainSendWizard): string {
+  switch (true) {
+    case wizard.submitting:
+      return "Submitting...";
+    case wizard.isLastStep && Boolean(wizard.transferResult):
+      return "Done";
+    case wizard.isLastStep:
+      return "Send transfer";
+    default:
+      return "Next";
+  }
+}
+
+export function OnchainSendRail({
+  wallets,
+  walletsError,
+  counterpartyId,
+  counterpartyName,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOnchainSendWizard({ wallets, walletsError, counterpartyId, onExit });
+
+  return (
+    <RampWizardShell
+      steps={[...preSteps, ...ONCHAIN_SEND_STEPS]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={wizard.submitting || !wizard.canProceed}
+      primaryLabel={sendPrimaryLabel(wizard)}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={() => void wizard.handlePrimary()}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
+    >
+      <OnchainSendStepContent wizard={wizard} counterpartyName={counterpartyName} />
+    </RampWizardShell>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
@@ -98,7 +98,7 @@ export function OnrampRail({
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       footerActions={
         transferTerminal ? (
-          <Button asChild type="button" variant="secondary" className="self-center">
+          <Button asChild type="button" className="h-14 rounded-full text-base">
             <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
               Go to transaction
             </Link>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { OnrampStepContent } from "./components/onramp-step-content";
+import { PoweredByRampProvider, RampWizardShell } from "./components/ramp-wizard-shell";
+import { type OnrampWizard, useOnrampWizard } from "./hooks/use-onramp-wizard";
+import { isTerminalRampTransferStatus } from "./hooks/use-ramp-wizard";
+import type { RailProps } from "./ramp-action-page";
+
+function onrampPrimaryLabel(
+  wizard: OnrampWizard,
+  verificationPending: boolean,
+  verificationUrl: string | undefined
+): string {
+  switch (true) {
+    case wizard.hostedQuoteLoading:
+      return "Processing";
+    case verificationPending:
+      return "Verification pending";
+    case verificationUrl !== undefined:
+      return "Complete Verification";
+    default:
+      return "Next";
+  }
+}
+
+function onrampPrimaryAction(
+  wizard: OnrampWizard,
+  verificationUrl: string | undefined
+): () => void {
+  switch (true) {
+    case verificationUrl !== undefined:
+      return () => window.open(verificationUrl, "_blank", "noopener");
+    case wizard.isLastStep:
+      return wizard.finish;
+    default:
+      return () => void wizard.handlePrimary();
+  }
+}
+
+export function OnrampRail({
+  wallets,
+  walletsError,
+  enabledRampProviders,
+  counterpartiesResult,
+  counterpartyId,
+  preSteps,
+  onExit,
+}: RailProps) {
+  const wizard = useOnrampWizard({
+    wallets,
+    walletsError,
+    enabledRampProviders,
+    counterpartiesResult,
+    initialCounterpartyId: counterpartyId,
+    onExit,
+  });
+
+  const verificationUrl =
+    wizard.currentStepId === "PROVIDER" &&
+    wizard.onboarding?.status === "customer_verification_required"
+      ? wizard.onboarding.verificationUrl
+      : undefined;
+
+  const verificationPending =
+    wizard.currentStepId === "PROVIDER" &&
+    (wizard.onboarding?.status === "customer_verifying" ||
+      wizard.onboarding?.status === "funding_account_provisioning");
+
+  const transferTerminal = wizard.transferStatus
+    ? isTerminalRampTransferStatus(wizard.transferStatus.status)
+    : false;
+
+  return (
+    <RampWizardShell
+      steps={[...preSteps, ...wizard.steps]}
+      stepIndex={preSteps.length + wizard.stepIndex}
+      primaryDisabled={
+        wizard.hostedQuoteLoading ||
+        verificationPending ||
+        !wizard.canProceed ||
+        (wizard.currentStepId === "DEPOSIT" && wizard.walletsLoading)
+      }
+      primaryLabel={onrampPrimaryLabel(wizard, verificationPending, verificationUrl)}
+      walletsError={wizard.liveWalletsError}
+      onPrimary={onrampPrimaryAction(wizard, verificationUrl)}
+      onSecondary={wizard.handleSecondary}
+      counterpartyDialogOpen={false}
+      setCounterpartyDialogOpen={() => {}}
+      onCounterpartyCreated={() => {}}
+      header={
+        wizard.fields.provider &&
+        (wizard.currentStepId === "REQUIREMENTS" || wizard.currentStepId === "PROVIDER") ? (
+          <PoweredByRampProvider provider={wizard.fields.provider} />
+        ) : null
+      }
+      secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
+      footerActions={
+        transferTerminal ? (
+          <Button asChild type="button" variant="secondary" className="self-center">
+            <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
+              Go to transaction
+            </Link>
+          </Button>
+        ) : null
+      }
+      hidePrimary={wizard.currentStepId === "PROVIDER" && !verificationUrl}
+    >
+      <OnrampStepContent wizard={wizard} />
+    </RampWizardShell>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
@@ -98,7 +98,7 @@ export function OnrampRail({
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       footerActions={
         transferTerminal ? (
-          <Button asChild type="button" className="h-14 rounded-full text-base">
+          <Button asChild type="button">
             <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
               Go to transaction
             </Link>

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -6,7 +6,6 @@ import type {
   PaymentsDashboardWallet,
   RampProviderId,
 } from "@sdp/types";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import useSWR, { preload } from "swr";
@@ -16,20 +15,14 @@ import {
   fetchCounterpartyAccounts,
   fetchWallets,
 } from "@/app/dashboard/payments/payments-workspace.data";
-import { Button } from "@/components/ui/button";
 import { CounterpartyPicker } from "./components/counterparty-picker";
 import { CounterpartyRecentTransfers } from "./components/counterparty-recent-transfers";
-import { OfframpStepContent } from "./components/offramp-step-content";
-import { OnchainReceiveStepContent } from "./components/onchain-receive-step-content";
-import { OnchainSendStepContent } from "./components/onchain-send-step-content";
-import { OnrampStepContent } from "./components/onramp-step-content";
 import { type PaymentMethod, PaymentMethodStep } from "./components/payment-method-step";
-import { PoweredByRampProvider, RampWizardShell } from "./components/ramp-wizard-shell";
-import { OFFRAMP_STEPS, useOfframpWizard } from "./hooks/use-offramp-wizard";
-import { ONCHAIN_RECEIVE_STEPS, useOnchainReceiveWizard } from "./hooks/use-onchain-receive-wizard";
-import { ONCHAIN_SEND_STEPS, useOnchainSendWizard } from "./hooks/use-onchain-send-wizard";
-import { useOnrampWizard } from "./hooks/use-onramp-wizard";
-import { isTerminalRampTransferStatus } from "./hooks/use-ramp-wizard";
+import { RampWizardShell } from "./components/ramp-wizard-shell";
+import { OfframpRail } from "./offramp-rail";
+import { OnchainReceiveRail } from "./onchain-receive-rail";
+import { OnchainSendRail } from "./onchain-send-rail";
+import { OnrampRail } from "./onramp-rail";
 
 interface PaymentsActionPageProps {
   mode: "send" | "receive";
@@ -47,9 +40,7 @@ type WizardStep = { label: string; title: string };
 const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
 const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 
-// ---- Rail children (mounted once the counterparty + method are known) ----
-
-interface RailProps {
+export interface RailProps {
   wallets: PaymentsDashboardWallet[];
   walletsError: string | null;
   enabledRampProviders: RampProviderId[];
@@ -60,227 +51,13 @@ interface RailProps {
   onExit: () => void;
 }
 
-function OnchainSendRail({
-  wallets,
-  walletsError,
-  counterpartyId,
-  counterpartyName,
-  preSteps,
-  onExit,
-}: RailProps) {
-  const wizard = useOnchainSendWizard({ wallets, walletsError, counterpartyId, onExit });
-  const primaryLabel = wizard.submitting
-    ? "Submitting..."
-    : wizard.isLastStep
-      ? wizard.transferResult
-        ? "Done"
-        : "Send transfer"
-      : "Next";
-
-  return (
-    <RampWizardShell
-      steps={[...preSteps, ...ONCHAIN_SEND_STEPS]}
-      stepIndex={preSteps.length + wizard.stepIndex}
-      primaryDisabled={wizard.submitting || !wizard.canProceed}
-      primaryLabel={primaryLabel}
-      walletsError={wizard.liveWalletsError}
-      onPrimary={() => void wizard.handlePrimary()}
-      onSecondary={wizard.handleSecondary}
-      counterpartyDialogOpen={false}
-      setCounterpartyDialogOpen={() => {}}
-      onCounterpartyCreated={() => {}}
-    >
-      <OnchainSendStepContent wizard={wizard} counterpartyName={counterpartyName} />
-    </RampWizardShell>
-  );
-}
-
-function OfframpRail({
-  wallets,
-  walletsError,
-  enabledRampProviders,
-  counterpartiesResult,
-  counterpartyId,
-  preSteps,
-  onExit,
-}: RailProps) {
-  const wizard = useOfframpWizard({
-    wallets,
-    walletsError,
-    enabledRampProviders,
-    counterpartiesResult,
-    initialCounterpartyId: counterpartyId,
-    onExit,
-  });
-
-  const transferTerminal = wizard.transferStatus
-    ? isTerminalRampTransferStatus(wizard.transferStatus.status)
-    : false;
-
-  return (
-    <RampWizardShell
-      steps={[...preSteps, ...OFFRAMP_STEPS]}
-      stepIndex={preSteps.length + wizard.stepIndex}
-      primaryDisabled={
-        wizard.hostedQuoteLoading ||
-        !wizard.canProceed ||
-        (wizard.currentStepId === "WALLET" && wizard.walletsLoading)
-      }
-      primaryLabel={wizard.hostedQuoteLoading ? "Processing" : wizard.isLastStep ? "Done" : "Next"}
-      walletsError={wizard.liveWalletsError}
-      onPrimary={() => void wizard.handlePrimary()}
-      onSecondary={wizard.handleSecondary}
-      counterpartyDialogOpen={false}
-      setCounterpartyDialogOpen={() => {}}
-      onCounterpartyCreated={() => {}}
-      header={
-        wizard.fields.provider &&
-        (wizard.currentStepId === "REQUIREMENTS" || wizard.currentStepId === "COMPLETE") ? (
-          <PoweredByRampProvider provider={wizard.fields.provider} />
-        ) : null
-      }
-      secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
-      footerActions={
-        transferTerminal ? (
-          <Button asChild type="button" variant="secondary" className="self-center rounded-full">
-            <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
-              Go to transaction
-            </Link>
-          </Button>
-        ) : null
-      }
-      hidePrimary={wizard.currentStepId === "COMPLETE"}
-    >
-      <OfframpStepContent wizard={wizard} />
-    </RampWizardShell>
-  );
-}
-
-function OnchainReceiveRail({
-  wallets,
-  walletsError,
-  counterpartyId,
-  preSteps,
-  onExit,
-}: RailProps) {
-  const wizard = useOnchainReceiveWizard({ wallets, walletsError, counterpartyId, onExit });
-
-  return (
-    <RampWizardShell
-      steps={[...preSteps, ...ONCHAIN_RECEIVE_STEPS]}
-      stepIndex={preSteps.length + wizard.stepIndex}
-      primaryDisabled={
-        !wizard.canProceed || (wizard.currentStepId === "WALLET" && wizard.walletsLoading)
-      }
-      primaryLabel={wizard.isLastStep ? "Done" : "Next"}
-      walletsError={wizard.liveWalletsError}
-      onPrimary={wizard.handlePrimary}
-      onSecondary={wizard.handleSecondary}
-      counterpartyDialogOpen={false}
-      setCounterpartyDialogOpen={() => {}}
-      onCounterpartyCreated={() => {}}
-    >
-      <OnchainReceiveStepContent wizard={wizard} />
-    </RampWizardShell>
-  );
-}
-
-function OnrampRail({
-  wallets,
-  walletsError,
-  enabledRampProviders,
-  counterpartiesResult,
-  counterpartyId,
-  preSteps,
-  onExit,
-}: RailProps) {
-  const wizard = useOnrampWizard({
-    wallets,
-    walletsError,
-    enabledRampProviders,
-    counterpartiesResult,
-    initialCounterpartyId: counterpartyId,
-    onExit,
-  });
-
-  const verificationUrl =
-    wizard.currentStepId === "PROVIDER" &&
-    wizard.onboarding?.status === "customer_verification_required"
-      ? wizard.onboarding.verificationUrl
-      : undefined;
-
-  const verificationPending =
-    wizard.currentStepId === "PROVIDER" &&
-    (wizard.onboarding?.status === "customer_verifying" ||
-      wizard.onboarding?.status === "funding_account_provisioning");
-
-  const transferTerminal = wizard.transferStatus
-    ? isTerminalRampTransferStatus(wizard.transferStatus.status)
-    : false;
-
-  return (
-    <RampWizardShell
-      steps={[...preSteps, ...wizard.steps]}
-      stepIndex={preSteps.length + wizard.stepIndex}
-      primaryDisabled={
-        wizard.hostedQuoteLoading ||
-        verificationPending ||
-        !wizard.canProceed ||
-        (wizard.currentStepId === "DEPOSIT" && wizard.walletsLoading)
-      }
-      primaryLabel={
-        wizard.hostedQuoteLoading
-          ? "Processing"
-          : verificationPending
-            ? "Verification pending"
-            : verificationUrl
-              ? "Complete Verification"
-              : "Next"
-      }
-      walletsError={wizard.liveWalletsError}
-      onPrimary={
-        verificationUrl
-          ? () => window.open(verificationUrl, "_blank", "noopener")
-          : wizard.isLastStep
-            ? wizard.finish
-            : () => void wizard.handlePrimary()
-      }
-      onSecondary={wizard.handleSecondary}
-      counterpartyDialogOpen={false}
-      setCounterpartyDialogOpen={() => {}}
-      onCounterpartyCreated={() => {}}
-      header={
-        wizard.fields.provider &&
-        (wizard.currentStepId === "REQUIREMENTS" || wizard.currentStepId === "PROVIDER") ? (
-          <PoweredByRampProvider provider={wizard.fields.provider} />
-        ) : null
-      }
-      secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
-      footerActions={
-        transferTerminal ? (
-          <Button asChild type="button" variant="secondary" className="self-center rounded-full">
-            <Link href={`/dashboard/payments/counterparty/${wizard.fields.counterpartyId}`}>
-              Go to transaction
-            </Link>
-          </Button>
-        ) : null
-      }
-      hidePrimary={wizard.currentStepId === "PROVIDER" && !verificationUrl}
-    >
-      <OnrampStepContent wizard={wizard} />
-    </RampWizardShell>
-  );
-}
-
-// ---- Orchestrator: counterparty -> method -> rail ----
-
-type Phase = "counterparty" | "method" | "rail";
+type RampsPhase = "counterparty" | "method" | "rail";
 
 export function PaymentsActionPage(props: PaymentsActionPageProps) {
   const { mode, enabledRampProviders } = props;
   const router = useRouter();
 
-  const [phase, setPhase] = useState<Phase>("counterparty");
+  const [phase, setPhase] = useState<RampsPhase>("counterparty");
   const [counterpartyId, setCounterpartyId] = useState("");
   const [method, setMethod] = useState<PaymentMethod | null>(null);
   const [counterpartyDialogOpen, setCounterpartyDialogOpen] = useState(false);
@@ -348,18 +125,21 @@ export function PaymentsActionPage(props: PaymentsActionPageProps) {
       onExit: railOnExit,
     };
 
-    if (mode === "send") {
-      return effectiveMethod === "onchain" ? (
-        <OnchainSendRail {...railProps} />
-      ) : (
-        <OfframpRail {...railProps} />
-      );
+    const railKey = `${mode}:${effectiveMethod}` as const;
+    switch (railKey) {
+      case "send:onchain":
+        return <OnchainSendRail {...railProps} />;
+      case "send:ramp":
+        return <OfframpRail {...railProps} />;
+      case "receive:onchain":
+        return <OnchainReceiveRail {...railProps} />;
+      case "receive:ramp":
+        return <OnrampRail {...railProps} />;
+      default: {
+        const exhaustive: never = railKey;
+        throw new Error(`Unhandled rail: ${JSON.stringify(exhaustive)}`);
+      }
     }
-    return effectiveMethod === "onchain" ? (
-      <OnchainReceiveRail {...railProps} />
-    ) : (
-      <OnrampRail {...railProps} />
-    );
   }
 
   const stepIndex = phase === "counterparty" ? 0 : 1;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/schema.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/schema.ts
@@ -1,4 +1,5 @@
 import { RAMP_PROVIDERS, type RampProviderId } from "@sdp/types/provider-access";
+import type { RequirementField } from "@sdp/types/ramp-requirements";
 import { z } from "zod";
 
 const providerField = z
@@ -101,3 +102,44 @@ export const onchainSendSchema = z.object({
 });
 
 export type OnchainSendFields = z.input<typeof onchainSendSchema>;
+
+export function applyRequirementMask(mask: string, raw: string): string {
+  const digits = raw.replace(/\D/g, "");
+  let out = "";
+  let next = 0;
+  for (const slot of mask) {
+    if (next >= digits.length) break;
+    if (slot === "#") {
+      out += digits[next];
+      next += 1;
+    } else {
+      out += slot;
+    }
+  }
+  return out;
+}
+
+export function requirementFieldError(
+  field: RequirementField,
+  raw: string | undefined
+): string | null {
+  const value = raw === undefined ? "" : raw.trim();
+  if (value.length === 0) {
+    return field.required ? `${field.label} is required.` : null;
+  }
+  if (field.kind === "select") {
+    return field.options.some((option) => option.value === value)
+      ? null
+      : `Select a valid ${field.label.toLowerCase()}.`;
+  }
+  if (field.minLength !== undefined && value.length < field.minLength) {
+    return `${field.label} must be at least ${field.minLength} characters.`;
+  }
+  if (field.maxLength !== undefined && value.length > field.maxLength) {
+    return `${field.label} must be at most ${field.maxLength} characters.`;
+  }
+  if (field.pattern !== undefined && !new RegExp(field.pattern).test(value)) {
+    return `${field.label} doesn't match the expected format${field.placeholder ? ` (e.g. ${field.placeholder})` : ""}.`;
+  }
+  return null;
+}

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { Toaster } from "sonner";
 import { shouldLoadClerkForPath } from "@/lib/auth-entry";
 import "./globals.css";
+import Script from "next/script";
 
 const ALLOWED_SATELLITE_REDIRECT_ORIGINS = [
   "https://ecosystem.solana.com",
@@ -39,6 +40,15 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
+      <head>
+        {process.env.NODE_ENV === "development" && (
+          <Script
+            src="//unpkg.com/react-grab/dist/index.global.js"
+            crossOrigin="anonymous"
+            strategy="beforeInteractive"
+          />
+        )}
+      </head>
       <body>
         {content}
         <Toaster position="bottom-right" richColors closeButton />

--- a/apps/sdp-web/src/app/layout.tsx
+++ b/apps/sdp-web/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { headers } from "next/headers";
 import { Toaster } from "sonner";
 import { shouldLoadClerkForPath } from "@/lib/auth-entry";
 import "./globals.css";
-import Script from "next/script";
 
 const ALLOWED_SATELLITE_REDIRECT_ORIGINS = [
   "https://ecosystem.solana.com",
@@ -40,15 +39,6 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
-      <head>
-        {process.env.NODE_ENV === "development" && (
-          <Script
-            src="//unpkg.com/react-grab/dist/index.global.js"
-            crossOrigin="anonymous"
-            strategy="beforeInteractive"
-          />
-        )}
-      </head>
       <body>
         {content}
         <Toaster position="bottom-right" richColors closeButton />

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -46,6 +46,23 @@ export interface PaymentWalletPolicyEnvelope {
   };
 }
 
+export type PaymentTransferStatus =
+  | "pending"
+  | "processing"
+  | "confirmed"
+  | "finalized"
+  | "failed"
+  | "awaiting_payment"
+  | "settling"
+  | "completed"
+  | "expired";
+
+export const SUCCESSFUL_PAYMENT_TRANSFER_STATUSES = [
+  "completed",
+  "confirmed",
+  "finalized",
+] as const satisfies readonly PaymentTransferStatus[];
+
 export interface PaymentTransferSummary {
   id: string;
   status: string;

--- a/packages/sdp-types/src/ramp-requirements.ts
+++ b/packages/sdp-types/src/ramp-requirements.ts
@@ -18,6 +18,7 @@ export type RequirementField =
       minLength?: number;
       maxLength?: number;
       placeholder?: string;
+      mask?: string;
     }
   | {
       kind: "select";


### PR DESCRIPTION
## What changed

Mirrors the on-ramp refactor (#471) for off-ramp: **the quote no longer provisions accounts** — a counterparty must satisfy `POST /counterparties/:id/requirements` first.

### Core change (requirements gate + provisioning-free quote)
- **`createOfframpQuote` is now pure.** The Lightspark branch reads the resolved Grid customer + active payout account from `counterparty.provider_data` and throws `counterpartyNotProvisioned` (409) when not provisioned. BVNK/MoonPay off-ramp quotes were already pure.
- **Provisioning moved to the requirements endpoint.** `advanceCounterpartyRequirements` now ensures the Lightspark payout account on off-ramp; BVNK off-ramp short-circuits to `ready` (no provisioning needed).
- `submitCounterpartyRequirementsSchema` gains off-ramp branches; `createOfframpQuoteSchema` drops `collectedData`.
- **Frontend wiring:** the off-ramp wizard sets `advanceRequirementsBeforeQuote`, and the requirements-advance helper now sends the real `direction` (was hardcoded `"onramp"` — latent bug). The ready→quote poll is lifted into the shared `use-ramp-wizard` hook (deduped across on/off-ramp). `rampDirectionSchema` is shared between the payments and counterparties schemas.

### Requirement-field UX (validate / format / mask)
Collecting payout + KYC details now fails fast on the client instead of returning a cryptic backend 400:
- **Client-side validation:** `requirementFieldError` mirrors the backend `fieldToZod` (`pattern`/`minLength`/`maxLength`), so Next stays disabled until the value is actually acceptable and an inline per-field message shows as the user types.
- **Placeholders:** added format hints to the shared Lightspark payout fields; gave the USD/ACH account number the `^[0-9]{4,17}$` validation it was missing.
- **Masking:** new optional `mask` on `RequirementField` (text). The backend tags the SSN/ITIN (`###-##-####`) and GBP sort code (`##-##-##`); the client groups digits live. Masking is presentation-only — `buildBvnkIndividualPayload` strips the tax number back to digits before sending to BVNK (TODO left noting the field is US-centric).

### Cleanup (incidental)
- Rail split: `ramp-action-page.tsx` broken into per-direction `offramp-rail.tsx` / `onramp-rail.tsx` / `onchain-*-rail.tsx`, plus related ramp UI/util tidy-ups.

## Verification
- `tsc --noEmit` + `biome check` clean across all changed files (eslint is broken repo-wide).
- Traced end-to-end: requirements advance → `ready` → shared poll fires the provisioning-free quote → COMPLETE renders instructions/widget. Polling stops once the quote is set.