### PR TITLE
feat(skills): PRO-1390 partner ramp-provider integration skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,35 @@
+# Ramp-provider integration skills
+
+A set of **agent skills** that walk an engineer through integrating a new fiat↔crypto on/off-ramp provider into the Solana Developer Platform (`apps/sdp-api`).
+
+## Who this is for
+
+**Partners and payment providers** who want to plug into SDP's ramps. Fork the repo, open it in your coding agent, and these skills guide the integration PR end to end — in SDP's architecture and conventions, so it compiles, follows the house rules, and reviews fast.
+
+## How agents pick them up
+
+Skills load automatically in coding agents that scan a skills directory. The canonical home is `.agents/skills/`:
+
+- **Codex** reads `$CWD/.agents/skills` natively — run it from the repo root.
+- **Claude Code** reads them via the `.claude/skills` → `.agents/skills` symlink.
+- Other agents (e.g. Cline): point your rules at `.agents/skills/`.
+
+## Where to start
+
+Open **`integrate-ramp-provider`** first — the umbrella that sequences the work and lists the non-negotiable rules (no fallbacks, HTTP in the provider / DB in the handler, fully typed webhooks, env-var secrets). Pass it a **`docs`** parameter pointing at your provider's API documentation (e.g. `docs: https://docs.yourprovider.com`) so each step maps your endpoints accurately. Then work the steps:
+
+| Skill | Covers |
+|---|---|
+| `register-provider` | Step 1 — wire the provider id, client registry, dispatch switches, availability, and secrets. "Add the id, follow `tsc`." |
+| `rail-discovery` | Declare supported fiat/crypto corridors and regenerate the support matrix |
+| `integrate-estimate` | Rate preview (`estimateOnramp` / `estimateOfframp`) |
+| `counterparty-requirements` | KYC / payout requirements (`validateCounterparty`) |
+| `integrate-onramp` | Fiat→crypto quote |
+| `integrate-offramp` | Crypto→fiat quote |
+| `integrate-webhook` | Signature verification + settlement events |
+
+Skip the flows you don't support — they're parallel capabilities, not a strict pipeline.
+
+## Reference implementation
+
+`apps/sdp-api/src/lib/ramps/providers/lightspark.ts` is the canonical example the skills point at. The type system is the checklist: adding your provider id to `RAMP_PROVIDERS` breaks compilation at every site you must wire.

--- a/.agents/skills/counterparty-requirements/SKILL.md
+++ b/.agents/skills/counterparty-requirements/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: counterparty-requirements
+description: Implement a ramp provider's validateCounterparty → CounterpartyRequirements — a pure, synchronous decision over stored provider_data — plus the JIT collected-field advance flow. Use when opening a PR against apps/sdp-api to add counterparty/KYC requirements for a ramp provider.
+---
+
+# Counterparty requirements
+
+Before a quote, the platform asks your provider what a counterparty still needs — KYC, a payout account, or nothing at all. `validateCounterparty` answers that. It is **pure and synchronous**: it reads the counterparty + its `provider_data` and returns a `CounterpartyRequirements`. No HTTP, no DB — the actual provisioning happens later, in the advance flow.
+
+Canonical examples: `lib/ramps/validation/lightspark.ts` and `validation/bvnk.ts` (MoonPay just returns ready).
+
+## Contract
+
+```ts
+validateCounterparty(counterparty: Counterparty, options: ValidateCounterpartyOptions): CounterpartyRequirements
+```
+
+`options` = `{ direction: RampDirection, providerData: CounterpartyProviderData, fiatCurrency? }`. Delegate the body to `lib/ramps/validation/<id>.ts`.
+
+`CounterpartyRequirements` is discriminated by `provider`; the `status` union (`packages/sdp-types/src/ramp-requirements.ts`):
+
+- `{ status: "ready" }` — good to quote.
+- `{ status: "collect"; fields: RequirementField[] }` — need input first.
+- `{ status: "unsupported"; reason }` — this counterparty/corridor can't be served, and why.
+- onboarding states (Lightspark/BVNK): `onboarding_not_started`, `customer_verification_required` (+`verificationUrl`), `customer_verifying`, `customer_verification_failed`, `funding_account_provisioning`, `provisioning_failed`.
+
+`RequirementField` is a discriminated union (same module):
+
+- `{ kind: "text"; key; label; required; pattern?; minLength?; maxLength?; placeholder?; mask? }`
+- `{ kind: "select"; key; label; required; options: { value; label }[] }`
+
+Build fields with the existing helpers in `validation/`; don't hand-roll the shape.
+
+## The decision (variety)
+
+| Provider | validateCounterparty |
+|---|---|
+| MoonPay | always `readyCounterparty(...)` — no KYC gating |
+| Lightspark | on-ramp ready; off-ramp `ready` if an active payout account exists, else `collect` payout fields (per-currency spec), else `unsupported` |
+| BVNK | off-ramp ready; on-ramp `ready` if a verified customer exists, else `collect` KYC fields, else `unsupported` (business entity / missing country) |
+
+## The advance / submit flow
+
+`POST /v1/counterparties/:counterpartyId/requirements` (`submitCounterpartyRequirementsSchema`, a `discriminatedUnion("provider", …)`). The handler re-runs `validateCounterparty`, validates the submitted `collectedData` against your fields (`buildRequirementSchema`), then calls `advanceCounterpartyRequirements` (`routes/payments/handlers/ramps.ts`), which dispatches to your DB-side `ensure*` helper (e.g. `ensureLightsparkPayoutAccount`, `ensureBvnkCustomer`).
+
+**Hard rule: collected KYC is never persisted.** `collectedData` (SSN, IBAN, CDD, tax id) flows into the provider API call only. What lands in `provider_data` is metadata — customer id, account id, status, timestamps. Raw secrets are transient. (`GET /v1/counterparties/:id/requirements` exposes the current requirements for the client wizard.)
+
+## Gating
+
+Quotes consume the provisioned state: a Lightspark quote needs `customerId` + an active payout account; a BVNK quote needs a verified customer + ready rule. If it's not there, the quote throws `counterpartyNotProvisioned` — it does not fall back to an ungated quote.
+
+## Rules + verify
+
+Shared rules live in `integrate-ramp-provider`. Hot here:
+
+- `validateCounterparty` is pure — no HTTP, no DB; read only `counterparty` + `providerData`.
+- No fallbacks — `unsupported` with a reason beats a silent empty requirement; never persist collected KYC.
+- Status + field types are discriminated unions — return exactly one arm; no `any`.
+- Verify with `tsc --noEmit` + `biome check`; test the decision table like `validation/lightspark.test.ts`.

--- a/.agents/skills/integrate-estimate/SKILL.md
+++ b/.agents/skills/integrate-estimate/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: integrate-estimate
+description: Implement a ramp provider's estimateOnramp / estimateOfframp → PaymentRampEstimate, the fiat↔crypto rate preview. The cheapest live call — no DB, no counterparty, no KYC — so build it first to prove your config and auth work. Use when opening a PR against apps/sdp-api to add ramp rate estimates for a provider.
+---
+
+# Integrate estimate
+
+An estimate is a rate preview: "how much USDC for 100 EUR?" It hits the provider's live rate API and nothing else — no counterparty, no wallet, no DB. That makes it the first capability to build: if `estimateOnramp` works, your `register-provider` config reader and credentials are correct.
+
+Canonical example: `estimateOnramp` / `estimateOfframp` in `lib/ramps/providers/lightspark.ts`.
+
+## Contract
+
+Both methods are required on `RampProvider` (`lib/ramps/types.ts`):
+
+```ts
+estimateOnramp(ctx: RampRuntimeContext, input: RampEstimateOnrampInput): Promise<PaymentRampEstimate>
+estimateOfframp(ctx: RampRuntimeContext, input: RampEstimateOfframpInput): Promise<PaymentRampEstimate>
+```
+
+Inputs (`lib/ramps/types.ts`):
+- onramp: `{ assetRail: CryptoRailId, fiatCurrency: RampFiatCurrency, fiatAmount: string }`
+- offramp: `{ assetRail: CryptoRailId, fiatCurrency: RampFiatCurrency, cryptoAmount: string }`
+
+Output `PaymentRampEstimate` (`@sdp/types`, `packages/sdp-types/src/payments.ts`):
+
+```ts
+{
+  provider; direction: "onramp" | "offramp";
+  fiatCurrency; assetRail; fiatAmount; cryptoAmount; exchangeRate;  // all strings
+  fees: { currency; total; network?; provider? };
+  minFiatAmount?; maxFiatAmount?; expiresAt?;
+}
+```
+
+## How to build it
+
+`ctx` is `{ env, mode }` — read your config with the mode-keyed reader from `register-provider`, then HTTP only. Convert the asset rail to the provider's currency code with `getCryptoRailAssetLabel(input.assetRail)`; convert amounts to/from the provider's minor units with `parseDecimalAmount(str, decimals)` / `formatDecimalAmount(bigint, decimals)` (`lib/amount.ts`).
+
+Lightspark's shape: GET the corridor's `exchange-rates` once to learn decimals, again with the amount to get the quote, then map into `PaymentRampEstimate`.
+
+## Fail loud
+
+A non-positive receiving amount is not a `0` estimate — it's a broken corridor. Throw, don't return zero:
+
+```ts
+if (rate.receivingAmount <= 0) {
+  throw providerUnavailable("<Provider> returned a non-positive on-ramp receiving amount");
+}
+```
+
+The **only** soft signal allowed here is declaring a pair genuinely unsupported: throw `new AppError("ESTIMATE_NOT_AVAILABLE", …)`. The estimate fan-out (`estimateAcrossProviders` in `routes/payments/handlers/ramps.ts`) catches that one code and reports the provider as `unsupported`; every other error surfaces. That's a typed signal, not a `?? 0`.
+
+## Dispatch + route
+
+Estimates fan out across all entitled providers at `POST /v1/ramps/{onramp|offramp}/estimate` (`routes/payments/handlers/ramps.ts` → `estimateAcrossProviders`, gated by `assertRampProviderAvailable`). You don't touch the fan-out — it calls `RAMP_PROVIDER_CLIENTS[provider].estimate*` for each provider that passes `filterProviders`.
+
+## Variety
+
+| Provider | How estimate is sourced |
+|---|---|
+| Lightspark | `GET exchange-rates?sourceCurrency=…&destinationCurrency=…` (corridor, then with amount) |
+| MoonPay | `GET /v3/currencies/{code}/buy_quote` (on) / `sell_quote` (off) |
+| BVNK | `POST` quote with `estimate=true` |
+
+## Rules + verify
+
+Shared rules live in `integrate-ramp-provider`. Hot here:
+
+- No fallbacks — non-positive/empty rate throws; never substitute a default amount or rate.
+- HTTP only; no DB, no counterparty lookups in estimate.
+- Strong typing — status/type maps are `as const satisfies Record<…>`; no `any`.
+- Verify with `tsc --noEmit` + `biome check`. Provider calls 503 when credentials aren't present in the environment, so unit-test the mapping with mocked fetch, like `providers/lightspark.test.ts`.

--- a/.agents/skills/integrate-offramp/SKILL.md
+++ b/.agents/skills/integrate-offramp/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: integrate-offramp
+description: Implement a ramp provider's crypto→fiat off-ramp quote — createOfframpQuote (required) → PaymentRampQuote — and wire the handler dispatch that resolves the source wallet and payout account. Use when opening a PR against apps/sdp-api to add off-ramp support for a ramp provider.
+---
+
+# Integrate off-ramp
+
+Off-ramp = a counterparty sells crypto for fiat paid to their bank account. The active flow is the **quote**: you implement `createOfframpQuote` and add a `case` to the off-ramp quote dispatch. (`executeOfframp` exists but isn't currently exercised — skip it for now.)
+
+`createOfframpQuote` is **required** on `RampProvider` (unlike `createOnrampQuote`, which is optional).
+
+Canonical example: `createOfframpQuote` in `lib/ramps/providers/lightspark.ts` + `routes/payments/handlers/ramps/lightspark.ts`.
+
+## Contract
+
+Input `RampOfframpQuoteInput` (`lib/ramps/types.ts`): `{ cryptoToken, fiatCurrency?, cryptoAmount, sourceWalletAddress, externalCustomerId, customerId?, payoutAccountId?, redirectUrl?, bvnkCompliance? }`. The handler pre-resolves `customerId` and `payoutAccountId`.
+
+Output `PaymentRampQuote` — same discriminated-union-on-`deliveryMode` shape as on-ramp (see `integrate-onramp`).
+
+## Two off-ramp-specific resolutions (handler-side)
+
+1. **Source wallet.** Off-ramp draws crypto from a wallet. For SDP-wallet providers the handler resolves the address via `resolveWalletAddress` and runs `assertWalletPolicyAllowsTransfer`. Lightspark is the exception — its source is an upstream account id passed through as-is (the dispatch special-cases `input.provider === "lightspark"`). Follow whichever model your provider uses.
+
+2. **Payout account.** The fiat needs a destination bank account. Lightspark resolves `payoutAccountId` from the counterparty's most recent active account (`latestLightsparkPayoutAccount`), JIT-created by `ensureLightsparkPayoutAccount` — content-addressed by a hash of the collected bank details, and **the raw bank details are sent to the provider and never stored**. That provisioning is `counterparty-requirements`; the quote consumes the resolved id and throws `counterpartyNotProvisioned` if it's missing or inactive.
+
+## Handler wiring (the DB side)
+
+Add a `case "<id>"` to the off-ramp quote dispatch in `routes/payments/handlers/ramps.ts`. The handler resolves counterparty + source wallet + payout account, calls your HTTP-only method, and persists via `persistRampQuoteTransfer` (off-ramp writes `sourceAddress` + `cryptoAmount`, `direction: "outbound"`).
+
+Route: `POST /v1/ramps/offramp/quote`, gated by `assertRampProviderAvailable` + `payments:write` / `wallets:read`.
+
+## Variety
+
+| Provider | deliveryMode | Off-ramp quote shape |
+|---|---|---|
+| Lightspark | `manual_instructions` | `REALTIME_FUNDING` quote: customer sends crypto to the instructions, the provider auto-executes into the payout account |
+| BVNK | `manual_instructions` | estimate → accept; carries `bvnkCompliance` (requester IP, etc.) |
+| MoonPay | `hosted` | signed `sell.moonpay.com` widget `hostedUrl` |
+
+## Rules + verify
+
+Shared rules live in `integrate-ramp-provider`. Hot here:
+
+- No fallbacks — missing/inactive payout account or customer throws; never default them.
+- HTTP in the provider; DB (wallet resolution, payout account, transfer row) in the handler.
+- Bank details are transient — passed to the provider, never persisted to `provider_data`.
+- Verify with `tsc --noEmit` + `biome check`; mock fetch in `providers/<id>.test.ts`.

--- a/.agents/skills/integrate-onramp/SKILL.md
+++ b/.agents/skills/integrate-onramp/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: integrate-onramp
+description: Implement a ramp provider's fiat→crypto on-ramp quote — createOnrampQuote → PaymentRampQuote — and wire the handler dispatch that resolves DB state. Use when opening a PR against apps/sdp-api to add on-ramp support for a ramp provider.
+---
+
+# Integrate on-ramp
+
+On-ramp = a counterparty buys crypto with fiat, delivered to an SDP-known wallet. The active flow is the **quote**: you implement `createOnrampQuote` on your provider and add a `case` to the quote dispatch. (`executeOnramp` exists on the interface but isn't currently exercised — skip it for now; the quote returns the payment instructions the user acts on.)
+
+`createOnrampQuote` is **optional** on `RampProvider` — implement it only if your provider has a lockable quote step.
+
+Canonical example: `createOnrampQuote` in `lib/ramps/providers/lightspark.ts` + the DB helpers in `routes/payments/handlers/ramps/lightspark.ts`.
+
+## Contract
+
+Input `RampOnrampQuoteInput` (`lib/ramps/types.ts`): `{ cryptoToken, fiatCurrency?, fiatAmount, destinationWalletAddress, externalCustomerId, customerId?, redirectUrl?, bvnkCompliance? }`. The handler pre-resolves `customerId` / `externalCustomerId` from the DB — your method never reads the database.
+
+`PaymentRampQuote` is a **discriminated union on `deliveryMode`** (`packages/sdp-types/src/payments.ts`) — return the arm that matches your product:
+
+- `deliveryMode: "manual_instructions"` — return `paymentInstructions` (bank/wire or on-chain funding details). Lightspark, BVNK.
+- `deliveryMode: "hosted"` — return a `hostedUrl` the client renders (widget/redirect). MoonPay.
+
+Use `rampId("ramp")` for ids; set `id` to the upstream quote id so the webhook can match the transfer later (`integrate-webhook`).
+
+## Handler wiring (the DB side)
+
+Add a `case "<id>"` to the on-ramp quote dispatch in `routes/payments/handlers/ramps.ts`. The handler owns all DB work:
+
+- resolves the counterparty + destination wallet,
+- ensures any provider-side customer/account exists (DB-touching `ensure*` helpers live in `routes/payments/handlers/ramps/<id>.ts`, like `ensureLightsparkCustomer`),
+- calls your HTTP-only `createOnrampQuote` with pre-resolved inputs,
+- persists the transfer via `persistRampQuoteTransfer` (dedups by `(provider, providerReference)`; `rampQuoteTransferStatus` maps a `manual_instructions` + `pending` quote to `awaiting_payment`).
+
+Route: `POST /v1/ramps/onramp/quote`, gated by `assertRampProviderAvailable` + `payments:write` / `wallets:read`.
+
+## Variety
+
+| Provider | deliveryMode | On-ramp quote shape |
+|---|---|---|
+| Lightspark | `manual_instructions` | `REALTIME_FUNDING` quote; funding `paymentInstructions` |
+| BVNK | `manual_instructions` | bank pay-in instructions built from the provisioned rule |
+| MoonPay | `hosted` | signed `buy.moonpay.com` widget `hostedUrl` |
+
+## Gating — throw, don't fallback
+
+A provider that needs provisioning must fail loud when it's missing: Lightspark throws if `customerId` is absent; BVNK throws `counterpartyNotProvisioned` if the customer isn't verified or the rule isn't ready. Getting the counterparty to a ready state is `counterparty-requirements` — never substitute a default.
+
+## Rules + verify
+
+Shared rules live in `integrate-ramp-provider`. Hot here:
+
+- No fallbacks — missing customer/account/instructions throws; never default them.
+- HTTP in the provider; DB (counterparty, wallet, customer, transfer row) in the handler.
+- `deliveryMode` arms are a real discriminated union — return exactly one arm's fields; no `any`.
+- Verify with `tsc --noEmit` + `biome check`; mock fetch in `providers/<id>.test.ts` (provider calls 503 without creds in the environment).

--- a/.agents/skills/integrate-ramp-provider/SKILL.md
+++ b/.agents/skills/integrate-ramp-provider/SKILL.md
@@ -11,6 +11,16 @@ The umbrella. This ties the per-capability skills into one sequence. Read `apps/
 
 - **`docs`** — your provider's API documentation URL (e.g. `docs: https://docs.yourprovider.com`). Pass it when you start; every step uses it as the source of truth for your endpoints, auth, and payload shapes when mapping your API onto SDP's contract. The closer your docs, the less guesswork.
 
+## Enabling Payments v2
+
+Ramps live in **Payments v2**, which is feature-flagged **off** by default — so set the override cookie in the browser to see the v2 dashboard and exercise your integration through the UI:
+
+```
+sdp_dashboard_payments_v2_override=enabled
+```
+
+(Constant `DASHBOARD_PAYMENTS_V2_OVERRIDE_COOKIE_NAME` in `apps/sdp-web/src/lib/dashboard-feature-flags.ts`; read server-side, default off. Set it yourself in the browser — `disabled` or clearing the cookie reverts to legacy payments.)
+
 ## Sequence
 
 Do them in this order; skip the flows you don't support.

--- a/.agents/skills/integrate-ramp-provider/SKILL.md
+++ b/.agents/skills/integrate-ramp-provider/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: integrate-ramp-provider
+description: Start here to add a new on/off-ramp provider (fiat↔crypto) to SDP. Routes you through the integration sequence and the non-negotiable rules; the individual steps live in their own skills. Use when opening a PR against apps/sdp-api to integrate a ramp or payment provider.
+---
+
+# Integrate a ramp provider
+
+The umbrella. This ties the per-capability skills into one sequence. Read `apps/sdp-api/src/lib/ramps/providers/lightspark.ts` as the canonical example, then work the steps below.
+
+## Inputs
+
+- **`docs`** — your provider's API documentation URL (e.g. `docs: https://docs.yourprovider.com`). Pass it when you start; every step uses it as the source of truth for your endpoints, auth, and payload shapes when mapping your API onto SDP's contract. The closer your docs, the less guesswork.
+
+## Sequence
+
+Do them in this order; skip the flows you don't support.
+
+1. **register-provider** — scaffold: add the id to `RAMP_PROVIDERS`, register the client, fill the dispatch switches, write the mode-keyed config reader + declare its env vars. Make it compile.
+2. **rail-discovery** — declare which fiat/crypto rails you support.
+3. **integrate-estimate** — rate preview; the cheapest live end-to-end check (no DB, no KYC).
+4. **counterparty-requirements** — KYC gating for the flows.
+5. **integrate-onramp** / **integrate-offramp** — the quote flow(s) for the direction(s) you support.
+6. **integrate-webhook** — settlement events and reconciliation.
+
+The type system is the checklist: adding the id in step 1 breaks compilation at every site a provider must be wired (the `as const satisfies Record<RampProviderId, …>` registry + the exhaustive `switch`/`never` defaults). Fix each — don't add a fallback to silence it.
+
+## Rules that aren't optional (shared by every step)
+
+- **No fallbacks.** No `?? default`, `|| []`, swallowed `try/catch`, or "shouldn't happen" guards. Required data is required — throw and fail loud.
+- **HTTP in the provider; DB in the route handler.** Providers read creds from the passed `env` keyed by `mode` and never touch the database.
+- **Secrets are environment variables**, mode-keyed (`<KEY>` and `<KEY>_SANDBOX`); a missing one throws `providerNotConfigured` → HTTP 503. (This repo injects them via Doppler in deploy, but your code just reads `env[...]` — supply them however your environment does.)
+- **Webhooks are fully typed** — parse the raw body as `unknown` only at the signature boundary, then narrow.
+- **Strong typing** — no `any`, no `enum`, finite sets are `as const satisfies Record<…>`.
+- **Verify** with `tsc --noEmit` + `biome check` (ESLint is broken repo-wide — don't use it).
+
+Per-step detail lives in each linked skill.

--- a/.agents/skills/integrate-webhook/SKILL.md
+++ b/.agents/skills/integrate-webhook/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: integrate-webhook
+description: Implement a ramp provider's webhook — validateWebhook (signature verification) plus parseSettlementEvent (→ RampSettlementEvent) — and a thin route handler that calls applyRampSettlementEvent to advance the transfer. Use when opening a PR against apps/sdp-api to add webhook/settlement handling for a ramp provider.
+---
+
+# Integrate webhook
+
+Webhooks drive a transfer's lifecycle after the quote: `awaiting_payment → settling → completed | failed | expired`. You implement two provider methods and add one thin handler file:
+
+- `validateWebhook(ctx)` — verify the signature, return `{ provider, payload }`.
+- `parseSettlementEvent(payload)` — map the upstream event to a `RampSettlementEvent`.
+
+Canonical example: `validateWebhook` + `parseSettlementEvent` in `lib/ramps/providers/lightspark.ts`, and the handler `routes/webhooks/ramps/lightspark.ts`.
+
+## Mount + flow
+
+Webhooks are **not** under `/v1`. They land at `POST /webhooks/payments/ramps/{sandbox|production}/:provider` (`routes/webhooks/index.ts`). `parseRampWebhookProvider` accepts your id automatically once it's in `RAMP_PROVIDER_CLIENTS`. `handleRampProviderWebhook` (`routes/webhooks/handlers.ts`) then reads the raw body → `validateWebhook` → dispatches to your `handle<Id>RampWebhook` → returns 2xx. The DB write runs in the background (`c.executionCtx.waitUntil`) so the ack isn't delayed.
+
+## validateWebhook
+
+`ctx: RampWebhookValidationContext` = `{ env, environment, headers, rawBody, requestUrl? }` → `Promise<{ provider, payload: unknown }>`. Read the mode-keyed verification secret/key from `env`, verify the signature over the **raw** body, then `JSON.parse`. Throw `UNAUTHORIZED` on a missing/invalid signature; throw `badRequest` on non-JSON. Use `verifyWebhookSignature` (`lib/webhook-signature.ts`) or the `hash.ts` helpers (`hmacSha256Base64`, `verifyHmacSha256Base64`).
+
+This is one of the few places `unknown` is allowed — it's a genuine trust boundary, narrowed immediately by `parseSettlementEvent`.
+
+Signature variety across the three providers:
+
+| Provider | Header | Algorithm | Env keys |
+|---|---|---|---|
+| Lightspark | `x-grid-signature` | ECDSA P-256 / SHA-256 (public key) | `LIGHTSPARK_GRID_WEBHOOK_PUBLIC_KEY` / `…_SANDBOX_…` |
+| MoonPay | `moonpay-signature-v2` | HMAC-SHA256 (hex, `t=…,s=…`) | `MOONPAY_WEBHOOK_KEY` / `MOONPAY_SANDBOX_WEBHOOK_KEY` |
+| BVNK | `x-signature` | HMAC-SHA256 (base64) | `BVNK_WEBHOOK_SECRET` / `BVNK_SANDBOX_WEBHOOK_SECRET` |
+
+## parseSettlementEvent
+
+`(payload: unknown) → RampSettlementEvent`. Narrow the payload with typed parse helpers, map the upstream event type to a `kind` via an `as const satisfies Record<string, RampSettlementEvent["kind"]>` table, and set `reference` to the id you returned from the quote — that's how `applyRampSettlementEvent` finds the transfer. Anything you don't handle → `{ provider, kind: "ignore", reason }`.
+
+`RampSettlementEvent` (`lib/ramps/types.ts`):
+
+```
+| { kind: "awaiting_payment"; provider; reference }
+| { kind: "settling";         provider; reference }
+| { kind: "settled";          provider; reference; receivedAmount?; settlement? }
+| { kind: "failed";           provider; reference; error?; settlement? }
+| { kind: "expired";          provider; reference; error?; settlement? }
+| { kind: "ignore";           provider; reason }
+```
+
+## The handler file
+
+`routes/webhooks/ramps/<id>.ts` is thin — parse, ignore, or apply:
+
+```ts
+export async function handle<Id>RampWebhook(c: AppContext, payload: unknown) {
+  const event = RAMP_PROVIDER_CLIENTS.<id>.parseSettlementEvent(payload);
+  if (event.kind === "ignore") return;
+  await applyRampSettlementEvent(c, event);
+}
+```
+
+Then add a `case "<id>"` to the dispatch switch in `routes/webhooks/handlers.ts` (it ends in `satisfies never`). `applyRampSettlementEvent` (`routes/webhooks/ramps/settlements.ts`) finds the transfer by `(provider, reference)`, is idempotent (skips terminal statuses — redelivered events never regress), maps `kind → status`, writes the received fiat amount on a settled off-ramp, and the error on failed/expired.
+
+## Beyond settlement (advanced)
+
+BVNK also receives customer/wallet/provisioning events and routes them separately (`parseBvnkWebhookEvent`, background provisioning). That's an extension — the standard contract a new provider implements is the settlement path above.
+
+## Rules + verify
+
+Shared rules live in `integrate-ramp-provider`. Hot here:
+
+- Verify the signature before trusting anything; never skip on a missing header — throw `UNAUTHORIZED`.
+- No swallowed errors in your own logic; the orchestration owns the 2xx + background write.
+- Event-type maps are `as const satisfies Record<string, RampSettlementEvent["kind"]>`; no `any` past the `validateWebhook` boundary.
+- Verify with `tsc --noEmit` + `biome check`; unit-test signature + parsing like `providers/lightspark.test.ts`.

--- a/.agents/skills/integrate-webhook/SKILL.md
+++ b/.agents/skills/integrate-webhook/SKILL.md
@@ -18,7 +18,7 @@ Webhooks are **not** under `/v1`. They land at `POST /webhooks/payments/ramps/{s
 
 ## validateWebhook
 
-`ctx: RampWebhookValidationContext` = `{ env, environment, headers, rawBody, requestUrl? }` → `Promise<{ provider, payload: unknown }>`. Read the mode-keyed verification secret/key from `env`, verify the signature over the **raw** body, then `JSON.parse`. Throw `UNAUTHORIZED` on a missing/invalid signature; throw `badRequest` on non-JSON. Use `verifyWebhookSignature` (`lib/webhook-signature.ts`) or the `hash.ts` helpers (`hmacSha256Base64`, `verifyHmacSha256Base64`).
+`ctx: RampWebhookValidationContext` = `{ env, environment, headers, rawBody, requestUrl? }` → `Promise<{ provider, payload: unknown }>`. Read the mode-keyed verification secret/key from `env`, verify the signature over the **raw** body, then `JSON.parse`. Throw `UNAUTHORIZED` on a missing/invalid signature; throw `badRequest` on non-JSON. Verify with the shared `verifyWebhookSignature` (`lib/webhook-signature.ts`) — pass it a discriminated `algorithm`: `hmac-sha256` (with `hex` or `base64` encoding) or `ecdsa-sha256` (with a PEM public key). It handles the constant-time comparison.
 
 This is one of the few places `unknown` is allowed — it's a genuine trust boundary, narrowed immediately by `parseSettlementEvent`.
 

--- a/.agents/skills/rail-discovery/SKILL.md
+++ b/.agents/skills/rail-discovery/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: rail-discovery
+description: Declare which fiat↔crypto rails a ramp provider supports. Implement _discoverRails + readRailSupport and add a RAMP_RAIL_DUMPS entry, then regenerate the committed support matrix. Use when opening a PR against apps/sdp-api to add or update a ramp provider's supported currencies/corridors.
+---
+
+# Rail discovery
+
+The platform serves a generated support matrix — which `(fiat, crypto)` pairs each provider can on/off-ramp — from `packages/sdp-types/src/generated/ramp-support.generated.ts` (`ONRAMP_SUPPORT`, `OFFRAMP_SUPPORT`, `RAMP_FIAT_CURRENCIES`). You do **not** hand-edit that file. You teach your provider to report its rails, then a script turns live provider responses into the matrix.
+
+You implement three things; the codegen (`apps/sdp-api/scripts/discover-ramp-rails.ts`) does the rest:
+
+1. a `RAMP_RAIL_DUMPS.<id>` entry in `lib/ramps/shared.ts`
+2. `_discoverRails` — HTTP → raw response dumps
+3. `readRailSupport` — dumps → a `ProviderRampSupport`
+
+**Canonical example: `lib/ramps/providers/lightspark.ts`** (one dump, simplest). For a multi-endpoint provider, copy `bvnk.ts` (three dumps).
+
+## The data flow
+
+```
+_discoverRails ──fetch──▶ .ramp-rails/<id>/*.json   (gitignored raw dumps)
+readRailSupport ──parse──▶ ProviderRampSupport       (4 sets of rails)
+codegen ──merge all providers──▶ ramp-support.generated.ts  (committed)
+```
+
+`.ramp-rails/` is gitignored — dumps are local scratch. The generated `.ts` is committed and must be regenerated when your support changes.
+
+## Step 1 — declare your dumps
+
+Add an entry to `RAMP_RAIL_DUMPS` in `lib/ramps/shared.ts`, one per upstream response you need:
+
+```ts
+<id>: {
+  currencies: { name: "<id>/currencies", file: dumpFile("<id>/currencies") },
+},
+```
+
+`name` is what `_discoverRails` writes; `file` is what `readRailSupport` reads back.
+
+## Step 2 — `_discoverRails`
+
+HTTP only. Read **sandbox** creds from the passed `env` with `requireEnv` (it throws on a missing key — don't add a presence check), fetch each upstream endpoint with the injected `fetchJson`, and `writeDump` the raw response. No parsing, no mapping here — just capture.
+
+```ts
+async _discoverRails({ env, fetchJson, writeDump }: Parameters<RampProvider["_discoverRails"]>[0]) {
+  const apiKey = requireEnv(env, "<PROVIDER>_SANDBOX_API_KEY");
+  await writeDump(
+    RAMP_RAIL_DUMPS.<id>.currencies.name,
+    await fetchJson(this.id, "GET /currencies", `https://.../currencies?apiKey=${apiKey}`)
+  );
+}
+```
+
+Use the provider's most public/anonymous discovery endpoints where possible (see BVNK's anon `/api/currency/*?offset=0&max=1000` paging). `_discoverRails` is `@internal` — only the discovery script ever calls it.
+
+## Step 3 — `readRailSupport`
+
+Pure: read the dump(s) with `readDump<T>(RAMP_RAIL_DUMPS.<id>.<key>.file)` and map into a `ProviderRampSupport`. Keep the mapping in a standalone `extractSupport()` so it's unit-testable without HTTP.
+
+`ProviderRampSupport` is four sets — start from `createProviderRampSupport()` and fill them:
+
+```ts
+{ onrampFiats: Set<FiatCurrencyCode>, onrampCryptos: Set<CryptoRailId>,
+  offrampFiats: Set<FiatCurrencyCode>, offrampCryptos: Set<CryptoRailId> }
+```
+
+Mapping rules (both helpers live in `shared.ts` / `@sdp/types/payment-rails`):
+
+- **Crypto code → `CryptoRailId`** — Solana assets only today: `isSolanaCryptoAsset(code)` then `SOLANA_ASSET_TO_RAIL[code]` (e.g. `USDC` → `usdc.solana`). Skip anything else.
+- **Fiat code → `FiatCurrencyCode`** — `parseFiatCurrency(code.toUpperCase())`; skip when it returns null. Uppercase ISO only.
+- Add a rail to `onramp*` vs `offramp*` based on what the upstream reports as enabled (Lightspark keys off `enabledTransactionTypes` `INCOMING`/`OUTGOING`; MoonPay off currency `type`; BVNK off which of the crypto/fiat/deposit lists it appears in).
+
+## Generate + verify
+
+Discovery hits live sandbox APIs, so it runs under Doppler:
+
+```bash
+# from apps/sdp-api — full refresh (all providers) + regenerate the committed matrix
+pnpm --filter @sdp/api rails:discover --emit
+# just your provider
+pnpm --filter @sdp/api rails:discover <id> --emit
+# fail loudly if any discovery call errors
+pnpm --filter @sdp/api rails:discover --emit --strict
+
+# regenerate from existing dumps only (no network, no creds)
+pnpm --filter @sdp/api rails:generate
+
+# confirm the committed matrix isn't stale
+pnpm --filter @sdp/api rails:drift
+```
+
+Commit the regenerated `ramp-support.generated.ts` (and confirm your provider's row in `RAMP_PROVIDER_SUPPORT_COUNTS` looks sane). Do **not** commit `.ramp-rails/`.
+
+## Rules
+
+- HTTP only in `_discoverRails` — no DB, no business logic.
+- `readRailSupport` is pure over the dumps — no fetching.
+- No fallbacks: a missing cred throws via `requireEnv`; a malformed dump should throw, not silently yield empty support.
+- Strong typing: status/type maps are `as const satisfies Record<…>`; no `any`.
+- Your provider must already be registered (`register-provider`) — the codegen iterates `RAMP_PROVIDERS` and will fail if a client is missing.

--- a/.agents/skills/register-provider/SKILL.md
+++ b/.agents/skills/register-provider/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: register-provider
+description: Scaffold and wire a new ramp provider into SDP so the platform knows it exists, dispatches to it, and gates it by availability. Add the id to RAMP_PROVIDERS, register the client, fill the dispatch switches, declare secrets, and stub the provider class. Step 1 — do this before the capability skills. Use when opening a PR against apps/sdp-api to add a ramp provider.
+---
+
+# Register a ramp provider
+
+Step 1. This makes the platform *aware* of your provider and routes to it. The method bodies (estimate, quote, webhook, requirements, rails) are the other skills — here you build the skeleton and wire every dispatch site.
+
+Canonical example to copy: **`apps/sdp-api/src/lib/ramps/providers/lightspark.ts`** (the class) + how it's referenced across the files below.
+
+## The mantra: add the id, follow the compiler
+
+Add your id to `RAMP_PROVIDERS` first, then run `tsc --noEmit`. The id is a closed union (`RampProviderId`), so the type checker now points at **every** site that must be wired. Fix each one — never add a fallback or a `default` branch to silence it.
+
+```ts
+// packages/sdp-types/src/provider-access.ts
+export const RAMP_PROVIDERS = ["moonpay", "lightspark", "bvnk", "<id>"] as const;
+```
+
+Five sites break, in roughly this order:
+
+| File | What's enforced | What you add |
+|---|---|---|
+| `lib/ramps/index.ts` | `RAMP_PROVIDER_CLIENTS` is `as const satisfies Record<RampProviderId, …>` | `<id>: new <Id>RampClient()` |
+| `services/provider-availability.service.ts` | `ramps: Record<RampProviderId, ProviderAvailabilityDefinition>` | `<id>: { label, isConfigured }` |
+| `routes/payments/handlers/ramps.ts` | quote, requirements, and (currently unused) execute switches end in `const _exhaustive: never` | a `case "<id>"` in each |
+| `routes/webhooks/handlers.ts` | webhook dispatch switch ends in `satisfies never` | a `case "<id>"` |
+| `provider-access.ts` tier defaults | `createBooleanRecord(RAMP_PROVIDERS, …)` | (optional) add `<id>` to a tier's enabled list |
+
+## The wiring
+
+### 1. Provider id + entitlements — `provider-access.ts`
+Add the id (above). Then decide default entitlement per tier — your provider is **disabled by default** unless you add it to the enabled list:
+
+```ts
+const ENTERPRISE_PROVIDER_DEFAULTS = {
+  ramps: createBooleanRecord(RAMP_PROVIDERS, ["moonpay", "lightspark", "bvnk", "<id>"]),
+  // …
+};
+```
+
+### 2. Client registry — `lib/ramps/index.ts`
+```ts
+export const RAMP_PROVIDER_CLIENTS = {
+  moonpay: new MoonpayRampClient(),
+  lightspark: new LightsparkRampClient(),
+  bvnk: new BvnkRampClient(),
+  <id>: new <Id>RampClient(),
+} as const satisfies Record<RampProviderId, RampProviderClient>;
+```
+`assertRampProviderRegistryComplete` also fails loudly at runtime if you miss this.
+
+### 3. Availability — `services/provider-availability.service.ts`
+Add an entry that reports whether the provider's secrets are present, for both modes. `isConfigured` returning false → the route returns HTTP 503 `PROVIDER_NOT_CONFIGURED`.
+
+```ts
+ramps: {
+  // …
+  <id>: {
+    label: "<Provider>",
+    isConfigured: (env, testMode) => {
+      const prod = hasAllEnv(env, ["<PROVIDER>_KEY", "<PROVIDER>_SECRET"]);
+      const sandbox = hasAllEnv(env, ["<PROVIDER>_SANDBOX_KEY", "<PROVIDER>_SANDBOX_SECRET"]);
+      return testMode ? sandbox : prod;
+    },
+  },
+},
+```
+
+### 4. Secrets — env vars on the `Env` type
+The keys you reference in step 3 (and in your config reader) must exist on the `Env` type (`apps/sdp-api/src/types/env.ts`) and be provided as environment variables — both prod and `*_SANDBOX_*` sets. (This repo injects the real values via Doppler in deploy, not `wrangler.toml` / `.dev.vars`; a fork can supply them however its environment does — a missing one just surfaces as a 503.)
+
+### 5. Dispatch — `routes/payments/handlers/ramps.ts`
+Add a `case "<id>"` to each switch the compiler flags — the quote paths and `advanceCounterpartyRequirements`, plus the `executeOnramp`/`executeOfframp` switches. (Execute isn't currently exercised, but those switches still end in a `never` default, so add a case to compile.) The handler resolves DB state (counterparty, wallet, customer) and passes pre-resolved inputs to your client — the client never touches the DB. Provider-specific DB resolution that's too big to inline goes in `routes/payments/handlers/ramps/<id>.ts` (see `ramps/lightspark.ts`).
+
+### 6. Webhook dispatch — `routes/webhooks/handlers.ts`
+Add a `case "<id>"` calling your `handle<Id>RampWebhook`. `parseRampWebhookProvider` accepts the id automatically once it's in `RAMP_PROVIDER_CLIENTS`. (Webhook *implementation* is the `integrate-webhook` skill.)
+
+## The provider class + config reader
+
+Create `lib/ramps/providers/<id>.ts`:
+
+```ts
+export class <Id>RampClient implements RampProvider {
+  readonly id = "<id>";
+  // estimate*, createOfframpQuote, validateCounterparty, _discoverRails,
+  // readRailSupport, validateWebhook — bodies live in the capability skills.
+}
+```
+
+Credentials are read from the passed `env`, keyed by `mode` — the provider never imports AppContext. The handler builds the `{ env, mode }` context with `rampRuntime(c)` (`routes/payments/context.ts`). Write one config reader that throws when unconfigured:
+
+```ts
+function read<Id>Config(env: Record<string, string | undefined>, mode: SdpEnvironment) {
+  const key = (mode === "sandbox" ? env.<PROVIDER>_SANDBOX_KEY : env.<PROVIDER>_KEY)?.trim();
+  if (!key) throw providerNotConfigured("<Provider> is not configured. Set <PROVIDER>_KEY.");
+  return { key, /* … */ };
+}
+```
+
+## Rules + verify
+
+Shared rules live in `integrate-ramp-provider`. The ones you'll hit here:
+
+- No fallbacks. Missing config throws `providerNotConfigured`; an unknown provider hits the `never` default and throws — don't soften either.
+- HTTP in the provider; DB in the handler.
+- Strong typing: the registry and availability maps are `as const satisfies Record<RampProviderId, …>`; no `any`.
+- Verify with `tsc --noEmit` (the real checklist — it must be clean) + `biome check`. ESLint is broken repo-wide; don't use it.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## What

Adds a set of **agent skills** under `.agents/skills/` that walk an engineer through integrating a new fiat↔crypto on/off-ramp provider into `apps/sdp-api`.

## Why

So our **integration partners can self-serve**: a provider forks the repo, opens it in their coding agent, and the skills guide the integration PR end to end — in SDP's architecture and conventions — so it compiles, follows the house rules, and reviews fast. Less back-and-forth, faster partner onboarding.

## How it's wired

- Canonical home `.agents/skills/` — read natively by Codex (from repo root).
- Symlinked into `.claude/skills` (`120000`) for Claude Code; relative target travels with forks.
- Partners point the agent at their own API docs via a `docs` parameter on the umbrella skill.

## The skills

`integrate-ramp-provider` is the umbrella (sequence + non-negotiable rules). It routes to:

| Skill | Covers |
|---|---|
| `register-provider` | Wire the id, registry, dispatch switches, availability, secrets — "add the id, follow `tsc`" |
| `rail-discovery` | Declare supported corridors + regenerate the support matrix |
| `integrate-estimate` | Rate preview |
| `counterparty-requirements` | KYC / payout requirements |
| `integrate-onramp` / `integrate-offramp` | Quote flows |
| `integrate-webhook` | Signature verification + settlement events |

All reference `lib/ramps/providers/lightspark.ts` as the canonical example. Docs only — no runtime code changes.