### PR TITLE
feat(payments): confirm + cancel ramp transfers

### DIFF
--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -222,6 +222,27 @@ export function createPostgresPaymentsRepository(db: AppDb): PaymentsRepository 
       return getTransferByIdInternal(db, input.transferId);
     },
 
+    async updateTransferStatusGuarded(input) {
+      const scope = buildTransferScopeWhere({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        extraClauses: ["id = ?", "status = ANY(?)"],
+        extraValues: [input.transferId, [...input.fromStatuses]],
+      });
+
+      const row = await db
+        .prepare(
+          `UPDATE payment_transfers
+           SET status = ?, updated_at = ?
+           WHERE ${scope.where}
+           RETURNING *`
+        )
+        .bind(input.toStatus, input.updatedAt, ...scope.values)
+        .first<Record<string, unknown>>();
+
+      return row ? mapTransferRow(row) : null;
+    },
+
     async getTransferById(params) {
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,

--- a/apps/sdp-api/src/db/repositories/payments.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
+import type { PaymentsRepository } from "./payments.repository";
+import { createPostgresPaymentsRepository } from "./payments.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_payments_repo_test";
+const OTHER_PROJECT_ID = "prj_payments_repo_test_other";
+const TEST_WALLET_ID = "wallet_payments_repo_test";
+const CANCELABLE = ["pending", "awaiting_payment"] as const;
+
+describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
+  let repo: PaymentsRepository;
+
+  beforeAll(async () => {
+    await seedTestDatabase(env as Parameters<typeof seedTestDatabase>[0]);
+  });
+
+  afterAll(async () => {
+    await clearTestDatabase(env as Parameters<typeof clearTestDatabase>[0]);
+  });
+
+  beforeEach(async () => {
+    const db = getDb(env);
+    await db.prepare("DELETE FROM payment_transfers").run();
+    await db.prepare("DELETE FROM projects").run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    for (const projectId of [TEST_PROJECT_ID, OTHER_PROJECT_ID]) {
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, TEST_ORG.id, projectId, TEST_USER.id)
+        .run();
+    }
+
+    repo = createPostgresPaymentsRepository(db);
+  });
+
+  async function seedTransfer(input: {
+    id: string;
+    status: string;
+    projectId?: string;
+  }): Promise<void> {
+    const now = new Date().toISOString();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers
+           (id, organization_id, project_id, wallet_id, token, type, direction, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        input.id,
+        TEST_ORG.id,
+        input.projectId ?? TEST_PROJECT_ID,
+        TEST_WALLET_ID,
+        "USDC",
+        "offramp",
+        "outbound",
+        input.status,
+        now,
+        now
+      )
+      .run();
+  }
+
+  async function readStatus(id: string): Promise<string | null> {
+    const row = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+      .bind(id)
+      .first<{ status: string }>();
+    return row?.status ?? null;
+  }
+
+  it("transitions the status when the current status is in fromStatuses", async () => {
+    await seedTransfer({ id: "xfr_guard_ok", status: "awaiting_payment" });
+
+    const updated = await repo.updateTransferStatusGuarded({
+      transferId: "xfr_guard_ok",
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      fromStatuses: CANCELABLE,
+      toStatus: "canceled",
+      updatedAt: new Date().toISOString(),
+    });
+
+    expect(updated?.status).toBe("canceled");
+    expect(await readStatus("xfr_guard_ok")).toBe("canceled");
+  });
+
+  it("is a no-op returning null when the status moved out of fromStatuses (the race)", async () => {
+    await seedTransfer({ id: "xfr_guard_race", status: "settling" });
+
+    const updated = await repo.updateTransferStatusGuarded({
+      transferId: "xfr_guard_race",
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      fromStatuses: CANCELABLE,
+      toStatus: "canceled",
+      updatedAt: new Date().toISOString(),
+    });
+
+    expect(updated).toBeNull();
+    expect(await readStatus("xfr_guard_race")).toBe("settling");
+  });
+
+  it("returns null for a transfer that does not exist", async () => {
+    const updated = await repo.updateTransferStatusGuarded({
+      transferId: "xfr_missing",
+      organizationId: TEST_ORG.id,
+      projectId: TEST_PROJECT_ID,
+      fromStatuses: CANCELABLE,
+      toStatus: "canceled",
+      updatedAt: new Date().toISOString(),
+    });
+
+    expect(updated).toBeNull();
+  });
+
+  it("does not transition a transfer owned by a different organization", async () => {
+    await seedTransfer({ id: "xfr_guard_org", status: "awaiting_payment" });
+
+    const updated = await repo.updateTransferStatusGuarded({
+      transferId: "xfr_guard_org",
+      organizationId: "org_someone_else",
+      projectId: TEST_PROJECT_ID,
+      fromStatuses: CANCELABLE,
+      toStatus: "canceled",
+      updatedAt: new Date().toISOString(),
+    });
+
+    expect(updated).toBeNull();
+    expect(await readStatus("xfr_guard_org")).toBe("awaiting_payment");
+  });
+
+  it("does not transition a transfer scoped to a different project", async () => {
+    await seedTransfer({ id: "xfr_guard_project", status: "awaiting_payment" });
+
+    const updated = await repo.updateTransferStatusGuarded({
+      transferId: "xfr_guard_project",
+      organizationId: TEST_ORG.id,
+      projectId: OTHER_PROJECT_ID,
+      fromStatuses: CANCELABLE,
+      toStatus: "canceled",
+      updatedAt: new Date().toISOString(),
+    });
+
+    expect(updated).toBeNull();
+    expect(await readStatus("xfr_guard_project")).toBe("awaiting_payment");
+  });
+});

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -163,6 +163,19 @@ export interface PaymentsRepositoryContext {
 export interface PaymentsRepository {
   createTransfer(input: CreatePaymentTransferInput): Promise<PaymentTransferRow | null>;
   updateTransfer(input: UpdatePaymentTransferInput): Promise<PaymentTransferRow | null>;
+  /**
+   * Atomically transitions a transfer's status only if it is currently one of
+   * `fromStatuses`, scoped to org/project. Returns the updated row, or null when
+   * no row matched (wrong owner, missing, or status changed concurrently).
+   */
+  updateTransferStatusGuarded(input: {
+    transferId: string;
+    organizationId: string;
+    projectId: string | null;
+    fromStatuses: readonly PaymentTransferStatus[];
+    toStatus: PaymentTransferStatus;
+    updatedAt: string;
+  }): Promise<PaymentTransferRow | null>;
   listTransfersByStatus(params: ListTransfersByStatusInput): Promise<PaymentTransferRow[]>;
   getTransferById(params: {
     transferId: string;

--- a/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
@@ -553,7 +553,8 @@ export interface CreateBvnkCustomerInput {
 }
 
 export interface CreateBvnkFiatWalletInput {
-  customerReference: string;
+  /** Omit to create a merchant-owned wallet (BVNK off-ramp dedicated wallet). */
+  customerReference?: string;
   name: string;
   currencyCode: string;
   walletProfile: string;
@@ -1021,10 +1022,12 @@ export class BvnkRampClient implements RampProvider {
    */
   async getFiatWalletProfile(
     { env, mode }: RampRuntimeContext,
-    input: { customerReference: string; currency: string }
+    input: { customerReference?: string; currency: string }
   ): Promise<string> {
     const config = readBvnkConfig(env, mode);
-    const query = `customerId:${input.customerReference} AND currency:${input.currency}`;
+    const query = input.customerReference
+      ? `customerId:${input.customerReference} AND currency:${input.currency}`
+      : `currency:${input.currency}`;
     const response = await this.request(
       config,
       `/ledger/v2/wallets/profiles?q=${encodeURIComponent(query)}`,
@@ -1062,7 +1065,7 @@ export class BvnkRampClient implements RampProvider {
       method: "POST",
       headers: { "Idempotency-Key": input.idempotencyKey },
       body: {
-        customerId: input.customerReference,
+        ...(input.customerReference ? { customerId: input.customerReference } : {}),
         currency: input.currencyCode,
         name: input.name,
         profileId: input.walletProfile,
@@ -1254,6 +1257,9 @@ export class BvnkRampClient implements RampProvider {
     if (!input.fiatCurrency) {
       throw badRequest("fiatCurrency is required for BVNK off-ramp.");
     }
+    if (!input.bvnkOfframpWalletId) {
+      throw internalError("BVNK off-ramp requires a provisioned wallet id.");
+    }
     const config = readBvnkConfig(env, mode);
     const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
     const fiatCurrency = input.fiatCurrency;
@@ -1266,7 +1272,7 @@ export class BvnkRampClient implements RampProvider {
     const estimate = await this.request<BvnkEstimateResponse>(config, "/api/v1/pay/estimate", {
       method: "POST",
       body: {
-        walletId: config.walletId,
+        walletId: input.bvnkOfframpWalletId,
         walletCurrency: fiatCurrency,
         paidCurrency: currency,
         paidRequiredAmount,
@@ -1285,7 +1291,7 @@ export class BvnkRampClient implements RampProvider {
       {
         method: "POST",
         body: {
-          customerId: input.customerId ?? input.externalCustomerId,
+          customerId: input.externalCustomerId,
           payOutDetails: { currency, address: input.sourceWalletAddress, network },
           complianceDetails,
         },
@@ -1340,11 +1346,6 @@ export class BvnkRampClient implements RampProvider {
     { env, mode }: RampRuntimeContext,
     input: BvnkExecuteOfframpInput
   ): Promise<BvnkPaymentRampExecution> {
-    const customerId = input.providerCustomer.customerReference;
-    if (!customerId) {
-      throw badRequest("providerCustomer.customerReference is required for BVNK off-ramp.");
-    }
-
     const config = readBvnkConfig(env, mode);
     const { currency, network } = normalizeBvnkCurrencyAndNetwork(input.cryptoToken);
     const fiatCurrency = input.fiatCurrency;
@@ -1357,7 +1358,7 @@ export class BvnkRampClient implements RampProvider {
     const estimate = await this.request<BvnkEstimateResponse>(config, "/api/v1/pay/estimate", {
       method: "POST",
       body: {
-        walletId: config.walletId,
+        walletId: input.walletId,
         walletCurrency: fiatCurrency,
         paidCurrency: currency,
         paidRequiredAmount,
@@ -1376,7 +1377,7 @@ export class BvnkRampClient implements RampProvider {
       {
         method: "POST",
         body: {
-          customerId,
+          customerId: input.externalCustomerId,
           payOutDetails: { currency, address: input.sourceWalletAddress, network },
           complianceDetails,
         },
@@ -1447,7 +1448,8 @@ export interface BvnkExecuteOfframpInput {
   cryptoToken: string;
   fiatCurrency: RampFiatCurrency;
   cryptoAmount: string;
-  providerCustomer: BvnkCustomerResolution;
+  externalCustomerId: string;
+  walletId: string;
   bvnkCompliance?: BvnkComplianceInput;
 }
 
@@ -1470,6 +1472,28 @@ export function readBvnkWallets(
 ): Record<string, BvnkOnrampEntry> {
   const wallets = readBvnkData(providerData).wallets;
   return wallets && typeof wallets === "object" ? (wallets as Record<string, BvnkOnrampEntry>) : {};
+}
+
+/** Merchant-owned BVNK off-ramp wallet, one per fiat currency. */
+export interface BvnkOfframpWallet {
+  id: string;
+  status?: string;
+}
+
+export function readBvnkOfframpWallets(
+  providerData: CounterpartyRow["provider_data"]
+): Record<string, BvnkOfframpWallet> {
+  const offramp = asRecord(readBvnkData(providerData).offramp).wallets;
+  return offramp && typeof offramp === "object"
+    ? (offramp as Record<string, BvnkOfframpWallet>)
+    : {};
+}
+
+export function readBvnkOfframpWallet(
+  providerData: CounterpartyRow["provider_data"],
+  fiatCurrency: string
+): BvnkOfframpWallet | undefined {
+  return readBvnkOfframpWallets(providerData)[fiatCurrency];
 }
 
 export function bvnkOnrampKey(

--- a/apps/sdp-api/src/lib/ramps/types.ts
+++ b/apps/sdp-api/src/lib/ramps/types.ts
@@ -133,6 +133,8 @@ export interface RampOfframpQuoteInput {
   customerId?: string;
   /** Handler-resolved Grid external payout account id (Lightspark). */
   payoutAccountId?: string;
+  /** Handler-provisioned merchant-owned BVNK off-ramp fiat wallet id. */
+  bvnkOfframpWalletId?: string;
   redirectUrl?: string;
   bvnkCompliance?: BvnkComplianceInput;
 }

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -2687,6 +2687,101 @@ describe("Payments routes", () => {
     expect(body.error.message).toContain("bvnkCompliance.partyDetails is required");
   });
 
+  async function seedRampTransfer(input: {
+    id: string;
+    provider: string;
+    providerReference: string;
+    status: string;
+  }): Promise<void> {
+    const now = new Date().toISOString();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers
+           (id, organization_id, project_id, wallet_id, token, amount, type, direction, status, provider, provider_reference, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        input.id,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_WALLET_ID,
+        "USDC",
+        null,
+        "offramp",
+        "outbound",
+        input.status,
+        input.provider,
+        input.providerReference,
+        now,
+        now
+      )
+      .run();
+  }
+
+  it("cancels a pending ramp transfer and marks the row canceled", async () => {
+    await seedRampTransfer({
+      id: "xfr_cancel_pending",
+      provider: "bvnk",
+      providerReference: "bvnk_ref_cancel_1",
+      status: "awaiting_payment",
+    });
+
+    const res = await app.request(
+      "/v1/payments/ramps/transfers/cancel",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({ provider: "bvnk", providerReference: "bvnk_ref_cancel_1" }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { transfer: { id: string; status: string } } };
+    expect(body.data.transfer.status).toBe("canceled");
+
+    const row = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+      .bind("xfr_cancel_pending")
+      .first<{ status: string }>();
+    expect(row?.status).toBe("canceled");
+  });
+
+  it("refuses to cancel a ramp transfer that is already settling", async () => {
+    await seedRampTransfer({
+      id: "xfr_cancel_settling",
+      provider: "bvnk",
+      providerReference: "bvnk_ref_cancel_2",
+      status: "settling",
+    });
+
+    const res = await app.request(
+      "/v1/payments/ramps/transfers/cancel",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({ provider: "bvnk", providerReference: "bvnk_ref_cancel_2" }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+
+    const row = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+      .bind("xfr_cancel_settling")
+      .first<{ status: string }>();
+    expect(row?.status).toBe("settling");
+  });
+
   it("returns bad request when provider is not supported", async () => {
     const res = await app.request(
       "/v1/payments/ramps/onramp/execute",

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -86,6 +86,7 @@ const LIGHTSPARK_GRID_API_BASE_URL = "https://api.lightspark.com/grid/2025-10-13
 const TEST_BVNK_HAWK_AUTH_ID = "bvnk_hawk_auth_id";
 const TEST_BVNK_HAWK_SECRET_KEY = "bvnk_hawk_secret_key";
 const TEST_BVNK_WALLET_ID = "a:24122329329347:HsdJVhW:1";
+const TEST_BVNK_OFFRAMP_WALLET_ID = "a:99887766554433:OffRmpW:1";
 const TEST_BVNK_API_BASE_URL = "https://api.sandbox.bvnk.test";
 const TEST_MAGICBLOCK_API_BASE_URL = "https://payments.magicblock.test";
 const TEST_MAGICBLOCK_AUTH_TOKEN = "magicblock_auth_token";
@@ -2527,9 +2528,13 @@ describe("Payments routes", () => {
 
   it("creates and accepts a BVNK off-ramp estimate through the execute endpoint", async () => {
     const counterpartyId = await seedCounterparty({
+      externalId: "customer_456",
       identity: { address: { countryCode: "US" } },
       providerData: {
-        bvnk: { customer: { customerReference: "customer_456", status: "VERIFIED" } },
+        bvnk: {
+          customer: { customerReference: "customer_456", status: "VERIFIED" },
+          offramp: { wallets: { USD: { id: TEST_BVNK_OFFRAMP_WALLET_ID, status: "ACTIVE" } } },
+        },
       },
     });
     const fetchSpy = vi
@@ -2623,7 +2628,7 @@ describe("Payments routes", () => {
       network: string;
       complianceDetails: { partyDetails: Record<string, unknown>[] };
     };
-    expect(estimatePayload.walletId).toBe(TEST_BVNK_WALLET_ID);
+    expect(estimatePayload.walletId).toBe(TEST_BVNK_OFFRAMP_WALLET_ID);
     expect(estimatePayload.walletCurrency).toBe("USD");
     expect(estimatePayload.paidCurrency).toBe("USDC");
     expect(estimatePayload.paidRequiredAmount).toBe(75.25);
@@ -2645,9 +2650,13 @@ describe("Payments routes", () => {
 
   it("returns bad request when BVNK off-ramp is missing compliance party details", async () => {
     const counterpartyId = await seedCounterparty({
+      externalId: "customer_456",
       identity: { address: { countryCode: "US" } },
       providerData: {
-        bvnk: { customer: { customerReference: "customer_456", status: "VERIFIED" } },
+        bvnk: {
+          customer: { customerReference: "customer_456", status: "VERIFIED" },
+          offramp: { wallets: { USD: { id: TEST_BVNK_OFFRAMP_WALLET_ID, status: "ACTIVE" } } },
+        },
       },
     });
 

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -1,5 +1,6 @@
 export { getWalletBalances, getWalletPolicy, updateWalletPolicy } from "./handlers/balances";
 export {
+  cancelRampTransfer,
   createOfframpQuote,
   createOnrampQuote,
   estimateOfframp,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -50,8 +50,10 @@ import {
   rampRuntime,
   resolveSdpEnvironment,
 } from "../context";
+import { mapTransferRow } from "../mappers";
 import { assertWalletPolicyAllowsTransfer } from "../policy";
 import {
+  cancelRampTransferSchema,
   createOfframpQuoteSchema,
   createOnrampQuoteSchema,
   estimateOfframpSchema,
@@ -64,8 +66,14 @@ import {
   type submitCounterpartyRequirementsSchema,
 } from "../schemas";
 import { type ResolvedScope, resolveScope, resolveWalletAddress } from "../wallets";
-import { bvnkOnrampQuote, ensureBvnkCustomer, ensureBvnkPaymentRule } from "./ramps/bvnk";
+import {
+  bvnkOnrampQuote,
+  ensureBvnkCustomer,
+  ensureBvnkOfframpWallet,
+  ensureBvnkPaymentRule,
+} from "./ramps/bvnk";
 import { ensureLightsparkCustomer, ensureLightsparkPayoutAccount } from "./ramps/lightspark";
+import { updateTransferRecord } from "./transfers";
 
 type OnrampCurrencyPair = {
   source: (typeof ONRAMP_SUPPORT)[number]["source"];
@@ -399,15 +407,20 @@ async function executeOfframpWithProvider(
     }
     case "bvnk": {
       if (!input.fiatCurrency) throw badRequest("fiatCurrency is required for BVNK off-ramp.");
-      const providerCustomer = await ensureBvnkCustomer(c, counterparty, projectId, {
-        fiatCurrency: input.fiatCurrency,
-      });
+      const walletId = await ensureBvnkOfframpWallet(
+        c,
+        ctx,
+        counterparty,
+        projectId,
+        input.fiatCurrency
+      );
       return await RAMP_PROVIDER_CLIENTS.bvnk.executeOfframp(ctx, {
         sourceWalletAddress,
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
         cryptoAmount: input.cryptoAmount,
-        providerCustomer,
+        externalCustomerId: counterparty.external_id ?? counterparty.id,
+        walletId,
         bvnkCompliance: input.bvnkCompliance,
       });
     }
@@ -683,14 +696,24 @@ export async function createOfframpQuote(c: AppContext) {
       break;
     }
     case "bvnk": {
+      if (!input.fiatCurrency) {
+        throw badRequest("fiatCurrency is required for BVNK off-ramp.");
+      }
+      const bvnkOfframpWalletId = await ensureBvnkOfframpWallet(
+        c,
+        rampRuntime(c),
+        counterparty,
+        projectId,
+        input.fiatCurrency
+      );
       quote = await RAMP_PROVIDER_CLIENTS.bvnk.createOfframpQuote(rampRuntime(c), {
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
         cryptoAmount: input.cryptoAmount,
         sourceWalletAddress,
         externalCustomerId: counterparty.external_id ?? counterparty.id,
-        customerId: counterparty.id,
         bvnkCompliance: buildBvnkPartyDetails(counterparty, "BENEFICIARY"),
+        bvnkOfframpWalletId,
         redirectUrl: input.redirectUrl,
       });
       break;
@@ -719,6 +742,44 @@ export async function createOfframpQuote(c: AppContext) {
   });
 
   return success(c, { quote });
+}
+
+const CANCELABLE_RAMP_TRANSFER_STATUSES: readonly PaymentTransferStatus[] = [
+  "pending",
+  "awaiting_payment",
+];
+
+export async function cancelRampTransfer(c: AppContext) {
+  const body = await c.req.json();
+  const parsed = cancelRampTransferSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const input = parsed.data;
+  const scope = await resolveScope(c);
+  const projectId = requireProjectId(c);
+  const repository = getPaymentsRepository(c);
+
+  const transfer = await repository.getTransferByProviderReference({
+    provider: input.provider,
+    providerReference: input.providerReference,
+    organizationId: scope.auth.organizationId,
+    projectId,
+  });
+  if (!transfer) {
+    throw notFound("Transfer");
+  }
+  if (!CANCELABLE_RAMP_TRANSFER_STATUSES.includes(transfer.status)) {
+    throw badRequest(`Transfer can no longer be canceled (status: ${transfer.status}).`);
+  }
+
+  const updated = await updateTransferRecord(c, transfer.id, { status: "canceled" });
+
+  return success(c, { transfer: mapTransferRow(updated) });
 }
 
 export async function executeOnramp(c: AppContext) {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -21,6 +21,7 @@ import {
   AppError,
   badRequest,
   badRequestQuery,
+  conflict,
   counterpartyNotProvisioned,
   internalError,
   notFound,
@@ -73,7 +74,6 @@ import {
   ensureBvnkPaymentRule,
 } from "./ramps/bvnk";
 import { ensureLightsparkCustomer, ensureLightsparkPayoutAccount } from "./ramps/lightspark";
-import { updateTransferRecord } from "./transfers";
 
 type OnrampCurrencyPair = {
   source: (typeof ONRAMP_SUPPORT)[number]["source"];
@@ -699,14 +699,15 @@ export async function createOfframpQuote(c: AppContext) {
       if (!input.fiatCurrency) {
         throw badRequest("fiatCurrency is required for BVNK off-ramp.");
       }
+      const ctx = rampRuntime(c);
       const bvnkOfframpWalletId = await ensureBvnkOfframpWallet(
         c,
-        rampRuntime(c),
+        ctx,
         counterparty,
         projectId,
         input.fiatCurrency
       );
-      quote = await RAMP_PROVIDER_CLIENTS.bvnk.createOfframpQuote(rampRuntime(c), {
+      quote = await RAMP_PROVIDER_CLIENTS.bvnk.createOfframpQuote(ctx, {
         cryptoToken: input.cryptoToken,
         fiatCurrency: input.fiatCurrency,
         cryptoAmount: input.cryptoAmount,
@@ -777,7 +778,17 @@ export async function cancelRampTransfer(c: AppContext) {
     throw badRequest(`Transfer can no longer be canceled (status: ${transfer.status}).`);
   }
 
-  const updated = await updateTransferRecord(c, transfer.id, { status: "canceled" });
+  const updated = await repository.updateTransferStatusGuarded({
+    transferId: transfer.id,
+    organizationId: scope.auth.organizationId,
+    projectId,
+    fromStatuses: CANCELABLE_RAMP_TRANSFER_STATUSES,
+    toStatus: "canceled",
+    updatedAt: new Date().toISOString(),
+  });
+  if (!updated) {
+    throw conflict("Transfer status changed before it could be canceled.");
+  }
 
   return success(c, { transfer: mapTransferRow(updated) });
 }

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
@@ -6,6 +6,7 @@ import { hashString } from "@/lib/hash";
 import { RAMP_PROVIDER_CLIENTS } from "@/lib/ramps";
 import {
   type BvnkCustomerResolution,
+  type BvnkFiatWallet,
   type BvnkOnrampEntry,
   type BvnkOnrampRequestSpec,
   type BvnkPaymentRuleResolution,
@@ -20,6 +21,8 @@ import {
   normalizeBvnkCurrencyAndNetwork,
   readBvnkCustomer,
   readBvnkData,
+  readBvnkOfframpWallet,
+  readBvnkOfframpWallets,
   readBvnkOnrampEntry,
   readBvnkWallets,
 } from "@/lib/ramps/providers/bvnk";
@@ -86,6 +89,68 @@ async function persistBvnkOnrampState(
       },
     },
   });
+}
+
+/** Persists a merchant-owned off-ramp wallet to provider_data.bvnk.offramp.wallets. */
+async function persistBvnkOfframpWallet(
+  c: AppContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  fiatCurrency: string,
+  wallet: BvnkFiatWallet
+): Promise<void> {
+  const repo = getCounterpartiesRepository(c);
+  const bvnk = readBvnkData(counterparty.provider_data);
+  const offramp =
+    bvnk.offramp && typeof bvnk.offramp === "object"
+      ? (bvnk.offramp as Record<string, unknown>)
+      : {};
+  const wallets = readBvnkOfframpWallets(counterparty.provider_data);
+  await repo.updateCounterparty({
+    counterpartyId: counterparty.id,
+    organizationId: counterparty.organization_id,
+    projectId,
+    providerData: {
+      ...counterparty.provider_data,
+      bvnk: {
+        ...bvnk,
+        offramp: {
+          ...offramp,
+          wallets: { ...wallets, [fiatCurrency]: { id: wallet.id, status: wallet.status } },
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Provisions (or reuses) a merchant-owned BVNK fiat wallet for an off-ramp,
+ * keyed per fiat currency in provider_data.bvnk.offramp.wallets — instead of the
+ * shared BVNK_WALLET_ID. No customer/KYC: the wallet is owned by the merchant.
+ */
+export async function ensureBvnkOfframpWallet(
+  c: AppContext,
+  ctx: RampRuntimeContext,
+  counterparty: CounterpartyRow,
+  projectId: string,
+  fiatCurrency: string
+): Promise<string> {
+  const existing = readBvnkOfframpWallet(counterparty.provider_data, fiatCurrency);
+  if (existing?.id) {
+    return existing.id;
+  }
+  const client = RAMP_PROVIDER_CLIENTS.bvnk;
+  const walletProfile = await client.getFiatWalletProfile(ctx, { currency: fiatCurrency });
+  const wallet = await client.createFiatWallet(ctx, {
+    name: `SDP offramp ${fiatCurrency} ${counterparty.id}`,
+    currencyCode: fiatCurrency,
+    walletProfile,
+    idempotencyKey: (
+      await hashString(`bvnk-offramp-wallet:${counterparty.id}:${fiatCurrency}`)
+    ).slice(0, 36),
+  });
+  await persistBvnkOfframpWallet(c, counterparty, projectId, fiatCurrency, wallet);
+  return wallet.id;
 }
 
 /**

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -259,7 +259,7 @@ async function createTransferRecord(
   return createdRow;
 }
 
-export async function updateTransferRecord(
+async function updateTransferRecord(
   c: AppContext,
   transferId: string,
   patch: {

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -259,7 +259,7 @@ async function createTransferRecord(
   return createdRow;
 }
 
-async function updateTransferRecord(
+export async function updateTransferRecord(
   c: AppContext,
   transferId: string,
   patch: {
@@ -1962,6 +1962,7 @@ export async function listTransfers(c: AppContext) {
       "awaiting_payment",
       "settling",
       "completed",
+      "canceled",
       "expired",
     ];
     const needsNonChainRecords =

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -6,6 +6,7 @@ import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
+  cancelRampTransfer,
   createOfframpQuote,
   createOnrampQuote,
   createRecurringPayment,
@@ -182,6 +183,7 @@ payments.post(
   requirePermissions("payments:write", "wallets:read"),
   executeOfframp
 );
+payments.post("/ramps/transfers/cancel", requirePermissions("payments:write"), cancelRampTransfer);
 payments.post(
   "/ramps/sandbox/simulate",
   requirePermissions("payments:write"),

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -323,6 +323,11 @@ export const rampFiatCurrencySchema = z.preprocess(
   z.enum(RAMP_FIAT_CURRENCIES)
 );
 
+export const cancelRampTransferSchema = z.object({
+  provider: rampProviderSchema,
+  providerReference: z.string().min(1),
+});
+
 export const listOnrampCurrenciesQuerySchema = z.object({
   source: rampFiatCurrencySchema.optional(),
   dest: onrampCryptoRailSchema.optional(),
@@ -386,6 +391,7 @@ export const transferStatusSchema = z.enum([
   "awaiting_payment",
   "settling",
   "completed",
+  "canceled",
   "expired",
 ]);
 

--- a/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
+++ b/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
@@ -55,6 +55,7 @@ describe("wallet-scoped route coverage inventory", () => {
       "POST /ramps/offramp/estimate",
       "POST /ramps/onramp/estimate",
       "POST /ramps/sandbox/simulate",
+      "POST /ramps/transfers/cancel",
       "POST /subscriptions",
       "POST /subscriptions/:subscriptionId/collection-attempts",
       "POST /subscriptions/:subscriptionId/prepare-authorization",

--- a/apps/sdp-web/src/app/api/dashboard/payments/ramps/transfers/cancel/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/ramps/transfers/cancel/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createSdpApiClient } from "@/lib/sdp-api";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.text();
+    const apiClient = await createSdpApiClient();
+    const response = await apiClient.request("/v1/payments/ramps/transfers/cancel", {
+      method: "POST",
+      body,
+    });
+
+    const responseBody = await response.text();
+    const contentType = response.headers.get("Content-Type") ?? "application/json";
+
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        "Content-Type": contentType,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          message: error instanceof Error ? error.message : "Transfer cancellation failed",
+        },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -384,6 +384,21 @@ export async function fetchTransferByProviderReference(input: {
   return body.data[0];
 }
 
+export async function cancelRampTransfer(input: {
+  provider: RampProviderId;
+  providerReference: string;
+}): Promise<void> {
+  const response = await fetch("/api/dashboard/payments/ramps/transfers/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const body = (await response.json()) as ApiErrorBody;
+  if (!response.ok) {
+    throw new Error(getApiError(body, `Transfer cancellation failed (${response.status}).`));
+  }
+}
+
 export async function fetchRampEstimates(input: {
   direction: RampDirection;
   assetRail: CryptoRailId;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/cancel-transaction-dialog.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/cancel-transaction-dialog.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+
+interface CancelTransactionDialogProps {
+  open: boolean;
+  onKeepGoing: () => void;
+  onConfirm: () => void;
+}
+
+export function CancelTransactionDialog({
+  open,
+  onKeepGoing,
+  onConfirm,
+}: CancelTransactionDialogProps) {
+  return (
+    <Modal isOpen={open} onClose={onKeepGoing} ariaLabel="Cancel transaction" size="sm">
+      <div className="space-y-6 p-6">
+        <div className="space-y-2">
+          <p className="text-xl font-medium tracking-tight text-text-extra-high">
+            Cancel this transaction?
+          </p>
+          <p className="text-sm text-text-low">
+            This transaction has already been started. If you cancel now you'll leave the flow.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button type="button" variant="secondary" onClick={onKeepGoing}>
+            Keep going
+          </Button>
+          <Button type="button" variant="destructive" onClick={onConfirm}>
+            Cancel transaction
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
@@ -2,11 +2,12 @@
 
 import type { Counterparty, RampProviderId } from "@sdp/types";
 import Image from "next/image";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { CounterpartyCreateDialog } from "@/app/dashboard/payments/counterparty/counterparty-create-dialog";
 import { Button } from "@/components/ui/button";
 import { getRampProviderLabel, RAMP_PROVIDER_LOGOS } from "@/lib/ramps";
 import { cn } from "@/lib/utils";
+import { CancelTransactionDialog } from "./cancel-transaction-dialog";
 
 export function PoweredByRampProvider({ provider }: { provider: RampProviderId }) {
   const providerLabel = getRampProviderLabel(provider);
@@ -44,6 +45,8 @@ interface RampWizardShellProps {
   header?: ReactNode;
   footerActions?: ReactNode;
   hidePrimary?: boolean;
+  /** Confirm before running the secondary action — used once a transaction is live. */
+  confirmSecondary?: boolean;
 }
 
 export function RampWizardShell({
@@ -62,7 +65,9 @@ export function RampWizardShell({
   header,
   footerActions,
   hidePrimary,
+  confirmSecondary,
 }: RampWizardShellProps) {
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
   return (
     <div className="mx-auto flex h-[80vh] w-full max-w-5xl flex-col py-6">
       <div className="mx-auto w-full max-w-3xl flex-1 space-y-6 overflow-y-auto px-1.5">
@@ -109,7 +114,7 @@ export function RampWizardShell({
           type="button"
           variant="secondary"
           className="h-14 rounded-full text-base"
-          onClick={onSecondary}
+          onClick={confirmSecondary ? () => setCancelConfirmOpen(true) : onSecondary}
         >
           {secondaryLabel ?? (stepIndex === 0 ? "Cancel" : "Previous")}
         </Button>
@@ -132,6 +137,15 @@ export function RampWizardShell({
         open={counterpartyDialogOpen}
         onClose={() => setCounterpartyDialogOpen(false)}
         onCreated={onCounterpartyCreated}
+      />
+
+      <CancelTransactionDialog
+        open={cancelConfirmOpen}
+        onKeepGoing={() => setCancelConfirmOpen(false)}
+        onConfirm={() => {
+          setCancelConfirmOpen(false);
+          onSecondary();
+        }}
       />
     </div>
   );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-wizard-shell.tsx
@@ -47,6 +47,7 @@ interface RampWizardShellProps {
   hidePrimary?: boolean;
   /** Confirm before running the secondary action — used once a transaction is live. */
   confirmSecondary?: boolean;
+  secondaryDisabled?: boolean;
 }
 
 export function RampWizardShell({
@@ -66,6 +67,7 @@ export function RampWizardShell({
   footerActions,
   hidePrimary,
   confirmSecondary,
+  secondaryDisabled,
 }: RampWizardShellProps) {
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
   return (
@@ -114,6 +116,7 @@ export function RampWizardShell({
           type="button"
           variant="secondary"
           className="h-14 rounded-full text-base"
+          disabled={secondaryDisabled}
           onClick={confirmSecondary ? () => setCancelConfirmOpen(true) : onSecondary}
         >
           {secondaryLabel ?? (stepIndex === 0 ? "Cancel" : "Previous")}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -137,6 +137,7 @@ export function useRampWizard<TId extends string>(
   const [counterpartyDialogOpen, setCounterpartyDialogOpen] = useState(false);
   const [quote, setQuote] = useState<PaymentRampQuote | null>(null);
   const [hostedQuoteLoading, setHostedQuoteLoading] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
   const { values: fields, setField } = useZodForm(rampSelectionSchema, {
     walletId: "",
     amount: "",
@@ -383,12 +384,17 @@ export function useRampWizard<TId extends string>(
     if (!quote) {
       throw new Error("Cannot cancel without an active quote.");
     }
+    if (isCanceling) {
+      return;
+    }
+    setIsCanceling(true);
     const toastId = toast.loading("Canceling transaction.", { position: "bottom-right" });
     try {
       await cancelRampTransfer({ provider: quote.provider, providerReference: quote.id });
       toast.success("Transaction canceled.", { id: toastId, position: "bottom-right" });
       finish();
     } catch (error) {
+      setIsCanceling(false);
       toast.error("Unable to cancel transaction.", {
         id: toastId,
         description: error instanceof Error ? error.message : "Cancellation failed.",
@@ -433,6 +439,7 @@ export function useRampWizard<TId extends string>(
     currentStepId,
     isLastStep,
     onTransactionStage,
+    isCanceling,
     canProceed,
     collectedData: requirements.collectedData,
     setCollectedField: requirements.setField,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -14,6 +14,7 @@ import useSWR from "swr";
 import type { z } from "zod";
 import {
   type CounterpartiesResult,
+  cancelRampTransfer,
   fetchAllCounterparties,
   fetchWallets,
   getApiError,
@@ -33,7 +34,9 @@ const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
 
 export function isTerminalRampTransferStatus(status: string) {
-  return status === "completed" || status === "failed" || status === "expired";
+  return (
+    status === "completed" || status === "failed" || status === "expired" || status === "canceled"
+  );
 }
 
 export type RampWizardStep<TId extends string = string> = {
@@ -376,8 +379,30 @@ export function useRampWizard<TId extends string>(
   // into amount/details would orphan the live quote, so back becomes an explicit exit.
   const onTransactionStage = isLastStep && quote !== null;
 
+  const cancelTransfer = async () => {
+    if (!quote) {
+      throw new Error("Cannot cancel without an active quote.");
+    }
+    const toastId = toast.loading("Canceling transaction.", { position: "bottom-right" });
+    try {
+      await cancelRampTransfer({ provider: quote.provider, providerReference: quote.id });
+      toast.success("Transaction canceled.", { id: toastId, position: "bottom-right" });
+      finish();
+    } catch (error) {
+      toast.error("Unable to cancel transaction.", {
+        id: toastId,
+        description: error instanceof Error ? error.message : "Cancellation failed.",
+        position: "bottom-right",
+      });
+    }
+  };
+
   const handleSecondary = () => {
-    if (stepIndex === 0 || onTransactionStage) {
+    if (onTransactionStage) {
+      void cancelTransfer();
+      return;
+    }
+    if (stepIndex === 0) {
       finish();
       return;
     }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
@@ -65,6 +65,7 @@ export function OfframpRail({
       }
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       confirmSecondary={wizard.onTransactionStage}
+      secondaryDisabled={wizard.isCanceling}
       footerActions={
         transferTerminal ? (
           <Button asChild type="button">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/offramp-rail.tsx
@@ -64,6 +64,7 @@ export function OfframpRail({
         ) : null
       }
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
+      confirmSecondary={wizard.onTransactionStage}
       footerActions={
         transferTerminal ? (
           <Button asChild type="button">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
@@ -97,6 +97,7 @@ export function OnrampRail({
       }
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
       confirmSecondary={wizard.onTransactionStage}
+      secondaryDisabled={wizard.isCanceling}
       footerActions={
         transferTerminal ? (
           <Button asChild type="button">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/onramp-rail.tsx
@@ -96,6 +96,7 @@ export function OnrampRail({
         ) : null
       }
       secondaryLabel={wizard.onTransactionStage ? "Cancel" : undefined}
+      confirmSecondary={wizard.onTransactionStage}
       footerActions={
         transferTerminal ? (
           <Button asChild type="button">

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -55,6 +55,7 @@ export type PaymentTransferStatus =
   | "awaiting_payment"
   | "settling"
   | "completed"
+  | "canceled"
   | "expired";
 
 export const SUCCESSFUL_PAYMENT_TRANSFER_STATUSES = [


### PR DESCRIPTION
## What

Adds a confirmation step + real cancellation for ramp wizard transfers. Once the `/quote` call persists a `payment_transfers` row, hitting **Cancel** in the wizard now (1) prompts a confirmation dialog and (2) actually flips the persisted row to `canceled` instead of silently navigating away.

### Problem
On/off-ramps check counterparty requirements, then call `/quote`, which **persists a transfer row**. Before this, the wizard's Cancel button just navigated away — leaving a live `pending`/`awaiting_payment` row orphaned, and it was far too easy to hit by accident.

<img width="3444" height="1982" alt="CleanShot 2026-06-19 at 18 17 47@2x" src="https://github.com/user-attachments/assets/1a429b5d-7901-4a95-aa8d-4e66ff9e0df8" />

## Changes

**API**
- `POST /v1/payments/ramps/transfers/cancel` (`payments:write`) — looks up the transfer by `provider` + `providerReference` (org/project scoped), guards that status is **cancelable** (`pending` / `awaiting_payment`), then sets it to `canceled` via the shared `updateTransferRecord` helper. Returns the updated transfer summary.
- New `canceled` value on `PaymentTransferStatus` (no migration — `payment_transfers.status` is free-text `TEXT`, no CHECK constraint).
- `canceled` added to `transferStatusSchema` (query filter) and the `listTransfers` non-chain status set so canceled rows still surface in listings.

**Web**
- `CancelTransactionDialog` (DS `Modal`) — "Keep going" / "Cancel transaction".
- `RampWizardShell` gains `confirmSecondary`; when set, the secondary button opens the dialog instead of firing immediately. Both rails pass `confirmSecondary={wizard.onTransactionStage}` (same flag that already drives the "Cancel" label).
- `useRampWizard.handleSecondary` routes the transaction stage through a new `cancelTransfer()` → calls the cancel endpoint, toasts, then exits.
- `isTerminalRampTransferStatus` now treats `canceled` as terminal, so the transfer-status SWR poll stops after cancel.
- Next proxy route for the new endpoint.

## Design notes
- **Local-only cancel.** Flips *our* row to `canceled`; does **not** call the provider's cancel API. An abandoned, unfunded quote just expires provider-side. Provider-side teardown can be a follow-up if needed.
- **Status guard fails loudly** — a transfer already `processing`/`settling`/`completed` returns 400 rather than faking a cancel on in-flight money.
- Cancel is keyed by `provider`+`providerReference` (what the wizard has client-side), under `/ramps/`.

## Out of scope / follow-ups
- Single source of truth for the transfer-status lists (`PaymentTransferStatus` / zod enum / non-chain array / terminal helper currently parallel) — pre-existing debt this change touches.
- This branch also carries in-progress **BVNK off-ramp dedicated-wallet provisioning** (`ensureBvnkOfframpWallet`), which is interleaved in `handlers/ramps.ts` and rides along here.

## Verification
- `tsc --noEmit` green on `sdp-api` and `sdp-web` (pre-existing unrelated errors aside); `biome check` clean. (ESLint is broken repo-wide.)
- Provider calls 503 locally without Doppler — endpoint logic verified by types + review, not a live ramp run.