### PR TITLE
feat(web): add wallet policy operation rules flow

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -56,6 +56,59 @@ export const tokenAmountSchema = z.string().openapi({
   example: "100.00",
 });
 
+const policyRuleSchema = z
+  .object({
+    id: z.string().optional().openapi({ description: "Stable client-side rule identifier." }),
+    name: z.string().optional().openapi({ description: "Human-readable rule name." }),
+    description: z.string().optional().openapi({ description: "Rule description." }),
+    action: z
+      .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+      .optional()
+      .openapi({ description: "Decision to apply when this rule matches." }),
+    kind: z
+      .enum(["operation_family", "destination", "amount", "approval", "always"])
+      .openapi({ description: "Policy rule kind." }),
+  })
+  .passthrough()
+  .openapi({
+    description:
+      "Wallet control profile rule. Supported kinds include operation_family, destination, amount, approval, and always.",
+    example: {
+      id: "deny-raw-signing",
+      kind: "operation_family",
+      family: "raw_sign",
+      action: "deny",
+    },
+  });
+
+const walletControlProfileSummarySchema = z
+  .object({
+    id: z.string().openapi({ description: "Wallet control profile ID." }),
+    status: z
+      .enum(["draft", "active", "disabled", "archived"])
+      .openapi({ description: "Wallet control profile status." }),
+    activeRevisionId: z.string().nullable().openapi({
+      description: "Currently active immutable revision ID.",
+    }),
+    revisionId: z.string().nullable().openapi({ description: "Returned revision ID." }),
+    revisionNumber: z.number().int().nullable().openapi({
+      description: "Returned immutable revision number.",
+    }),
+    defaultAction: z.enum(["allow", "deny", "approval_required", "review"]).openapi({
+      description: "Decision used when no rule matches.",
+    }),
+    rules: z.array(policyRuleSchema).openapi({ description: "Active policy rules." }),
+    providerMappingStatus: z
+      .enum(["not_applicable", "pending", "synced", "partial", "failed"])
+      .openapi({ description: "Provider mapping status for this policy profile." }),
+    createdAt: isoDateTimeSchema.openapi({ description: "Profile creation timestamp." }),
+    updatedAt: isoDateTimeSchema.openapi({ description: "Profile update timestamp." }),
+    activatedAt: isoDateTimeSchema.nullable().openapi({
+      description: "Profile activation timestamp.",
+    }),
+  })
+  .openapi({ description: "Wallet control profile summary." });
+
 export const walletPolicySchema = z
   .object({
     walletId: walletIdParamSchema.openapi({
@@ -76,6 +129,16 @@ export const walletPolicySchema = z
     maxDailyAmount: tokenAmountSchema
       .optional()
       .openapi({ description: "Maximum total amount allowed per day." }),
+    defaultAction: z.enum(["allow", "deny", "approval_required", "review"]).optional().openapi({
+      description: "Active wallet control profile default action when no rule matches.",
+    }),
+    rules: z
+      .array(policyRuleSchema)
+      .optional()
+      .openapi({ description: "Active wallet control profile rules." }),
+    controlProfile: walletControlProfileSummarySchema.optional().openapi({
+      description: "Active wallet control profile metadata.",
+    }),
     createdAt: isoDateTimeSchema.openapi({
       description: "Timestamp when the policy was created.",
       example: "2025-01-01T00:00:00.000Z",
@@ -122,6 +185,22 @@ export const updateWalletPolicyRequestSchema = updateWalletPolicySchemaBase
     maxDailyAmount: withOpenApi(updateWalletPolicySchemaBase.shape.maxDailyAmount, {
       description: "Maximum total amount allowed per day.",
       example: "1000.00",
+    }),
+    defaultAction: withOpenApi(updateWalletPolicySchemaBase.shape.defaultAction, {
+      description: "Default action for the activated wallet control profile revision.",
+      example: "allow",
+    }),
+    rules: withOpenApi(updateWalletPolicySchemaBase.shape.rules, {
+      description:
+        "Rules for a new immutable wallet control profile revision. When provided, the revision is activated after validation.",
+      example: [
+        {
+          id: "deny-raw-signing",
+          kind: "operation_family",
+          family: "raw_sign",
+          action: "deny",
+        },
+      ],
     }),
   })
   .openapi({

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -6080,6 +6080,142 @@ describe("Payments routes", () => {
     expect(body.error.message).toContain("BVNK is not configured");
   });
 
+  it("activates immutable wallet control profile revisions from wallet policy updates", async () => {
+    const rules = [
+      {
+        id: "deny-raw-signing",
+        kind: "operation_family",
+        family: "raw_sign",
+        action: "deny",
+      },
+      {
+        id: "approval-for-payments",
+        kind: "approval",
+        families: ["payment"],
+        action: "approval_required",
+      },
+    ];
+
+    const updateRes = await app.request(
+      `/v1/payments/wallets/${TEST_WALLET_ID}/policies`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationAllowlist: [TEST_SOLANA_ADDRESSES.wallet2],
+          maxTransferAmount: "5",
+          defaultAction: "allow",
+          rules,
+        }),
+      },
+      env
+    );
+
+    expect(updateRes.status).toBe(200);
+    const updateBody = (await updateRes.json()) as {
+      data: {
+        policy: {
+          destinationAllowlist: string[];
+          maxTransferAmount?: string;
+          defaultAction?: string;
+          rules?: unknown[];
+          controlProfile?: {
+            id: string;
+            status: string;
+            revisionId: string;
+            revisionNumber: number;
+            providerMappingStatus: string;
+          };
+        };
+      };
+    };
+    expect(updateBody.data.policy.destinationAllowlist).toEqual([TEST_SOLANA_ADDRESSES.wallet2]);
+    expect(updateBody.data.policy.maxTransferAmount).toBe("5");
+    expect(updateBody.data.policy.defaultAction).toBe("allow");
+    expect(updateBody.data.policy.rules).toEqual(rules);
+    expect(updateBody.data.policy.controlProfile).toMatchObject({
+      status: "active",
+      revisionNumber: 1,
+      providerMappingStatus: "not_applicable",
+    });
+
+    const revisionRows = await getDb(env)
+      .prepare(
+        `SELECT revision_number, default_action, rules
+         FROM wallet_control_profile_revisions
+         ORDER BY revision_number ASC`
+      )
+      .all<{
+        revision_number: number;
+        default_action: string;
+        rules: unknown;
+      }>();
+    expect(revisionRows.results).toHaveLength(1);
+    expect(revisionRows.results[0]).toMatchObject({
+      revision_number: 1,
+      default_action: "allow",
+    });
+
+    const secondRes = await app.request(
+      `/v1/payments/wallets/${TEST_WALLET_ID}/policies`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationAllowlist: [],
+          defaultAction: "allow",
+          rules: [
+            {
+              id: "deny-programs",
+              kind: "operation_family",
+              family: "program",
+              action: "deny",
+            },
+          ],
+        }),
+      },
+      env
+    );
+
+    expect(secondRes.status).toBe(200);
+    const secondBody = (await secondRes.json()) as typeof updateBody;
+    expect(secondBody.data.policy.controlProfile?.id).toBe(
+      updateBody.data.policy.controlProfile?.id
+    );
+    expect(secondBody.data.policy.controlProfile?.revisionNumber).toBe(2);
+
+    const getRes = await app.request(
+      `/v1/payments/wallets/${TEST_WALLET_ID}/policies`,
+      {
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as typeof updateBody;
+    expect(getBody.data.policy.controlProfile).toMatchObject({
+      id: updateBody.data.policy.controlProfile?.id,
+      revisionNumber: 2,
+    });
+    expect(getBody.data.policy.rules).toEqual([
+      {
+        id: "deny-programs",
+        kind: "operation_family",
+        family: "program",
+        action: "deny",
+      },
+    ]);
+  });
+
   it("blocks prepare transfer when destination is outside allowlist", async () => {
     await seedWalletPolicy({
       destinationAllowlist: [TEST_SOLANA_ADDRESSES.wallet2],

--- a/apps/sdp-api/src/routes/payments/context.ts
+++ b/apps/sdp-api/src/routes/payments/context.ts
@@ -5,6 +5,7 @@ import {
   createPaymentRecurringPaymentsRepository,
   createPaymentSubscriptionsRepository,
   createPaymentsRepository,
+  createPolicyRepository,
 } from "@/db/repositories";
 import type { RampRuntimeContext } from "@/lib/ramps/types";
 import * as feePaymentAdapters from "@/services/adapters/fee-payment";
@@ -42,6 +43,10 @@ export function getPaymentSubscriptionsRepository(c: AppContext) {
 
 export function getPaymentRecurringPaymentsRepository(c: AppContext) {
   return createPaymentRecurringPaymentsRepository(c.env);
+}
+
+export function getPolicyRepository(c: AppContext) {
+  return createPolicyRepository(c.env);
 }
 
 export function getFeePayment(c: AppContext) {

--- a/apps/sdp-api/src/routes/payments/handlers/balances.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/balances.ts
@@ -1,11 +1,13 @@
+import type { PaymentWalletControlProfileSummary, PolicyRule } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import { z } from "zod";
+import type { ActiveWalletControlProfileResult } from "@/db/repositories";
 import { formatDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { attachUsdValuesToBalances } from "@/services/helius-das.service";
 import * as solanaRpc from "@/services/solana/rpc";
-import { type AppContext, getPaymentsRepository } from "../context";
+import { type AppContext, getPaymentsRepository, getPolicyRepository } from "../context";
 import {
   buildWalletPolicyPayload,
   DESTINATION_ALLOWLIST_POLICY_TYPE,
@@ -15,6 +17,34 @@ import {
 import { updateWalletPolicySchema } from "../schemas";
 import * as tokenAccounts from "../token-accounts";
 import { resolveWalletFromParams } from "./transfers";
+
+function mapWalletControlProfileSummary(
+  active: ActiveWalletControlProfileResult
+): PaymentWalletControlProfileSummary {
+  return {
+    id: active.profile.id,
+    status: active.profile.status,
+    activeRevisionId: active.profile.active_revision_id,
+    revisionId: active.revision?.id ?? null,
+    revisionNumber: active.revision?.revision_number ?? null,
+    defaultAction: active.revision?.default_action ?? "allow",
+    rules: (active.revision?.rules ?? []) as unknown as PolicyRule[],
+    providerMappingStatus: "not_applicable",
+    createdAt: active.profile.created_at,
+    updatedAt: active.profile.updated_at,
+    activatedAt: active.profile.activated_at,
+  };
+}
+
+async function getWalletControlProfileSummary(
+  c: AppContext,
+  custodyWalletId: string
+): Promise<PaymentWalletControlProfileSummary | null> {
+  const active =
+    await getPolicyRepository(c).getActiveWalletControlProfileByCustodyWalletId(custodyWalletId);
+
+  return active ? mapWalletControlProfileSummary(active) : null;
+}
 
 export async function getWalletBalances(c: AppContext) {
   const { wallet } = await resolveWalletFromParams(c, ["wallets:read"]);
@@ -72,12 +102,24 @@ export async function getWalletPolicy(c: AppContext) {
 
   const rows = await repository.getWalletPoliciesByCustodyWalletId(wallet.id);
   const payload = buildWalletPolicyPayload(wallet.walletId, rows, wallet.createdAt);
+  const controlProfile = await getWalletControlProfileSummary(c, wallet.id);
 
-  return success(c, { policy: payload });
+  return success(c, {
+    policy: {
+      ...payload,
+      ...(controlProfile
+        ? {
+            defaultAction: controlProfile.defaultAction,
+            rules: controlProfile.rules,
+            controlProfile,
+          }
+        : {}),
+    },
+  });
 }
 
 export async function updateWalletPolicy(c: AppContext) {
-  const { wallet } = await resolveWalletFromParams(c, ["wallets:write"]);
+  const { auth, wallet } = await resolveWalletFromParams(c, ["wallets:write"]);
   const repository = getPaymentsRepository(c);
 
   const body = await c.req.json();
@@ -120,7 +162,65 @@ export async function updateWalletPolicy(c: AppContext) {
     throw new AppError("INTERNAL_ERROR", "Failed to persist wallet policy");
   }
 
+  let controlProfile: PaymentWalletControlProfileSummary | null = null;
+  if (parsed.data.rules || parsed.data.defaultAction) {
+    const policyRepository = getPolicyRepository(c);
+    const currentActive = await policyRepository.getActiveWalletControlProfileByCustodyWalletId(
+      wallet.id
+    );
+    const profile =
+      currentActive?.profile ??
+      (await policyRepository.createWalletControlProfile({
+        organizationId: auth.organizationId,
+        projectId: auth.projectId,
+        custodyWalletId: wallet.id,
+        name: `${wallet.label ?? wallet.walletId} controls`,
+        status: "draft",
+        createdBy: auth.userId ?? auth.apiKeyId ?? null,
+      }));
+
+    if (!profile) {
+      throw new AppError("INTERNAL_ERROR", "Failed to create wallet control profile");
+    }
+
+    const revision = await policyRepository.createWalletControlProfileRevision({
+      profileId: profile.id,
+      rules: parsed.data.rules ?? [],
+      defaultAction: parsed.data.defaultAction ?? "allow",
+      createdBy: auth.userId ?? auth.apiKeyId ?? null,
+    });
+
+    if (!revision) {
+      throw new AppError("INTERNAL_ERROR", "Failed to create wallet control profile revision");
+    }
+
+    const activated = await policyRepository.activateWalletControlProfileRevision({
+      profileId: profile.id,
+      revisionId: revision.id,
+      activatedAt: now,
+    });
+
+    if (!activated) {
+      throw new AppError("INTERNAL_ERROR", "Failed to activate wallet control profile revision");
+    }
+
+    controlProfile = mapWalletControlProfileSummary(activated);
+  } else {
+    controlProfile = await getWalletControlProfileSummary(c, wallet.id);
+  }
+
   const payload = buildWalletPolicyPayload(wallet.walletId, rows, now);
 
-  return success(c, { policy: payload });
+  return success(c, {
+    policy: {
+      ...payload,
+      ...(controlProfile
+        ? {
+            defaultAction: controlProfile.defaultAction,
+            rules: controlProfile.rules,
+            controlProfile,
+          }
+        : {}),
+    },
+  });
 }

--- a/apps/sdp-api/src/routes/payments/handlers/balances.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/balances.ts
@@ -1,7 +1,19 @@
-import type { PaymentWalletControlProfileSummary, PolicyRule } from "@sdp/types";
+import type {
+  PaymentWalletControlProfileSummary,
+  PolicyDefaultAction,
+  PolicyRule,
+} from "@sdp/types";
 import type { Address } from "@solana/kit";
 import { z } from "zod";
-import type { ActiveWalletControlProfileResult } from "@/db/repositories";
+import { type DatabaseExecutor, getDb } from "@/db";
+import {
+  type ActiveWalletControlProfileResult,
+  createPostgresPaymentsRepository,
+} from "@/db/repositories";
+import {
+  generateWalletControlProfileId,
+  generateWalletControlProfileRevisionId,
+} from "@/db/repositories/policy.repository";
 import { formatDecimalAmount } from "@/lib/amount";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
@@ -44,6 +56,120 @@ async function getWalletControlProfileSummary(
     await getPolicyRepository(c).getActiveWalletControlProfileByCustodyWalletId(custodyWalletId);
 
   return active ? mapWalletControlProfileSummary(active) : null;
+}
+
+async function activateWalletControlProfileRevisionInTransaction({
+  db,
+  organizationId,
+  projectId,
+  custodyWalletId,
+  profileName,
+  rules,
+  defaultAction,
+  createdBy,
+  activatedAt,
+}: {
+  db: DatabaseExecutor;
+  organizationId: string;
+  projectId: string | null;
+  custodyWalletId: string;
+  profileName: string;
+  rules: PolicyRule[];
+  defaultAction: PolicyDefaultAction;
+  createdBy: string | null;
+  activatedAt: string;
+}): Promise<void> {
+  const existingProfile = await db
+    .prepare(
+      `SELECT id
+       FROM wallet_control_profiles
+       WHERE custody_wallet_id = ?
+         AND status = 'active'
+       ORDER BY activated_at DESC NULLS LAST, created_at DESC
+       LIMIT 1
+       FOR UPDATE`
+    )
+    .bind(custodyWalletId)
+    .first<{ id: string }>();
+
+  const profileId = existingProfile?.id ?? generateWalletControlProfileId();
+
+  if (!existingProfile) {
+    await db
+      .prepare(
+        `INSERT INTO wallet_control_profiles (
+           id,
+           organization_id,
+           project_id,
+           custody_wallet_id,
+           name,
+           status,
+           created_by
+         ) VALUES (?, ?, ?, ?, ?, 'draft', ?)`
+      )
+      .bind(profileId, organizationId, projectId, custodyWalletId, profileName, createdBy)
+      .run();
+  }
+
+  const revisionId = generateWalletControlProfileRevisionId();
+  const revision = await db
+    .prepare(
+      `INSERT INTO wallet_control_profile_revisions (
+         id,
+         profile_id,
+         revision_number,
+         rules,
+         default_action,
+         created_by
+       )
+       SELECT
+         ?,
+         ?,
+         COALESCE(MAX(revision_number), 0) + 1,
+         ?::jsonb,
+         ?,
+         ?
+       FROM wallet_control_profile_revisions
+       WHERE profile_id = ?
+       RETURNING id`
+    )
+    .bind(revisionId, profileId, JSON.stringify(rules), defaultAction, createdBy, profileId)
+    .first<{ id: string }>();
+
+  if (!revision) {
+    throw new AppError("INTERNAL_ERROR", "Failed to create wallet control profile revision");
+  }
+
+  const activatedRevision = await db
+    .prepare(
+      `UPDATE wallet_control_profile_revisions
+       SET activated_at = COALESCE(activated_at, ?)
+       WHERE id = ? AND profile_id = ?
+       RETURNING id`
+    )
+    .bind(activatedAt, revisionId, profileId)
+    .first<{ id: string }>();
+
+  if (!activatedRevision) {
+    throw new AppError("INTERNAL_ERROR", "Failed to activate wallet control profile revision");
+  }
+
+  const activatedProfile = await db
+    .prepare(
+      `UPDATE wallet_control_profiles
+       SET status = 'active',
+           active_revision_id = ?,
+           activated_at = COALESCE(activated_at, ?),
+           updated_at = ?
+       WHERE id = ?
+       RETURNING id`
+    )
+    .bind(revisionId, activatedAt, activatedAt, profileId)
+    .first<{ id: string }>();
+
+  if (!activatedProfile) {
+    throw new AppError("INTERNAL_ERROR", "Failed to activate wallet control profile revision");
+  }
 }
 
 export async function getWalletBalances(c: AppContext) {
@@ -132,7 +258,7 @@ export async function updateWalletPolicy(c: AppContext) {
   }
 
   const now = new Date().toISOString();
-  const rows = await repository.upsertWalletPolicies([
+  const walletPolicyInputs = [
     {
       id: `pwp_${crypto.randomUUID()}`,
       custodyWalletId: wallet.id,
@@ -156,56 +282,42 @@ export async function updateWalletPolicy(c: AppContext) {
       createdAt: now,
       updatedAt: now,
     },
-  ]);
-
-  if (rows.length === 0) {
-    throw new AppError("INTERNAL_ERROR", "Failed to persist wallet policy");
-  }
+  ];
 
   let controlProfile: PaymentWalletControlProfileSummary | null = null;
+  let rows: Awaited<ReturnType<typeof repository.upsertWalletPolicies>>;
   if (parsed.data.rules || parsed.data.defaultAction) {
-    const policyRepository = getPolicyRepository(c);
-    const currentActive = await policyRepository.getActiveWalletControlProfileByCustodyWalletId(
-      wallet.id
-    );
-    const profile =
-      currentActive?.profile ??
-      (await policyRepository.createWalletControlProfile({
+    rows = await getDb(c.env).transaction(async (tx) => {
+      const txRepository = createPostgresPaymentsRepository(tx);
+      const savedRows = await txRepository.upsertWalletPolicies(walletPolicyInputs);
+
+      if (savedRows.length === 0) {
+        throw new AppError("INTERNAL_ERROR", "Failed to persist wallet policy");
+      }
+
+      await activateWalletControlProfileRevisionInTransaction({
+        db: tx,
         organizationId: auth.organizationId,
-        projectId: auth.projectId,
+        projectId: auth.projectId ?? null,
         custodyWalletId: wallet.id,
-        name: `${wallet.label ?? wallet.walletId} controls`,
-        status: "draft",
+        profileName: `${wallet.label ?? wallet.walletId} controls`,
+        rules: parsed.data.rules ?? [],
+        defaultAction: parsed.data.defaultAction ?? "allow",
         createdBy: auth.userId ?? auth.apiKeyId ?? null,
-      }));
+        activatedAt: now,
+      });
 
-    if (!profile) {
-      throw new AppError("INTERNAL_ERROR", "Failed to create wallet control profile");
-    }
-
-    const revision = await policyRepository.createWalletControlProfileRevision({
-      profileId: profile.id,
-      rules: parsed.data.rules ?? [],
-      defaultAction: parsed.data.defaultAction ?? "allow",
-      createdBy: auth.userId ?? auth.apiKeyId ?? null,
+      return savedRows;
     });
 
-    if (!revision) {
-      throw new AppError("INTERNAL_ERROR", "Failed to create wallet control profile revision");
-    }
-
-    const activated = await policyRepository.activateWalletControlProfileRevision({
-      profileId: profile.id,
-      revisionId: revision.id,
-      activatedAt: now,
-    });
-
-    if (!activated) {
-      throw new AppError("INTERNAL_ERROR", "Failed to activate wallet control profile revision");
-    }
-
-    controlProfile = mapWalletControlProfileSummary(activated);
+    controlProfile = await getWalletControlProfileSummary(c, wallet.id);
   } else {
+    rows = await repository.upsertWalletPolicies(walletPolicyInputs);
+
+    if (rows.length === 0) {
+      throw new AppError("INTERNAL_ERROR", "Failed to persist wallet policy");
+    }
+
     controlProfile = await getWalletControlProfileSummary(c, wallet.id);
   }
 

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -67,6 +67,115 @@ export const updateWalletPolicySchema = z.object({
     .string()
     .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
     .optional(),
+  defaultAction: z.enum(["allow", "deny", "approval_required", "review"]).optional(),
+  rules: z
+    .array(
+      z.discriminatedUnion("kind", [
+        z.object({
+          id: z.string().min(1).max(120).optional(),
+          name: z.string().min(1).max(120).optional(),
+          description: z.string().max(500).optional(),
+          action: z
+            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+            .optional(),
+          kind: z.literal("operation_family"),
+          family: z
+            .enum([
+              "transfer",
+              "payment",
+              "ramp",
+              "issuance",
+              "raw_sign",
+              "program",
+              "provider_admin",
+            ])
+            .optional(),
+          families: z
+            .array(
+              z.enum([
+                "transfer",
+                "payment",
+                "ramp",
+                "issuance",
+                "raw_sign",
+                "program",
+                "provider_admin",
+              ])
+            )
+            .max(20)
+            .optional(),
+        }),
+        z.object({
+          id: z.string().min(1).max(120).optional(),
+          name: z.string().min(1).max(120).optional(),
+          description: z.string().max(500).optional(),
+          action: z
+            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+            .optional(),
+          kind: z.literal("destination"),
+          allowlist: z.array(solanaAddressSchema("allowlist entry")).max(500).optional(),
+          blocklist: z.array(solanaAddressSchema("blocklist entry")).max(500).optional(),
+          destination: solanaAddressSchema("destination").optional(),
+          destinations: z.array(solanaAddressSchema("destinations entry")).max(500).optional(),
+        }),
+        z.object({
+          id: z.string().min(1).max(120).optional(),
+          name: z.string().min(1).max(120).optional(),
+          description: z.string().max(500).optional(),
+          action: z
+            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+            .optional(),
+          kind: z.literal("amount"),
+          min: z
+            .string()
+            .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
+            .optional(),
+          max: z
+            .string()
+            .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
+            .optional(),
+          asset: z.string().min(1).max(120).optional(),
+          assets: z.array(z.string().min(1).max(120)).max(100).optional(),
+        }),
+        z.object({
+          id: z.string().min(1).max(120).optional(),
+          name: z.string().min(1).max(120).optional(),
+          description: z.string().max(500).optional(),
+          action: z
+            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+            .optional(),
+          kind: z.literal("approval"),
+          families: z
+            .array(
+              z.enum([
+                "transfer",
+                "payment",
+                "ramp",
+                "issuance",
+                "raw_sign",
+                "program",
+                "provider_admin",
+              ])
+            )
+            .max(20)
+            .optional(),
+          operationTypes: z.array(z.string().min(1).max(120)).max(100).optional(),
+          assets: z.array(z.string().min(1).max(120)).max(100).optional(),
+          approvalGroupId: z.string().min(1).max(120).optional(),
+        }),
+        z.object({
+          id: z.string().min(1).max(120).optional(),
+          name: z.string().min(1).max(120).optional(),
+          description: z.string().max(500).optional(),
+          action: z
+            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+            .optional(),
+          kind: z.literal("always"),
+        }),
+      ])
+    )
+    .max(100)
+    .optional(),
 });
 
 export const paymentAmountSchema = z

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1183,7 +1183,7 @@
             "description": "Updates payment policy rules for a custody wallet. Wallet provisioning and default selection remain in /v1/wallets.",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"destinationAllowlist\": [\n    \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\"\n  ],\n  \"maxTransferAmount\": \"100.00\",\n  \"maxDailyAmount\": \"1000.00\"\n}",
+              "raw": "{\n  \"destinationAllowlist\": [\n    \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\"\n  ],\n  \"maxTransferAmount\": \"100.00\",\n  \"maxDailyAmount\": \"1000.00\",\n  \"defaultAction\": \"allow\",\n  \"rules\": [\n    {\n      \"id\": \"deny-raw-signing\",\n      \"kind\": \"operation_family\",\n      \"family\": \"raw_sign\",\n      \"action\": \"deny\"\n    }\n  ]\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
@@ -161,14 +161,15 @@ function categoriesFromPolicy(policy: PaymentWalletPolicy): RestrictionCategoryI
 }
 
 function blockedOperationFamiliesFromRules(rules: PolicyRule[]): WalletOperationFamily[] {
-  return rules
-    .filter(
-      (rule): rule is Extract<PolicyRule, { kind: "operation_family" }> =>
-        rule.kind === "operation_family" &&
-        rule.action === "deny" &&
-        !advancedDeniedFamiliesFromOperationRule(rule).length
-    )
-    .flatMap((rule) => rule.families ?? (rule.family ? [rule.family] : []));
+  return uniqueValues(
+    rules
+      .filter(
+        (rule): rule is Extract<PolicyRule, { kind: "operation_family" }> =>
+          rule.kind === "operation_family" && rule.action === "deny"
+      )
+      .flatMap((rule) => rule.families ?? (rule.family ? [rule.family] : []))
+      .filter((family) => family !== "raw_sign" && family !== "program")
+  ) as WalletOperationFamily[];
 }
 
 function advancedDeniedFamiliesFromRules(rules: PolicyRule[]): AdvancedFamily[] {

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { PaymentWalletPolicy } from "@sdp/types";
+import type {
+  PaymentWalletPolicy,
+  PolicyDefaultAction,
+  PolicyRule,
+  WalletOperationFamily,
+} from "@sdp/types";
 import { ArrowLeft, ArrowRight, Check, ChevronDown } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
@@ -11,7 +16,8 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 type FlowStep = "intent" | "details" | "review";
-type RestrictionCategoryId = "destinations" | "limits";
+type RestrictionCategoryId = "operations" | "destinations" | "limits" | "approvals" | "advanced";
+type AdvancedFamily = Extract<WalletOperationFamily, "raw_sign" | "program">;
 
 interface WalletPolicyStartingProfileFlowProps {
   wallet: {
@@ -34,9 +40,12 @@ interface StoredPolicyDraft {
   status: "draft" | "disabled";
   step: FlowStep;
   categories: RestrictionCategoryId[];
+  blockedOperationFamilies: WalletOperationFamily[];
   destinationAllowlist: string[];
   maxTransferAmount: string;
   maxDailyAmount: string;
+  approvalFamilies: WalletOperationFamily[];
+  advancedDeniedFamilies: AdvancedFamily[];
   updatedAt: string;
 }
 
@@ -68,6 +77,11 @@ const FLOW_STEPS = [
 
 const RESTRICTION_CATEGORIES = [
   {
+    id: "operations",
+    title: "Operation access",
+    description: "Block high-risk operation families while keeping normal usage available.",
+  },
+  {
     id: "destinations",
     title: "Allowed destinations",
     description: "Use when this wallet should only pay known addresses.",
@@ -77,9 +91,38 @@ const RESTRICTION_CATEGORIES = [
     title: "Transfer limits",
     description: "Use when this wallet needs spend caps or daily outflow limits.",
   },
+  {
+    id: "approvals",
+    title: "Approval checks",
+    description: "Pause selected operation families for approval before execution.",
+  },
+  {
+    id: "advanced",
+    title: "Advanced signing",
+    description: "Restrict raw signing and direct program interaction paths.",
+  },
 ] as const satisfies readonly RestrictionCategory[];
 
 const RESTRICTION_CATEGORY_IDS = RESTRICTION_CATEGORIES.map((category) => category.id);
+const DEFAULT_POLICY_ACTION = "allow" satisfies PolicyDefaultAction;
+const OPERATION_FAMILY_OPTIONS = [
+  { id: "payment", label: "Payments" },
+  { id: "transfer", label: "Transfers" },
+  { id: "ramp", label: "Ramps" },
+  { id: "issuance", label: "Issuance" },
+  { id: "provider_admin", label: "Provider admin" },
+] as const satisfies readonly { id: WalletOperationFamily; label: string }[];
+const APPROVAL_FAMILY_OPTIONS = [
+  { id: "payment", label: "Payments" },
+  { id: "ramp", label: "Ramps" },
+  { id: "issuance", label: "Issuance" },
+  { id: "raw_sign", label: "Raw signing" },
+  { id: "program", label: "Program interactions" },
+] as const satisfies readonly { id: WalletOperationFamily; label: string }[];
+const ADVANCED_FAMILY_OPTIONS = [
+  { id: "raw_sign", label: "Raw signing" },
+  { id: "program", label: "Program interactions" },
+] as const satisfies readonly { id: AdvancedFamily; label: string }[];
 
 const SOLANA_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 const CSV_HEADER_VALUES = new Set([
@@ -99,15 +142,60 @@ function policyHasRestrictions(policy: PaymentWalletPolicy): boolean {
   return (
     policy.destinationAllowlist.length > 0 ||
     Boolean(policy.maxTransferAmount) ||
-    Boolean(policy.maxDailyAmount)
+    Boolean(policy.maxDailyAmount) ||
+    Boolean(policy.rules?.length)
   );
 }
 
 function categoriesFromPolicy(policy: PaymentWalletPolicy): RestrictionCategoryId[] {
   const categories: RestrictionCategoryId[] = [];
+  const blockedFamilies = blockedOperationFamiliesFromRules(policy.rules ?? []);
+  const approvalFamilies = approvalFamiliesFromRules(policy.rules ?? []);
+  const advancedFamilies = advancedDeniedFamiliesFromRules(policy.rules ?? []);
+  if (blockedFamilies.length > 0) categories.push("operations");
   if (policy.destinationAllowlist.length > 0) categories.push("destinations");
   if (policy.maxTransferAmount || policy.maxDailyAmount) categories.push("limits");
+  if (approvalFamilies.length > 0) categories.push("approvals");
+  if (advancedFamilies.length > 0) categories.push("advanced");
   return categories;
+}
+
+function blockedOperationFamiliesFromRules(rules: PolicyRule[]): WalletOperationFamily[] {
+  return rules
+    .filter(
+      (rule): rule is Extract<PolicyRule, { kind: "operation_family" }> =>
+        rule.kind === "operation_family" &&
+        rule.action === "deny" &&
+        !advancedDeniedFamiliesFromOperationRule(rule).length
+    )
+    .flatMap((rule) => rule.families ?? (rule.family ? [rule.family] : []));
+}
+
+function advancedDeniedFamiliesFromRules(rules: PolicyRule[]): AdvancedFamily[] {
+  return uniqueValues(
+    rules
+      .filter(
+        (rule): rule is Extract<PolicyRule, { kind: "operation_family" }> =>
+          rule.kind === "operation_family" && rule.action === "deny"
+      )
+      .flatMap(advancedDeniedFamiliesFromOperationRule)
+  ) as AdvancedFamily[];
+}
+
+function advancedDeniedFamiliesFromOperationRule(
+  rule: Extract<PolicyRule, { kind: "operation_family" }>
+): AdvancedFamily[] {
+  return (rule.families ?? (rule.family ? [rule.family] : [])).filter(
+    (family): family is AdvancedFamily => family === "raw_sign" || family === "program"
+  );
+}
+
+function approvalFamiliesFromRules(rules: PolicyRule[]): WalletOperationFamily[] {
+  return uniqueValues(
+    rules
+      .filter((rule): rule is Extract<PolicyRule, { kind: "approval" }> => rule.kind === "approval")
+      .flatMap((rule) => rule.families ?? [])
+  ) as WalletOperationFamily[];
 }
 
 function uniqueValues(values: string[]): string[] {
@@ -207,9 +295,12 @@ function isStoredDraft(value: unknown): value is StoredPolicyDraft {
     (draft.status === "draft" || draft.status === "disabled") &&
     typeof draft.step === "string" &&
     Array.isArray(draft.categories) &&
+    Array.isArray(draft.blockedOperationFamilies) &&
     Array.isArray(draft.destinationAllowlist) &&
     typeof draft.maxTransferAmount === "string" &&
     typeof draft.maxDailyAmount === "string" &&
+    Array.isArray(draft.approvalFamilies) &&
+    Array.isArray(draft.advancedDeniedFamilies) &&
     typeof draft.updatedAt === "string"
   );
 }
@@ -231,6 +322,18 @@ function readStoredDraft(walletId: string): StoredPolicyDraft | null {
     return {
       ...parsed,
       categories: draftCategories,
+      blockedOperationFamilies: filterKnownValues(
+        parsed.blockedOperationFamilies,
+        OPERATION_FAMILY_OPTIONS.map((option) => option.id)
+      ),
+      approvalFamilies: filterKnownValues(
+        parsed.approvalFamilies,
+        APPROVAL_FAMILY_OPTIONS.map((option) => option.id)
+      ),
+      advancedDeniedFamilies: filterKnownValues(
+        parsed.advancedDeniedFamilies,
+        ADVANCED_FAMILY_OPTIONS.map((option) => option.id)
+      ),
     };
   } catch {
     return null;
@@ -245,6 +348,17 @@ function formatCount(count: number, singular: string, plural = `${singular}s`): 
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
+function formatFamilyLabel(family: WalletOperationFamily): string {
+  const match = [...OPERATION_FAMILY_OPTIONS, ...APPROVAL_FAMILY_OPTIONS].find(
+    (option) => option.id === family
+  );
+  return match?.label ?? family.replaceAll("_", " ");
+}
+
+function formatFamilyList(families: readonly WalletOperationFamily[]): string {
+  return families.map(formatFamilyLabel).join(", ");
+}
+
 function getWalletDetailHref(pathname: string, walletId: string): string {
   const section = pathname.startsWith("/dashboard/custody/") ? "custody" : "wallets";
   return `/dashboard/${section}/${encodeURIComponent(walletId)}`;
@@ -253,46 +367,141 @@ function getWalletDetailHref(pathname: string, walletId: string): string {
 function getPolicyFlowValidationState({
   selectedCategories,
   selectedCategorySet,
+  blockedOperationFamilies,
   destinationParse,
   maxTransferAmount,
   maxDailyAmount,
+  approvalFamilies,
+  advancedDeniedFamilies,
   isSubmitting,
   policyError,
 }: {
   selectedCategories: RestrictionCategoryId[];
   selectedCategorySet: ReadonlySet<RestrictionCategoryId>;
+  blockedOperationFamilies: WalletOperationFamily[];
   destinationParse: ReturnType<typeof parseDestinationText>;
   maxTransferAmount: string;
   maxDailyAmount: string;
+  approvalFamilies: WalletOperationFamily[];
+  advancedDeniedFamilies: AdvancedFamily[];
   isSubmitting: boolean;
   policyError: string | null;
 }) {
+  const hasOperationRule = selectedCategorySet.has("operations");
   const hasDestinationRule = selectedCategorySet.has("destinations");
   const hasLimitRule = selectedCategorySet.has("limits");
+  const hasApprovalRule = selectedCategorySet.has("approvals");
+  const hasAdvancedRule = selectedCategorySet.has("advanced");
   const hasLimitAmount = Boolean(maxTransferAmount.trim() || maxDailyAmount.trim());
+  const canActivateOperations = !hasOperationRule || blockedOperationFamilies.length > 0;
   const canActivateDestinations =
     !hasDestinationRule ||
     (destinationParse.addresses.length > 0 && destinationParse.invalid.length === 0);
   const canActivateLimits =
     !hasLimitRule ||
     (hasLimitAmount && isPositiveAmount(maxTransferAmount) && isPositiveAmount(maxDailyAmount));
+  const canActivateApprovals = !hasApprovalRule || approvalFamilies.length > 0;
+  const canActivateAdvanced = !hasAdvancedRule || advancedDeniedFamilies.length > 0;
   const hasActivatableRestriction =
+    (hasOperationRule && blockedOperationFamilies.length > 0) ||
     (hasDestinationRule && destinationParse.addresses.length > 0) ||
-    (hasLimitRule && hasLimitAmount);
+    (hasLimitRule && hasLimitAmount) ||
+    (hasApprovalRule && approvalFamilies.length > 0) ||
+    (hasAdvancedRule && advancedDeniedFamilies.length > 0);
   const canSubmit =
     selectedCategories.length > 0 &&
     hasActivatableRestriction &&
+    canActivateOperations &&
     canActivateDestinations &&
     canActivateLimits &&
+    canActivateApprovals &&
+    canActivateAdvanced &&
     !isSubmitting &&
     !policyError;
 
   return {
+    canActivateOperations,
     canActivateDestinations,
     canActivateLimits,
+    canActivateApprovals,
+    canActivateAdvanced,
     canActivate: canSubmit,
     canSubmitReview: canSubmit,
   };
+}
+
+function buildPolicyRules({
+  selectedCategorySet,
+  blockedOperationFamilies,
+  destinationAllowlist,
+  maxTransferAmount,
+  approvalFamilies,
+  advancedDeniedFamilies,
+}: {
+  selectedCategorySet: ReadonlySet<RestrictionCategoryId>;
+  blockedOperationFamilies: WalletOperationFamily[];
+  destinationAllowlist: string[];
+  maxTransferAmount: string;
+  approvalFamilies: WalletOperationFamily[];
+  advancedDeniedFamilies: AdvancedFamily[];
+}): PolicyRule[] {
+  const rules: PolicyRule[] = [];
+
+  if (selectedCategorySet.has("operations")) {
+    for (const family of blockedOperationFamilies) {
+      rules.push({
+        id: `deny-${family}`,
+        kind: "operation_family",
+        family,
+        action: "deny",
+        name: `Block ${formatFamilyLabel(family)}`,
+      });
+    }
+  }
+
+  if (selectedCategorySet.has("destinations") && destinationAllowlist.length > 0) {
+    rules.push({
+      id: "allowed-destinations",
+      kind: "destination",
+      allowlist: destinationAllowlist,
+      action: "allow",
+      name: "Allowed destinations",
+    });
+  }
+
+  if (selectedCategorySet.has("limits") && maxTransferAmount) {
+    rules.push({
+      id: "per-transfer-limit",
+      kind: "amount",
+      max: maxTransferAmount,
+      action: "allow",
+      name: "Per transfer limit",
+    });
+  }
+
+  if (selectedCategorySet.has("approvals") && approvalFamilies.length > 0) {
+    rules.push({
+      id: "approval-required",
+      kind: "approval",
+      families: approvalFamilies,
+      action: "approval_required",
+      name: "Approval checks",
+    });
+  }
+
+  if (selectedCategorySet.has("advanced")) {
+    for (const family of advancedDeniedFamilies) {
+      rules.push({
+        id: `deny-${family}`,
+        kind: "operation_family",
+        family,
+        action: "deny",
+        name: `Block ${formatFamilyLabel(family)}`,
+      });
+    }
+  }
+
+  return rules;
 }
 
 export function WalletPolicyStartingProfileFlow({
@@ -310,11 +519,20 @@ export function WalletPolicyStartingProfileFlow({
   const [expandedRuleIds, setExpandedRuleIds] = useState<RestrictionCategoryId[]>(
     categoriesFromPolicy(initialPolicy)
   );
+  const [blockedOperationFamilies, setBlockedOperationFamilies] = useState<WalletOperationFamily[]>(
+    blockedOperationFamiliesFromRules(initialPolicy.rules ?? [])
+  );
   const [destinationText, setDestinationText] = useState(
     initialPolicy.destinationAllowlist.join("\n")
   );
   const [maxTransferAmount, setMaxTransferAmount] = useState(initialPolicy.maxTransferAmount ?? "");
   const [maxDailyAmount, setMaxDailyAmount] = useState(initialPolicy.maxDailyAmount ?? "");
+  const [approvalFamilies, setApprovalFamilies] = useState<WalletOperationFamily[]>(
+    approvalFamiliesFromRules(initialPolicy.rules ?? [])
+  );
+  const [advancedDeniedFamilies, setAdvancedDeniedFamilies] = useState<AdvancedFamily[]>(
+    advancedDeniedFamiliesFromRules(initialPolicy.rules ?? [])
+  );
   const [savedDraft, setSavedDraft] = useState<StoredPolicyDraft | null>(null);
   const [localStatus, setLocalStatus] = useState<"draft" | "disabled" | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -327,9 +545,12 @@ export function WalletPolicyStartingProfileFlow({
       setLocalStatus(draft.status);
       setSelectedCategories(draft.categories);
       setExpandedRuleIds(draft.categories);
+      setBlockedOperationFamilies(draft.blockedOperationFamilies);
       setDestinationText(draft.destinationAllowlist.join("\n"));
       setMaxTransferAmount(draft.maxTransferAmount);
       setMaxDailyAmount(draft.maxDailyAmount);
+      setApprovalFamilies(draft.approvalFamilies);
+      setAdvancedDeniedFamilies(draft.advancedDeniedFamilies);
       const draftStepIndex = FLOW_STEPS.findIndex((step) => step.id === draft.step);
       setStepIndex(Math.max(0, draftStepIndex));
     }
@@ -342,16 +563,26 @@ export function WalletPolicyStartingProfileFlow({
   const destinationParse = useMemo(() => parseDestinationText(destinationText), [destinationText]);
   const hasLivePolicy = policyHasRestrictions(currentPolicy);
   const walletDetailHref = getWalletDetailHref(pathname, wallet.walletId);
-  const { canActivateDestinations, canActivateLimits, canActivate, canSubmitReview } =
-    getPolicyFlowValidationState({
-      selectedCategories,
-      selectedCategorySet,
-      destinationParse,
-      maxTransferAmount,
-      maxDailyAmount,
-      isSubmitting,
-      policyError,
-    });
+  const {
+    canActivateOperations,
+    canActivateDestinations,
+    canActivateLimits,
+    canActivateApprovals,
+    canActivateAdvanced,
+    canActivate,
+    canSubmitReview,
+  } = getPolicyFlowValidationState({
+    selectedCategories,
+    selectedCategorySet,
+    blockedOperationFamilies,
+    destinationParse,
+    maxTransferAmount,
+    maxDailyAmount,
+    approvalFamilies,
+    advancedDeniedFamilies,
+    isSubmitting,
+    policyError,
+  });
 
   function persistDraft(options: { notify: boolean } = { notify: false }) {
     if (typeof window === "undefined") return;
@@ -360,9 +591,12 @@ export function WalletPolicyStartingProfileFlow({
       status: "draft",
       step: currentStep.id,
       categories: selectedCategories,
+      blockedOperationFamilies,
       destinationAllowlist: destinationParse.addresses,
       maxTransferAmount: maxTransferAmount.trim(),
       maxDailyAmount: maxDailyAmount.trim(),
+      approvalFamilies,
+      advancedDeniedFamilies,
       updatedAt: new Date().toISOString(),
     };
 
@@ -428,9 +662,30 @@ export function WalletPolicyStartingProfileFlow({
         });
         return;
       }
+      if (!canActivateOperations) {
+        toast.error("Choose operation access controls.", {
+          description: "Select at least one operation family to block.",
+          position: "bottom-right",
+        });
+        return;
+      }
       if (!canActivateLimits) {
         toast.error("Check transfer limits.", {
           description: "Enter a positive number for each configured limit.",
+          position: "bottom-right",
+        });
+        return;
+      }
+      if (!canActivateApprovals) {
+        toast.error("Choose approval checks.", {
+          description: "Select at least one operation family that should require approval.",
+          position: "bottom-right",
+        });
+        return;
+      }
+      if (!canActivateAdvanced) {
+        toast.error("Choose advanced signing controls.", {
+          description: "Select raw signing, program interactions, or both.",
           position: "bottom-right",
         });
         return;
@@ -472,6 +727,15 @@ export function WalletPolicyStartingProfileFlow({
         ...(selectedCategorySet.has("limits") && maxDailyAmount.trim()
           ? { maxDailyAmount: maxDailyAmount.trim() }
           : {}),
+        defaultAction: DEFAULT_POLICY_ACTION,
+        rules: buildPolicyRules({
+          selectedCategorySet,
+          blockedOperationFamilies,
+          destinationAllowlist: destinationParse.addresses,
+          maxTransferAmount: maxTransferAmount.trim(),
+          approvalFamilies,
+          advancedDeniedFamilies,
+        }),
       });
 
       setCurrentPolicy(updated);
@@ -506,23 +770,31 @@ export function WalletPolicyStartingProfileFlow({
       const updated = await updateWalletPolicy(wallet.walletId, {
         walletId: wallet.walletId,
         destinationAllowlist: [],
+        defaultAction: DEFAULT_POLICY_ACTION,
+        rules: [],
       });
 
       const disabledDraft: StoredPolicyDraft = {
         status: "disabled",
         step: "intent",
         categories: [],
+        blockedOperationFamilies: [],
         destinationAllowlist: [],
         maxTransferAmount: "",
         maxDailyAmount: "",
+        approvalFamilies: [],
+        advancedDeniedFamilies: [],
         updatedAt: new Date().toISOString(),
       };
 
       setCurrentPolicy(updated);
       setSelectedCategories([]);
+      setBlockedOperationFamilies([]);
       setDestinationText("");
       setMaxTransferAmount("");
       setMaxDailyAmount("");
+      setApprovalFamilies([]);
+      setAdvancedDeniedFamilies([]);
       setExpandedRuleIds([]);
       setSavedDraft(disabledDraft);
       setLocalStatus("disabled");
@@ -590,15 +862,25 @@ export function WalletPolicyStartingProfileFlow({
             setMaxTransferAmount={setMaxTransferAmount}
             maxDailyAmount={maxDailyAmount}
             setMaxDailyAmount={setMaxDailyAmount}
+            blockedOperationFamilies={blockedOperationFamilies}
+            setBlockedOperationFamilies={setBlockedOperationFamilies}
+            approvalFamilies={approvalFamilies}
+            setApprovalFamilies={setApprovalFamilies}
+            advancedDeniedFamilies={advancedDeniedFamilies}
+            setAdvancedDeniedFamilies={setAdvancedDeniedFamilies}
           />
         ) : null}
         {isLoaded && currentStep.id === "review" ? (
           <ReviewStep
             selectedCategories={selectedCategories}
+            blockedOperationFamilies={blockedOperationFamilies}
             destinationCount={destinationParse.addresses.length}
             invalidDestinationCount={destinationParse.invalid.length}
             maxTransferAmount={maxTransferAmount.trim()}
             maxDailyAmount={maxDailyAmount.trim()}
+            approvalFamilies={approvalFamilies}
+            advancedDeniedFamilies={advancedDeniedFamilies}
+            controlProfile={currentPolicy.controlProfile ?? null}
           />
         ) : null}
       </div>
@@ -726,6 +1008,8 @@ function DetailsStep({
   selectedCategories,
   expandedRuleSet,
   onToggleExpandedRule,
+  blockedOperationFamilies,
+  setBlockedOperationFamilies,
   destinationText,
   setDestinationText,
   destinationCount,
@@ -734,10 +1018,16 @@ function DetailsStep({
   setMaxTransferAmount,
   maxDailyAmount,
   setMaxDailyAmount,
+  approvalFamilies,
+  setApprovalFamilies,
+  advancedDeniedFamilies,
+  setAdvancedDeniedFamilies,
 }: {
   selectedCategories: RestrictionCategoryId[];
   expandedRuleSet: Set<RestrictionCategoryId>;
   onToggleExpandedRule: (category: RestrictionCategoryId) => void;
+  blockedOperationFamilies: WalletOperationFamily[];
+  setBlockedOperationFamilies: (value: WalletOperationFamily[]) => void;
   destinationText: string;
   setDestinationText: (value: string) => void;
   destinationCount: number;
@@ -746,6 +1036,10 @@ function DetailsStep({
   setMaxTransferAmount: (value: string) => void;
   maxDailyAmount: string;
   setMaxDailyAmount: (value: string) => void;
+  approvalFamilies: WalletOperationFamily[];
+  setApprovalFamilies: (value: WalletOperationFamily[]) => void;
+  advancedDeniedFamilies: AdvancedFamily[];
+  setAdvancedDeniedFamilies: (value: AdvancedFamily[]) => void;
 }) {
   const selected = RESTRICTION_CATEGORIES.filter((category) =>
     selectedCategories.includes(category.id)
@@ -763,12 +1057,21 @@ function DetailsStep({
             expanded={expanded}
             summary={getRuleSummary({
               categoryId: category.id,
+              blockedOperationFamilies,
               destinationCount,
               maxTransferAmount,
               maxDailyAmount,
+              approvalFamilies,
+              advancedDeniedFamilies,
             })}
             onToggle={() => onToggleExpandedRule(category.id)}
           >
+            {category.id === "operations" ? (
+              <OperationRuleEditor
+                blockedOperationFamilies={blockedOperationFamilies}
+                setBlockedOperationFamilies={setBlockedOperationFamilies}
+              />
+            ) : null}
             {category.id === "destinations" ? (
               <DestinationRuleEditor
                 destinationText={destinationText}
@@ -782,6 +1085,18 @@ function DetailsStep({
                 setMaxTransferAmount={setMaxTransferAmount}
                 maxDailyAmount={maxDailyAmount}
                 setMaxDailyAmount={setMaxDailyAmount}
+              />
+            ) : null}
+            {category.id === "approvals" ? (
+              <ApprovalRuleEditor
+                approvalFamilies={approvalFamilies}
+                setApprovalFamilies={setApprovalFamilies}
+              />
+            ) : null}
+            {category.id === "advanced" ? (
+              <AdvancedRuleEditor
+                advancedDeniedFamilies={advancedDeniedFamilies}
+                setAdvancedDeniedFamilies={setAdvancedDeniedFamilies}
               />
             ) : null}
           </RuleSection>
@@ -828,6 +1143,63 @@ function RuleSection({
       </button>
       {expanded ? <div className="pb-4 pr-2">{children}</div> : null}
     </section>
+  );
+}
+
+function OptionGrid<TValue extends string>({
+  options,
+  values,
+  onChange,
+}: {
+  options: readonly { id: TValue; label: string }[];
+  values: TValue[];
+  onChange: (value: TValue[]) => void;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {options.map((option) => {
+        const selected = values.includes(option.id);
+
+        return (
+          <button
+            key={option.id}
+            type="button"
+            aria-pressed={selected}
+            onClick={() => onChange(toggleValue(values, option.id))}
+            className={cn(
+              "min-h-11 rounded-md border px-3 py-2 text-left text-sm font-medium transition-colors",
+              selected
+                ? "border-[rgba(28,28,29,0.72)] bg-[rgba(28,28,29,0.04)] text-text-extra-high"
+                : "border-border-light bg-white text-text-medium hover:bg-gray-100"
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function OperationRuleEditor({
+  blockedOperationFamilies,
+  setBlockedOperationFamilies,
+}: {
+  blockedOperationFamilies: WalletOperationFamily[];
+  setBlockedOperationFamilies: (value: WalletOperationFamily[]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm leading-6 text-text-medium">
+        Selected families are denied before signing or execution. Unselected families continue to
+        use default allow unless another rule applies.
+      </p>
+      <OptionGrid
+        options={OPERATION_FAMILY_OPTIONS}
+        values={blockedOperationFamilies}
+        onChange={setBlockedOperationFamilies}
+      />
+    </div>
   );
 }
 
@@ -907,17 +1279,72 @@ function LimitRuleEditor({
   );
 }
 
+function ApprovalRuleEditor({
+  approvalFamilies,
+  setApprovalFamilies,
+}: {
+  approvalFamilies: WalletOperationFamily[];
+  setApprovalFamilies: (value: WalletOperationFamily[]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm leading-6 text-text-medium">
+        Selected families pause with an approval-required policy decision. Approval inbox routing is
+        handled by the follow-up approval workflow.
+      </p>
+      <OptionGrid
+        options={APPROVAL_FAMILY_OPTIONS}
+        values={approvalFamilies}
+        onChange={setApprovalFamilies}
+      />
+    </div>
+  );
+}
+
+function AdvancedRuleEditor({
+  advancedDeniedFamilies,
+  setAdvancedDeniedFamilies,
+}: {
+  advancedDeniedFamilies: AdvancedFamily[];
+  setAdvancedDeniedFamilies: (value: AdvancedFamily[]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm leading-6 text-text-medium">
+        These controls are intentionally strict because they can bypass high-level payment intent.
+      </p>
+      <OptionGrid
+        options={ADVANCED_FAMILY_OPTIONS}
+        values={advancedDeniedFamilies}
+        onChange={setAdvancedDeniedFamilies}
+      />
+    </div>
+  );
+}
+
 function getRuleSummary({
   categoryId,
+  blockedOperationFamilies,
   destinationCount,
   maxTransferAmount,
   maxDailyAmount,
+  approvalFamilies,
+  advancedDeniedFamilies,
 }: {
   categoryId: RestrictionCategoryId;
+  blockedOperationFamilies: WalletOperationFamily[];
   destinationCount: number;
   maxTransferAmount: string;
   maxDailyAmount: string;
+  approvalFamilies: WalletOperationFamily[];
+  advancedDeniedFamilies: AdvancedFamily[];
 }) {
+  if (categoryId === "operations") {
+    return blockedOperationFamilies.length > 0
+      ? `Block ${formatFamilyList(blockedOperationFamilies)}`
+      : "Choose operation families to block.";
+  }
+
   if (categoryId === "destinations") {
     return destinationCount > 0
       ? formatCount(destinationCount, "address", "addresses")
@@ -932,21 +1359,41 @@ function getRuleSummary({
     return parts.length > 0 ? parts.join(" / ") : "Set a per-transfer cap, daily cap, or both.";
   }
 
+  if (categoryId === "approvals") {
+    return approvalFamilies.length > 0
+      ? `Require approval for ${formatFamilyList(approvalFamilies)}`
+      : "Choose operation families that should pause for approval.";
+  }
+
+  if (categoryId === "advanced") {
+    return advancedDeniedFamilies.length > 0
+      ? `Block ${formatFamilyList(advancedDeniedFamilies)}`
+      : "Block raw signing, program interactions, or both.";
+  }
+
   return "";
 }
 
 function ReviewStep({
   selectedCategories,
+  blockedOperationFamilies,
   destinationCount,
   invalidDestinationCount,
   maxTransferAmount,
   maxDailyAmount,
+  approvalFamilies,
+  advancedDeniedFamilies,
+  controlProfile,
 }: {
   selectedCategories: RestrictionCategoryId[];
+  blockedOperationFamilies: WalletOperationFamily[];
   destinationCount: number;
   invalidDestinationCount: number;
   maxTransferAmount: string;
   maxDailyAmount: string;
+  approvalFamilies: WalletOperationFamily[];
+  advancedDeniedFamilies: AdvancedFamily[];
+  controlProfile: PaymentWalletPolicy["controlProfile"] | null;
 }) {
   const selected = RESTRICTION_CATEGORIES.filter((category) =>
     selectedCategories.includes(category.id)
@@ -954,16 +1401,42 @@ function ReviewStep({
 
   return (
     <div className="space-y-4">
+      <div className="rounded-lg border border-border-light bg-white p-4">
+        <p className="text-sm font-semibold text-text-extra-high">Activation outcome</p>
+        <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-text-extra-low">Default</dt>
+            <dd className="mt-1 font-medium text-text-extra-high">Allow unmatched operations</dd>
+          </div>
+          <div>
+            <dt className="text-text-extra-low">Revision</dt>
+            <dd className="mt-1 font-medium text-text-extra-high">
+              {controlProfile?.revisionNumber ? `#${controlProfile.revisionNumber}` : "New"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-text-extra-low">Provider mapping</dt>
+            <dd className="mt-1 font-medium text-text-extra-high">
+              {controlProfile
+                ? formatProviderMappingStatus(controlProfile.providerMappingStatus)
+                : "SDP enforced"}
+            </dd>
+          </div>
+        </dl>
+      </div>
       <div className="overflow-hidden rounded-lg border border-border-light bg-white">
         {selected.length > 0 ? (
           selected.map((category) => (
             <ReviewCategory
               key={category.id}
               category={category}
+              blockedOperationFamilies={blockedOperationFamilies}
               destinationCount={destinationCount}
               invalidDestinationCount={invalidDestinationCount}
               maxTransferAmount={maxTransferAmount}
               maxDailyAmount={maxDailyAmount}
+              approvalFamilies={approvalFamilies}
+              advancedDeniedFamilies={advancedDeniedFamilies}
             />
           ))
         ) : (
@@ -976,18 +1449,30 @@ function ReviewStep({
 
 function ReviewCategory({
   category,
+  blockedOperationFamilies,
   destinationCount,
   invalidDestinationCount,
   maxTransferAmount,
   maxDailyAmount,
+  approvalFamilies,
+  advancedDeniedFamilies,
 }: {
   category: RestrictionCategory;
+  blockedOperationFamilies: WalletOperationFamily[];
   destinationCount: number;
   invalidDestinationCount: number;
   maxTransferAmount: string;
   maxDailyAmount: string;
+  approvalFamilies: WalletOperationFamily[];
+  advancedDeniedFamilies: AdvancedFamily[];
 }) {
   let value = "";
+  if (category.id === "operations") {
+    value =
+      blockedOperationFamilies.length > 0
+        ? `Deny ${formatFamilyList(blockedOperationFamilies)}`
+        : "No operation families blocked";
+  }
   if (category.id === "destinations") {
     value =
       invalidDestinationCount > 0
@@ -1003,6 +1488,18 @@ function ReviewCategory({
     ].filter(Boolean);
     value = parts.length > 0 ? parts.join(" / ") : "No cap";
   }
+  if (category.id === "approvals") {
+    value =
+      approvalFamilies.length > 0
+        ? `Approval required for ${formatFamilyList(approvalFamilies)}`
+        : "No approval checks";
+  }
+  if (category.id === "advanced") {
+    value =
+      advancedDeniedFamilies.length > 0
+        ? `Deny ${formatFamilyList(advancedDeniedFamilies)}`
+        : "No advanced signing controls";
+  }
 
   return (
     <div className="border-t border-border-light p-4 first:border-t-0">
@@ -1010,4 +1507,20 @@ function ReviewCategory({
       <p className="mt-1 text-sm leading-6 text-text-medium">{value}</p>
     </div>
   );
+}
+
+function formatProviderMappingStatus(
+  status: NonNullable<PaymentWalletPolicy["controlProfile"]>["providerMappingStatus"]
+): string {
+  const labels = {
+    not_applicable: "SDP enforced",
+    pending: "Provider mapping pending",
+    synced: "Provider mapped",
+    partial: "Partially provider mapped",
+    failed: "Provider mapping failed",
+  } satisfies Record<
+    NonNullable<PaymentWalletPolicy["controlProfile"]>["providerMappingStatus"],
+    string
+  >;
+  return labels[status];
 }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -464,6 +464,8 @@ export async function updateWalletPolicy(
         destinationAllowlist: policy.destinationAllowlist,
         ...(policy.maxTransferAmount ? { maxTransferAmount: policy.maxTransferAmount } : {}),
         ...(policy.maxDailyAmount ? { maxDailyAmount: policy.maxDailyAmount } : {}),
+        ...(policy.defaultAction ? { defaultAction: policy.defaultAction } : {}),
+        ...(policy.rules ? { rules: policy.rules } : {}),
       }),
     }
   );

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -1,6 +1,12 @@
 import type { CustodyWalletAggregate, CustodyWalletTokenBalance } from "./custody";
 import type { RampFiatCurrency } from "./generated/ramp-support.generated";
 import type { CryptoAssetSymbol, CryptoRailId } from "./payment-rails";
+import type {
+  PolicyDefaultAction,
+  PolicyProfileStatus,
+  PolicyProviderSyncStatus,
+  PolicyRule,
+} from "./policy";
 import type { PrivateTransferRequest } from "./private-transfers";
 import type { RampProviderId } from "./provider-access";
 
@@ -35,6 +41,23 @@ export interface PaymentWalletPolicy {
   destinationAllowlist: string[];
   maxTransferAmount?: string;
   maxDailyAmount?: string;
+  defaultAction?: PolicyDefaultAction;
+  rules?: PolicyRule[];
+  controlProfile?: PaymentWalletControlProfileSummary;
+}
+
+export interface PaymentWalletControlProfileSummary {
+  id: string;
+  status: PolicyProfileStatus;
+  activeRevisionId: string | null;
+  revisionId: string | null;
+  revisionNumber: number | null;
+  defaultAction: PolicyDefaultAction;
+  rules: PolicyRule[];
+  providerMappingStatus: PolicyProviderSyncStatus;
+  createdAt: string;
+  updatedAt: string;
+  activatedAt: string | null;
 }
 
 export interface PaymentWalletPolicyEnvelope {


### PR DESCRIPTION
Closes PRO-1363.

## Summary
- Extend wallet payment policies with control profile summaries, default actions, and immutable rule revisions.
- Let the dashboard policy starting-profile flow configure operation access, destination, limit, approval, and advanced signing rules.
- Persist and activate wallet control profile revisions through the existing wallet policy API surface.
- Update public payment policy schemas/generated docs and add route coverage for revision activation.

## Local validation
- `pnpm --filter @sdp/api test:node -- src/routes/payments.test.ts`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter sdp-web typecheck`
- `pnpm -C apps/sdp-api openapi:generate`
- `pnpm -C apps/sdp-docs generate:api`
- `pnpm -C apps/sdp-docs generate:ai`
- `git diff --check`

## Blocked local validation
- `pnpm --filter sdp-web lint` currently fails before linting this diff with `react/display-name`: `contextOrFilename.getFilename is not a function` from ESLint 10.4.1 / eslint-plugin-react while linting `apps/sdp-web/eslint.config.mjs`.
- `doppler run --project solana-developer-platform --config dev_personal -- pnpm --filter sdp-web test:e2e:dashboard -- --grep "dashboard recurring payments feature flag"` could not boot the local API because Postgres timed out at `136.114.29.38:5432`. No representative screenshot captured for this reason.
