### PR TITLE
test: slim Kora live smoke suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "kora:surfpool:integration": "scripts/kora-surfpool/integration.sh",
     "kora:surfpool:test": "scripts/kora-surfpool/test.sh",
     "kora:devnet:check": "infra/kora/cloud-run/check.sh",
-    "kora:devnet:test": "DATABASE_URL=${KORA_DEVNET_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp} node scripts/run-workspace-tests.mjs integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
+    "kora:devnet:test": "DATABASE_URL=${KORA_DEVNET_DATABASE_URL:-${DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp}} node scripts/run-workspace-tests.mjs integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "kora:surfpool:integration": "scripts/kora-surfpool/integration.sh",
     "kora:surfpool:test": "scripts/kora-surfpool/test.sh",
     "kora:devnet:check": "infra/kora/cloud-run/check.sh",
-    "kora:devnet:test": "pnpm --filter @sdp/api-integration test -- src/tests/kora.test.ts"
+    "kora:devnet:test": "DATABASE_URL=${DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp} pnpm test:integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "kora:surfpool:integration": "scripts/kora-surfpool/integration.sh",
     "kora:surfpool:test": "scripts/kora-surfpool/test.sh",
     "kora:devnet:check": "infra/kora/cloud-run/check.sh",
-    "kora:devnet:test": "DATABASE_URL=${DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp} pnpm test:integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
+    "kora:devnet:test": "DATABASE_URL=${KORA_DEVNET_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp} node scripts/run-workspace-tests.mjs integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -7,12 +7,16 @@ type SolanaRpcResponse<T> =
   | { jsonrpc: "2.0"; id: number; error: { code: number; message: string; data?: unknown } };
 
 const PRECHECK_CACHE_KEY = "__sdp_integration_preflight__";
-const REQUIRED_KORA_ALLOWED_PROGRAMS = [
+// biome-ignore lint/security/noSecrets: Public Solana program ID, not a secret.
+const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+const REQUIRED_SURFPOOL_ALLOWED_PROGRAMS = [
   // biome-ignore lint/security/noSecrets: Public Solana program ID, not a secret.
   "TACLkU6CiCdkQN2MjoyDkVg2yAH9zkxiHDsiztQ52TP",
   // biome-ignore lint/security/noSecrets: Public Solana program ID, not a secret.
   "GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz",
+  MEMO_PROGRAM_ADDRESS,
 ] as const;
+const REQUIRED_LIVE_KORA_ALLOWED_PROGRAMS = [MEMO_PROGRAM_ADDRESS] as const;
 
 type PreflightState = {
   promise: Promise<void>;
@@ -71,12 +75,13 @@ async function runPreflight(): Promise<void> {
   if (!config?.validation_config?.allowed_programs) {
     throw new Error("Kora preflight failed: missing validation_config.allowed_programs");
   }
-  const missingAllowedPrograms = REQUIRED_KORA_ALLOWED_PROGRAMS.filter(
+  const requiredAllowedPrograms = getRequiredKoraAllowedPrograms();
+  const missingAllowedPrograms = requiredAllowedPrograms.filter(
     (program) => !config.validation_config.allowed_programs.includes(program)
   );
   if (missingAllowedPrograms.length > 0) {
     throw new Error(
-      `Kora preflight failed: missing required sRFC-37 allowed programs: ${missingAllowedPrograms.join(", ")}. Update Kora validation_config.allowed_programs.`
+      `Kora preflight failed: missing required ${getKoraPreflightScopeLabel()} allowed programs: ${missingAllowedPrograms.join(", ")}. Update Kora validation_config.allowed_programs.`
     );
   }
 
@@ -99,6 +104,26 @@ async function runPreflight(): Promise<void> {
       `Kora preflight failed: fee payer balance too low (${feePayerLamports} lamports, min ${minLamports}).`
     );
   }
+}
+
+function getRequiredKoraAllowedPrograms(): readonly string[] {
+  if (isKoraSurfpoolShim()) {
+    return REQUIRED_SURFPOOL_ALLOWED_PROGRAMS;
+  }
+
+  return REQUIRED_LIVE_KORA_ALLOWED_PROGRAMS;
+}
+
+function getKoraPreflightScopeLabel(): string {
+  if (isKoraSurfpoolShim()) {
+    return "Surfpool-backed SDP";
+  }
+
+  return "live smoke";
+}
+
+function isKoraSurfpoolShim(): boolean {
+  return (env as { KORA_SURFPOOL_SHIM?: string }).KORA_SURFPOOL_SHIM === "true";
 }
 
 function getKoraMinBalanceLamports(): number {

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -1,18 +1,10 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import type {
-  BurnApiResponse,
-  FreezeApiResponse,
-  MintApiResponse,
-  SignerCheckApiResponse,
-  TokenApiResponse,
-  UnfreezeApiResponse,
-} from "../helpers/api-types";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { SignerCheckApiResponse } from "../helpers/api-types";
 import {
   cleanupIntegrationSuite,
   env,
   initIntegrationSuite,
   requestWithApiKey,
-  resetIntegrationState,
 } from "../helpers/integration";
 
 const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
@@ -34,6 +26,9 @@ type ParsedTransactionResponse = {
   };
   meta: { err: unknown } | null;
 };
+
+const TRANSACTION_LOOKUP_TIMEOUT_MS = 30_000;
+const TRANSACTION_LOOKUP_POLL_MS = 1_000;
 
 function normalizePubkey(accountKey: ParsedAccountKey): string {
   if (typeof accountKey === "string") {
@@ -62,7 +57,42 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
   return payload.result;
 }
 
-function assertKoraIntegrationEnvConfigured() {
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getConfirmedTransaction(signature: string): Promise<ParsedTransactionResponse> {
+  const deadline = Date.now() + TRANSACTION_LOOKUP_TIMEOUT_MS;
+  let lastError: unknown;
+
+  while (Date.now() <= deadline) {
+    try {
+      const tx = await callSolanaRpc<ParsedTransactionResponse | null>("getTransaction", [
+        signature,
+        {
+          commitment: "confirmed",
+          encoding: "jsonParsed",
+          maxSupportedTransactionVersion: 0,
+        },
+      ]);
+
+      if (tx) {
+        return tx;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(TRANSACTION_LOOKUP_POLL_MS);
+  }
+
+  const suffix = lastError instanceof Error ? ` Last RPC error: ${lastError.message}` : "";
+  throw new Error(
+    `Unable to fetch confirmed Kora signer-check transaction ${signature} from SOLANA_RPC_URL after ${TRANSACTION_LOOKUP_TIMEOUT_MS}ms.${suffix}`
+  );
+}
+
+function assertKoraLiveSmokeEnvConfigured() {
   const missing: string[] = [];
   if (env.RUN_INTEGRATION_TESTS !== "true") missing.push("RUN_INTEGRATION_TESTS=true");
   if (!env.SOLANA_RPC_URL) missing.push("SOLANA_RPC_URL");
@@ -71,123 +101,23 @@ function assertKoraIntegrationEnvConfigured() {
   if (!env.PRIVY_APP_SECRET) missing.push("PRIVY_APP_SECRET");
 
   if (missing.length > 0) {
-    throw new Error(`Kora integration tests require env configuration: ${missing.join(", ")}.`);
+    throw new Error(`Kora live smoke tests require env configuration: ${missing.join(", ")}.`);
   }
 }
 
-describe("Kora Fee Payment (Devnet)", () => {
-  let apiKeyHash: string;
-  let custodyAddress = "";
+describe("Kora Fee Payment (Live Smoke)", () => {
   const request = requestWithApiKey();
 
   beforeAll(async () => {
-    assertKoraIntegrationEnvConfigured();
-    const init = await initIntegrationSuite();
-    apiKeyHash = init.apiKeyHash;
-    custodyAddress = init.custodyAddress;
+    assertKoraLiveSmokeEnvConfigured();
+    await initIntegrationSuite();
   });
 
   afterAll(async () => {
     await cleanupIntegrationSuite();
   });
 
-  beforeEach(async () => {
-    const state = await resetIntegrationState(apiKeyHash);
-    custodyAddress = state.custodyAddress;
-  });
-
-  it("deploys and manages a token using Kora fee payer", { timeout: 120000 }, async () => {
-    const createRes = await request("/v1/issuance/tokens", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "Kora Devnet Token",
-        symbol: "KORA",
-        decimals: 6,
-        isMintable: true,
-        isFreezable: true,
-      }),
-    });
-
-    expect(createRes.status).toBe(201);
-    const created = (await createRes.json()) as TokenApiResponse;
-    const tokenId = created.data.token.id;
-
-    const deployRes = await request(`/v1/issuance/tokens/${tokenId}/deploy`, {
-      method: "POST",
-    });
-
-    expect(deployRes.status).toBe(200);
-    const deployed = (await deployRes.json()) as TokenApiResponse;
-    expect(deployed.data.token.mintAddress).toBeTruthy();
-
-    const mintRes = await request(`/v1/issuance/tokens/${tokenId}/mint`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        mint: {
-          destination: custodyAddress,
-          amount: "2",
-        },
-      }),
-    });
-
-    expect(mintRes.status).toBe(200);
-    const minted = (await mintRes.json()) as MintApiResponse;
-    expect(minted.data.transaction.status).toBe("confirmed");
-    expect(minted.data.transaction.signature).toBeTruthy();
-
-    const tokenAccount = minted.data.tokenAccount;
-    expect(tokenAccount).toBeTruthy();
-
-    const freezeRes = await request(`/v1/issuance/tokens/${tokenId}/freeze`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ accountAddress: tokenAccount }),
-    });
-
-    expect(freezeRes.status).toBe(201);
-    const frozen = (await freezeRes.json()) as FreezeApiResponse;
-    expect(frozen.data.frozenAccount.accountAddress).toBe(tokenAccount);
-
-    const unfreezeRes = await request(`/v1/issuance/tokens/${tokenId}/unfreeze`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ accountAddress: tokenAccount }),
-    });
-
-    expect(unfreezeRes.status).toBe(200);
-    const unfrozen = (await unfreezeRes.json()) as UnfreezeApiResponse;
-    expect(unfrozen.data.frozenAccount.accountAddress).toBe(tokenAccount);
-
-    const burnRes = await request(`/v1/issuance/tokens/${tokenId}/burn`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        burn: {
-          source: tokenAccount,
-          amount: "1",
-        },
-      }),
-    });
-
-    expect(burnRes.status).toBe(200);
-    const burned = (await burnRes.json()) as BurnApiResponse;
-    expect(burned.data.transaction.status).toBe("confirmed");
-    expect(burned.data.transaction.signature).toBeTruthy();
-  });
-
-  it("submits signer-check memo with Privy wallet-bound API key via Kora", {
+  it("submits a Privy signer-check memo through Kora signAndSend", {
     timeout: 120000,
   }, async () => {
     const createWalletRes = await request("/v1/wallets", {
@@ -249,8 +179,14 @@ describe("Kora Fee Payment (Devnet)", () => {
         body: JSON.stringify({ memo }),
       });
 
-      expect(signerCheckRes.status).toBe(200);
-      const signerCheckBody = (await signerCheckRes.json()) as SignerCheckApiResponse;
+      const signerCheckPayload = await signerCheckRes.text();
+      if (signerCheckRes.status !== 200) {
+        throw new Error(
+          `Kora signer-check failed (${signerCheckRes.status}): ${signerCheckPayload}`
+        );
+      }
+
+      const signerCheckBody = JSON.parse(signerCheckPayload) as SignerCheckApiResponse;
       const signerCheck = signerCheckBody.data;
 
       expect(signerCheck.walletId).toBe(walletId);
@@ -260,20 +196,7 @@ describe("Kora Fee Payment (Devnet)", () => {
       expect(signerCheck.feePayer).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
       expect(signerCheck.feePayer).not.toBe(signerCheck.walletAddress);
 
-      const tx = await callSolanaRpc<ParsedTransactionResponse | null>("getTransaction", [
-        signerCheck.signature,
-        {
-          commitment: "confirmed",
-          encoding: "jsonParsed",
-          maxSupportedTransactionVersion: 0,
-        },
-      ]);
-
-      expect(tx).toBeTruthy();
-      if (!tx) {
-        return;
-      }
-
+      const tx = await getConfirmedTransaction(signerCheck.signature);
       expect(tx.meta?.err).toBeNull();
       const accountKeys = tx.transaction.message.accountKeys.map(normalizePubkey);
       expect(accountKeys[0]).toBe(signerCheck.feePayer);

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -39,6 +39,7 @@ type ParsedTransactionResponse = {
 
 const TRANSACTION_LOOKUP_TIMEOUT_MS = 30_000;
 const TRANSACTION_LOOKUP_POLL_MS = 1_000;
+const SOLANA_RPC_REQUEST_TIMEOUT_MS = 10_000;
 
 function normalizePubkey(accountKey: ParsedAccountKey): string {
   if (typeof accountKey === "string") {
@@ -53,11 +54,27 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
     throw new Error("SOLANA_RPC_URL is not configured for integration tests.");
   }
 
-  const response = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SOLANA_RPC_REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new SolanaRpcError(
+        `Request timed out calling ${method} after ${SOLANA_RPC_REQUEST_TIMEOUT_MS}ms`,
+        408
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   const responseText = await response.text();
   if (!response.ok) {
@@ -148,6 +165,12 @@ function isRetryableTransactionLookupError(error: unknown): boolean {
     message.includes("timed out") ||
     message.includes("failed to fetch") ||
     message.includes("fetch failed") ||
+    message.includes("aborted") ||
+    message.includes("block not available") ||
+    message.includes("could not find transaction") ||
+    message.includes("not available from this node") ||
+    message.includes("transaction history is not available") ||
+    message.includes("node is behind") ||
     message.includes("service unavailable") ||
     message.includes("try again") ||
     message.includes("too many requests") ||

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -56,7 +56,8 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), SOLANA_RPC_REQUEST_TIMEOUT_MS);
-  let response: Response;
+  let response: Response | null = null;
+  let responseText = "";
   try {
     response = await fetch(rpcUrl, {
       method: "POST",
@@ -64,6 +65,7 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
       signal: controller.signal,
     });
+    responseText = await response.text();
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       throw new SolanaRpcError(
@@ -76,7 +78,10 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
     clearTimeout(timeout);
   }
 
-  const responseText = await response.text();
+  if (!response) {
+    throw new SolanaRpcError(`No response received calling ${method}`);
+  }
+
   if (!response.ok) {
     throw new SolanaRpcError(
       `HTTP ${response.status} calling ${method}: ${responseText.slice(0, 200)}`,

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -146,6 +146,8 @@ function isRetryableTransactionLookupError(error: unknown): boolean {
     message.includes("unable to complete request") ||
     message.includes("request timed out") ||
     message.includes("timed out") ||
+    message.includes("failed to fetch") ||
+    message.includes("fetch failed") ||
     message.includes("service unavailable") ||
     message.includes("try again") ||
     message.includes("too many requests") ||

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -40,6 +40,7 @@ type ParsedTransactionResponse = {
 const TRANSACTION_LOOKUP_TIMEOUT_MS = 30_000;
 const TRANSACTION_LOOKUP_POLL_MS = 1_000;
 const SOLANA_RPC_REQUEST_TIMEOUT_MS = 10_000;
+const RETRYABLE_SOLANA_RPC_CODES = new Set([-32004, -32005]);
 
 function normalizePubkey(accountKey: ParsedAccountKey): string {
   if (typeof accountKey === "string") {
@@ -151,12 +152,16 @@ function isRetryableTransactionLookupError(error: unknown): boolean {
   }
 
   if (error instanceof SolanaRpcError) {
-    if (error.code && [-32600, -32601, -32602].includes(error.code)) {
+    if (error.code !== undefined && [-32600, -32601, -32602].includes(error.code)) {
       return false;
     }
 
+    if (error.code !== undefined && RETRYABLE_SOLANA_RPC_CODES.has(error.code)) {
+      return true;
+    }
+
     if (
-      error.code &&
+      error.code !== undefined &&
       (error.code === 408 || error.code === 429 || (error.code >= 500 && error.code <= 599))
     ) {
       return true;

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -133,7 +133,10 @@ function isRetryableTransactionLookupError(error: unknown): boolean {
       return false;
     }
 
-    if (error.code && (error.code === 429 || (error.code >= 500 && error.code <= 599))) {
+    if (
+      error.code &&
+      (error.code === 408 || error.code === 429 || (error.code >= 500 && error.code <= 599))
+    ) {
       return true;
     }
   }

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -16,7 +16,7 @@ type SolanaRpcResponse<T> =
 class SolanaRpcError extends Error {
   constructor(
     message: string,
-    readonly code: number
+    readonly code?: number
   ) {
     super(message);
     this.name = "SolanaRpcError";
@@ -59,7 +59,22 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
   });
 
-  const payload = (await response.json()) as SolanaRpcResponse<T>;
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new SolanaRpcError(
+      `HTTP ${response.status} calling ${method}: ${responseText.slice(0, 200)}`,
+      response.status
+    );
+  }
+
+  let payload: SolanaRpcResponse<T>;
+  try {
+    payload = JSON.parse(responseText) as SolanaRpcResponse<T>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SolanaRpcError(`Invalid JSON response calling ${method}: ${message}`);
+  }
+
   if ("error" in payload) {
     throw new SolanaRpcError(
       payload.error.message ?? `RPC error calling ${method}`,
@@ -113,8 +128,14 @@ function isRetryableTransactionLookupError(error: unknown): boolean {
     return false;
   }
 
-  if (error instanceof SolanaRpcError && [-32600, -32601, -32602].includes(error.code)) {
-    return false;
+  if (error instanceof SolanaRpcError) {
+    if (error.code && [-32600, -32601, -32602].includes(error.code)) {
+      return false;
+    }
+
+    if (error.code && (error.code === 429 || (error.code >= 500 && error.code <= 599))) {
+      return true;
+    }
   }
 
   const message = error.message.toLowerCase();
@@ -125,6 +146,9 @@ function isRetryableTransactionLookupError(error: unknown): boolean {
     message.includes("service unavailable") ||
     message.includes("try again") ||
     message.includes("too many requests") ||
+    message.includes("invalid json response") ||
+    message.includes("bad gateway") ||
+    message.includes("gateway timeout") ||
     message.includes("429") ||
     message.includes("500") ||
     message.includes("502") ||

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -13,6 +13,16 @@ type SolanaRpcResponse<T> =
   | { jsonrpc: "2.0"; id: number; result: T }
   | { jsonrpc: "2.0"; id: number; error: { code: number; message: string; data?: unknown } };
 
+class SolanaRpcError extends Error {
+  constructor(
+    message: string,
+    readonly code: number
+  ) {
+    super(message);
+    this.name = "SolanaRpcError";
+  }
+}
+
 type ParsedAccountKey = string | { pubkey: string; signer?: boolean };
 type ParsedInstruction = { programId?: string; parsed?: unknown };
 
@@ -51,7 +61,10 @@ async function callSolanaRpc<T>(method: string, params: unknown[]): Promise<T> {
 
   const payload = (await response.json()) as SolanaRpcResponse<T>;
   if ("error" in payload) {
-    throw new Error(payload.error.message ?? `RPC error calling ${method}`);
+    throw new SolanaRpcError(
+      payload.error.message ?? `RPC error calling ${method}`,
+      payload.error.code
+    );
   }
 
   return payload.result;
@@ -80,6 +93,9 @@ async function getConfirmedTransaction(signature: string): Promise<ParsedTransac
         return tx;
       }
     } catch (error) {
+      if (!isRetryableTransactionLookupError(error)) {
+        throw error;
+      }
       lastError = error;
     }
 
@@ -89,6 +105,31 @@ async function getConfirmedTransaction(signature: string): Promise<ParsedTransac
   const suffix = lastError instanceof Error ? ` Last RPC error: ${lastError.message}` : "";
   throw new Error(
     `Unable to fetch confirmed Kora signer-check transaction ${signature} from SOLANA_RPC_URL after ${TRANSACTION_LOOKUP_TIMEOUT_MS}ms.${suffix}`
+  );
+}
+
+function isRetryableTransactionLookupError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (error instanceof SolanaRpcError && [-32600, -32601, -32602].includes(error.code)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("unable to complete request") ||
+    message.includes("request timed out") ||
+    message.includes("timed out") ||
+    message.includes("service unavailable") ||
+    message.includes("try again") ||
+    message.includes("too many requests") ||
+    message.includes("429") ||
+    message.includes("500") ||
+    message.includes("502") ||
+    message.includes("503") ||
+    message.includes("504")
   );
 }
 


### PR DESCRIPTION
## Summary
- Slim the live Kora shard by removing the duplicate deploy/mint/freeze/unfreeze/burn token lifecycle from `kora-flow.test.ts`.
- Keep the live provider proof focused on a Privy wallet-bound `/v1/wallets/signer-check` memo transaction that goes through SDP's Kora `signAndSend` path.
- Narrow live Kora preflight to Memo signer-check compatibility while preserving the broader SDP allowed-program checks for Surfpool/Kora shim runs.
- Update `pnpm kora:devnet:test` to run the same two-file live smoke shard via the workspace integration runner with a local Postgres default.

Closes PRO-1413.

## Local validation
- `pnpm exec biome check package.json packages/sdp-api-integration/src/helpers/preflight.ts packages/sdp-api-integration/src/tests/kora-flow.test.ts`
- `pnpm test:scripts`
- `DOPPLER_CONFIG=dev_ci scripts/doppler/run-with-config.sh pnpm kora:devnet:test`
- `DOPPLER_CONFIG=dev_ci DATABASE_URL=postgresql://sdp:sdp@127.0.0.1:5432/sdp pnpm kora:surfpool:test`
- `pnpm typecheck`
- `pnpm lint` exits 0 with existing repo warnings

## Notes
- A standalone `pnpm --filter @sdp/api-integration exec tsc --noEmit --project tsconfig.json` still fails on pre-existing helper strictness in `src/helpers/integration.ts`; the repo-level `pnpm typecheck` path passes.