### PR TITLE
feat(payments): PRO-1388 wire Lightspark on-ramp estimate

### DIFF
--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -50,7 +50,7 @@ describe("LightsparkRampClient", () => {
         gridExchangeRateResponse({
           sourceCurrency: "USDC",
           sourceDecimals: 6,
-          sendingAmount: 100000000,
+          sendingAmount: 10000,
           receivingAmount: 6400,
         })
       )
@@ -78,7 +78,7 @@ describe("LightsparkRampClient", () => {
     const amountSpecificUrl = new URL(String(fetchSpy.mock.calls[1]?.[0]));
     expect(amountSpecificUrl.searchParams.get("sourceCurrency")).toBe("USDC");
     expect(amountSpecificUrl.searchParams.get("destinationCurrency")).toBe("USD");
-    expect(amountSpecificUrl.searchParams.get("sendingAmount")).toBe("3000");
+    expect(amountSpecificUrl.searchParams.get("sendingAmount")).toBe("30000000");
   });
 
   it("uses each Grid source currency's decimals for estimate amounts", async () => {
@@ -88,7 +88,7 @@ describe("LightsparkRampClient", () => {
         gridExchangeRateResponse({
           sourceCurrency: "SOL",
           sourceDecimals: 9,
-          sendingAmount: 100000000,
+          sendingAmount: 10000,
           receivingAmount: 99833300,
         })
       )
@@ -109,7 +109,58 @@ describe("LightsparkRampClient", () => {
 
     const url = new URL(String(fetchSpy.mock.calls[1]?.[0]));
     expect(url.searchParams.get("sourceCurrency")).toBe("SOL");
-    expect(url.searchParams.get("sendingAmount")).toBe("125000");
+    expect(url.searchParams.get("sendingAmount")).toBe("1250000000");
+  });
+
+  it("uses fiat decimals and Grid receiving amount for USDC on-ramp estimate", async () => {
+    const onrampRate = (sendingAmount: number, receivingAmount: number, feeFixed: number) =>
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              sourceCurrency: { code: "USD", decimals: 2 },
+              destinationCurrency: { code: "USDC", decimals: 6 },
+              sendingAmount,
+              receivingAmount,
+              exchangeRate: 0.0001,
+              fees: { fixed: feeFixed },
+              minSendingAmount: 100,
+              maxSendingAmount: 500000,
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(onrampRate(10000, 100000000, 0))
+      .mockResolvedValueOnce(onrampRate(15000, 75000000, 5));
+
+    const estimate = await new LightsparkRampClient().estimateOnramp(LIGHTSPARK_CONTEXT, {
+      assetRail: "usdc.solana",
+      fiatCurrency: "USD",
+      fiatAmount: "150",
+    });
+
+    const probeUrl = new URL(String(fetchSpy.mock.calls[0]?.[0]));
+    expect(probeUrl.searchParams.get("sourceCurrency")).toBe("USD");
+    expect(probeUrl.searchParams.get("destinationCurrency")).toBe("USDC");
+    expect(probeUrl.searchParams.has("sendingAmount")).toBe(false);
+
+    const amountUrl = new URL(String(fetchSpy.mock.calls[1]?.[0]));
+    expect(amountUrl.searchParams.get("sendingAmount")).toBe("15000");
+
+    expect(estimate).toMatchObject({
+      provider: "lightspark",
+      direction: "onramp",
+      fiatCurrency: "USD",
+      assetRail: "usdc.solana",
+      fiatAmount: "150",
+      cryptoAmount: "75",
+      exchangeRate: "2",
+      fees: { currency: "USD", total: "0.05" },
+    });
   });
 
   it("returns Grid currency metadata on on-ramp quotes", async () => {

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.test.ts
@@ -38,6 +38,30 @@ function gridExchangeRateResponse(params: {
   );
 }
 
+function onrampExchangeRateResponse(
+  sendingAmount: number,
+  receivingAmount: number,
+  feeFixed: number
+): Response {
+  return new Response(
+    JSON.stringify({
+      data: [
+        {
+          sourceCurrency: { code: "USD", decimals: 2 },
+          destinationCurrency: { code: "USDC", decimals: 6 },
+          sendingAmount,
+          receivingAmount,
+          exchangeRate: 0.0001,
+          fees: { fixed: feeFixed },
+          minSendingAmount: 100,
+          maxSendingAmount: 500000,
+        },
+      ],
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
 describe("LightsparkRampClient", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -113,29 +137,10 @@ describe("LightsparkRampClient", () => {
   });
 
   it("uses fiat decimals and Grid receiving amount for USDC on-ramp estimate", async () => {
-    const onrampRate = (sendingAmount: number, receivingAmount: number, feeFixed: number) =>
-      new Response(
-        JSON.stringify({
-          data: [
-            {
-              sourceCurrency: { code: "USD", decimals: 2 },
-              destinationCurrency: { code: "USDC", decimals: 6 },
-              sendingAmount,
-              receivingAmount,
-              exchangeRate: 0.0001,
-              fees: { fixed: feeFixed },
-              minSendingAmount: 100,
-              maxSendingAmount: 500000,
-            },
-          ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(onrampRate(10000, 100000000, 0))
-      .mockResolvedValueOnce(onrampRate(15000, 75000000, 5));
+      .mockResolvedValueOnce(onrampExchangeRateResponse(10000, 100000000, 0))
+      .mockResolvedValueOnce(onrampExchangeRateResponse(15000, 75000000, 5));
 
     const estimate = await new LightsparkRampClient().estimateOnramp(LIGHTSPARK_CONTEXT, {
       assetRail: "usdc.solana",
@@ -161,6 +166,20 @@ describe("LightsparkRampClient", () => {
       exchangeRate: "2",
       fees: { currency: "USD", total: "0.05" },
     });
+  });
+
+  it("rejects a non-positive Grid receiving amount on on-ramp estimate", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(onrampExchangeRateResponse(10000, 100000000, 0))
+      .mockResolvedValueOnce(onrampExchangeRateResponse(15000, 0, 0));
+
+    await expect(
+      new LightsparkRampClient().estimateOnramp(LIGHTSPARK_CONTEXT, {
+        assetRail: "usdc.solana",
+        fiatCurrency: "USD",
+        fiatAmount: "150",
+      })
+    ).rejects.toThrow(/non-positive/);
   });
 
   it("returns Grid currency metadata on on-ramp quotes", async () => {

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -19,7 +19,7 @@ import {
 } from "@sdp/types/payment-rails";
 import type { CollectedFieldData, CounterpartyRequirements } from "@sdp/types/ramp-requirements";
 import { formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
-import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
+import { AppError, badRequest, providerNotConfigured, providerUnavailable } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
 import { isAddress } from "@/lib/solana";
 import { type ProviderRequestInit, providerFetchJson } from "../fetch";
@@ -953,6 +953,9 @@ export class LightsparkRampClient implements RampProvider {
       )
     );
 
+    if (rate.receivingAmount <= 0) {
+      throw providerUnavailable("Lightspark returned a non-positive on-ramp receiving amount");
+    }
     const cryptoAmount = formatDecimalAmount(
       BigInt(rate.receivingAmount),
       rate.destinationCurrency.decimals
@@ -1006,8 +1009,13 @@ export class LightsparkRampClient implements RampProvider {
       )
     );
 
-    const netFiatMinorUnits = rate.receivingAmount > 0 ? BigInt(rate.receivingAmount) : 0n;
-    const fiatAmount = formatDecimalAmount(netFiatMinorUnits, rate.destinationCurrency.decimals);
+    if (rate.receivingAmount <= 0) {
+      throw providerUnavailable("Lightspark returned a non-positive off-ramp receiving amount");
+    }
+    const fiatAmount = formatDecimalAmount(
+      BigInt(rate.receivingAmount),
+      rate.destinationCurrency.decimals
+    );
     return {
       provider: this.id,
       direction: "offramp",

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark.ts
@@ -49,7 +49,6 @@ import type {
 import { lightsparkCounterpartyRequirements } from "../validation/lightspark";
 
 const LIGHTSPARK_DEFAULT_GRID_API_URL = "https://api.lightspark.com/grid/2025-10-13";
-const GRID_EXCHANGE_RATE_DEFAULT_REQUEST_SENDING_AMOUNT = 10_000n;
 
 function readLightsparkConfig(
   env: Record<string, string | undefined>,
@@ -540,41 +539,6 @@ function parseGridExchangeRate(response: GridExchangeRatesResponse): GridExchang
   return entry;
 }
 
-function deriveGridExchangeRateRequestDecimals(rate: GridExchangeRate): number {
-  const defaultSourceAmount = BigInt(rate.sendingAmount);
-  if (defaultSourceAmount <= 0n) {
-    throw new AppError("PROVIDER_UNAVAILABLE", "Lightspark returned an invalid default amount");
-  }
-  if (defaultSourceAmount % GRID_EXCHANGE_RATE_DEFAULT_REQUEST_SENDING_AMOUNT !== 0n) {
-    throw new AppError(
-      "PROVIDER_UNAVAILABLE",
-      "Lightspark returned an unsupported exchange-rate amount scale"
-    );
-  }
-
-  let scale = defaultSourceAmount / GRID_EXCHANGE_RATE_DEFAULT_REQUEST_SENDING_AMOUNT;
-  let sourceDecimalsPerRequestDecimal = 0;
-  while (scale > 1n && scale % 10n === 0n) {
-    scale /= 10n;
-    sourceDecimalsPerRequestDecimal += 1;
-  }
-  if (scale !== 1n) {
-    throw new AppError(
-      "PROVIDER_UNAVAILABLE",
-      "Lightspark returned an unsupported exchange-rate amount scale"
-    );
-  }
-
-  const requestDecimals = rate.sourceCurrency.decimals - sourceDecimalsPerRequestDecimal;
-  if (requestDecimals < 0) {
-    throw new AppError(
-      "PROVIDER_UNAVAILABLE",
-      "Lightspark returned an invalid exchange-rate amount scale"
-    );
-  }
-  return requestDecimals;
-}
-
 export interface CreateLightsparkOnrampQuoteInput {
   /** Grid customer that will fund the quote in real time. */
   customerId: string;
@@ -956,14 +920,56 @@ export class LightsparkRampClient implements RampProvider {
   }
 
   async estimateOnramp(
-    _ctx: RampRuntimeContext,
-    _input: RampEstimateOnrampInput
+    { env, mode }: RampRuntimeContext,
+    input: RampEstimateOnrampInput
   ): Promise<PaymentRampEstimate> {
-    throw new AppError(
-      "ESTIMATE_NOT_AVAILABLE",
-      "Lightspark on-ramp rate is only known at quote time.",
-      { provider: this.id }
+    const config = readLightsparkConfig(env, mode);
+    const cryptoCurrency = normalizeLightsparkCurrencyCode(
+      getCryptoRailAssetLabel(input.assetRail)
     );
+    const corridor = parseGridExchangeRate(
+      await this.request<GridExchangeRatesResponse>(
+        config,
+        gridExchangeRatesPath({
+          sourceCurrency: input.fiatCurrency,
+          destinationCurrency: cryptoCurrency,
+        }),
+        { method: "GET" }
+      )
+    );
+    const sendingAmount = toLightsparkMinorUnitsInteger(
+      parseDecimalAmount(input.fiatAmount, corridor.sourceCurrency.decimals),
+      "fiatAmount"
+    );
+    const rate = parseGridExchangeRate(
+      await this.request<GridExchangeRatesResponse>(
+        config,
+        gridExchangeRatesPath({
+          sourceCurrency: input.fiatCurrency,
+          destinationCurrency: cryptoCurrency,
+          sendingAmount,
+        }),
+        { method: "GET" }
+      )
+    );
+
+    const cryptoAmount = formatDecimalAmount(
+      BigInt(rate.receivingAmount),
+      rate.destinationCurrency.decimals
+    );
+    return {
+      provider: this.id,
+      direction: "onramp",
+      fiatCurrency: input.fiatCurrency,
+      assetRail: input.assetRail,
+      fiatAmount: input.fiatAmount,
+      cryptoAmount,
+      exchangeRate: String(Number(input.fiatAmount) / Number(cryptoAmount)),
+      fees: {
+        currency: input.fiatCurrency,
+        total: formatDecimalAmount(BigInt(rate.fees.fixed), rate.sourceCurrency.decimals),
+      },
+    };
   }
 
   async estimateOfframp(
@@ -984,9 +990,8 @@ export class LightsparkRampClient implements RampProvider {
         { method: "GET" }
       )
     );
-    const requestDecimals = deriveGridExchangeRateRequestDecimals(corridor);
     const sendingAmount = toLightsparkMinorUnitsInteger(
-      parseDecimalAmount(input.cryptoAmount, requestDecimals),
+      parseDecimalAmount(input.cryptoAmount, corridor.sourceCurrency.decimals),
       "cryptoAmount"
     );
     const rate = parseGridExchangeRate(


### PR DESCRIPTION
Wires Lightspark on-ramp estimates into the multi-provider estimate endpoint (`POST /v1/payments/ramps/onramp/estimate`). Lightspark's Grid `/exchange-rates` previously 400'd for fiat→crypto, so `estimateOnramp` threw `ESTIMATE_NOT_AVAILABLE` and surfaced as `status: "unsupported"`. Lightspark has since fixed fiat→crypto support **and** the request-amount decimal scale, so `estimateOnramp` now mirrors `estimateOfframp` (source=fiat, dest=crypto).

Also removes `deriveGridExchangeRateRequestDecimals` — the scale-compensation workaround built when Grid returned request amounts at an undocumented scale. With the scale fixed for all pairs, both estimate paths now read `sourceCurrency.decimals` straight off the probe response.

<img width="1698" height="1018" alt="CleanShot 2026-06-18 at 19 39 34@2x" src="https://github.com/user-attachments/assets/fc610f33-adc5-4cb1-b6e6-f77f9fa4fe9b" />


## Before / After

Request:
```json
{ "assetRail": "usdc.solana", "fiatCurrency": "USD", "fiatAmount": "150" }
```

**Before** — Lightspark block in the `estimates` array:
```json
{ "provider": "lightspark", "status": "unsupported" }
```

**After** — Lightspark now priced (live sandbox: $150 → 150 USDC, 1:1, no fee):
```json
{
  "provider": "lightspark",
  "status": "ok",
  "estimate": {
    "provider": "lightspark",
    "direction": "onramp",
    "fiatCurrency": "USD",
    "assetRail": "usdc.solana",
    "fiatAmount": "150",
    "cryptoAmount": "150",
    "exchangeRate": "1",
    "fees": { "currency": "USD", "total": "0" }
  }
}
```

The BVNK block in the aggregated `estimates` array is unchanged.

Derived from the live Grid `/exchange-rates` response the handler now consumes:

| call | request | relevant response |
|------|---------|-------------------|
| probe | `?sourceCurrency=USD&destinationCurrency=USDC` | `sourceCurrency.decimals=2` |
| amount-locked | `&sendingAmount=15000` | `receivingAmount=150000000`, `destinationCurrency.decimals=6`, `fees.fixed=0` |

## Test plan

- Lightspark provider vitest suite: 8 passing — added a USD→USDC onramp test (asserts source decimals, `cryptoAmount`, rate inversion, fee scaling); updated 2 offramp tests to post-fix request amounts.
- `tsc --noEmit` + `biome check` clean.
- Verified live against Lightspark sandbox `/exchange-rates` (table above).
