### PR TITLE
feat(payments): settle payment requests on read via Solana Pay reference

### DIFF
--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -10,6 +10,7 @@ import type {
   UpdatePaymentTransferInput,
   UpsertPaymentWalletPolicyInput,
 } from "./payments.repository";
+import { generatePaymentTransferId } from "./payments.repository";
 
 function buildInClause(length: number): string {
   return Array.from({ length }, () => "?").join(", ");
@@ -87,18 +88,6 @@ function buildTransferScopeWhere(params: {
   };
 }
 
-async function getTransferByIdInternal(
-  db: DatabaseExecutor,
-  transferId: string
-): Promise<PaymentTransferRow | null> {
-  const row = await db
-    .prepare("SELECT * FROM payment_transfers WHERE id = ?")
-    .bind(transferId)
-    .first<Record<string, unknown>>();
-
-  return row ? mapTransferRow(row) : null;
-}
-
 async function getWalletPoliciesInternal(
   db: DatabaseExecutor,
   custodyWalletId: string
@@ -119,7 +108,7 @@ async function getWalletPoliciesInternal(
 export function createPostgresPaymentsRepository(db: DatabaseExecutor): PaymentsRepository {
   return {
     async createTransfer(input: CreatePaymentTransferInput) {
-      await db
+      const row = await db
         .prepare(
           `INSERT INTO payment_transfers (
              id,
@@ -142,13 +131,16 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
              fiat_amount,
              provider_data,
              serialized_tx,
+             signature,
+             slot,
              initiated_by_key_id,
              created_at,
              updated_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?)`
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, sdp_iso_now(), sdp_iso_now())
+           RETURNING *`
         )
         .bind(
-          input.id,
+          generatePaymentTransferId(),
           input.organizationId,
           input.projectId,
           input.walletId,
@@ -168,13 +160,13 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
           input.fiatAmount,
           JSON.stringify(input.providerData),
           input.serializedTx,
-          input.initiatedByKeyId,
-          input.createdAt,
-          input.updatedAt
+          input.signature,
+          input.slot,
+          input.initiatedByKeyId
         )
-        .run();
+        .first<Record<string, unknown>>();
 
-      return getTransferByIdInternal(db, input.id);
+      return row ? mapTransferRow(row) : null;
     },
 
     async updateTransfer(input: UpdatePaymentTransferInput) {

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -60,8 +60,11 @@ export interface PaymentTransferRow {
   updated_at: string;
 }
 
+export function generatePaymentTransferId(): string {
+  return `xfr_${crypto.randomUUID()}`;
+}
+
 export interface CreatePaymentTransferInput {
-  id: string;
   organizationId: string;
   projectId: string | null;
   walletId: string;
@@ -81,9 +84,9 @@ export interface CreatePaymentTransferInput {
   fiatAmount: string | null;
   providerData: Record<string, unknown>;
   serializedTx: string | null;
+  signature: string | null;
+  slot: number | null;
   initiatedByKeyId: string | null;
-  createdAt: string;
-  updatedAt: string;
 }
 
 export interface UpdatePaymentTransferInput {

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -5,7 +5,7 @@ import { notFound } from "@/lib/errors";
 import { assertValidAddress, getSolanaConfig } from "@/lib/solana";
 import {
   isPaymentRequestExpired,
-  reconcilePaymentRequest,
+  reconcilePaymentRequestBestEffort,
 } from "@/services/payments/payment-requests";
 import type { Env } from "@/types/env";
 import { resolveTokenLabel, SOL_MINT } from "./payments/token-accounts";
@@ -21,7 +21,7 @@ pay.get("/:token", async (c) => {
   if (!existing) {
     throw notFound("Payment request");
   }
-  const request = await reconcilePaymentRequest(c.env, existing);
+  const request = await reconcilePaymentRequestBestEffort(c.env, existing);
 
   const expired = isPaymentRequestExpired(request.expires_at);
   const status = expired && request.status === "awaiting_payment" ? "expired" : request.status;

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -3,6 +3,10 @@ import { Hono } from "hono";
 import { createPaymentRequestsRepository } from "@/db/repositories/repository-factory";
 import { notFound } from "@/lib/errors";
 import { assertValidAddress, getSolanaConfig } from "@/lib/solana";
+import {
+  isPaymentRequestExpired,
+  reconcilePaymentRequest,
+} from "@/services/payments/payment-requests";
 import type { Env } from "@/types/env";
 import { resolveTokenLabel, SOL_MINT } from "./payments/token-accounts";
 
@@ -11,14 +15,15 @@ const REQUEST_LABEL = "Solana Developer Platform";
 const pay = new Hono<{ Bindings: Env }>();
 
 pay.get("/:token", async (c) => {
-  const request = await createPaymentRequestsRepository(c.env).getPaymentRequestByPublicToken(
+  const existing = await createPaymentRequestsRepository(c.env).getPaymentRequestByPublicToken(
     c.req.param("token")
   );
-  if (!request) {
+  if (!existing) {
     throw notFound("Payment request");
   }
+  const request = await reconcilePaymentRequest(c.env, existing);
 
-  const expired = request.expires_at !== null && Date.parse(request.expires_at) <= Date.now();
+  const expired = isPaymentRequestExpired(request.expires_at);
   const status = expired && request.status === "awaiting_payment" ? "expired" : request.status;
   const payable = status === "awaiting_payment";
 

--- a/apps/sdp-api/src/routes/payments/handlers/payment-requests.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/payment-requests.ts
@@ -10,7 +10,7 @@ import { isAddress } from "@/lib/solana";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
 import {
   isPaymentRequestExpired,
-  reconcilePaymentRequest,
+  reconcilePaymentRequestBestEffort,
 } from "@/services/payments/payment-requests";
 import type { AppContext } from "../context";
 import { paymentAmountSchema } from "../schemas";
@@ -61,7 +61,9 @@ export async function listPaymentRequests(c: AppContext) {
     offset: (page - 1) * pageSize,
   });
 
-  const reconciledRows = await Promise.all(rows.map((row) => reconcilePaymentRequest(c.env, row)));
+  const reconciledRows = await Promise.all(
+    rows.map((row) => reconcilePaymentRequestBestEffort(c.env, row))
+  );
 
   const response: ListPaymentRequestsResponse = {
     paymentRequests: reconciledRows.map(mapPaymentRequest),

--- a/apps/sdp-api/src/routes/payments/handlers/payment-requests.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/payment-requests.ts
@@ -8,6 +8,10 @@ import { badRequest, badRequestQuery } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import { isAddress } from "@/lib/solana";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
+import {
+  isPaymentRequestExpired,
+  reconcilePaymentRequest,
+} from "@/services/payments/payment-requests";
 import type { AppContext } from "../context";
 import { paymentAmountSchema } from "../schemas";
 import { resolveScope, resolveWallet } from "../wallets";
@@ -19,7 +23,7 @@ const listPaymentRequestsQuerySchema = z.object({
 });
 
 function mapPaymentRequest(row: PaymentRequestRow): PaymentRequest {
-  const expired = row.expires_at !== null && Date.parse(row.expires_at) <= Date.now();
+  const expired = isPaymentRequestExpired(row.expires_at);
   return {
     id: row.id,
     publicToken: row.public_token,
@@ -57,8 +61,10 @@ export async function listPaymentRequests(c: AppContext) {
     offset: (page - 1) * pageSize,
   });
 
+  const reconciledRows = await Promise.all(rows.map((row) => reconcilePaymentRequest(c.env, row)));
+
   const response: ListPaymentRequestsResponse = {
-    paymentRequests: rows.map(mapPaymentRequest),
+    paymentRequests: reconciledRows.map(mapPaymentRequest),
     total,
     page,
     pageSize,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -151,10 +151,6 @@ interface PersistRampQuoteTransferInput {
   fiatAmount: string | null;
 }
 
-function paymentTransferId(): string {
-  return `xfr_${crypto.randomUUID()}`;
-}
-
 function requireRampTransferWallet(
   scope: ResolvedScope,
   walletIdOrAddress: string,
@@ -228,10 +224,8 @@ async function persistRampQuoteTransfer(
   }
 
   const apiKey = c.get("apiKey");
-  const now = new Date().toISOString();
   const isOnramp = input.direction === "onramp";
   const created = await repository.createTransfer({
-    id: paymentTransferId(),
     organizationId: input.scope.auth.organizationId,
     projectId: input.projectId,
     walletId: input.wallet.walletId,
@@ -251,9 +245,9 @@ async function persistRampQuoteTransfer(
     fiatAmount: input.fiatAmount,
     providerData: {},
     serializedTx: null,
+    signature: null,
+    slot: null,
     initiatedByKeyId: apiKey ? apiKey.id : null,
-    createdAt: now,
-    updatedAt: now,
   });
 
   if (!created) {

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -224,11 +224,8 @@ async function createTransferRecord(
   }
 ): Promise<TransferRow> {
   const repository = getPaymentsRepository(c);
-  const id = `xfr_${crypto.randomUUID()}`;
-  const now = new Date().toISOString();
 
   const createdRow = await repository.createTransfer({
-    id,
     organizationId: input.organizationId,
     projectId: input.projectId,
     walletId: input.walletId,
@@ -248,9 +245,9 @@ async function createTransferRecord(
     fiatAmount: null,
     providerData: {},
     serializedTx: input.serializedTx ?? null,
+    signature: null,
+    slot: null,
     initiatedByKeyId: input.initiatedByKeyId ?? null,
-    createdAt: now,
-    updatedAt: now,
   });
 
   if (!createdRow) {

--- a/apps/sdp-api/src/services/payments/payment-requests.test.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.test.ts
@@ -1,0 +1,185 @@
+import * as solanaPay from "@solana/pay";
+import { FindReferenceError, ValidateTransferError } from "@solana/pay";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
+import { getDb } from "@/db";
+import type { PaymentRequestRow } from "@/db/repositories/payment-requests.repository";
+import { createPaymentRequestsRepository } from "@/db/repositories/repository-factory";
+import { SOL_MINT } from "@/services/payment-operation.service";
+import { TEST_CUSTODY_PUBLIC_KEY } from "@/test/fixtures/custody";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { reconcilePaymentRequest } from "./payment-requests";
+
+const TEST_PROJECT_ID = "prj_preq_handler_test";
+const TEST_WALLET_ID = "wal_preq_handler_test";
+const SIGNATURE = "S".repeat(64);
+
+let findReferenceSpy: MockInstance<typeof solanaPay.findReference>;
+let validateTransferSpy: MockInstance<typeof solanaPay.validateTransfer>;
+
+function foundSignature(): Awaited<ReturnType<typeof solanaPay.findReference>> {
+  return {
+    signature: SIGNATURE as Awaited<ReturnType<typeof solanaPay.findReference>>["signature"],
+    slot: 1n,
+    err: null,
+    memo: null,
+    blockTime: null,
+    confirmationStatus: "confirmed",
+  };
+}
+
+function mockSettlementSucceeds() {
+  findReferenceSpy.mockResolvedValue(foundSignature());
+  validateTransferSpy.mockResolvedValue(
+    undefined as unknown as Awaited<ReturnType<typeof solanaPay.validateTransfer>>
+  );
+}
+
+async function createRequest(overrides?: { token?: string; expiresAt?: string }) {
+  return createPaymentRequestsRepository(env).createPaymentRequest({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT_ID,
+    counterpartyId: null,
+    walletId: TEST_WALLET_ID,
+    destinationAddress: TEST_CUSTODY_PUBLIC_KEY,
+    token: overrides?.token ?? SOL_MINT,
+    amount: "1.5",
+    expiresAt: overrides?.expiresAt ?? null,
+    createdBy: TEST_USER.id,
+  });
+}
+
+async function listInboundTransfers() {
+  const result = await getDb(env)
+    .prepare("SELECT * FROM payment_transfers WHERE wallet_id = ?")
+    .bind(TEST_WALLET_ID)
+    .all<Record<string, unknown>>();
+  return result.results;
+}
+
+describe("reconcilePaymentRequest", () => {
+  beforeAll(async () => {
+    await seedTestDatabase(env as Parameters<typeof seedTestDatabase>[0]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(async () => {
+    findReferenceSpy = vi.spyOn(solanaPay, "findReference");
+    validateTransferSpy = vi.spyOn(solanaPay, "validateTransfer");
+
+    const db = getDb(env);
+    await db.prepare("DELETE FROM payment_requests").run();
+    await db.prepare("DELETE FROM payment_transfers").run();
+    await db.prepare("DELETE FROM projects").run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+  });
+
+  it("settles an awaiting request and links a recorded inbound transfer", async () => {
+    mockSettlementSucceeds();
+
+    const settled = await reconcilePaymentRequest(env, await createRequest());
+
+    expect(settled.status).toBe("paid");
+    expect(settled.fulfilled_by_transfer_id).not.toBeNull();
+
+    const transfers = await listInboundTransfers();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0].id).toBe(settled.fulfilled_by_transfer_id);
+    expect(transfers[0].direction).toBe("inbound");
+    expect(transfers[0].status).toBe("confirmed");
+    expect(transfers[0].signature).toBe(SIGNATURE);
+  });
+
+  it("settles an SPL request, exercising the splToken branch", async () => {
+    mockSettlementSucceeds();
+
+    const settled = await reconcilePaymentRequest(
+      env,
+      await createRequest({ token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" })
+    );
+
+    expect(settled.status).toBe("paid");
+    const fields = validateTransferSpy.mock.calls[0][2];
+    expect(fields.splToken).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+  });
+
+  it("leaves the request awaiting when no transfer references it", async () => {
+    findReferenceSpy.mockRejectedValue(new FindReferenceError("not found"));
+
+    const result = await reconcilePaymentRequest(env, await createRequest());
+
+    expect(result.status).toBe("awaiting_payment");
+    expect(result.fulfilled_by_transfer_id).toBeNull();
+    expect(validateTransferSpy).not.toHaveBeenCalled();
+    expect(await listInboundTransfers()).toHaveLength(0);
+  });
+
+  it("leaves the request awaiting when the referenced transfer is invalid", async () => {
+    findReferenceSpy.mockResolvedValue(foundSignature());
+    validateTransferSpy.mockRejectedValue(new ValidateTransferError("wrong amount"));
+
+    const result = await reconcilePaymentRequest(env, await createRequest());
+
+    expect(result.status).toBe("awaiting_payment");
+    expect(result.fulfilled_by_transfer_id).toBeNull();
+    expect(await listInboundTransfers()).toHaveLength(0);
+  });
+
+  it("rethrows unexpected errors instead of swallowing them", async () => {
+    findReferenceSpy.mockRejectedValue(new Error("rpc exploded"));
+
+    await expect(reconcilePaymentRequest(env, await createRequest())).rejects.toThrow(
+      "rpc exploded"
+    );
+  });
+
+  it("short-circuits non-awaiting requests without touching the chain", async () => {
+    const canceled: PaymentRequestRow = { ...(await createRequest()), status: "canceled" };
+
+    const result = await reconcilePaymentRequest(env, canceled);
+
+    expect(result).toBe(canceled);
+    expect(findReferenceSpy).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits expired requests without touching the chain", async () => {
+    const expired = await createRequest({ expiresAt: "2000-01-01T00:00:00.000Z" });
+
+    const result = await reconcilePaymentRequest(env, expired);
+
+    expect(result.status).toBe("awaiting_payment");
+    expect(findReferenceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sdp-api/src/services/payments/payment-requests.test.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.test.ts
@@ -18,7 +18,7 @@ import { TEST_CUSTODY_PUBLIC_KEY } from "@/test/fixtures/custody";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
-import { reconcilePaymentRequest } from "./payment-requests";
+import { reconcilePaymentRequest, reconcilePaymentRequestBestEffort } from "./payment-requests";
 
 const TEST_PROJECT_ID = "prj_preq_handler_test";
 const TEST_WALLET_ID = "wal_preq_handler_test";
@@ -177,6 +177,18 @@ describe("reconcilePaymentRequest", () => {
     await expect(reconcilePaymentRequest(env, await createRequest())).rejects.toThrow(
       "rpc exploded"
     );
+  });
+
+  it("best-effort returns the stored row and logs when reconcile errors unexpectedly", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    findReferenceSpy.mockRejectedValue(new Error("rpc exploded"));
+    const request = await createRequest();
+
+    const result = await reconcilePaymentRequestBestEffort(env, request);
+
+    expect(result).toBe(request);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(await listInboundTransfers()).toHaveLength(0);
   });
 
   it("short-circuits non-awaiting requests without touching the chain", async () => {

--- a/apps/sdp-api/src/services/payments/payment-requests.test.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.test.ts
@@ -135,6 +135,20 @@ describe("reconcilePaymentRequest", () => {
     expect(fields.splToken).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
   });
 
+  it("converges concurrent reconciles of the same request to a single settlement", async () => {
+    mockSettlementSucceeds();
+    const request = await createRequest();
+
+    const [a, b] = await Promise.all([
+      reconcilePaymentRequest(env, request),
+      reconcilePaymentRequest(env, request),
+    ]);
+
+    expect(a.status).toBe("paid");
+    expect(b.status).toBe("paid");
+    expect(await listInboundTransfers()).toHaveLength(1);
+  });
+
   it("leaves the request awaiting when no transfer references it", async () => {
     findReferenceSpy.mockRejectedValue(new FindReferenceError("not found"));
 

--- a/apps/sdp-api/src/services/payments/payment-requests.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.ts
@@ -1,0 +1,105 @@
+import {
+  FindReferenceError,
+  findReference,
+  ValidateTransferError,
+  validateTransfer,
+} from "@solana/pay";
+import type { PaymentRequestRow } from "@/db/repositories/payment-requests.repository";
+import {
+  createPaymentRequestsRepository,
+  createPaymentsRepository,
+} from "@/db/repositories/repository-factory";
+import { internalError } from "@/lib/errors";
+import { assertValidAddress } from "@/lib/solana";
+import { SOL_MINT } from "@/services/payment-operation.service";
+import * as solanaRpc from "@/services/solana/rpc";
+import type { Env } from "@/types/env";
+
+export function isPaymentRequestExpired(expiresAt: string | null): boolean {
+  return expiresAt !== null && Date.parse(expiresAt) <= Date.now();
+}
+
+export async function reconcilePaymentRequest(
+  env: Env,
+  row: PaymentRequestRow
+): Promise<PaymentRequestRow> {
+  if (row.status !== "awaiting_payment") {
+    return row;
+  }
+  if (isPaymentRequestExpired(row.expires_at)) {
+    return row;
+  }
+
+  const projectId = row.project_id;
+  if (projectId === null) {
+    throw internalError("payment_requests row is missing project_id");
+  }
+
+  const rpc = solanaRpc.createRpc(env);
+  const reference = assertValidAddress(row.reference, "reference");
+
+  let found: Awaited<ReturnType<typeof findReference>>;
+  try {
+    found = await findReference(rpc, reference, { commitment: "confirmed" });
+  } catch (err) {
+    if (err instanceof FindReferenceError) {
+      return row;
+    }
+    throw err;
+  }
+
+  try {
+    await validateTransfer(rpc, found.signature, {
+      recipient: assertValidAddress(row.destination_address, "destinationAddress"),
+      amount: Number(row.amount),
+      reference,
+      ...(row.token === SOL_MINT ? {} : { splToken: assertValidAddress(row.token, "token") }),
+    });
+  } catch (err) {
+    if (err instanceof ValidateTransferError) {
+      return row;
+    }
+    throw err;
+  }
+
+  const transfer = await createPaymentsRepository(env).createTransfer({
+    organizationId: row.organization_id,
+    projectId,
+    walletId: row.wallet_id,
+    counterpartyId: row.counterparty_id,
+    sourceAddress: null,
+    destinationAddress: row.destination_address,
+    token: row.token,
+    amount: row.amount,
+    memo: null,
+    type: "transfer",
+    direction: "inbound",
+    status: "confirmed",
+    provider: null,
+    providerReference: null,
+    deliveryMode: null,
+    fiatCurrency: null,
+    fiatAmount: null,
+    providerData: {},
+    serializedTx: null,
+    signature: found.signature,
+    slot: Number(found.slot),
+    initiatedByKeyId: null,
+  });
+  if (!transfer) {
+    throw internalError("Failed to record inbound transfer for payment request settlement");
+  }
+
+  const settled = await createPaymentRequestsRepository(env).markPaymentRequest({
+    requestId: row.id,
+    organizationId: row.organization_id,
+    projectId,
+    status: "paid",
+    fulfilledByTransferId: transfer.id,
+    canceledBy: null,
+  });
+  if (settled) {
+    return settled;
+  }
+  return row;
+}

--- a/apps/sdp-api/src/services/payments/payment-requests.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.ts
@@ -4,7 +4,9 @@ import {
   ValidateTransferError,
   validateTransfer,
 } from "@solana/pay";
+import { isPostgresUniqueViolation } from "@/db/postgres-utils";
 import type { PaymentRequestRow } from "@/db/repositories/payment-requests.repository";
+import type { PaymentTransferRow } from "@/db/repositories/payments.repository";
 import {
   createPaymentRequestsRepository,
   createPaymentsRepository,
@@ -62,35 +64,56 @@ export async function reconcilePaymentRequest(
     throw err;
   }
 
-  const transfer = await createPaymentsRepository(env).createTransfer({
-    organizationId: row.organization_id,
-    projectId,
-    walletId: row.wallet_id,
-    counterpartyId: row.counterparty_id,
-    sourceAddress: null,
-    destinationAddress: row.destination_address,
-    token: row.token,
-    amount: row.amount,
-    memo: null,
-    type: "transfer",
-    direction: "inbound",
-    status: "confirmed",
-    provider: null,
-    providerReference: null,
-    deliveryMode: null,
-    fiatCurrency: null,
-    fiatAmount: null,
-    providerData: {},
-    serializedTx: null,
-    signature: found.signature,
-    slot: Number(found.slot),
-    initiatedByKeyId: null,
-  });
+  const paymentsRepo = createPaymentsRepository(env);
+  let transfer: PaymentTransferRow | null;
+  try {
+    transfer = await paymentsRepo.createTransfer({
+      organizationId: row.organization_id,
+      projectId,
+      walletId: row.wallet_id,
+      counterpartyId: row.counterparty_id,
+      sourceAddress: null,
+      destinationAddress: row.destination_address,
+      token: row.token,
+      amount: row.amount,
+      memo: null,
+      type: "transfer",
+      direction: "inbound",
+      status: "confirmed",
+      provider: null,
+      providerReference: null,
+      deliveryMode: null,
+      fiatCurrency: null,
+      fiatAmount: null,
+      providerData: {},
+      serializedTx: null,
+      signature: found.signature,
+      slot: Number(found.slot),
+      initiatedByKeyId: null,
+    });
+  } catch (err) {
+    // A concurrent reconcile of the same request inserts the same signature
+    // (payment_transfers.signature is UNIQUE); converge on its row instead of
+    // bubbling the duplicate-insert error.
+    if (!isPostgresUniqueViolation(err)) {
+      throw err;
+    }
+    const recorded = await paymentsRepo.listTransfersBySignatures({
+      signatures: [found.signature],
+      organizationId: row.organization_id,
+      projectId,
+    });
+    if (recorded.length === 0) {
+      throw err;
+    }
+    transfer = recorded[0];
+  }
   if (!transfer) {
     throw internalError("Failed to record inbound transfer for payment request settlement");
   }
 
-  const settled = await createPaymentRequestsRepository(env).markPaymentRequest({
+  const requestsRepo = createPaymentRequestsRepository(env);
+  const settled = await requestsRepo.markPaymentRequest({
     requestId: row.id,
     organizationId: row.organization_id,
     projectId,
@@ -101,5 +124,13 @@ export async function reconcilePaymentRequest(
   if (settled) {
     return settled;
   }
-  return row;
+  const current = await requestsRepo.getPaymentRequestById({
+    requestId: row.id,
+    organizationId: row.organization_id,
+    projectId,
+  });
+  if (!current) {
+    throw internalError("payment request not found after settlement");
+  }
+  return current;
 }

--- a/apps/sdp-api/src/services/payments/payment-requests.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.ts
@@ -134,3 +134,21 @@ export async function reconcilePaymentRequest(
   }
   return current;
 }
+
+// Read-path wrapper: a transient RPC failure while reconciling one row must not
+// take down a whole list (Promise.all) or the public pay page. Degrade to the
+// stored row and log; the next read retries.
+export async function reconcilePaymentRequestBestEffort(
+  env: Env,
+  row: PaymentRequestRow
+): Promise<PaymentRequestRow> {
+  try {
+    return await reconcilePaymentRequest(env, row);
+  } catch (err) {
+    console.error("reconcilePaymentRequestBestEffort: reconcile failed, returning stored row", {
+      paymentRequestId: row.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return row;
+  }
+}

--- a/apps/sdp-api/src/services/payments/recurring-payments.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments.ts
@@ -1653,9 +1653,7 @@ export async function collectRecurringPayment(input: {
       amount: input.recurringPayment.amount,
     });
 
-    const transferCreatedAt = new Date().toISOString();
     transfer = await paymentsRepo.createTransfer({
-      id: `xfr_${crypto.randomUUID()}`,
       organizationId: input.organizationId,
       projectId: input.projectId,
       walletId: input.sourceWallet.walletId,
@@ -1679,9 +1677,9 @@ export async function collectRecurringPayment(input: {
         collectionDueAt: dueAt,
       },
       serializedTx: null,
+      signature: null,
+      slot: null,
       initiatedByKeyId: input.initiatedByKeyId,
-      createdAt: transferCreatedAt,
-      updatedAt: transferCreatedAt,
     });
     if (!transfer) {
       throw new AppError("INTERNAL_ERROR", "Failed to create collection transfer");


### PR DESCRIPTION
## What

Payment requests now **settle on read**: when an awaiting request is viewed (public `GET /pay/:token` or the dashboard list), its Solana Pay `reference` is checked on-chain and, if a valid payment is found, the request is marked `paid` with a linked inbound transfer recorded.

This is the settlement path #515 shipped-then-reverted, rebuilt on `@solana/pay` instead of a hand-rolled validator.

## How

- `services/payments/payment-requests.ts` → `reconcilePaymentRequest(env, row)`: short-circuit non-awaiting/expired, then `findReference` → `validateTransfer` (`@solana/pay`, kit-native), then `createTransfer` (inbound) + `markPaymentRequest(paid)`. Wired into `pay.ts` and the list handler.
- Repo refactor (separate commit): `createTransfer` owns the `id` + timestamps and takes `signature`/`slot`, returning via `RETURNING` — one insert, no create-then-update.

## Decisions worth knowing

- **Settle-on-read, not push.** A request only flips to `paid` when someone looks; fine for now. `@solana/pay`'s `watchReference` is the push upgrade path if a non-human consumer ever needs it.
- **Reuse `@solana/pay`** for validation — it handles the failed-tx selection + SOL/SPL precision that #515 was reverted over.
- **Settlement persists a real inbound `payment_transfers` row** — required by the `CHECK (status != 'paid' OR fulfilled_by_transfer_id IS NOT NULL)`.
- **No KV coalesce**; the `/pay` route is already rate-limited. Add a cache/cap only if RPC cost spikes.

## Testing

`services/payments/payment-requests.test.ts` covers settle (SOL + SPL), not-found, invalid, rethrow-on-unexpected, and both short-circuits. `tsc`/`biome` clean; 123/123 across the 5 affected suites (DB tests: `--config vitest.workers.config.ts`).

Deferred (non-blocking): endpoint rename `/pay/:token` → `/payment-requests/:token`.
