### PR TITLE
fix(rpc): tolerate transient failures in confirmation polling

### DIFF
--- a/apps/sdp-api/src/services/solana/rpc.test.ts
+++ b/apps/sdp-api/src/services/solana/rpc.test.ts
@@ -1,6 +1,6 @@
 import type { RpcEnv } from "@sdp/rpc";
 import { isTransientRpcError } from "@sdp/rpc";
-import { SdpRpcError } from "@sdp/rpc/errors";
+import { SdpRpcError, solanaRpcError } from "@sdp/rpc/errors";
 import {
   confirmTransaction,
   createRpc,
@@ -75,6 +75,48 @@ describe("sendAndConfirmTransaction", () => {
     expect(appError.statusCode).toBe(502);
     expect(appError.message).toBe(`Transaction ${TEST_SIGNATURE} confirmation timed out after 1ms`);
     expect(sendTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("confirmTransaction transient poll tolerance", () => {
+  it("keeps polling through a transient poll failure and confirms", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(solanaRpcError("RPC request timed out after 25ms"))
+      .mockResolvedValueOnce({
+        value: [{ confirmationStatus: "confirmed", slot: 42n, err: null }],
+      });
+    const rpc = { getSignatureStatuses: vi.fn().mockReturnValue({ send }) } as unknown as SolanaRpc;
+
+    const confirmation = await confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 10_000 });
+
+    expect(confirmation.confirmationStatus).toBe("confirmed");
+    expect(confirmation.slot).toBe(42n);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("still propagates non-transient poll errors immediately", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("invalid params"));
+    const rpc = { getSignatureStatuses: vi.fn().mockReturnValue({ send }) } as unknown as SolanaRpc;
+
+    const error = await captureRejection(
+      confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 10_000 })
+    );
+
+    expect((error as Error).message).toBe("invalid params");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out with the confirmation error when every poll fails transiently", async () => {
+    const send = vi.fn().mockRejectedValue(solanaRpcError("RPC request timed out after 25ms"));
+    const rpc = { getSignatureStatuses: vi.fn().mockReturnValue({ send }) } as unknown as SolanaRpc;
+
+    const error = await captureRejection(confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 1 }));
+
+    expect(error).toBeInstanceOf(SdpRpcError);
+    expect((error as SdpRpcError).message).toBe(
+      `Transaction ${TEST_SIGNATURE} confirmation timed out after 1ms`
+    );
   });
 });
 

--- a/apps/sdp-api/src/services/solana/rpc.test.ts
+++ b/apps/sdp-api/src/services/solana/rpc.test.ts
@@ -50,7 +50,9 @@ describe("confirmTransaction", () => {
   it("throws a typed SOLANA_RPC_ERROR when confirmation never lands within the timeout", async () => {
     const { rpc, getSignatureStatuses } = makePendingRpc(TEST_SIGNATURE);
 
-    const error = await captureRejection(confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 1 }));
+    const error = await captureRejection(
+      confirmTransaction(rpc, TEST_SIGNATURE, { pollIntervalMs: 1, timeoutMs: 1 })
+    );
 
     expect(error).toBeInstanceOf(SdpRpcError);
     const appError = error as SdpRpcError;
@@ -66,7 +68,7 @@ describe("sendAndConfirmTransaction", () => {
     const { rpc, sendTransaction } = makePendingRpc(TEST_SIGNATURE);
 
     const error = await captureRejection(
-      sendAndConfirmTransaction(rpc, new Uint8Array([1, 2, 3]), { timeoutMs: 1 })
+      sendAndConfirmTransaction(rpc, new Uint8Array([1, 2, 3]), { pollIntervalMs: 1, timeoutMs: 1 })
     );
 
     expect(error).toBeInstanceOf(SdpRpcError);
@@ -88,7 +90,10 @@ describe("confirmTransaction transient poll tolerance", () => {
       });
     const rpc = { getSignatureStatuses: vi.fn().mockReturnValue({ send }) } as unknown as SolanaRpc;
 
-    const confirmation = await confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 10_000 });
+    const confirmation = await confirmTransaction(rpc, TEST_SIGNATURE, {
+      pollIntervalMs: 1,
+      timeoutMs: 10_000,
+    });
 
     expect(confirmation.confirmationStatus).toBe("confirmed");
     expect(confirmation.slot).toBe(42n);
@@ -100,7 +105,7 @@ describe("confirmTransaction transient poll tolerance", () => {
     const rpc = { getSignatureStatuses: vi.fn().mockReturnValue({ send }) } as unknown as SolanaRpc;
 
     const error = await captureRejection(
-      confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 10_000 })
+      confirmTransaction(rpc, TEST_SIGNATURE, { pollIntervalMs: 1, timeoutMs: 10_000 })
     );
 
     expect((error as Error).message).toBe("invalid params");
@@ -111,7 +116,9 @@ describe("confirmTransaction transient poll tolerance", () => {
     const send = vi.fn().mockRejectedValue(solanaRpcError("RPC request timed out after 25ms"));
     const rpc = { getSignatureStatuses: vi.fn().mockReturnValue({ send }) } as unknown as SolanaRpc;
 
-    const error = await captureRejection(confirmTransaction(rpc, TEST_SIGNATURE, { timeoutMs: 1 }));
+    const error = await captureRejection(
+      confirmTransaction(rpc, TEST_SIGNATURE, { pollIntervalMs: 1, timeoutMs: 1 })
+    );
 
     expect(error).toBeInstanceOf(SdpRpcError);
     expect((error as SdpRpcError).message).toBe(

--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -269,6 +269,24 @@ export async function sendTransaction(
 /**
  * Send a signed transaction and wait for confirmation
  */
+/**
+ * One signature-status poll that tolerates transient RPC failures: a stalled
+ * or timed-out request returns `null` ("not yet confirmed") so the caller's
+ * confirmation budget — not a single poll — decides the outcome.
+ * Non-transient errors propagate immediately.
+ */
+async function getSignatureStatusOrNull(rpc: SolanaRpc, signature: Signature) {
+  try {
+    const status = await rpc.getSignatureStatuses([signature]).send();
+    return status.value[0];
+  } catch (error) {
+    if (isTransientRpcError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export async function sendAndConfirmTransaction(
   rpc: SolanaRpc,
   signedTransaction: Uint8Array,
@@ -292,9 +310,7 @@ export async function sendAndConfirmTransaction(
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
-    const status = await rpc.getSignatureStatuses([signature]).send();
-
-    const result = status.value[0];
+    const result = await getSignatureStatusOrNull(rpc, signature);
 
     if (result) {
       // Check if confirmed to required level
@@ -346,9 +362,7 @@ export async function confirmTransaction(
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
-    const status = await rpc.getSignatureStatuses([signature]).send();
-
-    const result = status.value[0];
+    const result = await getSignatureStatusOrNull(rpc, signature);
 
     if (result) {
       const isConfirmed =

--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -267,9 +267,6 @@ export async function sendTransaction(
 }
 
 /**
- * Send a signed transaction and wait for confirmation
- */
-/**
  * One signature-status poll that tolerates transient RPC failures: a stalled
  * or timed-out request returns `null` ("not yet confirmed") so the caller's
  * confirmation budget — not a single poll — decides the outcome.
@@ -287,6 +284,9 @@ async function getSignatureStatusOrNull(rpc: SolanaRpc, signature: Signature) {
   }
 }
 
+/**
+ * Send a signed transaction and wait for confirmation
+ */
 export async function sendAndConfirmTransaction(
   rpc: SolanaRpc,
   signedTransaction: Uint8Array,
@@ -295,10 +295,12 @@ export async function sendAndConfirmTransaction(
     skipPreflight?: boolean;
     maxRetries?: bigint;
     timeoutMs?: number;
+    pollIntervalMs?: number;
   }
 ): Promise<TransactionConfirmation> {
   const commitment = options?.commitment ?? "confirmed";
   const timeoutMs = options?.timeoutMs ?? 60000;
+  const pollIntervalMs = options?.pollIntervalMs ?? 1000;
 
   // Send the transaction
   const signature = await sendTransaction(rpc, signedTransaction, {
@@ -340,7 +342,7 @@ export async function sendAndConfirmTransaction(
     }
 
     // Wait before polling again
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
   throw solanaRpcError(`Transaction ${signature} confirmation timed out after ${timeoutMs}ms`);
@@ -355,10 +357,12 @@ export async function confirmTransaction(
   options?: {
     commitment?: Commitment;
     timeoutMs?: number;
+    pollIntervalMs?: number;
   }
 ): Promise<TransactionConfirmation> {
   const commitment = options?.commitment ?? "confirmed";
   const timeoutMs = options?.timeoutMs ?? 60000;
+  const pollIntervalMs = options?.pollIntervalMs ?? 1000;
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
@@ -380,7 +384,7 @@ export async function confirmTransaction(
       }
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
   throw solanaRpcError(`Transaction ${signature} confirmation timed out after ${timeoutMs}ms`);


### PR DESCRIPTION
## Summary

- Extract a `getSignatureStatusOrNull` helper used by both `confirmTransaction` and `sendAndConfirmTransaction` poll loops: a transient poll failure (per `isTransientRpcError`, e.g. the 30s transport deadline from #637) is treated as "not yet confirmed" and polling continues; the loop's own `timeoutMs` (default 60s) remains the real confirmation budget.
- Non-transient errors (invalid params, etc.) still propagate immediately.

## Why

Follow-up to #637. That PR turned infinitely-hanging RPC requests into fast typed errors — CI evidence from PR #649 shows the Surfpool issuance test now failing in ~67s with a 502 (`RPC request timed out after 30000ms`) at the exact spot that used to hang 300s. But a single stalled poll shouldn't fail a confirmation wait that has 30+ seconds of budget left: Surfpool recovers within seconds, and the next poll would confirm. This closes that gap — recoverable stalls become successes instead of 502s.

## Validation

- `pnpm turbo typecheck` (9/9)
- `biome check` clean
- New tests: transient poll failure → keeps polling → confirms; non-transient error → propagates immediately; all-transient → clean confirmation-timeout error. 19 tests green across `rpc.test.ts` + `app.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)