### PR TITLE
feat(web): add recurring payment list and detail views

### DIFF
--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -1,8 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
+import type {
+  CreatePaymentRecurringPaymentRequest,
+  PaymentRecurringPaymentResponse,
+} from "@sdp/types";
+import { WELL_KNOWN_TOKENS } from "@sdp/types";
 import { getPlaywrightAdminSession } from "../support/auth-session";
 import { createLocalApiClient } from "../support/local-api-client";
 import {
+  bootstrapLocalWalletFixtures,
   createExternalSolanaAddress,
   ensureLinkedOrg,
   resolvePlaywrightProjectId,
@@ -19,14 +25,68 @@ const recurringPaymentsEnabled = process.env.NEXT_PUBLIC_PAYMENTS_RECURRING_ENAB
 test.describe
   .serial("dashboard recurring payments feature flag", () => {
     let bootstrapProjectId = "";
+    let recurringPaymentId = "";
+    let recurringCounterpartyName = "";
+    let recurringWalletLabel = "";
 
     test.beforeAll(async ({ browser }) => {
       const session = await getPlaywrightAdminSession(browser);
       await ensureLinkedOrg(session.identity, { tier: "enterprise" });
-      bootstrapProjectId = await resolvePlaywrightProjectId(
-        getBootstrapApiBaseUrl(),
-        session.getBearerToken
-      );
+      if (recurringPaymentsEnabled) {
+        const walletBootstrap = await bootstrapLocalWalletFixtures({
+          identity: session.identity,
+          bearerToken: session.getBearerToken,
+          walletCount: 1,
+          tier: "enterprise",
+          fundSourceWallet: false,
+          walletLabel: "E2E Recurring Treasury",
+        });
+        const sourceWallet = walletBootstrap.wallets[0];
+        if (!sourceWallet) {
+          throw new Error("Recurring payment E2E setup did not create a source wallet");
+        }
+        const projectId = await resolvePlaywrightProjectId(
+          getBootstrapApiBaseUrl(),
+          session.getBearerToken
+        );
+        const api = createLocalApiClient(
+          getBootstrapApiBaseUrl(),
+          session.getBearerToken,
+          projectId
+        );
+        const suffix = randomUUID().slice(0, 8);
+        const seededCounterparty = await seedCounterpartyWithSolanaAccount(api, {
+          displayName: `E2E Recurring ${suffix}`,
+          email: `e2e-recurring-${suffix}@example.com`,
+          accountLabel: `E2E Subscription ${suffix}`,
+          destinationAddress: sourceWallet.publicKey,
+        });
+
+        const input = {
+          sourceWalletId: sourceWallet.walletId,
+          counterpartyId: seededCounterparty.counterpartyId,
+          counterpartyAccountId: seededCounterparty.accountId,
+          token: WELL_KNOWN_TOKENS.USDC.mints.devnet,
+          amount: "7.5",
+          periodHours: 24,
+          firstCollectionAt: new Date(Date.now() + 3_600_000).toISOString(),
+          metadataUri: "https://example.com/metadata/e2e-recurring-payment.json",
+        } satisfies CreatePaymentRecurringPaymentRequest;
+        const response = await api.post<PaymentRecurringPaymentResponse>(
+          "/v1/payments/recurring-payments",
+          input
+        );
+
+        bootstrapProjectId = projectId;
+        recurringPaymentId = response.recurringPayment.id;
+        recurringCounterpartyName = seededCounterparty.displayName;
+        recurringWalletLabel = sourceWallet.label ?? sourceWallet.publicKey;
+      } else {
+        bootstrapProjectId = await resolvePlaywrightProjectId(
+          getBootstrapApiBaseUrl(),
+          session.getBearerToken
+        );
+      }
       await session.page.close();
     });
 
@@ -66,6 +126,23 @@ test.describe
       await expect(
         page.getByText("No recurring payments yet.").or(page.locator("tbody tr").first())
       ).toBeVisible({ timeout: 120_000 });
+
+      await expect(page.getByText(recurringCounterpartyName)).toBeVisible();
+      await expect(page.getByText(recurringWalletLabel)).toBeVisible();
+      await expect(page.getByText("7.50 USDC")).toBeVisible();
+
+      await page.locator("tbody tr").filter({ hasText: recurringCounterpartyName }).first().click();
+      await expect(page).toHaveURL(
+        new RegExp(`/dashboard/payments/recurring/${recurringPaymentId}$`)
+      );
+      await expect(
+        page.locator("main").getByRole("heading", { level: 1, name: "Recurring payment" })
+      ).toBeVisible();
+      await expect(page.getByRole("link", { name: "Back to recurring payments" })).toBeVisible();
+      await expect(page.getByText(recurringPaymentId)).toBeVisible();
+      await expect(page.getByText("Subscription lifecycle")).toBeVisible();
+      await expect(page.getByText("Plan ID")).toBeVisible();
+      await expect(page.getByText("Authorization signature")).toBeVisible();
     });
   });
 

--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -139,10 +139,15 @@ test.describe
         page.locator("main").getByRole("heading", { level: 1, name: "Recurring payment" })
       ).toBeVisible();
       await expect(page.getByRole("link", { name: "Back to recurring payments" })).toBeVisible();
-      await expect(page.getByText(recurringPaymentId)).toBeVisible();
-      await expect(page.getByText("Subscription lifecycle")).toBeVisible();
-      await expect(page.getByText("Plan ID")).toBeVisible();
-      await expect(page.getByText("Authorization signature")).toBeVisible();
+      await expect(page.getByText("Payment reference")).toBeVisible();
+      await expect(page.getByText("Billing setup")).toBeVisible();
+      await expect(page.getByText("Plan reference")).toBeVisible();
+      await expect(page.getByText("Authorization transaction")).toBeVisible();
+      await expect(page.locator("main").getByText("Token mint", { exact: true })).toHaveCount(0);
+      await expect(page.locator("main").getByText("Plan PDA", { exact: true })).toHaveCount(0);
+      await expect(page.locator("main").getByText("Subscription PDA", { exact: true })).toHaveCount(
+        0
+      );
     });
   });
 

--- a/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/payments.e2e.spec.ts
@@ -108,6 +108,11 @@ test.describe
         page.getByRole("heading", { name: "Recurring payments unavailable" })
       ).toBeVisible();
       await expect(page.getByText("No recurring payments yet.")).toHaveCount(0);
+
+      await page.goto("/dashboard/payments/recurring/prp_disabled_flag_test");
+      await expect(
+        page.getByRole("heading", { name: "Recurring payments unavailable" })
+      ).toBeVisible();
     });
 
     test("shows recurring payments when the dashboard feature flag is enabled", async ({

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-page.data.ts
@@ -1,4 +1,9 @@
-import type { Counterparty, ListCounterpartiesResponse, PaginatedResponse } from "@sdp/types";
+import type {
+  Counterparty,
+  CounterpartyResponse,
+  ListCounterpartiesResponse,
+  PaginatedResponse,
+} from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
 
 export const COUNTERPARTY_PAGE_SIZE = 10;
@@ -34,5 +39,22 @@ export async function fetchCounterparties(
       total: 0,
       error: error instanceof Error ? error.message : "Unable to load counterparties",
     };
+  }
+}
+
+export async function fetchCounterparty(
+  request: SdpApiClient["request"],
+  counterpartyId: string
+): Promise<Counterparty | null> {
+  try {
+    const response = await request(`/v1/counterparties/${encodeURIComponent(counterpartyId)}`);
+    if (!response.ok) {
+      return null;
+    }
+
+    const json = (await response.json()) as { data?: CounterpartyResponse };
+    return json.data?.counterparty ?? null;
+  } catch {
+    return null;
   }
 }

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
@@ -60,10 +60,10 @@ export default async function RecurringPaymentDetailRoute({
       }));
       const wallet =
         wallets.find((entry) => entry.walletId === recurringPayment.sourceWalletId) ?? null;
-      const counterpartyName =
+      const counterpartyLabel =
         counterpartiesResult.data.find(
           (counterparty) => counterparty.id === recurringPayment.counterpartyId
-        )?.displayName ?? recurringPayment.counterpartyId;
+        )?.displayName ?? "Counterparty unavailable";
       const knownToken = WELL_KNOWN_TOKEN_BY_MINT.get(recurringPayment.token);
       const tokenLabel =
         knownToken?.symbol ??
@@ -74,8 +74,9 @@ export default async function RecurringPaymentDetailRoute({
         <RecurringPaymentDetailWorkspace
           recurringPayment={recurringPayment}
           wallet={wallet}
-          counterpartyName={counterpartyName}
+          counterpartyLabel={counterpartyLabel}
           amountLabel={formatDisplayAmount(recurringPayment.amount, tokenLabel)}
+          currencyLabel={tokenLabel}
         />
       );
     }

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
@@ -1,9 +1,10 @@
 import { auth } from "@clerk/nextjs/server";
 import { WELL_KNOWN_TOKEN_BY_MINT } from "@sdp/types";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
-import { fetchCounterparties } from "../../counterparty/counterparty-page.data";
+import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
+import { fetchCounterparty } from "../../counterparty/counterparty-page.data";
 import { formatDisplayAmount, shortenAddress } from "../../payments-overview.utils";
 import { fetchPaymentsWallets } from "../../payments-page.data";
 import { fetchRecurringPaymentById } from "../recurring-payments.data";
@@ -16,6 +17,10 @@ export default async function RecurringPaymentDetailRoute({
 }: {
   params: Promise<{ recurringPaymentId: string }>;
 }) {
+  if (!isRecurringPaymentsDashboardEnabled()) {
+    notFound();
+  }
+
   const { userId, orgId } = await auth();
   if (!userId) {
     redirect(await getAuthEntryPath());
@@ -29,22 +34,18 @@ export default async function RecurringPaymentDetailRoute({
   return withDashboardPageTrace(
     "dashboard.recurring-payments.detail.page",
     async ({ trace, apiClient }) => {
-      const [recurringPaymentResult, walletsResult, counterpartiesResult] = await Promise.all([
+      const [recurringPaymentResult, walletsResult] = await Promise.all([
         trace.step("fetch_recurring_payment", () =>
           fetchRecurringPaymentById(apiClient.request, recurringPaymentId)
         ),
         trace.step("fetch_wallets", () =>
           fetchPaymentsWallets(apiClient.request, { includeBalances: true })
         ),
-        trace.step("fetch_counterparties", () =>
-          fetchCounterparties(apiClient.request, { pageSize: 100 })
-        ),
       ]);
 
       trace.log({
         ok: recurringPaymentResult.ok,
         walletsOk: walletsResult.ok,
-        counterpartiesOk: counterpartiesResult.ok,
       });
 
       if (!recurringPaymentResult.data) {
@@ -60,10 +61,10 @@ export default async function RecurringPaymentDetailRoute({
       }));
       const wallet =
         wallets.find((entry) => entry.walletId === recurringPayment.sourceWalletId) ?? null;
-      const counterpartyLabel =
-        counterpartiesResult.data.find(
-          (counterparty) => counterparty.id === recurringPayment.counterpartyId
-        )?.displayName ?? "Counterparty unavailable";
+      const counterparty = await trace.step("fetch_recurring_payment_counterparty", () =>
+        fetchCounterparty(apiClient.request, recurringPayment.counterpartyId)
+      );
+      const counterpartyLabel = counterparty?.displayName ?? "Counterparty unavailable";
       const knownToken = WELL_KNOWN_TOKEN_BY_MINT.get(recurringPayment.token);
       const tokenLabel =
         knownToken?.symbol ??

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
@@ -1,0 +1,83 @@
+import { auth } from "@clerk/nextjs/server";
+import { WELL_KNOWN_TOKEN_BY_MINT } from "@sdp/types";
+import { redirect } from "next/navigation";
+import { getAuthEntryPath } from "@/lib/auth-entry";
+import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
+import { fetchCounterparties } from "../../counterparty/counterparty-page.data";
+import { formatDisplayAmount, shortenAddress } from "../../payments-overview.utils";
+import { fetchPaymentsWallets } from "../../payments-page.data";
+import { fetchRecurringPaymentById } from "../recurring-payments.data";
+import { RecurringPaymentDetailWorkspace } from "../recurring-payments-workspace";
+
+export const dynamic = "force-dynamic";
+
+export default async function RecurringPaymentDetailRoute({
+  params,
+}: {
+  params: Promise<{ recurringPaymentId: string }>;
+}) {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect(await getAuthEntryPath());
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  const { recurringPaymentId } = await params;
+
+  return withDashboardPageTrace(
+    "dashboard.recurring-payments.detail.page",
+    async ({ trace, apiClient }) => {
+      const [recurringPaymentResult, walletsResult, counterpartiesResult] = await Promise.all([
+        trace.step("fetch_recurring_payment", () =>
+          fetchRecurringPaymentById(apiClient.request, recurringPaymentId)
+        ),
+        trace.step("fetch_wallets", () =>
+          fetchPaymentsWallets(apiClient.request, { includeBalances: true })
+        ),
+        trace.step("fetch_counterparties", () =>
+          fetchCounterparties(apiClient.request, { pageSize: 100 })
+        ),
+      ]);
+
+      trace.log({
+        ok: recurringPaymentResult.ok,
+        walletsOk: walletsResult.ok,
+        counterpartiesOk: counterpartiesResult.ok,
+      });
+
+      if (!recurringPaymentResult.data) {
+        redirect("/dashboard/payments/recurring");
+      }
+      const recurringPayment = recurringPaymentResult.data;
+
+      const wallets = (walletsResult.data ?? []).map((wallet) => ({
+        walletId: wallet.walletId,
+        label: wallet.label,
+        publicKey: wallet.publicKey,
+        balances: wallet.balances ?? [],
+      }));
+      const wallet =
+        wallets.find((entry) => entry.walletId === recurringPayment.sourceWalletId) ?? null;
+      const counterpartyName =
+        counterpartiesResult.data.find(
+          (counterparty) => counterparty.id === recurringPayment.counterpartyId
+        )?.displayName ?? recurringPayment.counterpartyId;
+      const knownToken = WELL_KNOWN_TOKEN_BY_MINT.get(recurringPayment.token);
+      const tokenLabel =
+        knownToken?.symbol ??
+        wallet?.balances.find((entry) => entry.mint === recurringPayment.token)?.token ??
+        shortenAddress(recurringPayment.token);
+
+      return (
+        <RecurringPaymentDetailWorkspace
+          recurringPayment={recurringPayment}
+          wallet={wallet}
+          counterpartyName={counterpartyName}
+          amountLabel={formatDisplayAmount(recurringPayment.amount, tokenLabel)}
+        />
+      );
+    }
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx
@@ -1,7 +1,11 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import { getAuthEntryPath } from "@/lib/auth-entry";
+import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
 import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
+import { fetchCounterparties } from "../counterparty/counterparty-page.data";
+import { fetchPaymentsWallets } from "../payments-page.data";
+import { fetchRecurringPayments } from "./recurring-payments.data";
 import { RecurringPaymentsWorkspace } from "./recurring-payments-workspace";
 
 export const dynamic = "force-dynamic";
@@ -19,5 +23,60 @@ export default async function RecurringPaymentsPage() {
     redirect("/dashboard");
   }
 
-  return <RecurringPaymentsWorkspace />;
+  return withDashboardPageTrace(
+    "dashboard.recurring-payments.page",
+    async ({ trace, apiClient }) => {
+      const [recurringPaymentsResult, walletsResult, counterpartiesResult] = await Promise.all([
+        trace.step("fetch_recurring_payments", () => fetchRecurringPayments(apiClient.request)),
+        trace.step("fetch_wallets", () =>
+          fetchPaymentsWallets(apiClient.request, { includeBalances: true })
+        ),
+        trace.step("fetch_counterparties", () =>
+          fetchCounterparties(apiClient.request, { pageSize: 100 })
+        ),
+      ]);
+
+      trace.log({
+        ok: recurringPaymentsResult.ok,
+        recurringPaymentCount: recurringPaymentsResult.data.length,
+        recurringPaymentTotal: recurringPaymentsResult.total,
+        walletsOk: walletsResult.ok,
+        walletCount: walletsResult.data?.length ?? 0,
+        counterpartiesOk: counterpartiesResult.ok,
+        counterpartyCount: counterpartiesResult.data.length,
+      });
+
+      return (
+        <div className="flex h-full min-h-0 w-full flex-col">
+          <RecurringPaymentsWorkspace
+            initialRecurringPayments={recurringPaymentsResult.data}
+            initialTotal={recurringPaymentsResult.total}
+            initialError={recurringPaymentsResult.error}
+            wallets={(walletsResult.data ?? []).map((wallet) => ({
+              walletId: wallet.walletId,
+              label: wallet.label,
+              publicKey: wallet.publicKey,
+              balances: wallet.balances ?? [],
+            }))}
+            counterparties={counterpartiesResult.data.map((counterparty) => ({
+              id: counterparty.id,
+              displayName: counterparty.displayName,
+            }))}
+            lookupError={
+              walletsResult.ok && counterpartiesResult.ok
+                ? undefined
+                : [
+                    walletsResult.ok ? null : (walletsResult.error ?? "Unable to load wallets"),
+                    counterpartiesResult.ok
+                      ? null
+                      : (counterpartiesResult.error ?? "Unable to load counterparties"),
+                  ]
+                    .filter(Boolean)
+                    .join(" ")
+            }
+          />
+        </div>
+      );
+    }
+  );
 }

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
 import { isRecurringPaymentsDashboardEnabled } from "@/lib/recurring-payments-feature";
-import { fetchCounterparties } from "../counterparty/counterparty-page.data";
+import { fetchCounterparty } from "../counterparty/counterparty-page.data";
 import { fetchPaymentsWallets } from "../payments-page.data";
 import { fetchRecurringPayments } from "./recurring-payments.data";
 import { RecurringPaymentsWorkspace } from "./recurring-payments-workspace";
@@ -26,15 +26,23 @@ export default async function RecurringPaymentsPage() {
   return withDashboardPageTrace(
     "dashboard.recurring-payments.page",
     async ({ trace, apiClient }) => {
-      const [recurringPaymentsResult, walletsResult, counterpartiesResult] = await Promise.all([
+      const [recurringPaymentsResult, walletsResult] = await Promise.all([
         trace.step("fetch_recurring_payments", () => fetchRecurringPayments(apiClient.request)),
         trace.step("fetch_wallets", () =>
           fetchPaymentsWallets(apiClient.request, { includeBalances: true })
         ),
-        trace.step("fetch_counterparties", () =>
-          fetchCounterparties(apiClient.request, { pageSize: 100 })
-        ),
       ]);
+      const counterpartyIds = [
+        ...new Set(recurringPaymentsResult.data.map((payment) => payment.counterpartyId)),
+      ];
+      const counterparties = await trace.step("fetch_recurring_payment_counterparties", () =>
+        Promise.all(
+          counterpartyIds.map((counterpartyId) =>
+            fetchCounterparty(apiClient.request, counterpartyId)
+          )
+        )
+      );
+      const resolvedCounterparties = counterparties.filter((counterparty) => counterparty !== null);
 
       trace.log({
         ok: recurringPaymentsResult.ok,
@@ -42,8 +50,8 @@ export default async function RecurringPaymentsPage() {
         recurringPaymentTotal: recurringPaymentsResult.total,
         walletsOk: walletsResult.ok,
         walletCount: walletsResult.data?.length ?? 0,
-        counterpartiesOk: counterpartiesResult.ok,
-        counterpartyCount: counterpartiesResult.data.length,
+        counterpartiesOk: resolvedCounterparties.length === counterpartyIds.length,
+        counterpartyCount: resolvedCounterparties.length,
       });
 
       return (
@@ -58,18 +66,18 @@ export default async function RecurringPaymentsPage() {
               publicKey: wallet.publicKey,
               balances: wallet.balances ?? [],
             }))}
-            counterparties={counterpartiesResult.data.map((counterparty) => ({
+            counterparties={resolvedCounterparties.map((counterparty) => ({
               id: counterparty.id,
               displayName: counterparty.displayName,
             }))}
             lookupError={
-              walletsResult.ok && counterpartiesResult.ok
+              walletsResult.ok && resolvedCounterparties.length === counterpartyIds.length
                 ? undefined
                 : [
                     walletsResult.ok ? null : (walletsResult.error ?? "Unable to load wallets"),
-                    counterpartiesResult.ok
+                    resolvedCounterparties.length === counterpartyIds.length
                       ? null
-                      : (counterpartiesResult.error ?? "Unable to load counterparties"),
+                      : "Unable to load some counterparties",
                   ]
                     .filter(Boolean)
                     .join(" ")

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import type { PaymentRecurringPayment, PaymentRecurringPaymentStatus } from "@sdp/types";
-import { useEffect, useState } from "react";
-import { Badge } from "@/components/ui/badge";
+import {
+  type PaymentRecurringPayment,
+  type PaymentRecurringPaymentStatus,
+  WELL_KNOWN_TOKEN_BY_MINT,
+} from "@sdp/types";
+import { CalendarClockIcon, CopyIcon, RepeatIcon, UserIcon, WalletIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { type KeyboardEvent, type ReactNode, useMemo } from "react";
+import { toast } from "sonner";
+import { Badge, type BadgeVariant } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -11,8 +20,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 import { formatDisplayAmount, formatTimestamp, shortenAddress } from "../payments-overview.utils";
-import { listRecurringPayments } from "./recurring-payments.data";
 
 const STATUS_LABELS = {
   pending_activation: "Pending activation",
@@ -25,115 +34,409 @@ const STATUS_LABELS = {
   expired: "Expired",
 } as const satisfies Record<PaymentRecurringPaymentStatus, string>;
 
-type LoadState =
-  | { status: "loading"; recurringPayments: PaymentRecurringPayment[]; total: number }
-  | { status: "ready"; recurringPayments: PaymentRecurringPayment[]; total: number }
-  | { status: "error"; recurringPayments: PaymentRecurringPayment[]; total: number; error: string };
+const STATUS_VARIANTS = {
+  pending_activation: "warning",
+  activating: "warning",
+  active: "success",
+  canceling: "warning",
+  resuming: "warning",
+  paused: "info",
+  canceled: "danger",
+  expired: "danger",
+} as const satisfies Record<PaymentRecurringPaymentStatus, BadgeVariant>;
 
-function RecurringPaymentStatusBadge({ status }: { status: PaymentRecurringPaymentStatus }) {
-  return <Badge>{STATUS_LABELS[status]}</Badge>;
+interface RecurringPaymentWalletView {
+  walletId: string;
+  label: string | null;
+  publicKey: string;
+  balances: Array<{ mint: string; token: string }>;
 }
 
-export function RecurringPaymentsWorkspace() {
-  const [state, setState] = useState<LoadState>({
-    status: "loading",
-    recurringPayments: [],
-    total: 0,
-  });
+interface RecurringPaymentCounterpartyView {
+  id: string;
+  displayName: string;
+}
 
-  useEffect(() => {
-    const controller = new AbortController();
+interface RecurringPaymentsWorkspaceProps {
+  initialRecurringPayments: PaymentRecurringPayment[];
+  initialTotal: number;
+  initialError?: string;
+  lookupError?: string;
+  wallets: RecurringPaymentWalletView[];
+  counterparties: RecurringPaymentCounterpartyView[];
+}
 
-    listRecurringPayments({ signal: controller.signal })
-      .then((response) => {
-        setState({
-          status: "ready",
-          recurringPayments: response.recurringPayments,
-          total: response.total,
-        });
-      })
-      .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          return;
-        }
-        setState({
-          status: "error",
-          recurringPayments: [],
-          total: 0,
-          error: error instanceof Error ? error.message : "Unable to load recurring payments",
-        });
-      });
+interface RecurringPaymentDetailWorkspaceProps {
+  recurringPayment: PaymentRecurringPayment;
+  wallet: RecurringPaymentWalletView | null;
+  counterpartyName: string;
+  amountLabel: string;
+}
 
-    return () => controller.abort();
-  }, []);
+function RecurringPaymentStatusBadge({ status }: { status: PaymentRecurringPaymentStatus }) {
+  return <Badge variant={STATUS_VARIANTS[status]}>{STATUS_LABELS[status]}</Badge>;
+}
 
-  const countLabel =
-    state.total === 1 ? "1 recurring payment" : `${state.total} recurring payments`;
+function formatOptionalTimestamp(value: string | null | undefined): string {
+  return value ? formatTimestamp(value) : "Not set";
+}
+
+function formatPeriodHours(periodHours: number): string {
+  if (periodHours === 24) {
+    return "Every day";
+  }
+  if (periodHours % 168 === 0) {
+    const weeks = periodHours / 168;
+    return weeks === 1 ? "Every week" : `Every ${weeks} weeks`;
+  }
+  if (periodHours % 24 === 0) {
+    const days = periodHours / 24;
+    return days === 1 ? "Every day" : `Every ${days} days`;
+  }
+  return periodHours === 1 ? "Every hour" : `Every ${periodHours} hours`;
+}
+
+function resolveTokenLabel(token: string, wallets: RecurringPaymentWalletView[]): string {
+  const knownToken = WELL_KNOWN_TOKEN_BY_MINT.get(token);
+  if (knownToken) {
+    return knownToken.symbol;
+  }
+
+  for (const wallet of wallets) {
+    const balance = wallet.balances.find((entry) => entry.mint === token);
+    if (balance?.token) {
+      return balance.token;
+    }
+  }
+
+  return token.length <= 12 ? token : shortenAddress(token);
+}
+
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3">
+      <span className="shrink-0 text-sm text-text-medium">{label}</span>
+      <span className="min-w-0 break-all text-right text-sm font-medium text-text-extra-high">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function CopyableValue({ value, empty = "Not set" }: { value: string | null; empty?: string }) {
+  if (!value) {
+    return <span className="text-text-low">{empty}</span>;
+  }
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col px-3 pb-5 md:px-6 md:pb-6">
-      <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border-light py-4">
-        <div className="min-w-0">
-          <h2 className="text-lg font-medium text-text-extra-high">Recurring payments</h2>
-          <p className="mt-1 text-sm text-text-medium">{countLabel}</p>
-        </div>
+    <span className="inline-flex max-w-full items-center justify-end gap-2">
+      <span className="min-w-0 truncate font-mono text-xs text-text-extra-high" title={value}>
+        {value}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label="Copy value"
+        onClick={() => {
+          void navigator.clipboard.writeText(value);
+          toast.success("Copied");
+        }}
+      >
+        <CopyIcon />
+      </Button>
+    </span>
+  );
+}
+
+function SummaryMetric({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-xl border border-border-light bg-white px-4 py-3">
+      <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase text-text-low">
+        <span className="[&_svg]:size-3.5">{icon}</span>
+        <span>{label}</span>
       </div>
+      <p className="truncate text-sm font-semibold text-text-extra-high">{value}</p>
+    </div>
+  );
+}
 
-      <div className="min-h-0 flex-1 overflow-auto py-4">
-        {state.status === "loading" ? (
-          <div className="border border-border-light bg-white p-4 text-sm text-text-medium">
-            Loading recurring payments...
-          </div>
-        ) : null}
+export function RecurringPaymentsWorkspace({
+  initialRecurringPayments,
+  initialTotal,
+  initialError,
+  lookupError,
+  wallets,
+  counterparties,
+}: RecurringPaymentsWorkspaceProps) {
+  const router = useRouter();
 
-        {state.status === "error" ? (
-          <div
-            role="alert"
-            className="border border-status-error-border bg-status-error-bg p-4 text-sm text-status-error-text"
-          >
-            <p className="font-medium">Unable to load recurring payments</p>
-            <p className="mt-1">{state.error}</p>
-          </div>
-        ) : null}
+  const walletById = useMemo(
+    () => new Map(wallets.map((wallet) => [wallet.walletId, wallet])),
+    [wallets]
+  );
+  const counterpartyById = useMemo(
+    () => new Map(counterparties.map((counterparty) => [counterparty.id, counterparty])),
+    [counterparties]
+  );
 
-        {state.status === "ready" && state.recurringPayments.length === 0 ? (
-          <div className="border border-border-light bg-white p-4 text-sm text-text-medium">
-            No recurring payments yet.
-          </div>
-        ) : null}
+  const countLabel =
+    initialTotal === 1 ? "1 recurring payment" : `${initialTotal} recurring payments`;
 
-        {state.status === "ready" && state.recurringPayments.length > 0 ? (
-          <div className="overflow-hidden border border-border-light bg-white">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Amount</TableHead>
-                  <TableHead>Destination</TableHead>
-                  <TableHead>Period</TableHead>
-                  <TableHead>Next due</TableHead>
-                  <TableHead>Status</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {state.recurringPayments.map((recurringPayment) => (
-                  <TableRow key={recurringPayment.id}>
-                    <TableCell className="font-medium">
-                      {formatDisplayAmount(recurringPayment.amount, recurringPayment.token)}
-                    </TableCell>
-                    <TableCell>{shortenAddress(recurringPayment.destinationAddress)}</TableCell>
-                    <TableCell>{recurringPayment.periodHours}h</TableCell>
-                    <TableCell>
-                      {formatTimestamp(recurringPayment.nextCollectionDueAt ?? undefined)}
-                    </TableCell>
-                    <TableCell>
-                      <RecurringPaymentStatusBadge status={recurringPayment.status} />
-                    </TableCell>
+  const getWalletLabel = (recurringPayment: PaymentRecurringPayment) => {
+    const wallet = walletById.get(recurringPayment.sourceWalletId);
+    return (
+      wallet?.label || (wallet ? shortenAddress(wallet.publicKey) : recurringPayment.sourceWalletId)
+    );
+  };
+  const getCounterpartyLabel = (recurringPayment: PaymentRecurringPayment) =>
+    counterpartyById.get(recurringPayment.counterpartyId)?.displayName ??
+    recurringPayment.counterpartyId;
+  const getAmountLabel = (recurringPayment: PaymentRecurringPayment) =>
+    formatDisplayAmount(
+      recurringPayment.amount,
+      resolveTokenLabel(recurringPayment.token, wallets)
+    );
+
+  return (
+    <div className="h-full min-h-0 w-full px-3 pt-6 pb-5 md:px-6 md:pb-6">
+      <Card className="flex h-full min-h-0 flex-col">
+        <CardHeader>
+          <CardTitle>Recurring payments</CardTitle>
+          <CardDescription>{countLabel}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex min-h-0 flex-1 flex-col">
+          {initialError ? (
+            <div
+              role="alert"
+              className="border border-status-error-border bg-status-error-bg p-4 text-sm text-status-error-text"
+            >
+              <p className="font-medium">Unable to load recurring payments</p>
+              <p className="mt-1">{initialError}</p>
+            </div>
+          ) : initialRecurringPayments.length === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-border-medium py-16 text-center">
+              <RepeatIcon className="h-10 w-10 text-text-extra-low" />
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-text-extra-high">
+                  No recurring payments yet.
+                </p>
+                <p className="text-sm text-text-low">
+                  Created recurring payment records will appear here.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="min-h-0 flex-1 overflow-hidden">
+              {lookupError ? (
+                <p className="mb-3 text-sm text-status-warning-text">{lookupError}</p>
+              ) : null}
+              <Table className="w-full [&_table]:table-fixed">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[34%] md:w-[26%] lg:w-[21%] xl:w-[18%] 2xl:w-[15%]">
+                      Status
+                    </TableHead>
+                    <TableHead className="w-[26%] md:w-[22%] lg:w-[20%] xl:w-[18%] 2xl:w-[16%]">
+                      Amount
+                    </TableHead>
+                    <TableHead className="w-[40%] md:w-[34%] lg:w-[31%] xl:w-[24%] 2xl:w-[18%]">
+                      Counterparty
+                    </TableHead>
+                    <TableHead className="hidden lg:table-cell lg:w-[28%] xl:w-[22%] 2xl:w-[17%]">
+                      Source wallet
+                    </TableHead>
+                    <TableHead className="hidden xl:table-cell xl:w-[18%] 2xl:w-[12%]">
+                      Period
+                    </TableHead>
+                    <TableHead className="hidden md:table-cell md:w-[18%] xl:hidden 2xl:table-cell 2xl:w-[12%]">
+                      Next due
+                    </TableHead>
+                    <TableHead className="hidden 2xl:table-cell 2xl:w-[10%]">Created</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {initialRecurringPayments.map((recurringPayment) => (
+                    <TableRow
+                      key={recurringPayment.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() =>
+                        router.push(
+                          `/dashboard/payments/recurring/${encodeURIComponent(recurringPayment.id)}`
+                        )
+                      }
+                      onKeyDown={(event: KeyboardEvent) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          router.push(
+                            `/dashboard/payments/recurring/${encodeURIComponent(recurringPayment.id)}`
+                          );
+                        }
+                      }}
+                      className="cursor-pointer"
+                    >
+                      <TableCell>
+                        <RecurringPaymentStatusBadge status={recurringPayment.status} />
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        <span className="block truncate">{getAmountLabel(recurringPayment)}</span>
+                      </TableCell>
+                      <TableCell className="text-sm text-text-medium">
+                        <span className="block truncate">
+                          {getCounterpartyLabel(recurringPayment)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="hidden text-sm text-text-medium lg:table-cell">
+                        <span className="block truncate">{getWalletLabel(recurringPayment)}</span>
+                      </TableCell>
+                      <TableCell className="hidden text-sm text-text-medium xl:table-cell">
+                        {formatPeriodHours(recurringPayment.periodHours)}
+                      </TableCell>
+                      <TableCell className="hidden text-sm text-text-medium md:table-cell xl:hidden 2xl:table-cell">
+                        {formatOptionalTimestamp(recurringPayment.nextCollectionDueAt)}
+                      </TableCell>
+                      <TableCell className="hidden text-sm text-text-medium 2xl:table-cell">
+                        {formatTimestamp(recurringPayment.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function RecurringPaymentDetailWorkspace({
+  recurringPayment,
+  wallet,
+  counterpartyName,
+  amountLabel,
+}: RecurringPaymentDetailWorkspaceProps) {
+  const sourceWalletLabel = wallet?.label || (wallet ? shortenAddress(wallet.publicKey) : null);
+  const sourceAddress = wallet?.publicKey ?? recurringPayment.sourceAddress;
+  const scheduleLabel = formatPeriodHours(recurringPayment.periodHours);
+
+  return (
+    <div className="h-full min-h-0 w-full overflow-auto px-3 pt-6 pb-5 md:px-6 md:pb-6">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 space-y-1">
+            <h2 className="text-3xl font-medium tracking-tight text-text-extra-high">
+              Recurring payment
+            </h2>
+            <p className="truncate text-sm text-text-medium">{recurringPayment.id}</p>
           </div>
-        ) : null}
+          <RecurringPaymentStatusBadge status={recurringPayment.status} />
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <SummaryMetric icon={<RepeatIcon />} label="Amount" value={amountLabel} />
+          <SummaryMetric icon={<CalendarClockIcon />} label="Period" value={scheduleLabel} />
+          <SummaryMetric
+            icon={<CalendarClockIcon />}
+            label="Next due"
+            value={formatOptionalTimestamp(recurringPayment.nextCollectionDueAt)}
+          />
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-xl border border-border-light p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-text-extra-high">
+              <WalletIcon className="h-4 w-4 text-text-low" />
+              Source
+            </div>
+            <p className="truncate text-sm font-medium text-text-extra-high">
+              {sourceWalletLabel ?? recurringPayment.sourceWalletId}
+            </p>
+            <p className="mt-1 truncate font-mono text-xs text-text-medium">{sourceAddress}</p>
+          </div>
+          <div className="rounded-xl border border-border-light p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-text-extra-high">
+              <UserIcon className="h-4 w-4 text-text-low" />
+              Counterparty
+            </div>
+            <p className="truncate text-sm font-medium text-text-extra-high">{counterpartyName}</p>
+            <p className="mt-1 truncate font-mono text-xs text-text-medium">
+              {recurringPayment.destinationAddress}
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-border-light px-4">
+          <div className="divide-y divide-border-light">
+            <DetailRow label="Status">
+              <RecurringPaymentStatusBadge status={recurringPayment.status} />
+            </DetailRow>
+            <DetailRow label="First collection">
+              {formatOptionalTimestamp(recurringPayment.firstCollectionAt)}
+            </DetailRow>
+            <DetailRow label="Next due">
+              {formatOptionalTimestamp(recurringPayment.nextCollectionDueAt)}
+            </DetailRow>
+            <DetailRow label="Destination token account">
+              <CopyableValue value={recurringPayment.destinationTokenAccount} />
+            </DetailRow>
+            <DetailRow label="Token mint">
+              <CopyableValue value={recurringPayment.token} />
+            </DetailRow>
+            <DetailRow label="Metadata URI">
+              {recurringPayment.metadataUri ? (
+                <a
+                  href={recurringPayment.metadataUri}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="break-all underline underline-offset-4"
+                >
+                  {recurringPayment.metadataUri}
+                </a>
+              ) : (
+                <span className="text-text-low">Not set</span>
+              )}
+            </DetailRow>
+            <DetailRow label="Created">{formatTimestamp(recurringPayment.createdAt)}</DetailRow>
+            <DetailRow label="Updated">{formatTimestamp(recurringPayment.updatedAt)}</DetailRow>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-3 text-sm font-medium text-text-extra-high">Subscription lifecycle</h3>
+          <div
+            className={cn(
+              "rounded-xl border border-border-light px-4",
+              "divide-y divide-border-light"
+            )}
+          >
+            <DetailRow label="Plan ID">
+              <CopyableValue value={recurringPayment.planId} />
+            </DetailRow>
+            <DetailRow label="Plan PDA">
+              <CopyableValue value={recurringPayment.planPda} />
+            </DetailRow>
+            <DetailRow label="Plan created">
+              {formatOptionalTimestamp(recurringPayment.planCreatedAt)}
+            </DetailRow>
+            <DetailRow label="Plan signature">
+              <CopyableValue value={recurringPayment.planCreationSignature} />
+            </DetailRow>
+            <DetailRow label="Subscription ID">
+              <CopyableValue value={recurringPayment.subscriptionId} />
+            </DetailRow>
+            <DetailRow label="Subscription PDA">
+              <CopyableValue value={recurringPayment.subscriptionPda} />
+            </DetailRow>
+            <DetailRow label="Authority">
+              <CopyableValue value={recurringPayment.subscriptionAuthorityAddress} />
+            </DetailRow>
+            <DetailRow label="Authorization signature">
+              <CopyableValue value={recurringPayment.authorizationSignature} />
+            </DetailRow>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -5,7 +5,8 @@ import {
   type PaymentRecurringPaymentStatus,
   WELL_KNOWN_TOKEN_BY_MINT,
 } from "@sdp/types";
-import { CalendarClockIcon, CopyIcon, RepeatIcon, UserIcon, WalletIcon } from "lucide-react";
+import { CalendarClockIcon, CopyIcon, ExternalLinkIcon, RepeatIcon, UserIcon } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { type KeyboardEvent, type ReactNode, useMemo } from "react";
 import { toast } from "sonner";
@@ -20,7 +21,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { cn } from "@/lib/utils";
 import { formatDisplayAmount, formatTimestamp, shortenAddress } from "../payments-overview.utils";
 
 const STATUS_LABELS = {
@@ -69,8 +69,9 @@ interface RecurringPaymentsWorkspaceProps {
 interface RecurringPaymentDetailWorkspaceProps {
   recurringPayment: PaymentRecurringPayment;
   wallet: RecurringPaymentWalletView | null;
-  counterpartyName: string;
+  counterpartyLabel: string;
   amountLabel: string;
+  currencyLabel: string;
 }
 
 function RecurringPaymentStatusBadge({ status }: { status: PaymentRecurringPaymentStatus }) {
@@ -123,15 +124,35 @@ function DetailRow({ label, children }: { label: string; children: ReactNode }) 
   );
 }
 
-function CopyableValue({ value, empty = "Not set" }: { value: string | null; empty?: string }) {
+function DetailLabel({ icon, children }: { icon: ReactNode; children: ReactNode }) {
+  return (
+    <div className="mb-3 flex items-center gap-2 text-sm font-medium text-text-medium">
+      <span className="[&_svg]:size-4 [&_svg]:text-text-medium">{icon}</span>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function CopyableValue({
+  value,
+  label,
+  empty = "Not set",
+}: {
+  value: string | null;
+  label?: string;
+  empty?: string;
+}) {
   if (!value) {
     return <span className="text-text-low">{empty}</span>;
   }
 
   return (
     <span className="inline-flex max-w-full items-center justify-end gap-2">
-      <span className="min-w-0 truncate font-mono text-xs text-text-extra-high" title={value}>
-        {value}
+      <span
+        className="min-w-0 truncate font-mono text-xs text-text-extra-high"
+        title={label ?? value}
+      >
+        {label ?? value}
       </span>
       <Button
         type="button"
@@ -149,16 +170,50 @@ function CopyableValue({ value, empty = "Not set" }: { value: string | null; emp
   );
 }
 
-function SummaryMetric({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
-  return (
-    <div className="min-w-0 rounded-xl border border-border-light bg-white px-4 py-3">
-      <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase text-text-low">
-        <span className="[&_svg]:size-3.5">{icon}</span>
-        <span>{label}</span>
-      </div>
+function SummaryMetric({
+  icon,
+  label,
+  value,
+  href,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  href?: string;
+}) {
+  const content = (
+    <>
+      {href ? (
+        <span
+          aria-hidden="true"
+          className="absolute top-3 right-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-text-low opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+        >
+          <ExternalLinkIcon className="h-4 w-4" />
+        </span>
+      ) : null}
+      <DetailLabel icon={icon}>{label}</DetailLabel>
       <p className="truncate text-sm font-semibold text-text-extra-high">{value}</p>
-    </div>
+    </>
   );
+
+  const className =
+    "group relative min-w-0 rounded-xl border border-border-light bg-white px-4 py-3 transition-[border-color,box-shadow] duration-150 ease-out hover:border-border-medium hover:shadow-sm";
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`Open ${label.toLowerCase()}`}
+        className={`${className} block focus:outline-none focus-visible:border-border-medium focus-visible:ring-2 focus-visible:ring-black/50`}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={className}>{content}</div>;
 }
 
 export function RecurringPaymentsWorkspace({
@@ -191,7 +246,7 @@ export function RecurringPaymentsWorkspace({
   };
   const getCounterpartyLabel = (recurringPayment: PaymentRecurringPayment) =>
     counterpartyById.get(recurringPayment.counterpartyId)?.displayName ??
-    recurringPayment.counterpartyId;
+    "Counterparty unavailable";
   const getAmountLabel = (recurringPayment: PaymentRecurringPayment) =>
     formatDisplayAmount(
       recurringPayment.amount,
@@ -234,25 +289,22 @@ export function RecurringPaymentsWorkspace({
               <Table className="w-full [&_table]:table-fixed">
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[34%] md:w-[26%] lg:w-[21%] xl:w-[18%] 2xl:w-[15%]">
+                    <TableHead className="w-[34%] md:w-[26%] lg:w-[21%] xl:w-[18%]">
                       Status
                     </TableHead>
-                    <TableHead className="w-[26%] md:w-[22%] lg:w-[20%] xl:w-[18%] 2xl:w-[16%]">
+                    <TableHead className="w-[26%] md:w-[22%] lg:w-[20%] xl:w-[18%]">
                       Amount
                     </TableHead>
-                    <TableHead className="w-[40%] md:w-[34%] lg:w-[31%] xl:w-[24%] 2xl:w-[18%]">
+                    <TableHead className="w-[40%] md:w-[34%] lg:w-[31%] xl:w-[24%]">
                       Counterparty
                     </TableHead>
-                    <TableHead className="hidden lg:table-cell lg:w-[28%] xl:w-[22%] 2xl:w-[17%]">
-                      Source wallet
+                    <TableHead className="hidden lg:table-cell lg:w-[28%] xl:w-[22%]">
+                      Funding wallet
                     </TableHead>
-                    <TableHead className="hidden xl:table-cell xl:w-[18%] 2xl:w-[12%]">
-                      Period
+                    <TableHead className="hidden xl:table-cell xl:w-[18%]">Interval</TableHead>
+                    <TableHead className="hidden md:table-cell md:w-[18%] xl:hidden 2xl:table-cell 2xl:w-[18%]">
+                      Next payment
                     </TableHead>
-                    <TableHead className="hidden md:table-cell md:w-[18%] xl:hidden 2xl:table-cell 2xl:w-[12%]">
-                      Next due
-                    </TableHead>
-                    <TableHead className="hidden 2xl:table-cell 2xl:w-[10%]">Created</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -296,9 +348,6 @@ export function RecurringPaymentsWorkspace({
                       <TableCell className="hidden text-sm text-text-medium md:table-cell xl:hidden 2xl:table-cell">
                         {formatOptionalTimestamp(recurringPayment.nextCollectionDueAt)}
                       </TableCell>
-                      <TableCell className="hidden text-sm text-text-medium 2xl:table-cell">
-                        {formatTimestamp(recurringPayment.createdAt)}
-                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -313,13 +362,12 @@ export function RecurringPaymentsWorkspace({
 
 export function RecurringPaymentDetailWorkspace({
   recurringPayment,
-  wallet,
-  counterpartyName,
+  counterpartyLabel,
   amountLabel,
+  currencyLabel,
 }: RecurringPaymentDetailWorkspaceProps) {
-  const sourceWalletLabel = wallet?.label || (wallet ? shortenAddress(wallet.publicKey) : null);
-  const sourceAddress = wallet?.publicKey ?? recurringPayment.sourceAddress;
   const scheduleLabel = formatPeriodHours(recurringPayment.periodHours);
+  const paymentReferenceLabel = shortenAddress(recurringPayment.id);
 
   return (
     <div className="h-full min-h-0 w-full overflow-auto px-3 pt-6 pb-5 md:px-6 md:pb-6">
@@ -329,42 +377,33 @@ export function RecurringPaymentDetailWorkspace({
             <h2 className="text-3xl font-medium tracking-tight text-text-extra-high">
               Recurring payment
             </h2>
-            <p className="truncate text-sm text-text-medium">{recurringPayment.id}</p>
+            <p className="truncate text-sm text-text-medium">
+              {counterpartyLabel} · {amountLabel} · {scheduleLabel}
+            </p>
           </div>
           <RecurringPaymentStatusBadge status={recurringPayment.status} />
         </div>
 
-        <div className="grid gap-3 md:grid-cols-3">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
           <SummaryMetric icon={<RepeatIcon />} label="Amount" value={amountLabel} />
-          <SummaryMetric icon={<CalendarClockIcon />} label="Period" value={scheduleLabel} />
           <SummaryMetric
             icon={<CalendarClockIcon />}
-            label="Next due"
+            label="Billing interval"
+            value={scheduleLabel}
+          />
+          <SummaryMetric
+            icon={<CalendarClockIcon />}
+            label="Next payment"
             value={formatOptionalTimestamp(recurringPayment.nextCollectionDueAt)}
           />
-        </div>
-
-        <div className="grid gap-3 md:grid-cols-2">
-          <div className="rounded-xl border border-border-light p-4">
-            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-text-extra-high">
-              <WalletIcon className="h-4 w-4 text-text-low" />
-              Source
-            </div>
-            <p className="truncate text-sm font-medium text-text-extra-high">
-              {sourceWalletLabel ?? recurringPayment.sourceWalletId}
-            </p>
-            <p className="mt-1 truncate font-mono text-xs text-text-medium">{sourceAddress}</p>
-          </div>
-          <div className="rounded-xl border border-border-light p-4">
-            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-text-extra-high">
-              <UserIcon className="h-4 w-4 text-text-low" />
-              Counterparty
-            </div>
-            <p className="truncate text-sm font-medium text-text-extra-high">{counterpartyName}</p>
-            <p className="mt-1 truncate font-mono text-xs text-text-medium">
-              {recurringPayment.destinationAddress}
-            </p>
-          </div>
+          <SummaryMetric
+            icon={<UserIcon />}
+            label="Counterparty"
+            value={counterpartyLabel}
+            href={`/dashboard/payments/counterparty/${encodeURIComponent(
+              recurringPayment.counterpartyId
+            )}`}
+          />
         </div>
 
         <div className="rounded-xl border border-border-light px-4">
@@ -372,27 +411,26 @@ export function RecurringPaymentDetailWorkspace({
             <DetailRow label="Status">
               <RecurringPaymentStatusBadge status={recurringPayment.status} />
             </DetailRow>
-            <DetailRow label="First collection">
+            <DetailRow label="Starts">
               {formatOptionalTimestamp(recurringPayment.firstCollectionAt)}
             </DetailRow>
-            <DetailRow label="Next due">
+            <DetailRow label="Next payment">
               {formatOptionalTimestamp(recurringPayment.nextCollectionDueAt)}
             </DetailRow>
-            <DetailRow label="Destination token account">
-              <CopyableValue value={recurringPayment.destinationTokenAccount} />
+            <DetailRow label="Billing interval">{scheduleLabel}</DetailRow>
+            <DetailRow label="Currency">{currencyLabel}</DetailRow>
+            <DetailRow label="Payment reference">
+              <CopyableValue value={recurringPayment.id} label={paymentReferenceLabel} />
             </DetailRow>
-            <DetailRow label="Token mint">
-              <CopyableValue value={recurringPayment.token} />
-            </DetailRow>
-            <DetailRow label="Metadata URI">
+            <DetailRow label="Metadata">
               {recurringPayment.metadataUri ? (
                 <a
                   href={recurringPayment.metadataUri}
                   target="_blank"
                   rel="noreferrer"
-                  className="break-all underline underline-offset-4"
+                  className="underline underline-offset-4"
                 >
-                  {recurringPayment.metadataUri}
+                  Open metadata
                 </a>
               ) : (
                 <span className="text-text-low">Not set</span>
@@ -404,35 +442,21 @@ export function RecurringPaymentDetailWorkspace({
         </div>
 
         <div>
-          <h3 className="mb-3 text-sm font-medium text-text-extra-high">Subscription lifecycle</h3>
-          <div
-            className={cn(
-              "rounded-xl border border-border-light px-4",
-              "divide-y divide-border-light"
-            )}
-          >
-            <DetailRow label="Plan ID">
+          <h3 className="mb-3 text-sm font-medium text-text-extra-high">Billing setup</h3>
+          <div className="divide-y divide-border-light rounded-xl border border-border-light px-4">
+            <DetailRow label="Plan reference">
               <CopyableValue value={recurringPayment.planId} />
             </DetailRow>
-            <DetailRow label="Plan PDA">
-              <CopyableValue value={recurringPayment.planPda} />
-            </DetailRow>
-            <DetailRow label="Plan created">
+            <DetailRow label="Setup confirmed">
               {formatOptionalTimestamp(recurringPayment.planCreatedAt)}
             </DetailRow>
-            <DetailRow label="Plan signature">
+            <DetailRow label="Setup transaction">
               <CopyableValue value={recurringPayment.planCreationSignature} />
             </DetailRow>
-            <DetailRow label="Subscription ID">
+            <DetailRow label="Subscription reference">
               <CopyableValue value={recurringPayment.subscriptionId} />
             </DetailRow>
-            <DetailRow label="Subscription PDA">
-              <CopyableValue value={recurringPayment.subscriptionPda} />
-            </DetailRow>
-            <DetailRow label="Authority">
-              <CopyableValue value={recurringPayment.subscriptionAuthorityAddress} />
-            </DetailRow>
-            <DetailRow label="Authorization signature">
+            <DetailRow label="Authorization transaction">
               <CopyableValue value={recurringPayment.authorizationSignature} />
             </DetailRow>
           </div>

--- a/apps/sdp-web/src/components/dashboard-shell.tsx
+++ b/apps/sdp-web/src/components/dashboard-shell.tsx
@@ -390,6 +390,16 @@ function getDashboardPageConfig(pathname: string): DashboardPageConfig {
       contentWidthClass: "max-w-none",
     };
   }
+  if (pathname.startsWith("/dashboard/payments/recurring/")) {
+    return {
+      title: "Recurring payment",
+      contentWidthClass: "max-w-none",
+      backAction: {
+        href: "/dashboard/payments/recurring",
+        label: "Back to recurring payments",
+      },
+    };
+  }
   if (pathname.startsWith("/dashboard/payments/")) {
     const action = PAYMENTS_ACTIONS.find((item) => pathname.startsWith(item.href));
     const centeredTitle = action


### PR DESCRIPTION
## Summary
- add the gated recurring payments list and detail dashboard views
- show recurring payment records with responsive columns and web-dashboard terminology
- add detail sections for payment status, billing setup, and linked counterparty navigation
- keep low-level mint/PDA details out of the primary UI

<img width="926" height="454" alt="Screenshot 2026-06-26 at 1 26 59 PM" src="https://github.com/user-attachments/assets/a1a8e5f2-befa-4e54-83e1-379c499a88b8" />


<img width="970" height="806" alt="Screenshot 2026-06-26 at 2 07 40 PM" src="https://github.com/user-attachments/assets/8b8dccb5-7ef7-4b2c-98f7-c48459782171" />


Closes PRO-1300

## Checks
- `pnpm exec biome check --write apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx`
- `doppler run --project solana-developer-platform --config dev_personal -- pnpm --filter sdp-web typecheck`
- `git diff --check`