### PR TITLE
docs: Drop stale infra/kora dir from repo map

### DIFF
--- a/docs/contributing/local-development.md
+++ b/docs/contributing/local-development.md
@@ -30,7 +30,6 @@ The OpenAPI source in `apps/sdp-api/src/openapi` is the source of truth for the 
 | `packages/sdp-types` | Shared runtime types and product constants |
 | `packages/sdp-api-integration` | Maintainer-oriented integration tests |
 | `infra/postgres` | Local Postgres setup |
-| `infra/kora` | Fee-payer service setup |
 | `docs/ops` | Operator and maintainer notes |
 
 ## Local Setup


### PR DESCRIPTION
The `infra/kora` directory was removed from this repo (fee-payer infra moved to sdp-infra), but contributor repo map still listed it, pointing readers at path that no longer exists