### PR TITLE
feat(api): [PRO-1360] scope API key wallet policies

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0012_api_key_policy_scoped_profiles.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0012_api_key_policy_scoped_profiles.sql
@@ -1,0 +1,9 @@
+-- Allow API keys to carry multiple active control profiles so policy-scoped
+-- wallet bindings can use per-wallet overrides. The unbound/default API key
+-- policy resolver still selects the latest active profile for legacy callers.
+
+DROP INDEX IF EXISTS idx_api_key_control_profiles_active_key;
+
+CREATE INDEX IF NOT EXISTS idx_api_key_control_profiles_active_key
+    ON api_key_control_profiles(api_key_id, activated_at DESC NULLS LAST, created_at DESC)
+    WHERE status = 'active';

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -72,6 +72,8 @@ export type {
   ActiveWalletControlProfileResult,
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
+  ApiKeyPolicySubjectRow,
+  ApiKeyWalletPolicyBindingResolutionRow,
   ApiKeyWalletPolicyBindingRow,
   ApiKeyWalletPolicyTargetRow,
   CreateApiKeyControlProfileInput,

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -73,6 +73,7 @@ export type {
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
   ApiKeyWalletPolicyBindingRow,
+  ApiKeyWalletPolicyTargetRow,
   CreateApiKeyControlProfileInput,
   CreateApiKeyControlProfileRevisionInput,
   CreatePolicyEvaluationInput,

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -10,6 +10,8 @@ import type {
   ActivateWalletControlProfileRevisionInput,
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
+  ApiKeyPolicySubjectRow,
+  ApiKeyWalletPolicyBindingResolutionRow,
   ApiKeyWalletPolicyBindingRow,
   ApiKeyWalletPolicyTargetRow,
   CreateApiKeyControlProfileInput,
@@ -116,6 +118,14 @@ function mapApiKeyWalletPolicyBindingRow(
   };
 }
 
+function mapApiKeyPolicySubjectRow(row: Record<string, unknown>): ApiKeyPolicySubjectRow {
+  return {
+    api_key_id: row.api_key_id as string,
+    organization_id: row.organization_id as string,
+    project_id: (row.project_id as string | null | undefined) ?? null,
+  };
+}
+
 function mapApiKeyWalletPolicyTargetRow(row: Record<string, unknown>): ApiKeyWalletPolicyTargetRow {
   return {
     api_key_id: row.api_key_id as string,
@@ -127,6 +137,22 @@ function mapApiKeyWalletPolicyTargetRow(row: Record<string, unknown>): ApiKeyWal
     endpoint_binding_count: Number(row.endpoint_binding_count ?? 0),
     endpoint_wallet_binding_id:
       (row.endpoint_wallet_binding_id as string | null | undefined) ?? null,
+  };
+}
+
+function mapApiKeyWalletPolicyBindingResolutionRow(
+  row: Record<string, unknown> | null
+): ApiKeyWalletPolicyBindingResolutionRow {
+  if (!row) {
+    return {
+      total_binding_count: 0,
+      binding: null,
+    };
+  }
+
+  return {
+    total_binding_count: Number(row.total_binding_count ?? 0),
+    binding: row.id ? mapApiKeyWalletPolicyBindingRow(row) : null,
   };
 }
 
@@ -654,6 +680,24 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       };
     },
 
+    async getApiKeyPolicySubject(apiKeyId: string) {
+      const row = await db
+        .prepare(
+          `SELECT
+             id AS api_key_id,
+             organization_id,
+             project_id
+           FROM api_keys
+           WHERE id = ?
+             AND status = 'active'
+           LIMIT 1`
+        )
+        .bind(apiKeyId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapApiKeyPolicySubjectRow(row) : null;
+    },
+
     async upsertApiKeyWalletPolicyBinding(input: UpsertApiKeyWalletPolicyBindingInput) {
       validateApiKeyWalletPolicyBindingInput(input);
 
@@ -710,40 +754,38 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       return rows.results.map(mapApiKeyWalletPolicyBindingRow);
     },
 
-    async hasApiKeyWalletPolicyBindings(apiKeyId: string) {
+    async getApiKeyWalletPolicyBindingResolution(apiKeyId: string, walletId: string) {
       const row = await db
         .prepare(
-          `SELECT 1 AS exists
-           FROM api_key_wallet_policy_bindings
-           WHERE api_key_id = ?
-           LIMIT 1`
+          `WITH binding_count AS (
+             SELECT COUNT(*) AS total_binding_count
+             FROM api_key_wallet_policy_bindings
+             WHERE api_key_id = ?
+           ),
+           applicable AS (
+             SELECT *
+             FROM api_key_wallet_policy_bindings
+             WHERE api_key_id = ?
+               AND (
+                 binding_scope = 'all'
+                 OR (binding_scope = 'selected' AND wallet_id = ?)
+               )
+             ORDER BY
+               CASE WHEN binding_scope = 'selected' THEN 0 ELSE 1 END,
+               updated_at DESC,
+               created_at DESC
+             LIMIT 1
+           )
+           SELECT
+             binding_count.total_binding_count,
+             applicable.*
+           FROM binding_count
+           LEFT JOIN applicable ON TRUE`
         )
-        .bind(apiKeyId)
-        .first<{ exists: number }>();
-
-      return Boolean(row);
-    },
-
-    async getApplicableApiKeyWalletPolicyBinding(apiKeyId: string, walletId: string) {
-      const row = await db
-        .prepare(
-          `SELECT *
-           FROM api_key_wallet_policy_bindings
-           WHERE api_key_id = ?
-             AND (
-               binding_scope = 'all'
-               OR (binding_scope = 'selected' AND wallet_id = ?)
-             )
-           ORDER BY
-             CASE WHEN binding_scope = 'selected' THEN 0 ELSE 1 END,
-             updated_at DESC,
-             created_at DESC
-           LIMIT 1`
-        )
-        .bind(apiKeyId, walletId)
+        .bind(apiKeyId, apiKeyId, walletId)
         .first<Record<string, unknown>>();
 
-      return row ? mapApiKeyWalletPolicyBindingRow(row) : null;
+      return mapApiKeyWalletPolicyBindingResolutionRow(row);
     },
 
     async getApiKeyWalletPolicyTarget(apiKeyId: string, walletId: string) {

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -11,6 +11,7 @@ import type {
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
   ApiKeyWalletPolicyBindingRow,
+  ApiKeyWalletPolicyTargetRow,
   CreateApiKeyControlProfileInput,
   CreateApiKeyControlProfileRevisionInput,
   CreatePolicyEvaluationInput,
@@ -112,6 +113,20 @@ function mapApiKeyWalletPolicyBindingRow(
       (row.api_key_control_profile_id as string | null | undefined) ?? null,
     created_at: row.created_at as string,
     updated_at: row.updated_at as string,
+  };
+}
+
+function mapApiKeyWalletPolicyTargetRow(row: Record<string, unknown>): ApiKeyWalletPolicyTargetRow {
+  return {
+    api_key_id: row.api_key_id as string,
+    organization_id: row.organization_id as string,
+    project_id: (row.project_id as string | null | undefined) ?? null,
+    wallet_id: row.wallet_id as string,
+    custody_wallet_id: row.custody_wallet_id as string,
+    wallet_project_id: (row.wallet_project_id as string | null | undefined) ?? null,
+    endpoint_binding_count: Number(row.endpoint_binding_count ?? 0),
+    endpoint_wallet_binding_id:
+      (row.endpoint_wallet_binding_id as string | null | undefined) ?? null,
   };
 }
 
@@ -438,6 +453,33 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       };
     },
 
+    async getActiveWalletControlProfileByProfileId(profileId: string) {
+      const profile = await db
+        .prepare(
+          `SELECT *
+           FROM wallet_control_profiles
+           WHERE id = ?
+             AND status = 'active'
+           LIMIT 1`
+        )
+        .bind(profileId)
+        .first<Record<string, unknown>>();
+
+      if (!profile) {
+        return null;
+      }
+
+      const mappedProfile = mapWalletControlProfileRow(profile);
+      const revision = mappedProfile.active_revision_id
+        ? await getWalletControlProfileRevisionById(db, mappedProfile.active_revision_id)
+        : null;
+
+      return {
+        profile: mappedProfile,
+        revision,
+      };
+    },
+
     async createApiKeyControlProfile(input: CreateApiKeyControlProfileInput) {
       const id = generateApiKeyControlProfileId();
 
@@ -585,6 +627,33 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       };
     },
 
+    async getActiveApiKeyControlProfileByProfileId(profileId: string) {
+      const profile = await db
+        .prepare(
+          `SELECT *
+           FROM api_key_control_profiles
+           WHERE id = ?
+             AND status = 'active'
+           LIMIT 1`
+        )
+        .bind(profileId)
+        .first<Record<string, unknown>>();
+
+      if (!profile) {
+        return null;
+      }
+
+      const mappedProfile = mapApiKeyControlProfileRow(profile);
+      const revision = mappedProfile.active_revision_id
+        ? await getApiKeyControlProfileRevisionById(db, mappedProfile.active_revision_id)
+        : null;
+
+      return {
+        profile: mappedProfile,
+        revision,
+      };
+    },
+
     async upsertApiKeyWalletPolicyBinding(input: UpsertApiKeyWalletPolicyBindingInput) {
       validateApiKeyWalletPolicyBindingInput(input);
 
@@ -639,6 +708,93 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
         .all<Record<string, unknown>>();
 
       return rows.results.map(mapApiKeyWalletPolicyBindingRow);
+    },
+
+    async hasApiKeyWalletPolicyBindings(apiKeyId: string) {
+      const row = await db
+        .prepare(
+          `SELECT 1 AS exists
+           FROM api_key_wallet_policy_bindings
+           WHERE api_key_id = ?
+           LIMIT 1`
+        )
+        .bind(apiKeyId)
+        .first<{ exists: number }>();
+
+      return Boolean(row);
+    },
+
+    async getApplicableApiKeyWalletPolicyBinding(apiKeyId: string, walletId: string) {
+      const row = await db
+        .prepare(
+          `SELECT *
+           FROM api_key_wallet_policy_bindings
+           WHERE api_key_id = ?
+             AND (
+               binding_scope = 'all'
+               OR (binding_scope = 'selected' AND wallet_id = ?)
+             )
+           ORDER BY
+             CASE WHEN binding_scope = 'selected' THEN 0 ELSE 1 END,
+             updated_at DESC,
+             created_at DESC
+           LIMIT 1`
+        )
+        .bind(apiKeyId, walletId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapApiKeyWalletPolicyBindingRow(row) : null;
+    },
+
+    async getApiKeyWalletPolicyTarget(apiKeyId: string, walletId: string) {
+      const row = await db
+        .prepare(
+          `WITH target_api_key AS (
+             SELECT id, organization_id, project_id
+             FROM api_keys
+             WHERE id = ?
+               AND status = 'active'
+           ),
+           endpoint_scope AS (
+             SELECT api_key_id, COUNT(*) AS binding_count
+             FROM api_key_wallet_permissions
+             WHERE api_key_id = ?
+             GROUP BY api_key_id
+           )
+           SELECT
+             ak.id AS api_key_id,
+             ak.organization_id,
+             ak.project_id,
+             w.wallet_id,
+             w.id AS custody_wallet_id,
+             c.project_id AS wallet_project_id,
+             COALESCE(es.binding_count, 0) AS endpoint_binding_count,
+             perm.id AS endpoint_wallet_binding_id
+           FROM target_api_key ak
+           JOIN custody_configs c
+             ON c.organization_id = ak.organization_id
+            AND c.status = 'active'
+           JOIN custody_wallets w
+             ON w.custody_config_id = c.id
+            AND w.status = 'active'
+            AND w.wallet_id = ?
+           LEFT JOIN endpoint_scope es ON es.api_key_id = ak.id
+           LEFT JOIN api_key_wallet_permissions perm
+             ON perm.api_key_id = ak.id
+            AND perm.wallet_id = w.wallet_id
+           ORDER BY
+             CASE
+               WHEN c.project_id = ak.project_id THEN 0
+               WHEN c.project_id IS NULL THEN 1
+               ELSE 2
+             END,
+             w.created_at DESC
+           LIMIT 1`
+        )
+        .bind(apiKeyId, apiKeyId, walletId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapApiKeyWalletPolicyTargetRow(row) : null;
     },
 
     async createWalletOperation(input: CreateWalletOperationInput) {

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -1,3 +1,4 @@
+import type { PolicyDefaultAction, PolicyRule } from "@sdp/types";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import { ApiKeyService } from "@/services/api-key.service";
@@ -8,8 +9,36 @@ import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { TEST_PROJECT } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
-import type { PolicyRepository } from "./policy.repository";
+import type {
+  ApiKeyControlProfileRevisionRow,
+  ApiKeyControlProfileRow,
+  PolicyRepository,
+} from "./policy.repository";
 import { createPostgresPolicyRepository } from "./policy.repository.postgres";
+
+const SECOND_CUSTODY_WALLET = {
+  id: "cw_policy_second",
+  walletId: "wallet_policy_second",
+  publicKey: "SecondPolicyWallet1111111111111111111111111",
+  label: "Second policy wallet",
+  purpose: "payments",
+};
+
+const OTHER_PROJECT = {
+  id: "prj_policy_other",
+  name: "Other policy project",
+  slug: "other-policy-project",
+  environment: "sandbox",
+};
+
+const OTHER_PROJECT_CUSTODY_CONFIG_ID = "ccfg_policy_other_project";
+const OTHER_PROJECT_CUSTODY_WALLET = {
+  id: "cw_policy_other_project",
+  walletId: "wallet_policy_other_project",
+  publicKey: "OtherProjectWallet1111111111111111111111",
+  label: "Other project policy wallet",
+  purpose: "payments",
+};
 
 describe("PolicyRepository (postgres)", () => {
   let repo: PolicyRepository;
@@ -326,6 +355,210 @@ describe("PolicyRepository (postgres)", () => {
     });
   });
 
+  it("resolves an all-wallet API key policy binding for every in-scope wallet", async () => {
+    const service = new PolicyFoundationService(repo);
+    await seedAdditionalCustodyWallet();
+    const { profile } = await createActiveApiKeyControlProfile(repo, {
+      name: "Shared all-wallet controls",
+      defaultAction: "review",
+    });
+
+    const binding = await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "all",
+      apiKeyControlProfileId: profile.id,
+    });
+    expect(binding.bindingScope).toBe("all");
+    expect(binding.walletId).toBeNull();
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: TEST_CUSTODY_WALLET.walletId,
+      })
+    ).resolves.toMatchObject({
+      binding: { bindingScope: "all", apiKeyControlProfileId: profile.id },
+      apiKeyPolicy: { profile: { id: profile.id }, defaultAction: "review" },
+    });
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: SECOND_CUSTODY_WALLET.walletId,
+      })
+    ).resolves.toMatchObject({
+      binding: { bindingScope: "all", apiKeyControlProfileId: profile.id },
+      apiKeyPolicy: { profile: { id: profile.id }, defaultAction: "review" },
+    });
+  });
+
+  it("resolves selected-wallet API key policy bindings for multiple endpoint-scoped wallets", async () => {
+    const service = new PolicyFoundationService(repo);
+    await seedAdditionalCustodyWallet();
+    await seedEndpointWalletPermission("akw_policy_selected_primary", TEST_CUSTODY_WALLET.walletId);
+    await seedEndpointWalletPermission(
+      "akw_policy_selected_second",
+      SECOND_CUSTODY_WALLET.walletId
+    );
+    const { profile } = await createActiveApiKeyControlProfile(repo, {
+      name: "Selected wallet controls",
+      defaultAction: "approval_required",
+    });
+
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "selected",
+      walletId: TEST_CUSTODY_WALLET.walletId,
+      apiKeyControlProfileId: profile.id,
+    });
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "selected",
+      walletId: SECOND_CUSTODY_WALLET.walletId,
+      apiKeyControlProfileId: profile.id,
+    });
+
+    const primary = await service.resolveApiKeyWalletPolicyScope({
+      apiKeyId: TEST_API_KEY.id,
+      walletId: TEST_CUSTODY_WALLET.walletId,
+    });
+    const second = await service.resolveApiKeyWalletPolicyScope({
+      apiKeyId: TEST_API_KEY.id,
+      walletId: SECOND_CUSTODY_WALLET.walletId,
+    });
+
+    expect(primary).toMatchObject({
+      binding: { bindingScope: "selected", walletId: TEST_CUSTODY_WALLET.walletId },
+      apiKeyPolicy: { profile: { id: profile.id }, defaultAction: "approval_required" },
+    });
+    expect(second).toMatchObject({
+      binding: { bindingScope: "selected", walletId: SECOND_CUSTODY_WALLET.walletId },
+      apiKeyPolicy: { profile: { id: profile.id }, defaultAction: "approval_required" },
+    });
+  });
+
+  it("prefers a selected per-wallet policy override over an all-wallet shared policy", async () => {
+    const service = new PolicyFoundationService(repo);
+    await seedAdditionalCustodyWallet();
+    const shared = await createActiveApiKeyControlProfile(repo, {
+      name: "Shared key controls",
+      defaultAction: "allow",
+    });
+    const override = await createActiveApiKeyControlProfile(repo, {
+      name: "Second wallet override",
+      defaultAction: "review",
+    });
+
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "all",
+      apiKeyControlProfileId: shared.profile.id,
+    });
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "selected",
+      walletId: SECOND_CUSTODY_WALLET.walletId,
+      apiKeyControlProfileId: override.profile.id,
+    });
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: TEST_CUSTODY_WALLET.walletId,
+      })
+    ).resolves.toMatchObject({
+      binding: { bindingScope: "all" },
+      apiKeyPolicy: { profile: { id: shared.profile.id }, defaultAction: "allow" },
+    });
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: SECOND_CUSTODY_WALLET.walletId,
+      })
+    ).resolves.toMatchObject({
+      binding: { bindingScope: "selected", walletId: SECOND_CUSTODY_WALLET.walletId },
+      apiKeyPolicy: { profile: { id: override.profile.id }, defaultAction: "review" },
+    });
+  });
+
+  it("fails closed when policy bindings exist but the requested wallet has no binding", async () => {
+    const service = new PolicyFoundationService(repo);
+    await seedAdditionalCustodyWallet();
+    const { profile } = await createActiveApiKeyControlProfile(repo, {
+      name: "Primary wallet only",
+      defaultAction: "review",
+    });
+
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "selected",
+      walletId: TEST_CUSTODY_WALLET.walletId,
+      apiKeyControlProfileId: profile.id,
+    });
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: SECOND_CUSTODY_WALLET.walletId,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "API key policy binding is not configured for the requested wallet",
+    });
+  });
+
+  it("fails closed when an all-wallet policy binding would exceed selected endpoint wallet access", async () => {
+    const service = new PolicyFoundationService(repo);
+    await seedAdditionalCustodyWallet();
+    await seedEndpointWalletPermission("akw_policy_endpoint_primary", TEST_CUSTODY_WALLET.walletId);
+    const { profile } = await createActiveApiKeyControlProfile(repo, {
+      name: "All policy selected endpoint",
+      defaultAction: "review",
+    });
+
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "all",
+      apiKeyControlProfileId: profile.id,
+    });
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: SECOND_CUSTODY_WALLET.walletId,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "API key is not authorized for the requested wallet",
+    });
+  });
+
+  it("fails closed when an all-wallet policy binding is requested for another project wallet", async () => {
+    const service = new PolicyFoundationService(repo);
+    await seedOtherProjectCustodyWallet();
+    const { profile } = await createActiveApiKeyControlProfile(repo, {
+      name: "All policy project boundary",
+      defaultAction: "review",
+    });
+
+    await service.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "all",
+      apiKeyControlProfileId: profile.id,
+    });
+
+    await expect(
+      service.resolveApiKeyWalletPolicyScope({
+        apiKeyId: TEST_API_KEY.id,
+        walletId: OTHER_PROJECT_CUSTODY_WALLET.walletId,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Project API keys cannot use wallets from other projects",
+    });
+  });
+
   it("rejects policy wallet bindings that do not match their scope before querying Postgres", async () => {
     const selectedWithoutWalletId = {
       apiKeyId: TEST_API_KEY.id,
@@ -401,6 +634,11 @@ describe("PolicyRepository (postgres)", () => {
     });
     await repo.upsertApiKeyWalletPolicyBinding({
       apiKeyId: TEST_API_KEY.id,
+      bindingScope: "all",
+      apiKeyControlProfileId: apiKeyProfile?.id,
+    });
+    await repo.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
       bindingScope: "selected",
       walletId: TEST_CUSTODY_WALLET.walletId,
       custodyWalletId: TEST_CUSTODY_WALLET.id,
@@ -417,9 +655,18 @@ describe("PolicyRepository (postgres)", () => {
     expect(rotation).not.toBeNull();
 
     const clonedBindings = await repo.listApiKeyWalletPolicyBindings(rotation?.apiKey.id ?? "");
-    expect(clonedBindings).toHaveLength(1);
-    expect(clonedBindings[0].wallet_id).toBe(TEST_CUSTODY_WALLET.walletId);
-    expect(clonedBindings[0].api_key_control_profile_id).not.toBe(apiKeyProfile?.id);
+    expect(clonedBindings).toHaveLength(2);
+    const clonedAllBinding = clonedBindings.find((binding) => binding.binding_scope === "all");
+    const clonedSelectedBinding = clonedBindings.find(
+      (binding) => binding.binding_scope === "selected"
+    );
+    expect(clonedAllBinding).toMatchObject({
+      wallet_id: null,
+      custody_wallet_id: null,
+    });
+    expect(clonedSelectedBinding?.wallet_id).toBe(TEST_CUSTODY_WALLET.walletId);
+    expect(clonedAllBinding?.api_key_control_profile_id).not.toBe(apiKeyProfile?.id);
+    expect(clonedSelectedBinding?.api_key_control_profile_id).not.toBe(apiKeyProfile?.id);
 
     const clonedProfile = await repo.getActiveApiKeyControlProfileByApiKeyId(
       rotation?.apiKey.id ?? ""
@@ -428,7 +675,8 @@ describe("PolicyRepository (postgres)", () => {
     expect(clonedProfile?.revision?.rules).toEqual([
       { kind: "destination", allowlist: ["recipient_1"] },
     ]);
-    expect(clonedBindings[0].api_key_control_profile_id).toBe(clonedProfile?.profile.id);
+    expect(clonedAllBinding?.api_key_control_profile_id).toBe(clonedProfile?.profile.id);
+    expect(clonedSelectedBinding?.api_key_control_profile_id).toBe(clonedProfile?.profile.id);
 
     const clonedEndpointPermissions = await getDb(env)
       .prepare("SELECT permissions FROM api_key_wallet_permissions WHERE api_key_id = ?")
@@ -525,4 +773,138 @@ async function seedPolicyFoundationFixtures(): Promise<void> {
       TEST_CUSTODY_WALLET.purpose
     )
     .run();
+}
+
+async function seedAdditionalCustodyWallet(): Promise<void> {
+  await getDb(env)
+    .prepare(
+      `INSERT INTO custody_wallets (
+         id,
+         custody_config_id,
+         wallet_id,
+         public_key,
+         label,
+         purpose,
+         status
+       ) VALUES (?, ?, ?, ?, ?, ?, 'active')`
+    )
+    .bind(
+      SECOND_CUSTODY_WALLET.id,
+      TEST_CUSTODY_CONFIG.id,
+      SECOND_CUSTODY_WALLET.walletId,
+      SECOND_CUSTODY_WALLET.publicKey,
+      SECOND_CUSTODY_WALLET.label,
+      SECOND_CUSTODY_WALLET.purpose
+    )
+    .run();
+}
+
+async function seedOtherProjectCustodyWallet(): Promise<void> {
+  const db = getDb(env);
+
+  await db
+    .prepare(
+      `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+       VALUES (?, ?, ?, ?, ?, 'active', ?)`
+    )
+    .bind(
+      OTHER_PROJECT.id,
+      TEST_ORG.id,
+      OTHER_PROJECT.name,
+      OTHER_PROJECT.slug,
+      OTHER_PROJECT.environment,
+      TEST_USER.id
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO custody_configs (
+         id,
+         organization_id,
+         project_id,
+         provider,
+         config_encrypted,
+         default_wallet_id,
+         status
+       ) VALUES (?, ?, ?, 'local', 'encrypted', ?, 'active')`
+    )
+    .bind(
+      OTHER_PROJECT_CUSTODY_CONFIG_ID,
+      TEST_ORG.id,
+      OTHER_PROJECT.id,
+      OTHER_PROJECT_CUSTODY_WALLET.walletId
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO custody_wallets (
+         id,
+         custody_config_id,
+         wallet_id,
+         public_key,
+         label,
+         purpose,
+         status
+       ) VALUES (?, ?, ?, ?, ?, ?, 'active')`
+    )
+    .bind(
+      OTHER_PROJECT_CUSTODY_WALLET.id,
+      OTHER_PROJECT_CUSTODY_CONFIG_ID,
+      OTHER_PROJECT_CUSTODY_WALLET.walletId,
+      OTHER_PROJECT_CUSTODY_WALLET.publicKey,
+      OTHER_PROJECT_CUSTODY_WALLET.label,
+      OTHER_PROJECT_CUSTODY_WALLET.purpose
+    )
+    .run();
+}
+
+async function seedEndpointWalletPermission(id: string, walletId: string): Promise<void> {
+  await getDb(env)
+    .prepare(
+      `INSERT INTO api_key_wallet_permissions (id, api_key_id, wallet_id, permissions)
+       VALUES (?, ?, ?, '["payments:write"]')`
+    )
+    .bind(id, TEST_API_KEY.id, walletId)
+    .run();
+}
+
+async function createActiveApiKeyControlProfile(
+  repository: PolicyRepository,
+  input: {
+    name: string;
+    defaultAction?: PolicyDefaultAction;
+    rules?: PolicyRule[];
+  }
+): Promise<{
+  profile: ApiKeyControlProfileRow;
+  revision: ApiKeyControlProfileRevisionRow;
+}> {
+  const profile = await repository.createApiKeyControlProfile({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT.id,
+    apiKeyId: TEST_API_KEY.id,
+    name: input.name,
+    createdBy: TEST_USER.id,
+  });
+  expect(profile).not.toBeNull();
+
+  const revision = await repository.createApiKeyControlProfileRevision({
+    profileId: profile?.id ?? "",
+    rules: input.rules,
+    defaultAction: input.defaultAction,
+    createdBy: TEST_USER.id,
+  });
+  expect(revision).not.toBeNull();
+
+  await repository.activateApiKeyControlProfileRevision({
+    profileId: profile?.id ?? "",
+    revisionId: revision?.id ?? "",
+  });
+
+  return {
+    profile: profile as ApiKeyControlProfileRow,
+    revision: revision as ApiKeyControlProfileRevisionRow,
+  };
 }

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -559,6 +559,48 @@ describe("PolicyRepository (postgres)", () => {
     });
   });
 
+  it("rejects all-wallet policy bindings that reference inactive API key profiles", async () => {
+    const service = new PolicyFoundationService(repo);
+    const profile = await repo.createApiKeyControlProfile({
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT.id,
+      apiKeyId: TEST_API_KEY.id,
+      name: "Inactive all-wallet controls",
+      createdBy: TEST_USER.id,
+    });
+    expect(profile).not.toBeNull();
+
+    await expect(
+      service.upsertApiKeyWalletPolicyBinding({
+        apiKeyId: TEST_API_KEY.id,
+        bindingScope: "all",
+        apiKeyControlProfileId: profile?.id,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "API key policy profile is not active for the requested wallet binding",
+    });
+
+    await expect(repo.listApiKeyWalletPolicyBindings(TEST_API_KEY.id)).resolves.toHaveLength(0);
+  });
+
+  it("rejects all-wallet policy bindings with wallet-specific profile references", async () => {
+    const service = new PolicyFoundationService(repo);
+
+    await expect(
+      service.upsertApiKeyWalletPolicyBinding({
+        apiKeyId: TEST_API_KEY.id,
+        bindingScope: "all",
+        walletControlProfileId: "wcp_unscoped",
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "walletControlProfileId cannot be used with all-wallet policy bindings",
+    });
+
+    await expect(repo.listApiKeyWalletPolicyBindings(TEST_API_KEY.id)).resolves.toHaveLength(0);
+  });
+
   it("rejects policy wallet bindings that do not match their scope before querying Postgres", async () => {
     const selectedWithoutWalletId = {
       apiKeyId: TEST_API_KEY.id,

--- a/apps/sdp-api/src/db/repositories/policy.repository.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.ts
@@ -150,6 +150,12 @@ export interface ActiveApiKeyControlProfileResult {
   revision: ApiKeyControlProfileRevisionRow | null;
 }
 
+export interface ApiKeyPolicySubjectRow {
+  api_key_id: string;
+  organization_id: string;
+  project_id: string | null;
+}
+
 export interface ApiKeyWalletPolicyTargetRow {
   api_key_id: string;
   organization_id: string;
@@ -159,6 +165,11 @@ export interface ApiKeyWalletPolicyTargetRow {
   wallet_project_id: string | null;
   endpoint_binding_count: number;
   endpoint_wallet_binding_id: string | null;
+}
+
+export interface ApiKeyWalletPolicyBindingResolutionRow {
+  total_binding_count: number;
+  binding: ApiKeyWalletPolicyBindingRow | null;
 }
 
 export interface CreateWalletControlProfileInput {
@@ -294,16 +305,16 @@ export interface PolicyRepository {
   getActiveApiKeyControlProfileByProfileId(
     profileId: string
   ): Promise<ActiveApiKeyControlProfileResult | null>;
+  getApiKeyPolicySubject(apiKeyId: string): Promise<ApiKeyPolicySubjectRow | null>;
 
   upsertApiKeyWalletPolicyBinding(
     input: UpsertApiKeyWalletPolicyBindingInput
   ): Promise<ApiKeyWalletPolicyBindingRow | null>;
   listApiKeyWalletPolicyBindings(apiKeyId: string): Promise<ApiKeyWalletPolicyBindingRow[]>;
-  hasApiKeyWalletPolicyBindings(apiKeyId: string): Promise<boolean>;
-  getApplicableApiKeyWalletPolicyBinding(
+  getApiKeyWalletPolicyBindingResolution(
     apiKeyId: string,
     walletId: string
-  ): Promise<ApiKeyWalletPolicyBindingRow | null>;
+  ): Promise<ApiKeyWalletPolicyBindingResolutionRow>;
   getApiKeyWalletPolicyTarget(
     apiKeyId: string,
     walletId: string

--- a/apps/sdp-api/src/db/repositories/policy.repository.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.ts
@@ -150,6 +150,17 @@ export interface ActiveApiKeyControlProfileResult {
   revision: ApiKeyControlProfileRevisionRow | null;
 }
 
+export interface ApiKeyWalletPolicyTargetRow {
+  api_key_id: string;
+  organization_id: string;
+  project_id: string | null;
+  wallet_id: string;
+  custody_wallet_id: string;
+  wallet_project_id: string | null;
+  endpoint_binding_count: number;
+  endpoint_wallet_binding_id: string | null;
+}
+
 export interface CreateWalletControlProfileInput {
   organizationId: string;
   projectId: string | null;
@@ -264,6 +275,9 @@ export interface PolicyRepository {
   getActiveWalletControlProfileByCustodyWalletId(
     custodyWalletId: string
   ): Promise<ActiveWalletControlProfileResult | null>;
+  getActiveWalletControlProfileByProfileId(
+    profileId: string
+  ): Promise<ActiveWalletControlProfileResult | null>;
 
   createApiKeyControlProfile(
     input: CreateApiKeyControlProfileInput
@@ -277,11 +291,23 @@ export interface PolicyRepository {
   getActiveApiKeyControlProfileByApiKeyId(
     apiKeyId: string
   ): Promise<ActiveApiKeyControlProfileResult | null>;
+  getActiveApiKeyControlProfileByProfileId(
+    profileId: string
+  ): Promise<ActiveApiKeyControlProfileResult | null>;
 
   upsertApiKeyWalletPolicyBinding(
     input: UpsertApiKeyWalletPolicyBindingInput
   ): Promise<ApiKeyWalletPolicyBindingRow | null>;
   listApiKeyWalletPolicyBindings(apiKeyId: string): Promise<ApiKeyWalletPolicyBindingRow[]>;
+  hasApiKeyWalletPolicyBindings(apiKeyId: string): Promise<boolean>;
+  getApplicableApiKeyWalletPolicyBinding(
+    apiKeyId: string,
+    walletId: string
+  ): Promise<ApiKeyWalletPolicyBindingRow | null>;
+  getApiKeyWalletPolicyTarget(
+    apiKeyId: string,
+    walletId: string
+  ): Promise<ApiKeyWalletPolicyTargetRow | null>;
 
   createWalletOperation(input: CreateWalletOperationInput): Promise<WalletOperationRow | null>;
   getWalletOperationById(walletOperationId: string): Promise<WalletOperationRow | null>;

--- a/apps/sdp-api/src/services/policy-evaluation.service.test.ts
+++ b/apps/sdp-api/src/services/policy-evaluation.service.test.ts
@@ -597,6 +597,103 @@ describe("PolicyFoundationService policy evaluation", () => {
     expect(repository.getActiveApiKeyControlProfileByApiKeyId).not.toHaveBeenCalled();
   });
 
+  it("uses a scoped wallet policy profile referenced by the binding", async () => {
+    const repository = {
+      getApiKeyWalletPolicyBindingResolution: vi.fn(async () => ({
+        total_binding_count: 1,
+        binding: {
+          id: "akwpol_1",
+          api_key_id: "key_1",
+          binding_scope: "selected",
+          wallet_id: "wal_1",
+          custody_wallet_id: "cw_1",
+          wallet_control_profile_id: "wcp_bound",
+          api_key_control_profile_id: null,
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        },
+      })),
+      getApiKeyWalletPolicyTarget: vi.fn(async () => ({
+        api_key_id: "key_1",
+        organization_id: "org_1",
+        project_id: "prj_1",
+        wallet_id: "wal_1",
+        custody_wallet_id: "cw_1",
+        wallet_project_id: "prj_1",
+        endpoint_binding_count: 0,
+        endpoint_wallet_binding_id: null,
+      })),
+      getActiveWalletControlProfileByCustodyWalletId: vi.fn(async () => {
+        throw new Error("Scoped wallet policy should be resolved from the binding");
+      }),
+      getActiveWalletControlProfileByProfileId: vi.fn(async () => ({
+        profile: {
+          id: "wcp_bound",
+          organization_id: "org_1",
+          project_id: "prj_1",
+          custody_wallet_id: "cw_1",
+          name: "Bound wallet controls",
+          status: "active",
+          active_revision_id: "wcpr_bound",
+          created_by: "usr_1",
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+          activated_at: "2026-06-18T00:00:00.000Z",
+          archived_at: null,
+        },
+        revision: {
+          id: "wcpr_bound",
+          profile_id: "wcp_bound",
+          revision_number: 1,
+          rules: [
+            {
+              id: "bound-wallet-blocklist",
+              kind: "destination",
+              blocklist: ["recipient_blocked"],
+            },
+          ],
+          default_action: "allow",
+          created_by: "usr_1",
+          created_at: "2026-06-18T00:00:00.000Z",
+          activated_at: "2026-06-18T00:00:00.000Z",
+        },
+      })),
+      getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => null),
+    } as unknown as PolicyRepository;
+    const service = new PolicyFoundationService(repository);
+
+    const result = await service.evaluateWalletOperationPolicies(operation);
+
+    expect(result).toMatchObject({
+      decision: "deny",
+      reasonCode: "wallet_policy_match",
+      walletPolicyRevisionId: "wcpr_bound",
+    });
+    expect(repository.getActiveWalletControlProfileByProfileId).toHaveBeenCalledWith("wcp_bound");
+    expect(repository.getActiveWalletControlProfileByCustodyWalletId).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing scoped binding before wallet target validation", async () => {
+    const repository = {
+      getApiKeyWalletPolicyBindingResolution: vi.fn(async () => ({
+        total_binding_count: 1,
+        binding: null,
+      })),
+      getApiKeyWalletPolicyTarget: vi.fn(async () => {
+        throw new Error("Missing bindings should be reported before wallet target validation");
+      }),
+      getActiveWalletControlProfileByCustodyWalletId: vi.fn(async () => null),
+      getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => null),
+    } as unknown as PolicyRepository;
+    const service = new PolicyFoundationService(repository);
+
+    await expect(service.evaluateWalletOperationPolicies(operation)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "API key policy binding is not configured for the requested wallet",
+    });
+    expect(repository.getApiKeyWalletPolicyTarget).not.toHaveBeenCalled();
+  });
+
   it("fails closed during evaluation when bindings exist but the wallet target is invalid", async () => {
     const repository = {
       getApiKeyWalletPolicyBindingResolution: vi.fn(async () => ({

--- a/apps/sdp-api/src/services/policy-evaluation.service.test.ts
+++ b/apps/sdp-api/src/services/policy-evaluation.service.test.ts
@@ -518,4 +518,112 @@ describe("PolicyFoundationService policy evaluation", () => {
     );
     expect(repository.getApiKeyWalletPolicyTarget).not.toHaveBeenCalled();
   });
+
+  it("evaluates a scoped API key policy when wallet policy bindings exist", async () => {
+    const repository = {
+      getApiKeyWalletPolicyBindingResolution: vi.fn(async () => ({
+        total_binding_count: 1,
+        binding: {
+          id: "akwpol_1",
+          api_key_id: "key_1",
+          binding_scope: "selected",
+          wallet_id: "wal_1",
+          custody_wallet_id: "cw_1",
+          wallet_control_profile_id: null,
+          api_key_control_profile_id: "akcp_scoped",
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        },
+      })),
+      getApiKeyWalletPolicyTarget: vi.fn(async () => ({
+        api_key_id: "key_1",
+        organization_id: "org_1",
+        project_id: "prj_1",
+        wallet_id: "wal_1",
+        custody_wallet_id: "cw_1",
+        wallet_project_id: "prj_1",
+        endpoint_binding_count: 1,
+        endpoint_wallet_binding_id: "akw_1",
+      })),
+      getActiveWalletControlProfileByCustodyWalletId: vi.fn(async () => null),
+      getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => null),
+      getActiveApiKeyControlProfileByProfileId: vi.fn(async () => ({
+        profile: {
+          id: "akcp_scoped",
+          organization_id: "org_1",
+          project_id: "prj_1",
+          api_key_id: "key_1",
+          name: "Scoped API key controls",
+          status: "active",
+          active_revision_id: "akcpr_scoped",
+          created_by: "usr_1",
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+          activated_at: "2026-06-18T00:00:00.000Z",
+          archived_at: null,
+        },
+        revision: {
+          id: "akcpr_scoped",
+          profile_id: "akcp_scoped",
+          revision_number: 1,
+          rules: [
+            {
+              id: "scoped-blocklist",
+              kind: "destination",
+              blocklist: ["recipient_blocked"],
+            },
+          ],
+          default_action: "allow",
+          created_by: "usr_1",
+          created_at: "2026-06-18T00:00:00.000Z",
+          activated_at: "2026-06-18T00:00:00.000Z",
+        },
+      })),
+    } as unknown as PolicyRepository;
+    const service = new PolicyFoundationService(repository);
+
+    const result = await service.evaluateWalletOperationPolicies(operation);
+
+    expect(result).toMatchObject({
+      decision: "deny",
+      reasonCode: "api_key_policy_match",
+      apiKeyPolicyRevisionId: "akcpr_scoped",
+    });
+    expect(result.apiKey).toMatchObject({
+      profileId: "akcp_scoped",
+      revisionId: "akcpr_scoped",
+    });
+    expect(repository.getApiKeyWalletPolicyTarget).toHaveBeenCalledWith("key_1", "wal_1");
+    expect(repository.getActiveApiKeyControlProfileByApiKeyId).not.toHaveBeenCalled();
+  });
+
+  it("fails closed during evaluation when bindings exist but the wallet target is invalid", async () => {
+    const repository = {
+      getApiKeyWalletPolicyBindingResolution: vi.fn(async () => ({
+        total_binding_count: 1,
+        binding: {
+          id: "akwpol_1",
+          api_key_id: "key_1",
+          binding_scope: "all",
+          wallet_id: null,
+          custody_wallet_id: null,
+          wallet_control_profile_id: null,
+          api_key_control_profile_id: "akcp_scoped",
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        },
+      })),
+      getApiKeyWalletPolicyTarget: vi.fn(async () => null),
+      getActiveWalletControlProfileByCustodyWalletId: vi.fn(async () => null),
+      getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => null),
+      getActiveApiKeyControlProfileByProfileId: vi.fn(async () => null),
+    } as unknown as PolicyRepository;
+    const service = new PolicyFoundationService(repository);
+
+    await expect(service.evaluateWalletOperationPolicies(operation)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "API key is not authorized for the requested wallet",
+    });
+    expect(repository.getActiveApiKeyControlProfileByProfileId).not.toHaveBeenCalled();
+  });
 });

--- a/apps/sdp-api/src/services/policy-evaluation.service.test.ts
+++ b/apps/sdp-api/src/services/policy-evaluation.service.test.ts
@@ -489,6 +489,18 @@ describe("PolicyFoundationService policy evaluation", () => {
         },
       })),
       getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => null),
+      getApiKeyWalletPolicyTarget: vi.fn(async () => ({
+        api_key_id: "key_1",
+        organization_id: "org_1",
+        project_id: "prj_1",
+        wallet_id: "wal_1",
+        custody_wallet_id: "cw_1",
+        wallet_project_id: "prj_1",
+        endpoint_binding_count: 0,
+        endpoint_wallet_binding_id: null,
+      })),
+      hasApiKeyWalletPolicyBindings: vi.fn(async () => false),
+      getApplicableApiKeyWalletPolicyBinding: vi.fn(async () => null),
       createPolicyEvaluation,
     } as unknown as PolicyRepository;
     const service = new PolicyFoundationService(repository);

--- a/apps/sdp-api/src/services/policy-evaluation.service.test.ts
+++ b/apps/sdp-api/src/services/policy-evaluation.service.test.ts
@@ -489,18 +489,13 @@ describe("PolicyFoundationService policy evaluation", () => {
         },
       })),
       getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => null),
-      getApiKeyWalletPolicyTarget: vi.fn(async () => ({
-        api_key_id: "key_1",
-        organization_id: "org_1",
-        project_id: "prj_1",
-        wallet_id: "wal_1",
-        custody_wallet_id: "cw_1",
-        wallet_project_id: "prj_1",
-        endpoint_binding_count: 0,
-        endpoint_wallet_binding_id: null,
+      getApiKeyWalletPolicyBindingResolution: vi.fn(async () => ({
+        total_binding_count: 0,
+        binding: null,
       })),
-      hasApiKeyWalletPolicyBindings: vi.fn(async () => false),
-      getApplicableApiKeyWalletPolicyBinding: vi.fn(async () => null),
+      getApiKeyWalletPolicyTarget: vi.fn(async () => {
+        throw new Error("No-policy API key evaluation should not validate wallet scope");
+      }),
       createPolicyEvaluation,
     } as unknown as PolicyRepository;
     const service = new PolicyFoundationService(repository);
@@ -521,5 +516,6 @@ describe("PolicyFoundationService policy evaluation", () => {
         decision: "deny",
       })
     );
+    expect(repository.getApiKeyWalletPolicyTarget).not.toHaveBeenCalled();
   });
 });

--- a/apps/sdp-api/src/services/policy-foundation.service.ts
+++ b/apps/sdp-api/src/services/policy-foundation.service.ts
@@ -65,6 +65,7 @@ export interface ResolvedApiKeyWalletPolicyScope {
     walletProjectId: string | null;
   };
   binding: ApiKeyWalletPolicyBinding | null;
+  walletPolicy: EffectiveWalletPolicy | null;
   apiKeyPolicy: EffectiveApiKeyPolicy;
 }
 
@@ -125,7 +126,7 @@ export class PolicyFoundationService {
         );
       }
       if (input.walletControlProfileId) {
-        await this.assertWalletPolicyProfileForBinding(input.walletControlProfileId, target);
+        await this.resolveWalletPolicyProfileForBinding(input.walletControlProfileId, target);
       }
 
       const row = await this.repository.upsertApiKeyWalletPolicyBinding({
@@ -161,11 +162,14 @@ export class PolicyFoundationService {
   async resolveApiKeyWalletPolicyScope(
     input: ResolveApiKeyWalletPolicyScopeInput
   ): Promise<ResolvedApiKeyWalletPolicyScope> {
-    const target = await this.assertApiKeyWalletPolicyTarget(input);
     const resolution = await this.repository.getApiKeyWalletPolicyBindingResolution(
       input.apiKeyId,
       input.walletId
     );
+
+    this.assertApplicablePolicyBindingExists(resolution);
+
+    const target = await this.assertApiKeyWalletPolicyTarget(input);
     return await this.resolveApiKeyWalletPolicyScopeForTarget(input, target, resolution);
   }
 
@@ -184,15 +188,16 @@ export class PolicyFoundationService {
       return {
         target: mapApiKeyWalletPolicyTarget(target),
         binding: null,
+        walletPolicy: null,
         apiKeyPolicy: await this.resolveEffectiveApiKeyPolicy(input.apiKeyId),
       };
     }
 
     this.assertPolicyBindingMatchesTarget(binding, target);
 
-    if (binding.wallet_control_profile_id) {
-      await this.assertWalletPolicyProfileForBinding(binding.wallet_control_profile_id, target);
-    }
+    const walletPolicy = binding.wallet_control_profile_id
+      ? await this.resolveWalletPolicyProfileForBinding(binding.wallet_control_profile_id, target)
+      : null;
 
     const apiKeyPolicy = binding.api_key_control_profile_id
       ? await this.resolveApiKeyPolicyProfileForBinding(
@@ -205,6 +210,7 @@ export class PolicyFoundationService {
     return {
       target: mapApiKeyWalletPolicyTarget(target),
       binding: mapApiKeyWalletPolicyBinding(binding),
+      walletPolicy,
       apiKeyPolicy,
     };
   }
@@ -247,6 +253,7 @@ export class PolicyFoundationService {
       );
 
       if (resolution.total_binding_count > 0) {
+        this.assertApplicablePolicyBindingExists(resolution);
         // Once an API key has wallet policy bindings, an inactive or out-of-scope
         // requested wallet must fail closed instead of falling back to legacy policy lookup.
         const input = {
@@ -263,9 +270,11 @@ export class PolicyFoundationService {
     }
 
     const custodyWalletId = apiKeyScope?.target.custodyWalletId ?? operation.custodyWalletId;
-    const walletPolicy = custodyWalletId
-      ? await this.resolveEffectiveWalletPolicy(custodyWalletId)
-      : IMPLICIT_DEFAULT_ALLOW_POLICY;
+    const walletPolicy =
+      apiKeyScope?.walletPolicy ??
+      (custodyWalletId
+        ? await this.resolveEffectiveWalletPolicy(custodyWalletId)
+        : IMPLICIT_DEFAULT_ALLOW_POLICY);
 
     return evaluateWalletOperationPolicies({
       operation,
@@ -289,6 +298,14 @@ export class PolicyFoundationService {
     }
 
     return subject;
+  }
+
+  private assertApplicablePolicyBindingExists(
+    resolution: ApiKeyWalletPolicyBindingResolutionRow
+  ): void {
+    if (resolution.total_binding_count > 0 && !resolution.binding) {
+      throw forbidden("API key policy binding is not configured for the requested wallet");
+    }
   }
 
   private async assertApiKeyWalletPolicyTarget(
@@ -362,10 +379,10 @@ export class PolicyFoundationService {
     };
   }
 
-  private async assertWalletPolicyProfileForBinding(
+  private async resolveWalletPolicyProfileForBinding(
     profileId: string,
     target: ApiKeyWalletPolicyTargetRow
-  ): Promise<void> {
+  ): Promise<EffectiveWalletPolicy> {
     const active = await this.repository.getActiveWalletControlProfileByProfileId(profileId);
 
     if (!active?.revision) {
@@ -379,6 +396,13 @@ export class PolicyFoundationService {
     ) {
       throw forbidden("Wallet policy profile is not scoped to the requested wallet");
     }
+
+    return {
+      source: "customer_profile",
+      profile: mapWalletControlProfile(active.profile),
+      revision: mapWalletControlProfileRevision(active.revision),
+      defaultAction: active.revision.default_action,
+    };
   }
 }
 

--- a/apps/sdp-api/src/services/policy-foundation.service.ts
+++ b/apps/sdp-api/src/services/policy-foundation.service.ts
@@ -16,6 +16,8 @@ import type {
 import type {
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
+  ApiKeyPolicySubjectRow,
+  ApiKeyWalletPolicyBindingResolutionRow,
   ApiKeyWalletPolicyBindingRow,
   ApiKeyWalletPolicyTargetRow,
   CreatePolicyEvaluationInput,
@@ -27,7 +29,7 @@ import type {
   WalletControlProfileRow,
   WalletOperationRow,
 } from "@/db/repositories";
-import { forbidden } from "@/lib/errors";
+import { badRequest, forbidden } from "@/lib/errors";
 import {
   createPolicyEvaluationInput,
   evaluateWalletOperationPolicies,
@@ -136,6 +138,19 @@ export class PolicyFoundationService {
       return mapApiKeyWalletPolicyBinding(row);
     }
 
+    const subject = await this.assertApiKeyPolicySubject(input.apiKeyId);
+
+    if (input.walletControlProfileId) {
+      throw badRequest("walletControlProfileId cannot be used with all-wallet policy bindings");
+    }
+    if (input.apiKeyControlProfileId) {
+      await this.resolveApiKeyPolicyProfileForBinding(
+        input.apiKeyControlProfileId,
+        subject,
+        input.apiKeyId
+      );
+    }
+
     const row = await this.repository.upsertApiKeyWalletPolicyBinding(input);
     if (!row) {
       throw new Error("Failed to upsert API key wallet policy binding");
@@ -147,13 +162,21 @@ export class PolicyFoundationService {
     input: ResolveApiKeyWalletPolicyScopeInput
   ): Promise<ResolvedApiKeyWalletPolicyScope> {
     const target = await this.assertApiKeyWalletPolicyTarget(input);
-    const bindingsConfigured = await this.repository.hasApiKeyWalletPolicyBindings(input.apiKeyId);
-    const binding = await this.repository.getApplicableApiKeyWalletPolicyBinding(
+    const resolution = await this.repository.getApiKeyWalletPolicyBindingResolution(
       input.apiKeyId,
       input.walletId
     );
+    return await this.resolveApiKeyWalletPolicyScopeForTarget(input, target, resolution);
+  }
 
-    if (bindingsConfigured && !binding) {
+  private async resolveApiKeyWalletPolicyScopeForTarget(
+    input: ResolveApiKeyWalletPolicyScopeInput,
+    target: ApiKeyWalletPolicyTargetRow,
+    resolution: ApiKeyWalletPolicyBindingResolutionRow
+  ): Promise<ResolvedApiKeyWalletPolicyScope> {
+    const binding = resolution.binding;
+
+    if (resolution.total_binding_count > 0 && !binding) {
       throw forbidden("API key policy binding is not configured for the requested wallet");
     }
 
@@ -214,18 +237,33 @@ export class PolicyFoundationService {
   async evaluateWalletOperationPolicies(
     operation: WalletOperationEnvelope
   ): Promise<WalletOperationPolicyEvaluation> {
-    const apiKeyScope = operation.apiKeyId
-      ? await this.resolveApiKeyWalletPolicyScope({
+    let apiKeyScope: ResolvedApiKeyWalletPolicyScope | null = null;
+    let apiKeyPolicy: EffectiveApiKeyPolicy | null = null;
+
+    if (operation.apiKeyId) {
+      const resolution = await this.repository.getApiKeyWalletPolicyBindingResolution(
+        operation.apiKeyId,
+        operation.walletId
+      );
+
+      if (resolution.total_binding_count > 0) {
+        const input = {
           apiKeyId: operation.apiKeyId,
           walletId: operation.walletId,
           custodyWalletId: operation.custodyWalletId,
-        })
-      : null;
+        };
+        const target = await this.assertApiKeyWalletPolicyTarget(input);
+        apiKeyScope = await this.resolveApiKeyWalletPolicyScopeForTarget(input, target, resolution);
+        apiKeyPolicy = apiKeyScope.apiKeyPolicy;
+      } else {
+        apiKeyPolicy = await this.resolveEffectiveApiKeyPolicy(operation.apiKeyId);
+      }
+    }
+
     const custodyWalletId = apiKeyScope?.target.custodyWalletId ?? operation.custodyWalletId;
     const walletPolicy = custodyWalletId
       ? await this.resolveEffectiveWalletPolicy(custodyWalletId)
       : IMPLICIT_DEFAULT_ALLOW_POLICY;
-    const apiKeyPolicy = apiKeyScope?.apiKeyPolicy ?? null;
 
     return evaluateWalletOperationPolicies({
       operation,
@@ -239,6 +277,16 @@ export class PolicyFoundationService {
   ): Promise<PolicyEvaluation> {
     const result = await this.evaluateWalletOperationPolicies(operation);
     return this.recordPolicyEvaluation(createPolicyEvaluationInput(result));
+  }
+
+  private async assertApiKeyPolicySubject(apiKeyId: string): Promise<ApiKeyPolicySubjectRow> {
+    const subject = await this.repository.getApiKeyPolicySubject(apiKeyId);
+
+    if (!subject) {
+      throw forbidden("API key is not active for policy binding");
+    }
+
+    return subject;
   }
 
   private async assertApiKeyWalletPolicyTarget(
@@ -287,7 +335,7 @@ export class PolicyFoundationService {
 
   private async resolveApiKeyPolicyProfileForBinding(
     profileId: string,
-    target: ApiKeyWalletPolicyTargetRow,
+    subject: ApiKeyPolicySubjectRow,
     apiKeyId: string
   ): Promise<EffectiveApiKeyPolicy> {
     const active = await this.repository.getActiveApiKeyControlProfileByProfileId(profileId);
@@ -298,8 +346,8 @@ export class PolicyFoundationService {
 
     if (
       active.profile.api_key_id !== apiKeyId ||
-      active.profile.organization_id !== target.organization_id ||
-      (active.profile.project_id !== null && active.profile.project_id !== target.project_id)
+      active.profile.organization_id !== subject.organization_id ||
+      (active.profile.project_id !== null && active.profile.project_id !== subject.project_id)
     ) {
       throw forbidden("API key policy profile is not scoped to the requested API key");
     }

--- a/apps/sdp-api/src/services/policy-foundation.service.ts
+++ b/apps/sdp-api/src/services/policy-foundation.service.ts
@@ -17,14 +17,17 @@ import type {
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
   ApiKeyWalletPolicyBindingRow,
+  ApiKeyWalletPolicyTargetRow,
   CreatePolicyEvaluationInput,
   CreateWalletOperationInput,
   PolicyEvaluationRow,
   PolicyRepository,
+  UpsertApiKeyWalletPolicyBindingInput,
   WalletControlProfileRevisionRow,
   WalletControlProfileRow,
   WalletOperationRow,
 } from "@/db/repositories";
+import { forbidden } from "@/lib/errors";
 import {
   createPolicyEvaluationInput,
   evaluateWalletOperationPolicies,
@@ -36,6 +39,32 @@ export const IMPLICIT_DEFAULT_ALLOW_POLICY = {
   revision: null,
   defaultAction: "allow",
 } as const satisfies EffectiveWalletPolicy;
+
+const IMPLICIT_DEFAULT_ALLOW_API_KEY_POLICY = {
+  source: "implicit_default_allow",
+  profile: null,
+  revision: null,
+  defaultAction: "allow",
+} as const satisfies EffectiveApiKeyPolicy;
+
+export interface ResolveApiKeyWalletPolicyScopeInput {
+  apiKeyId: string;
+  walletId: string;
+  custodyWalletId?: string | null;
+}
+
+export interface ResolvedApiKeyWalletPolicyScope {
+  target: {
+    apiKeyId: string;
+    organizationId: string;
+    projectId: string | null;
+    walletId: string;
+    custodyWalletId: string;
+    walletProjectId: string | null;
+  };
+  binding: ApiKeyWalletPolicyBinding | null;
+  apiKeyPolicy: EffectiveApiKeyPolicy;
+}
 
 export class PolicyFoundationService {
   constructor(private readonly repository: PolicyRepository) {}
@@ -60,12 +89,7 @@ export class PolicyFoundationService {
     const active = await this.repository.getActiveApiKeyControlProfileByApiKeyId(apiKeyId);
 
     if (!active?.revision) {
-      return {
-        source: "implicit_default_allow",
-        profile: null,
-        revision: null,
-        defaultAction: "allow",
-      };
+      return IMPLICIT_DEFAULT_ALLOW_API_KEY_POLICY;
     }
 
     return {
@@ -79,6 +103,94 @@ export class PolicyFoundationService {
   async listApiKeyWalletPolicyBindings(apiKeyId: string): Promise<ApiKeyWalletPolicyBinding[]> {
     const rows = await this.repository.listApiKeyWalletPolicyBindings(apiKeyId);
     return rows.map(mapApiKeyWalletPolicyBinding);
+  }
+
+  async upsertApiKeyWalletPolicyBinding(
+    input: UpsertApiKeyWalletPolicyBindingInput
+  ): Promise<ApiKeyWalletPolicyBinding> {
+    if (input.bindingScope === "selected") {
+      const target = await this.assertApiKeyWalletPolicyTarget({
+        apiKeyId: input.apiKeyId,
+        walletId: input.walletId,
+        custodyWalletId: input.custodyWalletId,
+      });
+
+      if (input.apiKeyControlProfileId) {
+        await this.resolveApiKeyPolicyProfileForBinding(
+          input.apiKeyControlProfileId,
+          target,
+          input.apiKeyId
+        );
+      }
+      if (input.walletControlProfileId) {
+        await this.assertWalletPolicyProfileForBinding(input.walletControlProfileId, target);
+      }
+
+      const row = await this.repository.upsertApiKeyWalletPolicyBinding({
+        ...input,
+        custodyWalletId: target.custody_wallet_id,
+      });
+      if (!row) {
+        throw new Error("Failed to upsert API key wallet policy binding");
+      }
+      return mapApiKeyWalletPolicyBinding(row);
+    }
+
+    const row = await this.repository.upsertApiKeyWalletPolicyBinding(input);
+    if (!row) {
+      throw new Error("Failed to upsert API key wallet policy binding");
+    }
+    return mapApiKeyWalletPolicyBinding(row);
+  }
+
+  async resolveApiKeyWalletPolicyScope(
+    input: ResolveApiKeyWalletPolicyScopeInput
+  ): Promise<ResolvedApiKeyWalletPolicyScope> {
+    const target = await this.assertApiKeyWalletPolicyTarget(input);
+    const bindingsConfigured = await this.repository.hasApiKeyWalletPolicyBindings(input.apiKeyId);
+    const binding = await this.repository.getApplicableApiKeyWalletPolicyBinding(
+      input.apiKeyId,
+      input.walletId
+    );
+
+    if (bindingsConfigured && !binding) {
+      throw forbidden("API key policy binding is not configured for the requested wallet");
+    }
+
+    if (!binding) {
+      return {
+        target: mapApiKeyWalletPolicyTarget(target),
+        binding: null,
+        apiKeyPolicy: await this.resolveEffectiveApiKeyPolicy(input.apiKeyId),
+      };
+    }
+
+    this.assertPolicyBindingMatchesTarget(binding, target);
+
+    if (binding.wallet_control_profile_id) {
+      await this.assertWalletPolicyProfileForBinding(binding.wallet_control_profile_id, target);
+    }
+
+    const apiKeyPolicy = binding.api_key_control_profile_id
+      ? await this.resolveApiKeyPolicyProfileForBinding(
+          binding.api_key_control_profile_id,
+          target,
+          input.apiKeyId
+        )
+      : await this.resolveEffectiveApiKeyPolicy(input.apiKeyId);
+
+    return {
+      target: mapApiKeyWalletPolicyTarget(target),
+      binding: mapApiKeyWalletPolicyBinding(binding),
+      apiKeyPolicy,
+    };
+  }
+
+  async resolveEffectiveApiKeyPolicyForWallet(
+    input: ResolveApiKeyWalletPolicyScopeInput
+  ): Promise<EffectiveApiKeyPolicy> {
+    const scoped = await this.resolveApiKeyWalletPolicyScope(input);
+    return scoped.apiKeyPolicy;
   }
 
   async recordWalletOperation(input: CreateWalletOperationInput): Promise<WalletOperationEnvelope> {
@@ -102,12 +214,18 @@ export class PolicyFoundationService {
   async evaluateWalletOperationPolicies(
     operation: WalletOperationEnvelope
   ): Promise<WalletOperationPolicyEvaluation> {
-    const walletPolicy = operation.custodyWalletId
-      ? await this.resolveEffectiveWalletPolicy(operation.custodyWalletId)
-      : IMPLICIT_DEFAULT_ALLOW_POLICY;
-    const apiKeyPolicy = operation.apiKeyId
-      ? await this.resolveEffectiveApiKeyPolicy(operation.apiKeyId)
+    const apiKeyScope = operation.apiKeyId
+      ? await this.resolveApiKeyWalletPolicyScope({
+          apiKeyId: operation.apiKeyId,
+          walletId: operation.walletId,
+          custodyWalletId: operation.custodyWalletId,
+        })
       : null;
+    const custodyWalletId = apiKeyScope?.target.custodyWalletId ?? operation.custodyWalletId;
+    const walletPolicy = custodyWalletId
+      ? await this.resolveEffectiveWalletPolicy(custodyWalletId)
+      : IMPLICIT_DEFAULT_ALLOW_POLICY;
+    const apiKeyPolicy = apiKeyScope?.apiKeyPolicy ?? null;
 
     return evaluateWalletOperationPolicies({
       operation,
@@ -122,6 +240,107 @@ export class PolicyFoundationService {
     const result = await this.evaluateWalletOperationPolicies(operation);
     return this.recordPolicyEvaluation(createPolicyEvaluationInput(result));
   }
+
+  private async assertApiKeyWalletPolicyTarget(
+    input: ResolveApiKeyWalletPolicyScopeInput
+  ): Promise<ApiKeyWalletPolicyTargetRow> {
+    const target = await this.repository.getApiKeyWalletPolicyTarget(
+      input.apiKeyId,
+      input.walletId
+    );
+
+    if (!target) {
+      throw forbidden("API key is not authorized for the requested wallet");
+    }
+
+    if (input.custodyWalletId && input.custodyWalletId !== target.custody_wallet_id) {
+      throw forbidden("API key wallet policy target does not match the requested custody wallet");
+    }
+
+    if (
+      target.project_id !== null &&
+      target.wallet_project_id !== null &&
+      target.wallet_project_id !== target.project_id
+    ) {
+      throw forbidden("Project API keys cannot use wallets from other projects");
+    }
+
+    if (target.endpoint_binding_count > 0 && !target.endpoint_wallet_binding_id) {
+      throw forbidden("API key is not authorized for the requested wallet");
+    }
+
+    return target;
+  }
+
+  private assertPolicyBindingMatchesTarget(
+    binding: ApiKeyWalletPolicyBindingRow,
+    target: ApiKeyWalletPolicyTargetRow
+  ): void {
+    if (binding.binding_scope === "selected" && binding.wallet_id !== target.wallet_id) {
+      throw forbidden("API key policy binding does not match the requested wallet");
+    }
+
+    if (binding.custody_wallet_id && binding.custody_wallet_id !== target.custody_wallet_id) {
+      throw forbidden("API key policy binding does not match the requested custody wallet");
+    }
+  }
+
+  private async resolveApiKeyPolicyProfileForBinding(
+    profileId: string,
+    target: ApiKeyWalletPolicyTargetRow,
+    apiKeyId: string
+  ): Promise<EffectiveApiKeyPolicy> {
+    const active = await this.repository.getActiveApiKeyControlProfileByProfileId(profileId);
+
+    if (!active?.revision) {
+      throw forbidden("API key policy profile is not active for the requested wallet binding");
+    }
+
+    if (
+      active.profile.api_key_id !== apiKeyId ||
+      active.profile.organization_id !== target.organization_id ||
+      (active.profile.project_id !== null && active.profile.project_id !== target.project_id)
+    ) {
+      throw forbidden("API key policy profile is not scoped to the requested API key");
+    }
+
+    return {
+      source: "customer_profile",
+      profile: mapApiKeyControlProfile(active.profile),
+      revision: mapApiKeyControlProfileRevision(active.revision),
+      defaultAction: active.revision.default_action,
+    };
+  }
+
+  private async assertWalletPolicyProfileForBinding(
+    profileId: string,
+    target: ApiKeyWalletPolicyTargetRow
+  ): Promise<void> {
+    const active = await this.repository.getActiveWalletControlProfileByProfileId(profileId);
+
+    if (!active?.revision) {
+      throw forbidden("Wallet policy profile is not active for the requested wallet binding");
+    }
+
+    if (
+      active.profile.custody_wallet_id !== target.custody_wallet_id ||
+      active.profile.organization_id !== target.organization_id ||
+      (active.profile.project_id !== null && active.profile.project_id !== target.wallet_project_id)
+    ) {
+      throw forbidden("Wallet policy profile is not scoped to the requested wallet");
+    }
+  }
+}
+
+function mapApiKeyWalletPolicyTarget(row: ApiKeyWalletPolicyTargetRow) {
+  return {
+    apiKeyId: row.api_key_id,
+    organizationId: row.organization_id,
+    projectId: row.project_id,
+    walletId: row.wallet_id,
+    custodyWalletId: row.custody_wallet_id,
+    walletProjectId: row.wallet_project_id,
+  };
 }
 
 function mapWalletControlProfile(row: WalletControlProfileRow): WalletControlProfile {

--- a/apps/sdp-api/src/services/policy-foundation.service.ts
+++ b/apps/sdp-api/src/services/policy-foundation.service.ts
@@ -247,6 +247,8 @@ export class PolicyFoundationService {
       );
 
       if (resolution.total_binding_count > 0) {
+        // Once an API key has wallet policy bindings, an inactive or out-of-scope
+        // requested wallet must fail closed instead of falling back to legacy policy lookup.
         const input = {
           apiKeyId: operation.apiKeyId,
           walletId: operation.walletId,


### PR DESCRIPTION
## What changed
- Add API-key wallet policy scope resolution for `all` and `selected` wallet bindings.
- Prefer selected per-wallet policy bindings over all-wallet shared bindings.
- Fail closed when a scoped binding is missing, outside endpoint wallet access, or outside the project wallet boundary.
- Preserve no-policy/default API key behavior for existing UI-created keys.
- Add a Postgres migration to allow multiple active API-key control profiles so per-wallet overrides can be bound independently.
- Extend rotation coverage to prove all-wallet and selected policy bindings clone with remapped profile references.

## Tested locally
- `pnpm --filter @sdp/api db:migrate:test`
- `pnpm --filter @sdp/api test -- policy.repository.test.ts policy-evaluation.service.test.ts`
- `pnpm --filter @sdp/api test:node`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter @sdp/api lint` (passes with existing unrelated warnings)
- `git diff --check`

Closes PRO-1360
