### PR TITLE
feat(kora): clone devnet to the new KMS + Redis structure

### DIFF
--- a/infra/kora/cloud-run/kora.devnet.toml
+++ b/infra/kora/cloud-run/kora.devnet.toml
@@ -7,8 +7,7 @@ rate_limit = 100
 # Set auth via env vars if needed (KORA_API_KEY / KORA_HMAC_SECRET)
 
 [kora.cache]
-enabled = false
-# url = "redis://..."
+enabled = true
 default_ttl = 300
 account_ttl = 60
 

--- a/infra/kora/cloud-run/signers.devnet.toml
+++ b/infra/kora/cloud-run/signers.devnet.toml
@@ -4,7 +4,8 @@
 strategy = "round_robin"
 
 [[signers]]
-name = "sdp_fee_payer"
-type = "memory"
-private_key_env = "SIGNER_PRIVATE_KEY"
+name = "sdp_devnet_fee_payer"
+type = "gcp_kms"
+key_name_env = "KORA_GCP_KMS_KEY_NAME"
+public_key_env = "KORA_GCP_KMS_PUBLIC_KEY"
 weight = 1


### PR DESCRIPTION
Clone the SDP devnet paymaster onto the same Terraform/KMS/Doppler structure as mainnet (PRO-1369). The module already supports `env=devnet`; this only updates the baked config so the devnet image works with the new stack:

- `signers.devnet.toml`: `memory` (`SIGNER_PRIVATE_KEY`) → `gcp_kms` (the `kora-devnet` KMS key), mirroring mainnet.
- `kora.devnet.toml`: enable the Redis cache (the new structure provisions a `kora-devnet` Memorystore instance; `KORA_REDIS_URL` injected via Doppler).

## Does this break the live `kora-sdp` (which serves traffic)? No.
The live service is named **`kora-sdp`**. The module names everything **`kora-devnet-*`** (`env=devnet`), so `terraform apply -var-file=envs/devnet.tfvars` creates a **fully parallel** stack and **never touches `kora-sdp`** — no in-place mutation, no downtime.

Migration is a cutover, not a mutation:
1. Owner applies the devnet stack → new `kora-devnet` service + KMS key + Redis + VPC connector (`10.8.0.0/28`, no collision; only `kora-mainnet` `10.8.1.0/28` exists) + SAs + WIF.
2. Deploy the real image to `kora-devnet`, airdrop devnet SOL to the new KMS-derived fee-payer address (the address changes: memory key → KMS key — trivial on devnet).
3. Validate, then cut clients/DNS from `kora-sdp` → `kora-devnet`.
4. Retire `kora-sdp` (and its `analytics-324114` cross-project image pull) last.

`kora-sdp` keeps serving on its own key throughout, so traffic is unaffected until the deliberate cutover.

## Dependencies / notes
- Same owner-apply requirement as mainnet (editor can't set IAM / create WIF / read KMS in SDP) — Gui runs the devnet apply in a `devnet` workspace.
- Needs the GCS backend + `create_wif` toggle from #483.
- Devnet config stays permissive (`price = free`, Mock, permissive fee_payer_policy) — appropriate for devnet; hardening is mainnet's concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)