### PR TITLE
feat(api): activate recurring payments [PRO-1295]

### DIFF
--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -27,6 +27,7 @@ export type {
   ListPaymentRecurringPaymentsResult,
   PaymentRecurringPaymentRow,
   PaymentRecurringPaymentsRepository,
+  UpdatePaymentRecurringPaymentActivationInput,
 } from "./payment-recurring-payments.repository";
 export { createPostgresPaymentRecurringPaymentsRepository } from "./payment-recurring-payments.repository.postgres";
 export type {

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -5,6 +5,7 @@ import type {
   ListPaymentRecurringPaymentsResult,
   PaymentRecurringPaymentRow,
   PaymentRecurringPaymentsRepository,
+  UpdatePaymentRecurringPaymentActivationInput,
 } from "./payment-recurring-payments.repository";
 
 function buildInClause(length: number): string {
@@ -113,6 +114,104 @@ export function createPostgresPaymentRecurringPaymentsRepository(
         organizationId: input.organizationId,
         projectId: input.projectId,
       });
+    },
+
+    async claimRecurringPaymentActivation(params) {
+      const row = await db
+        .prepare(
+          `UPDATE payment_recurring_payments
+              SET status = 'activating',
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND status = 'pending_activation'
+          RETURNING *`
+        )
+        .bind(params.updatedAt, params.recurringPaymentId, params.organizationId, params.projectId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapRecurringPaymentRow(row) : null;
+    },
+
+    async resetRecurringPaymentActivationIfNotActive(params) {
+      const row = await db
+        .prepare(
+          `UPDATE payment_recurring_payments
+              SET status = 'pending_activation',
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND status = 'activating'
+          RETURNING *`
+        )
+        .bind(params.updatedAt, params.recurringPaymentId, params.organizationId, params.projectId)
+        .first<Record<string, unknown>>();
+
+      return row ? mapRecurringPaymentRow(row) : null;
+    },
+
+    async updateRecurringPaymentActivation(input: UpdatePaymentRecurringPaymentActivationInput) {
+      const allowActiveUpdate = input.status === "active";
+      const row = await db
+        .prepare(
+          `UPDATE payment_recurring_payments
+              SET status = COALESCE(?, status),
+                  plan_id = CASE WHEN ?::boolean THEN ? ELSE plan_id END,
+                  subscription_id = CASE WHEN ?::boolean THEN ? ELSE subscription_id END,
+                  plan_pda = CASE WHEN ?::boolean THEN ? ELSE plan_pda END,
+                  plan_created_at = CASE WHEN ?::boolean THEN ? ELSE plan_created_at END,
+                  plan_creation_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE plan_creation_signature END,
+                  subscription_pda =
+                    CASE WHEN ?::boolean THEN ? ELSE subscription_pda END,
+                  subscription_authority_address =
+                    CASE WHEN ?::boolean THEN ? ELSE subscription_authority_address END,
+                  authorization_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE authorization_signature END,
+                  next_collection_due_at =
+                    CASE WHEN ?::boolean THEN ? ELSE next_collection_due_at END,
+                  destination_token_account =
+                    CASE WHEN ?::boolean THEN ? ELSE destination_token_account END,
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND (status = 'activating' OR ?::boolean)
+          RETURNING *`
+        )
+        .bind(
+          input.status ?? null,
+          input.planId !== undefined,
+          input.planId ?? null,
+          input.subscriptionId !== undefined,
+          input.subscriptionId ?? null,
+          input.planPda !== undefined,
+          input.planPda ?? null,
+          input.planCreatedAt !== undefined,
+          input.planCreatedAt ?? null,
+          input.planCreationSignature !== undefined,
+          input.planCreationSignature ?? null,
+          input.subscriptionPda !== undefined,
+          input.subscriptionPda ?? null,
+          input.subscriptionAuthorityAddress !== undefined,
+          input.subscriptionAuthorityAddress ?? null,
+          input.authorizationSignature !== undefined,
+          input.authorizationSignature ?? null,
+          input.nextCollectionDueAt !== undefined,
+          input.nextCollectionDueAt ?? null,
+          input.destinationTokenAccount !== undefined,
+          input.destinationTokenAccount ?? null,
+          input.updatedAt,
+          input.recurringPaymentId,
+          input.organizationId,
+          input.projectId,
+          allowActiveUpdate
+        )
+        .first<Record<string, unknown>>();
+
+      return row ? mapRecurringPaymentRow(row) : null;
     },
 
     async getRecurringPaymentById(params) {

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
@@ -49,6 +49,24 @@ export interface CreatePaymentRecurringPaymentInput {
   updatedAt: string;
 }
 
+export interface UpdatePaymentRecurringPaymentActivationInput {
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  status?: PaymentRecurringPaymentStatus;
+  planId?: string | null;
+  subscriptionId?: string | null;
+  planPda?: string | null;
+  planCreatedAt?: string | null;
+  planCreationSignature?: string | null;
+  subscriptionPda?: string | null;
+  subscriptionAuthorityAddress?: string | null;
+  authorizationSignature?: string | null;
+  nextCollectionDueAt?: string | null;
+  destinationTokenAccount?: string | null;
+  updatedAt: string;
+}
+
 export interface ListPaymentRecurringPaymentsInput {
   organizationId: string;
   projectId: string;
@@ -67,6 +85,21 @@ export interface ListPaymentRecurringPaymentsResult {
 export interface PaymentRecurringPaymentsRepository {
   createRecurringPayment(
     input: CreatePaymentRecurringPaymentInput
+  ): Promise<PaymentRecurringPaymentRow | null>;
+  claimRecurringPaymentActivation(params: {
+    recurringPaymentId: string;
+    organizationId: string;
+    projectId: string;
+    updatedAt: string;
+  }): Promise<PaymentRecurringPaymentRow | null>;
+  resetRecurringPaymentActivationIfNotActive(params: {
+    recurringPaymentId: string;
+    organizationId: string;
+    projectId: string;
+    updatedAt: string;
+  }): Promise<PaymentRecurringPaymentRow | null>;
+  updateRecurringPaymentActivation(
+    input: UpdatePaymentRecurringPaymentActivationInput
   ): Promise<PaymentRecurringPaymentRow | null>;
   getRecurringPaymentById(params: {
     recurringPaymentId: string;

--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -282,6 +282,28 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
   });
 
   registry.registerPath({
+    method: "post",
+    path: "/v1/payments/recurring-payments/{id}/activate",
+    tags: ["Payments"],
+    summary: "Activate recurring payment",
+    operationId: "activatePaymentRecurringPayment",
+    description:
+      "Activates a pending SDP-custody recurring payment by creating the Solana subscriptions plan, authorizing the subscription, and storing the resulting on-chain identifiers and signatures.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: paymentRecurringPaymentIdParamsSchema,
+    },
+    responses: {
+      200: {
+        description: "Recurring payment activated",
+        content: jsonContent(paymentRecurringPaymentResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 409, 500]),
+    },
+  });
+
+  registry.registerPath({
     method: "get",
     path: "/v1/payments/recurring-payments/{id}",
     tags: ["Payments"],

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -15,6 +15,7 @@ import {
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
 } from "@solana/kit";
+import * as subscriptionsProgram from "@solana/subscriptions";
 import { getTransferSolInstruction } from "@solana-program/system";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
@@ -39,6 +40,15 @@ const getSplTokenBalancesMock = vi.spyOn(tokenAccounts, "getSplTokenBalances");
 const getSplTokenAccountAddressesMock = vi.spyOn(tokenAccounts, "getSplTokenAccountAddresses");
 const createFeePaymentAdapterMock = vi.spyOn(feePaymentAdapters, "createFeePaymentAdapter");
 const createOrgSignerMock = vi.spyOn(solanaServices, "createOrgSigner");
+const fetchMaybePlanMock = vi.spyOn(subscriptionsProgram, "fetchMaybePlan");
+const fetchMaybeSubscriptionAuthorityMock = vi.spyOn(
+  subscriptionsProgram,
+  "fetchMaybeSubscriptionAuthority"
+);
+const fetchMaybeSubscriptionDelegationMock = vi.spyOn(
+  subscriptionsProgram,
+  "fetchMaybeSubscriptionDelegation"
+);
 
 const TEST_CONFIG_ID = "cust_cfg_payments_test";
 const TEST_CUSTODY_WALLET_ID = "cwlt_payments_test";
@@ -444,6 +454,34 @@ function expectPreparedSubscriptionTransaction(
   }
 }
 
+function mockRecurringActivationRpc() {
+  createRpcMock.mockReturnValue({
+    getTokenAccountsByOwner: () => ({
+      send: async () => ({
+        value: [
+          {
+            pubkey: TEST_SOLANA_ADDRESSES.wallet3,
+            account: {
+              data: {
+                parsed: {
+                  info: {
+                    mint: DEVNET_USDC_MINT,
+                    tokenAmount: {
+                      amount: "1000000000",
+                      decimals: 6,
+                      uiAmountString: "1000",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    }),
+  } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+}
+
 describe("Payments routes", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -480,6 +518,20 @@ describe("Payments routes", () => {
     getSignaturesForAddressMock.mockResolvedValue([]);
     getSplTokenBalancesMock.mockResolvedValue([]);
     getSplTokenAccountAddressesMock.mockResolvedValue([]);
+    fetchMaybePlanMock.mockResolvedValue({
+      exists: true,
+      address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      data: { data: { terms: { createdAt: 1_770_000_000n } } },
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybePlan>>);
+    fetchMaybeSubscriptionAuthorityMock.mockResolvedValue({
+      exists: false,
+      address: address(TEST_SOLANA_ADDRESSES.wallet3),
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionAuthority>>);
+    fetchMaybeSubscriptionDelegationMock.mockResolvedValue({
+      exists: true,
+      address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      data: {},
+    } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>);
     createFeePaymentAdapterMock.mockReturnValue({
       providerId: "mock",
       getFeePayer: vi.fn().mockResolvedValue("7iQJKBEwzBccKMvyZgnPmXfSPJB5XjN7hE2vgGYX5Kkv"),
@@ -666,6 +718,104 @@ describe("Payments routes", () => {
     };
     expect(getBody.data.recurringPayment.id).toBe(createBody.data.recurringPayment.id);
     expect(getBody.data.recurringPayment.status).toBe("pending_activation");
+  });
+
+  it("activates recurring payments through SDP API routes", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+      )
+      .mockResolvedValueOnce(
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      );
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(activateRes.status).toBe(200);
+    const activateBody = (await activateRes.json()) as {
+      data: {
+        recurringPayment: {
+          id: string;
+          status: string;
+          planId: string;
+          subscriptionId: string;
+          planPda: string;
+          planCreatedAt: string;
+          planCreationSignature: string;
+          subscriptionPda: string;
+          subscriptionAuthorityAddress: string;
+          authorizationSignature: string;
+          nextCollectionDueAt: string;
+        };
+      };
+    };
+    expect(activateBody.data.recurringPayment).toMatchObject({
+      id: createBody.data.recurringPayment.id,
+      status: "active",
+      planCreatedAt: "1770000000",
+      planCreationSignature:
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy",
+      authorizationSignature:
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV",
+    });
+    expect(activateBody.data.recurringPayment.planId).toMatch(/^psp_/);
+    expect(activateBody.data.recurringPayment.subscriptionId).toMatch(/^psub_/);
+    expect(activateBody.data.recurringPayment.planPda).toBeTruthy();
+    expect(activateBody.data.recurringPayment.subscriptionPda).toBeTruthy();
+    expect(activateBody.data.recurringPayment.subscriptionAuthorityAddress).toBeTruthy();
+    expect(activateBody.data.recurringPayment.nextCollectionDueAt).toBeTruthy();
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
   });
 
   it("requires owner wallet access when updating subscription plans", async () => {

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -12,6 +12,7 @@ export {
   simulateSandboxTransfer,
 } from "./handlers/ramps";
 export {
+  activateRecurringPayment,
   createRecurringPayment,
   getRecurringPayment,
   listRecurringPayments,

--- a/apps/sdp-api/src/routes/payments/handlers/recurring-payments.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/recurring-payments.ts
@@ -13,9 +13,13 @@ import {
   assertApiKeyWalletAccess,
   getAllowedApiKeyWalletIdsForPermissions,
 } from "@/services/api-key-scope.service";
-import { createRecurringPayment as createRecurringPaymentRecord } from "@/services/payments/recurring-payments";
+import {
+  activateRecurringPayment as activateRecurringPaymentRecord,
+  createRecurringPayment as createRecurringPaymentRecord,
+} from "@/services/payments/recurring-payments";
 import { type AppContext, getPaymentRecurringPaymentsRepository } from "../context";
 import {
+  activateRecurringPaymentSchema,
   createRecurringPaymentSchema,
   listRecurringPaymentsQuerySchema,
   recurringPaymentIdParamsSchema,
@@ -86,6 +90,65 @@ export const createRecurringPayment = async (c: AppContext) => {
     recurringPayment: mapRecurringPayment(recurringPayment),
   };
   return created(c, response);
+};
+
+async function readOptionalJsonBody(c: AppContext): Promise<unknown> {
+  const text = await c.req.text();
+  if (!text.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw badRequest("Invalid request body");
+  }
+}
+
+export const activateRecurringPayment = async (c: AppContext) => {
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const params = recurringPaymentIdParamsSchema.safeParse(c.req.param());
+
+  if (!params.success) {
+    throw badRequestParams();
+  }
+
+  const body = await readOptionalJsonBody(c);
+  const parsed = activateRecurringPaymentSchema.safeParse(body);
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", { errors: z.treeifyError(parsed.error) });
+  }
+
+  const allowedWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["payments:write"]);
+  const recurringPayment = await getPaymentRecurringPaymentsRepository(c).getRecurringPaymentById({
+    recurringPaymentId: params.data.id,
+    organizationId: auth.organizationId,
+    projectId,
+    sourceWalletIds: allowedWalletIds ?? undefined,
+  });
+
+  if (!recurringPayment) {
+    throw new AppError("NOT_FOUND", "Recurring payment not found");
+  }
+
+  const scope = await resolveScope(c);
+  const sourceWallet = resolveWallet(scope.wallets, recurringPayment.source_wallet_id);
+  assertApiKeyWalletAccess(scope.auth, sourceWallet.walletId, ["payments:write"]);
+
+  const activated = await activateRecurringPaymentRecord({
+    env: c.env,
+    organizationId: auth.organizationId,
+    projectId,
+    sourceWallet,
+    recurringPayment,
+    createdBy: await resolveCreatorUserId(c),
+  });
+  const response: PaymentRecurringPaymentResponse = {
+    recurringPayment: mapRecurringPayment(activated),
+  };
+
+  return success(c, response);
 };
 
 export const listRecurringPayments = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -6,6 +6,7 @@ import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
+  activateRecurringPayment,
   cancelRampTransfer,
   createOfframpQuote,
   createOnrampQuote,
@@ -93,6 +94,11 @@ payments.post(
   createRecurringPayment
 );
 payments.get("/recurring-payments", requirePermissions("payments:read"), listRecurringPayments);
+payments.post(
+  "/recurring-payments/:id/activate",
+  requirePermissions("payments:write", "wallets:read"),
+  activateRecurringPayment
+);
 payments.get("/recurring-payments/:id", requirePermissions("payments:read"), getRecurringPayment);
 payments.get("/subscription-plans", requirePermissions("payments:read"), listSubscriptionPlans);
 payments.post(

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -161,6 +161,8 @@ export const createRecurringPaymentSchema = z.object({
   metadataUri: z.string().url().max(128).optional(),
 });
 
+export const activateRecurringPaymentSchema = z.object({}).strict();
+
 export const listRecurringPaymentsQuerySchema = z.object({
   counterpartyId: z.string().min(1).optional(),
   status: paymentRecurringPaymentStatusSchema.optional(),

--- a/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
+++ b/apps/sdp-api/src/routes/wallet-scope-route-coverage.test.ts
@@ -76,6 +76,7 @@ describe("wallet-scoped route coverage inventory", () => {
       "POST /ramps/onramp/execute",
       "POST /ramps/onramp/quote",
       "POST /recurring-payments",
+      "POST /recurring-payments/:id/activate",
       "POST /subscription-plans",
       "POST /subscription-plans/:planId/prepare-create",
       "POST /subscriptions/:subscriptionId/prepare-collection",

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -1,15 +1,41 @@
 import {
+  type Address,
+  addSignersToTransactionMessage,
+  appendTransactionMessageInstructions,
+  createNoopSigner,
+  createTransactionMessage,
+  getTransactionEncoder,
+  type Instruction,
+  pipe,
+  type Signature,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
+import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
+import * as subscriptionsProgram from "@solana/subscriptions";
+import {
   createPaymentRecurringPaymentsRepository,
+  createPaymentSubscriptionsRepository,
   createPaymentsRepository,
 } from "@/db/repositories";
 import type { PaymentRecurringPaymentRow } from "@/db/repositories/payment-recurring-payments.repository";
+import { parseDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
+import {
+  resolveMintTokenProgram,
+  resolveSourceTokenAccount,
+} from "@/routes/payments/token-accounts";
+import { createFeePaymentAdapter } from "@/services/adapters/fee-payment";
 import { normalizePaymentToken, SOL_MINT } from "@/services/payment-operation.service";
 import { assertWalletPolicyAllowsTransferWithRepository } from "@/services/payments/wallet-policy";
+import * as solanaServices from "@/services/solana";
+import * as solanaRpc from "@/services/solana/rpc";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { resolveSolanaCounterpartyAccount } from "./counterparty-account-resolution";
+
+const U64_MAX = 18_446_744_073_709_551_615n;
 
 function assertRecurringPaymentTokenMint(token: string): string {
   const normalized = normalizePaymentToken(token);
@@ -18,6 +44,94 @@ function assertRecurringPaymentTokenMint(token: string): string {
   }
 
   return assertValidAddress(normalized, "token");
+}
+
+function generateProgramPlanId(): string {
+  const bytes = new Uint8Array(8);
+  let value = 0n;
+
+  while (value === 0n) {
+    crypto.getRandomValues(bytes);
+    value = 0n;
+    for (const byte of bytes) {
+      value = (value << 8n) | BigInt(byte);
+    }
+  }
+
+  return value.toString();
+}
+
+function parseU64String(value: string, fieldName: string): bigint {
+  try {
+    const parsed = BigInt(value);
+    if (parsed < 0n || parsed > U64_MAX) {
+      throw new Error("out of range");
+    }
+    return parsed;
+  } catch {
+    throw badRequest(`${fieldName} must fit in an unsigned 64-bit integer`);
+  }
+}
+
+async function sendSubscriptionInstructions(input: {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  sourceWallet: CustodyWallet;
+  instructions: Instruction[];
+  feePayer?: Address;
+}): Promise<Signature> {
+  const signer = await solanaServices.createOrgSigner(
+    input.env,
+    input.organizationId,
+    input.projectId,
+    input.sourceWallet.walletId
+  );
+
+  if (signer.address !== input.sourceWallet.publicKey) {
+    throw badRequest("Resolved signing wallet does not match source wallet");
+  }
+
+  const rpc = solanaRpc.createRpc(input.env);
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const feePayment = createFeePaymentAdapter(input.env);
+  const feePayer = input.feePayer ?? (await feePayment.getFeePayer());
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(feePayer, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(input.instructions, m),
+    (m) => addSignersToTransactionMessage([signer], m)
+  );
+  const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+  const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
+  return feePayment.signAndSend(txBytes);
+}
+
+async function confirmSubscriptionSignature(env: Env, signature: Signature): Promise<void> {
+  const rpc = solanaRpc.createRpc(env);
+  const confirmation = await solanaRpc.confirmTransaction(rpc, signature, {
+    commitment: "confirmed",
+  });
+
+  if (confirmation.err) {
+    throw new AppError("TRANSACTION_FAILED", "Recurring payment activation failed on-chain");
+  }
+}
+
+async function resetRecurringPaymentActivationUnlessAlreadyActive(input: {
+  recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
+  recurringPaymentId: string;
+  organizationId: string;
+  projectId: string;
+  updatedAt: string;
+}): Promise<void> {
+  await input.recurringRepo.resetRecurringPaymentActivationIfNotActive({
+    recurringPaymentId: input.recurringPaymentId,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    updatedAt: input.updatedAt,
+  });
 }
 
 export async function createRecurringPayment(input: {
@@ -80,4 +194,354 @@ export async function createRecurringPayment(input: {
   }
 
   return recurringPayment;
+}
+
+function assertActivationPreconditions(input: {
+  recurringPayment: PaymentRecurringPaymentRow;
+  sourceWallet: CustodyWallet;
+}): void {
+  if (input.recurringPayment.status === "activating") {
+    // PRO-1398 owns recovery for abandoned activations after crashes or partial chain state.
+    throw new AppError("CONFLICT", "Recurring payment activation is already processing");
+  }
+  if (input.recurringPayment.status !== "pending_activation") {
+    throw new AppError("CONFLICT", "Recurring payment cannot be activated from this status");
+  }
+  if (input.recurringPayment.source_wallet_id !== input.sourceWallet.walletId) {
+    throw badRequest("Recurring payment source wallet does not match request");
+  }
+  if (input.recurringPayment.source_address !== input.sourceWallet.publicKey) {
+    throw badRequest("Recurring payment source address does not match wallet");
+  }
+}
+
+export async function activateRecurringPayment(input: {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  sourceWallet: CustodyWallet;
+  recurringPayment: PaymentRecurringPaymentRow;
+  createdBy: string | null;
+}): Promise<PaymentRecurringPaymentRow> {
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
+  const rpc = solanaRpc.createRpc(input.env);
+  const nowIso = new Date().toISOString();
+
+  assertActivationPreconditions(input);
+
+  const claimed = await recurringRepo.claimRecurringPaymentActivation({
+    recurringPaymentId: input.recurringPayment.id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    updatedAt: nowIso,
+  });
+
+  if (!claimed) {
+    throw new AppError("CONFLICT", "Recurring payment activation is already processing");
+  }
+
+  let attemptedOnChainSubmission = false;
+
+  try {
+    const owner = assertValidAddress(claimed.source_address, "sourceAddress") as Address;
+    const destination = assertValidAddress(claimed.destination_address, "destinationAddress");
+    const mint = assertValidAddress(claimed.token, "token") as Address;
+    const tokenProgram = await resolveMintTokenProgram(rpc, mint);
+    const sourceTokenAccount = await resolveSourceTokenAccount(rpc, owner, mint, tokenProgram);
+    const amountBaseUnits = parseDecimalAmount(claimed.amount, sourceTokenAccount.decimals);
+
+    if (amountBaseUnits <= 0n) {
+      throw badRequest("Subscription amount must be greater than zero");
+    }
+
+    let plan = claimed.plan_id
+      ? await subscriptionsRepo.getPlanById({
+          planId: claimed.plan_id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+        })
+      : null;
+
+    if (!plan) {
+      const createdAt = new Date().toISOString();
+      plan = await subscriptionsRepo.createPlan({
+        id: `psp_${crypto.randomUUID()}`,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        ownerWalletId: input.sourceWallet.walletId,
+        ownerAddress: input.sourceWallet.publicKey,
+        token: claimed.token,
+        amount: claimed.amount,
+        periodHours: claimed.period_hours,
+        programPlanId: generateProgramPlanId(),
+        planPda: null,
+        destinationAddress: destination,
+        pullerWalletId: input.sourceWallet.walletId,
+        pullerAddress: input.sourceWallet.publicKey,
+        metadataUri: claimed.metadata_uri,
+        status: "draft",
+        createdBy: input.createdBy,
+        createdAt,
+        updatedAt: createdAt,
+      });
+
+      if (!plan) {
+        throw new AppError("INTERNAL_ERROR", "Failed to create subscription plan");
+      }
+    }
+
+    const programPlanId = parseU64String(plan.program_plan_id, "programPlanId");
+    const [planPda] = await subscriptionsProgram.findPlanPda({ owner, planId: programPlanId });
+    const planUpdatedAt = new Date().toISOString();
+
+    await subscriptionsRepo.updatePlan({
+      planId: plan.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planPda,
+      updatedAt: planUpdatedAt,
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planId: plan.id,
+      planPda,
+      updatedAt: planUpdatedAt,
+    });
+
+    const createPlanInstruction = await subscriptionsProgram.getCreatePlanOverlayInstructionAsync({
+      amount: amountBaseUnits,
+      destinations: [destination],
+      endTs: 0n,
+      metadataUri: claimed.metadata_uri ?? "",
+      mint,
+      owner: createNoopSigner(owner),
+      periodHours: BigInt(claimed.period_hours),
+      planId: programPlanId,
+      pullers: [owner],
+      tokenProgram,
+    });
+    attemptedOnChainSubmission = true;
+    const planCreationSignature = await sendSubscriptionInstructions({
+      env: input.env,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourceWallet: input.sourceWallet,
+      instructions: [createPlanInstruction],
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planCreationSignature,
+      updatedAt: new Date().toISOString(),
+    });
+    await confirmSubscriptionSignature(input.env, planCreationSignature);
+
+    const onChainPlan = await subscriptionsProgram.fetchMaybePlan(rpc, planPda, {
+      commitment: "confirmed",
+    });
+    if (!onChainPlan.exists) {
+      throw new AppError("TRANSACTION_FAILED", "Subscription plan was not found on-chain");
+    }
+    const planCreatedAt = onChainPlan.data.data.terms.createdAt.toString();
+
+    await subscriptionsRepo.updatePlan({
+      planId: plan.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planPda,
+      status: "active",
+      updatedAt: new Date().toISOString(),
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planCreatedAt,
+      updatedAt: new Date().toISOString(),
+    });
+
+    let subscription = claimed.subscription_id
+      ? await subscriptionsRepo.getSubscriptionById({
+          subscriptionId: claimed.subscription_id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+        })
+      : null;
+
+    if (!subscription) {
+      const createdAt = new Date().toISOString();
+      subscription = await subscriptionsRepo.createSubscription({
+        id: `psub_${crypto.randomUUID()}`,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        planId: plan.id,
+        counterpartyId: claimed.counterparty_id,
+        subscriberAddress: input.sourceWallet.publicKey,
+        subscriberTokenAccount: null,
+        subscriptionPda: null,
+        subscriptionAuthorityAddress: null,
+        authorizationSignature: null,
+        status: "pending_authorization",
+        currentPeriodStartAt: null,
+        nextCollectionDueAt: null,
+        createdBy: input.createdBy,
+        createdAt,
+        updatedAt: createdAt,
+      });
+
+      if (!subscription) {
+        throw new AppError("INTERNAL_ERROR", "Failed to create subscription");
+      }
+    }
+
+    const [subscriptionAuthorityAddress] = await subscriptionsProgram.findSubscriptionAuthorityPda({
+      tokenMint: mint,
+      user: owner,
+    });
+    const [subscriptionPda] = await subscriptionsProgram.findSubscriptionDelegationPda({
+      planPda,
+      subscriber: owner,
+    });
+    const authorizationUpdatedAt = new Date().toISOString();
+
+    await subscriptionsRepo.updateSubscription({
+      subscriptionId: subscription.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      subscriberTokenAccount: sourceTokenAccount.tokenAccount,
+      subscriptionPda,
+      subscriptionAuthorityAddress,
+      updatedAt: authorizationUpdatedAt,
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      subscriptionId: subscription.id,
+      subscriptionPda,
+      subscriptionAuthorityAddress,
+      updatedAt: authorizationUpdatedAt,
+    });
+
+    const subscriptionAuthority = await subscriptionsProgram.fetchMaybeSubscriptionAuthority(
+      rpc,
+      subscriptionAuthorityAddress,
+      { commitment: "confirmed" }
+    );
+    const expectedSubscriptionAuthorityInitId = subscriptionAuthority.exists
+      ? subscriptionAuthority.data.initId
+      : 0n;
+    const feePayer = await createFeePaymentAdapter(input.env).getFeePayer();
+    const payer = createNoopSigner(feePayer);
+    const subscriber = createNoopSigner(owner);
+    const initAuthorityInstruction =
+      await subscriptionsProgram.getInitSubscriptionAuthorityOverlayInstructionAsync({
+        owner: subscriber,
+        payer,
+        tokenMint: mint,
+        tokenProgram,
+        userAta: sourceTokenAccount.tokenAccount,
+      });
+    const subscribeInstruction = await subscriptionsProgram.getSubscribeOverlayInstructionAsync({
+      expectedAmount: amountBaseUnits,
+      expectedCreatedAt: BigInt(planCreatedAt),
+      expectedPeriodHours: BigInt(claimed.period_hours),
+      expectedSubscriptionAuthorityInitId,
+      merchant: owner,
+      payer,
+      planId: programPlanId,
+      subscriber,
+      tokenMint: mint,
+    });
+    attemptedOnChainSubmission = true;
+    const authorizationSignature = await sendSubscriptionInstructions({
+      env: input.env,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourceWallet: input.sourceWallet,
+      instructions: [initAuthorityInstruction, subscribeInstruction],
+      feePayer,
+    });
+    await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      authorizationSignature,
+      updatedAt: new Date().toISOString(),
+    });
+    await confirmSubscriptionSignature(input.env, authorizationSignature);
+
+    const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
+      rpc,
+      subscriptionPda,
+      { commitment: "confirmed" }
+    );
+    if (!onChainSubscription.exists) {
+      throw new AppError("TRANSACTION_FAILED", "Subscription authorization was not found on-chain");
+    }
+
+    const activatedAt = new Date().toISOString();
+    const nextCollectionDueAt =
+      claimed.first_collection_at ??
+      new Date(
+        new Date(activatedAt).getTime() + claimed.period_hours * 60 * 60 * 1000
+      ).toISOString();
+
+    await subscriptionsRepo.updateSubscription({
+      subscriptionId: subscription.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      authorizationSignature,
+      status: "active",
+      currentPeriodStartAt: activatedAt,
+      nextCollectionDueAt,
+      updatedAt: activatedAt,
+    });
+
+    const finalized = await recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "active",
+      planId: plan.id,
+      subscriptionId: subscription.id,
+      planPda,
+      planCreatedAt,
+      planCreationSignature,
+      subscriptionPda,
+      subscriptionAuthorityAddress,
+      authorizationSignature,
+      nextCollectionDueAt,
+      updatedAt: activatedAt,
+    });
+
+    if (!finalized) {
+      throw new AppError("INTERNAL_ERROR", "Failed to finalize recurring payment activation");
+    }
+
+    return finalized;
+  } catch (error) {
+    if (!attemptedOnChainSubmission) {
+      try {
+        await resetRecurringPaymentActivationUnlessAlreadyActive({
+          recurringRepo,
+          recurringPaymentId: claimed.id,
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          updatedAt: new Date().toISOString(),
+        });
+      } catch (resetError) {
+        console.error("Failed to reset recurring payment activation after local failure", {
+          error: resetError instanceof Error ? resetError.message : String(resetError),
+          recurringPaymentId: claimed.id,
+        });
+      }
+    }
+
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary
- Adds POST /v1/payments/recurring-payments/{id}/activate.
- Creates the Solana subscriptions plan and authorizes the subscription for a pending recurring payment.
- Persists plan/subscription PDAs, signatures, on-chain plan createdAt, subscription authority, and first due time for later collection work.
- Keeps recovery/idempotency/collection/cancel/resume/cron work out of this PR; PRO-1398 can layer recovery on top.
- Leaves rows in `activating` after attempted on-chain submission so PRO-1398 recovery can reconcile partial chain state instead of blind-retrying.

Supersedes the oversized/closed #419 with a clean branch from latest main.

## Diff Size
- 11 files changed, 843 insertions(+), 1 deletion(-).

## Local Checks
- `pnpm --filter @sdp/api lint`
- `doppler run -- pnpm --filter @sdp/api typecheck`
- `DATABASE_URL=postgresql://sdp:sdp@127.0.0.1:5432/sdp doppler run --preserve-env=DATABASE_URL -- pnpm --filter @sdp/api exec vitest run --config vitest.workers.config.ts src/routes/payments.test.ts`

## Notes
- Doppler is configured for this worktree with `dev_personal`; tests preserve local Postgres via `DATABASE_URL` to avoid shared secret DB writes.
- API lint currently exits 0 while printing existing repo warnings unrelated to this PR.
- Vitest emits existing Mosaic sourcemap warnings, but the focused payments route suite passes: 62 tests.