### PR TITLE
fix(payments): include SOL in Pay and Batch asset options

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/batch-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/batch-send-step-content.tsx
@@ -146,8 +146,15 @@ function RecipientsStep({ wizard }: { wizard: BatchSendWizard }) {
           options={assetOptions}
           placeholder="Select an asset"
           searchable={false}
+          disabled={!walletId || assetOptions.length === 0}
         />
       </div>
+
+      {walletId && assetOptions.length === 0 ? (
+        <p className="text-sm text-status-error-text">
+          This wallet has no assets available to send.
+        </p>
+      ) : null}
 
       <div className="flex items-center justify-between gap-4 px-1">
         <p className="text-xl font-medium tracking-tight text-text-extra-high">

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onchain-send-step-content.tsx
@@ -21,6 +21,15 @@ import { walletComboboxOptions } from "../wallet-options";
 import { AmountBalanceReadout } from "./amount-balance-readout";
 import { CounterpartyAccountSelector } from "./counterparty-account-selector";
 
+function NoAssetsHint({ walletId, assetCount }: { walletId: string; assetCount: number }) {
+  if (!walletId || assetCount > 0) {
+    return null;
+  }
+  return (
+    <p className="text-sm text-status-error-text">This wallet has no assets available to send.</p>
+  );
+}
+
 function DetailRow({ icon, label, value }: { icon: ReactNode; label: string; value: ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
@@ -166,6 +175,7 @@ export function OnchainSendStepContent({
             disabled={!fields.walletId || assetSelectOptions.length === 0}
           />
         </div>
+        <NoAssetsHint walletId={fields.walletId} assetCount={assetSelectOptions.length} />
         <div className="flex flex-col gap-2">
           <Label className="text-sm font-medium text-text-low" htmlFor="onchain-send-memo">
             Memo (optional)

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/wallet-options.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/wallet-options.ts
@@ -1,7 +1,6 @@
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import {
   formatCurrencyAmount,
-  isSolBalance,
   resolveAggregateBalanceDisplayToken,
   resolveTotalBalance,
 } from "@/app/dashboard/payments/payments-overview.utils";
@@ -42,10 +41,6 @@ export function walletBalanceAssetOptions(
   const assetOptions: ComboboxOption[] = [];
 
   for (const balance of wallet?.balances ?? []) {
-    if (isSolBalance(balance)) {
-      continue;
-    }
-
     const mint = balance.mint.trim();
     const label = resolveAggregateBalanceDisplayToken(balance, issuedTokenSymbolsByMint);
     if (


### PR DESCRIPTION
## Problem

A wallet holding only SOL cannot pay from the dashboard: the asset selector in the Pay flow (and Batch send, which shares the same helper) silently excluded native SOL, leaving an empty, unopenable dropdown with no explanation. The transfer API accepts `token: "SOL"` and settles plain SOL transfers fine, so the same payment was possible via API but not UI.

Closes #566

## Root cause

`walletBalanceAssetOptions` (`ramps/wallet-options.ts`) unconditionally skipped SOL balances via `isSolBalance`. Both the onchain-send and batch-send wizards build their asset options through it.

## Changes

- **`wallet-options.ts`** — removed the `isSolBalance` skip (and its now-unused import). SOL balances already carry the correct mint and resolve their label via `WELL_KNOWN_TOKEN_BY_MINT`, and the API normalizes the SOL mint to a native transfer, so no other wiring was needed.
- **`onchain-send-step-content.tsx`** — added a `NoAssetsHint` shown when a selected wallet has zero asset options: *"This wallet has no assets available to send."* (extracted as a sibling component to stay under Biome's cognitive-complexity budget).
- **`batch-send-step-content.tsx`** — same empty-state hint, plus the `disabled` guard on the Asset combobox that onchain send already had and batch was missing.

## Explicitly not changed

- Recurring payments' deliberate SOL exclusion (it has its own "Native SOL is not supported" notice) and the portfolio-total SOL filter (tracked separately in #564).
- Default asset ordering on wallet switch (batch prefers USDC, onchain picks the first option) — left as-is.

Fee note: transaction fees are paid by the platform fee payer, never the sending wallet, so a full-balance SOL send is safe.

## Verification

- `tsc --noEmit` and `biome check` clean (sdp-web has no unit-test infra; e2e only).
- Manual: Pay → onchain transfer with a SOL-only wallet now lists SOL and completes; a genuinely empty wallet shows the hint instead of a silent dead end.