### PR TITLE
fix(sdp-web): bootstrap project cookie in proxy on first login

### DIFF
--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -23,12 +23,15 @@ function getApiBaseUrl(): string {
   return base.replace(/\/$/, "");
 }
 
-async function getClerkToken(): Promise<string> {
-  const { getToken, orgId } = await auth();
-  if (!orgId) {
-    throw new Error("Active Clerk organization required");
-  }
+type ClerkGetToken = (options?: { template?: string }) => Promise<string | null>;
 
+/**
+ * Acquires the sdp-api bearer token from a Clerk `getToken`, honoring
+ * CLERK_JWT_TEMPLATE when configured. Takes `getToken` as a parameter because
+ * server contexts get it from `auth()` while the proxy middleware gets it from
+ * its `clerkMiddleware` callback.
+ */
+export async function acquireClerkToken(getToken: ClerkGetToken): Promise<string> {
   const template = process.env.CLERK_JWT_TEMPLATE;
   if (template) {
     const token = await getToken({ template });
@@ -44,6 +47,14 @@ async function getClerkToken(): Promise<string> {
   }
 
   return token;
+}
+
+async function getClerkToken(): Promise<string> {
+  const { getToken, orgId } = await auth();
+  if (!orgId) {
+    throw new Error("Active Clerk organization required");
+  }
+  return acquireClerkToken(getToken);
 }
 
 type SdpApiRequestFn = (path: string, options?: RequestInit) => Promise<Response>;
@@ -145,13 +156,7 @@ export async function getSelectedProjectId(): Promise<string | undefined> {
   return jar.get(PROJECT_COOKIE_NAME)?.value;
 }
 
-async function buildSdpApiClient(
-  projectId: string | null,
-  traceContext?: TraceContext
-): Promise<SdpApiClient> {
-  const token = await getClerkToken();
-  const request = createSdpApiRequest(token, projectId, traceContext);
-
+function assembleSdpApiClient(request: SdpApiRequestFn): SdpApiClient {
   return {
     request,
     fetch: async <T>(path: string, options: RequestInit = {}): Promise<T> => {
@@ -159,6 +164,22 @@ async function buildSdpApiClient(
       return parseSdpApiResponse<T>(res);
     },
   };
+}
+
+async function buildSdpApiClient(
+  projectId: string | null,
+  traceContext?: TraceContext
+): Promise<SdpApiClient> {
+  const token = await getClerkToken();
+  return assembleSdpApiClient(createSdpApiRequest(token, projectId, traceContext));
+}
+
+/**
+ * Creates an org-scoped client from an explicit bearer token, for the proxy
+ * middleware where Clerk's request-bound `auth()` helper is unavailable.
+ */
+export function createTokenSdpApiClient(token: string): SdpApiClient {
+  return assembleSdpApiClient(createSdpApiRequest(token, null));
 }
 
 /**

--- a/apps/sdp-web/src/proxy.ts
+++ b/apps/sdp-web/src/proxy.ts
@@ -27,6 +27,12 @@ function getUnauthenticatedUrl(req: NextRequest): string {
  * projects or the lookup fails; the request then proceeds cookieless and the
  * existing route-level "Selected project required" handling surfaces the
  * failure instead of the proxy taking down every dashboard request.
+ *
+ * The "default-sandbox" slug is safe to hardcode: sdp-api's project
+ * provisioning (project.service.ts) assigns exactly that slug to every org's
+ * auto-created sandbox project and slugs aren't user-editable, so it's a
+ * platform invariant — the same discriminator DashboardWorkspaceProvider and
+ * reconcileProjectCookieAction already match on.
  */
 async function resolveDefaultProjectId(
   getToken: (options?: { template?: string }) => Promise<string | null>

--- a/apps/sdp-web/src/proxy.ts
+++ b/apps/sdp-web/src/proxy.ts
@@ -1,14 +1,45 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import type { ListProjectsResponse } from "@sdp/types";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { AUTH_ENTRY_PATH } from "@/lib/auth-entry";
+import { PROJECT_COOKIE_NAME, PROJECT_COOKIE_OPTIONS } from "@/lib/project-cookie";
+import { acquireClerkToken, createTokenSdpApiClient } from "@/lib/sdp-api";
 
 const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/", "/docs(.*)"]);
+
+const needsSelectedProject = createRouteMatcher([
+  "/dashboard(.*)",
+  "/api/dashboard(.*)",
+  "/api/playground(.*)",
+]);
 
 function getUnauthenticatedUrl(req: NextRequest): string {
   const authEntryUrl = new URL(AUTH_ENTRY_PATH, req.url);
   authEntryUrl.searchParams.set("redirect_url", `${req.nextUrl.pathname}${req.nextUrl.search}`);
   return authEntryUrl.toString();
+}
+
+/**
+ * Resolves the org's default project (sandbox, else first) so a fresh session
+ * enters the dashboard with the project cookie already in place — before any
+ * page SSR or dashboard API route runs. Returns null when the org has no
+ * projects or the lookup fails; the request then proceeds cookieless and the
+ * existing route-level "Selected project required" handling surfaces the
+ * failure instead of the proxy taking down every dashboard request.
+ */
+async function resolveDefaultProjectId(
+  getToken: (options?: { template?: string }) => Promise<string | null>
+): Promise<string | null> {
+  try {
+    const client = createTokenSdpApiClient(await acquireClerkToken(getToken));
+    const { projects } = await client.fetch<ListProjectsResponse>("/v1/projects");
+    return (
+      (projects.find((project) => project.slug === "default-sandbox") ?? projects[0])?.id ?? null
+    );
+  } catch {
+    return null;
+  }
 }
 
 export const proxy = clerkMiddleware(async (auth, req) => {
@@ -18,14 +49,29 @@ export const proxy = clerkMiddleware(async (auth, req) => {
     });
   }
 
+  let bootstrappedProjectId: string | null = null;
+  if (needsSelectedProject(req) && !req.cookies.has(PROJECT_COOKIE_NAME)) {
+    const { getToken, orgId } = await auth();
+    if (orgId) {
+      bootstrappedProjectId = await resolveDefaultProjectId(getToken);
+      if (bootstrappedProjectId) {
+        req.cookies.set(PROJECT_COOKIE_NAME, bootstrappedProjectId);
+      }
+    }
+  }
+
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-sdp-pathname", req.nextUrl.pathname);
 
-  return NextResponse.next({
+  const response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   });
+  if (bootstrappedProjectId) {
+    response.cookies.set(PROJECT_COOKIE_NAME, bootstrappedProjectId, PROJECT_COOKIE_OPTIONS);
+  }
+  return response;
 });
 
 export const config = {


### PR DESCRIPTION
## Problem

On a fresh enter to platform.solana.org (no `sdp_selected_project_id` cookie), the dashboard fails with **"Selected project required"**:

- Server pages (`dashboard/page.tsx`, payments, custody, ...) call `createSdpApiClient()` during SSR, which throws when no project is selected.
- Client SWR fetches to `/api/dashboard/*` hit the same guard and 400.

The cookie *was* being persisted, but only client-side: `DashboardWorkspaceProvider` picks the sandbox project and calls `selectProjectAction` in a mount effect. By then the SSR pass has already thrown and the child components' fetches have already fired — a race the first paint always loses. The cookie is also `httpOnly`, so the client can't self-heal it synchronously.

## Fix

Bootstrap the cookie in the proxy (middleware) — the only layer that runs before any rendering:

- On `/dashboard(.*)`, `/api/dashboard(.*)`, `/api/playground(.*)` requests with no project cookie, resolve `/v1/projects` with the session's Clerk token, pick the default project (`default-sandbox`, else first — same rule as `reconcileProjectCookieAction`), and stamp the cookie on both the forwarded request headers (so the current SSR pass sees it) and the response (so the browser stores it).
- Requests that already carry the cookie are untouched — the extra API call only happens on the cookieless first entry.
- If the org has no projects or the lookup fails, the request proceeds cookieless and the existing route-level "Selected project required" handling surfaces the failure as before.

Supporting refactor in `lib/sdp-api.ts` (middleware can't use Clerk's request-bound `auth()` or `cookies()`):

- Extracted `acquireClerkToken(getToken)` — the `CLERK_JWT_TEMPLATE` token logic, now shared between server contexts and the proxy.
- Extracted `assembleSdpApiClient(request)` and added `createTokenSdpApiClient(token)` — builds an org-scoped client from an explicit bearer token.

The client-side persist effect in `DashboardWorkspaceProvider` and the route-handler 400 guards stay as defense in depth (they still cover the stale-cookie case).

## Testing

- `tsc --noEmit` and `biome check` clean on the changed files.
- Manual: clear the `sdp_selected_project_id` cookie, hard-reload `/dashboard` — page renders with the sandbox project selected, no 400s in the network tab.
