### PR TITLE
fix(counterparties): validate dateOfBirth and phone identity fields

### DIFF
--- a/apps/sdp-api/src/routes/counterparties/schemas.test.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.test.ts
@@ -93,6 +93,40 @@ describe("counterpartyIdentitySchema phone", () => {
   });
 });
 
+describe("updateCounterpartyObjectSchema identity.dateOfBirth partial update", () => {
+  it("rejects today's date", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: { dateOfBirth: todayIsoDate() },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a future date", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: { dateOfBirth: futureIsoDate() },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a past date", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: { dateOfBirth: "1990-01-15" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an omitted dateOfBirth", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: {},
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("updateCounterpartyObjectSchema identity.phone partial update", () => {
   it("rejects a non-E.164 short number", () => {
     const result = updateCounterpartyObjectSchema.safeParse({

--- a/apps/sdp-api/src/routes/counterparties/schemas.test.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { createCounterpartySchema, updateCounterpartyObjectSchema } from "./schemas";
+
+const BASE_COUNTERPARTY = {
+  entityType: "individual",
+  displayName: "Jane Doe",
+  email: "jane@example.com",
+} as const;
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function futureIsoDate(): string {
+  const future = new Date();
+  future.setUTCFullYear(future.getUTCFullYear() + 1);
+  return future.toISOString().slice(0, 10);
+}
+
+describe("counterpartyIdentitySchema dateOfBirth", () => {
+  it("rejects today's date", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: { dateOfBirth: todayIsoDate() },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a future date", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: { dateOfBirth: futureIsoDate() },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a past date", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: { dateOfBirth: "1990-01-15" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an omitted dateOfBirth", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: {},
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("counterpartyIdentitySchema phone", () => {
+  it("rejects a non-E.164 short number", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: { phone: "12345" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid E.164 number", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: { phone: "+14155551234" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a number missing the leading plus", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: { phone: "14155551234" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an omitted phone", () => {
+    const result = createCounterpartySchema.safeParse({
+      ...BASE_COUNTERPARTY,
+      identity: {},
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("updateCounterpartyObjectSchema identity.phone partial update", () => {
+  it("rejects a non-E.164 short number", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: { phone: "12345" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid E.164 number", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: { phone: "+14155551234" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a number missing the leading plus", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: { phone: "14155551234" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an omitted phone", () => {
+    const result = updateCounterpartyObjectSchema.safeParse({
+      identity: {},
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -21,6 +21,16 @@ import {
 const countryCodeSchema = z.enum(COUNTRY_CODES);
 const currencyCodeSchema = z.string().trim().toUpperCase().length(3);
 const subdivisionCodeSchema = z.string().min(1).max(16);
+const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
+
+/**
+ * Returns the current UTC date as a `YYYY-MM-DD` string, so date-only values
+ * can be compared lexicographically without timezone-boundary drift from
+ * `Date` object comparisons.
+ */
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 export const counterpartyAddressSchema = z.object({
   line1: z.string().min(1).max(512),
@@ -74,8 +84,14 @@ export const counterpartyIdentitySchema = z.looseObject({
   middleName: z.string().max(256).optional(),
   lastName: z.string().min(1).max(256).optional(),
   secondLastName: z.string().max(256).optional(),
-  dateOfBirth: z.iso.date().optional(),
-  phone: z.string().min(1).max(64).optional(),
+  dateOfBirth: z.iso
+    .date()
+    .refine((value) => value < todayIsoDate(), { message: "dateOfBirth must be in the past" })
+    .optional(),
+  phone: z
+    .string()
+    .regex(E164_PHONE_PATTERN, { message: "phone must be in E.164 format" })
+    .optional(),
   address: counterpartyAddressSchema.optional(),
   birthCountryCode: countryCodeSchema.optional(),
   citizenshipCountryCode: countryCodeSchema.optional(),

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-schemas.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-create-schemas.ts
@@ -21,11 +21,36 @@ function optionalUppercase(max: number, min = 1) {
     .pipe(inner.optional());
 }
 
+function optionalPattern(max: number, pattern: RegExp, message: string) {
+  const inner = z.string().min(1).max(max).regex(pattern, message);
+  return z
+    .string()
+    .trim()
+    .transform((v) => (v.length > 0 ? v : undefined))
+    .pipe(inner.optional());
+}
+
+const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
+
+/**
+ * Returns the current UTC date as a `YYYY-MM-DD` string, so date-only values
+ * can be compared lexicographically without timezone-boundary drift from
+ * `Date` object comparisons.
+ */
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 const optionalIsoDate = z
   .string()
   .trim()
   .transform((v) => (v.length > 0 ? v : undefined))
-  .pipe(z.iso.date().optional());
+  .pipe(
+    z.iso
+      .date()
+      .refine((value) => value < todayIsoDate(), { message: "Must be in the past" })
+      .optional()
+  );
 
 export const basicsSchema = z.object({
   entityType: z.enum(COUNTERPARTY_ENTITY_TYPES),
@@ -38,7 +63,7 @@ export const identitySchema = z.object({
   firstName: optionalString(256),
   lastName: optionalString(256),
   dateOfBirth: optionalIsoDate,
-  phone: optionalString(64),
+  phone: optionalPattern(64, E164_PHONE_PATTERN, "Must be in E.164 format (e.g. +14155551234)"),
 });
 
 export const addressSchema = z


### PR DESCRIPTION
## Problem

Counterparty identity fields were accepted without semantic validation at both the API and the dashboard form: a counterparty could be created `Active` with a date of birth in the current year and a five-digit phone number. Invalid identity data feeds provider KYC and Travel Rule reporting, where it either propagates or bounces back later as a confusing provider error.

This is a temporary bandaid, i would love to add more formal validations around these things.

Closes #563

## Changes

- **`apps/sdp-api` `counterparties/schemas.ts`** — `counterpartyIdentitySchema.dateOfBirth` now refines to a strictly-past date (lexicographic compare against a UTC `YYYY-MM-DD` today-string, avoiding timezone-boundary drift from `Date` comparisons); `phone` now enforces E.164 (`^\+[1-9]\d{1,14}$`). Create and update both reuse this schema, so `POST` and `PATCH` inherit automatically — the refinements fire per-key on partial update bodies too.
- **`apps/sdp-web` `counterparty-create-schemas.ts`** — mirrors both checks in the form schemas using the file's existing optional-helper idiom (new `optionalPattern`), so the wizard rejects the same inputs client-side with field-level messages.
- **New `schemas.test.ts`** — 12 cases covering past/today/future DOB and valid/invalid/omitted phone through both the create and partial-update schemas.

The OpenAPI spec already documented `phone` as E.164; the schema now actually enforces it, and the generated spec picks up the `pattern` automatically.

## Deliberately out of scope

- No minimum-age floor — an age gate is provider policy and belongs in the per-provider requirements framework if needed.
- No backfill/audit of existing rows — validation gates writes going forward; an existing bad row only fails when its identity keys are next resent.

## Verification

`tsc --noEmit`, `biome check`, new tests 12/12, existing counterparty + OpenAPI spec tests 21/21.