### PR TITLE
feat: finalize recurring payment detail UI

### DIFF
--- a/apps/sdp-docs/scripts/link-check.config.json
+++ b/apps/sdp-docs/scripts/link-check.config.json
@@ -1,4 +1,8 @@
 {
   "ignoredExternalHosts": [],
-  "ignoredExternalUrls": ["https://api.solana.com/openapi.json", "https://api.solana.com/llms.txt"]
+  "ignoredExternalUrls": [
+    "https://api.solana.com/openapi.json",
+    "https://api.solana.com/llms.txt",
+    "https://www.sec.gov/newsroom/speeches-statements/corp-fin-statement-tokenized-securities-012826"
+  ]
 }

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
@@ -110,7 +110,7 @@ export default async function RecurringPaymentDetailRoute({
         ? await trace.step("fetch_recurring_payment_collection_attempts", () =>
             fetchRecurringPaymentCollectionAttempts(apiClient.request, subscriptionId)
           )
-        : { ok: true as const, data: [] };
+        : { ok: true as const, data: { collectionAttempts: [], total: 0 } };
       const knownToken = WELL_KNOWN_TOKEN_BY_MINT.get(recurringPayment.token);
       const tokenLabel =
         knownToken?.symbol ??
@@ -128,7 +128,8 @@ export default async function RecurringPaymentDetailRoute({
           counterpartyLabel={counterpartyLabel}
           amountLabel={formatDisplayAmount(recurringPayment.amount, tokenLabel)}
           currencyLabel={tokenLabel}
-          collectionAttempts={collectionAttemptsResult.data ?? []}
+          collectionAttempts={collectionAttemptsResult.data?.collectionAttempts ?? []}
+          collectionAttemptsTotal={collectionAttemptsResult.data?.total ?? 0}
           collectionAttemptsError={
             collectionAttemptsResult.ok ? undefined : collectionAttemptsResult.error
           }

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx
@@ -9,7 +9,10 @@ import type { SdpApiClient } from "@/lib/sdp-api";
 import { fetchCounterparty } from "../../counterparty/counterparty-page.data";
 import { formatDisplayAmount, shortenAddress } from "../../payments-overview.utils";
 import { fetchPaymentsWallets } from "../../payments-page.data";
-import { fetchRecurringPaymentById } from "../recurring-payments.data";
+import {
+  fetchRecurringPaymentById,
+  fetchRecurringPaymentCollectionAttempts,
+} from "../recurring-payments.data";
 import { RecurringPaymentDetailWorkspace } from "../recurring-payments-workspace";
 
 export const dynamic = "force-dynamic";
@@ -102,6 +105,12 @@ export default async function RecurringPaymentDetailRoute({
         "fetch_recurring_payment_counterparty_accounts",
         () => fetchAllCounterpartyWalletAccounts(apiClient.request, recurringPayment.counterpartyId)
       );
+      const subscriptionId = recurringPayment.subscriptionId;
+      const collectionAttemptsResult = subscriptionId
+        ? await trace.step("fetch_recurring_payment_collection_attempts", () =>
+            fetchRecurringPaymentCollectionAttempts(apiClient.request, subscriptionId)
+          )
+        : { ok: true as const, data: [] };
       const knownToken = WELL_KNOWN_TOKEN_BY_MINT.get(recurringPayment.token);
       const tokenLabel =
         knownToken?.symbol ??
@@ -119,6 +128,10 @@ export default async function RecurringPaymentDetailRoute({
           counterpartyLabel={counterpartyLabel}
           amountLabel={formatDisplayAmount(recurringPayment.amount, tokenLabel)}
           currencyLabel={tokenLabel}
+          collectionAttempts={collectionAttemptsResult.data ?? []}
+          collectionAttemptsError={
+            collectionAttemptsResult.ok ? undefined : collectionAttemptsResult.error
+          }
         />
       );
     }

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -4,19 +4,27 @@ import {
   type CounterpartyAccount,
   type PaymentRecurringPayment,
   type PaymentRecurringPaymentStatus,
+  type PaymentSubscriptionCollectionAttempt,
+  type PaymentSubscriptionCollectionAttemptStatus,
   type PaymentsDashboardWallet,
   WELL_KNOWN_TOKEN_BY_MINT,
 } from "@sdp/types";
 import {
   AlertCircleIcon,
+  BanIcon,
   CheckCircle2Icon,
+  ChevronDownIcon,
   CopyIcon,
   CreditCardIcon,
+  ExternalLinkIcon,
   InfoIcon,
   Loader2Icon,
+  PauseIcon,
   PencilIcon,
   PlusIcon,
+  RefreshCwIcon,
   RepeatIcon,
+  RotateCcwIcon,
   WalletIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -27,6 +35,13 @@ import { Badge, type BadgeVariant } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Combobox } from "@/components/ui/combobox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Modal } from "@/components/ui/modal";
@@ -39,6 +54,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { formatDisplayAmount, formatTimestamp, shortenAddress } from "../payments-overview.utils";
+import { getDevnetExplorerUrl } from "../payments-workspace.data";
 import { walletBalanceAssetOptions } from "../ramps/wallet-options";
 import {
   type RecurringPaymentAction,
@@ -70,6 +86,25 @@ const STATUS_VARIANTS = {
   expired: "danger",
 } as const satisfies Record<PaymentRecurringPaymentStatus, BadgeVariant>;
 
+const COLLECTION_STATUS_LABELS = {
+  pending: "Pending",
+  processing: "Processing",
+  confirmed: "Collected",
+  failed: "Failed",
+  skipped: "Skipped",
+} as const satisfies Record<PaymentSubscriptionCollectionAttemptStatus, string>;
+
+const COLLECTION_STATUS_VARIANTS = {
+  pending: "warning",
+  processing: "info",
+  confirmed: "success",
+  failed: "danger",
+  skipped: "default",
+} as const satisfies Record<PaymentSubscriptionCollectionAttemptStatus, BadgeVariant>;
+
+const COLLECTION_ATTEMPTED_COLUMN_CLASS = "hidden @4xl/collection-history:table-cell";
+const COLLECTION_TRANSFER_COLUMN_CLASS = "hidden @6xl/collection-history:table-cell";
+
 type RecurringPaymentWalletView = PaymentsDashboardWallet;
 
 interface RecurringPaymentCounterpartyView {
@@ -94,6 +129,8 @@ interface RecurringPaymentDetailWorkspaceProps {
   counterpartyLabel: string;
   amountLabel: string;
   currencyLabel: string;
+  collectionAttempts: PaymentSubscriptionCollectionAttempt[];
+  collectionAttemptsError?: string;
 }
 
 function RecurringPaymentStatusBadge({ status }: { status: PaymentRecurringPaymentStatus }) {
@@ -215,6 +252,137 @@ function CopyableValue({
         <CopyIcon />
       </Button>
     </span>
+  );
+}
+
+function CollectionStatusBadge({ status }: { status: PaymentSubscriptionCollectionAttemptStatus }) {
+  return (
+    <Badge variant={COLLECTION_STATUS_VARIANTS[status]}>{COLLECTION_STATUS_LABELS[status]}</Badge>
+  );
+}
+
+function ExplorerValue({ value }: { value: string | null }) {
+  if (!value) {
+    return <span className="text-text-low">Not set</span>;
+  }
+
+  return (
+    <span className="inline-flex max-w-full items-center gap-1.5">
+      <CopyableValue value={value} label={shortenAddress(value)} />
+      <Button asChild variant="ghost" size="icon-xs" aria-label="Open signature">
+        <a href={getDevnetExplorerUrl(value)} target="_blank" rel="noreferrer">
+          <ExternalLinkIcon />
+        </a>
+      </Button>
+    </span>
+  );
+}
+
+function RecurringPaymentCollectionHistory({
+  attempts,
+  error,
+  wallets,
+}: {
+  attempts: PaymentSubscriptionCollectionAttempt[];
+  error?: string;
+  wallets: RecurringPaymentWalletView[];
+}) {
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-text-extra-high">Collection history</h3>
+        {attempts.length > 0 ? (
+          <span className="text-xs text-text-low">
+            {attempts.length === 1 ? "1 attempt" : `${attempts.length} attempts`}
+          </span>
+        ) : null}
+      </div>
+      <div className="@container/collection-history rounded-xl border border-border-light">
+        {error ? (
+          <div role="alert" className="p-4 text-sm text-status-error-text">
+            Unable to load collection history: {error}
+          </div>
+        ) : attempts.length === 0 ? (
+          <div className="p-4 text-sm text-text-medium">
+            No collection attempts yet. The next scheduled collection is shown above.
+          </div>
+        ) : (
+          <div className="overflow-hidden">
+            <Table className="[&_table]:w-full [&_table]:min-w-0 [&_table]:table-fixed">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[28%] @4xl/collection-history:w-[20%] @6xl/collection-history:w-[17%] @7xl/collection-history:w-[15%]">
+                    Due
+                  </TableHead>
+                  <TableHead
+                    className={`${COLLECTION_ATTEMPTED_COLUMN_CLASS} w-[20%] @6xl/collection-history:w-[16%] @7xl/collection-history:w-[15%]`}
+                  >
+                    Attempted
+                  </TableHead>
+                  <TableHead className="w-[25%] @4xl/collection-history:w-[21%] @6xl/collection-history:w-[17%] @7xl/collection-history:w-[16%]">
+                    Amount
+                  </TableHead>
+                  <TableHead className="w-[23%] @4xl/collection-history:w-[18%] @6xl/collection-history:w-[15%] @7xl/collection-history:w-[14%]">
+                    Status
+                  </TableHead>
+                  <TableHead
+                    className={`${COLLECTION_TRANSFER_COLUMN_CLASS} w-[22%] @7xl/collection-history:w-[18%]`}
+                  >
+                    Transfer
+                  </TableHead>
+                  <TableHead className="w-[24%] @4xl/collection-history:w-[21%] @6xl/collection-history:w-[18%] @7xl/collection-history:w-[22%]">
+                    Explorer
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {attempts.map((attempt) => (
+                  <TableRow key={attempt.id}>
+                    <TableCell className="whitespace-nowrap text-sm">
+                      <span className="block truncate">{formatTimestamp(attempt.dueAt)}</span>
+                    </TableCell>
+                    <TableCell
+                      className={`${COLLECTION_ATTEMPTED_COLUMN_CLASS} whitespace-nowrap text-sm text-text-medium`}
+                    >
+                      <span className="block truncate">
+                        {attempt.attemptedAt ? formatTimestamp(attempt.attemptedAt) : "Not set"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-sm font-medium">
+                      <span className="block truncate">
+                        {formatDisplayAmount(
+                          attempt.amount,
+                          resolveTokenLabel(attempt.token, wallets)
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <CollectionStatusBadge status={attempt.status} />
+                        {attempt.error ? (
+                          <p className="max-w-[14rem] truncate text-xs text-status-error-text">
+                            {attempt.error}
+                          </p>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                    <TableCell className={COLLECTION_TRANSFER_COLUMN_CLASS}>
+                      <CopyableValue
+                        value={attempt.transferId}
+                        label={attempt.transferId ? shortenAddress(attempt.transferId) : undefined}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <ExplorerValue value={attempt.signature} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -360,20 +528,26 @@ function secondaryDetailAction(
   };
 }
 
-function RecurringPaymentActionButtons({
+function RecurringPaymentActionsMenu({
   status,
   dueNow,
   pendingAction,
   actionError,
   disabled,
+  editable,
+  onEdit,
   onAction,
+  onCancel,
 }: {
   status: PaymentRecurringPaymentStatus;
   dueNow: boolean;
   pendingAction: RecurringPaymentAction | null;
   actionError: DetailActionError | null;
   disabled?: boolean;
+  editable: boolean;
+  onEdit: () => void;
   onAction: (action: RecurringPaymentAction) => void;
+  onCancel: () => void;
 }) {
   const disabledLabel = disabledActionLabel(status);
   const primaryAction = primaryDetailAction(status, dueNow, actionError);
@@ -381,49 +555,79 @@ function RecurringPaymentActionButtons({
   const actionsDisabled = Boolean(pendingAction) || Boolean(disabled);
 
   return (
-    <div className="flex flex-wrap items-center justify-end gap-2">
-      {disabledLabel ? (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <Button
           type="button"
-          size="sm"
-          disabled
-          iconLeft={<Loader2Icon className="size-4 shrink-0 animate-spin" />}
-        >
-          {disabledLabel}
-        </Button>
-      ) : null}
-      {primaryAction ? (
-        <Button
-          type="button"
+          variant="secondary"
           size="sm"
           disabled={actionsDisabled}
-          iconLeft={
-            pendingAction === primaryAction.action ? (
-              <Loader2Icon className="size-4 shrink-0 animate-spin" />
-            ) : undefined
-          }
-          onClick={() => onAction(primaryAction.action)}
+          iconRight={<ChevronDownIcon className="size-4" />}
         >
-          {primaryAction.label}
+          Actions
         </Button>
-      ) : null}
-      {secondaryAction ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          disabled={actionsDisabled}
-          iconLeft={
-            pendingAction === secondaryAction.action ? (
-              <Loader2Icon className="size-4 shrink-0 animate-spin" />
-            ) : undefined
-          }
-          onClick={() => onAction(secondaryAction.action)}
-        >
-          {secondaryAction.label}
-        </Button>
-      ) : null}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuItem onSelect={onEdit} disabled={!editable || actionsDisabled}>
+          <PencilIcon className="size-4" />
+          <span>Edit payment</span>
+        </DropdownMenuItem>
+        {primaryAction ? (
+          <DropdownMenuItem
+            onSelect={() => onAction(primaryAction.action)}
+            disabled={actionsDisabled}
+          >
+            {pendingAction === primaryAction.action ? (
+              <Loader2Icon className="size-4 animate-spin" />
+            ) : primaryAction.action === "resume" ? (
+              <RotateCcwIcon className="size-4" />
+            ) : (
+              <RefreshCwIcon className="size-4" />
+            )}
+            <span>{primaryAction.label}</span>
+          </DropdownMenuItem>
+        ) : null}
+        {status === "active" ? (
+          <DropdownMenuItem disabled className="items-start">
+            <PauseIcon className="mt-0.5 size-4" />
+            <span className="grid gap-0.5">
+              <span>Pause payment</span>
+              <span className="text-xs font-normal text-text-low">
+                Pause is not supported by the API yet.
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ) : null}
+        {disabledLabel ? (
+          <DropdownMenuItem disabled>
+            <Loader2Icon className="size-4 animate-spin" />
+            <span>{disabledLabel}</span>
+          </DropdownMenuItem>
+        ) : null}
+        {secondaryAction ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={onCancel}
+              disabled={actionsDisabled}
+              className="items-start text-status-error-text focus:text-status-error-text"
+            >
+              {pendingAction === secondaryAction.action ? (
+                <Loader2Icon className="mt-0.5 size-4 animate-spin" />
+              ) : (
+                <BanIcon className="mt-0.5 size-4" />
+              )}
+              <span className="grid gap-0.5">
+                <span>{secondaryAction.label}</span>
+                <span className="text-xs font-normal text-status-error-text">
+                  Stop future collections
+                </span>
+              </span>
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -641,10 +845,13 @@ export function RecurringPaymentDetailWorkspace({
   counterpartyLabel,
   amountLabel,
   currencyLabel,
+  collectionAttempts,
+  collectionAttemptsError,
 }: RecurringPaymentDetailWorkspaceProps) {
   const router = useRouter();
   const [pendingAction, setPendingAction] = useState<RecurringPaymentAction | null>(null);
   const [actionError, setActionError] = useState<DetailActionError | null>(null);
+  const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
   const [editingWallet, setEditingWallet] = useState(false);
   const [selectedWalletId, setSelectedWalletId] = useState(recurringPayment.sourceWalletId);
   const [walletValidationError, setWalletValidationError] = useState<string | null>(null);
@@ -931,11 +1138,12 @@ export function RecurringPaymentDetailWorkspace({
               {counterpartyLabel} · {amountLabel} · {scheduleLabel}
             </p>
           </div>
-          <RecurringPaymentActionButtons
+          <RecurringPaymentActionsMenu
             status={recurringPayment.status}
             dueNow={dueNow}
             pendingAction={pendingAction}
             actionError={actionError}
+            editable={isEditable}
             disabled={
               savingWallet ||
               savingReceivingAccount ||
@@ -943,7 +1151,13 @@ export function RecurringPaymentDetailWorkspace({
               savingCurrency ||
               savingAmount
             }
+            onEdit={() => {
+              setSelectedAmount(recurringPayment.amount);
+              setAmountValidationError(null);
+              setEditingAmount(true);
+            }}
             onAction={(action) => void submitAction(action)}
+            onCancel={() => setCancelConfirmOpen(true)}
           />
         </div>
 
@@ -1479,26 +1693,58 @@ export function RecurringPaymentDetailWorkspace({
           </form>
         </Modal>
 
-        <div>
-          <h3 className="mb-3 text-sm font-medium text-text-extra-high">Billing setup</h3>
-          <div className="divide-y divide-border-light rounded-xl border border-border-light px-4">
-            <DetailRow label="Plan reference">
-              <CopyableValue value={recurringPayment.planId} />
-            </DetailRow>
-            <DetailRow label="Setup confirmed">
-              {formatOptionalTimestamp(recurringPayment.planCreatedAt)}
-            </DetailRow>
-            <DetailRow label="Setup transaction">
-              <CopyableValue value={recurringPayment.planCreationSignature} />
-            </DetailRow>
-            <DetailRow label="Subscription reference">
-              <CopyableValue value={recurringPayment.subscriptionId} />
-            </DetailRow>
-            <DetailRow label="Authorization transaction">
-              <CopyableValue value={recurringPayment.authorizationSignature} />
-            </DetailRow>
+        <RecurringPaymentCollectionHistory
+          attempts={collectionAttempts}
+          error={collectionAttemptsError}
+          wallets={wallets}
+        />
+
+        <Modal
+          isOpen={cancelConfirmOpen}
+          ariaLabel="Cancel recurring payment"
+          onClose={pendingAction === "cancel" ? undefined : () => setCancelConfirmOpen(false)}
+          size="sm"
+        >
+          <div className="space-y-5 p-6">
+            <div className="space-y-1">
+              <h2 className="text-lg font-medium tracking-tight text-text-extra-high">
+                Cancel recurring payment?
+              </h2>
+              <p className="text-sm text-text-medium">
+                This stops future collections for {counterpartyLabel}. You can resume the payment
+                later from the Actions menu.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pendingAction === "cancel"}
+                onClick={() => setCancelConfirmOpen(false)}
+              >
+                Keep payment
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="destructive"
+                disabled={pendingAction === "cancel"}
+                iconLeft={
+                  pendingAction === "cancel" ? (
+                    <Loader2Icon className="size-4 shrink-0 animate-spin" />
+                  ) : undefined
+                }
+                onClick={() => {
+                  setCancelConfirmOpen(false);
+                  void submitAction("cancel");
+                }}
+              >
+                Cancel payment
+              </Button>
+            </div>
           </div>
-        </div>
+        </Modal>
       </div>
     </div>
   );

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -12,14 +12,12 @@ import {
 import {
   AlertCircleIcon,
   BanIcon,
-  CheckCircle2Icon,
   ChevronDownIcon,
   CopyIcon,
   CreditCardIcon,
   ExternalLinkIcon,
   InfoIcon,
   Loader2Icon,
-  PauseIcon,
   PencilIcon,
   PlusIcon,
   RefreshCwIcon,
@@ -448,18 +446,16 @@ function ActionBand({
   title,
   children,
 }: {
-  variant: "info" | "success" | "warning" | "danger";
+  variant: "info" | "warning" | "danger";
   title: string;
   children: ReactNode;
 }) {
   const styles = {
     info: "border-border-light bg-[var(--sdp-color-info-bg)] text-[color:var(--sdp-color-info-text)]",
-    success: "border-border-light bg-status-success-bg text-status-success-text",
     warning: "border-border-light bg-status-warning-bg text-status-warning-text",
     danger: "border-status-error-border bg-status-error-bg text-status-error-text",
   }[variant];
-  const Icon =
-    variant === "danger" ? AlertCircleIcon : variant === "success" ? CheckCircle2Icon : InfoIcon;
+  const Icon = variant === "danger" ? AlertCircleIcon : InfoIcon;
 
   return (
     <div className={`flex items-start gap-3 rounded-xl border px-4 py-3 text-sm ${styles}`}>
@@ -595,17 +591,6 @@ function RecurringPaymentActionsMenu({
             <span>{primaryAction.label}</span>
           </DropdownMenuItem>
         ) : null}
-        {status === "active" ? (
-          <DropdownMenuItem disabled className="items-start">
-            <PauseIcon className="mt-0.5 size-4" />
-            <span className="grid gap-0.5">
-              <span>Pause payment</span>
-              <span className="text-xs font-normal text-text-low">
-                Pause is not supported by the API yet.
-              </span>
-            </span>
-          </DropdownMenuItem>
-        ) : null}
         {disabledLabel ? (
           <DropdownMenuItem disabled>
             <Loader2Icon className="size-4 animate-spin" />
@@ -641,11 +626,9 @@ function RecurringPaymentActionsMenu({
 
 function RecurringPaymentLifecycleBand({
   status,
-  dueNow,
   actionError,
 }: {
   status: PaymentRecurringPaymentStatus;
-  dueNow: boolean;
   actionError: DetailActionError | null;
 }) {
   if (actionError) {
@@ -662,13 +645,6 @@ function RecurringPaymentLifecycleBand({
     return (
       <ActionBand variant="info" title="Ready to activate">
         Creates the subscription and schedules the first payment.
-      </ActionBand>
-    );
-  }
-  if (dueNow) {
-    return (
-      <ActionBand variant="success" title="Due now">
-        Manual collection is available until the automated collector runs.
       </ActionBand>
     );
   }
@@ -1170,11 +1146,7 @@ export function RecurringPaymentDetailWorkspace({
           />
         </div>
 
-        <RecurringPaymentLifecycleBand
-          status={recurringPayment.status}
-          dueNow={dueNow}
-          actionError={actionError}
-        />
+        <RecurringPaymentLifecycleBand status={recurringPayment.status} actionError={actionError} />
 
         <div className="rounded-xl border border-border-light px-4">
           <div className="divide-y divide-border-light">

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -130,6 +130,7 @@ interface RecurringPaymentDetailWorkspaceProps {
   amountLabel: string;
   currencyLabel: string;
   collectionAttempts: PaymentSubscriptionCollectionAttempt[];
+  collectionAttemptsTotal: number;
   collectionAttemptsError?: string;
 }
 
@@ -280,21 +281,28 @@ function ExplorerValue({ value }: { value: string | null }) {
 
 function RecurringPaymentCollectionHistory({
   attempts,
+  total,
   error,
   wallets,
 }: {
   attempts: PaymentSubscriptionCollectionAttempt[];
+  total: number;
   error?: string;
   wallets: RecurringPaymentWalletView[];
 }) {
+  const attemptsLabel =
+    total > attempts.length
+      ? `Showing ${attempts.length} of ${total} attempts`
+      : attempts.length === 1
+        ? "1 attempt"
+        : `${attempts.length} attempts`;
+
   return (
     <div>
       <div className="mb-3 flex items-center justify-between gap-3">
         <h3 className="text-sm font-medium text-text-extra-high">Collection history</h3>
         {attempts.length > 0 ? (
-          <span className="text-xs text-text-low">
-            {attempts.length === 1 ? "1 attempt" : `${attempts.length} attempts`}
-          </span>
+          <span className="text-xs text-text-low">{attemptsLabel}</span>
         ) : null}
       </div>
       <div className="@container/collection-history rounded-xl border border-border-light">
@@ -846,6 +854,7 @@ export function RecurringPaymentDetailWorkspace({
   amountLabel,
   currencyLabel,
   collectionAttempts,
+  collectionAttemptsTotal,
   collectionAttemptsError,
 }: RecurringPaymentDetailWorkspaceProps) {
   const router = useRouter();
@@ -1695,6 +1704,7 @@ export function RecurringPaymentDetailWorkspace({
 
         <RecurringPaymentCollectionHistory
           attempts={collectionAttempts}
+          total={collectionAttemptsTotal}
           error={collectionAttemptsError}
           wallets={wallets}
         />

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx
@@ -1746,8 +1746,7 @@ export function RecurringPaymentDetailWorkspace({
                   ) : undefined
                 }
                 onClick={() => {
-                  setCancelConfirmOpen(false);
-                  void submitAction("cancel");
+                  void submitAction("cancel").finally(() => setCancelConfirmOpen(false));
                 }}
               >
                 Cancel payment

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts
@@ -39,6 +39,11 @@ type DashboardApiEnvelope<T> = {
   message?: string;
 };
 
+export interface RecurringPaymentCollectionAttemptsResult {
+  collectionAttempts: PaymentSubscriptionCollectionAttempt[];
+  total: number;
+}
+
 function setPositiveInteger(query: URLSearchParams, key: string, value: number | undefined) {
   if (typeof value === "number" && Number.isInteger(value) && value > 0) {
     query.set(key, String(value));
@@ -244,7 +249,7 @@ export async function fetchRecurringPaymentById(
 export async function fetchRecurringPaymentCollectionAttempts(
   request: SdpApiClient["request"],
   subscriptionId: string
-): Promise<FetchResult<PaymentSubscriptionCollectionAttempt[]>> {
+): Promise<FetchResult<RecurringPaymentCollectionAttemptsResult>> {
   try {
     const response = await request(
       `/v1/payments/subscriptions/${encodeURIComponent(
@@ -262,7 +267,13 @@ export async function fetchRecurringPaymentCollectionAttempts(
     const json = (await response.json()) as {
       data?: ListPaymentSubscriptionCollectionAttemptsResponse;
     };
-    return { ok: true, data: json.data?.collectionAttempts ?? [] };
+    return {
+      ok: true,
+      data: {
+        collectionAttempts: json.data?.collectionAttempts ?? [],
+        total: json.data?.total ?? 0,
+      },
+    };
   } catch (error) {
     return {
       ok: false,

--- a/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts
@@ -1,11 +1,13 @@
 import type {
   CreatePaymentRecurringPaymentRequest,
   ListPaymentRecurringPaymentsResponse,
+  ListPaymentSubscriptionCollectionAttemptsResponse,
   PaginatedResponse,
   PaymentRecurringPayment,
   PaymentRecurringPaymentCollectionResponse,
   PaymentRecurringPaymentResponse,
   PaymentRecurringPaymentStatus,
+  PaymentSubscriptionCollectionAttempt,
   UpdatePaymentRecurringPaymentRequest,
 } from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
@@ -235,6 +237,36 @@ export async function fetchRecurringPaymentById(
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Unable to load recurring payment",
+    };
+  }
+}
+
+export async function fetchRecurringPaymentCollectionAttempts(
+  request: SdpApiClient["request"],
+  subscriptionId: string
+): Promise<FetchResult<PaymentSubscriptionCollectionAttempt[]>> {
+  try {
+    const response = await request(
+      `/v1/payments/subscriptions/${encodeURIComponent(
+        subscriptionId
+      )}/collection-attempts?page=1&pageSize=25`
+    );
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: parsePaymentApiErrorText(await response.text()),
+      };
+    }
+
+    const json = (await response.json()) as {
+      data?: ListPaymentSubscriptionCollectionAttemptsResponse;
+    };
+    return { ok: true, data: json.data?.collectionAttempts ?? [] };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unable to load collection history",
     };
   }
 }


### PR DESCRIPTION
## Summary
- Remove Billing setup from recurring payment detail and move Collection history into the main detail view.
- Load real subscription collection attempts from the SDP API.
- Replace separate lifecycle buttons with a compact Actions menu, including cancel confirmation and the existing edit modal entry point.
- Make collection history responsive: Source is removed; Explorer remains visible; lower-priority columns appear as space allows.

<img width="286" height="234" alt="Screenshot 2026-07-02 at 6 05 44 PM" src="https://github.com/user-attachments/assets/5392d3ba-b978-4236-966d-492dd8faa31d" />

<img width="960" height="209" alt="Screenshot 2026-07-02 at 6 04 53 PM" src="https://github.com/user-attachments/assets/1d982e94-4a7c-4b22-a91a-9f1f704e3d61" />

<img width="971" height="676" alt="Screenshot 2026-07-02 at 6 06 44 PM" src="https://github.com/user-attachments/assets/f74b4f96-f7b3-4b01-8106-5000a9191456" />

## Local validation
- `pnpm exec biome check apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments.data.ts 'apps/sdp-web/src/app/dashboard/payments/recurring/[recurringPaymentId]/page.tsx' apps/sdp-web/src/app/dashboard/payments/recurring/recurring-payments-workspace.tsx`
- `pnpm --filter sdp-web typecheck`
- `git diff --check --cached`
- API health checked locally on `http://127.0.0.1:8790/health`

## Notes
- Screenshots intentionally omitted per operator request.
- `sdp-web` lint is blocked by the existing ESLint 10 / `eslint-plugin-react` compatibility error (`react/display-name`: `contextOrFilename.getFilename is not a function`).

Linear: PRO-1303
