### PR TITLE
test: run access custody shard on Surfpool local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,11 +381,12 @@ jobs:
             provider: surfpool
             test_files: src/tests/payments-wallet-scope.test.ts src/tests/api-keys-flow.test.ts src/tests/api-keys-rotation.test.ts src/tests/custody-local.test.ts
             rpc_provider: alchemy
-            custody_provider: privy
+            custody_provider: local
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
       DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
       SOLANA_NETWORK: devnet
+      INTEGRATION_SHARD_NAME: ${{ matrix.name }}
       INTEGRATION_TEST_FILES: ${{ matrix.test_files }}
       SOLANA_RPC_CI_PREFERRED_PROVIDER: ${{ matrix.rpc_provider }}
       SDP_INTEGRATION_CUSTODY_PROVIDER: ${{ matrix.custody_provider }}
@@ -464,8 +465,11 @@ jobs:
           read -r -a test_files <<< "${INTEGRATION_TEST_FILES}"
           if [ "${CI_HAS_DOPPLER_TOKEN}" = "true" ]; then
             scripts/doppler/run-with-config.sh pnpm kora:surfpool:integration -- "${test_files[@]}"
+          elif [ "${CI_IS_FORK_PULL_REQUEST}" = "true" ] && [ "${INTEGRATION_SHARD_NAME}" = "Surfpool / Access" ]; then
+            echo "::notice title=Fork-safe Surfpool Access::Running the Surfpool Access shard without managed RPC or hosted custody secrets."
+            SOLANA_RPC_CI_PREFERRED_PROVIDER=default pnpm kora:surfpool:integration -- "${test_files[@]}"
           elif [ "${CI_IS_FORK_PULL_REQUEST}" = "true" ]; then
-            echo "::notice title=Fork-safe Surfpool integration skip::Forked pull requests cannot access managed Solana RPC secrets, so Surfpool-backed integration shards are skipped."
+            echo "::notice title=Fork-safe Surfpool integration skip::Forked pull requests cannot access managed Solana RPC secrets, so this Surfpool shard is skipped."
           else
             echo "DOPPLER_TOKEN_CI must be configured for Surfpool integration shards." >&2
             exit 1

--- a/packages/sdp-api-integration/src/helpers/integration.ts
+++ b/packages/sdp-api-integration/src/helpers/integration.ts
@@ -11,7 +11,10 @@ import {
   getMinimumBalanceForRentExemption,
   getRecentBlockhash,
 } from "@sdp/api/services/solana/rpc";
-import type { CustodyWallet } from "@sdp/api/services/stores/custody-config.store";
+import {
+  CustodyConfigStore,
+  type CustodyWallet,
+} from "@sdp/api/services/stores/custody-config.store";
 import { TEST_ORG, TEST_USER } from "@sdp/api-test/fixtures/organizations";
 import {
   TEST_PROJECT,
@@ -667,6 +670,57 @@ export async function createFundedPrivyWallet(input: {
     label: input.label,
     setDefault: input.setDefault,
   });
+
+  if (input.fundLamports && input.fundLamports > 0) {
+    await fundAddressToLamports(wallet.publicKey, input.fundLamports);
+  } else {
+    await ensureAddressAccountExists(wallet.publicKey);
+  }
+
+  return wallet;
+}
+
+export async function createFundedIntegrationWallet(input: {
+  label: string;
+  fundLamports?: number;
+  setDefault?: boolean;
+}): Promise<CustodyWallet> {
+  if (INTEGRATION_CUSTODY_PROVIDER === "local") {
+    return createFundedLocalWallet(input);
+  }
+
+  return createFundedPrivyWallet(input);
+}
+
+async function createFundedLocalWallet(input: {
+  label: string;
+  fundLamports?: number;
+  setDefault?: boolean;
+}): Promise<CustodyWallet> {
+  const publicKey = await ensureLocalCustodyAddress();
+  const signingService = createSigningService(env);
+  const config = await signingService.getConfigurationByProvider(TEST_ORG.id, undefined, "local");
+  if (!config) {
+    throw new Error("Integration precondition failed: local signer configuration not found.");
+  }
+
+  const configStore = new CustodyConfigStore(getDb(env), env.CUSTODY_ENCRYPTION_KEY);
+  // Local custody has one signing key; access tests still need distinct wallet IDs.
+  const wallet = await configStore.createWallet(config.id, {
+    walletId: `local_${crypto.randomUUID()}`,
+    publicKey,
+    label: input.label,
+    purpose: "transfer",
+  });
+
+  if (input.setDefault) {
+    await getDb(env)
+      .prepare(
+        "UPDATE custody_configs SET default_wallet_id = ?, updated_at = datetime('now') WHERE id = ?"
+      )
+      .bind(wallet.walletId, config.id)
+      .run();
+  }
 
   if (input.fundLamports && input.fundLamports > 0) {
     await fundAddressToLamports(wallet.publicKey, input.fundLamports);

--- a/packages/sdp-api-integration/src/tests/api-keys-rotation.test.ts
+++ b/packages/sdp-api-integration/src/tests/api-keys-rotation.test.ts
@@ -2,7 +2,7 @@ import { TEST_PROJECT } from "@sdp/api-test/fixtures/tokens";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   cleanupIntegrationSuite,
-  createFundedPrivyWallet,
+  createFundedIntegrationWallet,
   initIntegrationSuite,
   RUN_INTEGRATION_TESTS,
   requestWithApiKey,
@@ -63,7 +63,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("API Key Rotation 
   it("rotates a selected-wallet key, preserves old-key access until revoke, then rejects it", {
     timeout: 240000,
   }, async () => {
-    const wallet = await createFundedPrivyWallet({
+    const wallet = await createFundedIntegrationWallet({
       label: "Rotation Wallet",
       fundLamports: 5_000_000,
     });

--- a/packages/sdp-api-integration/src/tests/custody-local.test.ts
+++ b/packages/sdp-api-integration/src/tests/custody-local.test.ts
@@ -4,6 +4,7 @@ import type { TokenApiResponse } from "../helpers/api-types";
 import {
   cleanupIntegrationSuite,
   env,
+  INTEGRATION_CUSTODY_PROVIDER,
   initIntegrationSuite,
   RUN_INTEGRATION_TESTS,
   request as rawRequest,
@@ -12,7 +13,11 @@ import {
   SOLANA_CONFIGURED,
 } from "../helpers/integration";
 
-describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Privy Signing", () => {
+const describeIfIntegrationConfigured = describe.skipIf(
+  !SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS
+);
+
+describeIfIntegrationConfigured("Custody Access and Default Signing", () => {
   let apiKeyHash: string;
   const request = requestWithApiKey();
 
@@ -29,7 +34,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Privy Sig
     await resetIntegrationState(apiKeyHash);
   });
 
-  it("uses the Privy default signer for deployments", { timeout: 120000 }, async () => {
+  it("uses the configured default signer for deployments", { timeout: 120000 }, async () => {
     const configRes = await request("/v1/wallets/config");
 
     expect(configRes.status).toBe(200);
@@ -38,7 +43,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Privy Sig
     };
 
     const { id: configId, provider, publicKey } = configBody.data.config;
-    expect(provider).toBe("privy");
+    expect(provider).toBe(INTEGRATION_CUSTODY_PROVIDER);
     expect(publicKey).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
 
     const configRow = await getDb(env)
@@ -83,7 +88,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Custody Privy Sig
     const initRes = await rawRequest("/v1/wallets", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ provider: "privy" }),
+      body: JSON.stringify({ provider: INTEGRATION_CUSTODY_PROVIDER }),
     });
     expect(initRes.status).toBe(401);
   });

--- a/packages/sdp-api-integration/src/tests/payments-wallet-scope.test.ts
+++ b/packages/sdp-api-integration/src/tests/payments-wallet-scope.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   cleanupIntegrationSuite,
-  createFundedPrivyWallet,
+  createFundedIntegrationWallet,
   initIntegrationSuite,
   RUN_INTEGRATION_TESTS,
   requestWithApiKey,
@@ -52,11 +52,11 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Payments Wallet S
   it("limits transfer list/get access to the API key wallet bindings", {
     timeout: 240000,
   }, async () => {
-    const walletA = await createFundedPrivyWallet({
+    const walletA = await createFundedIntegrationWallet({
       label: "Wallet A",
       fundLamports: 12_000_000,
     });
-    const walletB = await createFundedPrivyWallet({
+    const walletB = await createFundedIntegrationWallet({
       label: "Wallet B",
       fundLamports: 12_000_000,
     });
@@ -89,7 +89,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Payments Wallet S
         source: walletA.walletId,
         destination: DESTINATION_A,
         token: "SOL",
-        amount: "0.01",
+        amount: "0.001",
       }),
     });
     expect(transferARes.status).toBe(200);
@@ -104,7 +104,7 @@ describe.skipIf(!SOLANA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Payments Wallet S
         source: walletB.walletId,
         destination: DESTINATION_B,
         token: "SOL",
-        amount: "0.01",
+        amount: "0.001",
       }),
     });
     expect(transferBRes.status).toBe(200);


### PR DESCRIPTION
## Summary
- move the Surfpool Access integration shard to local custody instead of Privy
- add a provider-aware funded wallet helper so access tests can run with local custody while live Kora smoke still uses Privy
- allow fork PRs to run the Surfpool Access shard without Doppler, managed RPC, or hosted custody secrets

## Testing
- `SOLANA_RPC_CI_PREFERRED_PROVIDER=default pnpm kora:surfpool:integration -- src/tests/payments-wallet-scope.test.ts src/tests/api-keys-flow.test.ts src/tests/api-keys-rotation.test.ts src/tests/custody-local.test.ts`
- `DOPPLER_CONFIG=dev_ci scripts/doppler/run-with-config.sh pnpm kora:surfpool:integration -- src/tests/payments-wallet-scope.test.ts src/tests/api-keys-flow.test.ts src/tests/api-keys-rotation.test.ts src/tests/custody-local.test.ts`
- `pnpm exec biome check .github/workflows/ci.yml packages/sdp-api-integration/src/helpers/integration.ts packages/sdp-api-integration/src/tests/api-keys-rotation.test.ts packages/sdp-api-integration/src/tests/payments-wallet-scope.test.ts packages/sdp-api-integration/src/tests/custody-local.test.ts`
- `bash -n scripts/kora-surfpool/*.sh`
- `pnpm test:scripts`
- `pnpm typecheck`

Closes PRO-1414