### PR TITLE
fix(ramps): normalize subdivision codes to BVNK's 2-char stateCode

### DIFF
--- a/apps/sdp-api/src/lib/ramps/providers/bvnk.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/bvnk.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import { AppError } from "@/lib/errors";
 import {
   BvnkRampClient,
   buildBvnkCustomerExternalReference,
   buildBvnkOfframpWalletName,
   buildBvnkOnrampPaymentRuleKey,
   buildBvnkOnrampWalletName,
+  buildBvnkRuleEntity,
   buildBvnkWalletIdempotencyKey,
   bvnkOnrampStatusFromProviderData,
   bvnkUnverifiedOnboardingStatus,
@@ -289,5 +292,58 @@ describe("BVNK on-ramp payment rule key", () => {
     expect(() => buildBvnkOnrampPaymentRuleKey("NOPE", "USDC", "SOLANA", "dest")).toThrow(
       "Malformed BVNK on-ramp payment rule key input"
     );
+  });
+});
+
+function counterpartyRow(overrides?: Partial<CounterpartyRow>): CounterpartyRow {
+  return {
+    id: "cp_123",
+    organization_id: "org_123",
+    project_id: "proj_123",
+    external_id: null,
+    entity_type: "individual",
+    display_name: "Ada Lovelace",
+    email: "ada@example.com",
+    identity: {
+      firstName: "Ada",
+      lastName: "Lovelace",
+      address: {
+        line1: "1 Market St",
+        city: "San Francisco",
+        countryCode: "US",
+        subdivisionCode: "US-TX",
+      },
+    },
+    provider_data: {},
+    status: "active",
+    created_by: null,
+    created_at: "2026-06-11T00:00:00.000Z",
+    updated_at: "2026-06-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildBvnkRuleEntity", () => {
+  it("normalizes an ISO-prefixed stored subdivision code to BVNK's bare stateCode", () => {
+    const entity = buildBvnkRuleEntity(counterpartyRow());
+
+    expect(entity.address?.stateCode).toBe("TX");
+  });
+
+  it("throws for a non-US subdivision that does not resolve to 2 characters", () => {
+    const row = counterpartyRow({
+      identity: {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        address: {
+          line1: "1 High St",
+          city: "London",
+          countryCode: "GB",
+          subdivisionCode: "GB-ENG",
+        },
+      },
+    });
+
+    expect(() => buildBvnkRuleEntity(row)).toThrowError(AppError);
   });
 });

--- a/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/bvnk.ts
@@ -48,7 +48,7 @@ import type {
   RampWebhookValidationResult,
   ValidateCounterpartyOptions,
 } from "../types";
-import { bvnkCounterpartyRequirements } from "../validation/bvnk";
+import { bvnkCounterpartyRequirements, normalizeBvnkStateCode } from "../validation/bvnk";
 
 const BVNK_PRODUCTION_API_URL = "https://api.bvnk.com";
 const BVNK_SANDBOX_API_URL = "https://api.sandbox.bvnk.com";
@@ -1845,7 +1845,9 @@ export function buildBvnkRuleEntity(counterparty: CounterpartyRow): BvnkRuleEnti
             city: address.city,
             countryCode: address.countryCode,
             country: address.countryCode,
-            ...(address.subdivisionCode ? { stateCode: address.subdivisionCode } : {}),
+            ...(address.subdivisionCode
+              ? { stateCode: normalizeBvnkStateCode(address.countryCode, address.subdivisionCode) }
+              : {}),
           },
         }
       : {}),

--- a/apps/sdp-api/src/lib/ramps/validation/bvnk.test.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/bvnk.test.ts
@@ -1,6 +1,12 @@
 import type { Counterparty } from "@sdp/types";
 import { describe, expect, it } from "vitest";
-import { bvnkCounterpartyRequirements } from "./bvnk";
+import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import { AppError } from "@/lib/errors";
+import {
+  buildBvnkIndividualPayload,
+  bvnkCounterpartyRequirements,
+  normalizeBvnkStateCode,
+} from "./bvnk";
 
 function counterparty(overrides?: Partial<Counterparty>): Counterparty {
   return {
@@ -44,6 +50,25 @@ function counterparty(overrides?: Partial<Counterparty>): Counterparty {
   };
 }
 
+function counterpartyRow(overrides?: Partial<CounterpartyRow>): CounterpartyRow {
+  return {
+    id: "cp_123",
+    organization_id: "org_123",
+    project_id: "proj_123",
+    external_id: null,
+    entity_type: "individual",
+    display_name: "Ada Lovelace",
+    email: "ada@example.com",
+    identity: counterparty().identity,
+    provider_data: {},
+    status: "active",
+    created_by: null,
+    created_at: "2026-06-11T00:00:00.000Z",
+    updated_at: "2026-06-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
 describe("bvnkCounterpartyRequirements", () => {
   it("does not report ready just because the BVNK customer exists", () => {
     const requirements = bvnkCounterpartyRequirements(counterparty(), {
@@ -73,5 +98,51 @@ describe("bvnkCounterpartyRequirements", () => {
       direction: "onramp",
       status: "onboarding_not_started",
     });
+  });
+});
+
+describe("normalizeBvnkStateCode", () => {
+  it("strips a matching ISO 3166-2 country prefix", () => {
+    expect(normalizeBvnkStateCode("US", "US-TX")).toBe("TX");
+  });
+
+  it("returns an already-bare code unchanged", () => {
+    expect(normalizeBvnkStateCode("US", "TX")).toBe("TX");
+  });
+
+  it("uppercases a lowercase code", () => {
+    expect(normalizeBvnkStateCode("US", "tx")).toBe("TX");
+  });
+
+  it("throws when the stripped remainder is not 2 characters", () => {
+    expect(() => normalizeBvnkStateCode("GB", "GB-ENG")).toThrowError(AppError);
+  });
+
+  it("does not strip a prefix that does not match the country code", () => {
+    expect(() => normalizeBvnkStateCode("US", "XX-TX")).toThrowError(AppError);
+  });
+
+  it("throws for a 1-character code", () => {
+    expect(() => normalizeBvnkStateCode("US", "X")).toThrowError(AppError);
+  });
+});
+
+describe("buildBvnkIndividualPayload", () => {
+  it("normalizes an ISO-prefixed stored subdivision code to BVNK's bare stateCode", () => {
+    const row = counterpartyRow({
+      identity: {
+        ...counterparty().identity,
+        address: {
+          line1: "1 Market St",
+          city: "San Francisco",
+          countryCode: "US",
+          subdivisionCode: "US-TX",
+        },
+      },
+    });
+
+    const payload = buildBvnkIndividualPayload(row, undefined, "USD");
+
+    expect(payload.address).toMatchObject({ countryCode: "US", stateCode: "TX" });
   });
 });

--- a/apps/sdp-api/src/lib/ramps/validation/bvnk.ts
+++ b/apps/sdp-api/src/lib/ramps/validation/bvnk.ts
@@ -318,6 +318,33 @@ export function bvnkCounterpartyRequirements(
   return { provider: "bvnk", direction, status: "collect", fields: missing };
 }
 
+/**
+ * Normalizes a stored subdivision code to the bare 2-letter form BVNK's
+ * `stateCode` field requires. Strips a leading ISO 3166-2 country prefix
+ * (e.g. `US-TX` -> `TX`) only when the prefix matches the address's own
+ * country code; throws a typed bad-request error when the result is not
+ * exactly 2 characters.
+ *
+ * TODO(zach, 2026-07-02): temporary translation layer. The counterparty
+ * location model will be refactored to store both ISO code variants so
+ * provider mappers can read the form they need directly — remove this
+ * normalization when that lands.
+ */
+export function normalizeBvnkStateCode(countryCode: string, subdivisionCode: string): string {
+  const prefixMatch = /^([A-Z]{2})-([A-Z0-9]{2,3})$/.exec(subdivisionCode.toUpperCase());
+  const candidate =
+    prefixMatch && prefixMatch[1] === countryCode.toUpperCase()
+      ? prefixMatch[2]
+      : subdivisionCode.toUpperCase();
+  if (candidate.length !== 2) {
+    throw badRequest("BVNK requires a 2-letter state/subdivision code.", {
+      field: "identity.address.subdivisionCode",
+      value: subdivisionCode,
+    });
+  }
+  return candidate;
+}
+
 export function buildBvnkIndividualPayload(
   counterparty: CounterpartyRow,
   collectedData: CollectedFieldData | undefined,
@@ -381,7 +408,14 @@ export function buildBvnkIndividualPayload(
             city: address.city,
             ...(address.postalCode ? { postalCode: address.postalCode } : {}),
             countryCode: address.countryCode,
-            ...(isUnitedStates ? { stateCode: resolveField("address.stateCode") } : {}),
+            ...(isUnitedStates
+              ? {
+                  stateCode: normalizeBvnkStateCode(
+                    address.countryCode,
+                    resolveField("address.stateCode")
+                  ),
+                }
+              : {}),
           },
         }
       : {}),

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -90,8 +90,9 @@ export const counterpartyAddressSchema = withOpenApi(
       example: "US",
     }),
     subdivisionCode: withOpenApi(counterpartyAddressSchemaBase.shape.subdivisionCode, {
-      description: "ISO 3166-2 subdivision code (state, province, region).",
-      example: "US-CA",
+      description:
+        "Subdivision code (state, province, region) — bare 2-letter code (e.g. `CA`); ISO 3166-2 (`US-CA`) is also accepted, but some providers require the bare form.",
+      example: "CA",
     }),
   }),
   { description: "Postal address for a counterparty." }
@@ -109,8 +110,9 @@ export const counterpartyGovernmentIdSchema = withOpenApi(
       example: "US",
     }),
     subdivisionCode: withOpenApi(counterpartyGovernmentIdSchemaBase.shape.subdivisionCode, {
-      description: "ISO 3166-2 subdivision code of the issuing authority.",
-      example: "US-CA",
+      description:
+        "Subdivision code of the issuing authority — bare 2-letter code (e.g. `CA`); ISO 3166-2 (`US-CA`) is also accepted, but some providers require the bare form.",
+      example: "CA",
     }),
     issueDate: withOpenApi(isoDateSchema.optional(), {
       description: "Issue date (YYYY-MM-DD).",


### PR DESCRIPTION
## Problem

BVNK on-ramp requirement submission fails with `ACCOUNTS-2000` / `individual.address.stateCode: size must be between 2 and 2` when a counterparty's `subdivisionCode` is stored ISO-prefixed (`US-TX`). SDP forwarded the stored value verbatim; BVNK wants exactly the bare 2-char code (`TX`).

another bandaid - oversight on my end where we should have stored iso-3166-2 and -3 variants lol.

Closes #544

## Why both forms exist in storage

Web-created counterparties store bare codes, but the JSONB column has no shape constraint and the OpenAPI docs described `subdivisionCode` as ISO 3166-2 with `example: "US-CA"` — so spec-following API clients wrote the prefixed form. Both sources were "right"; the boundary just never reconciled them.

## Changes

- **`lib/ramps/validation/bvnk.ts`** — new `normalizeBvnkStateCode(countryCode, subdivisionCode)`: strips a leading ISO 3166-2 prefix only when it matches the address's own country code, uppercases, and throws a typed 400 (`details.field`/`details.value`) when the result is not exactly 2 characters. Wired into `buildBvnkIndividualPayload`'s US-gated `stateCode`.
- **`lib/ramps/providers/bvnk.ts`** — `buildBvnkRuleEntity` routes `subdivisionCode` through the same normalization for all countries (it previously forwarded any stored value unguarded).
- **`openapi/schemas/counterparties.ts`** — both `subdivisionCode` examples corrected to the bare form (`US-CA` → `CA`); descriptions state bare is canonical and the ISO-prefixed form is accepted.
- **Tests** — 6 unit cases for the normalizer (strip, bare, lowercase, mismatched prefix, non-2-char rejection) plus integration cases through both builders, including a GB `GB-ENG` rejection proving the non-US guard.

## Note: temporary translation layer

Per review discussion, the durable fix is storing both ISO code variants on the counterparty location model so provider mappers never transform. This normalization is explicitly temporary — `TODO(zach, 2026-07-02)` in the helper's JSDoc tracks the planned refactor.

## Verification

`tsc --noEmit`, `biome check`, 36/36 tests across both BVNK test files (`vitest --config vitest.workers.config.ts`), `openapi:generate` shows zero remaining `US-CA` examples. Existing stored `US-TX` rows self-heal on next use — no backfill needed.