### PR TITLE
fix(kora): deploy.sh uses crane, not gcrane

### DIFF
--- a/.github/workflows/deploy-kora.yml
+++ b/.github/workflows/deploy-kora.yml
@@ -91,7 +91,7 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
       - uses: google-github-actions/setup-gcloud@v2
-      - name: Install gcrane
+      - name: Install crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 
       - name: Deploy

--- a/infra/kora/cloud-run/deploy.sh
+++ b/infra/kora/cloud-run/deploy.sh
@@ -47,10 +47,10 @@ gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 AR_IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/kora-${ENV}/kora:${KORA_TAG}"
 # Resolve the tag to an immutable digest first, log it, and copy by digest — so the exact bits
 # deployed are auditable and a mutated/overwritten upstream tag can't silently change the mirror.
-DIGEST="$(gcrane digest "${GHCR_REPO}:${KORA_TAG}")"
+DIGEST="$(crane digest "${GHCR_REPO}:${KORA_TAG}")"
 echo "Resolved ${GHCR_REPO}:${KORA_TAG} -> ${DIGEST}"
 echo "Mirroring ${GHCR_REPO}@${DIGEST} -> ${AR_IMAGE}"
-gcrane cp "${GHCR_REPO}@${DIGEST}" "${AR_IMAGE}"
+crane cp "${GHCR_REPO}@${DIGEST}" "${AR_IMAGE}"
 
 SERVICE="kora-${ENV}"
 ENV_VARS="^##^RUST_LOG=info##RPC_URL=${RPC_URL}##KORA_GCP_KMS_KEY_NAME=${KORA_GCP_KMS_KEY_NAME}##KORA_GCP_KMS_PUBLIC_KEY=${KORA_GCP_KMS_PUBLIC_KEY}"


### PR DESCRIPTION
The deploy from #501 failed at `gcrane: command not found`. `imjasonh/setup-crane` installs `crane`, not `gcrane`; switched deploy.sh to `crane` (identical `digest`/`cp` for a single-image mirror; AR auth already via `gcloud auth configure-docker`). WIF auth + Doppler are confirmed working — this was the only remaining blocker for the 61add05 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)