### PR TITLE
docs: align Node/pnpm prereqs with package.json engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Repo Layout and Prerequisites
 
 - [AGENTS.md](./AGENTS.md) — repo layout, public vs. internal API surfaces, generated-file rules, and the canonical `pnpm` check commands.
-- [README.md](./README.md) — Node `>=20` and `pnpm@10.15.1` prerequisites (listed under [README "Prereqs"](./README.md#prereqs)), and the release/deploy model.
+- [README.md](./README.md) — Node `>=22` and `pnpm@10.16.0` prerequisites (listed under [README "Local Development"](./README.md#local-development)), and the release/deploy model.
 - [docs/ops/doppler-secrets.md](./docs/ops/doppler-secrets.md) — Doppler configuration and secrets setup required for local development.
 
 ## Pull Requests

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The supported public API areas are health, API keys, wallets, projects, issuance
 
 Prerequisites:
 
-- Node.js 20+
-- pnpm 10.15+
+- Node.js 22+
+- pnpm 10.16+
 - Git
 
 Install dependencies:


### PR DESCRIPTION
The README and CONTRIBUTING guide listed Node >=20 and pnpm 10.15, but `package.json`'s engines field requires Node >=22 and pnpm >=10.16, so contributors on documented versions might hit engine error on install. Also fix broken README "#prereqs" anchor in CONTRIBUTING to point at existing "Local Development" section.

## Related PR
#667 