### PR TITLE
feat(web): add recurring payments dashboard plumbing

### DIFF
--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -4,6 +4,8 @@ import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient } from "../support/local-api-client";
 import {
   createExternalSolanaAddress,
+  ensureLinkedOrg,
+  resolvePlaywrightProjectId,
   seedCounterpartyWithSolanaAccount,
   seedProjectCookie,
 } from "../support/local-dashboard-bootstrap";
@@ -11,6 +13,61 @@ import {
   bootstrapLocalPaymentFixtures,
   getBootstrapApiBaseUrl,
 } from "../support/local-issuance-bootstrap";
+
+const recurringPaymentsEnabled = process.env.NEXT_PUBLIC_PAYMENTS_RECURRING_ENABLED === "true";
+
+test.describe
+  .serial("dashboard recurring payments feature flag", () => {
+    let bootstrapProjectId = "";
+
+    test.beforeAll(async ({ browser }) => {
+      const session = await getPlaywrightAdminSession(browser);
+      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
+      bootstrapProjectId = await resolvePlaywrightProjectId(
+        getBootstrapApiBaseUrl(),
+        session.getBearerToken
+      );
+      await session.page.close();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await seedProjectCookie(page, bootstrapProjectId);
+    });
+
+    test("hides recurring payments when the dashboard feature flag is disabled", async ({
+      page,
+    }) => {
+      test.skip(recurringPaymentsEnabled, "Covered by the feature-enabled recurring payment test");
+
+      await page.goto("/dashboard/payments");
+
+      await expect(page.getByRole("link", { name: "Recurring" })).toHaveCount(0);
+
+      await page.goto("/dashboard/payments/recurring");
+      await expect(
+        page.getByRole("heading", { name: "Recurring payments unavailable" })
+      ).toBeVisible();
+      await expect(page.getByText("No recurring payments yet.")).toHaveCount(0);
+    });
+
+    test("shows recurring payments when the dashboard feature flag is enabled", async ({
+      page,
+    }) => {
+      test.skip(!recurringPaymentsEnabled, "Requires NEXT_PUBLIC_PAYMENTS_RECURRING_ENABLED=true");
+
+      await page.goto("/dashboard/payments");
+
+      await expect(page.getByRole("link", { name: "Recurring" })).toBeVisible();
+      await page.getByRole("link", { name: "Recurring" }).click();
+      await expect(page).toHaveURL(/\/dashboard\/payments\/recurring$/);
+      await expect(
+        page.locator("main").getByRole("heading", { name: "Recurring payments" }).first()
+      ).toBeVisible();
+      await expect(
+        page.getByText("No recurring payments yet.").or(page.locator("tbody tr").first())
+      ).toBeVisible({ timeout: 120_000 });
+    });
+  });
 
 test.describe
   .serial("dashboard payments e2e", () => {

--- a/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/[recurringPaymentId]/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/[recurringPaymentId]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+
+type RouteContext = { params: Promise<{ recurringPaymentId: string }> };
+
+function disabledResponse(trace: ReturnType<typeof createTimedTrace>) {
+  logRouteResult(trace, 404, { recurringPaymentsEnabled: false });
+  return NextResponse.json(
+    { error: { message: "Recurring payments are not enabled" } },
+    {
+      status: 404,
+      headers: {
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    }
+  );
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  const trace = createTimedTrace("route.dashboard.recurring-payments.get", request);
+
+  if (!isRecurringPaymentsDashboardEnabled()) {
+    return disabledResponse(trace);
+  }
+
+  try {
+    const { recurringPaymentId } = await context.params;
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.recurring-payments.api")
+    );
+    const response = await apiClient.request(
+      `/v1/payments/recurring-payments/${encodeURIComponent(recurringPaymentId)}`,
+      { method: "GET" }
+    );
+    const body = await response.text();
+
+    logRouteResult(trace, response.status, { recurringPaymentId });
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to fetch recurring payment",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch recurring payment" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/[recurringPaymentId]/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/[recurringPaymentId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
 import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
-import { createSdpApiClient } from "@/lib/sdp-api";
+import { getRecurringPaymentsProxyClient } from "../proxy-guard";
 
 type RouteContext = { params: Promise<{ recurringPaymentId: string }> };
 
@@ -28,10 +28,12 @@ export async function GET(request: Request, context: RouteContext) {
 
   try {
     const { recurringPaymentId } = await context.params;
-    const apiClient = await createSdpApiClient(
-      trace.childContext("route.dashboard.recurring-payments.api")
-    );
-    const response = await apiClient.request(
+    const proxyClient = await getRecurringPaymentsProxyClient(trace);
+    if (!proxyClient.ok) {
+      return proxyClient.response;
+    }
+
+    const response = await proxyClient.apiClient.request(
       `/v1/payments/recurring-payments/${encodeURIComponent(recurringPaymentId)}`,
       { method: "GET" }
     );

--- a/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/proxy-guard.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/proxy-guard.ts
@@ -1,0 +1,49 @@
+import { auth } from "@clerk/nextjs/server";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { PROJECT_COOKIE_NAME } from "@/lib/project-cookie";
+import type { createTimedTrace } from "@/lib/request-tracing";
+import { logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
+
+type TimedTrace = ReturnType<typeof createTimedTrace>;
+
+type RecurringPaymentsProxyClientResult =
+  | { ok: true; apiClient: SdpApiClient }
+  | { ok: false; response: NextResponse };
+
+function guardedResponse(trace: TimedTrace, status: number, message: string) {
+  logRouteResult(trace, status, { error: message });
+  return NextResponse.json(
+    { error: { message } },
+    {
+      status,
+      headers: {
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    }
+  );
+}
+
+export async function getRecurringPaymentsProxyClient(
+  trace: TimedTrace
+): Promise<RecurringPaymentsProxyClientResult> {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    return { ok: false, response: guardedResponse(trace, 401, "Authentication required") };
+  }
+  if (!orgId) {
+    return { ok: false, response: guardedResponse(trace, 403, "Active organization required") };
+  }
+
+  const selectedProjectId = (await cookies()).get(PROJECT_COOKIE_NAME)?.value;
+  if (!selectedProjectId) {
+    return { ok: false, response: guardedResponse(trace, 400, "Selected project required") };
+  }
+
+  const apiClient = await createSdpApiClient(
+    trace.childContext("route.dashboard.recurring-payments.api")
+  );
+  return { ok: true, apiClient };
+}

--- a/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
+import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
+import { createSdpApiClient } from "@/lib/sdp-api";
+
+function disabledResponse(trace: ReturnType<typeof createTimedTrace>) {
+  logRouteResult(trace, 404, { recurringPaymentsEnabled: false });
+  return NextResponse.json(
+    { error: { message: "Recurring payments are not enabled" } },
+    {
+      status: 404,
+      headers: {
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    }
+  );
+}
+
+export async function GET(request: Request) {
+  const trace = createTimedTrace("route.dashboard.recurring-payments.list", request);
+
+  if (!isRecurringPaymentsDashboardEnabled()) {
+    return disabledResponse(trace);
+  }
+
+  try {
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.recurring-payments.api")
+    );
+    const url = new URL(request.url);
+    const search = url.searchParams.toString();
+    const response = await apiClient.request(
+      `/v1/payments/recurring-payments${search ? `?${search}` : ""}`,
+      { method: "GET" }
+    );
+    const body = await response.text();
+
+    logRouteResult(trace, response.status, { query: search });
+
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to list recurring payments",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to list recurring payments" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const trace = createTimedTrace("route.dashboard.recurring-payments.create", request);
+
+  if (!isRecurringPaymentsDashboardEnabled()) {
+    return disabledResponse(trace);
+  }
+
+  try {
+    const body = await request.text();
+    const apiClient = await createSdpApiClient(
+      trace.childContext("route.dashboard.recurring-payments.api")
+    );
+    const response = await apiClient.request("/v1/payments/recurring-payments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    const responseBody = await response.text();
+
+    logRouteResult(trace, response.status, { bodyBytes: body.length });
+
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") ?? "application/json",
+        "X-SDP-Trace-ID": trace.traceId,
+        "Server-Timing": trace.serverTiming(),
+      },
+    });
+  } catch (error) {
+    logRouteResult(trace, 500, {
+      error: error instanceof Error ? error.message : "Failed to create recurring payment",
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to create recurring payment" },
+      {
+        status: 500,
+        headers: { "X-SDP-Trace-ID": trace.traceId, "Server-Timing": trace.serverTiming() },
+      }
+    );
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
 import { createTimedTrace, logRouteResult } from "@/lib/request-tracing";
-import { createSdpApiClient } from "@/lib/sdp-api";
+import { getRecurringPaymentsProxyClient } from "./proxy-guard";
 
 function disabledResponse(trace: ReturnType<typeof createTimedTrace>) {
   logRouteResult(trace, 404, { recurringPaymentsEnabled: false });
@@ -25,12 +25,14 @@ export async function GET(request: Request) {
   }
 
   try {
-    const apiClient = await createSdpApiClient(
-      trace.childContext("route.dashboard.recurring-payments.api")
-    );
+    const proxyClient = await getRecurringPaymentsProxyClient(trace);
+    if (!proxyClient.ok) {
+      return proxyClient.response;
+    }
+
     const url = new URL(request.url);
     const search = url.searchParams.toString();
-    const response = await apiClient.request(
+    const response = await proxyClient.apiClient.request(
       `/v1/payments/recurring-payments${search ? `?${search}` : ""}`,
       { method: "GET" }
     );
@@ -69,10 +71,12 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.text();
-    const apiClient = await createSdpApiClient(
-      trace.childContext("route.dashboard.recurring-payments.api")
-    );
-    const response = await apiClient.request("/v1/payments/recurring-payments", {
+    const proxyClient = await getRecurringPaymentsProxyClient(trace);
+    if (!proxyClient.ok) {
+      return proxyClient.response;
+    }
+
+    const response = await proxyClient.apiClient.request("/v1/payments/recurring-payments", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,

--- a/apps/sdp-web/src/app/dashboard/payments/payment-api-errors.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payment-api-errors.ts
@@ -1,0 +1,34 @@
+export type PaymentApiErrorBody = {
+  error?:
+    | string
+    | {
+        message?: string;
+      };
+  message?: string;
+};
+
+export function getPaymentApiError(body: PaymentApiErrorBody, fallback: string): string {
+  const error = body.error;
+  if (typeof error === "string" && error) {
+    return error;
+  }
+  if (typeof error === "object" && typeof error.message === "string" && error.message) {
+    return error.message;
+  }
+  if (typeof body.message === "string" && body.message) {
+    return body.message;
+  }
+  return fallback;
+}
+
+export function parsePaymentApiErrorText(body: string, fallback = body): string {
+  if (!body) {
+    return fallback;
+  }
+
+  try {
+    return getPaymentApiError(JSON.parse(body) as PaymentApiErrorBody, fallback);
+  } catch {
+    return body;
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
@@ -4,6 +4,7 @@ import type {
   PaymentTransferSummary,
 } from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
+import { parsePaymentApiErrorText } from "./payment-api-errors";
 
 export interface FetchResult<T> {
   ok: boolean;
@@ -22,18 +23,6 @@ export interface PaymentsIssuedTokenSymbol {
   symbol: string;
 }
 
-function parseErrorMessage(body: string): string {
-  try {
-    const parsed = JSON.parse(body) as {
-      error?: { message?: string };
-      message?: string;
-    };
-    return parsed?.error?.message ?? parsed?.message ?? body;
-  } catch {
-    return body;
-  }
-}
-
 export async function fetchPaymentsWallets(
   request: SdpApiClient["request"],
   options: FetchPaymentsWalletsOptions = {}
@@ -50,7 +39,7 @@ export async function fetchPaymentsWallets(
       return {
         ok: false,
         status: response.status,
-        error: parseErrorMessage(body),
+        error: parsePaymentApiErrorText(body),
       };
     }
 
@@ -108,7 +97,7 @@ export async function fetchPaymentsAggregate(
       return {
         ok: false,
         status: response.status,
-        error: parseErrorMessage(body),
+        error: parsePaymentApiErrorText(body),
       };
     }
 
@@ -153,7 +142,7 @@ export async function fetchPaymentTransfers(
       return {
         ok: false,
         status: response.status,
-        error: parseErrorMessage(body),
+        error: parsePaymentApiErrorText(body),
       };
     }
 
@@ -287,7 +276,7 @@ export async function fetchPaymentsIssuedTokenSymbols(
       return {
         ok: false,
         status: response.status,
-        error: parseErrorMessage(body),
+        error: parsePaymentApiErrorText(body),
       };
     }
 

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -27,15 +27,14 @@ import {
   type ComplianceProviderResult,
   screenAddressCompliance,
 } from "@/lib/compliance";
+import {
+  type PaymentApiErrorBody as ApiErrorBody,
+  getPaymentApiError as getApiError,
+} from "./payment-api-errors";
 import type { ComplianceSnapshot } from "./payments-workspace.types";
 
 export type { PaymentRampExecution, PaymentRampInstruction } from "@sdp/types";
-
-type ApiErrorBody = {
-  error?: {
-    message?: string;
-  };
-};
+export { getPaymentApiError as getApiError } from "./payment-api-errors";
 
 export interface PaymentWalletBalance {
   token: string;
@@ -55,13 +54,6 @@ type RiskTone = "green" | "yellow" | "red" | "neutral";
 
 export function getDevnetExplorerUrl(signature: string): string {
   return `https://explorer.solana.com/tx/${encodeURIComponent(signature)}?cluster=devnet`;
-}
-
-export function getApiError(body: ApiErrorBody, fallback: string): string {
-  if (typeof body.error?.message === "string" && body.error.message) {
-    return body.error.message;
-  }
-  return fallback;
 }
 
 export function toProviderLabel(value: string): string {

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/not-found.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/not-found.tsx
@@ -1,0 +1,9 @@
+export default function RecurringPaymentsNotFound() {
+  return (
+    <div className="px-3 pb-5 md:px-6 md:pb-6">
+      <div className="border border-border-light bg-white p-4">
+        <h2 className="text-lg font-medium text-text-extra-high">Recurring payments unavailable</h2>
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx
@@ -1,0 +1,23 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
+import { getAuthEntryPath } from "@/lib/auth-entry";
+import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
+import { RecurringPaymentsWorkspace } from "./recurring-payments-workspace";
+
+export const dynamic = "force-dynamic";
+
+export default async function RecurringPaymentsPage() {
+  if (!isRecurringPaymentsDashboardEnabled()) {
+    notFound();
+  }
+
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect(await getAuthEntryPath());
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  return <RecurringPaymentsWorkspace />;
+}

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { PaymentRecurringPayment, PaymentRecurringPaymentStatus } from "@sdp/types";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDisplayAmount, formatTimestamp, shortenAddress } from "../payments-overview.utils";
+import { listRecurringPayments } from "./recurring-payments.data";
+
+const STATUS_LABELS = {
+  pending_activation: "Pending activation",
+  activating: "Activating",
+  active: "Active",
+  canceling: "Canceling",
+  resuming: "Resuming",
+  paused: "Paused",
+  canceled: "Canceled",
+  expired: "Expired",
+} as const satisfies Record<PaymentRecurringPaymentStatus, string>;
+
+type LoadState =
+  | { status: "loading"; recurringPayments: PaymentRecurringPayment[]; total: number }
+  | { status: "ready"; recurringPayments: PaymentRecurringPayment[]; total: number }
+  | { status: "error"; recurringPayments: PaymentRecurringPayment[]; total: number; error: string };
+
+function RecurringPaymentStatusBadge({ status }: { status: PaymentRecurringPaymentStatus }) {
+  return <Badge>{STATUS_LABELS[status]}</Badge>;
+}
+
+export function RecurringPaymentsWorkspace() {
+  const [state, setState] = useState<LoadState>({
+    status: "loading",
+    recurringPayments: [],
+    total: 0,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    listRecurringPayments({ signal: controller.signal })
+      .then((response) => {
+        setState({
+          status: "ready",
+          recurringPayments: response.recurringPayments,
+          total: response.total,
+        });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        setState({
+          status: "error",
+          recurringPayments: [],
+          total: 0,
+          error: error instanceof Error ? error.message : "Unable to load recurring payments",
+        });
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  const countLabel =
+    state.total === 1 ? "1 recurring payment" : `${state.total} recurring payments`;
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col px-3 pb-5 md:px-6 md:pb-6">
+      <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border-light py-4">
+        <div className="min-w-0">
+          <h2 className="text-lg font-medium text-text-extra-high">Recurring payments</h2>
+          <p className="mt-1 text-sm text-text-medium">{countLabel}</p>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto py-4">
+        {state.status === "loading" ? (
+          <div className="border border-border-light bg-white p-4 text-sm text-text-medium">
+            Loading recurring payments...
+          </div>
+        ) : null}
+
+        {state.status === "error" ? (
+          <div
+            role="alert"
+            className="border border-status-error-border bg-status-error-bg p-4 text-sm text-status-error-text"
+          >
+            <p className="font-medium">Unable to load recurring payments</p>
+            <p className="mt-1">{state.error}</p>
+          </div>
+        ) : null}
+
+        {state.status === "ready" && state.recurringPayments.length === 0 ? (
+          <div className="border border-border-light bg-white p-4 text-sm text-text-medium">
+            No recurring payments yet.
+          </div>
+        ) : null}
+
+        {state.status === "ready" && state.recurringPayments.length > 0 ? (
+          <div className="overflow-hidden border border-border-light bg-white">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Destination</TableHead>
+                  <TableHead>Period</TableHead>
+                  <TableHead>Next due</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {state.recurringPayments.map((recurringPayment) => (
+                  <TableRow key={recurringPayment.id}>
+                    <TableCell className="font-medium">
+                      {formatDisplayAmount(recurringPayment.amount, recurringPayment.token)}
+                    </TableCell>
+                    <TableCell>{shortenAddress(recurringPayment.destinationAddress)}</TableCell>
+                    <TableCell>{recurringPayment.periodHours}h</TableCell>
+                    <TableCell>
+                      {formatTimestamp(recurringPayment.nextCollectionDueAt ?? undefined)}
+                    </TableCell>
+                    <TableCell>
+                      <RecurringPaymentStatusBadge status={recurringPayment.status} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts
@@ -1,0 +1,193 @@
+import type {
+  CreatePaymentRecurringPaymentRequest,
+  ListPaymentRecurringPaymentsResponse,
+  PaginatedResponse,
+  PaymentRecurringPayment,
+  PaymentRecurringPaymentResponse,
+  PaymentRecurringPaymentStatus,
+} from "@sdp/types";
+import type { SdpApiClient } from "@/lib/sdp-api";
+import { getPaymentApiError, parsePaymentApiErrorText } from "../payment-api-errors";
+import type { FetchResult } from "../payments-page.data";
+
+export const RECURRING_PAYMENTS_PAGE_SIZE = 100;
+
+export interface RecurringPaymentsListOptions {
+  page?: number;
+  pageSize?: number;
+  status?: PaymentRecurringPaymentStatus;
+  counterpartyId?: string;
+}
+
+interface ClientRecurringPaymentsListOptions extends RecurringPaymentsListOptions {
+  signal?: AbortSignal;
+}
+
+type DashboardApiEnvelope<T> = {
+  data?: T;
+  error?:
+    | string
+    | {
+        message?: string;
+      };
+  message?: string;
+};
+
+function setPositiveInteger(query: URLSearchParams, key: string, value: number | undefined) {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    query.set(key, String(value));
+  }
+}
+
+export function buildRecurringPaymentsQuery(
+  options: RecurringPaymentsListOptions = {}
+): URLSearchParams {
+  const query = new URLSearchParams();
+  setPositiveInteger(query, "page", options.page);
+  setPositiveInteger(query, "pageSize", options.pageSize);
+  if (options.status) {
+    query.set("status", options.status);
+  }
+  if (options.counterpartyId) {
+    query.set("counterpartyId", options.counterpartyId);
+  }
+  return query;
+}
+
+async function readDashboardEnvelope<T>(response: Response, fallback: string): Promise<T> {
+  const body = (await response.json().catch(() => ({}))) as DashboardApiEnvelope<T>;
+  if (!response.ok) {
+    throw new Error(getPaymentApiError(body, `${fallback} (${response.status}).`));
+  }
+  if (!body.data) {
+    throw new Error(`${fallback} returned an empty response.`);
+  }
+  return body.data;
+}
+
+export async function listRecurringPayments(
+  options: ClientRecurringPaymentsListOptions = {}
+): Promise<ListPaymentRecurringPaymentsResponse> {
+  const { signal, ...filters } = options;
+  const query = buildRecurringPaymentsQuery({
+    page: filters.page ?? 1,
+    pageSize: filters.pageSize ?? RECURRING_PAYMENTS_PAGE_SIZE,
+    status: filters.status,
+    counterpartyId: filters.counterpartyId,
+  });
+  const response = await fetch(`/api/dashboard/payments/recurring-payments?${query.toString()}`, {
+    method: "GET",
+    cache: "no-store",
+    signal,
+  });
+  return readDashboardEnvelope<ListPaymentRecurringPaymentsResponse>(
+    response,
+    "Recurring payment list request failed"
+  );
+}
+
+export async function getRecurringPayment(
+  recurringPaymentId: string,
+  signal?: AbortSignal
+): Promise<PaymentRecurringPayment> {
+  const response = await fetch(
+    `/api/dashboard/payments/recurring-payments/${encodeURIComponent(recurringPaymentId)}`,
+    {
+      method: "GET",
+      cache: "no-store",
+      signal,
+    }
+  );
+  const data = await readDashboardEnvelope<PaymentRecurringPaymentResponse>(
+    response,
+    "Recurring payment request failed"
+  );
+  return data.recurringPayment;
+}
+
+export async function createRecurringPayment(
+  input: CreatePaymentRecurringPaymentRequest,
+  signal?: AbortSignal
+): Promise<PaymentRecurringPayment> {
+  const response = await fetch("/api/dashboard/payments/recurring-payments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    signal,
+  });
+  const data = await readDashboardEnvelope<PaymentRecurringPaymentResponse>(
+    response,
+    "Recurring payment creation failed"
+  );
+  return data.recurringPayment;
+}
+
+export async function fetchRecurringPayments(
+  request: SdpApiClient["request"],
+  options: RecurringPaymentsListOptions = {}
+): Promise<PaginatedResponse<PaymentRecurringPayment>> {
+  try {
+    const query = buildRecurringPaymentsQuery({
+      page: options.page ?? 1,
+      pageSize: options.pageSize ?? RECURRING_PAYMENTS_PAGE_SIZE,
+      status: options.status,
+      counterpartyId: options.counterpartyId,
+    });
+    const response = await request(`/v1/payments/recurring-payments?${query.toString()}`);
+    if (!response.ok) {
+      return {
+        ok: false,
+        data: [],
+        total: 0,
+        error: parsePaymentApiErrorText(await response.text()),
+      };
+    }
+
+    const json = (await response.json()) as { data?: ListPaymentRecurringPaymentsResponse };
+    return {
+      ok: true,
+      data: json.data?.recurringPayments ?? [],
+      total: json.data?.total ?? 0,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      data: [],
+      total: 0,
+      error: error instanceof Error ? error.message : "Unable to load recurring payments",
+    };
+  }
+}
+
+export async function fetchRecurringPaymentById(
+  request: SdpApiClient["request"],
+  recurringPaymentId: string
+): Promise<FetchResult<PaymentRecurringPayment>> {
+  try {
+    const response = await request(
+      `/v1/payments/recurring-payments/${encodeURIComponent(recurringPaymentId)}`
+    );
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: parsePaymentApiErrorText(await response.text()),
+      };
+    }
+
+    const json = (await response.json()) as { data?: PaymentRecurringPaymentResponse };
+    if (!json.data?.recurringPayment) {
+      return {
+        ok: false,
+        error: "Recurring payment response is missing recurring payment details.",
+      };
+    }
+
+    return { ok: true, data: json.data.recurringPayment };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unable to load recurring payment",
+    };
+  }
+}

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -32,6 +32,7 @@ import { SentryUserContext } from "@/components/sentry-user-context";
 import { Badge } from "@/components/ui/badge";
 import { WorkspaceSwitcher } from "@/components/workspace-switcher";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
+import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
 import { cn } from "@/lib/utils";
 
 type SubNavItem = {
@@ -60,6 +61,15 @@ const PAYMENTS_ACTIONS: readonly SubNavItem[] = [
   { label: "Requests", href: "/dashboard/payments/requests" },
 ];
 
+function getPaymentsActions(): SubNavItem[] {
+  return [
+    ...PAYMENTS_ACTIONS,
+    ...(isRecurringPaymentsDashboardEnabled()
+      ? [{ label: "Recurring", href: "/dashboard/payments/recurring" }]
+      : []),
+  ];
+}
+
 function getNavSections(): NavSection[] {
   return [
     {
@@ -77,7 +87,7 @@ function getNavSections(): NavSection[] {
           label: "Payments",
           href: "/dashboard/payments",
           icon: ArrowLeftRightIcon,
-          children: [...PAYMENTS_ACTIONS],
+          children: getPaymentsActions(),
         },
         { label: "API keys", href: "/dashboard/api-keys", icon: KeyRoundIcon },
       ],
@@ -374,6 +384,12 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
       contentWidthClass: "max-w-none",
     };
   }
+  if (pathname === "/dashboard/payments/recurring") {
+    return {
+      title: "Recurring payments",
+      contentWidthClass: "max-w-none",
+    };
+  }
   if (pathname.startsWith("/dashboard/payments/")) {
     const action = PAYMENTS_ACTIONS.find((item) => pathname.startsWith(item.href));
     const centeredTitle = action
@@ -654,6 +670,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
     (pathname.startsWith("/dashboard/payments/counterparty/") &&
       pathname !== "/dashboard/payments/counterparty/create") ||
     pathname === "/dashboard/payments/requests" ||
+    pathname === "/dashboard/payments/recurring" ||
     isWalletDetailRoute;
   const shouldLockViewportScroll = shouldUseWorkspaceViewport;
   const shouldLockShellViewport = shouldLockViewportScroll || isMobileSidebarOpen;

--- a/apps/sdp-web/src/lib/recurring-payments-feature.ts
+++ b/apps/sdp-web/src/lib/recurring-payments-feature.ts
@@ -1,0 +1,3 @@
+export function isRecurringPaymentsDashboardEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_PAYMENTS_RECURRING_ENABLED === "true";
+}


### PR DESCRIPTION
## Summary
- Add `NEXT_PUBLIC_PAYMENTS_RECURRING_ENABLED` dashboard gating for recurring payments.
- Add typed recurring payment dashboard helpers plus proxy routes for list/create/get.
- Add a gated `/dashboard/payments/recurring` page with minimal loading/error/empty/list states.
- Add focused dashboard feature-flag E2E coverage.

Closes PRO-1299

## Local validation
- `git diff --check`
- `pnpm exec biome check apps/sdp-web/src/lib/recurring-payments-feature.ts apps/sdp-web/src/app/dashboard/payments/payment-api-errors.ts apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx apps/sdp-web/src/app/dashboard/payments/recurring/not-found.tsx apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/route.ts 'apps/sdp-web/src/app/api/dashboard/payments/recurring-payments/[recurringPaymentId]/route.ts' apps/sdp-web/src/components/dashboard-shell.tsx apps/sdp-web/playwright/tests/payments.e2e.spec.ts`
- `doppler run --project solana-developer-platform --config dev_personal -- pnpm --filter sdp-web typecheck`
- Disabled flag E2E: `doppler run --project solana-developer-platform --config dev_personal --preserve-env=DATABASE_URL,PATH -- pnpm -C apps/sdp-web exec playwright test --config=playwright.config.ts --project=dashboard --grep "dashboard recurring payments feature flag"`
- Enabled flag E2E with `PAYMENTS_RECURRING_ENABLED=true NEXT_PUBLIC_PAYMENTS_RECURRING_ENABLED=true`
- Manual local smoke with local API/web under Doppler: through the dashboard proxy/API only, created a recurring payment, listed it, and fetched it by id.

## Screenshot
Captured locally after starting local API/web under Doppler with recurring flags enabled: `/tmp/pro-1299-recurring-payments-dashboard.png`.

I could not attach the PNG programmatically through `gh`: GitHub CLI gists reject binary files and GitHub does not expose a public PR attachment upload API. The screenshot was still captured before PR creation per the UI-change workflow.

## Blocked validation
- `doppler run --project solana-developer-platform --config dev_personal -- pnpm --filter sdp-web lint` is blocked by the current repo-wide ESLint/React plugin setup. With stock config it crashes in `eslint-plugin-react` under ESLint 10 while loading `react/display-name`; when locally bypassed for diagnosis, it exposed existing unrelated lint errors across dashboard files.
