### PR TITLE
ci: create release branch when ref update returns 422

### DIFF
--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -398,7 +398,8 @@ async function resetReleaseBranch(baseSha) {
   try {
     await githubRequest("PATCH", refPath, { sha: baseSha, force: true });
   } catch (error) {
-    if (error.status !== 404) {
+    // Updating a missing ref returns 422 "Reference does not exist", not 404.
+    if (error.status !== 404 && error.status !== 422) {
       throw error;
     }
 


### PR DESCRIPTION
## Summary

The Release Flow workflow has been failing at the prepare step with:

```
Error: PATCH /repos/solana-foundation/solana-developer-platform/git/refs/heads/codex/release-main failed: 422 {"message":"Reference does not exist", ...}
    at resetReleaseBranch (.github/scripts/release-flow.mjs:399)
```

`resetReleaseBranch` force-updates `codex/release-main` and falls back to creating the branch only when the PATCH fails with **404** — but GitHub's [update-a-reference](https://docs.github.com/rest/git/refs#update-a-reference) endpoint returns **422 "Reference does not exist"** for a missing ref (404 is only what GET returns).

The branch was deleted when the 0.35.1 release PR was squash-merged, and this was the first prepare run needing to *create* the branch since the switch to signed commits via `createCommitOnBranch` (the old `git push` flow created branches implicitly), so the fallback never fired and all 3 retry attempts failed identically.

## Fix

Treat 422 the same as 404 in the fallback so the branch gets created. `force: true` is always sent on the PATCH, so a 422 here can't be a non-fast-forward rejection.

Once merged, the flow self-heals: this push to `main` re-triggers prepare, which recreates `codex/release-main` and opens the release PR covering the pending unreleased commits.

## Testing

- `node --check` and `biome check` pass on the edited script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)