### PR TITLE
feat(policy): expose complete wallet policy rule schema

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -78,13 +78,21 @@ const policyRuleSchema = z
       .optional()
       .openapi({ description: "Decision to apply when this rule matches." }),
     kind: z
-      .enum(["operation_family", "destination", "amount", "approval", "always"])
+      .enum([
+        "operation_family",
+        "operation_type",
+        "asset",
+        "destination",
+        "amount",
+        "approval",
+        "always",
+      ])
       .openapi({ description: "Policy rule kind." }),
   })
   .passthrough()
   .openapi({
     description:
-      "Wallet control profile rule. Supported kinds include operation_family, destination, amount, approval, and always.",
+      "Wallet control profile rule. Supported kinds include operation_family, operation_type, asset, destination, amount, approval, and always.",
     example: {
       id: "deny-raw-signing",
       kind: "operation_family",

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -68,38 +68,16 @@ export const tokenAmountSchema = z.string().openapi({
   example: "100.00",
 });
 
-const policyRuleSchema = z
-  .object({
-    id: z.string().optional().openapi({ description: "Stable client-side rule identifier." }),
-    name: z.string().optional().openapi({ description: "Human-readable rule name." }),
-    description: z.string().optional().openapi({ description: "Rule description." }),
-    action: z
-      .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
-      .optional()
-      .openapi({ description: "Decision to apply when this rule matches." }),
-    kind: z
-      .enum([
-        "operation_family",
-        "operation_type",
-        "asset",
-        "destination",
-        "amount",
-        "approval",
-        "always",
-      ])
-      .openapi({ description: "Policy rule kind." }),
-  })
-  .passthrough()
-  .openapi({
-    description:
-      "Wallet control profile rule. Supported kinds include operation_family, operation_type, asset, destination, amount, approval, and always.",
-    example: {
-      id: "deny-raw-signing",
-      kind: "operation_family",
-      family: "raw_sign",
-      action: "deny",
-    },
-  });
+const policyRuleSchema = withOpenApi(updateWalletPolicySchemaBase.shape.rules.unwrap().element, {
+  description:
+    "Wallet control profile rule. Supported kinds include operation_family, operation_type, asset, destination, amount, approval, and always.",
+  example: {
+    id: "deny-raw-signing",
+    kind: "operation_family",
+    family: "raw_sign",
+    action: "deny",
+  },
+});
 
 const walletControlProfileSummarySchema = z
   .object({

--- a/apps/sdp-api/src/openapi/spec.test.ts
+++ b/apps/sdp-api/src/openapi/spec.test.ts
@@ -34,6 +34,24 @@ describe("OpenAPI spec", () => {
     expect(requirementsPath?.responses?.["200"]).toMatchSnapshot();
   });
 
+  it("documents every supported public wallet policy rule kind", () => {
+    const doc = createPublicOpenApiDocument();
+    const updatePolicy = doc.paths?.["/v1/payments/wallets/{walletId}/policies"]?.put;
+    const serializedOperation = JSON.stringify(updatePolicy);
+
+    for (const kind of [
+      "operation_family",
+      "operation_type",
+      "asset",
+      "destination",
+      "amount",
+      "approval",
+      "always",
+    ]) {
+      expect(serializedOperation).toContain(`"${kind}"`);
+    }
+  });
+
   it("limits the public document to supported public API families", () => {
     const doc = createPublicOpenApiDocument();
 

--- a/apps/sdp-api/src/openapi/spec.test.ts
+++ b/apps/sdp-api/src/openapi/spec.test.ts
@@ -36,8 +36,9 @@ describe("OpenAPI spec", () => {
 
   it("documents every supported public wallet policy rule kind", () => {
     const doc = createPublicOpenApiDocument();
-    const updatePolicy = doc.paths?.["/v1/payments/wallets/{walletId}/policies"]?.put;
-    const serializedOperation = JSON.stringify(updatePolicy);
+    const policyPath = doc.paths?.["/v1/payments/wallets/{walletId}/policies"];
+    const serializedUpdate = JSON.stringify(policyPath?.put);
+    const serializedResponse = JSON.stringify(policyPath?.get?.responses?.["200"]);
 
     for (const kind of [
       "operation_family",
@@ -48,7 +49,12 @@ describe("OpenAPI spec", () => {
       "approval",
       "always",
     ]) {
-      expect(serializedOperation).toContain(`"${kind}"`);
+      expect(serializedUpdate).toContain(`"${kind}"`);
+      expect(serializedResponse).toContain(`"${kind}"`);
+    }
+
+    for (const field of ["operationType", "operationTypes", "asset", "assets"]) {
+      expect(serializedResponse).toContain(`"${field}"`);
     }
   });
 

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -5717,6 +5717,18 @@ describe("Payments routes", () => {
         families: ["payment"],
         action: "approval_required",
       },
+      {
+        id: "deny-payment-execution",
+        kind: "operation_type",
+        operationType: "payment_transfer_execute",
+        action: "deny",
+      },
+      {
+        id: "approve-usdc",
+        kind: "asset",
+        asset: "USDC",
+        action: "approval_required",
+      },
     ];
 
     const updateRes = await app.request(
@@ -5837,6 +5849,32 @@ describe("Payments routes", () => {
         action: "deny",
       },
     ]);
+  });
+
+  it("rejects invalid public wallet policy rule values", async () => {
+    const updateRes = await app.request(
+      `/v1/payments/wallets/${TEST_WALLET_ID}/policies`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationAllowlist: [],
+          rules: [{ kind: "operation_type", operationType: "" }],
+        }),
+      },
+      env
+    );
+
+    expect(updateRes.status).toBe(400);
+    const body = (await updateRes.json()) as {
+      error: { code: string; message: string; details?: { errors?: Record<string, string[]> } };
+    };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("Invalid request body");
+    expect(body.error.details?.errors?.rules).toContain("operationType must not be empty");
   });
 
   it("blocks create transfer when projected daily total exceeds maxDailyAmount", async () => {

--- a/apps/sdp-api/src/routes/payments/schemas.test.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.test.ts
@@ -1,4 +1,4 @@
-import { SOL_MINT, WELL_KNOWN_TOKENS } from "@sdp/types";
+import { type PolicyRule, SOL_MINT, WELL_KNOWN_TOKENS } from "@sdp/types";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { z } from "zod";
 import {
@@ -235,5 +235,68 @@ describe("wallet policy destinationAllowlist schema", () => {
       const messages = result.error.issues.map((issue) => issue.message);
       expect(messages).toContain("destinationAllowlist entry must be a base58 Solana address");
     }
+  });
+});
+
+describe("wallet policy rule schema", () => {
+  it("accepts operation_type and standalone asset rules", () => {
+    const rules = [
+      {
+        id: "deny-payment-execution",
+        kind: "operation_type",
+        operationType: "payment_transfer_execute",
+        action: "deny",
+      },
+      {
+        id: "approve-usdc",
+        kind: "asset",
+        assets: ["USDC", USDC_MINT],
+        action: "approval_required",
+      },
+    ] satisfies PolicyRule[];
+
+    const parsed = updateWalletPolicySchema.parse({ destinationAllowlist: [], rules });
+
+    expect(parsed.rules).toEqual(rules);
+  });
+
+  it("rejects invalid operation_type and asset values with field-specific errors", () => {
+    const result = updateWalletPolicySchema.safeParse({
+      destinationAllowlist: [],
+      rules: [
+        { kind: "operation_type", operationType: "" },
+        { kind: "asset", assets: [""] },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["rules", 0, "operationType"],
+            message: "operationType must not be empty",
+          }),
+          expect.objectContaining({
+            path: ["rules", 1, "assets", 0],
+            message: "assets entries must not be empty",
+          }),
+        ])
+      );
+    }
+  });
+
+  it("keeps all existing public rule kinds backward-compatible", () => {
+    const rules = [
+      { kind: "operation_family", family: "payment", action: "allow" },
+      { kind: "destination", destination: VALID_DESTINATION, action: "deny" },
+      { kind: "amount", max: "100", asset: "USDC", action: "approval_required" },
+      { kind: "approval", families: ["payment"], approvalGroupId: "group-1" },
+      { kind: "always", action: "review" },
+    ] satisfies PolicyRule[];
+
+    const parsed = updateWalletPolicySchema.parse({ destinationAllowlist: [], rules });
+
+    expect(parsed.rules).toEqual(rules);
   });
 });

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -7,6 +7,7 @@ import {
   MURAL_SANDBOX_PAYIN_CURRENCIES,
   OFFRAMP_CRYPTO_RAILS,
   ONRAMP_CRYPTO_RAILS,
+  type PolicyRule,
   type PrivateTransferRequest,
   RAMP_PROVIDERS,
 } from "@sdp/types";
@@ -61,6 +62,86 @@ export const transferIdParamsSchema = z.object({
   transferId: z.string().min(1),
 });
 
+const policyRuleBaseShape = {
+  id: z.string().min(1).max(120).optional(),
+  name: z.string().min(1).max(120).optional(),
+  description: z.string().max(500).optional(),
+  action: z
+    .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+    .optional(),
+};
+
+const walletOperationFamilySchema = z.enum([
+  "transfer",
+  "payment",
+  "ramp",
+  "issuance",
+  "raw_sign",
+  "program",
+  "provider_admin",
+]);
+
+const walletPolicyRuleSchema: z.ZodType<PolicyRule> = z.discriminatedUnion("kind", [
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("operation_family"),
+    family: walletOperationFamilySchema.optional(),
+    families: z.array(walletOperationFamilySchema).max(20).optional(),
+  }),
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("operation_type"),
+    operationType: z.string().min(1, "operationType must not be empty").max(120).optional(),
+    operationTypes: z
+      .array(z.string().min(1, "operationTypes entries must not be empty").max(120))
+      .max(100)
+      .optional(),
+  }),
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("asset"),
+    asset: z.string().min(1, "asset must not be empty").max(120).optional(),
+    assets: z
+      .array(z.string().min(1, "assets entries must not be empty").max(120))
+      .max(100)
+      .optional(),
+  }),
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("destination"),
+    allowlist: z.array(solanaAddressSchema("allowlist entry")).max(500).optional(),
+    blocklist: z.array(solanaAddressSchema("blocklist entry")).max(500).optional(),
+    destination: solanaAddressSchema("destination").optional(),
+    destinations: z.array(solanaAddressSchema("destinations entry")).max(500).optional(),
+  }),
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("amount"),
+    min: z
+      .string()
+      .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
+      .optional(),
+    max: z
+      .string()
+      .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
+      .optional(),
+    asset: z.string().min(1).max(120).optional(),
+    assets: z.array(z.string().min(1).max(120)).max(100).optional(),
+  }),
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("approval"),
+    families: z.array(walletOperationFamilySchema).max(20).optional(),
+    operationTypes: z.array(z.string().min(1).max(120)).max(100).optional(),
+    assets: z.array(z.string().min(1).max(120)).max(100).optional(),
+    approvalGroupId: z.string().min(1).max(120).optional(),
+  }),
+  z.object({
+    ...policyRuleBaseShape,
+    kind: z.literal("always"),
+  }),
+]);
+
 export const updateWalletPolicySchema = z.object({
   destinationAllowlist: z.array(solanaAddressSchema("destinationAllowlist entry")).max(500),
   maxTransferAmount: z
@@ -72,114 +153,7 @@ export const updateWalletPolicySchema = z.object({
     .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
     .optional(),
   defaultAction: z.enum(["allow", "deny", "approval_required", "review"]).optional(),
-  rules: z
-    .array(
-      z.discriminatedUnion("kind", [
-        z.object({
-          id: z.string().min(1).max(120).optional(),
-          name: z.string().min(1).max(120).optional(),
-          description: z.string().max(500).optional(),
-          action: z
-            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
-            .optional(),
-          kind: z.literal("operation_family"),
-          family: z
-            .enum([
-              "transfer",
-              "payment",
-              "ramp",
-              "issuance",
-              "raw_sign",
-              "program",
-              "provider_admin",
-            ])
-            .optional(),
-          families: z
-            .array(
-              z.enum([
-                "transfer",
-                "payment",
-                "ramp",
-                "issuance",
-                "raw_sign",
-                "program",
-                "provider_admin",
-              ])
-            )
-            .max(20)
-            .optional(),
-        }),
-        z.object({
-          id: z.string().min(1).max(120).optional(),
-          name: z.string().min(1).max(120).optional(),
-          description: z.string().max(500).optional(),
-          action: z
-            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
-            .optional(),
-          kind: z.literal("destination"),
-          allowlist: z.array(solanaAddressSchema("allowlist entry")).max(500).optional(),
-          blocklist: z.array(solanaAddressSchema("blocklist entry")).max(500).optional(),
-          destination: solanaAddressSchema("destination").optional(),
-          destinations: z.array(solanaAddressSchema("destinations entry")).max(500).optional(),
-        }),
-        z.object({
-          id: z.string().min(1).max(120).optional(),
-          name: z.string().min(1).max(120).optional(),
-          description: z.string().max(500).optional(),
-          action: z
-            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
-            .optional(),
-          kind: z.literal("amount"),
-          min: z
-            .string()
-            .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
-            .optional(),
-          max: z
-            .string()
-            .refine((value) => isDecimalString(value), { message: "Invalid amount format" })
-            .optional(),
-          asset: z.string().min(1).max(120).optional(),
-          assets: z.array(z.string().min(1).max(120)).max(100).optional(),
-        }),
-        z.object({
-          id: z.string().min(1).max(120).optional(),
-          name: z.string().min(1).max(120).optional(),
-          description: z.string().max(500).optional(),
-          action: z
-            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
-            .optional(),
-          kind: z.literal("approval"),
-          families: z
-            .array(
-              z.enum([
-                "transfer",
-                "payment",
-                "ramp",
-                "issuance",
-                "raw_sign",
-                "program",
-                "provider_admin",
-              ])
-            )
-            .max(20)
-            .optional(),
-          operationTypes: z.array(z.string().min(1).max(120)).max(100).optional(),
-          assets: z.array(z.string().min(1).max(120)).max(100).optional(),
-          approvalGroupId: z.string().min(1).max(120).optional(),
-        }),
-        z.object({
-          id: z.string().min(1).max(120).optional(),
-          name: z.string().min(1).max(120).optional(),
-          description: z.string().max(500).optional(),
-          action: z
-            .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
-            .optional(),
-          kind: z.literal("always"),
-        }),
-      ])
-    )
-    .max(100)
-    .optional(),
+  rules: z.array(walletPolicyRuleSchema).max(100).optional(),
 });
 
 export const paymentAmountSchema = z


### PR DESCRIPTION
## Summary
- expose existing `operation_type` and standalone `asset` wallet policy rules through public request validation
- keep the request union statically aligned with the canonical `PolicyRule` type while preserving all existing rule kinds
- document the complete seven-kind wallet policy contract and add accepted, invalid, backward-compatibility, routed API, and OpenAPI coverage

## Local verification
- `pnpm --dir apps/sdp-api exec vitest run --config vitest.workers.config.ts src/routes/payments/schemas.test.ts src/openapi/spec.test.ts`
- `pnpm --dir apps/sdp-api exec vitest run --config vitest.workers.config.ts src/routes/payments.test.ts -t "activates immutable wallet control profile revisions|rejects invalid public wallet policy rule values"`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter @sdp/api lint` (passes with two pre-existing Clerk warnings)
- `pnpm -C apps/sdp-api openapi:generate`
- `pnpm -C apps/sdp-docs generate:api`
- `pnpm -C apps/sdp-docs generate:ai`
- `pnpm --filter sdp-docs check:links`
- `pnpm --filter sdp-docs build`
- Doppler-backed local API and Postgres: `GET /health` returned 200

## Notes
- The linked canonical Notion PRD could not be read because the Notion connector requires reauthentication. The Linear ticket and Policies epic contain explicit scope, acceptance criteria, and non-goals, with no blockers or ticket comments.
- Docs generation surfaced unrelated stale generated drift from current `main`; those unrelated artifacts are intentionally excluded from this PR.

Closes PRO-1535