### PR TITLE
fix: standardize UI for lightspark/bvnk and ramps in general

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { getCryptoRailAssetLabel } from "@sdp/types/payment-rails";
-import { CheckCircle2Icon, SendIcon, WalletIcon, XCircleIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { SendIcon, WalletIcon } from "lucide-react";
+import { useMemo } from "react";
 import { Combobox } from "@/components/ui/combobox";
 import { OFFRAMP_PAIRS, RAMP_PROVIDER_OPTIONS, toRampCryptoToken } from "@/lib/ramps";
 import type { OfframpWizard } from "../hooks/use-offramp-wizard";
@@ -10,97 +10,13 @@ import { walletComboboxOptions } from "../wallet-options";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { MoneygramRampWidget } from "./moneygram-ramp-widget";
+import { RampCompleteScreen } from "./ramp-complete-screen";
+import { RampOnboardingPanel } from "./ramp-onboarding-panel";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
 import { RampQuoteSkeleton } from "./ramp-quote-skeleton";
+import { RampStatusPanel } from "./ramp-status-panel";
 import { RequirementsFields } from "./requirements-fields";
 import { WalletAssetBreakdown } from "./wallet-asset-breakdown";
-
-function getOfframpTransferStatusCopy(status: string) {
-  switch (status) {
-    case "pending":
-    case "awaiting_payment":
-      return {
-        title: "Waiting to send",
-        description:
-          "Complete the payout using the instructions above. We will update this outgoing transfer automatically once the provider receives your crypto.",
-        state: "loading" as const,
-      };
-    case "processing":
-    case "settling":
-      return {
-        title: "Sending payout",
-        description:
-          "The provider received your crypto and is settling the outgoing payout to the recipient.",
-        state: "loading" as const,
-      };
-    case "completed":
-      return {
-        title: "Payout sent",
-        description:
-          "The outgoing payout has settled. You can review this transfer from the counterparty record.",
-        state: "success" as const,
-      };
-    case "failed":
-      return {
-        title: "Payout failed",
-        description:
-          "The provider reported that this outgoing payout failed. Review the counterparty record for the latest transfer status.",
-        state: "error" as const,
-      };
-    case "expired":
-      return {
-        title: "Quote expired",
-        description:
-          "This quote expired before the payout completed. Create a new quote to continue the withdrawal.",
-        state: "error" as const,
-      };
-    default:
-      return {
-        title: "Transfer status updated",
-        description: `Current provider status: ${status}.`,
-        state: "loading" as const,
-      };
-  }
-}
-
-function AnimatedDots() {
-  const [count, setCount] = useState(1);
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => setCount((current) => (current % 3) + 1), 500);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
-  return <span aria-hidden>{".".repeat(count)}</span>;
-}
-
-function OfframpTransferStatusPanel({ transfer }: { transfer: OfframpWizard["transferStatus"] }) {
-  const copy = transfer
-    ? getOfframpTransferStatusCopy(transfer.status)
-    : {
-        title: "Preparing transfer status",
-        description: "We are waiting for the transfer record tied to this quote.",
-        state: "loading" as const,
-      };
-  const icon =
-    copy.state === "success" ? (
-      <CheckCircle2Icon className="size-5 text-status-success-text" />
-    ) : copy.state === "error" ? (
-      <XCircleIcon className="size-5 text-status-error-text" />
-    ) : null;
-  return (
-    <div className="flex items-start gap-3">
-      {icon ? <span className="mt-0.5 shrink-0">{icon}</span> : null}
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-text-extra-high">
-          {copy.title}
-          {copy.state === "loading" ? <AnimatedDots /> : null}
-        </p>
-        <p className="mt-1 text-sm leading-relaxed text-text-low">{copy.description}</p>
-      </div>
-    </div>
-  );
-}
 
 function OfframpManualQuoteStep({
   wizard,
@@ -156,7 +72,7 @@ function OfframpManualQuoteStep({
         action={sendAction}
       />
       <div className="border-t border-border-light pt-5">
-        <OfframpTransferStatusPanel transfer={transferStatus} />
+        <RampStatusPanel direction="offramp" transfer={transferStatus} />
       </div>
     </div>
   );
@@ -182,6 +98,8 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     sourceTokenMint,
     refreshQuote,
     liveCounterpartiesResult,
+    onboarding,
+    retryOnboarding,
   } = wizard;
 
   const walletOptions = useMemo(() => walletComboboxOptions(liveWallets), [liveWallets]);
@@ -259,12 +177,22 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     );
   }
 
+  if (currentStepId === "COMPLETE" && onboarding && !quote) {
+    return (
+      <RampOnboardingPanel direction="offramp" onboarding={onboarding} onRetry={retryOnboarding} />
+    );
+  }
+
+  if (currentStepId === "COMPLETE" && quote && transferStatus?.status === "completed") {
+    return <RampCompleteScreen direction="offramp" quote={quote} transfer={transferStatus} />;
+  }
+
   if (currentStepId === "COMPLETE" && quote?.deliveryMode === "hosted") {
     return (
       <div className="space-y-6">
         <HostedRampFrame title={`${quote.provider} payout`} src={quote.hostedUrl} />
         <div className="border-t border-border-light pt-5">
-          <OfframpTransferStatusPanel transfer={transferStatus} />
+          <RampStatusPanel direction="offramp" transfer={transferStatus} />
         </div>
       </div>
     );
@@ -289,7 +217,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
           onSessionExpiring={refreshQuote}
         />
         <div className="border-t border-border-light pt-5">
-          <OfframpTransferStatusPanel transfer={transferStatus} />
+          <RampStatusPanel direction="offramp" transfer={transferStatus} />
         </div>
       </div>
     );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -10,6 +10,7 @@ import { walletComboboxOptions } from "../wallet-options";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { MoneygramRampWidget } from "./moneygram-ramp-widget";
+import { hasOnboardingLifecycle } from "./providers";
 import { RampCompleteScreen } from "./ramp-complete-screen";
 import { RampOnboardingPanel } from "./ramp-onboarding-panel";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
@@ -177,7 +178,12 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     );
   }
 
-  if (currentStepId === "COMPLETE" && onboarding && !quote) {
+  if (
+    currentStepId === "COMPLETE" &&
+    onboarding &&
+    !quote &&
+    hasOnboardingLifecycle(onboarding.provider)
+  ) {
     return (
       <RampOnboardingPanel direction="offramp" onboarding={onboarding} onRetry={retryOnboarding} />
     );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -120,6 +120,17 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     }
 
     const labels = simulateActionLabels(quote.provider);
+    const simulateAction = labels
+      ? {
+          loading: quoteSimulationLoading,
+          succeeded: quoteSimulationSucceeded,
+          onClick: () => void simulateCurrentQuote(),
+          icon: <DollarSignIcon />,
+          idleLabel: labels.idle,
+          busyLabel: labels.busy,
+          doneLabel: labels.done,
+        }
+      : undefined;
     return (
       <div className="space-y-6">
         <ManualInstructionsQuote
@@ -128,15 +139,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
           fiatCurrency={selectedRampPair.fiatCurrency}
           cryptoToken={toRampCryptoToken(selectedRampPair.assetRail)}
           instructions={quote.paymentInstructions}
-          action={{
-            loading: quoteSimulationLoading,
-            succeeded: quoteSimulationSucceeded,
-            onClick: () => void simulateCurrentQuote(),
-            icon: <DollarSignIcon />,
-            idleLabel: labels.idle,
-            busyLabel: labels.busy,
-            doneLabel: labels.done,
-          }}
+          action={simulateAction}
         />
         <div className="border-t border-border-light pt-5">
           <RampStatusPanel direction="onramp" transfer={transferStatus} />

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -5,7 +5,7 @@ import { ONRAMP_PAIRS, RAMP_PROVIDER_OPTIONS, toRampCryptoToken } from "@/lib/ra
 import type { OnrampWizard } from "../hooks/use-onramp-wizard";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
-import { simulateActionLabels } from "./providers";
+import { hasOnboardingLifecycle, simulateActionLabels } from "./providers";
 import { RampCompleteScreen } from "./ramp-complete-screen";
 import { RampOnboardingPanel } from "./ramp-onboarding-panel";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
@@ -84,7 +84,12 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     );
   }
 
-  if (currentStepId === "PROVIDER" && onboarding && !quote) {
+  if (
+    currentStepId === "PROVIDER" &&
+    onboarding &&
+    !quote &&
+    hasOnboardingLifecycle(onboarding.provider)
+  ) {
     return (
       <RampOnboardingPanel direction="onramp" onboarding={onboarding} onRetry={retryOnboarding} />
     );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -1,283 +1,17 @@
 "use client";
 
-import {
-  CheckCircle2Icon,
-  DollarSignIcon,
-  Loader2Icon,
-  ShieldCheckIcon,
-  XCircleIcon,
-} from "lucide-react";
-import {
-  formatMinorCurrencyAmount,
-  formatTimestamp,
-} from "@/app/dashboard/payments/payments-overview.utils";
-import { Button } from "@/components/ui/button";
-import {
-  getRampProviderLabel,
-  ONRAMP_PAIRS,
-  RAMP_PROVIDER_OPTIONS,
-  toRampCryptoToken,
-} from "@/lib/ramps";
+import { DollarSignIcon } from "lucide-react";
+import { ONRAMP_PAIRS, RAMP_PROVIDER_OPTIONS, toRampCryptoToken } from "@/lib/ramps";
 import type { OnrampWizard } from "../hooks/use-onramp-wizard";
 import { HostedRampFrame } from "./hosted-ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
+import { simulateActionLabels } from "./providers";
+import { RampCompleteScreen } from "./ramp-complete-screen";
+import { RampOnboardingPanel } from "./ramp-onboarding-panel";
 import { RampPairProviderSelector } from "./ramp-pair-provider-selector";
 import { RampQuoteSkeleton } from "./ramp-quote-skeleton";
+import { RampStatusPanel } from "./ramp-status-panel";
 import { RequirementsFields } from "./requirements-fields";
-
-function getOnrampTransferStatusCopy(status: string) {
-  switch (status) {
-    case "pending":
-    case "awaiting_payment":
-      return {
-        title: "Waiting for funding",
-        description:
-          "Send the funds using the instructions above. We will update this deposit automatically once the provider receives payment.",
-        state: "loading" as const,
-      };
-    case "processing":
-    case "settling":
-      return {
-        title: "Deposit received",
-        description:
-          "The provider has received funds and is settling the deposit to the destination wallet.",
-        state: "loading" as const,
-      };
-    case "completed":
-      return {
-        title: "Transfer complete",
-        description:
-          "The deposit is complete. You can review the transfer from the counterparty record.",
-        state: "success" as const,
-      };
-    case "failed":
-      return {
-        title: "Transfer failed",
-        description:
-          "The provider reported that this deposit failed. Review the counterparty record for the latest transfer status.",
-        state: "error" as const,
-      };
-    case "expired":
-      return {
-        title: "Quote expired",
-        description:
-          "This quote expired before the transfer completed. Create a new quote to continue funding.",
-        state: "error" as const,
-      };
-    default:
-      return {
-        title: "Transfer status updated",
-        description: `Current provider status: ${status}.`,
-        state: "loading" as const,
-      };
-  }
-}
-
-function OnrampTransferStatusPanel({ transfer }: { transfer: OnrampWizard["transferStatus"] }) {
-  const copy = transfer
-    ? getOnrampTransferStatusCopy(transfer.status)
-    : {
-        title: "Preparing transfer status",
-        description: "We are waiting for the transfer record tied to this quote.",
-        state: "loading" as const,
-      };
-  const icon =
-    copy.state === "success" ? (
-      <CheckCircle2Icon className="size-5 text-status-success-text" />
-    ) : copy.state === "error" ? (
-      <XCircleIcon className="size-5 text-status-error-text" />
-    ) : (
-      <Loader2Icon className="size-5 animate-spin text-text-medium" />
-    );
-  return (
-    <div className="flex items-start gap-3">
-      <span className="mt-0.5 shrink-0">{icon}</span>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-text-extra-high">{copy.title}</p>
-        <p className="mt-1 text-sm leading-relaxed text-text-low">
-          {copy.description}
-          {copy.state === "loading" ? " Checking transfer status…" : null}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function TransferDetailRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex items-start justify-between gap-4 py-2.5 first:pt-0 last:pb-0">
-      <span className="shrink-0 text-sm text-text-low">{label}</span>
-      <span className="min-w-0 break-all text-right text-sm font-medium text-text-extra-high">
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function OnrampCompleteScreen({
-  quote,
-  transfer,
-}: {
-  quote: NonNullable<OnrampWizard["quote"]>;
-  transfer: NonNullable<OnrampWizard["transferStatus"]>;
-}) {
-  const receivedAmount =
-    transfer.amount && transfer.token ? `${transfer.amount} ${transfer.token.toUpperCase()}` : null;
-  const fundedAmount =
-    transfer.fiatAmount && transfer.fiatCurrency
-      ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
-      : null;
-
-  const detailRows: { label: string; value: string }[] = [];
-  if (!receivedAmount && fundedAmount) {
-    detailRows.push({ label: "Funded", value: fundedAmount });
-  }
-  detailRows.push({ label: "Provider", value: getRampProviderLabel(quote.provider) });
-
-  if (quote.provider === "lightspark") {
-    const sendingAmount = formatMinorCurrencyAmount(
-      quote.totalSendingAmount,
-      quote.sendingCurrency.code,
-      quote.sendingCurrency.decimals
-    );
-    const receivingAmount = formatMinorCurrencyAmount(
-      quote.totalReceivingAmount,
-      quote.receivingCurrency.code,
-      quote.receivingCurrency.decimals
-    );
-    if (sendingAmount) {
-      detailRows.push({ label: "Final funded amount", value: sendingAmount });
-    }
-    if (receivingAmount) {
-      detailRows.push({ label: "Final received amount", value: receivingAmount });
-    }
-  }
-
-  if (transfer.updatedAt) {
-    detailRows.push({ label: "Completed", value: formatTimestamp(transfer.updatedAt) });
-  }
-  detailRows.push({ label: "Transfer ID", value: transfer.id });
-  detailRows.push({ label: "Quote ID", value: quote.id });
-
-  return (
-    <div className="flex flex-col items-center gap-6">
-      <div className="flex size-16 items-center justify-center rounded-full bg-status-success-bg text-status-success-text">
-        <CheckCircle2Icon className="size-8" />
-      </div>
-      <div className="space-y-1 text-center">
-        <p className="text-2xl font-medium tracking-tight text-text-extra-high">Deposit complete</p>
-        <p className="text-sm text-text-low">The funds have settled to the destination wallet.</p>
-      </div>
-      <section className="w-full space-y-4 rounded-2xl bg-border-extra-light p-5">
-        {receivedAmount ? (
-          <div className="flex flex-col items-center gap-0.5 border-b border-border-light pb-4">
-            <p className="text-3xl font-semibold tracking-tight text-text-extra-high">
-              {receivedAmount}
-            </p>
-            {fundedAmount ? (
-              <p className="text-sm text-text-low">funded with {fundedAmount}</p>
-            ) : null}
-          </div>
-        ) : null}
-        <div>
-          {detailRows.map((detail) => (
-            <TransferDetailRow key={detail.label} label={detail.label} value={detail.value} />
-          ))}
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function OnboardingErrorPanel({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div className="flex flex-col items-center gap-4 px-6 py-12 text-center">
-      <XCircleIcon className="size-10 text-status-error-text" />
-      <p className="text-lg font-medium text-text-extra-high">
-        We couldn't finish setting up your account
-      </p>
-      <p className="max-w-md text-sm leading-relaxed text-text-low">
-        Something went wrong provisioning your funding account. Please try again.
-      </p>
-      <Button type="button" variant="secondary" onClick={onRetry}>
-        Try again
-      </Button>
-    </div>
-  );
-}
-
-function OnboardingVerificationFailedPanel() {
-  return (
-    <div className="flex flex-col items-center gap-4 px-6 py-12 text-center">
-      <XCircleIcon className="size-10 text-status-error-text" />
-      <p className="text-lg font-medium text-text-extra-high">
-        Identity verification was not approved
-      </p>
-      <p className="max-w-md text-sm leading-relaxed text-text-low">
-        BVNK couldn't verify your identity, so this funding account can't be activated. Contact
-        support if you believe this is a mistake.
-      </p>
-    </div>
-  );
-}
-
-function OnboardingPanel({
-  onboarding,
-  onRetry,
-}: {
-  onboarding: NonNullable<OnrampWizard["onboarding"]>;
-  onRetry: () => void;
-}) {
-  switch (onboarding.status) {
-    case "provisioning_failed":
-      return <OnboardingErrorPanel onRetry={onRetry} />;
-    case "customer_verification_failed":
-      return <OnboardingVerificationFailedPanel />;
-    default:
-      return <OnboardingPendingPanel status={onboarding.status} />;
-  }
-}
-
-function OnboardingPendingPanel({
-  status,
-}: {
-  status: NonNullable<OnrampWizard["onboarding"]>["status"];
-}) {
-  const needsVerification = status === "customer_verification_required";
-  let title: string;
-  let description: string;
-  switch (status) {
-    case "customer_verification_required":
-      title = "Verify your identity";
-      description =
-        "BVNK partners with Sumsub to confirm your identity before activating your funding account. Hit “Complete Verification” below to get started — this page refreshes automatically once you're approved, and your deposit instructions will appear right here.";
-      break;
-    case "customer_verifying":
-      title = "Verification in review";
-      description =
-        "Sumsub is reviewing your details — this usually takes just a few minutes. Feel free to come back later; your deposit instructions will show up here as soon as you're approved.";
-      break;
-    case "ready":
-      title = "Preparing your deposit instructions";
-      description = "Your funding account is ready — fetching your deposit details now.";
-      break;
-    default:
-      title = "Setting up your funding account";
-      description =
-        "Almost there — we're provisioning your virtual account now. Your deposit instructions will appear here in a moment.";
-  }
-  return (
-    <div className="flex flex-col items-center gap-4 px-6 py-12 text-center">
-      {needsVerification ? (
-        <ShieldCheckIcon className="size-10 text-text-extra-high" />
-      ) : (
-        <Loader2Icon className="size-10 animate-spin text-text-medium" />
-      )}
-      <p className="text-lg font-medium text-text-extra-high">{title}</p>
-      <p className="max-w-md text-sm leading-relaxed text-text-low">{description}</p>
-    </div>
-  );
-}
 
 export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
   const {
@@ -351,13 +85,13 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
   }
 
   if (currentStepId === "PROVIDER" && onboarding && !quote) {
-    return <OnboardingPanel onboarding={onboarding} onRetry={retryOnboarding} />;
+    return (
+      <RampOnboardingPanel direction="onramp" onboarding={onboarding} onRetry={retryOnboarding} />
+    );
   }
 
-  if (currentStepId === "PROVIDER" && quote) {
-    if (transferStatus && transferStatus.status === "completed") {
-      return <OnrampCompleteScreen quote={quote} transfer={transferStatus} />;
-    }
+  if (currentStepId === "PROVIDER" && quote && transferStatus?.status === "completed") {
+    return <RampCompleteScreen direction="onramp" quote={quote} transfer={transferStatus} />;
   }
 
   if (currentStepId === "PROVIDER" && quote?.deliveryMode === "hosted") {
@@ -365,7 +99,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
       <div className="space-y-6">
         <HostedRampFrame title={`${quote.provider} deposit`} src={quote.hostedUrl} />
         <div className="border-t border-border-light pt-5">
-          <OnrampTransferStatusPanel transfer={transferStatus} />
+          <RampStatusPanel direction="onramp" transfer={transferStatus} />
         </div>
       </div>
     );
@@ -380,6 +114,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
       );
     }
 
+    const labels = simulateActionLabels(quote.provider);
     return (
       <div className="space-y-6">
         <ManualInstructionsQuote
@@ -388,22 +123,18 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
           fiatCurrency={selectedRampPair.fiatCurrency}
           cryptoToken={toRampCryptoToken(selectedRampPair.assetRail)}
           instructions={quote.paymentInstructions}
-          action={
-            quote.provider === "lightspark" || quote.provider === "bvnk"
-              ? {
-                  loading: quoteSimulationLoading,
-                  succeeded: quoteSimulationSucceeded,
-                  onClick: () => void simulateCurrentQuote(),
-                  icon: <DollarSignIcon />,
-                  idleLabel: quote.provider === "bvnk" ? "Simulate Deposit" : "Simulate Quote",
-                  busyLabel: "Simulating...",
-                  doneLabel: quote.provider === "bvnk" ? "Deposit Simulated" : "Quote Simulated",
-                }
-              : undefined
-          }
+          action={{
+            loading: quoteSimulationLoading,
+            succeeded: quoteSimulationSucceeded,
+            onClick: () => void simulateCurrentQuote(),
+            icon: <DollarSignIcon />,
+            idleLabel: labels.idle,
+            busyLabel: labels.busy,
+            doneLabel: labels.done,
+          }}
         />
         <div className="border-t border-border-light pt-5">
-          <OnrampTransferStatusPanel transfer={transferStatus} />
+          <RampStatusPanel direction="onramp" transfer={transferStatus} />
         </div>
       </div>
     );

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/bvnk.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/bvnk.ts
@@ -1,0 +1,57 @@
+import type { RampDirection } from "@sdp/types/ramp-requirements";
+import { Loader2Icon, ShieldCheckIcon, XCircleIcon } from "lucide-react";
+import type { OnboardingCopy, OnboardingPanelStatus, SimulateActionLabels } from "./index";
+
+export const BVNK_ONBOARDING_COPY = {
+  customer_verification_required: {
+    title: "Verify your identity",
+    description:
+      "BVNK partners with Sumsub to confirm your identity before activating your funding account. Hit “Complete Verification” to get started — this page refreshes automatically once you're approved, and your instructions will appear right here.",
+    icon: ShieldCheckIcon,
+    iconClassName: "text-text-extra-high",
+  },
+  customer_verifying: {
+    title: "Verification in review",
+    description:
+      "Sumsub is reviewing your details — this usually takes just a few minutes. Feel free to come back later; your instructions will show up here as soon as you're approved.",
+    icon: Loader2Icon,
+    iconClassName: "animate-spin text-text-medium",
+  },
+  customer_verification_failed: {
+    title: "Identity verification was not approved",
+    description:
+      "BVNK couldn't verify your identity, so this funding account can't be activated. Contact support if you believe this is a mistake.",
+    icon: XCircleIcon,
+    iconClassName: "text-status-error-text",
+  },
+  funding_account_provisioning: {
+    title: "Setting up your funding account",
+    description:
+      "Almost there — we're provisioning your virtual account now. Your instructions will appear here in a moment.",
+    icon: Loader2Icon,
+    iconClassName: "animate-spin text-text-medium",
+  },
+  provisioning_failed: {
+    title: "We couldn't finish setting up your account",
+    description: "Something went wrong provisioning your funding account. Please try again.",
+    icon: XCircleIcon,
+    iconClassName: "text-status-error-text",
+  },
+  ready: {
+    title: "Preparing your instructions",
+    description: "Your funding account is ready — fetching your details now.",
+    icon: Loader2Icon,
+    iconClassName: "animate-spin text-text-medium",
+  },
+} as const satisfies Record<OnboardingPanelStatus, OnboardingCopy>;
+
+export const BVNK_PROVISIONING_DETAIL = {
+  onramp: "Provisioning a BVNK wallet and fiat→crypto payment rule for this quote.",
+  offramp: "Provisioning a dedicated BVNK payout wallet for this currency.",
+} as const satisfies Record<RampDirection, string>;
+
+export const BVNK_SIMULATE_LABELS = {
+  idle: "Simulate Deposit",
+  busy: "Simulating...",
+  done: "Deposit Simulated",
+} as const satisfies SimulateActionLabels;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/index.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/index.ts
@@ -1,0 +1,57 @@
+import type { RampProviderId } from "@sdp/types";
+import type { CounterpartyRequirements, RampDirection } from "@sdp/types/ramp-requirements";
+import type { LucideIcon } from "lucide-react";
+import { BVNK_ONBOARDING_COPY, BVNK_PROVISIONING_DETAIL, BVNK_SIMULATE_LABELS } from "./bvnk";
+import {
+  LIGHTSPARK_ONBOARDING_COPY,
+  LIGHTSPARK_PROVISIONING_DETAIL,
+  LIGHTSPARK_SIMULATE_LABELS,
+} from "./lightspark";
+
+export interface OnboardingCopy {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  iconClassName: string;
+}
+
+export type OnboardingPanelStatus = Exclude<
+  CounterpartyRequirements["status"],
+  "collect" | "unsupported" | "onboarding_not_started"
+>;
+
+export interface SimulateActionLabels {
+  idle: string;
+  busy: string;
+  done: string;
+}
+
+export function onboardingCopy(
+  provider: RampProviderId,
+  status: OnboardingPanelStatus
+): OnboardingCopy {
+  switch (provider) {
+    case "bvnk":
+      return BVNK_ONBOARDING_COPY[status];
+    case "lightspark":
+      return LIGHTSPARK_ONBOARDING_COPY[status];
+    default:
+      throw new Error(`No onboarding copy for ramp provider: ${provider}`);
+  }
+}
+
+export function simulateActionLabels(provider: "bvnk" | "lightspark"): SimulateActionLabels {
+  return provider === "bvnk" ? BVNK_SIMULATE_LABELS : LIGHTSPARK_SIMULATE_LABELS;
+}
+
+/** One-line "what we're setting up under the hood" — varies by provider and direction. */
+export function provisioningDetail(provider: RampProviderId, direction: RampDirection): string {
+  switch (provider) {
+    case "bvnk":
+      return BVNK_PROVISIONING_DETAIL[direction];
+    case "lightspark":
+      return LIGHTSPARK_PROVISIONING_DETAIL[direction];
+    default:
+      throw new Error(`No provisioning detail for ramp provider: ${provider}`);
+  }
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/index.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/index.ts
@@ -49,16 +49,15 @@ export function onboardingCopy(
   }
 }
 
-export function simulateActionLabels(provider: "bvnk" | "lightspark"): SimulateActionLabels {
+/** Sandbox simulate-action labels for providers that support the simulate flow; null otherwise (caller hides the action). */
+export function simulateActionLabels(provider: RampProviderId): SimulateActionLabels | null {
   switch (provider) {
     case "bvnk":
       return BVNK_SIMULATE_LABELS;
     case "lightspark":
       return LIGHTSPARK_SIMULATE_LABELS;
-    default: {
-      const exhaustive: never = provider;
-      throw new Error(`No simulate labels for ramp provider: ${exhaustive}`);
-    }
+    default:
+      return null;
   }
 }
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/index.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/index.ts
@@ -26,6 +26,15 @@ export interface SimulateActionLabels {
   done: string;
 }
 
+/**
+ * Providers with a counterparty onboarding/provisioning lifecycle (and thus panel copy).
+ * Widget providers (moonpay, moneygram) report `ready` and go straight to a quote — they
+ * never render the onboarding panel, so callers must gate on this before rendering it.
+ */
+export function hasOnboardingLifecycle(provider: RampProviderId): boolean {
+  return provider === "bvnk" || provider === "lightspark";
+}
+
 export function onboardingCopy(
   provider: RampProviderId,
   status: OnboardingPanelStatus
@@ -41,7 +50,16 @@ export function onboardingCopy(
 }
 
 export function simulateActionLabels(provider: "bvnk" | "lightspark"): SimulateActionLabels {
-  return provider === "bvnk" ? BVNK_SIMULATE_LABELS : LIGHTSPARK_SIMULATE_LABELS;
+  switch (provider) {
+    case "bvnk":
+      return BVNK_SIMULATE_LABELS;
+    case "lightspark":
+      return LIGHTSPARK_SIMULATE_LABELS;
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`No simulate labels for ramp provider: ${exhaustive}`);
+    }
+  }
 }
 
 /** One-line "what we're setting up under the hood" — varies by provider and direction. */

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/lightspark.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/providers/lightspark.ts
@@ -1,0 +1,57 @@
+import type { RampDirection } from "@sdp/types/ramp-requirements";
+import { Loader2Icon, ShieldCheckIcon, XCircleIcon } from "lucide-react";
+import type { OnboardingCopy, OnboardingPanelStatus, SimulateActionLabels } from "./index";
+
+export const LIGHTSPARK_ONBOARDING_COPY = {
+  customer_verification_required: {
+    title: "Verify your identity",
+    description:
+      "We need to confirm your identity before activating your funding account. This page refreshes automatically once you're approved.",
+    icon: ShieldCheckIcon,
+    iconClassName: "text-text-extra-high",
+  },
+  customer_verifying: {
+    title: "Verification in review",
+    description:
+      "Your details are under review — this usually takes just a few minutes. Your instructions will show up here as soon as you're approved.",
+    icon: Loader2Icon,
+    iconClassName: "animate-spin text-text-medium",
+  },
+  customer_verification_failed: {
+    title: "Identity verification was not approved",
+    description:
+      "We couldn't verify your identity, so this funding account can't be activated. Contact support if you believe this is a mistake.",
+    icon: XCircleIcon,
+    iconClassName: "text-status-error-text",
+  },
+  funding_account_provisioning: {
+    title: "Setting up your account",
+    description:
+      "Almost there — we're getting your funding account ready. Your instructions will appear here in a moment.",
+    icon: Loader2Icon,
+    iconClassName: "animate-spin text-text-medium",
+  },
+  provisioning_failed: {
+    title: "We couldn't finish setting up your account",
+    description: "Something went wrong getting your funding account ready. Please try again.",
+    icon: XCircleIcon,
+    iconClassName: "text-status-error-text",
+  },
+  ready: {
+    title: "Preparing your instructions",
+    description: "Your account is ready — fetching your details now.",
+    icon: Loader2Icon,
+    iconClassName: "animate-spin text-text-medium",
+  },
+} as const satisfies Record<OnboardingPanelStatus, OnboardingCopy>;
+
+export const LIGHTSPARK_PROVISIONING_DETAIL = {
+  onramp: "Provisioning your Lightspark customer and deposit details for this quote.",
+  offramp: "Provisioning a just-in-time Lightspark payout account for this withdrawal.",
+} as const satisfies Record<RampDirection, string>;
+
+export const LIGHTSPARK_SIMULATE_LABELS = {
+  idle: "Simulate Quote",
+  busy: "Simulating...",
+  done: "Quote Simulated",
+} as const satisfies SimulateActionLabels;

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-complete-screen.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-complete-screen.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import type { PaymentRampQuote, PaymentTransferSummary } from "@sdp/types";
+import type { RampDirection } from "@sdp/types/ramp-requirements";
+import { CheckCircle2Icon } from "lucide-react";
+import {
+  formatMinorCurrencyAmount,
+  formatTimestamp,
+} from "@/app/dashboard/payments/payments-overview.utils";
+import { getRampProviderLabel } from "@/lib/ramps";
+
+function TransferDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-2.5 first:pt-0 last:pb-0">
+      <span className="shrink-0 text-sm text-text-low">{label}</span>
+      <span className="min-w-0 break-all text-right text-sm font-medium text-text-extra-high">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function RampCompleteScreen({
+  direction,
+  quote,
+  transfer,
+}: {
+  direction: RampDirection;
+  quote: PaymentRampQuote;
+  transfer: PaymentTransferSummary;
+}) {
+  const onramp = direction === "onramp";
+  const cryptoAmount =
+    transfer.amount && transfer.token ? `${transfer.amount} ${transfer.token.toUpperCase()}` : null;
+  const fiatAmount =
+    transfer.fiatAmount && transfer.fiatCurrency
+      ? `${transfer.fiatAmount} ${transfer.fiatCurrency.toUpperCase()}`
+      : null;
+
+  // onramp: received crypto, funded with fiat. offramp: paid out fiat, sent crypto.
+  const primaryAmount = onramp ? cryptoAmount : fiatAmount;
+  const secondaryAmount = onramp ? fiatAmount : cryptoAmount;
+
+  const detailRows: { label: string; value: string }[] = [];
+  if (!primaryAmount && secondaryAmount) {
+    detailRows.push({ label: onramp ? "Funded" : "Sent", value: secondaryAmount });
+  }
+  detailRows.push({ label: "Provider", value: getRampProviderLabel(quote.provider) });
+
+  if (quote.provider === "lightspark") {
+    const sendingAmount = formatMinorCurrencyAmount(
+      quote.totalSendingAmount,
+      quote.sendingCurrency.code,
+      quote.sendingCurrency.decimals
+    );
+    const receivingAmount = formatMinorCurrencyAmount(
+      quote.totalReceivingAmount,
+      quote.receivingCurrency.code,
+      quote.receivingCurrency.decimals
+    );
+    if (sendingAmount) {
+      detailRows.push({
+        label: onramp ? "Final funded amount" : "Final sent amount",
+        value: sendingAmount,
+      });
+    }
+    if (receivingAmount) {
+      detailRows.push({
+        label: onramp ? "Final received amount" : "Final payout amount",
+        value: receivingAmount,
+      });
+    }
+  }
+
+  if (transfer.updatedAt) {
+    detailRows.push({ label: "Completed", value: formatTimestamp(transfer.updatedAt) });
+  }
+  detailRows.push({ label: "Transfer ID", value: transfer.id });
+  detailRows.push({ label: "Quote ID", value: quote.id });
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div className="flex size-16 items-center justify-center rounded-full bg-status-success-bg text-status-success-text">
+        <CheckCircle2Icon className="size-8" />
+      </div>
+      <div className="space-y-1 text-center">
+        <p className="text-2xl font-medium tracking-tight text-text-extra-high">
+          {onramp ? "Deposit complete" : "Payout complete"}
+        </p>
+        <p className="text-sm text-text-low">
+          {onramp
+            ? "The funds have settled to the destination wallet."
+            : "The payout has settled to the recipient's bank account."}
+        </p>
+      </div>
+      <section className="w-full space-y-4 rounded-2xl bg-border-extra-light p-5">
+        {primaryAmount ? (
+          <div className="flex flex-col items-center gap-0.5 border-b border-border-light pb-4">
+            <p className="text-3xl font-semibold tracking-tight text-text-extra-high">
+              {primaryAmount}
+            </p>
+            {secondaryAmount ? (
+              <p className="text-sm text-text-low">
+                {onramp ? "funded with" : "from"} {secondaryAmount}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+        <div>
+          {detailRows.map((detail) => (
+            <TransferDetailRow key={detail.label} label={detail.label} value={detail.value} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-onboarding-panel.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-onboarding-panel.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { CounterpartyRequirements, RampDirection } from "@sdp/types/ramp-requirements";
+import { Button } from "@/components/ui/button";
+import { onboardingCopy, provisioningDetail } from "./providers";
+
+export function RampOnboardingPanel({
+  direction,
+  onboarding,
+  onRetry,
+}: {
+  direction: RampDirection;
+  onboarding: CounterpartyRequirements;
+  onRetry: () => void;
+}) {
+  const { provider, status } = onboarding;
+  if (status === "collect" || status === "unsupported" || status === "onboarding_not_started") {
+    throw new Error(`RampOnboardingPanel received non-onboarding status: ${status}`);
+  }
+  const copy = onboardingCopy(provider, status);
+  const Icon = copy.icon;
+  return (
+    <div className="flex flex-col items-center gap-4 px-6 py-12 text-center">
+      <Icon className={`size-10 ${copy.iconClassName}`} />
+      <p className="text-lg font-medium text-text-extra-high">{copy.title}</p>
+      <p className="max-w-md text-sm leading-relaxed text-text-low">{copy.description}</p>
+      {status === "funding_account_provisioning" ? (
+        <div className="flex items-center gap-2 rounded-full bg-border-extra-light px-3 py-1.5">
+          <span className="size-2 shrink-0 animate-pulse rounded-full bg-text-medium" />
+          <span className="text-xs text-text-low">{provisioningDetail(provider, direction)}</span>
+        </div>
+      ) : null}
+      {status === "provisioning_failed" ? (
+        <Button type="button" variant="secondary" onClick={onRetry}>
+          Try again
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-status-panel.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/ramp-status-panel.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { PaymentTransferSummary } from "@sdp/types";
+import type { RampDirection } from "@sdp/types/ramp-requirements";
+import { CheckCircle2Icon, Loader2Icon, XCircleIcon } from "lucide-react";
+
+interface TransferStatusCopy {
+  title: string;
+  description: string;
+  state: "loading" | "success" | "error";
+}
+
+function transferStatusCopy(direction: RampDirection, status: string): TransferStatusCopy {
+  const onramp = direction === "onramp";
+  switch (status) {
+    case "pending":
+    case "awaiting_payment":
+      return {
+        title: onramp ? "Waiting for funding" : "Waiting to send",
+        description: onramp
+          ? "Send the funds using the instructions above. We will update this deposit automatically once the provider receives payment."
+          : "Complete the payout using the instructions above. We will update this outgoing transfer automatically once the provider receives your crypto.",
+        state: "loading",
+      };
+    case "processing":
+    case "settling":
+      return {
+        title: onramp ? "Deposit received" : "Sending payout",
+        description: onramp
+          ? "The provider has received funds and is settling the deposit to the destination wallet."
+          : "The provider received your crypto and is settling the outgoing payout to the recipient.",
+        state: "loading",
+      };
+    case "completed":
+      return {
+        title: onramp ? "Transfer complete" : "Payout sent",
+        description: onramp
+          ? "The deposit is complete. You can review the transfer from the counterparty record."
+          : "The outgoing payout has settled. You can review this transfer from the counterparty record.",
+        state: "success",
+      };
+    case "failed":
+      return {
+        title: onramp ? "Transfer failed" : "Payout failed",
+        description: onramp
+          ? "The provider reported that this deposit failed. Review the counterparty record for the latest transfer status."
+          : "The provider reported that this outgoing payout failed. Review the counterparty record for the latest transfer status.",
+        state: "error",
+      };
+    case "expired":
+      return {
+        title: "Quote expired",
+        description: onramp
+          ? "This quote expired before the transfer completed. Create a new quote to continue funding."
+          : "This quote expired before the payout completed. Create a new quote to continue the withdrawal.",
+        state: "error",
+      };
+    default:
+      return {
+        title: "Transfer status updated",
+        description: `Current provider status: ${status}.`,
+        state: "loading",
+      };
+  }
+}
+
+function statusIcon(state: TransferStatusCopy["state"]) {
+  switch (state) {
+    case "success":
+      return <CheckCircle2Icon className="size-5 text-status-success-text" />;
+    case "error":
+      return <XCircleIcon className="size-5 text-status-error-text" />;
+    case "loading":
+      return <Loader2Icon className="size-5 animate-spin text-text-medium" />;
+    default: {
+      const exhaustive: never = state;
+      throw new Error(`Unhandled transfer status state: ${exhaustive}`);
+    }
+  }
+}
+
+export function RampStatusPanel({
+  direction,
+  transfer,
+}: {
+  direction: RampDirection;
+  transfer: PaymentTransferSummary | null | undefined;
+}) {
+  const copy: TransferStatusCopy = transfer
+    ? transferStatusCopy(direction, transfer.status)
+    : {
+        title: "Preparing transfer status",
+        description: "We are waiting for the transfer record tied to this quote.",
+        state: "loading",
+      };
+  return (
+    <div className="flex items-start gap-3">
+      <span className="mt-0.5 shrink-0">{statusIcon(copy.state)}</span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-text-extra-high">{copy.title}</p>
+        <p className="mt-1 text-sm leading-relaxed text-text-low">{copy.description}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Standardize the ramp wizard UI for onramp/offramp (lightspark + bvnk). The two step-content files had drifted into divergent copies of the same flow — offramp was missing a success screen, onboarding copy was inline and provider names leaked. This pulls the shared structure into reusable components and moves per-provider copy into per-provider files.

## Before / after file structure

**Before** — two divergent files, copy inline:

```
ramps/components/
  onramp-step-content.tsx     status copy + onboarding panels + complete screen, all inline
  offramp-step-content.tsx    divergent copy of the same — NO complete screen, drifting copy
```

**After** — shared components + per-provider copy files; routers go thin:

```
ramps/components/
  providers/
    index.ts                  onboardingCopy() / provisioningDetail() / simulateActionLabels() resolvers
    bvnk.ts                   bvnk onboarding copy (per status, w/ icon) + provisioning detail + simulate labels
    lightspark.ts             lightspark onboarding copy + provisioning detail + simulate labels
  ramp-status-panel.tsx       transfer status copy/icon — shared, switched by direction
  ramp-onboarding-panel.tsx   onboarding lifecycle panel — shared, + pulsing provisioning dot
  ramp-complete-screen.tsx    success screen — shared, now used by offramp too
  onramp-step-content.tsx     thin router
  offramp-step-content.tsx    thin router
```

The only per-provider difference now lives in `providers/*`; direction copy lives in the shared components. Offramp gains the success screen it was missing.
