### PR TITLE
refactor: centralize well-known token mints into a shared registry

### DIFF
--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -1,5 +1,10 @@
 import { createHmac } from "node:crypto";
-import type { CachedApiKey, PolicyDefaultAction, PolicyRule } from "@sdp/types";
+import {
+  type CachedApiKey,
+  type PolicyDefaultAction,
+  type PolicyRule,
+  WELL_KNOWN_TOKENS,
+} from "@sdp/types";
 import type { Address, Signature } from "@solana/kit";
 import {
   address,
@@ -103,7 +108,7 @@ const TEST_BVNK_API_BASE_URL = "https://api.sandbox.bvnk.test";
 const TEST_MAGICBLOCK_API_BASE_URL = "https://payments.magicblock.test";
 const TEST_MAGICBLOCK_AUTH_TOKEN = "magicblock_auth_token";
 const TEST_MAGICBLOCK_SPONSOR_FEE_PAYER = "CrankS2fXgMGvQJ3VBrZmRfGrfogDY6pq5YcgkPEpSNf";
-const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+const DEVNET_USDC_MINT = WELL_KNOWN_TOKENS.USDC.mints.devnet;
 const MOONPAY_PARAM_BASE_CURRENCY_AMOUNT = "baseCurrencyAmount";
 const MOONPAY_PARAM_EXTERNAL_CUSTOMER_ID = "externalCustomerId";
 const MOONPAY_PARAM_QUOTE_CURRENCY_CODE = "quoteCurrencyCode";
@@ -6425,7 +6430,7 @@ describe("Payments routes", () => {
                 preTokenBalances: [
                   {
                     accountIndex: 0,
-                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    mint: DEVNET_USDC_MINT,
                     owner: TEST_SOLANA_ADDRESSES.wallet2,
                     uiTokenAmount: {
                       amount: "10000000",
@@ -6435,7 +6440,7 @@ describe("Payments routes", () => {
                   },
                   {
                     accountIndex: 1,
-                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    mint: DEVNET_USDC_MINT,
                     owner: TEST_SOLANA_ADDRESSES.wallet1,
                     uiTokenAmount: {
                       amount: "0",
@@ -6447,7 +6452,7 @@ describe("Payments routes", () => {
                 postTokenBalances: [
                   {
                     accountIndex: 0,
-                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    mint: DEVNET_USDC_MINT,
                     owner: TEST_SOLANA_ADDRESSES.wallet2,
                     uiTokenAmount: {
                       amount: "0",
@@ -6457,7 +6462,7 @@ describe("Payments routes", () => {
                   },
                   {
                     accountIndex: 1,
-                    mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    mint: DEVNET_USDC_MINT,
                     owner: TEST_SOLANA_ADDRESSES.wallet1,
                     uiTokenAmount: {
                       amount: "10000000",
@@ -6481,7 +6486,7 @@ describe("Payments routes", () => {
                         info: {
                           source: "SrcTokenAcct111111111111111111111111111111",
                           destination: "DstTokenAcct111111111111111111111111111111",
-                          mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                          mint: DEVNET_USDC_MINT,
                           tokenAmount: {
                             amount: "10000000",
                             decimals: 6,

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -1,4 +1,4 @@
-import type { Permission, PrivateTransferRequest } from "@sdp/types";
+import { type Permission, type PrivateTransferRequest, WELL_KNOWN_TOKEN_BY_MINT } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import {
   addSignersToTransactionMessage,
@@ -89,10 +89,6 @@ import {
 } from "../token-accounts";
 import { type ResolvedScope, resolveScope, resolveWallet } from "../wallets";
 
-// biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
-const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-// biome-ignore lint/security/noSecrets: Mainnet USDC mint address constant, not a secret.
-const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const SIGNATURE_HISTORY_LOOKUP_CONCURRENCY = 5;
 
 interface ParsedInstructionPayload {
@@ -1093,8 +1089,9 @@ function resolveObservedTokenSymbol(mint: string, tokenSymbolsByMint: Map<string
     return known;
   }
 
-  if (normalizedMint === DEVNET_USDC_MINT || normalizedMint === MAINNET_USDC_MINT) {
-    return "USDC";
+  const wellKnownSymbol = WELL_KNOWN_TOKEN_BY_MINT.get(normalizedMint)?.symbol;
+  if (wellKnownSymbol) {
+    return wellKnownSymbol;
   }
 
   return normalizedMint;
@@ -1302,10 +1299,7 @@ async function resolveWalletTokenAccountAddresses(
 }
 
 async function resolveObservedTokenSymbols(env: Env): Promise<Map<string, string>> {
-  const symbolsByMint = new Map<string, string>([
-    [DEVNET_USDC_MINT, "USDC"],
-    [MAINNET_USDC_MINT, "USDC"],
-  ]);
+  const symbolsByMint = new Map<string, string>();
 
   try {
     const result = await getDb(env)

--- a/apps/sdp-api/src/routes/payments/schemas.test.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.test.ts
@@ -1,3 +1,4 @@
+import { SOL_MINT, WELL_KNOWN_TOKENS } from "@sdp/types";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { z } from "zod";
 import {
@@ -8,8 +9,7 @@ import {
   updateWalletPolicySchema,
 } from "./schemas";
 
-const SOL_MINT = "So11111111111111111111111111111111111111112";
-const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const USDC_MINT = WELL_KNOWN_TOKENS.USDC.mints["mainnet-beta"];
 const VALID_DESTINATION = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
 
 const tokenSchema = createTransferSchema.shape.token;

--- a/apps/sdp-api/src/routes/payments/token-accounts.ts
+++ b/apps/sdp-api/src/routes/payments/token-accounts.ts
@@ -1,30 +1,19 @@
+import { SPL_TOKEN_PROGRAMS, WELL_KNOWN_TOKEN_BY_MINT } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import { findAssociatedTokenPda } from "@solana-program/token-2022";
 import { formatDecimalAmount } from "@/lib/amount";
 import { badRequest } from "@/lib/errors";
 import { assertValidAddress } from "@/lib/solana";
-import { SOL_MINT } from "@/services/payment-operation.service";
 import { type createRpc, getAccountInfo } from "@/services/solana/rpc";
 
 export { SOL_MINT } from "@/services/payment-operation.service";
 
-// biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
-const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-// biome-ignore lint/security/noSecrets: Mainnet USDC mint address constant, not a secret.
-const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
-// biome-ignore lint/security/noSecrets: Solana SPL Token program ID, not a secret.
-const SPL_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
-// biome-ignore lint/security/noSecrets: Solana Token-2022 program ID, not a secret.
-const SPL_TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" as Address;
+const SPL_TOKEN_PROGRAM_ID = SPL_TOKEN_PROGRAMS["spl-token"] as Address;
+const SPL_TOKEN_2022_PROGRAM_ID = SPL_TOKEN_PROGRAMS["token-2022"] as Address;
 const SPL_TOKEN_PROGRAM_IDS = [SPL_TOKEN_PROGRAM_ID, SPL_TOKEN_2022_PROGRAM_ID] as const;
-const KNOWN_TOKEN_LABELS_BY_MINT = new Map<string, string>([
-  [SOL_MINT, "SOL"],
-  [DEVNET_USDC_MINT, "USDC"],
-  [MAINNET_USDC_MINT, "USDC"],
-]);
 
 function resolveTokenLabel(mint: string): string {
-  return KNOWN_TOKEN_LABELS_BY_MINT.get(mint) ?? mint;
+  return WELL_KNOWN_TOKEN_BY_MINT.get(mint)?.symbol ?? mint;
 }
 
 type JsonParsedTokenAccountEntry = {

--- a/apps/sdp-api/src/services/helius-das.service.ts
+++ b/apps/sdp-api/src/services/helius-das.service.ts
@@ -134,7 +134,10 @@ function resolveKnownUsdPrice(
   }
 
   const normalizedToken = balance.token.trim().toUpperCase();
-  if (normalizedToken === "USDC" || WELL_KNOWN_TOKEN_BY_MINT.get(normalizedMint)?.isUsdStable) {
+  const wellKnown =
+    WELL_KNOWN_TOKEN_BY_MINT.get(normalizedMint) ??
+    Object.values(WELL_KNOWN_TOKENS).find((token) => token.symbol === normalizedToken);
+  if (wellKnown?.isUsdStable) {
     return 1;
   }
 

--- a/apps/sdp-api/src/services/helius-das.service.ts
+++ b/apps/sdp-api/src/services/helius-das.service.ts
@@ -1,13 +1,12 @@
-import type { CustodyWalletTokenBalance } from "@sdp/types";
+import {
+  type CustodyWalletTokenBalance,
+  WELL_KNOWN_TOKEN_BY_MINT,
+  WELL_KNOWN_TOKENS,
+} from "@sdp/types";
 import { getDb } from "@/db";
 import { formatDecimalAmount } from "@/lib/amount";
 import { withHeliusApiKey } from "@/services/rpc-relay.service";
 import type { Env } from "@/types/env";
-
-// biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
-const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-// biome-ignore lint/security/noSecrets: Mainnet USDC mint address constant, not a secret.
-const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 interface TrackedAssetDefinition {
   decimals: number;
@@ -66,10 +65,15 @@ interface HeliusGetAssetBatchResponse {
 
 async function resolveTrackedAssets(env: Env): Promise<Map<string, TrackedAssetDefinition>> {
   const network = env.SOLANA_NETWORK ?? "devnet";
-  const trackedAssets: TrackedAssetDefinition[] =
-    network === "mainnet-beta"
-      ? [{ token: "USDC", mint: MAINNET_USDC_MINT, decimals: 6, isUsdStable: true }]
-      : [{ token: "USDC", mint: DEVNET_USDC_MINT, decimals: 6, isUsdStable: true }];
+  const usdc = WELL_KNOWN_TOKENS.USDC;
+  const trackedAssets: TrackedAssetDefinition[] = [
+    {
+      token: usdc.symbol,
+      mint: usdc.mints[network],
+      decimals: usdc.decimals,
+      isUsdStable: usdc.isUsdStable,
+    },
+  ];
 
   const trackedAssetsByMint = new Map(trackedAssets.map((asset) => [asset.mint, asset]));
 
@@ -123,17 +127,14 @@ function resolveKnownUsdPrice(
   balance: Pick<CustodyWalletTokenBalance, "mint" | "token">,
   trackedAssets: Map<string, TrackedAssetDefinition>
 ): number | null {
-  const trackedAsset = trackedAssets.get(balance.mint.trim());
+  const normalizedMint = balance.mint.trim();
+  const trackedAsset = trackedAssets.get(normalizedMint);
   if (trackedAsset?.isUsdStable) {
     return 1;
   }
 
   const normalizedToken = balance.token.trim().toUpperCase();
-  if (
-    normalizedToken === "USDC" ||
-    balance.mint === DEVNET_USDC_MINT ||
-    balance.mint === MAINNET_USDC_MINT
-  ) {
+  if (normalizedToken === "USDC" || WELL_KNOWN_TOKEN_BY_MINT.get(normalizedMint)?.isUsdStable) {
     return 1;
   }
 

--- a/apps/sdp-api/src/services/payment-operation.service.ts
+++ b/apps/sdp-api/src/services/payment-operation.service.ts
@@ -1,4 +1,4 @@
-import type { Permission } from "@sdp/types";
+import { type Permission, SOL_MINT } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import { isDecimalString } from "@/lib/amount";
 import type { ApiKeyContext } from "@/lib/auth";
@@ -7,8 +7,7 @@ import { assertValidAddress } from "@/lib/solana";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 
-// biome-ignore lint/security/noSecrets: Solana native SOL mint address constant, not a secret.
-export const SOL_MINT = "So11111111111111111111111111111111111111112";
+export { SOL_MINT };
 
 export interface OutboundPaymentOperation {
   sourceWallet: CustodyWallet;

--- a/apps/sdp-api/src/services/private-transfers/magicblock.test.ts
+++ b/apps/sdp-api/src/services/private-transfers/magicblock.test.ts
@@ -1,3 +1,4 @@
+import { WELL_KNOWN_TOKENS } from "@sdp/types";
 import { address } from "@solana/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -9,7 +10,7 @@ import { env } from "@/test/helpers/env";
 const TEST_MAGICBLOCK_API_BASE_URL = "https://payments.magicblock.test";
 const TEST_SOURCE = address("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ");
 const TEST_DESTINATION = address("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU");
-const DEVNET_USDC_MINT = address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+const DEVNET_USDC_MINT = address(WELL_KNOWN_TOKENS.USDC.mints.devnet);
 
 let originalMagicBlockApiBaseUrl: string | undefined;
 let originalSolanaNetwork: "devnet" | "mainnet-beta" | undefined;

--- a/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-overview.utils.ts
@@ -1,18 +1,13 @@
-import type {
-  CustodyWalletAggregate,
-  CustodyWalletTokenBalance,
-  RampDirection,
-  PaymentTransferSummary as TransferRecord,
-  PaymentsDashboardWallet as WalletRecord,
+import {
+  type CustodyWalletAggregate,
+  type CustodyWalletTokenBalance,
+  type RampDirection,
+  SOL_MINT,
+  type PaymentTransferSummary as TransferRecord,
+  type PaymentsDashboardWallet as WalletRecord,
+  WELL_KNOWN_TOKEN_BY_MINT,
 } from "@sdp/types";
 import { toTitleCase } from "../activity-format-utils";
-
-// biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
-const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-// biome-ignore lint/security/noSecrets: Mainnet USDC mint address constant, not a secret.
-const MAINNET_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
-// biome-ignore lint/security/noSecrets: Solana native mint address constant, not a secret.
-const SOL_MINT = "So11111111111111111111111111111111111111112";
 
 function parseIntegerAmount(value: string): bigint | null {
   if (!/^\d+$/.test(value)) {
@@ -44,8 +39,7 @@ function resolveFallbackUsdValue(
   const normalizedToken = balance.token.trim().toUpperCase();
   if (
     normalizedToken !== "USDC" &&
-    balance.mint !== DEVNET_USDC_MINT &&
-    balance.mint !== MAINNET_USDC_MINT
+    !WELL_KNOWN_TOKEN_BY_MINT.get(balance.mint.trim())?.isUsdStable
   ) {
     return null;
   }

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -20,3 +20,4 @@ export * from "./provider-access";
 export * from "./sessions";
 export * from "./site";
 export * from "./tokens";
+export * from "./well-known-tokens";

--- a/packages/sdp-types/src/well-known-tokens.ts
+++ b/packages/sdp-types/src/well-known-tokens.ts
@@ -1,0 +1,79 @@
+export type SolanaCluster = "devnet" | "mainnet-beta";
+
+export const SPL_TOKEN_PROGRAMS = {
+  // biome-ignore lint/security/noSecrets: Solana SPL Token program ID, not a secret.
+  "spl-token": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  // biome-ignore lint/security/noSecrets: Solana Token-2022 program ID, not a secret.
+  "token-2022": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+} as const satisfies Record<string, string>;
+
+export type TokenProgramKind = keyof typeof SPL_TOKEN_PROGRAMS;
+
+export interface WellKnownToken {
+  symbol: string;
+  decimals: number;
+  isUsdStable: boolean;
+  tokenProgram: TokenProgramKind;
+  /** Mint addresses by cluster; mainnet is always present, devnet only when the token is deployed there. */
+  mints: { "mainnet-beta": string; devnet?: string };
+}
+
+/** Native SOL pseudo-mint (wrapped SOL), identical across clusters. */
+// biome-ignore lint/security/noSecrets: Solana native SOL mint address constant, not a secret.
+export const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+export const WELL_KNOWN_TOKENS = {
+  SOL: {
+    symbol: "SOL",
+    decimals: 9,
+    isUsdStable: false,
+    tokenProgram: "spl-token",
+    mints: {
+      devnet: SOL_MINT,
+      "mainnet-beta": SOL_MINT,
+    },
+  },
+  USDC: {
+    symbol: "USDC",
+    decimals: 6,
+    isUsdStable: true,
+    tokenProgram: "spl-token",
+    mints: {
+      // biome-ignore lint/security/noSecrets: Devnet USDC mint address constant, not a secret.
+      devnet: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      // biome-ignore lint/security/noSecrets: Mainnet USDC mint address constant, not a secret.
+      "mainnet-beta": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    },
+  },
+  USDT: {
+    symbol: "USDT",
+    decimals: 6,
+    isUsdStable: true,
+    tokenProgram: "spl-token",
+    mints: {
+      // biome-ignore lint/security/noSecrets: Mainnet USDT mint address constant, not a secret.
+      "mainnet-beta": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+    },
+  },
+  PYUSD: {
+    symbol: "PYUSD",
+    decimals: 6,
+    isUsdStable: true,
+    tokenProgram: "token-2022",
+    mints: {
+      // biome-ignore lint/security/noSecrets: Devnet PYUSD mint address constant, not a secret.
+      devnet: "CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM",
+      // biome-ignore lint/security/noSecrets: Mainnet PYUSD mint address constant, not a secret.
+      "mainnet-beta": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+    },
+  },
+} as const satisfies Record<string, WellKnownToken>;
+
+export type WellKnownTokenSymbol = keyof typeof WELL_KNOWN_TOKENS;
+
+/** Lookup from any cluster's mint address to its well-known token definition. */
+export const WELL_KNOWN_TOKEN_BY_MINT: ReadonlyMap<string, WellKnownToken> = new Map(
+  Object.values(WELL_KNOWN_TOKENS).flatMap((token) =>
+    Object.values(token.mints).map((mint): [string, WellKnownToken] => [mint, token])
+  )
+);

--- a/packages/sdp-types/src/well-known-tokens.ts
+++ b/packages/sdp-types/src/well-known-tokens.ts
@@ -74,6 +74,6 @@ export type WellKnownTokenSymbol = keyof typeof WELL_KNOWN_TOKENS;
 /** Lookup from any cluster's mint address to its well-known token definition. */
 export const WELL_KNOWN_TOKEN_BY_MINT: ReadonlyMap<string, WellKnownToken> = new Map(
   Object.values(WELL_KNOWN_TOKENS).flatMap((token) =>
-    Object.values(token.mints).map((mint): [string, WellKnownToken] => [mint, token])
+    [...new Set(Object.values(token.mints))].map((mint): [string, WellKnownToken] => [mint, token])
   )
 );


### PR DESCRIPTION
## What

Adds `@sdp/types/well-known-tokens` as the single source of truth for well-known Solana tokens, and repoints the call sites that previously each redefined the same mint constants.

Registry contents (`WELL_KNOWN_TOKENS`):

| Symbol | Program | Decimals | USD-stable | devnet | mainnet-beta |
|---|---|---|---|---|---|
| SOL | spl-token | 9 | no | ✓ | ✓ |
| USDC | spl-token | 6 | yes | ✓ | ✓ |
| USDT | spl-token | 6 | yes | — | ✓ |
| PYUSD | token-2022 | 6 | yes | ✓ | ✓ |

Also exports `WELL_KNOWN_TOKEN_BY_MINT` (mint → token lookup), `SPL_TOKEN_PROGRAMS` (SPL / Token-2022 program IDs), `SOL_MINT`, and `SolanaCluster`.

## Why

`DEVNET_USDC_MINT` / `MAINNET_USDC_MINT` / `SOL_MINT` and the SPL/Token-2022 program IDs were copy-pasted across `helius-das.service.ts`, `token-accounts.ts`, `transfers.ts`, `payment-operation.service.ts`, and the web payments overview. This consolidates them so adding a token (or fixing a mint) is a one-line change in one place.

## Changes

- **New** `packages/sdp-types/src/well-known-tokens.ts` — registry + types. `mints` is typed `{ "mainnet-beta": string; devnet?: string }` so a mainnet mint is always required and devnet is opt-in (USDT has no canonical devnet deployment).
- `payment-operation.service.ts` re-exports `SOL_MINT` from the registry, so existing `@/services/...` import chains keep working off one source of truth.
- `token-accounts.ts` consumes `SPL_TOKEN_PROGRAMS` instead of redefining the program IDs.
- `helius-das.service.ts`, `transfers.ts`, `payments-overview.utils.ts` resolve mints/symbols/USD-stable via the registry.

## Notes

- PYUSD's devnet mint (`CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM`) was verified on-chain as Token-2022 PYUSD. PYUSD's mint carries transfer-hook + permanent-delegate extensions, so transferring it needs T22-aware instruction building (out of scope here).
- OpenAPI `example:` values and test fixtures intentionally keep inline mint literals.

## Verification

`tsc --noEmit` clean on `@sdp/types` and `sdp-api`; biome clean.

PRO-1419