### PR TITLE
fix(web): [PRO-1396] redirect counterparty not-found to list + branded 404 page

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/[counterpartyId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/[counterpartyId]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { notFound, redirect } from "next/navigation";
+import { redirect } from "next/navigation";
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
 import { fetchCounterpartyDetail } from "../counterparty-detail.data";
@@ -36,7 +36,7 @@ export default async function CounterpartyDetailRoute({
       });
 
       if (!detail.counterparty) {
-        notFound();
+        redirect("/dashboard/payments/counterparty");
       }
 
       return (

--- a/apps/sdp-web/src/app/not-found.tsx
+++ b/apps/sdp-web/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#e9e7de] to-[#f5f4ef] px-6 text-center text-[#1c1c1d]">
+      <Image src="/landing/solana-logo.svg" alt="Solana" width={24} height={22} />
+
+      <p className="mt-10 text-7xl font-medium leading-none tracking-tight">404</p>
+
+      <h1 className="mt-5 text-2xl font-medium tracking-tight">Page not found</h1>
+
+      <p className="mt-3 max-w-[420px] text-base leading-6 text-[rgba(28,28,29,0.72)]">
+        The page you&apos;re looking for doesn&apos;t exist or may have moved.
+      </p>
+
+      <div className="mt-8 flex items-center gap-3">
+        <Button asChild>
+          <Link href="/dashboard">Back to dashboard</Link>
+        </Button>
+        <Button asChild variant="ghost">
+          <Link href="/">Go home</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## What

- **Counterparty not-found redirect** — the counterparty detail page now redirects to `/dashboard/payments/counterparty` when the counterparty can't be found (e.g. after switching workspaces, where the ID belongs to another org), instead of rendering a 404.
- **SDP-branded 404** — adds a root `app/not-found.tsx` to replace the default Next.js/Vercel 404. Server component, matches the landing aesthetic (gradient + Solana logo), with **Back to dashboard** / **Go home** CTAs. As the root `not-found.tsx` it covers both unmatched URLs and any `notFound()` call.

## Why

Switching workspaces left users stranded on a 404 for a counterparty that simply belongs to a different org. Redirecting to the list is the expected behavior, and the branded 404 gives a consistent fallback for genuinely missing routes.

## Test

- `tsc --noEmit` + `biome check` pass on both files.