### PR TITLE
feat(api): harden recurring payment activation recovery

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0013_payment_recurring_payment_activation_attempts.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0013_payment_recurring_payment_activation_attempts.sql
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS payment_recurring_payment_activation_attempts (
     FOREIGN KEY (recurring_payment_id) REFERENCES payment_recurring_payments(id) ON DELETE CASCADE,
     CONSTRAINT payment_recurring_payment_activation_attempts_status_check
         CHECK (status IN ('processing', 'confirmed', 'failed')),
+    CONSTRAINT payment_recurring_payment_activation_attempts_stage_check
+        CHECK (stage IN ('claim', 'create_plan', 'authorize_subscription', 'finalize')),
     CONSTRAINT payment_recurring_payment_activation_attempts_metadata_is_object
         CHECK (jsonb_typeof(metadata) = 'object')
 );

--- a/apps/sdp-api/src/db/migrations/postgres/0013_payment_recurring_payment_activation_attempts.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0013_payment_recurring_payment_activation_attempts.sql
@@ -1,0 +1,30 @@
+-- Durable activation attempts for Recurring Payments. These rows make failed
+-- and resumed activation runs inspectable without exposing collection state.
+
+CREATE TABLE IF NOT EXISTS payment_recurring_payment_activation_attempts (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    recurring_payment_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'processing',
+    stage TEXT NOT NULL,
+    plan_creation_signature TEXT,
+    authorization_signature TEXT,
+    error TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (recurring_payment_id) REFERENCES payment_recurring_payments(id) ON DELETE CASCADE,
+    CONSTRAINT payment_recurring_payment_activation_attempts_status_check
+        CHECK (status IN ('processing', 'confirmed', 'failed')),
+    CONSTRAINT payment_recurring_payment_activation_attempts_metadata_is_object
+        CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_recurring_payment_activation_attempts_payment_created
+    ON payment_recurring_payment_activation_attempts(recurring_payment_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_payment_recurring_payment_activation_attempts_project_status
+    ON payment_recurring_payment_activation_attempts(organization_id, project_id, status, updated_at);

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -22,11 +22,15 @@ export type {
 } from "./counterparty-account.repository";
 export { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 export type {
+  CreatePaymentRecurringPaymentActivationAttemptInput,
   CreatePaymentRecurringPaymentInput,
   ListPaymentRecurringPaymentsInput,
   ListPaymentRecurringPaymentsResult,
+  PaymentRecurringPaymentActivationAttemptRow,
+  PaymentRecurringPaymentActivationAttemptStatus,
   PaymentRecurringPaymentRow,
   PaymentRecurringPaymentsRepository,
+  UpdatePaymentRecurringPaymentActivationAttemptInput,
   UpdatePaymentRecurringPaymentActivationInput,
 } from "./payment-recurring-payments.repository";
 export { createPostgresPaymentRecurringPaymentsRepository } from "./payment-recurring-payments.repository.postgres";

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -157,6 +157,7 @@ export function createPostgresPaymentRecurringPaymentsRepository(
     },
 
     async claimRecurringPaymentActivation(params) {
+      const staleBefore = params.staleBefore ?? null;
       const row = await db
         .prepare(
           `UPDATE payment_recurring_payments
@@ -167,7 +168,7 @@ export function createPostgresPaymentRecurringPaymentsRepository(
               AND project_id = ?
               AND (
                 status = 'pending_activation'
-                OR (status = 'activating' AND updated_at <= ?)
+                OR (status = 'activating' AND ?::text IS NOT NULL AND updated_at <= ?)
               )
           RETURNING *`
         )
@@ -176,7 +177,8 @@ export function createPostgresPaymentRecurringPaymentsRepository(
           params.recurringPaymentId,
           params.organizationId,
           params.projectId,
-          params.staleBefore ?? ""
+          staleBefore,
+          staleBefore
         )
         .first<Record<string, unknown>>();
 

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.postgres.ts
@@ -1,10 +1,13 @@
 import type { DatabaseExecutor } from "@/db";
 import type {
+  CreatePaymentRecurringPaymentActivationAttemptInput,
   CreatePaymentRecurringPaymentInput,
   ListPaymentRecurringPaymentsInput,
   ListPaymentRecurringPaymentsResult,
+  PaymentRecurringPaymentActivationAttemptRow,
   PaymentRecurringPaymentRow,
   PaymentRecurringPaymentsRepository,
+  UpdatePaymentRecurringPaymentActivationAttemptInput,
   UpdatePaymentRecurringPaymentActivationInput,
 } from "./payment-recurring-payments.repository";
 
@@ -45,6 +48,25 @@ function mapRecurringPaymentRow(row: Record<string, unknown>): PaymentRecurringP
   };
 }
 
+function mapActivationAttemptRow(
+  row: Record<string, unknown>
+): PaymentRecurringPaymentActivationAttemptRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    recurring_payment_id: row.recurring_payment_id as string,
+    status: row.status as PaymentRecurringPaymentActivationAttemptRow["status"],
+    stage: row.stage as string,
+    plan_creation_signature: (row.plan_creation_signature as string | null | undefined) ?? null,
+    authorization_signature: (row.authorization_signature as string | null | undefined) ?? null,
+    error: (row.error as string | null | undefined) ?? null,
+    metadata: (row.metadata as Record<string, unknown> | null | undefined) ?? {},
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
 async function getRecurringPaymentByIdInternal(
   db: DatabaseExecutor,
   params: { recurringPaymentId: string; organizationId: string; projectId: string }
@@ -61,6 +83,24 @@ async function getRecurringPaymentByIdInternal(
     .first<Record<string, unknown>>();
 
   return row ? mapRecurringPaymentRow(row) : null;
+}
+
+async function getActivationAttemptByIdInternal(
+  db: DatabaseExecutor,
+  params: { attemptId: string; organizationId: string; projectId: string }
+): Promise<PaymentRecurringPaymentActivationAttemptRow | null> {
+  const row = await db
+    .prepare(
+      `SELECT *
+         FROM payment_recurring_payment_activation_attempts
+        WHERE id = ?
+          AND organization_id = ?
+          AND project_id = ?`
+    )
+    .bind(params.attemptId, params.organizationId, params.projectId)
+    .first<Record<string, unknown>>();
+
+  return row ? mapActivationAttemptRow(row) : null;
 }
 
 export function createPostgresPaymentRecurringPaymentsRepository(
@@ -125,10 +165,19 @@ export function createPostgresPaymentRecurringPaymentsRepository(
             WHERE id = ?
               AND organization_id = ?
               AND project_id = ?
-              AND status = 'pending_activation'
+              AND (
+                status = 'pending_activation'
+                OR (status = 'activating' AND updated_at <= ?)
+              )
           RETURNING *`
         )
-        .bind(params.updatedAt, params.recurringPaymentId, params.organizationId, params.projectId)
+        .bind(
+          params.updatedAt,
+          params.recurringPaymentId,
+          params.organizationId,
+          params.projectId,
+          params.staleBefore ?? ""
+        )
         .first<Record<string, unknown>>();
 
       return row ? mapRecurringPaymentRow(row) : null;
@@ -212,6 +261,89 @@ export function createPostgresPaymentRecurringPaymentsRepository(
         .first<Record<string, unknown>>();
 
       return row ? mapRecurringPaymentRow(row) : null;
+    },
+
+    async createActivationAttempt(input: CreatePaymentRecurringPaymentActivationAttemptInput) {
+      await db
+        .prepare(
+          `INSERT INTO payment_recurring_payment_activation_attempts (
+             id,
+             organization_id,
+             project_id,
+             recurring_payment_id,
+             status,
+             stage,
+             plan_creation_signature,
+             authorization_signature,
+             error,
+             metadata,
+             created_at,
+             updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)`
+        )
+        .bind(
+          input.id,
+          input.organizationId,
+          input.projectId,
+          input.recurringPaymentId,
+          input.status,
+          input.stage,
+          input.planCreationSignature,
+          input.authorizationSignature,
+          input.error,
+          JSON.stringify(input.metadata),
+          input.createdAt,
+          input.updatedAt
+        )
+        .run();
+
+      return getActivationAttemptByIdInternal(db, {
+        attemptId: input.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
+    },
+
+    async updateActivationAttempt(input: UpdatePaymentRecurringPaymentActivationAttemptInput) {
+      await db
+        .prepare(
+          `UPDATE payment_recurring_payment_activation_attempts
+              SET status = COALESCE(?, status),
+                  stage = COALESCE(?, stage),
+                  plan_creation_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE plan_creation_signature END,
+                  authorization_signature =
+                    CASE WHEN ?::boolean THEN ? ELSE authorization_signature END,
+                  error = CASE WHEN ?::boolean THEN ? ELSE error END,
+                  metadata = CASE WHEN ?::boolean THEN ?::jsonb ELSE metadata END,
+                  updated_at = ?
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?`
+        )
+        .bind(
+          input.status ?? null,
+          input.stage ?? null,
+          input.planCreationSignature !== undefined,
+          input.planCreationSignature ?? null,
+          input.authorizationSignature !== undefined,
+          input.authorizationSignature ?? null,
+          input.error !== undefined,
+          input.error ?? null,
+          input.metadata !== undefined,
+          JSON.stringify(input.metadata ?? {}),
+          input.updatedAt,
+          input.attemptId,
+          input.organizationId,
+          input.projectId
+        )
+        .run();
+
+      return getActivationAttemptByIdInternal(db, {
+        attemptId: input.attemptId,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      });
     },
 
     async getRecurringPaymentById(params) {

--- a/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-recurring-payments.repository.ts
@@ -30,6 +30,23 @@ export interface PaymentRecurringPaymentRow {
   updated_at: string;
 }
 
+export type PaymentRecurringPaymentActivationAttemptStatus = "processing" | "confirmed" | "failed";
+
+export interface PaymentRecurringPaymentActivationAttemptRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  recurring_payment_id: string;
+  status: PaymentRecurringPaymentActivationAttemptStatus;
+  stage: string;
+  plan_creation_signature: string | null;
+  authorization_signature: string | null;
+  error: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface CreatePaymentRecurringPaymentInput {
   id: string;
   organizationId: string;
@@ -67,6 +84,34 @@ export interface UpdatePaymentRecurringPaymentActivationInput {
   updatedAt: string;
 }
 
+export interface CreatePaymentRecurringPaymentActivationAttemptInput {
+  id: string;
+  organizationId: string;
+  projectId: string;
+  recurringPaymentId: string;
+  status: PaymentRecurringPaymentActivationAttemptStatus;
+  stage: string;
+  planCreationSignature: string | null;
+  authorizationSignature: string | null;
+  error: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdatePaymentRecurringPaymentActivationAttemptInput {
+  attemptId: string;
+  organizationId: string;
+  projectId: string;
+  status?: PaymentRecurringPaymentActivationAttemptStatus;
+  stage?: string;
+  planCreationSignature?: string | null;
+  authorizationSignature?: string | null;
+  error?: string | null;
+  metadata?: Record<string, unknown>;
+  updatedAt: string;
+}
+
 export interface ListPaymentRecurringPaymentsInput {
   organizationId: string;
   projectId: string;
@@ -91,6 +136,7 @@ export interface PaymentRecurringPaymentsRepository {
     organizationId: string;
     projectId: string;
     updatedAt: string;
+    staleBefore?: string;
   }): Promise<PaymentRecurringPaymentRow | null>;
   resetRecurringPaymentActivationIfNotActive(params: {
     recurringPaymentId: string;
@@ -101,6 +147,12 @@ export interface PaymentRecurringPaymentsRepository {
   updateRecurringPaymentActivation(
     input: UpdatePaymentRecurringPaymentActivationInput
   ): Promise<PaymentRecurringPaymentRow | null>;
+  createActivationAttempt(
+    input: CreatePaymentRecurringPaymentActivationAttemptInput
+  ): Promise<PaymentRecurringPaymentActivationAttemptRow | null>;
+  updateActivationAttempt(
+    input: UpdatePaymentRecurringPaymentActivationAttemptInput
+  ): Promise<PaymentRecurringPaymentActivationAttemptRow | null>;
   getRecurringPaymentById(params: {
     recurringPaymentId: string;
     organizationId: string;

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1215,6 +1215,138 @@ describe("Payments routes", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(3);
   });
 
+  it("clears failed authorization signatures when finalization cannot find the subscription", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    fetchMaybeSubscriptionDelegationMock
+      .mockResolvedValueOnce({
+        exists: false,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>)
+      .mockResolvedValue({
+        exists: true,
+        address: address(TEST_SOLANA_ADDRESSES.wallet3),
+        data: {},
+      } as Awaited<ReturnType<typeof subscriptionsProgram.fetchMaybeSubscriptionDelegation>>);
+    const planSignature =
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+    const failedAuthorizationSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const retryAuthorizationSignature =
+      "3eWxmHfS3EPf7nmtdDQ6CTwWqCnX2bAdtc9h1kReBLbqjP99kphnf3UhpSGA8qpmkHxnhqsWyVbRoQY2yagRZkzp" as Signature;
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(planSignature)
+      .mockResolvedValueOnce(failedAuthorizationSignature)
+      .mockResolvedValueOnce(retryAuthorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_missing_delegation_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(failedRes.status).toBe(400);
+    const getAfterFailureRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}`,
+      { headers: { Authorization: `Bearer ${TEST_API_KEY.raw}` } },
+      env
+    );
+    const getAfterFailureBody = (await getAfterFailureRes.json()) as {
+      data: {
+        recurringPayment: {
+          status: string;
+          planCreationSignature: string | null;
+          authorizationSignature: string | null;
+        };
+      };
+    };
+    expect(getAfterFailureBody.data.recurringPayment).toMatchObject({
+      status: "pending_activation",
+      planCreationSignature: planSignature,
+      authorizationSignature: null,
+    });
+
+    const attempts = await getDb(env)
+      .prepare(
+        `SELECT status, stage, error
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?
+          ORDER BY created_at DESC`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .all<{ status: string; stage: string; error: string | null }>();
+    expect(attempts.results[0]).toMatchObject({
+      status: "failed",
+      stage: "finalize",
+      error: "Subscription authorization was not found on-chain",
+    });
+
+    const retryRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(retryRes.status).toBe(200);
+    const retryBody = (await retryRes.json()) as {
+      data: {
+        recurringPayment: {
+          status: string;
+          planCreationSignature: string;
+          authorizationSignature: string;
+        };
+      };
+    };
+    expect(retryBody.data.recurringPayment).toMatchObject({
+      status: "active",
+      planCreationSignature: planSignature,
+      authorizationSignature: retryAuthorizationSignature,
+    });
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
+  });
+
   it("requires owner wallet access when updating subscription plans", async () => {
     env.PAYMENTS_RECURRING_ENABLED = "true";
     const headers = {

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -816,6 +816,403 @@ describe("Payments routes", () => {
     expect(activateBody.data.recurringPayment.subscriptionAuthorityAddress).toBeTruthy();
     expect(activateBody.data.recurringPayment.nextCollectionDueAt).toBeTruthy();
     expect(signAndSendMock).toHaveBeenCalledTimes(2);
+    const confirmedAttempts = await getDb(env)
+      .prepare(
+        `SELECT status, stage, plan_creation_signature, authorization_signature
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?
+          ORDER BY created_at DESC`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .all<{
+        status: string;
+        stage: string;
+        plan_creation_signature: string | null;
+        authorization_signature: string | null;
+      }>();
+    expect(confirmedAttempts.results[0]).toMatchObject({
+      status: "confirmed",
+      stage: "finalize",
+      plan_creation_signature: activateBody.data.recurringPayment.planCreationSignature,
+      authorization_signature: activateBody.data.recurringPayment.authorizationSignature,
+    });
+
+    const replayRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      {
+        method: "POST",
+        headers,
+      },
+      env
+    );
+
+    expect(replayRes.status).toBe(200);
+    const replayBody = (await replayRes.json()) as {
+      data: { recurringPayment: { id: string; status: string; authorizationSignature: string } };
+    };
+    expect(replayBody.data.recurringPayment).toMatchObject({
+      id: createBody.data.recurringPayment.id,
+      status: "active",
+      authorizationSignature: activateBody.data.recurringPayment.authorizationSignature,
+    });
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("journals failed activation attempts and allows activation retry", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock
+      .mockRejectedValueOnce(new Error("signer temporarily unavailable"))
+      .mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+      )
+      .mockResolvedValueOnce(
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      );
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_recovery_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(failedRes.status).toBe(500);
+    const getAfterFailureRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}`,
+      { headers: { Authorization: `Bearer ${TEST_API_KEY.raw}` } },
+      env
+    );
+    expect(getAfterFailureRes.status).toBe(200);
+    const getAfterFailureBody = (await getAfterFailureRes.json()) as {
+      data: { recurringPayment: { status: string } };
+    };
+    expect(getAfterFailureBody.data.recurringPayment.status).toBe("pending_activation");
+
+    const attempts = await getDb(env)
+      .prepare(
+        `SELECT status, stage, error
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?
+          ORDER BY created_at DESC`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .all<{ status: string; stage: string; error: string | null }>();
+    expect(attempts.results[0]).toMatchObject({
+      status: "failed",
+      stage: "create_plan",
+    });
+    expect(attempts.results[0]?.error).toContain("signer temporarily unavailable");
+
+    const retryRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(retryRes.status).toBe(200);
+    const retryBody = (await retryRes.json()) as {
+      data: { recurringPayment: { status: string } };
+    };
+    expect(retryBody.data.recurringPayment.status).toBe("active");
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers stale activating recurring payments without recreating the plan", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const authorizationSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const signAndSendMock = vi.fn().mockResolvedValue(authorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_stale_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+    const planId = `psp_${crypto.randomUUID()}`;
+    const now = new Date().toISOString();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_subscription_plans (
+           id,
+           organization_id,
+           project_id,
+           owner_wallet_id,
+           owner_address,
+           token,
+           amount,
+           period_hours,
+           program_plan_id,
+           status,
+           created_by,
+           created_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        planId,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_WALLET_ID,
+        sourceSigner.address,
+        DEVNET_USDC_MINT,
+        "25.00",
+        24,
+        "1001",
+        "active",
+        TEST_USER.id,
+        now,
+        now
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        `UPDATE payment_recurring_payments
+            SET status = 'activating',
+                plan_id = ?,
+                plan_created_at = ?,
+                plan_creation_signature = ?,
+                updated_at = ?
+          WHERE id = ?`
+      )
+      .bind(
+        planId,
+        "1770000000",
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy",
+        now,
+        createBody.data.recurringPayment.id
+      )
+      .run();
+
+    const freshRetryRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+    expect(freshRetryRes.status).toBe(409);
+
+    await getDb(env)
+      .prepare("UPDATE payment_recurring_payments SET updated_at = ? WHERE id = ?")
+      .bind(
+        new Date(Date.now() - 16 * 60 * 1000).toISOString(),
+        createBody.data.recurringPayment.id
+      )
+      .run();
+
+    const staleRetryRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(staleRetryRes.status).toBe(200);
+    const staleRetryBody = (await staleRetryRes.json()) as {
+      data: { recurringPayment: { status: string; authorizationSignature: string } };
+    };
+    expect(staleRetryBody.data.recurringPayment).toMatchObject({
+      status: "active",
+      authorizationSignature,
+    });
+    expect(signAndSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("journals failed on-chain activation attempts and retries with a fresh signature", async () => {
+    env.PAYMENTS_RECURRING_ENABLED = "true";
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const failedPlanSignature =
+      "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+    const retryPlanSignature =
+      "3eWxmHfS3EPf7nmtdDQ6CTwWqCnX2bAdtc9h1kReBLbqjP99kphnf3UhpSGA8qpmkHxnhqsWyVbRoQY2yagRZkzp" as Signature;
+    const authorizationSignature =
+      "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature;
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(failedPlanSignature)
+      .mockResolvedValueOnce(retryPlanSignature)
+      .mockResolvedValueOnce(authorizationSignature);
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock
+      .mockResolvedValueOnce({
+        signature: failedPlanSignature,
+        slot: 100n,
+        confirmationStatus: "confirmed",
+        err: { InstructionError: [0, "Custom"] },
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>)
+      .mockResolvedValue({
+        signature: retryPlanSignature,
+        slot: 101n,
+        confirmationStatus: "confirmed",
+        err: null,
+      } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const counterpartyId = await seedCounterparty({
+      externalId: "recurring_activation_onchain_failure_counterparty",
+    });
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      address: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const createRes = await app.request(
+      "/v1/payments/recurring-payments",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          sourceWalletId: TEST_WALLET_ID,
+          counterpartyId,
+          counterpartyAccountId,
+          token: DEVNET_USDC_MINT,
+          amount: "25.00",
+          periodHours: 24,
+        }),
+      },
+      env
+    );
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as {
+      data: { recurringPayment: { id: string } };
+    };
+
+    const failedRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(failedRes.status).toBe(400);
+    const getAfterFailureRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}`,
+      { headers: { Authorization: `Bearer ${TEST_API_KEY.raw}` } },
+      env
+    );
+    const getAfterFailureBody = (await getAfterFailureRes.json()) as {
+      data: { recurringPayment: { status: string; planCreationSignature: string | null } };
+    };
+    expect(getAfterFailureBody.data.recurringPayment).toMatchObject({
+      status: "pending_activation",
+      planCreationSignature: null,
+    });
+
+    const attempts = await getDb(env)
+      .prepare(
+        `SELECT status, stage, error
+           FROM payment_recurring_payment_activation_attempts
+          WHERE recurring_payment_id = ?
+          ORDER BY created_at DESC`
+      )
+      .bind(createBody.data.recurringPayment.id)
+      .all<{ status: string; stage: string; error: string | null }>();
+    expect(attempts.results[0]).toMatchObject({
+      status: "failed",
+      stage: "create_plan",
+      error: "Recurring payment activation failed on-chain",
+    });
+
+    const retryRes = await app.request(
+      `/v1/payments/recurring-payments/${createBody.data.recurringPayment.id}/activate`,
+      { method: "POST", headers },
+      env
+    );
+
+    expect(retryRes.status).toBe(200);
+    const retryBody = (await retryRes.json()) as {
+      data: { recurringPayment: { status: string; planCreationSignature: string } };
+    };
+    expect(retryBody.data.recurringPayment).toMatchObject({
+      status: "active",
+      planCreationSignature: retryPlanSignature,
+    });
+    expect(signAndSendMock).toHaveBeenCalledTimes(3);
   });
 
   it("requires owner wallet access when updating subscription plans", async () => {

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -287,12 +287,14 @@ async function recordActivationFailure(input: {
   });
 
   if (input.error instanceof AppError && input.error.code === "TRANSACTION_FAILED") {
+    const shouldClearAuthorizationSignature =
+      input.stage === "authorize_subscription" || input.stage === "finalize";
     await input.recurringRepo.updateRecurringPaymentActivation({
       recurringPaymentId: input.claimed.id,
       organizationId: input.organizationId,
       projectId: input.projectId,
       ...(input.stage === "create_plan" ? { planCreationSignature: null } : {}),
-      ...(input.stage === "authorize_subscription" ? { authorizationSignature: null } : {}),
+      ...(shouldClearAuthorizationSignature ? { authorizationSignature: null } : {}),
       updatedAt: input.failedAt,
     });
   }

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -17,8 +17,13 @@ import {
   createPaymentRecurringPaymentsRepository,
   createPaymentSubscriptionsRepository,
   createPaymentsRepository,
+  type PaymentRecurringPaymentActivationAttemptRow,
+  type PaymentRecurringPaymentRow,
+  type PaymentRecurringPaymentsRepository,
+  type PaymentSubscriptionPlanRow,
+  type PaymentSubscriptionRow,
+  type PaymentSubscriptionsRepository,
 } from "@/db/repositories";
-import type { PaymentRecurringPaymentRow } from "@/db/repositories/payment-recurring-payments.repository";
 import { parseDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
@@ -36,6 +41,9 @@ import type { Env } from "@/types/env";
 import { resolveSolanaCounterpartyAccount } from "./counterparty-account-resolution";
 
 const U64_MAX = 18_446_744_073_709_551_615n;
+const ACTIVATION_STALE_AFTER_MS = 15 * 60 * 1000;
+
+type ActivationAttemptStage = "claim" | "create_plan" | "authorize_subscription" | "finalize";
 
 function assertRecurringPaymentTokenMint(token: string): string {
   const normalized = normalizePaymentToken(token);
@@ -134,6 +142,170 @@ async function resetRecurringPaymentActivationUnlessAlreadyActive(input: {
   });
 }
 
+function activationStaleBefore(nowIso: string): string {
+  return new Date(new Date(nowIso).getTime() - ACTIVATION_STALE_AFTER_MS).toISOString();
+}
+
+function isStaleActivation(row: PaymentRecurringPaymentRow, nowIso: string): boolean {
+  return new Date(row.updated_at).getTime() <= new Date(activationStaleBefore(nowIso)).getTime();
+}
+
+function activationErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function getOrCreateActivationPlan(input: {
+  subscriptionsRepo: PaymentSubscriptionsRepository;
+  claimed: PaymentRecurringPaymentRow;
+  organizationId: string;
+  projectId: string;
+  sourceWallet: CustodyWallet;
+  destination: string;
+  createdBy: string | null;
+}): Promise<PaymentSubscriptionPlanRow> {
+  const existing = input.claimed.plan_id
+    ? await input.subscriptionsRepo.getPlanById({
+        planId: input.claimed.plan_id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      })
+    : null;
+
+  if (existing) {
+    return existing;
+  }
+
+  const createdAt = new Date().toISOString();
+  const plan = await input.subscriptionsRepo.createPlan({
+    id: `psp_${crypto.randomUUID()}`,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    ownerWalletId: input.sourceWallet.walletId,
+    ownerAddress: input.sourceWallet.publicKey,
+    token: input.claimed.token,
+    amount: input.claimed.amount,
+    periodHours: input.claimed.period_hours,
+    programPlanId: generateProgramPlanId(),
+    planPda: null,
+    destinationAddress: input.destination,
+    pullerWalletId: input.sourceWallet.walletId,
+    pullerAddress: input.sourceWallet.publicKey,
+    metadataUri: input.claimed.metadata_uri,
+    status: "draft",
+    createdBy: input.createdBy,
+    createdAt,
+    updatedAt: createdAt,
+  });
+
+  if (!plan) {
+    throw new AppError("INTERNAL_ERROR", "Failed to create subscription plan");
+  }
+
+  return plan;
+}
+
+async function getOrCreateActivationSubscription(input: {
+  subscriptionsRepo: PaymentSubscriptionsRepository;
+  claimed: PaymentRecurringPaymentRow;
+  organizationId: string;
+  projectId: string;
+  planId: string;
+  subscriberAddress: string;
+  createdBy: string | null;
+}): Promise<PaymentSubscriptionRow> {
+  const existing = input.claimed.subscription_id
+    ? await input.subscriptionsRepo.getSubscriptionById({
+        subscriptionId: input.claimed.subscription_id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      })
+    : null;
+
+  if (existing) {
+    return existing;
+  }
+
+  const createdAt = new Date().toISOString();
+  const created = await input.subscriptionsRepo.createSubscription({
+    id: `psub_${crypto.randomUUID()}`,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    planId: input.planId,
+    counterpartyId: input.claimed.counterparty_id,
+    subscriberAddress: input.subscriberAddress,
+    subscriberTokenAccount: null,
+    subscriptionPda: null,
+    subscriptionAuthorityAddress: null,
+    authorizationSignature: null,
+    status: "pending_authorization",
+    currentPeriodStartAt: null,
+    nextCollectionDueAt: null,
+    createdBy: input.createdBy,
+    createdAt,
+    updatedAt: createdAt,
+  });
+
+  if (created) {
+    return created;
+  }
+
+  const matched = await input.subscriptionsRepo.listSubscriptions({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    planId: input.planId,
+    counterpartyId: input.claimed.counterparty_id,
+    limit: 1,
+    offset: 0,
+  });
+
+  const subscription = matched.rows[0] ?? null;
+  if (!subscription) {
+    throw new AppError("INTERNAL_ERROR", "Failed to create subscription");
+  }
+
+  return subscription;
+}
+
+async function recordActivationFailure(input: {
+  recurringRepo: PaymentRecurringPaymentsRepository;
+  attempt: PaymentRecurringPaymentActivationAttemptRow;
+  claimed: PaymentRecurringPaymentRow;
+  organizationId: string;
+  projectId: string;
+  stage: ActivationAttemptStage;
+  error: unknown;
+  failedAt: string;
+}): Promise<void> {
+  await input.recurringRepo.updateActivationAttempt({
+    attemptId: input.attempt.id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    status: "failed",
+    stage: input.stage,
+    error: activationErrorMessage(input.error),
+    updatedAt: input.failedAt,
+  });
+
+  if (input.error instanceof AppError && input.error.code === "TRANSACTION_FAILED") {
+    await input.recurringRepo.updateRecurringPaymentActivation({
+      recurringPaymentId: input.claimed.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      ...(input.stage === "create_plan" ? { planCreationSignature: null } : {}),
+      ...(input.stage === "authorize_subscription" ? { authorizationSignature: null } : {}),
+      updatedAt: input.failedAt,
+    });
+  }
+
+  await resetRecurringPaymentActivationUnlessAlreadyActive({
+    recurringRepo: input.recurringRepo,
+    recurringPaymentId: input.claimed.id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    updatedAt: input.failedAt,
+  });
+}
+
 export async function createRecurringPayment(input: {
   env: Env;
   organizationId: string;
@@ -199,19 +371,25 @@ export async function createRecurringPayment(input: {
 function assertActivationPreconditions(input: {
   recurringPayment: PaymentRecurringPaymentRow;
   sourceWallet: CustodyWallet;
+  nowIso: string;
 }): void {
-  if (input.recurringPayment.status === "activating") {
-    // PRO-1398 owns recovery for abandoned activations after crashes or partial chain state.
-    throw new AppError("CONFLICT", "Recurring payment activation is already processing");
-  }
-  if (input.recurringPayment.status !== "pending_activation") {
-    throw new AppError("CONFLICT", "Recurring payment cannot be activated from this status");
-  }
   if (input.recurringPayment.source_wallet_id !== input.sourceWallet.walletId) {
     throw badRequest("Recurring payment source wallet does not match request");
   }
   if (input.recurringPayment.source_address !== input.sourceWallet.publicKey) {
     throw badRequest("Recurring payment source address does not match wallet");
+  }
+  if (input.recurringPayment.status === "active") {
+    return;
+  }
+  if (input.recurringPayment.status === "activating") {
+    if (isStaleActivation(input.recurringPayment, input.nowIso)) {
+      return;
+    }
+    throw new AppError("CONFLICT", "Recurring payment activation is already processing");
+  }
+  if (input.recurringPayment.status !== "pending_activation") {
+    throw new AppError("CONFLICT", "Recurring payment cannot be activated from this status");
   }
 }
 
@@ -228,20 +406,54 @@ export async function activateRecurringPayment(input: {
   const rpc = solanaRpc.createRpc(input.env);
   const nowIso = new Date().toISOString();
 
-  assertActivationPreconditions(input);
+  assertActivationPreconditions({ ...input, nowIso });
+  if (input.recurringPayment.status === "active") {
+    return input.recurringPayment;
+  }
+
+  const attempt = await recurringRepo.createActivationAttempt({
+    id: `prpa_${crypto.randomUUID()}`,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    recurringPaymentId: input.recurringPayment.id,
+    status: "processing",
+    stage: "claim",
+    planCreationSignature: input.recurringPayment.plan_creation_signature,
+    authorizationSignature: input.recurringPayment.authorization_signature,
+    error: null,
+    metadata: {},
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  if (!attempt) {
+    throw new AppError("INTERNAL_ERROR", "Failed to journal recurring payment activation");
+  }
 
   const claimed = await recurringRepo.claimRecurringPaymentActivation({
     recurringPaymentId: input.recurringPayment.id,
     organizationId: input.organizationId,
     projectId: input.projectId,
     updatedAt: nowIso,
+    staleBefore: activationStaleBefore(nowIso),
   });
 
   if (!claimed) {
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "failed",
+      stage: "claim",
+      error: "Recurring payment activation is already processing",
+      updatedAt: new Date().toISOString(),
+    });
     throw new AppError("CONFLICT", "Recurring payment activation is already processing");
   }
 
-  let attemptedOnChainSubmission = false;
+  let currentStage: ActivationAttemptStage = "create_plan";
+  let planCreationSignature = claimed.plan_creation_signature as Signature | null;
+  let authorizationSignature = claimed.authorization_signature as Signature | null;
 
   try {
     const owner = assertValidAddress(claimed.source_address, "sourceAddress") as Address;
@@ -255,41 +467,15 @@ export async function activateRecurringPayment(input: {
       throw badRequest("Subscription amount must be greater than zero");
     }
 
-    let plan = claimed.plan_id
-      ? await subscriptionsRepo.getPlanById({
-          planId: claimed.plan_id,
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-        })
-      : null;
-
-    if (!plan) {
-      const createdAt = new Date().toISOString();
-      plan = await subscriptionsRepo.createPlan({
-        id: `psp_${crypto.randomUUID()}`,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        ownerWalletId: input.sourceWallet.walletId,
-        ownerAddress: input.sourceWallet.publicKey,
-        token: claimed.token,
-        amount: claimed.amount,
-        periodHours: claimed.period_hours,
-        programPlanId: generateProgramPlanId(),
-        planPda: null,
-        destinationAddress: destination,
-        pullerWalletId: input.sourceWallet.walletId,
-        pullerAddress: input.sourceWallet.publicKey,
-        metadataUri: claimed.metadata_uri,
-        status: "draft",
-        createdBy: input.createdBy,
-        createdAt,
-        updatedAt: createdAt,
-      });
-
-      if (!plan) {
-        throw new AppError("INTERNAL_ERROR", "Failed to create subscription plan");
-      }
-    }
+    const plan = await getOrCreateActivationPlan({
+      subscriptionsRepo,
+      claimed,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourceWallet: input.sourceWallet,
+      destination,
+      createdBy: input.createdBy,
+    });
 
     const programPlanId = parseU64String(plan.program_plan_id, "programPlanId");
     const [planPda] = await subscriptionsProgram.findPlanPda({ owner, planId: programPlanId });
@@ -311,33 +497,51 @@ export async function activateRecurringPayment(input: {
       updatedAt: planUpdatedAt,
     });
 
-    const createPlanInstruction = await subscriptionsProgram.getCreatePlanOverlayInstructionAsync({
-      amount: amountBaseUnits,
-      destinations: [destination],
-      endTs: 0n,
-      metadataUri: claimed.metadata_uri ?? "",
-      mint,
-      owner: createNoopSigner(owner),
-      periodHours: BigInt(claimed.period_hours),
-      planId: programPlanId,
-      pullers: [owner],
-      tokenProgram,
-    });
-    attemptedOnChainSubmission = true;
-    const planCreationSignature = await sendSubscriptionInstructions({
-      env: input.env,
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
       organizationId: input.organizationId,
       projectId: input.projectId,
-      sourceWallet: input.sourceWallet,
-      instructions: [createPlanInstruction],
-    });
-    await recurringRepo.updateRecurringPaymentActivation({
-      recurringPaymentId: claimed.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      planCreationSignature,
+      stage: currentStage,
       updatedAt: new Date().toISOString(),
     });
+    if (!planCreationSignature) {
+      const createPlanInstruction = await subscriptionsProgram.getCreatePlanOverlayInstructionAsync(
+        {
+          amount: amountBaseUnits,
+          destinations: [destination],
+          endTs: 0n,
+          metadataUri: claimed.metadata_uri ?? "",
+          mint,
+          owner: createNoopSigner(owner),
+          periodHours: BigInt(claimed.period_hours),
+          planId: programPlanId,
+          pullers: [owner],
+          tokenProgram,
+        }
+      );
+      planCreationSignature = await sendSubscriptionInstructions({
+        env: input.env,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourceWallet: input.sourceWallet,
+        instructions: [createPlanInstruction],
+      });
+      const signatureUpdatedAt = new Date().toISOString();
+      await recurringRepo.updateRecurringPaymentActivation({
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        planCreationSignature,
+        updatedAt: signatureUpdatedAt,
+      });
+      await recurringRepo.updateActivationAttempt({
+        attemptId: attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        planCreationSignature,
+        updatedAt: signatureUpdatedAt,
+      });
+    }
     await confirmSubscriptionSignature(input.env, planCreationSignature);
 
     const onChainPlan = await subscriptionsProgram.fetchMaybePlan(rpc, planPda, {
@@ -364,40 +568,17 @@ export async function activateRecurringPayment(input: {
       updatedAt: new Date().toISOString(),
     });
 
-    let subscription = claimed.subscription_id
-      ? await subscriptionsRepo.getSubscriptionById({
-          subscriptionId: claimed.subscription_id,
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-        })
-      : null;
+    const subscription = await getOrCreateActivationSubscription({
+      subscriptionsRepo,
+      claimed,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      planId: plan.id,
+      subscriberAddress: input.sourceWallet.publicKey,
+      createdBy: input.createdBy,
+    });
 
-    if (!subscription) {
-      const createdAt = new Date().toISOString();
-      subscription = await subscriptionsRepo.createSubscription({
-        id: `psub_${crypto.randomUUID()}`,
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        planId: plan.id,
-        counterpartyId: claimed.counterparty_id,
-        subscriberAddress: input.sourceWallet.publicKey,
-        subscriberTokenAccount: null,
-        subscriptionPda: null,
-        subscriptionAuthorityAddress: null,
-        authorizationSignature: null,
-        status: "pending_authorization",
-        currentPeriodStartAt: null,
-        nextCollectionDueAt: null,
-        createdBy: input.createdBy,
-        createdAt,
-        updatedAt: createdAt,
-      });
-
-      if (!subscription) {
-        throw new AppError("INTERNAL_ERROR", "Failed to create subscription");
-      }
-    }
-
+    currentStage = "authorize_subscription";
     const [subscriptionAuthorityAddress] = await subscriptionsProgram.findSubscriptionAuthorityPda({
       tokenMint: mint,
       user: owner,
@@ -426,55 +607,72 @@ export async function activateRecurringPayment(input: {
       subscriptionAuthorityAddress,
       updatedAt: authorizationUpdatedAt,
     });
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      stage: currentStage,
+      updatedAt: authorizationUpdatedAt,
+    });
 
-    const subscriptionAuthority = await subscriptionsProgram.fetchMaybeSubscriptionAuthority(
-      rpc,
-      subscriptionAuthorityAddress,
-      { commitment: "confirmed" }
-    );
-    const expectedSubscriptionAuthorityInitId = subscriptionAuthority.exists
-      ? subscriptionAuthority.data.initId
-      : 0n;
-    const feePayer = await createFeePaymentAdapter(input.env).getFeePayer();
-    const payer = createNoopSigner(feePayer);
-    const subscriber = createNoopSigner(owner);
-    const initAuthorityInstruction =
-      await subscriptionsProgram.getInitSubscriptionAuthorityOverlayInstructionAsync({
-        owner: subscriber,
+    if (!authorizationSignature) {
+      const subscriptionAuthority = await subscriptionsProgram.fetchMaybeSubscriptionAuthority(
+        rpc,
+        subscriptionAuthorityAddress,
+        { commitment: "confirmed" }
+      );
+      const expectedSubscriptionAuthorityInitId = subscriptionAuthority.exists
+        ? subscriptionAuthority.data.initId
+        : 0n;
+      const feePayer = await createFeePaymentAdapter(input.env).getFeePayer();
+      const payer = createNoopSigner(feePayer);
+      const subscriber = createNoopSigner(owner);
+      const initAuthorityInstruction =
+        await subscriptionsProgram.getInitSubscriptionAuthorityOverlayInstructionAsync({
+          owner: subscriber,
+          payer,
+          tokenMint: mint,
+          tokenProgram,
+          userAta: sourceTokenAccount.tokenAccount,
+        });
+      const subscribeInstruction = await subscriptionsProgram.getSubscribeOverlayInstructionAsync({
+        expectedAmount: amountBaseUnits,
+        expectedCreatedAt: BigInt(planCreatedAt),
+        expectedPeriodHours: BigInt(claimed.period_hours),
+        expectedSubscriptionAuthorityInitId,
+        merchant: owner,
         payer,
+        planId: programPlanId,
+        subscriber,
         tokenMint: mint,
-        tokenProgram,
-        userAta: sourceTokenAccount.tokenAccount,
       });
-    const subscribeInstruction = await subscriptionsProgram.getSubscribeOverlayInstructionAsync({
-      expectedAmount: amountBaseUnits,
-      expectedCreatedAt: BigInt(planCreatedAt),
-      expectedPeriodHours: BigInt(claimed.period_hours),
-      expectedSubscriptionAuthorityInitId,
-      merchant: owner,
-      payer,
-      planId: programPlanId,
-      subscriber,
-      tokenMint: mint,
-    });
-    attemptedOnChainSubmission = true;
-    const authorizationSignature = await sendSubscriptionInstructions({
-      env: input.env,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      sourceWallet: input.sourceWallet,
-      instructions: [initAuthorityInstruction, subscribeInstruction],
-      feePayer,
-    });
-    await recurringRepo.updateRecurringPaymentActivation({
-      recurringPaymentId: claimed.id,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      authorizationSignature,
-      updatedAt: new Date().toISOString(),
-    });
+      authorizationSignature = await sendSubscriptionInstructions({
+        env: input.env,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourceWallet: input.sourceWallet,
+        instructions: [initAuthorityInstruction, subscribeInstruction],
+        feePayer,
+      });
+      const signatureUpdatedAt = new Date().toISOString();
+      await recurringRepo.updateRecurringPaymentActivation({
+        recurringPaymentId: claimed.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        authorizationSignature,
+        updatedAt: signatureUpdatedAt,
+      });
+      await recurringRepo.updateActivationAttempt({
+        attemptId: attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        authorizationSignature,
+        updatedAt: signatureUpdatedAt,
+      });
+    }
     await confirmSubscriptionSignature(input.env, authorizationSignature);
 
+    currentStage = "finalize";
     const onChainSubscription = await subscriptionsProgram.fetchMaybeSubscriptionDelegation(
       rpc,
       subscriptionPda,
@@ -523,23 +721,37 @@ export async function activateRecurringPayment(input: {
       throw new AppError("INTERNAL_ERROR", "Failed to finalize recurring payment activation");
     }
 
+    await recurringRepo.updateActivationAttempt({
+      attemptId: attempt.id,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      status: "confirmed",
+      stage: currentStage,
+      planCreationSignature,
+      authorizationSignature,
+      error: null,
+      updatedAt: activatedAt,
+    });
+
     return finalized;
   } catch (error) {
-    if (!attemptedOnChainSubmission) {
-      try {
-        await resetRecurringPaymentActivationUnlessAlreadyActive({
-          recurringRepo,
-          recurringPaymentId: claimed.id,
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          updatedAt: new Date().toISOString(),
-        });
-      } catch (resetError) {
-        console.error("Failed to reset recurring payment activation after local failure", {
-          error: resetError instanceof Error ? resetError.message : String(resetError),
-          recurringPaymentId: claimed.id,
-        });
-      }
+    const failedAt = new Date().toISOString();
+    try {
+      await recordActivationFailure({
+        recurringRepo,
+        attempt,
+        claimed,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        stage: currentStage,
+        error,
+        failedAt,
+      });
+    } catch (resetError) {
+      console.error("Failed to journal/reset recurring payment activation after failure", {
+        error: resetError instanceof Error ? resetError.message : String(resetError),
+        recurringPaymentId: claimed.id,
+      });
     }
 
     throw error;

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -25,6 +25,7 @@ const POSTGRES_TEST_TABLES = [
   "custody_wallets",
   "signing_requests",
   "custody_configs",
+  "payment_recurring_payment_activation_attempts",
   "payment_subscription_collection_attempts",
   "payment_recurring_payments",
   "payment_subscriptions",


### PR DESCRIPTION
Closes PRO-1398

## Summary
- add durable recurring payment activation attempt journaling for processing/failed/confirmed runs
- make activation idempotent for already-active recurring payments
- recover signer/runtime/on-chain activation failures by journaling, resetting safely, and retrying with persisted checkpoints
- allow stale `activating` rows to resume without recreating completed Solana subscription plan work

## Out of scope
- collection
- cancel/resume
- cron recovery workers

## Local checks
- `pnpm --filter @sdp/api lint`
- `doppler run -- pnpm --filter @sdp/api typecheck`
- `DATABASE_URL=postgresql://sdp:sdp@127.0.0.1:5432/sdp doppler run --preserve-env=DATABASE_URL -- pnpm --filter @sdp/api exec vitest run --config vitest.workers.config.ts src/routes/payments.test.ts`

Note: API lint exits 0 with existing repo warnings unrelated to this PR.