### PR TITLE
feat(payments): offer all well-known tokens when creating payment requests

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/requests/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/requests/page.tsx
@@ -5,7 +5,7 @@ import { withDashboardPageTrace } from "@/lib/dashboard-page-trace";
 import { fetchActiveApiKeys, resolvePlaygroundApiBaseUrl } from "../../playground-api-data";
 import { fetchCounterparties } from "../counterparty/counterparty-page.data";
 import { fetchPaymentsWallets } from "../payments-page.data";
-import { deriveTokenOptions, fetchPaymentRequests } from "./payment-requests-page.data";
+import { fetchPaymentRequests } from "./payment-requests-page.data";
 import { PaymentRequestsWorkspace } from "./payment-requests-workspace";
 
 export const dynamic = "force-dynamic";
@@ -24,9 +24,7 @@ export default async function PaymentRequestsPage() {
   return withDashboardPageTrace("dashboard.payment-requests.page", async ({ trace, apiClient }) => {
     const [result, walletsResult, apiKeysResult, counterpartiesResult] = await Promise.all([
       trace.step("fetch_payment_requests", () => fetchPaymentRequests(apiClient.request)),
-      trace.step("fetch_wallets", () =>
-        fetchPaymentsWallets(apiClient.request, { includeBalances: true })
-      ),
+      trace.step("fetch_wallets", () => fetchPaymentsWallets(apiClient.request)),
       trace.step("fetch_active_api_keys", () => fetchActiveApiKeys(apiClient.request)),
       trace.step("fetch_counterparties", () => fetchCounterparties(apiClient.request)),
     ]);
@@ -43,7 +41,6 @@ export default async function PaymentRequestsPage() {
           apiBaseUrl={apiBaseUrl}
           apiKeys={apiKeysResult.ok && apiKeysResult.data ? apiKeysResult.data : []}
           wallets={wallets}
-          tokens={deriveTokenOptions(wallets)}
           counterparties={counterpartiesResult.data}
         />
       </div>

--- a/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-page.data.ts
@@ -1,43 +1,44 @@
-import type {
-  CryptoAssetSymbol,
-  ListPaymentRequestsResponse,
-  PaginatedResponse,
-  PaymentRequest,
-  PaymentsDashboardWallet,
+import {
+  type ListPaymentRequestsResponse,
+  type PaginatedResponse,
+  type PaymentRequest,
+  type SolanaCluster,
+  WELL_KNOWN_TOKENS,
+  type WellKnownToken,
 } from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
 
 export const PAYMENT_REQUESTS_PAGE_SIZE = 100;
-
-const SUPPORTED_REQUEST_TOKENS = [
-  "SOL",
-  "USDC",
-  "USDT",
-] as const satisfies readonly CryptoAssetSymbol[];
 
 export interface PaymentRequestTokenOption {
   mintAddress: string;
   symbol: string;
 }
 
-export function deriveTokenOptions(
-  wallets: PaymentsDashboardWallet[]
-): PaymentRequestTokenOption[] {
-  const supported = new Set<string>(SUPPORTED_REQUEST_TOKENS);
-  const symbolByMint = new Map<string, string>();
-  for (const wallet of wallets) {
-    if (!wallet.balances) {
-      continue;
-    }
-    for (const balance of wallet.balances) {
-      if (supported.has(balance.token) && !symbolByMint.has(balance.mint)) {
-        symbolByMint.set(balance.mint, balance.token);
-      }
-    }
-  }
-  return [...symbolByMint].map(([mintAddress, symbol]) => ({ mintAddress, symbol }));
+/**
+ * Well-known tokens deployed on the given cluster. Payment requests are
+ * receives, so options are not gated by wallet balances — any requestable
+ * token qualifies.
+ *
+ * @param cluster - Solana cluster the dashboard is currently pointed at.
+ * @returns One `{ mintAddress, symbol }` option per well-known token that has
+ *   a mint on the cluster (e.g. USDT is skipped on devnet). Never throws.
+ */
+export function deriveTokenOptions(cluster: SolanaCluster): PaymentRequestTokenOption[] {
+  return Object.values(WELL_KNOWN_TOKENS).flatMap((token: WellKnownToken) => {
+    const mintAddress = token.mints[cluster];
+    return mintAddress ? [{ mintAddress, symbol: token.symbol }] : [];
+  });
 }
 
+/**
+ * Fetches the first {@link PAYMENT_REQUESTS_PAGE_SIZE} payment requests for
+ * the authenticated project.
+ *
+ * @param request - Authenticated SDP API fetcher.
+ * @returns `{ ok: true, data, total }` on success; on any failure (non-2xx or
+ *   network error) `{ ok: false, data: [], total: 0, error }` — never throws.
+ */
 export async function fetchPaymentRequests(
   request: SdpApiClient["request"]
 ): Promise<PaginatedResponse<PaymentRequest>> {

--- a/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
@@ -99,9 +99,24 @@ function resolveExpiryDate(expiryLabel: string): Date | null {
   return new Date(Date.now() + option.hours * 3_600_000);
 }
 
+/**
+ * Formats an expiry instant in the viewer's locale and timezone, e.g.
+ * "June 27, 2026 at 2:30 PM GMT+8". The server stores UTC; this is the
+ * local-time translation for display only.
+ *
+ * @param date - Expiry instant (any timezone; rendered in the browser's).
+ * @returns Locale-formatted date with 12-hour time and timezone name.
+ */
 function formatLocalExpiry(date: Date): string {
-  const pad = (value: number) => String(value).padStart(2, "0");
-  return `${pad(date.getDate())}-${pad(date.getMonth() + 1)}-${date.getFullYear()} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+  return date.toLocaleString(undefined, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZoneName: "short",
+  });
 }
 
 function statusTone(status: PaymentRequestStatus): "success" | "error" | "pending" {

--- a/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
@@ -105,7 +105,7 @@ function resolveExpiryDate(expiryLabel: string): Date | null {
  * local-time translation for display only.
  *
  * @param date - Expiry instant (any timezone; rendered in the browser's).
- * @returns Locale-formatted date with 12-hour time and timezone name.
+ * @returns Locale-formatted date with time and timezone name.
  */
 function formatLocalExpiry(date: Date): string {
   return date.toLocaleString(undefined, {
@@ -114,7 +114,6 @@ function formatLocalExpiry(date: Date): string {
     year: "numeric",
     hour: "numeric",
     minute: "2-digit",
-    hour12: true,
     timeZoneName: "short",
   });
 }
@@ -286,7 +285,6 @@ function CreateRequestModal({
                 id="pr-amount"
                 type="number"
                 inputMode="decimal"
-                min="0"
                 step="any"
                 iconLeft={<BanknoteIcon />}
                 placeholder="0.00"
@@ -695,6 +693,7 @@ export function PaymentRequestsWorkspace({
 
       {createOpen ? (
         <CreateRequestModal
+          key={sdpEnvironment}
           wallets={wallets}
           tokens={tokens}
           counterparties={counterparties}

--- a/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import type {
-  Counterparty,
-  CounterpartyAccount,
-  PaymentRequest,
-  PaymentRequestStatus,
-  PaymentsDashboardWallet,
+import {
+  CLUSTER_BY_SDP_ENVIRONMENT,
+  type Counterparty,
+  type CounterpartyAccount,
+  type PaymentRequest,
+  type PaymentRequestStatus,
+  type PaymentsDashboardWallet,
 } from "@sdp/types";
 import {
   BanknoteIcon,
@@ -64,7 +65,7 @@ import { cn } from "@/lib/utils";
 import { AddExternalAccountDialog } from "../counterparty/add-external-account-dialog";
 import { formatDisplayAmount, formatTimestamp, shortenAddress } from "../payments-overview.utils";
 import { fetchCounterpartyAccounts } from "../payments-workspace.data";
-import type { PaymentRequestTokenOption } from "./payment-requests-page.data";
+import { deriveTokenOptions, type PaymentRequestTokenOption } from "./payment-requests-page.data";
 
 const PaymentRequestsPlayground = dynamic(
   () => import("./payment-requests-playground").then((module) => module.PaymentRequestsPlayground),
@@ -268,9 +269,13 @@ function CreateRequestModal({
               <Input
                 size="xl"
                 id="pr-amount"
+                type="number"
                 inputMode="decimal"
+                min="0"
+                step="any"
                 iconLeft={<BanknoteIcon />}
                 placeholder="0.00"
+                className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 value={form.values.amount}
                 onChange={(event: ChangeEvent<HTMLInputElement>) =>
                   form.setField("amount", event.target.value)
@@ -419,7 +424,6 @@ interface PaymentRequestsWorkspaceProps {
   apiBaseUrl: string | null;
   apiKeys: DashboardPlaygroundApiKeyOption[];
   wallets: PaymentsDashboardWallet[];
-  tokens: PaymentRequestTokenOption[];
   counterparties: Counterparty[];
 }
 
@@ -429,12 +433,15 @@ export function PaymentRequestsWorkspace({
   apiBaseUrl,
   apiKeys,
   wallets,
-  tokens,
   counterparties,
 }: PaymentRequestsWorkspaceProps) {
   const router = useRouter();
-  const { counterpartyTab, selectedPlaygroundApiKeyId, setPlaygroundApiKeys } =
+  const { counterpartyTab, sdpEnvironment, selectedPlaygroundApiKeyId, setPlaygroundApiKeys } =
     useDashboardWorkspace();
+  const tokens = useMemo(
+    () => deriveTokenOptions(CLUSTER_BY_SDP_ENVIRONMENT[sdpEnvironment]),
+    [sdpEnvironment]
+  );
   const isPlaygroundTab = counterpartyTab === "playground";
   const [selected, setSelected] = useState<PaymentRequest | null>(null);
   const [createOpen, setCreateOpen] = useState(false);


### PR DESCRIPTION
## What

The create-payment-request token picker previously derived its options from the org's wallet **balances** (filtered to SOL/USDC/USDT), so a wallet holding only SOL could request only SOL. Payment requests are receives — held balances are irrelevant.

Previously only SOL offered, now all well known spl-tokens are offered
<img width="601" height="555" alt="CleanShot 2026-07-02 at 15 10 03" src="https://github.com/user-attachments/assets/3af705b3-b8d7-43f0-8fb0-bf1b4c17868c" />

- Token options now come from the well-known token registry (`WELL_KNOWN_TOKENS`) for the active cluster, computed from the dashboard's environment toggle. On devnet that's SOL, USDC, PYUSD; USDT joins on mainnet.
- Dropped the now-dead `includeBalances: true` wallet fetch on the requests page (was fanning out per-wallet balance lookups on every load of this `force-dynamic` route, purely to feed the old derivation).
- Amount field is now a number input (`type="number"`, decimal input mode, spinners hidden), matching the send flows.
- Expiry preview in the modal is locale-formatted via `toLocaleString` (long month, 12-hour time, timezone name) instead of hand-rolled `dd-mm-yyyy hh:mm:ss`; storage stays UTC.

## Notes

- The API already accepted any valid mint (`token` is validated with `isAddress`); this is UI policy only. Custom-mint entry was considered and deliberately left out — Solana Pay transfer-request support for arbitrary (esp. token-2022) mints is wallet-dependent.
- PYUSD is token-2022; major wallets handle it, but it carries the same t22 caveat.

## Testing

- `tsc --noEmit` and `biome check` clean on sdp-web.