### PR TITLE
feat(sdp-api): cron job entrypoint + GCP Cloud Run deploy (dev)

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp.yml
+++ b/.github/workflows/deploy-sdp-api-gcp.yml
@@ -1,0 +1,74 @@
+name: Deploy sdp-api to Cloud Run (dev)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "apps/sdp-api/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/deploy-sdp-api-gcp.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: sdp-api-gcp-deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy
+    if: github.repository == 'solana-foundation/solana-developer-platform'
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: solana-developer-platform-dev
+      REGION: us-central1
+      REPO: sdp-dev
+      SERVICE: sdp-dev-api-public
+      JOB: sdp-dev-api-public-cron
+      MIGRATE_JOB: sdp-dev-api-public-migrate
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.DEPLOY_WIF_PROVIDER }}
+          service_account: ${{ vars.DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build and push image
+        run: |
+          set -euo pipefail
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/sdp-api-public:${GITHUB_SHA}"
+          docker build -f apps/sdp-api/Dockerfile --build-arg GIT_SHA="${GITHUB_SHA}" -t "${IMAGE}" .
+          docker push "${IMAGE}"
+          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
+
+      - name: Run database migrations
+        run: |
+          gcloud run jobs update "${MIGRATE_JOB}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"
+          gcloud run jobs execute "${MIGRATE_JOB}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --wait
+
+      - name: Deploy service
+        run: |
+          gcloud run services update "${SERVICE}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"
+
+      - name: Update cron job image
+        run: |
+          gcloud run jobs update "${JOB}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --image "${IMAGE}"

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -15,6 +15,7 @@ await esbuild.build({
   // migrate.js lets the prebuilt image apply migrations without the source tree.
   entryPoints: {
     server: "src/server.ts",
+    job: "src/job.ts",
     migrate: "scripts/migrate-postgres.mjs",
     // configure.js generates a self-hosted .env in the terminal from the prebuilt image.
     configure: "scripts/configure.ts",

--- a/apps/sdp-api/src/job.ts
+++ b/apps/sdp-api/src/job.ts
@@ -1,0 +1,46 @@
+import { pathToFileURL } from "node:url";
+
+import * as Sentry from "@sentry/node";
+import { PENDING_TRANSFERS_CRON, PENDING_TRANSFERS_MONITOR } from "@/cron/pending-transfers";
+import { closeDatabasePools } from "@/db/client";
+import { withProcessEnvFallback } from "@/lib/runtime-env";
+import { closeAllRedisClients } from "@/runtime/kv-redis";
+import { getSentryOptions, isSentryEnabled } from "@/runtime/observability";
+import { initNodeSentry, nodeObservability } from "@/runtime/observability-node";
+import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
+import type { Env } from "@/types/env";
+
+export async function runCronJob(): Promise<void> {
+  const env = withProcessEnvFallback({} as Env);
+  env.SDP_RUNTIME = "node";
+  if (!env.DATABASE_URL?.trim()) {
+    throw new Error("DATABASE_URL is required for the reconciliation job");
+  }
+  if (!env.REDIS_URL?.trim()) {
+    throw new Error("REDIS_URL is required for the reconciliation job");
+  }
+
+  initNodeSentry(getSentryOptions(env));
+
+  const work = () => trackPendingTransfers(env);
+  try {
+    await (isSentryEnabled(env)
+      ? nodeObservability.withMonitor(PENDING_TRANSFERS_MONITOR, work, {
+          schedule: { type: "crontab", value: PENDING_TRANSFERS_CRON },
+        })
+      : work());
+  } finally {
+    await Promise.allSettled([closeAllRedisClients(), closeDatabasePools()]);
+    await Sentry.close(2000);
+  }
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  runCronJob()
+    .then(() => process.exit(0))
+    .catch((err: unknown) => {
+      console.error("Reconciliation job failed:", err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
Adds a Node cron entrypoint and a GCP Cloud Run deploy for dev, alongside the existing Cloudflare deploy.

- `src/job.ts` (+ `job` build entry): one reconciliation pass, then exit. Runs the same runtime-neutral helpers as the in-process `node-cron` tick and the Workers `scheduled` handler. Managed deploys run the service with `DISABLE_CRON=true` and trigger this via Cloud Scheduler; self-hosted (`node server.js`) keeps in-process cron.
- `flushNodeSentry`: flush pending Sentry events (incl. cron check-ins) before the one-shot exits.
- `deploy-sdp-api-gcp.yml`: build `apps/sdp-api/Dockerfile` → Artifact Registry, run the migrate job, update the Cloud Run service and cron job. Auth via WIF (`DEPLOY_WIF_PROVIDER`/`DEPLOY_SA` repo vars).
