### PR TITLE
fix(observability): kora PagerDuty alerts never delivered (missing payload.source)

### DIFF
--- a/notification-policies/contact-points/pagerduty.json
+++ b/notification-policies/contact-points/pagerduty.json
@@ -3,10 +3,11 @@
   "type": "pagerduty",
   "settings": {
     "integrationKey": "${PAGERDUTY_INTEGRATION_KEY}",
-    "severity": "{{ .CommonLabels.severity | default \"critical\" }}",
-    "class": "{{ .CommonLabels.scope | default \"sdp\" }}",
-    "component": "{{ .CommonLabels.service | default \"kora\" }}",
+    "severity": "{{ if eq .CommonLabels.severity \"critical\" }}critical{{ else if eq .CommonLabels.severity \"warning\" }}warning{{ else }}info{{ end }}",
+    "class": "sdp",
+    "component": "{{ .CommonLabels.alertname }}",
     "group": "sdp",
+    "source": "sdp.grafana.net",
     "summary": "{{ .CommonAnnotations.summary }}{{ if not .CommonAnnotations.summary }}{{ .CommonLabels.alertname }}{{ end }}"
   },
   "disableResolveMessage": false


### PR DESCRIPTION
## Problem

Kora's PagerDuty alerts **never actually paged**. Grafana's per-receiver delivery log showed every kora→PagerDuty event rejected with HTTP 400:

```
lastNotifyAttemptError: send notification to Pagerduty: webhook response 400 Bad Request:
  {"errors":["'payload.source' is missing or blank"],"message":"Event object is invalid"}
```

PagerDuty's Events API requires a non-blank `payload.source`; the contact point never set it, so every trigger was dropped at PD. Slack (lenient) always delivered, which masked the gap — the alerts *looked* wired.

## Fix

- Set a static `source` (`sdp.grafana.net`) so PD accepts the event.
- Align `severity` to PD's allowed set (critical/warning/error/info).
- File now matches the live contact point exactly, so `grafana-push` is a no-op (no regression / no clobber of the live fix).

## Verification

Fired a real alert end-to-end (raised `kora-fee-payer-balance-low` threshold on live data → Grafana eval → notification policy → PD), held past `group_wait`, then restored the rule. Result:

```
[pagerduty] lastNotifyAttempt: 2026-07-02T06:55:25Z  lastNotifyAttemptError: (none)   ✅ delivered + paged
```

Confirmed the on-call page fired and self-resolved. Part of Kora mainnet readiness (PRO-1311).