### PR TITLE
feat(sdp-api): batch payment transfers to multiple counterparties

### DIFF
--- a/apps/sdp-api/src/db/repositories/payment-transfer-batches.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payment-transfer-batches.repository.postgres.ts
@@ -16,6 +16,7 @@ import type {
   PaymentTransferRecipientRow,
   UpdatePaymentTransferBatchInput,
   UpdatePaymentTransferRecipientInput,
+  UpdatePaymentTransferRecipientsStatusInput,
   UpsertPaymentTransferBatchInput,
   UpsertPaymentTransferRecipientInput,
 } from "./payment-transfer-batches.repository";
@@ -325,6 +326,12 @@ export function createPostgresPaymentTransferBatchesRepository(
       if (input.walletId) {
         extraClauses.push("source_wallet_id = ?");
         extraValues.push(input.walletId);
+      } else if (input.walletIds) {
+        if (input.walletIds.length === 0) {
+          return { rows: [], total: 0 };
+        }
+        extraClauses.push(`source_wallet_id IN (${input.walletIds.map(() => "?").join(", ")})`);
+        extraValues.push(...input.walletIds);
       }
       if (input.token) {
         extraClauses.push("token = ?");
@@ -425,6 +432,54 @@ export function createPostgresPaymentTransferBatchesRepository(
       return mapPaymentTransferRecipientRow(row);
     },
 
+    async createTransferRecipients(inputs: CreatePaymentTransferRecipientInput[]) {
+      if (inputs.length === 0) {
+        return [];
+      }
+
+      const rowPlaceholder = `(${Array(12).fill("?").join(", ")})`;
+      const values = inputs.flatMap((input) => [
+        generatePaymentTransferRecipientId(),
+        input.batchId,
+        input.organizationId,
+        input.projectId,
+        input.transferId ?? null,
+        input.externalId ?? null,
+        input.counterpartyId,
+        input.counterpartyAccountId,
+        input.destinationAddress,
+        input.amount,
+        input.status ?? "pending",
+        input.error ?? null,
+      ]);
+
+      const result = await db
+        .prepare(
+          `INSERT INTO payment_transfer_recipients (
+             id,
+             batch_id,
+             organization_id,
+             project_id,
+             transfer_id,
+             external_id,
+             counterparty_id,
+             counterparty_account_id,
+             destination_address,
+             amount,
+             status,
+             error
+           ) VALUES ${inputs.map(() => rowPlaceholder).join(", ")}
+           RETURNING *`
+        )
+        .bind(...values)
+        .all<Record<string, unknown>>();
+
+      if (result.results.length !== inputs.length) {
+        throw internalError("payment_transfer_recipients bulk INSERT returned an unexpected count");
+      }
+      return result.results.map(mapPaymentTransferRecipientRow);
+    },
+
     async upsertTransferRecipient(input: UpsertPaymentTransferRecipientInput) {
       const recipientId = input.recipientId ?? generatePaymentTransferRecipientId();
       const row = await db
@@ -522,6 +577,37 @@ export function createPostgresPaymentTransferBatchesRepository(
         .first<Record<string, unknown>>();
 
       return row ? mapPaymentTransferRecipientRow(row) : null;
+    },
+
+    async updateTransferRecipientsStatus(input: UpdatePaymentTransferRecipientsStatusInput) {
+      if (input.recipientIds.length === 0) {
+        return [];
+      }
+
+      const scope = buildScopeWhere({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        extraClauses: [
+          `id IN (${input.recipientIds.map(() => "?").join(", ")})`,
+          "status <> 'archived'",
+        ],
+        extraValues: input.recipientIds,
+      });
+
+      const result = await db
+        .prepare(
+          `UPDATE payment_transfer_recipients
+             SET transfer_id = ?,
+                 status = ?,
+                 error = ?,
+                 updated_at = sdp_iso_now()
+           WHERE ${scope.where}
+           RETURNING *`
+        )
+        .bind(input.transferId, input.status, input.error, ...scope.values)
+        .all<Record<string, unknown>>();
+
+      return result.results.map(mapPaymentTransferRecipientRow);
     },
 
     async deleteTransferRecipient(input: DeletePaymentTransferRecipientInput) {

--- a/apps/sdp-api/src/db/repositories/payment-transfer-batches.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payment-transfer-batches.repository.ts
@@ -93,6 +93,7 @@ export interface ListPaymentTransferBatchesInput {
   organizationId: string;
   projectId: string;
   walletId?: string;
+  walletIds?: string[];
   token?: string;
   status?: PaymentTransferBatchStatus;
   externalId?: string;
@@ -163,6 +164,15 @@ export interface ListPaymentTransferRecipientsResult {
   total: number;
 }
 
+export interface UpdatePaymentTransferRecipientsStatusInput {
+  recipientIds: string[];
+  organizationId: string;
+  projectId: string;
+  transferId: string | null;
+  status: PaymentTransferBatchRecipientStatus;
+  error: string | null;
+}
+
 export interface PaymentTransferBatchesRepository {
   createTransferBatch(input: CreatePaymentTransferBatchInput): Promise<PaymentTransferBatchRow>;
   upsertTransferBatch(input: UpsertPaymentTransferBatchInput): Promise<PaymentTransferBatchRow>;
@@ -182,12 +192,18 @@ export interface PaymentTransferBatchesRepository {
   createTransferRecipient(
     input: CreatePaymentTransferRecipientInput
   ): Promise<PaymentTransferRecipientRow>;
+  createTransferRecipients(
+    inputs: CreatePaymentTransferRecipientInput[]
+  ): Promise<PaymentTransferRecipientRow[]>;
   upsertTransferRecipient(
     input: UpsertPaymentTransferRecipientInput
   ): Promise<PaymentTransferRecipientRow>;
   updateTransferRecipient(
     input: UpdatePaymentTransferRecipientInput
   ): Promise<PaymentTransferRecipientRow | null>;
+  updateTransferRecipientsStatus(
+    input: UpdatePaymentTransferRecipientsStatusInput
+  ): Promise<PaymentTransferRecipientRow[]>;
   deleteTransferRecipient(
     input: DeletePaymentTransferRecipientInput
   ): Promise<PaymentTransferRecipientRow | null>;

--- a/apps/sdp-api/src/lib/errors.ts
+++ b/apps/sdp-api/src/lib/errors.ts
@@ -208,6 +208,10 @@ export function internalError(message?: string): AppError {
   return new AppError("INTERNAL_ERROR", message);
 }
 
+export function transactionFailed(message?: string, details?: Record<string, unknown>): AppError {
+  return new AppError("TRANSACTION_FAILED", message, details);
+}
+
 export function providerNotConfigured(message?: string): AppError {
   return new AppError("PROVIDER_NOT_CONFIGURED", message);
 }

--- a/apps/sdp-api/src/routes/payments/context.ts
+++ b/apps/sdp-api/src/routes/payments/context.ts
@@ -2,6 +2,8 @@ import type { SdpEnvironment } from "@sdp/types";
 import type { Address } from "@solana/kit";
 import type { Context } from "hono";
 import {
+  createCounterpartiesRepository,
+  createCounterpartyAccountsRepository,
   createPaymentRecurringPaymentsRepository,
   createPaymentSubscriptionsRepository,
   createPaymentsRepository,
@@ -36,6 +38,14 @@ export function rampRuntime(c: AppContext): RampRuntimeContext {
 
 export function getPaymentsRepository(c: AppContext) {
   return createPaymentsRepository(c.env);
+}
+
+export function getCounterpartiesRepository(c: AppContext) {
+  return createCounterpartiesRepository(c.env);
+}
+
+export function getCounterpartyAccountsRepository(c: AppContext) {
+  return createCounterpartyAccountsRepository(c.env);
 }
 
 export function getPaymentSubscriptionsRepository(c: AppContext) {

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches.ts
@@ -1,18 +1,784 @@
+import { WELL_KNOWN_TOKENS } from "@sdp/types";
+import type {
+  Address,
+  Instruction,
+  TransactionMessageBytesBase64,
+  TransactionSigner,
+} from "@solana/kit";
+import {
+  addSignersToTransactionMessage,
+  appendTransactionMessageInstructions,
+  compileTransaction,
+  createNoopSigner,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  getTransactionEncoder,
+  getTransactionSize,
+  getTransactionSizeLimit,
+  isTransactionWithinSizeLimit,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
+import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
+import { getTransferSolInstruction } from "@solana-program/system";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getTokenSize,
+  getTransferCheckedInstruction,
+} from "@solana-program/token-2022";
 import { z } from "zod";
-import { AppError, badRequest, badRequestParams, badRequestQuery } from "@/lib/errors";
-import type { AppContext } from "../context";
+import type { CounterpartyAccountRow } from "@/db/repositories/counterparty-account.repository";
+import type {
+  PaymentTransferBatchRow,
+  PaymentTransferRecipientRow,
+} from "@/db/repositories/payment-transfer-batches.repository";
+import type {
+  PaymentTransferRow,
+  PaymentTransferStatus,
+} from "@/db/repositories/payments.repository";
+import { AmountError, formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import { AppError, badRequest, badRequestParams, badRequestQuery, notFound } from "@/lib/errors";
+import { paginated, success } from "@/lib/response";
+import { assertValidAddress } from "@/lib/solana";
+import {
+  assertApiKeyWalletAccess,
+  getAllowedApiKeyWalletIds,
+} from "@/services/api-key-scope.service";
+import {
+  assertPaymentProjectScope,
+  assertPositivePaymentAmount,
+  normalizePaymentToken,
+} from "@/services/payment-operation.service";
+import {
+  enforceWalletOperationPolicy,
+  recordLegacyWalletPolicyDenial,
+  walletOperationActorFromAuth,
+} from "@/services/policy-enforcement.service";
+import * as solanaServices from "@/services/solana";
+import * as solanaRpc from "@/services/solana/rpc";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import {
+  type AppContext,
+  getCounterpartiesRepository,
+  getCounterpartyAccountsRepository,
+  getFeePayment,
+  getPaymentsRepository,
+  getPaymentTransferBatchesRepository,
+} from "../context";
+import { mapTransferRow } from "../mappers";
+import { assertWalletPolicyAllowsTransfer } from "../policy";
 import {
   createTransferBatchSchema,
   estimateTransferBatchSchema,
   listTransferBatchesQuerySchema,
   transferBatchIdParamsSchema,
 } from "../schemas";
+import { resolveMintTokenProgram, resolveSourceTokenAccount } from "../token-accounts";
+import { type ResolvedScope, resolveScope, resolveWallet } from "../wallets";
 
-function todo(operation: string): never {
-  throw new AppError(
-    "BAD_REQUEST",
-    `TODO: ${operation} transfer batch handler is not implemented yet`
+const DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION = 20;
+
+type CreateTransferBatchInput = z.infer<typeof createTransferBatchSchema>;
+type TransferBatchRecipientInput = CreateTransferBatchInput["recipients"][number];
+type Rpc = solanaRpc.SolanaRpc;
+type RecentBlockhash = Awaited<ReturnType<typeof solanaRpc.getRecentBlockhash>>;
+
+type TokenContext =
+  | {
+      kind: "sol";
+      token: "SOL";
+      decimals: 9;
+    }
+  | {
+      kind: "spl";
+      token: string;
+      decimals: number;
+      mintAddress: Address;
+      tokenProgram: Address;
+      sourceTokenAccount: Address;
+    };
+
+interface ResolvedRecipient {
+  index: number;
+  externalId: string | null;
+  counterpartyId: string;
+  counterpartyAccountId: string;
+  destinationAddress: Address;
+  amount: string;
+  amountBaseUnits: bigint;
+}
+
+interface RecipientInstructionGroup extends ResolvedRecipient {
+  instructions: Instruction[];
+  destinationTokenAccount?: Address;
+}
+
+interface TransactionChunk {
+  recipientIndexes: number[];
+  instructions: Instruction[];
+  message: ReturnType<typeof buildBatchTransactionMessage>;
+  amountBaseUnits: bigint;
+}
+
+interface ResolvedBatchRequest {
+  scope: ResolvedScope;
+  projectId: string;
+  sourceWallet: CustodyWallet;
+  sourceAddress: Address;
+  tokenContext: TokenContext;
+  recipients: ResolvedRecipient[];
+  totalAmount: string;
+  totalAmountBaseUnits: bigint;
+  rpc: Rpc;
+}
+
+function parseRecipientAmount(amount: string, decimals: number): bigint {
+  try {
+    return parseDecimalAmount(assertPositivePaymentAmount(amount), decimals);
+  } catch (error) {
+    if (error instanceof AmountError) {
+      throw badRequest(error.message);
+    }
+    throw error;
+  }
+}
+
+function mapBatchRow(row: PaymentTransferBatchRow) {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    projectId: row.project_id,
+    externalId: row.external_id,
+    sourceWalletId: row.source_wallet_id,
+    sourceAddress: row.source_address,
+    token: row.token,
+    status: row.status,
+    totalAmount: row.total_amount,
+    recipientCount: row.recipient_count,
+    transactionCount: row.transaction_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapRecipientRow(row: PaymentTransferRecipientRow) {
+  return {
+    id: row.id,
+    batchId: row.batch_id,
+    transferId: row.transfer_id,
+    externalId: row.external_id,
+    counterpartyId: row.counterparty_id,
+    counterpartyAccountId: row.counterparty_account_id,
+    destination: row.destination_address,
+    amount: row.amount,
+    status: row.status,
+    error: row.error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function resolveTokenContext(
+  rpc: Rpc,
+  token: string,
+  sourceAddress: Address
+): Promise<TokenContext> {
+  if (token === "SOL") {
+    return { kind: "sol", token: "SOL", decimals: WELL_KNOWN_TOKENS.SOL.decimals };
+  }
+
+  const mintAddress = assertValidAddress(token, "token");
+  const tokenProgram = await resolveMintTokenProgram(rpc, mintAddress);
+  const sourceTokenAccount = await resolveSourceTokenAccount(
+    rpc,
+    sourceAddress,
+    mintAddress,
+    tokenProgram
   );
+
+  return {
+    kind: "spl",
+    token,
+    decimals: sourceTokenAccount.decimals,
+    mintAddress,
+    tokenProgram,
+    sourceTokenAccount: sourceTokenAccount.tokenAccount,
+  };
+}
+
+function readCryptoWalletAddress(account: CounterpartyAccountRow, index: number): Address {
+  if (account.account_kind !== "crypto_wallet") {
+    throw badRequest(`recipients.${index}.counterpartyAccountId must be a crypto wallet account`);
+  }
+
+  const { network, address } = account.details;
+  if (network !== "solana") {
+    throw badRequest(`recipients.${index}.counterpartyAccountId must be a Solana wallet account`);
+  }
+  if (typeof address !== "string") {
+    throw badRequest(`recipients.${index}.counterpartyAccountId is missing a wallet address`);
+  }
+
+  return assertValidAddress(address, `recipients.${index}.counterpartyAccountId`);
+}
+
+async function resolveRecipients(params: {
+  c: AppContext;
+  organizationId: string;
+  projectId: string;
+  recipients: TransferBatchRecipientInput[];
+  decimals: number;
+}): Promise<ResolvedRecipient[]> {
+  const counterpartiesRepository = getCounterpartiesRepository(params.c);
+  const accountsRepository = getCounterpartyAccountsRepository(params.c);
+
+  return Promise.all(
+    params.recipients.map(async (recipient, index) => {
+      const [counterparty, account] = await Promise.all([
+        counterpartiesRepository.getCounterpartyById({
+          counterpartyId: recipient.counterpartyId,
+          organizationId: params.organizationId,
+          projectId: params.projectId,
+        }),
+        accountsRepository.getCounterpartyAccountById({
+          counterpartyAccountId: recipient.counterpartyAccountId,
+          counterpartyId: recipient.counterpartyId,
+          organizationId: params.organizationId,
+          projectId: params.projectId,
+        }),
+      ]);
+
+      if (!counterparty) {
+        throw notFound(`Counterparty ${recipient.counterpartyId}`);
+      }
+      if (!account) {
+        throw notFound(`Counterparty account ${recipient.counterpartyAccountId}`);
+      }
+
+      const amountBaseUnits = parseRecipientAmount(recipient.amount, params.decimals);
+      return {
+        index,
+        externalId: recipient.externalId ?? null,
+        counterpartyId: recipient.counterpartyId,
+        counterpartyAccountId: recipient.counterpartyAccountId,
+        destinationAddress: readCryptoWalletAddress(account, index),
+        amount: formatDecimalAmount(amountBaseUnits, params.decimals),
+        amountBaseUnits,
+      };
+    })
+  );
+}
+
+async function resolveBatchRequest(
+  c: AppContext,
+  input: CreateTransferBatchInput,
+  requiredWalletPermissions: Parameters<typeof assertApiKeyWalletAccess>[2]
+): Promise<ResolvedBatchRequest> {
+  const projectId = requireProjectId(c);
+  const scope = await resolveScope(c);
+  assertPaymentProjectScope(input.projectId, scope.auth.projectId);
+
+  const sourceWallet = resolveWallet(scope.wallets, input.source);
+  assertApiKeyWalletAccess(scope.auth, sourceWallet.walletId, requiredWalletPermissions ?? []);
+
+  const sourceAddress = assertValidAddress(sourceWallet.publicKey, "source");
+  const token = normalizePaymentToken(input.token);
+  const rpc = solanaRpc.createRpc(c.env);
+  const tokenContext = await resolveTokenContext(rpc, token, sourceAddress);
+  const recipients = await resolveRecipients({
+    c,
+    organizationId: scope.auth.organizationId,
+    projectId,
+    recipients: input.recipients,
+    decimals: tokenContext.decimals,
+  });
+  const totalAmountBaseUnits = recipients.reduce(
+    (total, recipient) => total + recipient.amountBaseUnits,
+    0n
+  );
+
+  return {
+    scope,
+    projectId,
+    sourceWallet,
+    sourceAddress,
+    tokenContext,
+    recipients,
+    totalAmount: formatDecimalAmount(totalAmountBaseUnits, tokenContext.decimals),
+    totalAmountBaseUnits,
+    rpc,
+  };
+}
+
+async function buildInstructionGroups(params: {
+  rpc: Rpc;
+  tokenContext: TokenContext;
+  recipients: ResolvedRecipient[];
+  sourceSigner: TransactionSigner;
+  feePayer: Address;
+}): Promise<RecipientInstructionGroup[]> {
+  if (params.tokenContext.kind === "sol") {
+    return params.recipients.map((recipient) => ({
+      ...recipient,
+      instructions: [
+        getTransferSolInstruction({
+          source: params.sourceSigner,
+          destination: recipient.destinationAddress,
+          amount: recipient.amountBaseUnits,
+        }),
+      ],
+    }));
+  }
+
+  const tokenContext = params.tokenContext;
+  const feePayerSigner = createNoopSigner(params.feePayer);
+  return Promise.all(
+    params.recipients.map(async (recipient) => {
+      const [destinationTokenAccount] = await findAssociatedTokenPda({
+        owner: recipient.destinationAddress,
+        tokenProgram: tokenContext.tokenProgram,
+        mint: tokenContext.mintAddress,
+      });
+      const createDestinationAtaInstruction = getCreateAssociatedTokenIdempotentInstruction({
+        payer: feePayerSigner,
+        ata: destinationTokenAccount,
+        owner: recipient.destinationAddress,
+        mint: tokenContext.mintAddress,
+        tokenProgram: tokenContext.tokenProgram,
+      });
+      const transferInstruction = getTransferCheckedInstruction(
+        {
+          source: tokenContext.sourceTokenAccount,
+          mint: tokenContext.mintAddress,
+          destination: destinationTokenAccount,
+          authority: params.sourceSigner,
+          amount: recipient.amountBaseUnits,
+          decimals: tokenContext.decimals,
+        },
+        { programAddress: tokenContext.tokenProgram }
+      );
+
+      return {
+        ...recipient,
+        destinationTokenAccount,
+        instructions: [createDestinationAtaInstruction, transferInstruction],
+      };
+    })
+  );
+}
+
+function buildBatchTransactionMessage(params: {
+  instructions: Instruction[];
+  sourceSigner: TransactionSigner;
+  feePayer: Address;
+  lifetime: RecentBlockhash;
+}) {
+  return pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(params.feePayer, m),
+    (m) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        {
+          blockhash: params.lifetime.blockhash,
+          lastValidBlockHeight: params.lifetime.lastValidBlockHeight,
+        },
+        m
+      ),
+    (m) => appendTransactionMessageInstructions(params.instructions, m),
+    (m) => addSignersToTransactionMessage([params.sourceSigner], m)
+  );
+}
+
+function buildCandidateChunk(
+  groups: RecipientInstructionGroup[],
+  params: {
+    sourceSigner: TransactionSigner;
+    feePayer: Address;
+    lifetime: RecentBlockhash;
+  }
+): TransactionChunk {
+  const instructions = groups.flatMap((group) => group.instructions);
+  return {
+    recipientIndexes: groups.map((group) => group.index),
+    instructions,
+    message: buildBatchTransactionMessage({
+      instructions,
+      sourceSigner: params.sourceSigner,
+      feePayer: params.feePayer,
+      lifetime: params.lifetime,
+    }),
+    amountBaseUnits: groups.reduce((total, group) => total + group.amountBaseUnits, 0n),
+  };
+}
+
+function assertTransactionFits(chunk: TransactionChunk): void {
+  const transaction = compileTransaction(chunk.message);
+  if (isTransactionWithinSizeLimit(transaction)) {
+    return;
+  }
+
+  throw badRequest("A batch transaction exceeds Solana transaction size limits", {
+    transactionSize: getTransactionSize(transaction),
+    transactionSizeLimit: getTransactionSizeLimit(transaction),
+    recipientCount: chunk.recipientIndexes.length,
+  });
+}
+
+function chunkInstructionGroups(params: {
+  groups: RecipientInstructionGroup[];
+  sourceSigner: TransactionSigner;
+  feePayer: Address;
+  lifetime: RecentBlockhash;
+  maxRecipientsPerTransaction: number;
+}): TransactionChunk[] {
+  const chunks: TransactionChunk[] = [];
+  let pending: RecipientInstructionGroup[] = [];
+
+  const flush = () => {
+    if (pending.length === 0) {
+      return;
+    }
+    const chunk = buildCandidateChunk(pending, params);
+    assertTransactionFits(chunk);
+    chunks.push(chunk);
+    pending = [];
+  };
+
+  for (const group of params.groups) {
+    if (pending.length >= params.maxRecipientsPerTransaction) {
+      flush();
+    }
+
+    const candidateGroups = [...pending, group];
+    const candidate = buildCandidateChunk(candidateGroups, params);
+    if (isTransactionWithinSizeLimit(compileTransaction(candidate.message))) {
+      pending = candidateGroups;
+      continue;
+    }
+
+    flush();
+    pending = [group];
+    assertTransactionFits(buildCandidateChunk(pending, params));
+  }
+
+  flush();
+  return chunks;
+}
+
+async function estimateNetworkFeeLamports(rpc: Rpc, chunks: TransactionChunk[]): Promise<bigint> {
+  const fees = await Promise.all(
+    chunks.map(async (chunk) => {
+      const { messageBytes } = compileTransaction(chunk.message);
+      const message = Buffer.from(messageBytes).toString("base64") as TransactionMessageBytesBase64;
+      const { value } = await rpc.getFeeForMessage(message, { commitment: "confirmed" }).send();
+      if (value === null) {
+        throw new AppError("ESTIMATE_NOT_AVAILABLE", "Unable to estimate Solana transaction fees");
+      }
+      return value;
+    })
+  );
+
+  return fees.reduce((total, fee) => total + fee, 0n);
+}
+
+async function estimateMissingAtaRentLamports(
+  rpc: Rpc,
+  groups: RecipientInstructionGroup[],
+  tokenContext: TokenContext
+): Promise<bigint> {
+  if (tokenContext.kind === "sol") {
+    return 0n;
+  }
+
+  const [rentLamports, existence] = await Promise.all([
+    solanaRpc.getMinimumBalanceForRentExemption(rpc, getTokenSize()),
+    Promise.all(
+      groups.map((group) =>
+        group.destinationTokenAccount
+          ? solanaRpc.accountExists(rpc, group.destinationTokenAccount)
+          : Promise.resolve(true)
+      )
+    ),
+  ]);
+
+  const missing = existence.filter((exists) => !exists).length;
+  return rentLamports * BigInt(missing);
+}
+
+async function enforceBatchPolicies(
+  c: AppContext,
+  resolved: ResolvedBatchRequest,
+  input: CreateTransferBatchInput
+): Promise<void> {
+  const enforcement = await enforceWalletOperationPolicy(c.env, {
+    organizationId: resolved.scope.auth.organizationId,
+    projectId: resolved.scope.auth.projectId,
+    custodyWalletId: resolved.sourceWallet.id,
+    walletId: resolved.sourceWallet.walletId,
+    apiKeyId: resolved.scope.auth.apiKeyId,
+    actor: walletOperationActorFromAuth(resolved.scope.auth),
+    operationFamily: "payment",
+    operationType: "payment_transfer_batch_execute",
+    asset: resolved.tokenContext.token,
+    amount: resolved.totalAmount,
+    destination: null,
+    context: {
+      sourceAddress: resolved.sourceAddress,
+      recipientCount: resolved.recipients.length,
+      transactionCount: null,
+    },
+    rawPayload: {
+      externalId: input.externalId ?? null,
+      source: input.source,
+      token: input.token,
+      recipients: input.recipients.map((recipient) => ({
+        externalId: recipient.externalId ?? null,
+        counterpartyId: recipient.counterpartyId,
+        counterpartyAccountId: recipient.counterpartyAccountId,
+        amount: recipient.amount,
+      })),
+      options: input.options ?? null,
+    },
+  });
+
+  try {
+    for (const recipient of resolved.recipients) {
+      await assertWalletPolicyAllowsTransfer(c, {
+        organizationId: resolved.scope.auth.organizationId,
+        projectId: resolved.projectId,
+        wallet: resolved.sourceWallet,
+        destinationAddress: recipient.destinationAddress,
+        enforceDailyLimit: false,
+        token: resolved.tokenContext.token,
+        amount: recipient.amount,
+      });
+    }
+
+    await assertWalletPolicyAllowsTransfer(c, {
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      wallet: resolved.sourceWallet,
+      destinationAddress: null,
+      enforceDestinationAllowlist: false,
+      token: resolved.tokenContext.token,
+      amount: resolved.totalAmount,
+    });
+  } catch (error) {
+    await recordLegacyWalletPolicyDenial(c.env, enforcement, error);
+    throw error;
+  }
+}
+
+async function updateTransferRecord(
+  c: AppContext,
+  params: {
+    transferId: string;
+    organizationId: string;
+    projectId: string;
+    status: PaymentTransferStatus;
+    signature?: string | null;
+    serializedTx?: string | null;
+    slot?: number | null;
+    blockTime?: string | null;
+    fee?: number | null;
+    error?: string | null;
+  }
+): Promise<PaymentTransferRow> {
+  const updated = await getPaymentsRepository(c).updateTransfer({
+    transferId: params.transferId,
+    organizationId: params.organizationId,
+    projectId: params.projectId,
+    status: params.status,
+    signature: params.signature,
+    serializedTx: params.serializedTx,
+    slot: params.slot,
+    blockTime: params.blockTime,
+    fee: params.fee,
+    error: params.error,
+    updatedAt: new Date().toISOString(),
+  });
+
+  if (!updated) {
+    throw new AppError("INTERNAL_ERROR", "Payment transfer record not found for update");
+  }
+
+  return updated;
+}
+
+async function updateRecipientRows(
+  c: AppContext,
+  params: {
+    recipientsByIndex: Map<number, PaymentTransferRecipientRow>;
+    recipientIndexes: number[];
+    organizationId: string;
+    projectId: string;
+    transferId?: string | null;
+    status: PaymentTransferRecipientRow["status"];
+    error?: string | null;
+  }
+): Promise<PaymentTransferRecipientRow[]> {
+  const targets = params.recipientIndexes.map((index) => {
+    const existing = params.recipientsByIndex.get(index);
+    if (!existing) {
+      throw new AppError("INTERNAL_ERROR", "Transfer batch recipient row is missing");
+    }
+    return { index, id: existing.id };
+  });
+
+  const updatedRows = await getPaymentTransferBatchesRepository(c).updateTransferRecipientsStatus({
+    recipientIds: targets.map((target) => target.id),
+    organizationId: params.organizationId,
+    projectId: params.projectId,
+    transferId: params.transferId ?? null,
+    status: params.status,
+    error: params.error ?? null,
+  });
+
+  const updatedById = new Map(updatedRows.map((row) => [row.id, row]));
+  for (const target of targets) {
+    const updated = updatedById.get(target.id);
+    if (!updated) {
+      throw new AppError("INTERNAL_ERROR", "Transfer batch recipient row not found for update");
+    }
+    params.recipientsByIndex.set(target.index, updated);
+  }
+
+  return updatedRows;
+}
+
+async function executeChunk(params: {
+  c: AppContext;
+  resolved: ResolvedBatchRequest;
+  chunk: TransactionChunk;
+  recipientsByIndex: Map<number, PaymentTransferRecipientRow>;
+  feePayment: ReturnType<typeof getFeePayment>;
+  preflight: boolean;
+}): Promise<PaymentTransferRow> {
+  const { c, resolved, chunk } = params;
+  const partiallySigned = await partiallySignTransactionMessageWithSigners(chunk.message);
+  const serializedTx = getBase64EncodedWireTransaction(partiallySigned);
+  const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
+  const recipientRows = chunk.recipientIndexes.map((index) => params.recipientsByIndex.get(index));
+  if (recipientRows.some((row) => !row)) {
+    throw new AppError("INTERNAL_ERROR", "Transfer batch recipient row is missing");
+  }
+
+  const firstRecipient = recipientRows[0] as PaymentTransferRecipientRow;
+  const transfer = await getPaymentsRepository(c).createTransfer({
+    organizationId: resolved.scope.auth.organizationId,
+    projectId: resolved.projectId,
+    walletId: resolved.sourceWallet.walletId,
+    counterpartyId: recipientRows.length === 1 ? firstRecipient.counterparty_id : null,
+    sourceAddress: resolved.sourceAddress,
+    destinationAddress: recipientRows.length === 1 ? firstRecipient.destination_address : null,
+    token: resolved.tokenContext.token,
+    amount: formatDecimalAmount(chunk.amountBaseUnits, resolved.tokenContext.decimals),
+    memo: null,
+    type: "transfer_batch",
+    direction: "outbound",
+    status: "processing",
+    provider: null,
+    providerReference: null,
+    deliveryMode: null,
+    fiatCurrency: null,
+    fiatAmount: null,
+    providerData: {
+      batchRecipientCount: recipientRows.length,
+      recipientIds: recipientRows.map((row) => row?.id).filter(Boolean),
+    },
+    serializedTx,
+    signature: null,
+    slot: null,
+    initiatedByKeyId: resolved.scope.auth.id,
+  });
+
+  if (!transfer) {
+    throw new AppError("INTERNAL_ERROR", "Failed to create payment transfer record");
+  }
+
+  await updateRecipientRows(c, {
+    recipientsByIndex: params.recipientsByIndex,
+    recipientIndexes: chunk.recipientIndexes,
+    organizationId: resolved.scope.auth.organizationId,
+    projectId: resolved.projectId,
+    transferId: transfer.id,
+    status: "processing",
+    error: null,
+  });
+
+  try {
+    if (params.preflight) {
+      const simulated = await solanaRpc.simulateTransaction(resolved.rpc, txBytes);
+      if (!simulated.success) {
+        throw new AppError(
+          "TRANSACTION_FAILED",
+          `Batch transfer preflight failed: ${simulated.error ?? "unknown simulation error"}`,
+          { logs: simulated.logs }
+        );
+      }
+    }
+
+    const signature = await params.feePayment.signAndSend(txBytes);
+    const confirmation = await solanaRpc.confirmTransaction(resolved.rpc, signature, {
+      commitment: "confirmed",
+    });
+
+    if (confirmation.err) {
+      throw new AppError("TRANSACTION_FAILED", "Batch transfer failed on-chain");
+    }
+
+    await updateRecipientRows(c, {
+      recipientsByIndex: params.recipientsByIndex,
+      recipientIndexes: chunk.recipientIndexes,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      transferId: transfer.id,
+      status: "confirmed",
+      error: null,
+    });
+
+    return updateTransferRecord(c, {
+      transferId: transfer.id,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      status: "confirmed",
+      signature,
+      serializedTx,
+      slot: Number(confirmation.slot),
+      blockTime: null,
+      error: null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await updateRecipientRows(c, {
+      recipientsByIndex: params.recipientsByIndex,
+      recipientIndexes: chunk.recipientIndexes,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      transferId: transfer.id,
+      status: "failed",
+      error: message,
+    });
+    return updateTransferRecord(c, {
+      transferId: transfer.id,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      status: "failed",
+      serializedTx,
+      error: message,
+    });
+  }
+}
+
+function finalBatchStatus(transfers: PaymentTransferRow[]): PaymentTransferBatchRow["status"] {
+  const confirmed = transfers.filter((transfer) => transfer.status === "confirmed").length;
+  if (confirmed === transfers.length) {
+    return "confirmed";
+  }
+  return confirmed === 0 ? "failed" : "partially_failed";
 }
 
 export async function estimateTransferBatch(c: AppContext) {
@@ -25,8 +791,45 @@ export async function estimateTransferBatch(c: AppContext) {
     });
   }
 
-  // TODO: resolve recipients, chunk transactions, and return fee/completion estimates.
-  todo("estimate");
+  const resolved = await resolveBatchRequest(c, parsed.data, ["payments:read"]);
+  const feePayment = getFeePayment(c);
+  const sourceSigner = createNoopSigner(resolved.sourceAddress);
+  const [feePayer, lifetime] = await Promise.all([
+    feePayment.getFeePayer(),
+    solanaRpc.getRecentBlockhash(resolved.rpc, "confirmed"),
+  ]);
+  const groups = await buildInstructionGroups({
+    rpc: resolved.rpc,
+    tokenContext: resolved.tokenContext,
+    recipients: resolved.recipients,
+    sourceSigner,
+    feePayer,
+  });
+  const chunks = chunkInstructionGroups({
+    groups,
+    sourceSigner,
+    feePayer,
+    lifetime,
+    maxRecipientsPerTransaction:
+      parsed.data.options?.maxRecipientsPerTransaction ?? DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION,
+  });
+  const [networkFeeLamports, tokenAccountRentLamports] = await Promise.all([
+    estimateNetworkFeeLamports(resolved.rpc, chunks),
+    estimateMissingAtaRentLamports(resolved.rpc, groups, resolved.tokenContext),
+  ]);
+
+  return success(c, {
+    estimate: {
+      recipientCount: resolved.recipients.length,
+      transactionCount: chunks.length,
+      estimatedFees: {
+        networkFeeLamports: networkFeeLamports.toString(),
+        priorityFeeLamports: "0",
+        tokenAccountRentLamports: tokenAccountRentLamports.toString(),
+        sponsored: true,
+      },
+    },
+  });
 }
 
 export async function createTransferBatch(c: AppContext) {
@@ -39,8 +842,105 @@ export async function createTransferBatch(c: AppContext) {
     });
   }
 
-  // TODO: create batch/recipient rows, build chunked transactions, custody-sign, submit, and confirm.
-  todo("create");
+  const resolved = await resolveBatchRequest(c, parsed.data, ["payments:write"]);
+  await enforceBatchPolicies(c, resolved, parsed.data);
+
+  const feePayment = getFeePayment(c);
+  const [signer, feePayer, lifetime] = await Promise.all([
+    solanaServices.createOrgSigner(
+      c.env,
+      resolved.scope.auth.organizationId,
+      resolved.projectId,
+      resolved.sourceWallet.walletId
+    ),
+    feePayment.getFeePayer(),
+    solanaRpc.getRecentBlockhash(resolved.rpc, "confirmed"),
+  ]);
+  if (signer.address !== resolved.sourceWallet.publicKey) {
+    throw badRequest("Resolved signing wallet does not match source wallet");
+  }
+  const groups = await buildInstructionGroups({
+    rpc: resolved.rpc,
+    tokenContext: resolved.tokenContext,
+    recipients: resolved.recipients,
+    sourceSigner: signer,
+    feePayer,
+  });
+  const chunks = chunkInstructionGroups({
+    groups,
+    sourceSigner: signer,
+    feePayer,
+    lifetime,
+    maxRecipientsPerTransaction:
+      parsed.data.options?.maxRecipientsPerTransaction ?? DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION,
+  });
+
+  const batchRepository = getPaymentTransferBatchesRepository(c);
+  const batch = await batchRepository.createTransferBatch({
+    organizationId: resolved.scope.auth.organizationId,
+    projectId: resolved.projectId,
+    externalId: parsed.data.externalId ?? null,
+    sourceWalletId: resolved.sourceWallet.walletId,
+    sourceAddress: resolved.sourceAddress,
+    token: resolved.tokenContext.token,
+    status: "processing",
+    totalAmount: resolved.totalAmount,
+    recipientCount: resolved.recipients.length,
+    transactionCount: chunks.length,
+    options: parsed.data.options ?? {},
+    initiatedByKeyId: resolved.scope.auth.id,
+  });
+  const recipientRows = await batchRepository.createTransferRecipients(
+    resolved.recipients.map((recipient) => ({
+      batchId: batch.id,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      externalId: recipient.externalId,
+      counterpartyId: recipient.counterpartyId,
+      counterpartyAccountId: recipient.counterpartyAccountId,
+      destinationAddress: recipient.destinationAddress,
+      amount: recipient.amount,
+      status: "pending",
+      error: null,
+    }))
+  );
+  const recipientsByIndex = new Map<number, PaymentTransferRecipientRow>(
+    resolved.recipients.map((recipient, position) => [recipient.index, recipientRows[position]])
+  );
+
+  const transfers: PaymentTransferRow[] = [];
+  for (const chunk of chunks) {
+    const transfer = await executeChunk({
+      c,
+      resolved,
+      chunk,
+      recipientsByIndex,
+      feePayment,
+      preflight: parsed.data.options?.preflight !== false,
+    });
+    transfers.push(transfer);
+  }
+
+  const status = finalBatchStatus(transfers);
+  const finalBatch =
+    (await batchRepository.updateTransferBatch({
+      batchId: batch.id,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      status,
+      error:
+        status === "confirmed"
+          ? null
+          : "One or more transfer batch transactions failed during execution",
+    })) ?? batch;
+
+  return success(c, {
+    batch: mapBatchRow(finalBatch),
+    recipients: Array.from(recipientsByIndex.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([, row]) => mapRecipientRow(row)),
+    transfers: transfers.map(mapTransferRow),
+  });
 }
 
 export async function listTransferBatches(c: AppContext) {
@@ -51,8 +951,33 @@ export async function listTransferBatches(c: AppContext) {
     });
   }
 
-  // TODO: list transfer batches for the authenticated org/project scope.
-  todo("list");
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  if (query.data.wallet) {
+    assertApiKeyWalletAccess(auth, query.data.wallet, ["payments:read"]);
+  }
+  const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
+  const result = await getPaymentTransferBatchesRepository(c).listTransferBatches({
+    organizationId: auth.organizationId,
+    projectId,
+    walletId: query.data.wallet,
+    walletIds: query.data.wallet ? undefined : (allowedWalletIds ?? undefined),
+    token: query.data.token ? normalizePaymentToken(query.data.token) : undefined,
+    status: query.data.status,
+    externalId: query.data.externalId,
+    limit: query.data.pageSize,
+    offset: (query.data.page - 1) * query.data.pageSize,
+  });
+
+  return paginated(
+    c,
+    result.rows.map((row) => mapBatchRow(row)),
+    {
+      total: result.total,
+      page: query.data.page,
+      pageSize: query.data.pageSize,
+    }
+  );
 }
 
 export async function getTransferBatch(c: AppContext) {
@@ -63,6 +988,53 @@ export async function getTransferBatch(c: AppContext) {
     });
   }
 
-  // TODO: load a transfer batch with its recipient rows and chunk transfer summaries.
-  todo("get");
+  const auth = getAuth(c);
+  const projectId = requireProjectId(c);
+  const batchRepository = getPaymentTransferBatchesRepository(c);
+  const batch = await batchRepository.getTransferBatchById({
+    batchId: params.data.batchId,
+    organizationId: auth.organizationId,
+    projectId,
+  });
+
+  if (!batch) {
+    throw notFound("Transfer batch");
+  }
+
+  const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
+  if (allowedWalletIds && !allowedWalletIds.includes(batch.source_wallet_id)) {
+    throw new AppError("FORBIDDEN", "API key is not authorized for the requested wallet");
+  }
+
+  const recipients = await batchRepository.listTransferRecipientsByBatch({
+    batchId: batch.id,
+    organizationId: auth.organizationId,
+    projectId,
+    limit: 500,
+    offset: 0,
+  });
+  const transferIds = Array.from(
+    new Set(
+      recipients.rows
+        .map((recipient) => recipient.transfer_id)
+        .filter((transferId): transferId is string => Boolean(transferId))
+    )
+  );
+  const transferRows = await Promise.all(
+    transferIds.map((transferId) =>
+      getPaymentsRepository(c).getTransferById({
+        transferId,
+        organizationId: auth.organizationId,
+        projectId,
+      })
+    )
+  );
+
+  return success(c, {
+    batch: mapBatchRow(batch),
+    recipients: recipients.rows.map(mapRecipientRow),
+    transfers: transferRows
+      .filter((row): row is PaymentTransferRow => Boolean(row))
+      .map(mapTransferRow),
+  });
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches.ts
@@ -40,7 +40,16 @@ import type {
 } from "@/db/repositories/payments.repository";
 import { AmountError, formatDecimalAmount, parseDecimalAmount } from "@/lib/amount";
 import { getAuth, requireProjectId } from "@/lib/auth";
-import { AppError, badRequest, badRequestParams, badRequestQuery, notFound } from "@/lib/errors";
+import {
+  badRequest,
+  badRequestParams,
+  badRequestQuery,
+  estimateNotAvailable,
+  forbidden,
+  internalError,
+  notFound,
+  transactionFailed,
+} from "@/lib/errors";
 import { paginated, success } from "@/lib/response";
 import { assertValidAddress } from "@/lib/solana";
 import {
@@ -475,7 +484,7 @@ async function estimateNetworkFeeLamports(rpc: Rpc, chunks: TransactionChunk[]):
       const message = Buffer.from(messageBytes).toString("base64") as TransactionMessageBytesBase64;
       const { value } = await rpc.getFeeForMessage(message, { commitment: "confirmed" }).send();
       if (value === null) {
-        throw new AppError("ESTIMATE_NOT_AVAILABLE", "Unable to estimate Solana transaction fees");
+        throw estimateNotAvailable("Unable to estimate Solana transaction fees");
       }
       return value;
     })
@@ -602,7 +611,7 @@ async function updateTransferRecord(
   });
 
   if (!updated) {
-    throw new AppError("INTERNAL_ERROR", "Payment transfer record not found for update");
+    throw internalError("Payment transfer record not found for update");
   }
 
   return updated;
@@ -623,7 +632,7 @@ async function updateRecipientRows(
   const targets = params.recipientIndexes.map((index) => {
     const existing = params.recipientsByIndex.get(index);
     if (!existing) {
-      throw new AppError("INTERNAL_ERROR", "Transfer batch recipient row is missing");
+      throw internalError("Transfer batch recipient row is missing");
     }
     return { index, id: existing.id };
   });
@@ -641,7 +650,7 @@ async function updateRecipientRows(
   for (const target of targets) {
     const updated = updatedById.get(target.id);
     if (!updated) {
-      throw new AppError("INTERNAL_ERROR", "Transfer batch recipient row not found for update");
+      throw internalError("Transfer batch recipient row not found for update");
     }
     params.recipientsByIndex.set(target.index, updated);
   }
@@ -658,12 +667,17 @@ async function executeChunk(params: {
   preflight: boolean;
 }): Promise<PaymentTransferRow> {
   const { c, resolved, chunk } = params;
-  const partiallySigned = await partiallySignTransactionMessageWithSigners(chunk.message);
+  const lifetime = await solanaRpc.getRecentBlockhash(resolved.rpc, "confirmed");
+  const message = setTransactionMessageLifetimeUsingBlockhash(
+    { blockhash: lifetime.blockhash, lastValidBlockHeight: lifetime.lastValidBlockHeight },
+    chunk.message
+  );
+  const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
   const serializedTx = getBase64EncodedWireTransaction(partiallySigned);
   const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
   const recipientRows = chunk.recipientIndexes.map((index) => params.recipientsByIndex.get(index));
   if (recipientRows.some((row) => !row)) {
-    throw new AppError("INTERNAL_ERROR", "Transfer batch recipient row is missing");
+    throw internalError("Transfer batch recipient row is missing");
   }
 
   const firstRecipient = recipientRows[0] as PaymentTransferRecipientRow;
@@ -696,7 +710,7 @@ async function executeChunk(params: {
   });
 
   if (!transfer) {
-    throw new AppError("INTERNAL_ERROR", "Failed to create payment transfer record");
+    throw internalError("Failed to create payment transfer record");
   }
 
   await updateRecipientRows(c, {
@@ -709,71 +723,94 @@ async function executeChunk(params: {
     error: null,
   });
 
+  const settle = async (params2: {
+    status: PaymentTransferStatus;
+    recipientStatus: PaymentTransferRecipientRow["status"];
+    signature?: string | null;
+    slot?: number | null;
+    error: string | null;
+  }): Promise<PaymentTransferRow> => {
+    await updateRecipientRows(c, {
+      recipientsByIndex: params.recipientsByIndex,
+      recipientIndexes: chunk.recipientIndexes,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      transferId: transfer.id,
+      status: params2.recipientStatus,
+      error: params2.error,
+    });
+    return updateTransferRecord(c, {
+      transferId: transfer.id,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      status: params2.status,
+      signature: params2.signature,
+      serializedTx,
+      slot: params2.slot,
+      blockTime: null,
+      error: params2.error,
+    });
+  };
+
+  // Build/sign/submit: any failure here means nothing reached the chain → failed.
+  let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
   try {
     if (params.preflight) {
       const simulated = await solanaRpc.simulateTransaction(resolved.rpc, txBytes);
       if (!simulated.success) {
-        throw new AppError(
-          "TRANSACTION_FAILED",
+        throw transactionFailed(
           `Batch transfer preflight failed: ${simulated.error ?? "unknown simulation error"}`,
           { logs: simulated.logs }
         );
       }
     }
-
-    const signature = await params.feePayment.signAndSend(txBytes);
-    const confirmation = await solanaRpc.confirmTransaction(resolved.rpc, signature, {
-      commitment: "confirmed",
-    });
-
-    if (confirmation.err) {
-      throw new AppError("TRANSACTION_FAILED", "Batch transfer failed on-chain");
-    }
-
-    await updateRecipientRows(c, {
-      recipientsByIndex: params.recipientsByIndex,
-      recipientIndexes: chunk.recipientIndexes,
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.projectId,
-      transferId: transfer.id,
-      status: "confirmed",
-      error: null,
-    });
-
-    return updateTransferRecord(c, {
-      transferId: transfer.id,
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.projectId,
-      status: "confirmed",
-      signature,
-      serializedTx,
-      slot: Number(confirmation.slot),
-      blockTime: null,
-      error: null,
-    });
+    signature = await params.feePayment.signAndSend(txBytes);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    await updateRecipientRows(c, {
-      recipientsByIndex: params.recipientsByIndex,
-      recipientIndexes: chunk.recipientIndexes,
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.projectId,
-      transferId: transfer.id,
+    return settle({
       status: "failed",
-      error: message,
-    });
-    return updateTransferRecord(c, {
-      transferId: transfer.id,
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.projectId,
-      status: "failed",
-      serializedTx,
-      error: message,
+      recipientStatus: "failed",
+      error: error instanceof Error ? error.message : String(error),
     });
   }
+
+  // Submitted: a confirmation timeout is inconclusive (the tx may still land), so keep the
+  // signature and leave it processing for reconciliation — only a definitive on-chain error fails.
+  let confirmation: Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>;
+  try {
+    confirmation = await solanaRpc.confirmTransaction(resolved.rpc, signature, {
+      commitment: "confirmed",
+    });
+  } catch (error) {
+    return settle({
+      status: "processing",
+      recipientStatus: "processing",
+      signature,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  if (confirmation.err) {
+    return settle({
+      status: "failed",
+      recipientStatus: "failed",
+      signature,
+      error: "Batch transfer failed on-chain",
+    });
+  }
+
+  return settle({
+    status: "confirmed",
+    recipientStatus: "confirmed",
+    signature,
+    slot: Number(confirmation.slot),
+    error: null,
+  });
 }
 
 function finalBatchStatus(transfers: PaymentTransferRow[]): PaymentTransferBatchRow["status"] {
+  if (transfers.some((transfer) => transfer.status === "processing")) {
+    return "processing";
+  }
   const confirmed = transfers.filter((transfer) => transfer.status === "confirmed").length;
   if (confirmed === transfers.length) {
     return "confirmed";
@@ -929,9 +966,9 @@ export async function createTransferBatch(c: AppContext) {
       projectId: resolved.projectId,
       status,
       error:
-        status === "confirmed"
-          ? null
-          : "One or more transfer batch transactions failed during execution",
+        status === "failed" || status === "partially_failed"
+          ? "One or more transfer batch transactions failed during execution"
+          : null,
     })) ?? batch;
 
   return success(c, {
@@ -1003,7 +1040,7 @@ export async function getTransferBatch(c: AppContext) {
 
   const allowedWalletIds = getAllowedApiKeyWalletIds(auth);
   if (allowedWalletIds && !allowedWalletIds.includes(batch.source_wallet_id)) {
-    throw new AppError("FORBIDDEN", "API key is not authorized for the requested wallet");
+    throw forbidden("API key is not authorized for the requested wallet");
   }
 
   const recipients = await batchRepository.listTransferRecipientsByBatch({

--- a/apps/sdp-api/src/routes/payments/policy.ts
+++ b/apps/sdp-api/src/routes/payments/policy.ts
@@ -24,6 +24,7 @@ export async function assertWalletPolicyAllowsTransfer(
     wallet: CustodyWallet;
     destinationAddress?: string | null;
     enforceDestinationAllowlist?: boolean;
+    enforceDailyLimit?: boolean;
     token: string;
     amount: string;
   }

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -1,0 +1,633 @@
+import { type CachedApiKey, SPL_TOKEN_PROGRAMS } from "@sdp/types";
+import { address, createNoopSigner, generateKeyPairSigner } from "@solana/kit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import app from "@/index";
+import { hashString } from "@/lib/hash";
+import * as feePaymentAdapters from "@/services/adapters/fee-payment";
+import * as solanaServices from "@/services/solana";
+import * as solanaRpc from "@/services/solana/rpc";
+import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
+import { clearKVNamespaces, seedCachedApiKey } from "@/test/mocks/kv";
+
+const createRpcMock = vi.spyOn(solanaRpc, "createRpc");
+const getAccountInfoMock = vi.spyOn(solanaRpc, "getAccountInfo");
+const getRecentBlockhashMock = vi.spyOn(solanaRpc, "getRecentBlockhash");
+const confirmTransactionMock = vi.spyOn(solanaRpc, "confirmTransaction");
+const createFeePaymentAdapterMock = vi.spyOn(feePaymentAdapters, "createFeePaymentAdapter");
+const createOrgSignerMock = vi.spyOn(solanaServices, "createOrgSigner");
+
+const TEST_CONFIG_ID = "cust_cfg_batch_payments_test";
+const TEST_CUSTODY_WALLET_ID = "cwlt_batch_payments_test";
+const TEST_WALLET_ID = "wal_batch_payments_test";
+const TEST_ORG = {
+  id: "org_batch_payments_test",
+  name: "Batch Payments Test Org",
+  slug: "batch-payments-test-org",
+};
+const TEST_PROJECT = {
+  id: "prj_batch_payments_test",
+  slug: "batch-payments-test-project",
+};
+const TEST_USER = {
+  id: "usr_batch_payments_test",
+  email: "batch-payments-test@example.com",
+};
+const TEST_API_KEY = {
+  id: "key_batch_payments_test",
+  raw: "sk_test_batch_payments",
+  prefix: "sk_test_bat",
+};
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT.id,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+const TEST_KORA_FEE_PAYER = "4YhMUz8xDgHMPAevvfMpnJX9TJmw9DTNDA1sNWPRZG9q";
+const FIRST_SIGNATURE =
+  "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy";
+const SECOND_SIGNATURE =
+  "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV";
+const TEST_TOKEN_ACCOUNT = TEST_SOLANA_ADDRESSES.wallet3;
+
+function mockSourceTokenAccountRpc(params: {
+  mint: string;
+  tokenAccount: string;
+  decimals: number;
+}) {
+  createRpcMock.mockReturnValue({
+    getTokenAccountsByOwner: () => ({
+      send: async () => ({
+        value: [
+          {
+            pubkey: params.tokenAccount,
+            account: {
+              data: {
+                parsed: {
+                  info: {
+                    mint: params.mint,
+                    tokenAmount: {
+                      amount: "1000000000",
+                      decimals: params.decimals,
+                      uiAmountString: "1000",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }),
+    }),
+  } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+}
+
+async function seedAuthAndWallet(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+  await getDb(env).batch([
+    getDb(env)
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
+    getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+      .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    getDb(env)
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_PROJECT.id,
+        TEST_ORG.id,
+        "Batch Payments Test Project",
+        TEST_PROJECT.slug,
+        "sandbox",
+        "active",
+        TEST_USER.id
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_API_KEY.id,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_USER.id,
+        "Batch Payments Test Key",
+        TEST_API_KEY.prefix,
+        keyHash,
+        "api_admin",
+        JSON.stringify(["*"]),
+        "active"
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, encryption_version, default_wallet_id, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_CONFIG_ID,
+        TEST_ORG.id,
+        null,
+        "local",
+        "test-config",
+        "sdp-custody-encryption-v1",
+        TEST_WALLET_ID,
+        "active"
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_scope_defaults
+           (id, organization_id, project_id, default_custody_config_id)
+         VALUES (?, ?, ?, ?)`
+      )
+      .bind(`csd_${TEST_CONFIG_ID}`, TEST_ORG.id, null, TEST_CONFIG_ID),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_CUSTODY_WALLET_ID,
+        TEST_CONFIG_ID,
+        TEST_WALLET_ID,
+        TEST_SOLANA_ADDRESSES.wallet1,
+        "Batch Payments Wallet",
+        "transfer",
+        "active"
+      ),
+  ]);
+}
+
+async function updateSeededWalletPublicKey(publicKey: string): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE custody_wallets SET public_key = ? WHERE wallet_id = ?")
+    .bind(publicKey, TEST_WALLET_ID)
+    .run();
+}
+
+async function seedCounterparty(externalId: string): Promise<string> {
+  const id = `counterparty_${crypto.randomUUID()}`;
+  await getDb(env)
+    .prepare(
+      `INSERT INTO counterparties (
+         id,
+         organization_id,
+         project_id,
+         external_id,
+         entity_type,
+         display_name,
+         email,
+         identity,
+         provider_data,
+         status,
+         created_by
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)`
+    )
+    .bind(
+      id,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      externalId,
+      "individual",
+      "Batch Test Counterparty",
+      "batch-counterparty@example.com",
+      {},
+      {},
+      TEST_USER.id
+    )
+    .run();
+
+  return id;
+}
+
+async function seedCryptoWalletCounterpartyAccount(params: {
+  counterpartyId: string;
+  walletAddress: string;
+}): Promise<string> {
+  const id = `counterparty_account_${crypto.randomUUID()}`;
+  const now = new Date().toISOString();
+
+  await getDb(env)
+    .prepare(
+      `INSERT INTO counterparty_accounts (
+         id,
+         organization_id,
+         project_id,
+         counterparty_id,
+         account_kind,
+         label,
+         details,
+         provider_account_data,
+         status,
+         created_at,
+         updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      id,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      params.counterpartyId,
+      "crypto_wallet",
+      "Batch payment wallet",
+      JSON.stringify({ network: "solana", address: params.walletAddress }),
+      JSON.stringify({}),
+      "active",
+      now,
+      now
+    )
+    .run();
+
+  return id;
+}
+
+describe("payment transfer batches", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    createRpcMock.mockReturnValue({} as ReturnType<typeof solanaRpc.createRpc>);
+    getAccountInfoMock.mockResolvedValue({
+      lamports: 4200000000n,
+      owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    } as Awaited<ReturnType<typeof solanaRpc.getAccountInfo>>);
+    getRecentBlockhashMock.mockResolvedValue({
+      blockhash: "EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N" as Awaited<
+        ReturnType<typeof solanaRpc.getRecentBlockhash>
+      >["blockhash"],
+      lastValidBlockHeight: 1000n,
+    });
+    confirmTransactionMock.mockResolvedValue({
+      signature: FIRST_SIGNATURE as Awaited<
+        ReturnType<typeof solanaRpc.confirmTransaction>
+      >["signature"],
+      slot: 100n,
+      confirmationStatus: "confirmed",
+      err: null,
+    });
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: vi.fn().mockResolvedValue(FIRST_SIGNATURE),
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    createOrgSignerMock.mockResolvedValue(
+      createNoopSigner(address("8dHEsGLpCZHZbXnFVvqWq4kMfM2pVDuNrXvVJVhQWRGZ"))
+    );
+
+    await seedTestDatabase(env);
+    await seedAuthAndWallet();
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+    await clearKVNamespaces(env);
+  });
+
+  it("estimates a SOL transfer batch", async () => {
+    const getFeeForMessageMock = vi.fn(() => ({
+      send: async () => ({ value: 5000n }),
+    }));
+    createRpcMock.mockReturnValueOnce({
+      getFeeForMessage: getFeeForMessageMock,
+    } as unknown as ReturnType<typeof solanaRpc.createRpc>);
+
+    const counterpartyId = await seedCounterparty("batch_estimate_counterparty");
+    const firstAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const secondAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet3,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches/estimate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [
+            {
+              counterpartyId,
+              counterpartyAccountId: firstAccountId,
+              amount: "0.1",
+            },
+            {
+              counterpartyId,
+              counterpartyAccountId: secondAccountId,
+              amount: "0.2",
+            },
+          ],
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        estimate: {
+          recipientCount: number;
+          transactionCount: number;
+          estimatedFees: {
+            networkFeeLamports: string;
+            priorityFeeLamports: string;
+            tokenAccountRentLamports: string;
+            sponsored: boolean;
+          };
+        };
+      };
+    };
+    expect(body.data.estimate).toMatchObject({
+      recipientCount: 2,
+      transactionCount: 1,
+      estimatedFees: {
+        networkFeeLamports: "5000",
+        priorityFeeLamports: "0",
+        tokenAccountRentLamports: "0",
+        sponsored: true,
+      },
+    });
+    expect(getFeeForMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a SOL transfer batch and records chunk transfers", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(FIRST_SIGNATURE)
+      .mockResolvedValueOnce(SECOND_SIGNATURE);
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+
+    const counterpartyId = await seedCounterparty("batch_create_counterparty");
+    const firstAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+    const secondAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet3,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          externalId: "batch-create-001",
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [
+            {
+              externalId: "batch-recipient-001",
+              counterpartyId,
+              counterpartyAccountId: firstAccountId,
+              amount: "0.1",
+            },
+            {
+              externalId: "batch-recipient-002",
+              counterpartyId,
+              counterpartyAccountId: secondAccountId,
+              amount: "0.2",
+            },
+          ],
+          options: {
+            maxRecipientsPerTransaction: 1,
+            preflight: false,
+          },
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        batch: {
+          id: string;
+          status: string;
+          externalId: string | null;
+          totalAmount: string | null;
+          recipientCount: number;
+          transactionCount: number;
+        };
+        recipients: Array<{ status: string; transferId: string | null }>;
+        transfers: Array<{ id: string; type: string; status: string; signature: string | null }>;
+      };
+    };
+    expect(body.data.batch).toMatchObject({
+      status: "confirmed",
+      externalId: "batch-create-001",
+      totalAmount: "0.3",
+      recipientCount: 2,
+      transactionCount: 2,
+    });
+    expect(body.data.recipients).toHaveLength(2);
+    expect(body.data.recipients.every((recipient) => recipient.status === "confirmed")).toBe(true);
+    expect(body.data.recipients.every((recipient) => Boolean(recipient.transferId))).toBe(true);
+    expect(body.data.transfers).toHaveLength(2);
+    expect(body.data.transfers.map((transfer) => transfer.signature)).toEqual([
+      FIRST_SIGNATURE,
+      SECOND_SIGNATURE,
+    ]);
+    expect(body.data.transfers.every((transfer) => transfer.type === "transfer_batch")).toBe(true);
+    expect(signAndSendMock).toHaveBeenCalledTimes(2);
+
+    const batchRow = await getDb(env)
+      .prepare(
+        `SELECT status, total_amount, recipient_count, transaction_count
+           FROM payment_transfer_batches
+          WHERE id = ?`
+      )
+      .bind(body.data.batch.id)
+      .first<{
+        status: string;
+        total_amount: string | null;
+        recipient_count: number;
+        transaction_count: number;
+      }>();
+    expect(batchRow).toMatchObject({
+      status: "confirmed",
+      total_amount: "0.3",
+      recipient_count: 2,
+      transaction_count: 2,
+    });
+
+    const recipientRows = await getDb(env)
+      .prepare(
+        `SELECT status, transfer_id
+           FROM payment_transfer_recipients
+          WHERE batch_id = ?
+          ORDER BY external_id ASC`
+      )
+      .bind(body.data.batch.id)
+      .all<{ status: string; transfer_id: string | null }>();
+    expect(recipientRows.results).toHaveLength(2);
+    expect(recipientRows.results.every((recipient) => recipient.status === "confirmed")).toBe(true);
+    expect(recipientRows.results.every((recipient) => Boolean(recipient.transfer_id))).toBe(true);
+
+    const transferRows = await getDb(env)
+      .prepare(
+        `SELECT type, status, signature
+           FROM payment_transfers
+          WHERE type = 'transfer_batch'
+          ORDER BY signature ASC`
+      )
+      .all<{ type: string; status: string; signature: string | null }>();
+    expect(transferRows.results).toHaveLength(2);
+    expect(transferRows.results.every((transfer) => transfer.status === "confirmed")).toBe(true);
+
+    const detailRes = await app.request(
+      `/v1/payments/transfer-batches/${body.data.batch.id}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+    expect(detailRes.status).toBe(200);
+    const detailBody = (await detailRes.json()) as {
+      data: { recipients: unknown[]; transfers: unknown[] };
+    };
+    expect(detailBody.data.recipients).toHaveLength(2);
+    expect(detailBody.data.transfers).toHaveLength(2);
+
+    const listRes = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as { data: Array<{ id: string }> };
+    expect(listBody.data.map((batch) => batch.id)).toContain(body.data.batch.id);
+  });
+
+  it.each([
+    ["legacy SPL Token", SPL_TOKEN_PROGRAMS["spl-token"]],
+    ["Token-2022", SPL_TOKEN_PROGRAMS["token-2022"]],
+  ])("creates a %s transfer batch", async (_label, tokenProgram) => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+    getAccountInfoMock.mockResolvedValueOnce({
+      lamports: 4200000000n,
+      owner: tokenProgram,
+    } as Awaited<ReturnType<typeof solanaRpc.getAccountInfo>>);
+    mockSourceTokenAccountRpc({
+      mint: TEST_SOLANA_ADDRESSES.mint,
+      tokenAccount: TEST_TOKEN_ACCOUNT,
+      decimals: 6,
+    });
+
+    const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+
+    const counterpartyId = await seedCounterparty(`batch_token_counterparty_${tokenProgram}`);
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: TEST_SOLANA_ADDRESSES.mint,
+          recipients: [
+            {
+              counterpartyId,
+              counterpartyAccountId,
+              amount: "1.25",
+            },
+          ],
+          options: {
+            preflight: false,
+          },
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        batch: { status: string; token: string; totalAmount: string | null };
+        recipients: Array<{ status: string; destination: string }>;
+        transfers: Array<{ type: string; status: string; signature: string | null }>;
+      };
+    };
+    expect(body.data.batch).toMatchObject({
+      status: "confirmed",
+      token: TEST_SOLANA_ADDRESSES.mint,
+      totalAmount: "1.25",
+    });
+    expect(body.data.recipients).toMatchObject([
+      {
+        status: "confirmed",
+        destination: TEST_SOLANA_ADDRESSES.wallet2,
+      },
+    ]);
+    expect(body.data.transfers).toMatchObject([
+      {
+        type: "transfer_batch",
+        status: "confirmed",
+        signature: FIRST_SIGNATURE,
+      },
+    ]);
+    expect(signAndSendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -630,4 +630,118 @@ describe("payment transfer batches", () => {
     ]);
     expect(signAndSendMock).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps a chunk processing when confirmation times out (tx may still land)", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+
+    const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock.mockRejectedValueOnce(
+      new Error(`Transaction ${FIRST_SIGNATURE} confirmation timed out`)
+    );
+
+    const counterpartyId = await seedCounterparty("batch_timeout_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        batch: { status: string };
+        recipients: Array<{ status: string }>;
+        transfers: Array<{ status: string; signature: string | null }>;
+      };
+    };
+    expect(body.data.batch.status).toBe("processing");
+    expect(body.data.recipients).toMatchObject([{ status: "processing" }]);
+    expect(body.data.transfers).toMatchObject([
+      { status: "processing", signature: FIRST_SIGNATURE },
+    ]);
+    expect(signAndSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a chunk failed on a definitive on-chain error", async () => {
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+
+    const signAndSendMock = vi.fn().mockResolvedValueOnce(FIRST_SIGNATURE);
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    confirmTransactionMock.mockResolvedValueOnce({
+      signature: FIRST_SIGNATURE as Awaited<
+        ReturnType<typeof solanaRpc.confirmTransaction>
+      >["signature"],
+      slot: 100n,
+      confirmationStatus: "confirmed",
+      err: { InstructionError: [0, { Custom: 1 }] },
+    } as Awaited<ReturnType<typeof solanaRpc.confirmTransaction>>);
+
+    const counterpartyId = await seedCounterparty("batch_onchain_error_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        batch: { status: string };
+        recipients: Array<{ status: string }>;
+        transfers: Array<{ status: string }>;
+      };
+    };
+    expect(body.data.batch.status).toBe("failed");
+    expect(body.data.recipients).toMatchObject([{ status: "failed" }]);
+    expect(body.data.transfers).toMatchObject([{ status: "failed" }]);
+  });
 });

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -32,6 +32,8 @@ const POSTGRES_TEST_TABLES = [
   "payment_subscriptions",
   "payment_subscription_plans",
   "payment_requests",
+  "payment_transfer_recipients",
+  "payment_transfer_batches",
   "payment_transfers",
   "payment_wallet_policies",
   "frozen_accounts",


### PR DESCRIPTION
## Summary

Implements **batch payments** for `sdp-api` (PRO-1446, phase 8 part 2): send **SOL** or an **SPL / token-2022** token from a single SDP custody wallet to **N counterparty crypto-wallet accounts** in one API call. Recipients are size-packed into one or more **sponsored** Solana transactions, executed and confirmed server-side, with full per-recipient state tracking.

Builds on the persistence layer (table + repository scaffold) already in `main`.

## Endpoints

| Method | Path | Permissions | Purpose |
|---|---|---|---|
| `POST` | `/v1/payments/transfer-batches/estimate` | `payments:read`, `wallets:read`, `counterparties:read` | Dry-run: recipient/transaction counts + fee & rent estimate. No DB writes, no signing. |
| `POST` | `/v1/payments/transfer-batches` | `payments:write`, `wallets:read`, `counterparties:read` | Create + execute a batch. |
| `GET` | `/v1/payments/transfer-batches` | `payments:read` | List batches (wallet/token/status/externalId filters, paginated). |
| `GET` | `/v1/payments/transfer-batches/:batchId` | `payments:read` | Batch detail + recipients + per-chunk transfers. |

Request shape (`createTransferBatchSchema`): `{ source, token, recipients[1..500]{ counterpartyId, counterpartyAccountId, amount, externalId? }, externalId?, options?{ maxRecipientsPerTransaction(1..64), preflight, priorityFee } }`.

## The flow

**1. Validate & resolve (`resolveBatchRequest`)**
- Parse body; resolve auth scope; assert the input `projectId` matches the key's project.
- Resolve the `source` custody wallet and assert the API key is scoped to it.
- Resolve **token context**: `SOL` → 9 decimals; otherwise resolve the mint's token program + the source token account (and its decimals) on-chain.
- Resolve **recipients** concurrently — each recipient's counterparty + counterparty-account are fetched (org/project-scoped), the account is required to be a `crypto_wallet` with `details.network = "solana"`, and the destination address is extracted. Amounts are parsed to base units (bigint) and summed for the batch total.

**2. Policy enforcement (`enforceBatchPolicies`, create only)**
- Per recipient: destination-allowlist + per-transfer max-amount.
- Once for the aggregate: the per-transaction max-amount against the **batch total** (so it can't be split-bypassed) and the **daily limit** against the day's running outbound total. Denials are recorded via the legacy wallet-policy denial path.

**3. Build instructions (`buildInstructionGroups`)**
- **SOL**: one `transferSol` instruction per recipient.
- **SPL/token-2022**: `createAssociatedTokenIdempotent` (destination ATA) + `transferChecked` per recipient. ATAs are derived via `findAssociatedTokenPda`.

**4. Pack into transactions (`chunkInstructionGroups`)**
- Greedy bin-packing under **two limits**: a recipient-count cap (`maxRecipientsPerTransaction`, default 20) and the real constraint — the **1232-byte** v0 transaction size limit, checked by compiling each candidate and calling `isTransactionWithinSizeLimit`. A single recipient that can't fit alone is a `400`.
- Each resulting chunk is a self-contained transaction message (fee payer = sponsor, lifetime = recent blockhash, source as signer).

**5. Persist (create only)**
- Insert one `payment_transfer_batches` row (`processing`) and **bulk-insert** all `payment_transfer_recipients` rows (`pending`) in a single statement.

**6. Execute each chunk (`executeChunk`, sequential)**
- Partially sign with the source signer; create a `payment_transfers` row (`type: transfer_batch`, `processing`) for the chunk; bulk-update the chunk's recipients to `processing`.
- Optional **preflight** simulation (`options.preflight`, default on; `sigVerify: false`).
- Hand the bytes to the fee-payment adapter (`signAndSend`) — the sponsor co-signs and submits — then confirm.
- On success: bulk-mark recipients + transfer `confirmed`. On failure: bulk-mark `failed` with the error. Chunks run sequentially so the source wallet emits one transaction at a time.

**7. Finalize**
- Batch status derived from the chunk transfers: all confirmed → `confirmed`, none → `failed`, mixed → `partially_failed`.
- Response: `{ batch, recipients[], transfers[] }`.

The **estimate** path runs steps 1, 3, 4 with a noop signer, then reports recipient/transaction counts, network fee (`getFeeForMessage` per chunk), and missing-ATA rent — no DB writes, no signing.

## Data model

- `payment_transfer_batches` — one row per batch (source wallet, token, totals, counts, status).
- `payment_transfer_recipients` — one row per recipient, linked to its chunk's `transfer_id`, with its own status/error.
- `payment_transfers` — one row per **chunk** (`type: transfer_batch`); `counterpartyId`/`destination` are set only for single-recipient chunks, and `providerData.recipientIds` always links the recipients. Reconciliation by counterparty goes through `payment_transfer_recipients`.

## Efficiency

- Recipient resolution and fee/rent estimation **fan out** (`Promise.all`) instead of serial loops.
- Recipient create and per-chunk status updates use **bulk SQL** (one multi-row `INSERT`, one `UPDATE ... WHERE id IN (...)`) instead of N round-trips.
- Chunk *execution* stays sequential on purpose (one on-chain tx at a time from the source wallet; deterministic partial-failure accounting).

## Testing

`transfer-batches.test.ts` (workers pool, real Postgres): SOL estimate; multi-chunk SOL create (asserts 2 transactions, confirmed batch, recipient/transfer rows, detail + list); SPL create for both `spl-token` and `token-2022`. `tsc --noEmit` and biome clean.

## Known limitations (devnet, deferred)

- **No idempotency** — a retried create with the same `externalId` re-sends the batch. Devnet only for now; fix later by promoting the `(organization_id, external_id)` partial index to `UNIQUE`.
- **`options.priorityFee` is accepted but not yet applied** (no compute-budget instruction; estimate reports `0`).
- If a chunk throws *outside* `executeChunk`'s inner try (e.g. signing), the batch is left `processing` rather than finalized — no outer reconciliation yet.
