### PR TITLE
fix: tab highlights

### DIFF
--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -427,15 +427,9 @@ function isItemActive(
     return pathname.startsWith("/dashboard/wallets") || pathname.startsWith("/dashboard/custody");
   }
   if (href === "/dashboard/payments") {
-    const isGatedPaymentsV2Route =
-      pathname.startsWith("/dashboard/payments/pay") ||
-      pathname.startsWith("/dashboard/payments/deposit");
-
-    return (
-      pathname.startsWith("/dashboard/payments") &&
-      !pathname.startsWith("/dashboard/payments/counterparty") &&
-      (featureFlags.paymentsV2 || !isGatedPaymentsV2Route)
-    );
+    if (pathname.startsWith("/dashboard/payments/counterparty")) return false;
+    if (featureFlags.paymentsV2) return pathname === "/dashboard/payments";
+    return pathname.startsWith("/dashboard/payments");
   }
   return pathname === href || pathname.startsWith(`${href}/`);
 }


### PR DESCRIPTION
Before
<img width="586" height="576" alt="CleanShot 2026-06-22 at 12 06 38@2x" src="https://github.com/user-attachments/assets/986c74db-f377-4b4b-94a3-c8869e478bd7" />

After
<img width="580" height="556" alt="CleanShot 2026-06-22 at 12 06 05@2x" src="https://github.com/user-attachments/assets/36153285-53a9-4055-be9d-43b276aecc6e" />

Fix: tab highlights

---

**Behavioral note (sidebar highlight):** With `paymentsV2=false`, deep-linking to `/dashboard/payments/pay` or `/dashboard/payments/deposit` now highlights the parent Payments tab (previously it highlighted nothing). These routes aren't linked anywhere in the UI when the flag is off, so this only affects direct URL access, and the new behavior matches how every other payments sub-route already highlights the parent. Whether those routes should render at all with the flag off is a separate route-gating question, untouched here.