### PR TITLE
test(payments): fix hardcoded expiry time-bomb in payment-request repo test

### DIFF
--- a/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payment-requests.repository.test.ts
@@ -97,7 +97,7 @@ describe("PaymentRequestsRepository (postgres)", () => {
       destinationAddress: "OurWallet",
       token: "USDC",
       amount: "25.00",
-      expiresAt: "2026-07-01T00:00:00.000Z",
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
       createdBy: TEST_USER.id,
       ...overrides,
     };


### PR DESCRIPTION
## Problem

`createInput` in `payment-requests.repository.test.ts` hardcoded the default `expiresAt` to `"2026-07-01T00:00:00.000Z"`. That timestamp is **today** (2026-07-01) at midnight UTC — i.e. already in the past.

The `awaiting_payment` status filter in the repository is:

```sql
status = 'awaiting_payment' AND (expires_at IS NULL OR expires_at > sdp_iso_now())
```

Once that instant passed, every request seeded with the default expiry read as *expired*, so the `listPaymentRequests > "filters by status"` test got `total = 0` instead of `1` and failed. Classic hardcoded-date time bomb.

## Fix

Default `expiresAt` to a relative future timestamp (`Date.now() + 7d`) so seeded requests stay live and the value can't rot again. The field isn't asserted anywhere, and a future non-null expiry also exercises the `expires_at > now()` branch of the awaiting filter.

Reviewed the rest of both payment-request suites — the service test's `"2000-01-01T00:00:00.000Z"` is an intentional past date for the expired short-circuit case and is correct.

## Verification

```
Test Files  2 passed (2)
Tests  28 passed (28)
```
(`payment-requests.repository.test.ts` + `services/payments/payment-requests.test.ts`)