### PR TITLE
fix(payments): revalidate wallet and counterparty caches in action wizards

### DIFF
--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-batch-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-batch-send-wizard.ts
@@ -16,11 +16,11 @@ import {
   createTransferBatch,
   estimateTransferBatch,
   fetchBatchRecipients,
-  fetchWallets,
 } from "@/app/dashboard/payments/payments-workspace.data";
 import type { BulkImportRow } from "../bulk-import";
 import { batchSendSchema, MAX_BATCH_RECIPIENTS } from "../schema";
 import { walletBalanceAssetOptions } from "../wallet-options";
+import { usePaymentsActionWallets } from "./use-payments-action-wallets";
 import type { RampWizardStep } from "./use-ramp-wizard";
 
 export const BATCH_SEND_STEPS = [
@@ -32,7 +32,6 @@ export type BatchSendStepId = (typeof BATCH_SEND_STEPS)[number]["id"];
 
 export type BatchEligibleRecipient = CounterpartyAccountSummary;
 
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 const RECIPIENTS_PAGE_SIZE = 6;
 
 export interface BatchRecipientDraft {
@@ -74,24 +73,10 @@ export function useBatchSendWizard({
   const [submitting, setSubmitting] = useState(false);
   const [batchResult, setBatchResult] = useState<CreateTransferBatchResult | null>(null);
 
-  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
-    PAYMENTS_ACTION_WALLETS_KEY,
-    () => fetchWallets({ includeBalances: true }),
-    {
-      fallbackData: wallets.length > 0 ? wallets : undefined,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
+  const { liveWallets, walletsLoading, liveWalletsError } = usePaymentsActionWallets(
+    wallets,
+    walletsError
   );
-  const liveWallets = swrWallets ?? wallets;
-  const walletsLoading = swrWallets === undefined && !walletsFetchError;
-  const liveWalletsError = walletsFetchError
-    ? walletsFetchError instanceof Error
-      ? walletsFetchError.message
-      : "Request failed."
-    : swrWallets === undefined
-      ? walletsError
-      : null;
 
   const trimmedSearch = search.trim();
   const { data: recipientPage, isLoading: recipientsLoading } = useSWR(

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-receive-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-receive-wizard.ts
@@ -3,8 +3,7 @@
 import type { PaymentsDashboardWallet } from "@sdp/types";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
-import useSWR from "swr";
-import { fetchWallets } from "@/app/dashboard/payments/payments-workspace.data";
+import { usePaymentsActionWallets } from "./use-payments-action-wallets";
 import type { RampWizardStep } from "./use-ramp-wizard";
 
 export const ONCHAIN_RECEIVE_STEPS = [
@@ -13,8 +12,6 @@ export const ONCHAIN_RECEIVE_STEPS = [
 ] as const satisfies readonly RampWizardStep[];
 
 export type OnchainReceiveStepId = (typeof ONCHAIN_RECEIVE_STEPS)[number]["id"];
-
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 
 export interface UseOnchainReceiveWizardProps {
   wallets: PaymentsDashboardWallet[];
@@ -33,24 +30,10 @@ export function useOnchainReceiveWizard({
   const [stepIndex, setStepIndex] = useState(0);
   const [walletId, setWalletId] = useState("");
 
-  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
-    PAYMENTS_ACTION_WALLETS_KEY,
-    () => fetchWallets({ includeBalances: true }),
-    {
-      fallbackData: wallets.length > 0 ? wallets : undefined,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
+  const { liveWallets, walletsLoading, liveWalletsError } = usePaymentsActionWallets(
+    wallets,
+    walletsError
   );
-  const liveWallets = swrWallets ?? wallets;
-  const walletsLoading = swrWallets === undefined && !walletsFetchError;
-  const liveWalletsError = walletsFetchError
-    ? walletsFetchError instanceof Error
-      ? walletsFetchError.message
-      : "Request failed."
-    : swrWallets === undefined
-      ? walletsError
-      : null;
 
   const selectedWallet = useMemo(
     () => liveWallets.find((wallet) => wallet.walletId === walletId) ?? null,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-onchain-send-wizard.ts
@@ -12,11 +12,11 @@ import useSWR from "swr";
 import {
   createTransfer,
   fetchCounterpartyAccounts,
-  fetchWallets,
 } from "@/app/dashboard/payments/payments-workspace.data";
 import { useZodForm } from "@/lib/use-zod-form";
 import { onchainDestinationSchema, onchainDetailsSchema, onchainSendSchema } from "../schema";
 import { walletBalanceAssetOptions } from "../wallet-options";
+import { usePaymentsActionWallets } from "./use-payments-action-wallets";
 import type { RampWizardStep } from "./use-ramp-wizard";
 
 export const ONCHAIN_SEND_STEPS = [
@@ -26,8 +26,6 @@ export const ONCHAIN_SEND_STEPS = [
 ] as const satisfies readonly RampWizardStep[];
 
 export type OnchainSendStepId = (typeof ONCHAIN_SEND_STEPS)[number]["id"];
-
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 
 function resolveAccountAddress(account: CounterpartyAccount | null): string {
   if (!account) {
@@ -65,24 +63,10 @@ export function useOnchainSendWizard({
   const [submitting, setSubmitting] = useState(false);
   const [transferResult, setTransferResult] = useState<PaymentTransferSummary | null>(null);
 
-  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
-    PAYMENTS_ACTION_WALLETS_KEY,
-    () => fetchWallets({ includeBalances: true }),
-    {
-      fallbackData: wallets.length > 0 ? wallets : undefined,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
+  const { liveWallets, walletsLoading, liveWalletsError } = usePaymentsActionWallets(
+    wallets,
+    walletsError
   );
-  const liveWallets = swrWallets ?? wallets;
-  const walletsLoading = swrWallets === undefined && !walletsFetchError;
-  const liveWalletsError = walletsFetchError
-    ? walletsFetchError instanceof Error
-      ? walletsFetchError.message
-      : "Request failed."
-    : swrWallets === undefined
-      ? walletsError
-      : null;
 
   const {
     data: accounts,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-payments-action-wallets.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-payments-action-wallets.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import type { PaymentsDashboardWallet } from "@sdp/types";
+import { fetchWallets } from "@/app/dashboard/payments/payments-workspace.data";
+import { usePersistedDashboardSWR } from "@/lib/dashboard-swr";
+
+export const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
+
+/**
+ * Loads payment action wallets with live balances while preserving the initial server wallet state.
+ */
+export function usePaymentsActionWallets(
+  wallets: PaymentsDashboardWallet[],
+  walletsError: string | null
+): {
+  liveWallets: PaymentsDashboardWallet[];
+  walletsLoading: boolean;
+  liveWalletsError: string | null;
+} {
+  const { data: swrWallets, error: walletsFetchError } = usePersistedDashboardSWR<
+    PaymentsDashboardWallet[]
+  >(PAYMENTS_ACTION_WALLETS_KEY, () => fetchWallets({ includeBalances: true }), {
+    fallbackData: wallets.length > 0 ? wallets : undefined,
+  });
+  const liveWallets = swrWallets ?? wallets;
+  const walletsLoading = swrWallets === undefined && !walletsFetchError;
+  const liveWalletsError = walletsFetchError
+    ? walletsFetchError instanceof Error
+      ? walletsFetchError.message
+      : "Request failed."
+    : swrWallets === undefined
+      ? walletsError
+      : null;
+
+  return {
+    liveWallets,
+    walletsLoading,
+    liveWalletsError,
+  };
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/hooks/use-ramp-wizard.ts
@@ -16,7 +16,6 @@ import {
   type CounterpartiesResult,
   cancelRampTransfer,
   fetchAllCounterparties,
-  fetchWallets,
   getApiError,
 } from "@/app/dashboard/payments/payments-workspace.data";
 import {
@@ -29,8 +28,8 @@ import {
 import { useZodForm } from "@/lib/use-zod-form";
 import { type RampFields, rampSelectionSchema } from "../schema";
 import { useCounterpartyRequirements } from "./use-counterparty-requirements";
+import { usePaymentsActionWallets } from "./use-payments-action-wallets";
 
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
 
 export function isTerminalRampTransferStatus(status: string) {
@@ -161,32 +160,16 @@ export function useRampWizard<TId extends string>(
       : null
   );
 
-  const { data: swrWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
-    PAYMENTS_ACTION_WALLETS_KEY,
-    () => fetchWallets({ includeBalances: true }),
-    {
-      fallbackData: wallets.length > 0 ? wallets : undefined,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
+  const { liveWallets, walletsLoading, liveWalletsError } = usePaymentsActionWallets(
+    wallets,
+    walletsError
   );
-  const liveWallets = swrWallets ?? wallets;
-  const walletsLoading = swrWallets === undefined && !walletsFetchError;
-  const liveWalletsError = walletsFetchError
-    ? walletsFetchError instanceof Error
-      ? walletsFetchError.message
-      : "Request failed."
-    : swrWallets === undefined
-      ? walletsError
-      : null;
 
   const { data: liveCounterpartiesResult, mutate: mutateCounterparties } = useSWR(
     PAYMENTS_ACTION_COUNTERPARTIES_KEY,
     fetchAllCounterparties,
     {
       fallbackData: counterpartiesResult,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
     }
   );
 

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/ramp-action-page.tsx
@@ -21,6 +21,7 @@ import { CounterpartyRecentTransfers } from "./components/counterparty-recent-tr
 import { type PaymentMethod, PaymentMethodStep } from "./components/payment-method-step";
 import { RampWizardShell } from "./components/ramp-wizard-shell";
 import { type SendMode, SendModeToggle } from "./components/send-mode-toggle";
+import { PAYMENTS_ACTION_WALLETS_KEY } from "./hooks/use-payments-action-wallets";
 import { OfframpRail } from "./offramp-rail";
 import { OnchainReceiveRail } from "./onchain-receive-rail";
 import { OnchainSendRail } from "./onchain-send-rail";
@@ -40,7 +41,6 @@ interface PaymentsActionPageProps {
 type WizardStep = { label: string; title: string };
 
 const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 
 export interface RailProps {
   wallets: PaymentsDashboardWallet[];
@@ -71,8 +71,6 @@ export function PaymentsActionPage(props: PaymentsActionPageProps) {
     fetchAllCounterparties,
     {
       fallbackData: props.counterpartiesResult,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
     }
   );
   const liveCounterparties = counterpartiesResult ?? props.counterpartiesResult;

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payment-create-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payment-create-workspace.tsx
@@ -19,6 +19,10 @@ import {
 } from "../payments-workspace.data";
 import { CounterpartyPicker } from "../ramps/components/counterparty-picker";
 import { RampWizardShell } from "../ramps/components/ramp-wizard-shell";
+import {
+  PAYMENTS_ACTION_WALLETS_KEY,
+  usePaymentsActionWallets,
+} from "../ramps/hooks/use-payments-action-wallets";
 import { walletBalanceAssetOptions } from "../ramps/wallet-options";
 import { createRecurringPayment } from "./recurring-payments.data";
 
@@ -55,7 +59,6 @@ const CREATE_STEPS = [
 ] as const satisfies readonly { id: StepId; label: string; title: string }[];
 
 const PAYMENTS_ACTION_COUNTERPARTIES_KEY = "payments-action-counterparties";
-const PAYMENTS_ACTION_WALLETS_KEY = "payments-action-wallets";
 
 const SCHEDULE_PRESETS = [
   { value: "24", label: "Every day", description: "Collect once per day." },
@@ -191,29 +194,14 @@ export function RecurringPaymentCreateWorkspace({
     fetchAllCounterparties,
     {
       fallbackData: counterpartiesResult,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
     }
   );
   const liveCounterparties = liveCounterpartiesResult ?? counterpartiesResult;
 
-  const { data: liveWallets, error: walletsFetchError } = useSWR<PaymentsDashboardWallet[]>(
-    PAYMENTS_ACTION_WALLETS_KEY,
-    () => fetchWallets({ includeBalances: true }),
-    {
-      fallbackData: wallets.length > 0 ? wallets : undefined,
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-    }
+  const { liveWallets: availableWallets, liveWalletsError } = usePaymentsActionWallets(
+    wallets,
+    walletsError
   );
-  const availableWallets = liveWallets ?? wallets;
-  const liveWalletsError = walletsFetchError
-    ? walletsFetchError instanceof Error
-      ? walletsFetchError.message
-      : "Unable to load wallets."
-    : liveWallets === undefined
-      ? walletsError
-      : null;
 
   const {
     data: accounts,


### PR DESCRIPTION
## Problem

Funding a wallet and then opening Pay showed the wallet's pre-funding balance and an empty asset dropdown; only a full browser reload surfaced the new balance. The natural "fund your wallet, then pay" sequence dead-ended, reading like the funds never arrived (compounds #566).

Closes #568

## Root cause

The action wizards fetched wallets on the shared `"payments-action-wallets"` SWR key with `revalidateOnFocus: false, revalidateIfStale: false`. With SWR 2.x, `revalidateIfStale: false` suppresses revalidation on every remount of an already-populated key, and the SWR cache survives client-side navigation — so after the first fetch, nothing short of a hard reload ever refreshed. The same copy-pasted override existed at five wallet call sites and three more on the counterparties key. No `mutate()` call existed anywhere.

## Changes

- **New `ramps/hooks/use-payments-action-wallets.ts`** — one shared `usePaymentsActionWallets` hook wrapping the existing `usePersistedDashboardSWR`, inheriting the dashboard-wide revalidation defaults (focus + stale revalidation on). The wallets key constant moves here. The wallet/error derivation logic is the same code the five call sites each had — moved, not rewritten.
- **Five wallet call sites** (`use-ramp-wizard`, `use-onchain-send-wizard`, `use-onchain-receive-wizard`, `use-batch-send-wizard`, `recurring-payment-create-workspace`) now use the shared hook — the override class can't be reintroduced per-file.
- **Three counterparties-key call sites** (`use-ramp-wizard`, `ramp-action-page`, `recurring-payment-create-workspace`) drop the same two overrides and inherit the defaults.

Net −80 lines.

## Scoped out deliberately

- No `mutate()`-on-write after send/receive completion (focus/remount revalidation covers the observed failure).
- No manual refresh control — focus revalidation handles the fund-in-another-tab-then-return flow.
- No localStorage persistence on the new hook.

## Verification

`tsc --noEmit` clean, biome clean across all 7 touched files (sdp-web has no unit-test infra). Manual repro: fund a wallet, navigate to Pay — balance and asset options now refresh on mount/focus without a reload.