### PR TITLE
feat(api): add credential redaction baseline

### DIFF
--- a/apps/sdp-api/src/app.test.ts
+++ b/apps/sdp-api/src/app.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, type SdpPlugin } from "@/app";
+import { AppError } from "@/lib/errors";
 import type { MonitorOptions, Observability, ObservabilityScope } from "@/runtime/observability";
-import { FeePaymentError } from "@/services/ports";
+import { FeePaymentError, SigningError } from "@/services/ports";
 import { env as baseEnv } from "@/test/helpers/env";
 import type { Env } from "@/types/env";
 
 const THROW_PATH = "/__internal_error_test_throw";
+const SECRET_APP_ERROR_PATH = "/__secret_app_error_test_throw";
+const SECRET_SIGNING_ERROR_PATH = "/__secret_signing_error_test_throw";
+const SECRET_UNEXPECTED_ERROR_PATH = "/__secret_unexpected_error_test_throw";
 const FEE_ERROR_PATH = "/__fee_error_test_throw";
 
 function makeObservability(): {
@@ -38,6 +42,24 @@ function buildApp(observability: Observability) {
   // onError path without modifying the production createApp surface.
   app.all(THROW_PATH, () => {
     throw new Error("test trigger for onError");
+  });
+  app.all(SECRET_APP_ERROR_PATH, () => {
+    throw new AppError("BAD_REQUEST", "Invalid appSecret=privy-secret", {
+      appSecret: "privy-secret",
+      tokenId: "tok_public",
+    });
+  });
+  app.all(SECRET_SIGNING_ERROR_PATH, () => {
+    throw new SigningError(
+      'Privy API error: 401 - {"appSecret":"privy-secret"}',
+      "PROVIDER_NOT_CONFIGURED"
+    );
+  });
+  app.all(SECRET_UNEXPECTED_ERROR_PATH, () => {
+    throw Object.assign(new Error("privateKey=raw-private-key"), {
+      context: { authorization: "Bearer raw-token" },
+      cause: { password: "pw" },
+    });
   });
   app.all(FEE_ERROR_PATH, () => {
     throw new FeePaymentError(
@@ -133,5 +155,61 @@ describe("createApp onError SENTRY_DSN guard", () => {
     expect(body.error.message).not.toContain("custom program error");
     expect(withScope).not.toHaveBeenCalled();
     expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("redacts app error messages and details", async () => {
+    const { obs } = makeObservability();
+    const app = buildApp(obs);
+
+    const res = await app.request(SECRET_APP_ERROR_PATH, {}, baseEnv);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { message: string; details: Record<string, unknown> };
+    };
+    expect(JSON.stringify(body)).not.toContain("privy-secret");
+    expect(body.error.message).toBe("Invalid appSecret=[REDACTED]");
+    expect(body.error.details).toEqual({
+      appSecret: "[REDACTED]",
+      tokenId: "tok_public",
+    });
+  });
+
+  it("uses safe signing provider messages", async () => {
+    const { obs } = makeObservability();
+    const app = buildApp(obs);
+
+    const res = await app.request(SECRET_SIGNING_ERROR_PATH, {}, baseEnv);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toBe(
+      "The signing provider is not configured. Check provider configuration and try again."
+    );
+    expect(JSON.stringify(body)).not.toContain("privy-secret");
+  });
+
+  it("redacts unexpected error log context", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { obs, captureException } = makeObservability();
+    const app = buildApp(obs);
+
+    await app.request(
+      SECRET_UNEXPECTED_ERROR_PATH,
+      {},
+      { ...baseEnv, SENTRY_DSN: "https://x@y/1" }
+    );
+
+    const logged = JSON.stringify(consoleError.mock.calls);
+    const captured = JSON.stringify(captureException.mock.calls);
+    expect(logged).not.toContain("raw-private-key");
+    expect(logged).not.toContain("raw-token");
+    expect(logged).not.toContain("pw");
+    expect(captured).not.toContain("raw-private-key");
+    expect(captured).not.toContain("raw-token");
+    expect(captured).not.toContain("pw");
+    expect(logged).toContain("[REDACTED]");
+    expect(captured).toContain("[REDACTED]");
+    consoleError.mockRestore();
   });
 });

--- a/apps/sdp-api/src/app.ts
+++ b/apps/sdp-api/src/app.ts
@@ -15,6 +15,7 @@ import { prettyJSON } from "hono/pretty-json";
 import { secureHeaders } from "hono/secure-headers";
 
 import { AppError } from "@/lib/errors";
+import { redactCredentialSecrets, redactCredentialString } from "@/lib/redaction";
 import { corsMiddleware } from "@/middleware/cors";
 import { kvStoreMiddleware } from "@/middleware/kv-store";
 import { skipRateLimitPaths } from "@/middleware/rate-limit";
@@ -79,21 +80,34 @@ function mapSigningError(err: SigningError): {
   code: string;
   message: string;
 } {
+  const message = getSafeSigningErrorMessage(err);
   switch (err.code) {
     case "WALLET_NOT_FOUND":
     case "NOT_FOUND":
-      return { status: 404, code: err.code, message: err.message };
+      return { status: 404, code: err.code, message };
     case "ALREADY_INITIALIZED":
-      return { status: 409, code: err.code, message: err.message };
+      return { status: 409, code: err.code, message };
     case "APPROVAL_TIMEOUT":
-      return { status: 504, code: err.code, message: err.message };
+      return { status: 504, code: err.code, message };
     case "APPROVAL_REJECTED":
-      return { status: 409, code: err.code, message: err.message };
+      return { status: 409, code: err.code, message };
     case "NETWORK_ERROR":
     case "SIGNING_FAILED":
-      return { status: 502, code: err.code, message: err.message };
+      return { status: 502, code: err.code, message };
     default:
-      return { status: 400, code: err.code, message: err.message };
+      return { status: 400, code: err.code, message };
+  }
+}
+
+function getSafeSigningErrorMessage(err: SigningError): string {
+  switch (err.code) {
+    case "NETWORK_ERROR":
+    case "SIGNING_FAILED":
+      return "The signing provider could not complete the request. Check provider status and try again.";
+    case "PROVIDER_NOT_CONFIGURED":
+      return "The signing provider is not configured. Check provider configuration and try again.";
+    default:
+      return redactCredentialString(err.message);
   }
 }
 
@@ -203,8 +217,31 @@ function captureUnexpectedError(
       scope.setUser({ id: clerk.userId });
     }
 
-    observability.captureException(err);
+    observability.captureException(redactErrorForCapture(err));
   });
+}
+
+function redactErrorForCapture(err: Error): Error {
+  const sanitized = new Error(redactCredentialString(err.message));
+  sanitized.name = err.name;
+  sanitized.stack = err.stack ? redactCredentialString(err.stack) : undefined;
+
+  const source = err as Error & {
+    context?: unknown;
+    cause?: unknown;
+  };
+  const target = sanitized as Error & {
+    context?: unknown;
+    cause?: unknown;
+  };
+  if (source.context !== undefined) {
+    target.context = redactCredentialSecrets(source.context);
+  }
+  if (source.cause !== undefined) {
+    target.cause = redactCredentialSecrets(source.cause);
+  }
+
+  return sanitized;
 }
 
 export function createApp(deps: AppDeps): Hono<{ Bindings: Env }> {
@@ -315,11 +352,7 @@ export function createApp(deps: AppDeps): Hono<{ Bindings: Env }> {
       c.header("X-SDP-Trace-ID", traceId);
       return c.json(
         {
-          error: {
-            code: err.code,
-            message: err.message,
-            ...(err.details && { details: err.details }),
-          },
+          error: err.toResponse().error,
           meta: { requestId },
         },
         err.statusCode as 400
@@ -378,15 +411,18 @@ export function createApp(deps: AppDeps): Hono<{ Bindings: Env }> {
       context?: Record<string, unknown>;
       cause?: unknown;
     };
-    console.error("Unexpected error:", {
-      requestId,
-      traceId,
-      source: requestSource,
-      error: err.message,
-      stack: err.stack,
-      context: solanaErr.context,
-      cause: solanaErr.cause,
-    });
+    console.error(
+      "Unexpected error:",
+      redactCredentialSecrets({
+        requestId,
+        traceId,
+        source: requestSource,
+        error: err.message,
+        stack: err.stack,
+        context: solanaErr.context,
+        cause: solanaErr.cause,
+      })
+    );
     // SENTRY_DSN gate is the runtime-wiring decision: app-level error handling
     // shouldn't pay the cost of building a scope when no observability backend
     // is wired up. Kept at this seam (rather than inside captureUnexpectedError)

--- a/apps/sdp-api/src/lib/errors.test.ts
+++ b/apps/sdp-api/src/lib/errors.test.ts
@@ -41,6 +41,19 @@ describe("AppError", () => {
 
     expect(response.error.details).toEqual({ errors: ["a", "b"] });
   });
+
+  it("redacts credential-shaped response details", () => {
+    const error = new AppError("BAD_REQUEST", "Invalid", {
+      appSecret: "privy-secret",
+      tokenId: "tok_public",
+    });
+    const response = error.toResponse();
+
+    expect(response.error.details).toEqual({
+      appSecret: "[REDACTED]",
+      tokenId: "tok_public",
+    });
+  });
 });
 
 describe("error helper functions", () => {

--- a/apps/sdp-api/src/lib/errors.ts
+++ b/apps/sdp-api/src/lib/errors.ts
@@ -4,6 +4,7 @@
 
 import type { RampProviderId } from "@sdp/types/provider-access";
 import type { CounterpartyRequirements, RampDirection } from "@sdp/types/ramp-requirements";
+import { redactCredentialSecrets, redactCredentialString } from "@/lib/redaction";
 
 export type ErrorCode =
   | "BAD_REQUEST"
@@ -162,11 +163,12 @@ export class AppError extends Error {
   }
 
   toResponse(): ErrorResponse {
+    const details = this.details ? redactCredentialSecrets(this.details) : undefined;
     return {
       error: {
         code: this.code,
-        message: this.message,
-        ...(this.details && { details: this.details }),
+        message: redactCredentialString(this.message),
+        ...(details && { details }),
       },
     };
   }

--- a/apps/sdp-api/src/lib/redaction.test.ts
+++ b/apps/sdp-api/src/lib/redaction.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { redactCredentialSecrets, redactCredentialString } from "./redaction";
+
+describe("credential redaction", () => {
+  it("redacts credential-shaped object fields without hiding safe ids", () => {
+    const redacted = redactCredentialSecrets({
+      tokenId: "tok_public",
+      appSecret: "privy-secret",
+      apiSecret: "api-secret",
+      privateKey: "private-key",
+      authorization: "Bearer raw-token",
+      nested: {
+        fireblocksApiSecretPem: "pem-secret",
+        coinbaseCdpWalletSecret: "wallet-secret",
+        turnkeyApiPrivateKey: "turnkey-private-key",
+      },
+    });
+
+    expect(redacted).toEqual({
+      tokenId: "tok_public",
+      appSecret: "[REDACTED]",
+      apiSecret: "[REDACTED]",
+      privateKey: "[REDACTED]",
+      authorization: "[REDACTED]",
+      nested: {
+        fireblocksApiSecretPem: "[REDACTED]",
+        coinbaseCdpWalletSecret: "[REDACTED]",
+        turnkeyApiPrivateKey: "[REDACTED]",
+      },
+    });
+  });
+
+  it("redacts credential-shaped strings from provider errors", () => {
+    const message = redactCredentialString(
+      'Privy API error: 401 - {"appSecret":"privy-secret","apiKey":"api-key","password":"pw"} authorization=Bearer raw-token apiSecret: raw-api-secret api_key=raw-key'
+    );
+
+    expect(message).toContain('"appSecret":"[REDACTED]"');
+    expect(message).toContain('"apiKey":"[REDACTED]"');
+    expect(message).toContain('"password":"[REDACTED]"');
+    expect(message).toContain("authorization=[REDACTED]");
+    expect(message).toContain("apiSecret: [REDACTED]");
+    expect(message).toContain("api_key=[REDACTED]");
+    expect(message).not.toContain("privy-secret");
+    expect(message).not.toContain("api-key");
+    expect(message).not.toContain("raw-token");
+    expect(message).not.toContain("raw-api-secret");
+    expect(message).not.toContain("raw-key");
+  });
+
+  it("keeps plain Basic/Bearer prose intact", () => {
+    expect(redactCredentialString("Basic validation failed")).toBe("Basic validation failed");
+    expect(redactCredentialString("Bearer access denied")).toBe("Bearer access denied");
+  });
+
+  it("redacts PEM blocks", () => {
+    const redacted = redactCredentialString(
+      "bad pem -----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----"
+    );
+
+    expect(redacted).toBe("bad pem [REDACTED]");
+  });
+});

--- a/apps/sdp-api/src/lib/redaction.ts
+++ b/apps/sdp-api/src/lib/redaction.ts
@@ -1,0 +1,101 @@
+const REDACTED = "[REDACTED]";
+
+const SENSITIVE_JSON_FIELD_PATTERN =
+  /(["'])(app[-_ ]?secret|api[-_ ]?secret|api[-_ ]?key|client[-_ ]?secret|wallet[-_ ]?secret|signing[-_ ]?secret|private[-_ ]?key|secret[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token|authorization|password|pem|token|secret|credential)\1\s*:\s*(["'])(.*?)\3/gi;
+const SENSITIVE_ASSIGNMENT_PATTERN =
+  /\b(app[-_ ]?secret|api[-_ ]?secret|api[-_ ]?key|client[-_ ]?secret|wallet[-_ ]?secret|signing[-_ ]?secret|private[-_ ]?key|secret[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|id[-_ ]?token|authorization|password|pem|token|secret|credential)\b(\s*[:=]\s*)[^,\s}]+/gi;
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN [^-]*PRIVATE KEY-----[\s\S]*?-----END [^-]*PRIVATE KEY-----/g;
+const AUTH_HEADER_PATTERN = /\b(Bearer|Basic)\s+([A-Za-z0-9._~+/=-]+)/gi;
+
+export function redactCredentialString(value: string): string {
+  return value
+    .replace(PRIVATE_KEY_PATTERN, REDACTED)
+    .replace(AUTH_HEADER_PATTERN, (match, scheme: string, token: string) =>
+      isLikelyAuthToken(scheme, token) ? `${scheme} ${REDACTED}` : match
+    )
+    .replace(
+      SENSITIVE_JSON_FIELD_PATTERN,
+      (_match, quote: string, key: string, valueQuote: string) =>
+        `${quote}${key}${quote}:${valueQuote}${REDACTED}${valueQuote}`
+    )
+    .replace(
+      SENSITIVE_ASSIGNMENT_PATTERN,
+      (_match, key: string, separator: string) => `${key}${separator}${REDACTED}`
+    );
+}
+
+function isLikelyAuthToken(scheme: string, token: string): boolean {
+  const minLength = scheme.toLowerCase() === "basic" ? 12 : 16;
+  return token.length >= minLength || /[0-9._~+/=-]/.test(token);
+}
+
+export function redactCredentialSecrets<T>(value: T): T {
+  return redactValue(value, new WeakSet<object>()) as T;
+}
+
+function redactValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === "string") {
+    return redactCredentialString(value);
+  }
+
+  if (value === null || value === undefined || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactCredentialString(value.message),
+      ...(value.stack ? { stack: redactCredentialString(value.stack) } : {}),
+      ...("cause" in value ? { cause: redactValue(value.cause, seen) } : {}),
+    };
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof URL) {
+    return value.toString();
+  }
+
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    return REDACTED;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, seen));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    result[key] = isSensitiveCredentialKey(key) ? REDACTED : redactValue(item, seen);
+  }
+  return result;
+}
+
+function isSensitiveCredentialKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return (
+    normalized === "secret" ||
+    normalized === "credential" ||
+    normalized === "credentials" ||
+    normalized === "apikey" ||
+    normalized === "authorization" ||
+    normalized === "password" ||
+    normalized === "pem" ||
+    normalized === "token" ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("password") ||
+    normalized.endsWith("token") ||
+    normalized.endsWith("pem") ||
+    normalized.includes("privatekey") ||
+    normalized.includes("secretpayload")
+  );
+}

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { getDb } from "@/db";
 import { AppError, badRequest } from "@/lib/errors";
+import { redactCredentialString } from "@/lib/redaction";
 import { created, success } from "@/lib/response";
 import { clearWalletCaches } from "@/routes/custody/handlers/wallets";
 import { AuditService } from "@/services/audit.service";
@@ -498,9 +499,12 @@ function toInitializeSigningResponse(
 function handleSigningInitializationError(error: unknown): never {
   if (error instanceof SigningError) {
     if (error.code === "ALREADY_INITIALIZED") {
-      throw new AppError("CONFLICT", error.message);
+      throw new AppError("CONFLICT", redactCredentialString(error.message));
     }
-    throw badRequest(error.message);
+    if (error.code === "NETWORK_ERROR" || error.code === "PROVIDER_NOT_CONFIGURED") {
+      throw badRequest("Provider setup failed. Check provider configuration and try again.");
+    }
+    throw badRequest(redactCredentialString(error.message));
   }
 
   throw error;

--- a/apps/sdp-api/src/services/adapters/signing/keychain/keychain-fireblocks.adapter.ts
+++ b/apps/sdp-api/src/services/adapters/signing/keychain/keychain-fireblocks.adapter.ts
@@ -13,6 +13,7 @@
 import type { SolanaSigner } from "@solana/keychain-core";
 import { FireblocksSigner } from "@solana/keychain-fireblocks";
 import type { Address } from "@solana/kit";
+import { redactCredentialSecrets } from "@/lib/redaction";
 import type { SignRequest, SignResult } from "@/services/ports";
 import { BaseKeychainAdapter } from "./base-keychain.adapter";
 import type { KeychainFireblocksConfig } from "./types";
@@ -139,35 +140,32 @@ export class KeychainFireblocksAdapter extends BaseKeychainAdapter {
 
     signer.request = (async <T>(method: string, uri: string, body?: unknown): Promise<T> => {
       try {
-        console.info("sdp_fireblocks_api_request", {
-          method,
-          uri,
-          body,
-        });
+        console.info("sdp_fireblocks_api_request", redactCredentialSecrets({ method, uri, body }));
 
         const response = await originalRequest<T>(method, uri, body);
 
-        console.info("sdp_fireblocks_api_response", {
-          method,
-          uri,
-          body,
-          response,
-        });
+        console.info(
+          "sdp_fireblocks_api_response",
+          redactCredentialSecrets({ method, uri, body, response })
+        );
 
         return response;
       } catch (error) {
-        console.error("sdp_fireblocks_api_error", {
-          method,
-          uri,
-          body,
-          error:
-            error instanceof Error
-              ? {
-                  message: error.message,
-                  stack: error.stack,
-                }
-              : String(error),
-        });
+        console.error(
+          "sdp_fireblocks_api_error",
+          redactCredentialSecrets({
+            method,
+            uri,
+            body,
+            error:
+              error instanceof Error
+                ? {
+                    message: error.message,
+                    stack: error.stack,
+                  }
+                : String(error),
+          })
+        );
         throw error;
       }
     }) as typeof signer.request;

--- a/apps/sdp-api/src/services/audit.service.test.ts
+++ b/apps/sdp-api/src/services/audit.service.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { AuditService } from "./audit.service";
+
+describe("AuditService", () => {
+  it("redacts credential-shaped metadata before persisting", async () => {
+    const run = vi.fn(async () => undefined);
+    const bind = vi.fn((..._args: unknown[]) => ({ run }));
+    const db = { prepare: vi.fn(() => ({ bind })) };
+    const context = {
+      get: (key: string) =>
+        key === "apiKey" ? { id: "ak_123", organizationId: "org_123" } : "req_123",
+      req: { header: () => null },
+    };
+
+    await new AuditService(db as never).log(context as never, {
+      action: "validate_failed",
+      resourceType: "provider_credential",
+      resourceId: "pcred_123",
+      metadata: {
+        provider: "privy",
+        appSecret: "privy-secret",
+        nested: { authorization: "Bearer raw-token" },
+      },
+      status: "failure",
+    });
+
+    const metadata = String(bind.mock.calls[0]?.[7]);
+    expect(metadata).toContain('"provider":"privy"');
+    expect(metadata).toContain('"appSecret":"[REDACTED]"');
+    expect(metadata).toContain('"authorization":"[REDACTED]"');
+    expect(metadata).not.toContain("privy-secret");
+    expect(metadata).not.toContain("raw-token");
+  });
+});

--- a/apps/sdp-api/src/services/audit.service.ts
+++ b/apps/sdp-api/src/services/audit.service.ts
@@ -6,6 +6,7 @@
 
 import type { Context } from "hono";
 import { parseOptionalPostgresJson } from "@/db/postgres-utils";
+import { redactCredentialSecrets } from "@/lib/redaction";
 import type { Env } from "@/types/env";
 
 export type AuditAction =
@@ -33,7 +34,15 @@ export type AuditAction =
   | "submit"
   | "submit_failed"
   | "sign"
-  | "sign_requested";
+  | "sign_requested"
+  // BYO credential lifecycle actions
+  | "validate_failed"
+  | "check"
+  | "activate"
+  | "rotate"
+  | "rollback"
+  | "deactivate"
+  | "blocked_deactivation";
 
 export type ResourceType =
   | "organization"
@@ -56,7 +65,9 @@ export type ResourceType =
   | "signing_request"
   | "counterparty"
   | "counterparty_account"
-  | "asset_profile";
+  | "asset_profile"
+  | "provider_credential"
+  | "custody_connection";
 
 export interface AuditLogEntry {
   organizationId?: string;
@@ -82,6 +93,7 @@ export class AuditService {
     const id = `aud_${crypto.randomUUID()}`;
     const ipAddress = c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for") || null;
     const userAgent = c.req.header("user-agent") || null;
+    const metadata = entry.metadata ? redactCredentialSecrets(entry.metadata) : null;
 
     try {
       await this.db
@@ -99,7 +111,7 @@ export class AuditService {
           entry.action,
           entry.resourceType,
           entry.resourceId || null,
-          entry.metadata ? JSON.stringify(entry.metadata) : null,
+          metadata ? JSON.stringify(metadata) : null,
           ipAddress,
           userAgent,
           requestId,
@@ -108,7 +120,7 @@ export class AuditService {
         .run();
     } catch (err) {
       // Log but don't fail the request
-      console.error("Failed to write audit log:", err);
+      console.error("Failed to write audit log:", redactCredentialSecrets(err));
     }
   }
 

--- a/apps/sdp-api/src/services/custody/provisioning.common.ts
+++ b/apps/sdp-api/src/services/custody/provisioning.common.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { redactCredentialString } from "@/lib/redaction";
 import { SigningError } from "@/services/ports";
 
 function hasEmptyResponseBody(response: Response): boolean {
@@ -6,7 +7,10 @@ function hasEmptyResponseBody(response: Response): boolean {
 }
 
 export async function readErrorResponseText(response: Response): Promise<string> {
-  return response.text().catch(() => "Failed to read error response");
+  return response
+    .text()
+    .then((body) => redactCredentialString(body))
+    .catch(() => "Failed to read error response");
 }
 
 export async function parseJsonResponse<T>(response: Response): Promise<T> {

--- a/apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.ts
+++ b/apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.ts
@@ -291,7 +291,7 @@ async function withProvisioningError<T>(providerName: string, run: () => Promise
     }
 
     throw new SigningError(
-      `Failed to provision ${providerName} wallet: ${error instanceof Error ? error.message : "Unknown error"}`,
+      `Failed to provision ${providerName} wallet`,
       "NETWORK_ERROR",
       error instanceof Error ? error : undefined
     );


### PR DESCRIPTION
## Summary
- Add a central credential redaction helper for credential-shaped fields, provider error strings, PEM blocks, auth headers, and nested metadata.
- Apply redaction before API error responses, unexpected-error logs/Sentry capture, audit metadata persistence, provider setup failures, and Fireblocks debug logs.
- Extend the audit type baseline for BYO credential lifecycle actions/resources without adding an audit viewer or provider-specific validation in this phase.

## Why
HOO-766 establishes the safety baseline for the BYO keys feature: credential material and provider secrets should not leak through public API/dashboard responses, logs, traces, metrics, or audit metadata while the app starts exposing provider setup/status flows.

## Validation
- `doppler run --project solana-developer-platform --config "${DOPPLER_CONFIG:-dev_personal}" -- printenv CLERK_SECRET_KEY >/dev/null`
- `pnpm db:postgres:up`
- `DATABASE_URL="postgresql://sdp:sdp@127.0.0.1:5432/sdp" pnpm --filter @sdp/api db:postgres:bootstrap`
- `pnpm exec biome check apps/sdp-api/src/lib/redaction.ts apps/sdp-api/src/lib/redaction.test.ts apps/sdp-api/src/lib/errors.ts apps/sdp-api/src/lib/errors.test.ts apps/sdp-api/src/app.ts apps/sdp-api/src/app.test.ts apps/sdp-api/src/services/audit.service.ts apps/sdp-api/src/services/audit.service.test.ts apps/sdp-api/src/services/custody/provisioning.common.ts apps/sdp-api/src/services/domain/signing/provider-wallet-lifecycle.ts apps/sdp-api/src/routes/custody/handlers/provider.ts apps/sdp-api/src/services/adapters/signing/keychain/keychain-fireblocks.adapter.ts`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter @sdp/api test`
- `curl -fsS http://127.0.0.1:8795/health`
- `curl -fsS http://127.0.0.1:8795/health/ready`

Linear: HOO-766