### PR TITLE
feat(payments): PRO-1389 redesign on-ramp success screen

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -128,9 +128,11 @@ function OnrampCompleteScreen({
       ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
       : null;
 
-  const detailRows: { label: string; value: string }[] = [
-    { label: "Provider", value: getRampProviderLabel(quote.provider) },
-  ];
+  const detailRows: { label: string; value: string }[] = [];
+  if (!receivedAmount && fundedAmount) {
+    detailRows.push({ label: "Funded", value: fundedAmount });
+  }
+  detailRows.push({ label: "Provider", value: getRampProviderLabel(quote.provider) });
 
   if (quote.provider === "lightspark") {
     const sendingAmount = formatMinorCurrencyAmount(

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -12,7 +12,12 @@ import {
   formatTimestamp,
 } from "@/app/dashboard/payments/payments-overview.utils";
 import { Button } from "@/components/ui/button";
-import { ONRAMP_PAIRS, RAMP_PROVIDER_OPTIONS, toRampCryptoToken } from "@/lib/ramps";
+import {
+  getRampProviderLabel,
+  ONRAMP_PAIRS,
+  RAMP_PROVIDER_OPTIONS,
+  toRampCryptoToken,
+} from "@/lib/ramps";
 import type { OnrampWizard } from "../hooks/use-onramp-wizard";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
@@ -100,9 +105,11 @@ function OnrampTransferStatusPanel({ transfer }: { transfer: OnrampWizard["trans
 
 function TransferDetailRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-xl bg-white px-4 py-3">
-      <p className="text-xs font-medium uppercase tracking-wide text-text-low">{label}</p>
-      <p className="mt-1 break-all text-sm font-medium text-text-extra-high">{value}</p>
+    <div className="flex items-start justify-between gap-4 py-2.5 first:pt-0 last:pb-0">
+      <span className="shrink-0 text-sm text-text-low">{label}</span>
+      <span className="min-w-0 break-all text-right text-sm font-medium text-text-extra-high">
+        {value}
+      </span>
     </div>
   );
 }
@@ -114,26 +121,16 @@ function OnrampCompleteScreen({
   quote: NonNullable<OnrampWizard["quote"]>;
   transfer: NonNullable<OnrampWizard["transferStatus"]>;
 }) {
-  const finalizedDetails: { label: string; value: string }[] = [
-    { label: "Transfer ID", value: transfer.id },
-    { label: "Status", value: "Completed" },
-    { label: "Provider", value: quote.provider },
-    { label: "Quote ID", value: quote.id },
+  const receivedAmount =
+    transfer.amount && transfer.token ? `${transfer.amount} ${transfer.token.toUpperCase()}` : null;
+  const fundedAmount =
+    transfer.fiatAmount && transfer.fiatCurrency
+      ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
+      : null;
+
+  const detailRows: { label: string; value: string }[] = [
+    { label: "Provider", value: getRampProviderLabel(quote.provider) },
   ];
-
-  if (transfer.fiatAmount && transfer.fiatCurrency) {
-    finalizedDetails.push({
-      label: "Funded",
-      value: `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`,
-    });
-  }
-
-  if (transfer.amount && transfer.token) {
-    finalizedDetails.push({
-      label: "Received",
-      value: `${transfer.amount} ${transfer.token.toUpperCase()}`,
-    });
-  }
 
   if (quote.provider === "lightspark") {
     const sendingAmount = formatMinorCurrencyAmount(
@@ -147,36 +144,45 @@ function OnrampCompleteScreen({
       quote.receivingCurrency.decimals
     );
     if (sendingAmount) {
-      finalizedDetails.push({ label: "Final funded amount", value: sendingAmount });
+      detailRows.push({ label: "Final funded amount", value: sendingAmount });
     }
     if (receivingAmount) {
-      finalizedDetails.push({ label: "Final received amount", value: receivingAmount });
+      detailRows.push({ label: "Final received amount", value: receivingAmount });
     }
   }
 
   if (transfer.updatedAt) {
-    finalizedDetails.push({ label: "Completed", value: formatTimestamp(transfer.updatedAt) });
+    detailRows.push({ label: "Completed", value: formatTimestamp(transfer.updatedAt) });
   }
+  detailRows.push({ label: "Transfer ID", value: transfer.id });
+  detailRows.push({ label: "Quote ID", value: quote.id });
 
   return (
-    <div className="rounded-3xl border border-status-success-border bg-status-success-bg p-6 text-status-success-text">
-      <div className="flex items-start gap-4">
-        <span className="flex size-12 shrink-0 items-center justify-center rounded-2xl bg-white">
-          <CheckCircle2Icon className="size-6" />
-        </span>
+    <div className="flex flex-col items-center gap-6">
+      <div className="flex size-16 items-center justify-center rounded-full bg-status-success-bg text-status-success-text">
+        <CheckCircle2Icon className="size-8" />
+      </div>
+      <div className="space-y-1 text-center">
+        <p className="text-2xl font-medium tracking-tight text-text-extra-high">Deposit complete</p>
+        <p className="text-sm text-text-low">The funds have settled to the destination wallet.</p>
+      </div>
+      <section className="w-full space-y-4 rounded-2xl bg-border-extra-light p-5">
+        {receivedAmount ? (
+          <div className="flex flex-col items-center gap-0.5 border-b border-border-light pb-4">
+            <p className="text-3xl font-semibold tracking-tight text-text-extra-high">
+              {receivedAmount}
+            </p>
+            {fundedAmount ? (
+              <p className="text-sm text-text-low">funded with {fundedAmount}</p>
+            ) : null}
+          </div>
+        ) : null}
         <div>
-          <p className="text-2xl font-medium tracking-tight">Transaction complete!</p>
-          <p className="mt-2 max-w-2xl text-sm leading-relaxed">
-            The deposit has settled. You can review this transfer from the counterparty record.
-          </p>
+          {detailRows.map((detail) => (
+            <TransferDetailRow key={detail.label} label={detail.label} value={detail.value} />
+          ))}
         </div>
-      </div>
-
-      <div className="mt-6 grid gap-3 sm:grid-cols-2">
-        {finalizedDetails.map((detail) => (
-          <TransferDetailRow key={detail.label} label={detail.label} value={detail.value} />
-        ))}
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## What

Redesigns the on-ramp **Deposit complete** screen so it stops looking like a flat green block with white chips punched into it, and matches the polished terminal-success pattern already used by the on-chain send wizard.

<img width="1736" height="1578" alt="CleanShot 2026-06-18 at 20 39 45@2x" src="https://github.com/user-attachments/assets/65c64178-318a-480f-871e-1463646a2f09" />


## Changes
- Centered success affordance: green circle badge (`size-16`, `bg-status-success-bg`) + heading + subcopy, instead of a full-bleed green panel.
- Amount hero: the received crypto amount is the focal point (`text-3xl`), with the funding fiat amount as subcopy, on a `bg-border-extra-light` card with a divider.
- Detail rows reworked from a 2-col grid of white boxes into a clean label/value list (matching the on-chain send `DetailRow` style).
- Provider now shows its friendly label via `getRampProviderLabel` instead of the raw id.
- Dropped the redundant `Status: Completed` row (the whole screen says complete).

## Notes
- Off-ramp's terminal state is an inline status line within the instructions view, not a standalone success page — left as-is.

## Verification
- `tsc --noEmit`: no new errors in the touched file (pre-existing errors elsewhere unchanged).
- `biome check`: clean.