### PR TITLE
fix(payments): isolate MoneyGram SDK DOM to prevent removeChild crash

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
@@ -270,6 +270,9 @@ export function MoneygramRampWidget({
       return;
     }
     const { sessionId, sessionToken, widgetUrl, sdkUrl } = quote;
+    const mountPoint = document.createElement("div");
+    mountPoint.className = "h-full w-full";
+    container.appendChild(mountPoint);
     let cancelled = false;
     let handle: MoneygramRampsHandle | null = null;
 
@@ -288,7 +291,7 @@ export function MoneygramRampWidget({
           return;
         }
         handle = sdk.createRamps({
-          container,
+          container: mountPoint,
           sessionToken,
           widgetUrl,
           devConfig: { apiBaseUrl: `${new URL(widgetUrl).origin}/api`, mockMode: false },
@@ -379,6 +382,7 @@ export function MoneygramRampWidget({
     return () => {
       cancelled = true;
       handle?.destroy();
+      mountPoint.remove();
     };
   }, [
     quote,


### PR DESCRIPTION
The widget handed its React-rendered ref div straight to the MoneyGram SDK, which injects and tears down its own DOM in that node. On unmount React's fiber pointed at a node the SDK had already detached, throwing "Cannot read properties of null (reading 'removeChild')" and white- screening /dashboard after sign-in.

Mount the SDK into a child div we create and remove ourselves, so React only ever owns the empty container and the two trees stay disjoint.