### PR TITLE
fix(api): enforce API key allowed IPs

### DIFF
--- a/apps/sdp-api/src/lib/ip-allowlist.node.test.ts
+++ b/apps/sdp-api/src/lib/ip-allowlist.node.test.ts
@@ -13,6 +13,11 @@ describe("IP allowlist matching", () => {
     expect(ipMatchesAllowedIps("203.0.114.42", ["203.0.113.0/24"])).toBe(false);
   });
 
+  it("matches IPv4-mapped IPv6 request IPs against IPv4 entries", () => {
+    expect(ipMatchesAllowedIps("::ffff:203.0.113.42", ["203.0.113.42"])).toBe(true);
+    expect(ipMatchesAllowedIps("::ffff:203.0.113.42", ["203.0.113.0/24"])).toBe(true);
+  });
+
   it("matches exact IPv6 entries and IPv6 CIDR ranges", () => {
     expect(ipMatchesAllowedIps("2001:db8::42", ["2001:db8::42"])).toBe(true);
     expect(ipMatchesAllowedIps("2001:db8::42", ["2001:db8::/32"])).toBe(true);

--- a/apps/sdp-api/src/lib/ip-allowlist.node.test.ts
+++ b/apps/sdp-api/src/lib/ip-allowlist.node.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { ipMatchesAllowedIps, isValidIpAllowlistEntry } from "./ip-allowlist";
+
+describe("IP allowlist matching", () => {
+  it("allows requests when no allowlist is configured", () => {
+    expect(ipMatchesAllowedIps(null, null)).toBe(true);
+    expect(ipMatchesAllowedIps("203.0.113.42", [])).toBe(true);
+  });
+
+  it("matches exact IPv4 entries and IPv4 CIDR ranges", () => {
+    expect(ipMatchesAllowedIps("203.0.113.42", ["203.0.113.42"])).toBe(true);
+    expect(ipMatchesAllowedIps("203.0.113.42", ["203.0.113.0/24"])).toBe(true);
+    expect(ipMatchesAllowedIps("203.0.114.42", ["203.0.113.0/24"])).toBe(false);
+  });
+
+  it("matches exact IPv6 entries and IPv6 CIDR ranges", () => {
+    expect(ipMatchesAllowedIps("2001:db8::42", ["2001:db8::42"])).toBe(true);
+    expect(ipMatchesAllowedIps("2001:db8::42", ["2001:db8::/32"])).toBe(true);
+    expect(ipMatchesAllowedIps("2001:db9::42", ["2001:db8::/32"])).toBe(false);
+  });
+
+  it("denies requests without a parseable source IP when an allowlist exists", () => {
+    expect(ipMatchesAllowedIps(null, ["203.0.113.0/24"])).toBe(false);
+    expect(ipMatchesAllowedIps("not-an-ip", ["203.0.113.0/24"])).toBe(false);
+  });
+
+  it("denies malformed allowlists even when another entry would match", () => {
+    expect(ipMatchesAllowedIps("203.0.113.42", ["203.0.113.0/24", "not-a-cidr"])).toBe(false);
+  });
+
+  it("denies non-array allowlist data", () => {
+    expect(ipMatchesAllowedIps("203.0.113.42", "203.0.113.42")).toBe(false);
+  });
+
+  it("validates allowlist entry syntax", () => {
+    expect(isValidIpAllowlistEntry("203.0.113.42")).toBe(true);
+    expect(isValidIpAllowlistEntry("203.0.113.0/24")).toBe(true);
+    expect(isValidIpAllowlistEntry("2001:db8::/32")).toBe(true);
+    expect(isValidIpAllowlistEntry("203.0.113.0/33")).toBe(false);
+    expect(isValidIpAllowlistEntry("2001:db8::/129")).toBe(false);
+    expect(isValidIpAllowlistEntry("not-a-cidr")).toBe(false);
+  });
+});

--- a/apps/sdp-api/src/lib/ip-allowlist.ts
+++ b/apps/sdp-api/src/lib/ip-allowlist.ts
@@ -1,0 +1,200 @@
+type IpVersion = 4 | 6;
+
+interface ParsedIp {
+  version: IpVersion;
+  bytes: number[];
+}
+
+interface ParsedIpRange extends ParsedIp {
+  prefixLength: number;
+}
+
+export function isValidIpAllowlistEntry(value: string): boolean {
+  return parseIpRange(value) !== null;
+}
+
+export function ipMatchesAllowedIps(ip: string | null, allowedIps: unknown): boolean {
+  if (allowedIps == null) {
+    return true;
+  }
+
+  if (!Array.isArray(allowedIps)) {
+    return false;
+  }
+
+  if (allowedIps.length === 0) {
+    return true;
+  }
+
+  const parsedIp = ip ? parseIp(ip) : null;
+  if (!parsedIp) {
+    return false;
+  }
+
+  const ranges: ParsedIpRange[] = [];
+  for (const entry of allowedIps) {
+    if (typeof entry !== "string") {
+      return false;
+    }
+
+    const range = parseIpRange(entry);
+    if (!range) {
+      return false;
+    }
+
+    ranges.push(range);
+  }
+
+  for (const range of ranges) {
+    if (range.version === parsedIp.version && matchesPrefix(parsedIp.bytes, range)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function parseIpRange(value: string): ParsedIpRange | null {
+  const [rawIp, rawPrefix, extra] = value.trim().split("/");
+  if (!rawIp || extra !== undefined) {
+    return null;
+  }
+
+  const ip = parseIp(rawIp);
+  if (!ip) {
+    return null;
+  }
+
+  const maxPrefix = ip.version === 4 ? 32 : 128;
+  const prefixLength = rawPrefix === undefined ? maxPrefix : parsePrefix(rawPrefix, maxPrefix);
+  if (prefixLength === null) {
+    return null;
+  }
+
+  return { ...ip, prefixLength };
+}
+
+function parsePrefix(value: string, max: number): number | null {
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const prefix = Number(value);
+  return Number.isInteger(prefix) && prefix >= 0 && prefix <= max ? prefix : null;
+}
+
+function parseIp(value: string): ParsedIp | null {
+  const normalized = stripIpv6Brackets(value.trim());
+  if (normalized.includes(":")) {
+    const bytes = parseIpv6(normalized);
+    return bytes ? { version: 6, bytes } : null;
+  }
+
+  const bytes = parseIpv4(normalized);
+  return bytes ? { version: 4, bytes } : null;
+}
+
+function stripIpv6Brackets(value: string): string {
+  return value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
+}
+
+function parseIpv4(value: string): number[] | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  const bytes = parts.map((part) => {
+    if (!/^\d+$/.test(part)) {
+      return null;
+    }
+
+    const byte = Number(part);
+    return byte >= 0 && byte <= 255 ? byte : null;
+  });
+
+  return bytes.every((byte): byte is number => byte !== null) ? bytes : null;
+}
+
+function parseIpv6(value: string): number[] | null {
+  if (value.includes("%")) {
+    return null;
+  }
+
+  const halves = value.split("::");
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const head = parseIpv6Side(halves[0]);
+  const tail = halves.length === 2 ? parseIpv6Side(halves[1]) : [];
+  if (!head || !tail) {
+    return null;
+  }
+
+  const missingGroups = 8 - head.length - tail.length;
+  let groups: number[] | null = null;
+  if (halves.length === 2 && missingGroups >= 1) {
+    groups = [...head, ...Array(missingGroups).fill(0), ...tail];
+  } else if (halves.length === 1 && head.length === 8) {
+    groups = head;
+  }
+
+  if (groups?.length !== 8) {
+    return null;
+  }
+
+  return groups.flatMap((group) => [(group >> 8) & 0xff, group & 0xff]);
+}
+
+function parseIpv6Side(value: string): number[] | null {
+  if (!value) {
+    return [];
+  }
+
+  const groups: number[] = [];
+  const parts = value.split(":");
+
+  for (let index = 0; index < parts.length; index++) {
+    const part = parts[index];
+    if (part.includes(".")) {
+      if (index !== parts.length - 1) {
+        return null;
+      }
+
+      const ipv4 = parseIpv4(part);
+      if (!ipv4) {
+        return null;
+      }
+
+      groups.push((ipv4[0] << 8) | ipv4[1], (ipv4[2] << 8) | ipv4[3]);
+      continue;
+    }
+
+    if (!/^[0-9a-fA-F]{1,4}$/.test(part)) {
+      return null;
+    }
+
+    groups.push(Number.parseInt(part, 16));
+  }
+
+  return groups.length <= 8 ? groups : null;
+}
+
+function matchesPrefix(bytes: number[], range: ParsedIpRange): boolean {
+  const fullBytes = Math.floor(range.prefixLength / 8);
+  const remainingBits = range.prefixLength % 8;
+
+  for (let index = 0; index < fullBytes; index++) {
+    if (bytes[index] !== range.bytes[index]) {
+      return false;
+    }
+  }
+
+  if (remainingBits === 0) {
+    return true;
+  }
+
+  const mask = (0xff << (8 - remainingBits)) & 0xff;
+  return (bytes[fullBytes] & mask) === (range.bytes[fullBytes] & mask);
+}

--- a/apps/sdp-api/src/lib/ip-allowlist.ts
+++ b/apps/sdp-api/src/lib/ip-allowlist.ts
@@ -26,7 +26,7 @@ export function ipMatchesAllowedIps(ip: string | null, allowedIps: unknown): boo
     return true;
   }
 
-  const parsedIp = ip ? parseIp(ip) : null;
+  const parsedIp = ip ? normalizeIpv4MappedIp(parseIp(ip)) : null;
   if (!parsedIp) {
     return false;
   }
@@ -96,6 +96,18 @@ function parseIp(value: string): ParsedIp | null {
 
 function stripIpv6Brackets(value: string): string {
   return value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
+}
+
+function normalizeIpv4MappedIp(ip: ParsedIp | null): ParsedIp | null {
+  if (ip?.version !== 6) {
+    return ip;
+  }
+
+  const isMapped =
+    ip.bytes.slice(0, 10).every((byte) => byte === 0) &&
+    ip.bytes[10] === 0xff &&
+    ip.bytes[11] === 0xff;
+  return isMapped ? { version: 4, bytes: ip.bytes.slice(12) } : ip;
 }
 
 function parseIpv4(value: string): number[] | null {

--- a/apps/sdp-api/src/middleware/auth.node.test.ts
+++ b/apps/sdp-api/src/middleware/auth.node.test.ts
@@ -75,6 +75,26 @@ describe("authMiddleware allowed IPs", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("rejects cached API keys without a trusted Cloudflare source IP", async () => {
+    const context = createAuthContext(
+      {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["203.0.113.0/24"],
+      },
+      {
+        Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        "x-forwarded-for": "203.0.113.42",
+      }
+    );
+    const next = vi.fn() as Next;
+
+    await expect(authMiddleware()(context, next)).rejects.toMatchObject({
+      code: "INVALID_API_KEY",
+      statusCode: 401,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("rejects cached API keys when any allowlist entry is malformed", async () => {
     const context = createAuthContext(
       {

--- a/apps/sdp-api/src/middleware/auth.node.test.ts
+++ b/apps/sdp-api/src/middleware/auth.node.test.ts
@@ -1,0 +1,97 @@
+import type { CachedApiKey } from "@sdp/types";
+import type { Context, Next } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { KVStore } from "@/runtime/kv";
+import { TEST_API_KEY, TEST_CACHED_API_KEY } from "@/test/fixtures/api-keys";
+import type { Env } from "@/types/env";
+import { authMiddleware } from "./auth";
+
+class FakeKVStore implements KVStore {
+  constructor(private readonly cachedKey: CachedApiKey) {}
+
+  async get(_key: string): Promise<string | null>;
+  async get<T>(_key: string, type: "json"): Promise<T | null>;
+  async get<T>(_key: string, type?: "json"): Promise<string | T | null> {
+    return type === "json" ? (this.cachedKey as T) : JSON.stringify(this.cachedKey);
+  }
+
+  async put(): Promise<void> {}
+
+  async delete(): Promise<void> {}
+
+  async list(): Promise<{ keys: [] }> {
+    return { keys: [] };
+  }
+}
+
+function createAuthContext(
+  cachedKey: CachedApiKey,
+  headers: Record<string, string>
+): Context<{ Bindings: Env }> {
+  const normalizedHeaders = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  const kv = new FakeKVStore(cachedKey);
+
+  return {
+    env: {
+      ENVIRONMENT: "development",
+      API_VERSION: "v1",
+      API_KEY_PEPPER: "test-pepper-for-unit-tests",
+    },
+    req: {
+      header: (name: string) => normalizedHeaders.get(name.toLowerCase()),
+    },
+    var: {
+      kv: {
+        apiKeys: kv,
+        rateLimits: kv,
+        cache: kv,
+        sessions: kv,
+      },
+    },
+    set: vi.fn(),
+  } as unknown as Context<{ Bindings: Env }>;
+}
+
+describe("authMiddleware allowed IPs", () => {
+  it("rejects cached API keys used outside the configured CIDR", async () => {
+    const context = createAuthContext(
+      {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["203.0.113.0/24"],
+      },
+      {
+        Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        "cf-connecting-ip": "198.51.100.42",
+      }
+    );
+    const next = vi.fn() as Next;
+
+    await expect(authMiddleware()(context, next)).rejects.toMatchObject({
+      code: "INVALID_API_KEY",
+      statusCode: 401,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects cached API keys when any allowlist entry is malformed", async () => {
+    const context = createAuthContext(
+      {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["203.0.113.0/24", "not-a-cidr"],
+      },
+      {
+        Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        "cf-connecting-ip": "203.0.113.42",
+      }
+    );
+    const next = vi.fn() as Next;
+
+    await expect(authMiddleware()(context, next)).rejects.toMatchObject({
+      code: "INVALID_API_KEY",
+      statusCode: 401,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sdp-api/src/middleware/auth.test.ts
+++ b/apps/sdp-api/src/middleware/auth.test.ts
@@ -12,7 +12,8 @@ import {
   TEST_EXPIRED_KEY,
   TEST_REVOKED_KEY,
 } from "@/test/fixtures/api-keys";
-import { TEST_ORG } from "@/test/fixtures/organizations";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { TEST_PROJECT } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 import { clearKVNamespaces, seedCachedApiKey } from "@/test/mocks/kv";
@@ -40,6 +41,49 @@ describe("Auth Middleware", () => {
     await clearTestDatabase(env);
     await clearKVNamespaces(env);
   });
+
+  async function seedDatabaseApiKey(allowedIps: string[] | null): Promise<void> {
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)"
+        )
+        .bind(TEST_USER.id, TEST_USER.email, 1, TEST_USER.status),
+      getDb(env)
+        .prepare(
+          `INSERT OR REPLACE INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          TEST_PROJECT.id,
+          TEST_PROJECT.organizationId,
+          TEST_PROJECT.name,
+          TEST_PROJECT.slug,
+          TEST_PROJECT.environment,
+          TEST_PROJECT.status,
+          TEST_PROJECT.createdBy
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO api_keys
+             (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, allowed_ips, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          TEST_API_KEY.id,
+          TEST_ORG.id,
+          TEST_PROJECT.id,
+          TEST_USER.id,
+          "Allowed IPs test key",
+          TEST_API_KEY.prefix,
+          validKeyHash,
+          TEST_CACHED_API_KEY.role,
+          JSON.stringify(TEST_CACHED_API_KEY.permissions),
+          allowedIps ? JSON.stringify(allowedIps) : null,
+          "active"
+        ),
+    ]);
+  }
 
   describe("key extraction", () => {
     it("accepts Bearer token format", async () => {
@@ -155,6 +199,111 @@ describe("Auth Middleware", () => {
 
       // Auth succeeded and org exists
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("allowed IPs", () => {
+    it("allows cached API keys from a configured CIDR", async () => {
+      await seedCachedApiKey(env, validKeyHash, {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["203.0.113.0/24"],
+      });
+
+      const res = await app.request(
+        `/v1/organizations/${TEST_CACHED_API_KEY.organizationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "cf-connecting-ip": "203.0.113.42",
+          },
+        },
+        env
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("uses x-forwarded-for when Cloudflare IP is unavailable", async () => {
+      await seedCachedApiKey(env, validKeyHash, {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["203.0.113.42"],
+      });
+
+      const res = await app.request(
+        `/v1/organizations/${TEST_CACHED_API_KEY.organizationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "x-forwarded-for": "203.0.113.42, 198.51.100.10",
+          },
+        },
+        env
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects cached API keys outside the configured CIDR", async () => {
+      await seedCachedApiKey(env, validKeyHash, {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["203.0.113.0/24"],
+      });
+
+      const res = await app.request(
+        `/v1/organizations/${TEST_CACHED_API_KEY.organizationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "cf-connecting-ip": "198.51.100.42",
+          },
+        },
+        env
+      );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("INVALID_API_KEY");
+    });
+
+    it("rejects malformed cached allowlists closed", async () => {
+      await seedCachedApiKey(env, validKeyHash, {
+        ...TEST_CACHED_API_KEY,
+        allowedIps: ["not-a-cidr"],
+      });
+
+      const res = await app.request(
+        `/v1/organizations/${TEST_CACHED_API_KEY.organizationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "cf-connecting-ip": "203.0.113.42",
+          },
+        },
+        env
+      );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("INVALID_API_KEY");
+    });
+
+    it("enforces allowed IPs for database-loaded API keys", async () => {
+      await seedDatabaseApiKey(["203.0.113.0/24"]);
+
+      const res = await app.request(
+        `/v1/organizations/${TEST_CACHED_API_KEY.organizationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "cf-connecting-ip": "198.51.100.42",
+          },
+        },
+        env
+      );
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("INVALID_API_KEY");
     });
   });
 

--- a/apps/sdp-api/src/middleware/auth.test.ts
+++ b/apps/sdp-api/src/middleware/auth.test.ts
@@ -223,7 +223,7 @@ describe("Auth Middleware", () => {
       expect(res.status).toBe(200);
     });
 
-    it("uses x-forwarded-for when Cloudflare IP is unavailable", async () => {
+    it("rejects cached API keys without a trusted Cloudflare source IP", async () => {
       await seedCachedApiKey(env, validKeyHash, {
         ...TEST_CACHED_API_KEY,
         allowedIps: ["203.0.113.42"],
@@ -240,7 +240,9 @@ describe("Auth Middleware", () => {
         env
       );
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("INVALID_API_KEY");
     });
 
     it("rejects cached API keys outside the configured CIDR", async () => {
@@ -304,6 +306,23 @@ describe("Auth Middleware", () => {
       expect(res.status).toBe(401);
       const body = (await res.json()) as { error: { code: string } };
       expect(body.error.code).toBe("INVALID_API_KEY");
+    });
+
+    it("allows database-loaded API keys from a configured CIDR", async () => {
+      await seedDatabaseApiKey(["203.0.113.0/24"]);
+
+      const res = await app.request(
+        `/v1/organizations/${TEST_CACHED_API_KEY.organizationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${TEST_API_KEY.raw}`,
+            "cf-connecting-ip": "203.0.113.42",
+          },
+        },
+        env
+      );
+
+      expect(res.status).toBe(200);
     });
   });
 

--- a/apps/sdp-api/src/middleware/auth.ts
+++ b/apps/sdp-api/src/middleware/auth.ts
@@ -82,13 +82,7 @@ function looksLikeJwt(token: string): boolean {
 }
 
 function getRequestIp(c: Context<{ Bindings: Env }>): string | null {
-  const cfIp = c.req.header("cf-connecting-ip")?.trim();
-  if (cfIp) {
-    return cfIp;
-  }
-
-  const forwarded = c.req.header("x-forwarded-for");
-  return forwarded?.split(",")[0]?.trim() || null;
+  return c.req.header("cf-connecting-ip")?.trim() || null;
 }
 
 /**

--- a/apps/sdp-api/src/middleware/auth.ts
+++ b/apps/sdp-api/src/middleware/auth.ts
@@ -21,6 +21,7 @@ import {
 } from "@/db/postgres-utils";
 import { AppError } from "@/lib/errors";
 import { hashString } from "@/lib/hash";
+import { ipMatchesAllowedIps } from "@/lib/ip-allowlist";
 import type { KVStore } from "@/runtime/kv";
 import type { Env } from "@/types/env";
 
@@ -78,6 +79,16 @@ function looksLikeApiKey(token: string): boolean {
 
 function looksLikeJwt(token: string): boolean {
   return token.split(".").length === 3;
+}
+
+function getRequestIp(c: Context<{ Bindings: Env }>): string | null {
+  const cfIp = c.req.header("cf-connecting-ip")?.trim();
+  if (cfIp) {
+    return cfIp;
+  }
+
+  const forwarded = c.req.header("x-forwarded-for");
+  return forwarded?.split(",")[0]?.trim() || null;
 }
 
 /**
@@ -271,6 +282,10 @@ export function authMiddleware() {
     // Check expiration
     if (cachedKey.expiresAt && new Date(cachedKey.expiresAt) < new Date()) {
       throw new AppError("EXPIRED_API_KEY");
+    }
+
+    if (!ipMatchesAllowedIps(getRequestIp(c), cachedKey.allowedIps)) {
+      throw new AppError("INVALID_API_KEY", "Invalid API key");
     }
 
     // Set auth context

--- a/apps/sdp-api/src/openapi/schemas/api-keys.ts
+++ b/apps/sdp-api/src/openapi/schemas/api-keys.ts
@@ -156,8 +156,8 @@ export const apiKeyDetailSchema = z
       .array(z.string())
       .nullable()
       .openapi({
-        description: "CIDR ranges permitted to use the key.",
-        example: ["203.0.113.0/24"],
+        description: "IP addresses or CIDR ranges permitted to use the key.",
+        example: ["203.0.113.42", "203.0.113.0/24"],
       }),
     walletScope: apiKeyWalletScopeSchema,
     signingWalletId: z.string().nullable().openapi({
@@ -293,8 +293,8 @@ export const createApiKeyRequestSchema = apiKeyCreateSchemaBase
       example: "selected",
     }),
     allowedIps: withOpenApi(apiKeyCreateSchemaBase.shape.allowedIps, {
-      description: "Optional list of CIDR ranges allowed to use the key.",
-      example: ["203.0.113.0/24"],
+      description: "Optional list of IP addresses or CIDR ranges allowed to use the key.",
+      example: ["203.0.113.42", "203.0.113.0/24"],
     }),
     expiresAt: withOpenApi(apiKeyCreateSchemaBase.shape.expiresAt, {
       description: "Optional expiration timestamp.",
@@ -348,8 +348,8 @@ export const updateApiKeyRequestSchema = apiKeyUpdateSchemaBase
       example: "all",
     }),
     allowedIps: withOpenApi(apiKeyUpdateSchemaBase.shape.allowedIps, {
-      description: "Updated IP allowlist. Use null to clear.",
-      example: ["203.0.113.0/24"],
+      description: "Updated IP address or CIDR allowlist. Use null to clear.",
+      example: ["203.0.113.42", "203.0.113.0/24"],
     }),
     expiresAt: withOpenApi(apiKeyUpdateSchemaBase.shape.expiresAt, {
       description: "Updated expiration. Use null to clear.",

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -374,9 +374,10 @@ export const updateApiKey = async (c: AppContext) => {
     await replaceApiKeyWalletBindings(getDb(c.env), keyId, walletSelection.bindings);
   }
 
-  // Invalidate cache if auth-relevant fields changed
+  // Auth middleware caches these fields by key hash; evict on every auth-relevant write.
   if (
     parsed.data.allowedIps !== undefined ||
+    parsed.data.expiresAt !== undefined ||
     parsed.data.permissions !== undefined ||
     walletSelection.touched
   ) {

--- a/apps/sdp-api/src/routes/api-keys/schemas.ts
+++ b/apps/sdp-api/src/routes/api-keys/schemas.ts
@@ -1,5 +1,10 @@
 import { PERMISSIONS } from "@sdp/types";
 import { z } from "zod";
+import { isValidIpAllowlistEntry } from "@/lib/ip-allowlist";
+
+const ipAllowlistEntrySchema = z.string().refine(isValidIpAllowlistEntry, {
+  message: "Invalid IP allowlist entry",
+});
 
 const apiKeyWalletBindingSchema = z.object({
   walletId: z.string().min(1),
@@ -12,7 +17,7 @@ export const apiKeyCreateSchema = z.object({
   role: z.enum(["api_admin", "api_developer", "api_readonly"]).optional(),
   permissions: z.array(z.enum(PERMISSIONS)).optional(),
   walletScope: z.enum(["all", "selected"]),
-  allowedIps: z.array(z.string()).optional(),
+  allowedIps: z.array(ipAllowlistEntrySchema).optional(),
   expiresAt: z.string().datetime().optional(),
   signingWalletId: z.string().min(1).optional(),
   signingWalletIds: z.array(z.string().min(1)).optional(),
@@ -28,7 +33,7 @@ export const apiKeyUpdateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(500).nullable().optional(),
   walletScope: z.enum(["all", "selected"]).optional(),
-  allowedIps: z.array(z.string()).nullable().optional(),
+  allowedIps: z.array(ipAllowlistEntrySchema).nullable().optional(),
   expiresAt: z.string().datetime().nullable().optional(),
   permissions: z.array(z.enum(PERMISSIONS)).nullable().optional(),
   signingWalletId: z.string().min(1).nullable().optional(),

--- a/packages/sdp-types/src/api-keys.ts
+++ b/packages/sdp-types/src/api-keys.ts
@@ -46,7 +46,7 @@ export interface ApiKey {
   permissions: Permission[] | null; // Override permissions, null = use role defaults
   environment: ApiKeyEnvironment;
   rateLimitTier: RateLimitTier;
-  allowedIps: string[] | null; // CIDR ranges for IP restriction
+  allowedIps: string[] | null; // IP addresses or CIDR ranges for IP restriction
   lastUsedAt: string | null;
   expiresAt: string | null;
   revokedAt: string | null;
@@ -89,7 +89,7 @@ export interface CreateApiKeyRequest {
   role?: ApiKeyRole;
   permissions?: Permission[];
   walletScope: ApiKeyWalletScope;
-  allowedIps?: string[]; // CIDR ranges for IP restriction
+  allowedIps?: string[]; // IP addresses or CIDR ranges for IP restriction
   expiresAt?: string; // ISO date string
   signingWalletId?: string;
   signingWalletIds?: string[];


### PR DESCRIPTION
## Summary
- enforce API key `allowedIps` during auth for cached and database-loaded keys
- support exact IPs and CIDR ranges for IPv4/IPv6, failing closed on malformed allowlist data
- validate `allowedIps` on API key create/update schemas and align API docs/type comments

## Local checks
- `pnpm --filter @sdp/api exec vitest run --config vitest.node.config.ts src/lib/ip-allowlist.node.test.ts src/middleware/auth.node.test.ts --reporter=verbose`
- `pnpm --filter @sdp/api typecheck`
- `pnpm exec biome check apps/sdp-api/src/lib/ip-allowlist.ts apps/sdp-api/src/lib/ip-allowlist.node.test.ts apps/sdp-api/src/middleware/auth.ts apps/sdp-api/src/middleware/auth.test.ts apps/sdp-api/src/middleware/auth.node.test.ts apps/sdp-api/src/routes/api-keys/schemas.ts apps/sdp-api/src/openapi/schemas/api-keys.ts packages/sdp-types/src/api-keys.ts`

## Blocked local validation
- `pnpm --filter @sdp/api test:workers -- src/middleware/auth.test.ts --reporter=verbose` hung before running auth assertions twice in the local Workers harness; interrupted both attempts.