### PR TITLE
fix(api): surface typed errors from on-chain submit and confirm paths

### DIFF
--- a/apps/sdp-api/src/lib/errors.ts
+++ b/apps/sdp-api/src/lib/errors.ts
@@ -212,6 +212,10 @@ export function transactionFailed(message?: string, details?: Record<string, unk
   return new AppError("TRANSACTION_FAILED", message, details);
 }
 
+export function solanaRpcError(message?: string, details?: Record<string, unknown>): AppError {
+  return new AppError("SOLANA_RPC_ERROR", message, details);
+}
+
 export function providerNotConfigured(message?: string): AppError {
   return new AppError("PROVIDER_NOT_CONFIGURED", message);
 }

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -7,6 +7,7 @@ import { findAssociatedTokenPda, TOKEN_2022_PROGRAM_ADDRESS } from "@solana-prog
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import app from "@/index";
+import { AppError } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
 import type { Address } from "@/lib/solana";
 import * as AuthorityResolution from "@/routes/issuance/handlers/authority-resolution";
@@ -4425,6 +4426,88 @@ describe("Issuance Routes", () => {
           createOrgSignerSpy.mockRestore();
           createTokenSpy.mockRestore();
           updateTokenAuthoritiesSpy.mockRestore();
+        }
+      });
+
+      it("returns TRANSACTION_FAILED with the on-chain reason when the create tx fails on-chain", async () => {
+        const token = await seedIssuedToken({
+          id: "tok_deploy_onchain_fail",
+          mintAddress: null,
+          status: "pending",
+          uri: null,
+          requiresAllowlist: false,
+        });
+
+        const onChainDetail = 'Transaction failed: {"InstructionError":[0,{"Custom":6001}]}';
+        const createOrgSignerSpy = vi
+          .spyOn(SolanaServices, "createOrgSigner")
+          .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
+        const createTokenSpy = vi
+          .spyOn(MosaicService.prototype, "createToken")
+          .mockRejectedValueOnce(new AppError("TRANSACTION_FAILED", onChainDetail));
+
+        try {
+          const res = await app.request(
+            `/v1/issuance/tokens/${token.id}/deploy`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              },
+              body: JSON.stringify({}),
+            },
+            env
+          );
+
+          expect(res.status).toBe(400);
+          const payload = (await res.json()) as { error: { code: string; message: string } };
+          expect(payload.error.code).toBe("TRANSACTION_FAILED");
+          expect(payload.error.message).toBe(onChainDetail);
+        } finally {
+          createOrgSignerSpy.mockRestore();
+          createTokenSpy.mockRestore();
+        }
+      });
+
+      it("returns SOLANA_RPC_ERROR when the create tx confirmation times out", async () => {
+        const token = await seedIssuedToken({
+          id: "tok_deploy_confirm_timeout",
+          mintAddress: null,
+          status: "pending",
+          uri: null,
+          requiresAllowlist: false,
+        });
+
+        const timeoutDetail = "Transaction 5timeoutSig confirmation timed out after 60000ms";
+        const createOrgSignerSpy = vi
+          .spyOn(SolanaServices, "createOrgSigner")
+          .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
+        const createTokenSpy = vi
+          .spyOn(MosaicService.prototype, "createToken")
+          .mockRejectedValueOnce(new AppError("SOLANA_RPC_ERROR", timeoutDetail));
+
+        try {
+          const res = await app.request(
+            `/v1/issuance/tokens/${token.id}/deploy`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              },
+              body: JSON.stringify({}),
+            },
+            env
+          );
+
+          expect(res.status).toBe(502);
+          const payload = (await res.json()) as { error: { code: string; message: string } };
+          expect(payload.error.code).toBe("SOLANA_RPC_ERROR");
+          expect(payload.error.message).toBe(timeoutDetail);
+        } finally {
+          createOrgSignerSpy.mockRestore();
+          createTokenSpy.mockRestore();
         }
       });
     });

--- a/apps/sdp-api/src/services/mosaic/service.test.ts
+++ b/apps/sdp-api/src/services/mosaic/service.test.ts
@@ -14,6 +14,7 @@ import * as Kit from "@solana/kit";
 import * as MosaicSdk from "@solana/mosaic-sdk";
 import * as Signers from "@solana/signers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@/lib/errors";
 import { MosaicService } from "@/services/mosaic";
 import type { CreateTokenOptions } from "@/services/mosaic/types";
 import type { FeePaymentPort } from "@/services/ports/fee-payment.port";
@@ -261,6 +262,38 @@ describe("MosaicService.createToken — Kora sponsorship", () => {
       expect(confirmSpy).toHaveBeenCalledTimes(1);
       expect(result.signature).toBe(koraSignature);
       expect(result.slot).toBe(7n);
+    });
+
+    it("throws TRANSACTION_FAILED carrying the on-chain error when confirmation reports failure", async () => {
+      const koraSignature = "kora-sig" as Signature;
+      fee.signAndSend.mockResolvedValue(koraSignature);
+
+      vi.spyOn(Signers, "partiallySignTransactionMessageWithSigners").mockResolvedValue({
+        __sentinel: "partial-tx",
+      } as never);
+      vi.spyOn(Kit, "getTransactionEncoder").mockReturnValue({
+        encode: () => new Uint8Array([1, 2, 3]),
+      } as never);
+      const onChainError = { InstructionError: [0, { Custom: 6001 }] };
+      vi.spyOn(RpcModule, "confirmTransaction").mockResolvedValue({
+        signature: koraSignature,
+        slot: 7n,
+        confirmationStatus: "confirmed",
+        err: onChainError,
+      } as Awaited<ReturnType<typeof RpcModule.confirmTransaction>>);
+
+      const error = await service.createToken(srfc37Options()).then(
+        () => {
+          throw new Error("expected createToken to reject");
+        },
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.code).toBe("TRANSACTION_FAILED");
+      expect(appError.statusCode).toBe(400);
+      expect(appError.message).toBe(`Transaction failed: ${JSON.stringify(onChainError)}`);
     });
   });
 

--- a/apps/sdp-api/src/services/mosaic/service.test.ts
+++ b/apps/sdp-api/src/services/mosaic/service.test.ts
@@ -295,6 +295,46 @@ describe("MosaicService.createToken — Kora sponsorship", () => {
       expect(appError.statusCode).toBe(400);
       expect(appError.message).toBe(`Transaction failed: ${JSON.stringify(onChainError)}`);
     });
+
+    it("throws TRANSACTION_FAILED carrying the on-chain error on the direct-submit path", async () => {
+      const directSignature = "direct-sig" as Signature;
+      const sendTransaction = vi.fn().mockReturnValue({
+        send: vi.fn().mockResolvedValue(directSignature),
+      });
+      vi.spyOn(RpcModule, "createRpcForSdk").mockReturnValue({
+        sendTransaction,
+      } as unknown as ReturnType<typeof RpcModule.createRpcForSdk>);
+      const unsponsored = new MosaicService(
+        env as ConstructorParameters<typeof MosaicService>[0],
+        signer
+      );
+
+      vi.spyOn(Kit, "signTransactionMessageWithSigners").mockResolvedValue({
+        __sentinel: "signed-tx",
+      } as never);
+      vi.spyOn(Kit, "getBase64EncodedWireTransaction").mockReturnValue("base64-tx" as never);
+      const onChainError = { InstructionError: [1, { Custom: 42 }] };
+      vi.spyOn(RpcModule, "confirmTransaction").mockResolvedValue({
+        signature: directSignature,
+        slot: 9n,
+        confirmationStatus: "confirmed",
+        err: onChainError,
+      } as Awaited<ReturnType<typeof RpcModule.confirmTransaction>>);
+
+      const error = await unsponsored.createToken(srfc37Options()).then(
+        () => {
+          throw new Error("expected createToken to reject");
+        },
+        (e: unknown) => e
+      );
+
+      expect(sendTransaction).toHaveBeenCalledTimes(1);
+      expect(error).toBeInstanceOf(AppError);
+      const appError = error as AppError;
+      expect(appError.code).toBe("TRANSACTION_FAILED");
+      expect(appError.statusCode).toBe(400);
+      expect(appError.message).toBe(`Transaction failed: ${JSON.stringify(onChainError)}`);
+    });
   });
 
   describe("list address derivation", () => {

--- a/apps/sdp-api/src/services/mosaic/service.ts
+++ b/apps/sdp-api/src/services/mosaic/service.ts
@@ -69,6 +69,7 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
 import { parseDecimalAmount } from "@/lib/amount";
+import { AppError } from "@/lib/errors";
 import type { FeePaymentPort } from "@/services/ports/fee-payment.port";
 import { confirmTransaction, createRpcForSdk } from "@/services/solana/rpc";
 import type { Env } from "@/types/env";
@@ -1165,7 +1166,10 @@ export class MosaicService {
       );
 
       if (confirmation.err) {
-        throw new Error(`Transaction failed: ${safeStringify(confirmation.err)}`);
+        throw new AppError(
+          "TRANSACTION_FAILED",
+          `Transaction failed: ${safeStringify(confirmation.err)}`
+        );
       }
 
       return {
@@ -1192,7 +1196,10 @@ export class MosaicService {
     );
 
     if (confirmation.err) {
-      throw new Error(`Transaction failed: ${safeStringify(confirmation.err)}`);
+      throw new AppError(
+        "TRANSACTION_FAILED",
+        `Transaction failed: ${safeStringify(confirmation.err)}`
+      );
     }
 
     return {

--- a/apps/sdp-api/src/services/mosaic/service.ts
+++ b/apps/sdp-api/src/services/mosaic/service.ts
@@ -69,7 +69,7 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
 import { parseDecimalAmount } from "@/lib/amount";
-import { AppError } from "@/lib/errors";
+import { transactionFailed } from "@/lib/errors";
 import type { FeePaymentPort } from "@/services/ports/fee-payment.port";
 import { confirmTransaction, createRpcForSdk } from "@/services/solana/rpc";
 import type { Env } from "@/types/env";
@@ -1166,10 +1166,7 @@ export class MosaicService {
       );
 
       if (confirmation.err) {
-        throw new AppError(
-          "TRANSACTION_FAILED",
-          `Transaction failed: ${safeStringify(confirmation.err)}`
-        );
+        throw transactionFailed(`Transaction failed: ${safeStringify(confirmation.err)}`);
       }
 
       return {
@@ -1196,10 +1193,7 @@ export class MosaicService {
     );
 
     if (confirmation.err) {
-      throw new AppError(
-        "TRANSACTION_FAILED",
-        `Transaction failed: ${safeStringify(confirmation.err)}`
-      );
+      throw transactionFailed(`Transaction failed: ${safeStringify(confirmation.err)}`);
     }
 
     return {

--- a/apps/sdp-api/src/services/solana/rpc.test.ts
+++ b/apps/sdp-api/src/services/solana/rpc.test.ts
@@ -1,0 +1,72 @@
+import type { Signature } from "@solana/kit";
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/lib/errors";
+import { confirmTransaction, type SolanaRpc, sendAndConfirmTransaction } from "./rpc";
+
+const TEST_SIGNATURE = "5confirmTimeoutSig" as Signature;
+
+/**
+ * Fake RPC whose signature statuses never resolve past pending, so both
+ * confirmation helpers exhaust their polling budget and time out.
+ */
+function makePendingRpc(signature: Signature): {
+  rpc: SolanaRpc;
+  getSignatureStatuses: ReturnType<typeof vi.fn>;
+  sendTransaction: ReturnType<typeof vi.fn>;
+} {
+  const getSignatureStatuses = vi.fn().mockReturnValue({
+    send: vi.fn().mockResolvedValue({ value: [null] }),
+  });
+  const sendTransaction = vi.fn().mockReturnValue({
+    send: vi.fn().mockResolvedValue(signature),
+  });
+  return {
+    rpc: { getSignatureStatuses, sendTransaction } as unknown as SolanaRpc,
+    getSignatureStatuses,
+    sendTransaction,
+  };
+}
+
+/**
+ * Await a promise that is expected to reject and hand back the rejection value.
+ */
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => {
+      throw new Error("expected the promise to reject");
+    },
+    (error: unknown) => error
+  );
+}
+
+describe("confirmTransaction", () => {
+  it("throws a typed SOLANA_RPC_ERROR when confirmation never lands within the timeout", async () => {
+    const { rpc, getSignatureStatuses } = makePendingRpc(TEST_SIGNATURE);
+
+    const error = await captureRejection(confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 1 }));
+
+    expect(error).toBeInstanceOf(AppError);
+    const appError = error as AppError;
+    expect(appError.code).toBe("SOLANA_RPC_ERROR");
+    expect(appError.statusCode).toBe(502);
+    expect(appError.message).toBe(`Transaction ${TEST_SIGNATURE} confirmation timed out after 1ms`);
+    expect(getSignatureStatuses).toHaveBeenCalledWith([TEST_SIGNATURE]);
+  });
+});
+
+describe("sendAndConfirmTransaction", () => {
+  it("throws a typed SOLANA_RPC_ERROR when the sent transaction never confirms", async () => {
+    const { rpc, sendTransaction } = makePendingRpc(TEST_SIGNATURE);
+
+    const error = await captureRejection(
+      sendAndConfirmTransaction(rpc, new Uint8Array([1, 2, 3]), { timeoutMs: 1 })
+    );
+
+    expect(error).toBeInstanceOf(AppError);
+    const appError = error as AppError;
+    expect(appError.code).toBe("SOLANA_RPC_ERROR");
+    expect(appError.statusCode).toBe(502);
+    expect(appError.message).toBe(`Transaction ${TEST_SIGNATURE} confirmation timed out after 1ms`);
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/sdp-api/src/services/solana/rpc.ts
+++ b/apps/sdp-api/src/services/solana/rpc.ts
@@ -14,6 +14,7 @@ import {
   createSolanaRpcSubscriptions,
   type Signature,
 } from "@solana/kit";
+import { AppError } from "@/lib/errors";
 import { isTransientRpcError } from "@/lib/rpc";
 import { getSolanaConfig } from "@/lib/solana";
 import type { Env } from "@/types/env";
@@ -277,7 +278,10 @@ export async function sendAndConfirmTransaction(
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
-  throw new Error(`Transaction ${signature} confirmation timed out after ${timeoutMs}ms`);
+  throw new AppError(
+    "SOLANA_RPC_ERROR",
+    `Transaction ${signature} confirmation timed out after ${timeoutMs}ms`
+  );
 }
 
 /**
@@ -319,7 +323,10 @@ export async function confirmTransaction(
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
-  throw new Error(`Transaction ${signature} confirmation timed out`);
+  throw new AppError(
+    "SOLANA_RPC_ERROR",
+    `Transaction ${signature} confirmation timed out after ${timeoutMs}ms`
+  );
 }
 
 /**

--- a/apps/sdp-api/src/services/solana/rpc.ts
+++ b/apps/sdp-api/src/services/solana/rpc.ts
@@ -14,7 +14,7 @@ import {
   createSolanaRpcSubscriptions,
   type Signature,
 } from "@solana/kit";
-import { AppError } from "@/lib/errors";
+import { solanaRpcError } from "@/lib/errors";
 import { isTransientRpcError } from "@/lib/rpc";
 import { getSolanaConfig } from "@/lib/solana";
 import type { Env } from "@/types/env";
@@ -278,10 +278,7 @@ export async function sendAndConfirmTransaction(
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
-  throw new AppError(
-    "SOLANA_RPC_ERROR",
-    `Transaction ${signature} confirmation timed out after ${timeoutMs}ms`
-  );
+  throw solanaRpcError(`Transaction ${signature} confirmation timed out after ${timeoutMs}ms`);
 }
 
 /**
@@ -323,10 +320,7 @@ export async function confirmTransaction(
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
-  throw new AppError(
-    "SOLANA_RPC_ERROR",
-    `Transaction ${signature} confirmation timed out after ${timeoutMs}ms`
-  );
+  throw solanaRpcError(`Transaction ${signature} confirmation timed out after ${timeoutMs}ms`);
 }
 
 /**


### PR DESCRIPTION
## Problem

`POST /v1/issuance/tokens/:id/deploy` failed with a bare `500 {"code":"INTERNAL_ERROR"}` for every template, leaving tokens stuck in `pending` (mint then 400s `TOKEN_NOT_ACTIVE`) with no way for the caller to see what broke. Investigation on #567.


<img width="401" height="122" alt="CleanShot 2026-07-02 at 15 12 54" src="https://github.com/user-attachments/assets/e4dfce15-01c7-4cdf-9b61-3d44e5d112e1" />

Errors are now shown exactly as what they are instead of internal error 

```
{
  "ok": false,
  "status": 503,
  "statusText": "Service Unavailable",
  "body": {
    "error": {
      "code": "PROVIDER_UNAVAILABLE",
      "message": "The signing provider is temporarily unavailable. Try again."
    },
    "meta": {
      "requestId": "web_b66d8e8826754acda775e7c6102c2f59:01"
    }
  }
}
```

Closes #567

## Root cause

The custody deploy path's on-chain submit/confirm steps threw **plain `Error`s**, and the global error handler in `app.ts` maps typed errors to actionable responses but collapses any plain `Error` to `INTERNAL_ERROR`. The real failure (on-chain program error or confirm timeout) was already logged server-side under the trace ID — it just never reached the response.

## Changes

- **`services/mosaic/service.ts`** — both `confirmation.err` sites in `signAndSubmit` now throw `AppError("TRANSACTION_FAILED", ...)` carrying the full stringified on-chain error.
- **`services/solana/rpc.ts`** — both confirm-timeout sites (`sendAndConfirmTransaction`, `confirmTransaction`) now throw `AppError("SOLANA_RPC_ERROR", ...)` with signature + timeout; also aligned the two messages (one previously omitted the timeout).
- Both error codes already existed in `lib/errors.ts` — no new codes, no changes to the global handler's catch-all, no change to the deploy handler (its re-throw and DB error-recording pass the typed errors through cleanly).

**Blast radius (intentional):** `signAndSubmit`/`confirmTransaction` are shared by payments transfers/batches, custody, and recurring payments — all those callers now surface the same detail instead of opaque 500s. Their suites pass unchanged.

**Not changed:** `app.ts` fee-payment mapping (already implemented upstream via `mapFeePaymentError`); mosaic-SDK build errors (deferred per plan).

## Tests

- New unit test: `signAndSubmit` with an on-chain error → `AppError` `TRANSACTION_FAILED`/400 with the exact `InstructionError` detail.
- New `rpc.test.ts`: both confirm helpers → `SOLANA_RPC_ERROR`/502 with signature + timeout in the message.
- New route-level deploy tests: on-chain failure → `400 TRANSACTION_FAILED`, confirm timeout → `502 SOLANA_RPC_ERROR`, detail intact in `error.message`.

## Verification

`tsc --noEmit` clean; biome clean; vitest: mosaic + rpc + app 18/18, issuance 107 pass, payments + transfer-batches 84/84, custody + recurring + fee adapters 39/39.

Note: this PR makes the deploy failure *visible*; diagnosing and fixing the underlying devnet deploy failure (per the trace-ID runbook in the investigation) is follow-up work on #567.