### PR TITLE
feat(api): add API-key policy authoring endpoints (PRO-1534)

### DIFF
--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -150,6 +150,7 @@ export type {
   PolicyEvaluationRow,
   PolicyRepository,
   PolicyRepositoryContext,
+  ReplaceApiKeyWalletPolicyBindingsInput,
   UpdateApprovalRequestStatusInput,
   UpsertApiKeyWalletPolicyBindingInput,
   WalletControlProfileRevisionRow,

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -1,4 +1,4 @@
-import type { AppDb } from "@/db";
+import type { AppDb, DatabaseExecutor } from "@/db";
 import {
   asPostgresJsonArray,
   asPostgresJsonObject,
@@ -29,6 +29,7 @@ import type {
   ListWalletPolicyEvaluationAuditsInput,
   PolicyEvaluationRow,
   PolicyRepository,
+  ReplaceApiKeyWalletPolicyBindingsInput,
   UpdateApprovalRequestStatusInput,
   UpsertApiKeyWalletPolicyBindingInput,
   WalletControlProfileRevisionRow,
@@ -464,6 +465,49 @@ async function getApiKeyControlProfileRevisionById(
   return row ? mapApiKeyControlProfileRevisionRow(row) : null;
 }
 
+async function upsertApiKeyWalletPolicyBindingInternal(
+  db: DatabaseExecutor,
+  input: UpsertApiKeyWalletPolicyBindingInput
+): Promise<ApiKeyWalletPolicyBindingRow | null> {
+  const id = generateApiKeyWalletPolicyBindingId();
+  const conflictTarget =
+    input.bindingScope === "all"
+      ? "(api_key_id) WHERE binding_scope = 'all'"
+      : "(api_key_id, wallet_id) WHERE binding_scope = 'selected'";
+
+  const row = await db
+    .prepare(
+      `INSERT INTO api_key_wallet_policy_bindings (
+         id,
+         api_key_id,
+         binding_scope,
+         wallet_id,
+         custody_wallet_id,
+         wallet_control_profile_id,
+         api_key_control_profile_id
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT ${conflictTarget}
+       DO UPDATE SET
+         custody_wallet_id = EXCLUDED.custody_wallet_id,
+         wallet_control_profile_id = EXCLUDED.wallet_control_profile_id,
+         api_key_control_profile_id = EXCLUDED.api_key_control_profile_id,
+         updated_at = sdp_iso_now()
+       RETURNING *`
+    )
+    .bind(
+      id,
+      input.apiKeyId,
+      input.bindingScope,
+      input.walletId ?? null,
+      input.custodyWalletId ?? null,
+      input.walletControlProfileId ?? null,
+      input.apiKeyControlProfileId ?? null
+    )
+    .first<Record<string, unknown>>();
+
+  return row ? mapApiKeyWalletPolicyBindingRow(row) : null;
+}
+
 async function getWalletOperationByIdInternal(
   db: AppDb,
   walletOperationId: string
@@ -710,6 +754,10 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       return getApiKeyControlProfileById(db, id);
     },
 
+    async getApiKeyControlProfileById(profileId: string) {
+      return getApiKeyControlProfileById(db, profileId);
+    },
+
     async createApiKeyControlProfileRevision(input: CreateApiKeyControlProfileRevisionInput) {
       const id = generateApiKeyControlProfileRevisionId();
       const row = await db.transaction(async (tx) => {
@@ -755,6 +803,10 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       });
 
       return row ? mapApiKeyControlProfileRevisionRow(row) : null;
+    },
+
+    async getApiKeyControlProfileRevisionById(revisionId: string) {
+      return getApiKeyControlProfileRevisionById(db, revisionId);
     },
 
     async activateApiKeyControlProfileRevision(input: ActivateApiKeyControlProfileRevisionInput) {
@@ -875,44 +927,32 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
 
     async upsertApiKeyWalletPolicyBinding(input: UpsertApiKeyWalletPolicyBindingInput) {
       validateApiKeyWalletPolicyBindingInput(input);
+      return upsertApiKeyWalletPolicyBindingInternal(db, input);
+    },
 
-      const id = generateApiKeyWalletPolicyBindingId();
-      const conflictTarget =
-        input.bindingScope === "all"
-          ? "(api_key_id) WHERE binding_scope = 'all'"
-          : "(api_key_id, wallet_id) WHERE binding_scope = 'selected'";
+    async replaceApiKeyWalletPolicyBindings(input: ReplaceApiKeyWalletPolicyBindingsInput) {
+      if (input.bindings.some((binding) => binding.apiKeyId !== input.apiKeyId)) {
+        throw badRequest("Policy bindings must target the requested API key");
+      }
+      for (const binding of input.bindings) {
+        validateApiKeyWalletPolicyBindingInput(binding);
+      }
 
-      const row = await db
-        .prepare(
-          `INSERT INTO api_key_wallet_policy_bindings (
-             id,
-             api_key_id,
-             binding_scope,
-             wallet_id,
-             custody_wallet_id,
-             wallet_control_profile_id,
-             api_key_control_profile_id
-           ) VALUES (?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT ${conflictTarget}
-           DO UPDATE SET
-             custody_wallet_id = EXCLUDED.custody_wallet_id,
-             wallet_control_profile_id = EXCLUDED.wallet_control_profile_id,
-             api_key_control_profile_id = EXCLUDED.api_key_control_profile_id,
-             updated_at = sdp_iso_now()
-           RETURNING *`
-        )
-        .bind(
-          id,
-          input.apiKeyId,
-          input.bindingScope,
-          input.walletId ?? null,
-          input.custodyWalletId ?? null,
-          input.walletControlProfileId ?? null,
-          input.apiKeyControlProfileId ?? null
-        )
-        .first<Record<string, unknown>>();
+      return db.transaction(async (tx) => {
+        await tx
+          .prepare("DELETE FROM api_key_wallet_policy_bindings WHERE api_key_id = ?")
+          .bind(input.apiKeyId)
+          .run();
 
-      return row ? mapApiKeyWalletPolicyBindingRow(row) : null;
+        const rows: ApiKeyWalletPolicyBindingRow[] = [];
+        for (const binding of input.bindings) {
+          const row = await upsertApiKeyWalletPolicyBindingInternal(tx, binding);
+          if (row) {
+            rows.push(row);
+          }
+        }
+        return rows;
+      });
     },
 
     async listApiKeyWalletPolicyBindings(apiKeyId: string) {

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -947,9 +947,10 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
         const rows: ApiKeyWalletPolicyBindingRow[] = [];
         for (const binding of input.bindings) {
           const row = await upsertApiKeyWalletPolicyBindingInternal(tx, binding);
-          if (row) {
-            rows.push(row);
+          if (!row) {
+            throw new Error("Failed to upsert API key wallet policy binding");
           }
+          rows.push(row);
         }
         return rows;
       });

--- a/apps/sdp-api/src/db/repositories/policy.repository.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.ts
@@ -321,6 +321,11 @@ export type UpsertApiKeyWalletPolicyBindingInput = UpsertApiKeyWalletPolicyBindi
       }
   );
 
+export interface ReplaceApiKeyWalletPolicyBindingsInput {
+  apiKeyId: string;
+  bindings: UpsertApiKeyWalletPolicyBindingInput[];
+}
+
 export interface CreateWalletOperationInput {
   organizationId: string;
   projectId: string | null;
@@ -419,8 +424,12 @@ export interface PolicyRepository {
   createApiKeyControlProfile(
     input: CreateApiKeyControlProfileInput
   ): Promise<ApiKeyControlProfileRow | null>;
+  getApiKeyControlProfileById(profileId: string): Promise<ApiKeyControlProfileRow | null>;
   createApiKeyControlProfileRevision(
     input: CreateApiKeyControlProfileRevisionInput
+  ): Promise<ApiKeyControlProfileRevisionRow | null>;
+  getApiKeyControlProfileRevisionById(
+    revisionId: string
   ): Promise<ApiKeyControlProfileRevisionRow | null>;
   activateApiKeyControlProfileRevision(
     input: ActivateApiKeyControlProfileRevisionInput
@@ -436,6 +445,9 @@ export interface PolicyRepository {
   upsertApiKeyWalletPolicyBinding(
     input: UpsertApiKeyWalletPolicyBindingInput
   ): Promise<ApiKeyWalletPolicyBindingRow | null>;
+  replaceApiKeyWalletPolicyBindings(
+    input: ReplaceApiKeyWalletPolicyBindingsInput
+  ): Promise<ApiKeyWalletPolicyBindingRow[]>;
   listApiKeyWalletPolicyBindings(apiKeyId: string): Promise<ApiKeyWalletPolicyBindingRow[]>;
   listApiKeyWalletPolicyBindingsForApiKeys(
     apiKeyIds: string[]

--- a/apps/sdp-api/src/openapi/paths/api-keys.ts
+++ b/apps/sdp-api/src/openapi/paths/api-keys.ts
@@ -3,16 +3,23 @@ import { z } from "zod";
 
 import {
   apiKeyIdParamSchema,
+  createApiKeyControlProfileRequestSchema,
+  createApiKeyControlProfileRevisionRequestSchema,
   createApiKeyRequestSchema,
   errorResponseSchema,
   rotateApiKeyRequestSchema,
   updateApiKeyRequestSchema,
+  writeApiKeyPolicyBindingsRequestSchema,
 } from "../schemas";
 import { errorResponses, jsonContent, projectScopeHeaders } from "./helpers";
 import {
   actionSuccessResponse,
+  apiKeyControlProfileActivationResponse,
+  apiKeyControlProfileResponse,
+  apiKeyControlProfileRevisionResponse,
   apiKeyCreateResponse,
   apiKeyDetailResponse,
+  apiKeyPolicyBindingsResponse,
   apiKeyRevokeResponse,
   apiKeyRotateResponse,
   listApiKeysResponse,
@@ -108,6 +115,105 @@ export function registerApiKeyPaths(registry: OpenAPIRegistry) {
       200: {
         description: "API key updated",
         content: jsonContent(actionSuccessResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/api-keys/{keyId}/policy-profiles",
+    tags: ["API Keys"],
+    summary: "Create API-key policy profile",
+    operationId: "createApiKeyControlProfile",
+    description: "Creates a draft operation-level control profile for one API key.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({ keyId: apiKeyIdParamSchema }),
+      body: { required: true, content: jsonContent(createApiKeyControlProfileRequestSchema) },
+    },
+    responses: {
+      201: {
+        description: "API-key control profile created",
+        content: jsonContent(apiKeyControlProfileResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/api-keys/{keyId}/policy-profiles/{profileId}/revisions",
+    tags: ["API Keys"],
+    summary: "Create API-key policy revision",
+    operationId: "createApiKeyControlProfileRevision",
+    description:
+      "Appends an immutable rule snapshot to an API-key control profile without activating it.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({
+        keyId: apiKeyIdParamSchema,
+        profileId: z.string().min(1),
+      }),
+      body: {
+        required: true,
+        content: jsonContent(createApiKeyControlProfileRevisionRequestSchema),
+      },
+    },
+    responses: {
+      201: {
+        description: "API-key control profile revision created",
+        content: jsonContent(apiKeyControlProfileRevisionResponse),
+      },
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/v1/api-keys/{keyId}/policy-profiles/{profileId}/revisions/{revisionId}/activate",
+    tags: ["API Keys"],
+    summary: "Activate API-key policy revision",
+    operationId: "activateApiKeyControlProfileRevision",
+    description: "Makes one immutable revision the active policy for its API-key control profile.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({
+        keyId: apiKeyIdParamSchema,
+        profileId: z.string().min(1),
+        revisionId: z.string().min(1),
+      }),
+    },
+    responses: {
+      200: {
+        description: "API-key control profile revision activated",
+        content: jsonContent(apiKeyControlProfileActivationResponse),
+      },
+      ...errorResponses(errorResponseSchema, [401, 403, 404, 500]),
+    },
+  });
+
+  registry.registerPath({
+    method: "put",
+    path: "/v1/api-keys/{keyId}/policy-bindings",
+    tags: ["API Keys"],
+    summary: "Replace or clear API-key policy bindings",
+    operationId: "writeApiKeyPolicyBindings",
+    description:
+      "Explicitly replaces the complete all-wallet/selected-wallet policy binding set, or clears it. Existing bindings are otherwise preserved by API-key updates and rotation.",
+    security: [{ apiKeyAuth: [] }],
+    request: {
+      headers: projectScopeHeaders,
+      params: z.object({ keyId: apiKeyIdParamSchema }),
+      body: { required: true, content: jsonContent(writeApiKeyPolicyBindingsRequestSchema) },
+    },
+    responses: {
+      200: {
+        description: "API-key policy bindings updated",
+        content: jsonContent(apiKeyPolicyBindingsResponse),
       },
       ...errorResponses(errorResponseSchema, [400, 401, 403, 404, 500]),
     },

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -5,7 +5,11 @@ import {
   addressScreeningResponseSchema,
   allowlistEntriesResponseSchema,
   allowlistEntrySchema,
+  apiKeyControlProfileActivationResponseSchema,
+  apiKeyControlProfileResponseSchema,
+  apiKeyControlProfileRevisionResponseSchema,
   apiKeyDetailSchema,
+  apiKeyPolicyBindingsResponseSchema,
   apiKeyResponseSchema,
   assetProfileFieldOptionsResponseSchema,
   assetProfileResponseSchema,
@@ -107,6 +111,18 @@ export const apiKeyDetailResponse = successResponseSchema(apiKeyDetailSchema);
 export const apiKeyCreateResponse = successResponseSchema(apiKeyResponseSchema);
 export const apiKeyRotateResponse = successResponseSchema(rotateApiKeyResponseSchema);
 export const apiKeyRevokeResponse = successResponseSchema(revokeApiKeyResponseSchema);
+export const apiKeyControlProfileResponse = successResponseSchema(
+  apiKeyControlProfileResponseSchema
+);
+export const apiKeyControlProfileRevisionResponse = successResponseSchema(
+  apiKeyControlProfileRevisionResponseSchema
+);
+export const apiKeyControlProfileActivationResponse = successResponseSchema(
+  apiKeyControlProfileActivationResponseSchema
+);
+export const apiKeyPolicyBindingsResponse = successResponseSchema(
+  apiKeyPolicyBindingsResponseSchema
+);
 
 export const assetProfileResponse = successResponseSchema(assetProfileResponseSchema);
 export const assetProfileFieldOptionsResponse = successResponseSchema(

--- a/apps/sdp-api/src/openapi/schemas/api-keys.ts
+++ b/apps/sdp-api/src/openapi/schemas/api-keys.ts
@@ -195,7 +195,14 @@ const writeSelectedApiKeyPolicyBindingSchema = z
       description: "Optional active API-key control profile for this wallet.",
     }),
   })
-  .openapi({ description: "Selected-wallet policy binding replacement." });
+  .refine(
+    (binding) => binding.walletControlProfileId || binding.apiKeyControlProfileId,
+    "Selected-wallet policy bindings must reference at least one control profile"
+  )
+  .openapi({
+    description:
+      "Selected-wallet policy binding replacement. At least one control profile ID is required.",
+  });
 
 const writeAllApiKeyPolicyBindingSchema = z
   .object({

--- a/apps/sdp-api/src/openapi/schemas/api-keys.ts
+++ b/apps/sdp-api/src/openapi/schemas/api-keys.ts
@@ -1,5 +1,7 @@
 import { PERMISSIONS } from "@sdp/types";
 import {
+  apiKeyControlProfileCreateSchema as apiKeyControlProfileCreateSchemaBase,
+  apiKeyControlProfileRevisionCreateSchema as apiKeyControlProfileRevisionCreateSchemaBase,
   apiKeyCreateSchema as apiKeyCreateSchemaBase,
   apiKeyRotateSchema as apiKeyRotateSchemaBase,
   apiKeyUpdateSchema as apiKeyUpdateSchemaBase,
@@ -91,6 +93,151 @@ export const apiKeyWalletPolicyBindingSchema = z
     }),
   })
   .openapi({ description: "Read-only policy binding summary for an API key wallet scope." });
+
+export const apiKeyPolicyRuleSchema = z
+  .object({
+    id: z.string().optional().openapi({ description: "Stable client-side rule identifier." }),
+    name: z.string().optional().openapi({ description: "Human-readable rule name." }),
+    description: z.string().optional().openapi({ description: "Rule description." }),
+    action: z
+      .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+      .optional()
+      .openapi({ description: "Decision to apply when this rule matches." }),
+    kind: z
+      .enum([
+        "operation_family",
+        "operation_type",
+        "asset",
+        "destination",
+        "amount",
+        "approval",
+        "always",
+      ])
+      .openapi({ description: "API-key policy rule kind." }),
+  })
+  .passthrough()
+  .openapi({
+    description: "Operation-level API-key policy rule.",
+    example: {
+      id: "deny-raw-signing",
+      kind: "operation_family",
+      family: "raw_sign",
+      action: "deny",
+    },
+  });
+
+export const apiKeyControlProfileSchema = z
+  .object({
+    id: z.string().openapi({ description: "API-key control profile ID." }),
+    organizationId: z.string().openapi({ description: "Owning organization ID." }),
+    projectId: projectIdParamSchema.nullable().openapi({ description: "Owning project ID." }),
+    apiKeyId: apiKeyIdParamSchema,
+    name: z.string().openapi({ description: "Control profile name." }),
+    status: z.enum(["draft", "active", "disabled", "archived"]).openapi({
+      description: "Control profile status.",
+    }),
+    activeRevisionId: z.string().nullable().openapi({
+      description: "Currently active immutable revision ID.",
+    }),
+    createdBy: z.string().nullable().openapi({ description: "Profile author ID." }),
+    createdAt: isoDateTimeSchema,
+    updatedAt: isoDateTimeSchema,
+    activatedAt: isoDateTimeSchema.nullable(),
+    archivedAt: isoDateTimeSchema.nullable(),
+  })
+  .openapi({ description: "API-key control profile." });
+
+export const apiKeyControlProfileRevisionSchema = z
+  .object({
+    id: z.string().openapi({ description: "Immutable API-key control profile revision ID." }),
+    profileId: z.string().openapi({ description: "Parent control profile ID." }),
+    revisionNumber: z.number().int().positive().openapi({ description: "Revision number." }),
+    rules: z.array(apiKeyPolicyRuleSchema).openapi({ description: "Revision policy rules." }),
+    defaultAction: z.enum(["allow", "deny", "approval_required", "review"]).openapi({
+      description: "Decision used when no rule matches.",
+    }),
+    createdBy: z.string().nullable().openapi({ description: "Revision author ID." }),
+    createdAt: isoDateTimeSchema,
+    activatedAt: isoDateTimeSchema.nullable(),
+  })
+  .openapi({ description: "Immutable API-key control profile revision." });
+
+export const createApiKeyControlProfileRequestSchema = apiKeyControlProfileCreateSchemaBase
+  .extend({
+    name: withOpenApi(apiKeyControlProfileCreateSchemaBase.shape.name, {
+      description: "Human-readable name for the API-key control profile.",
+      example: "Treasury service controls",
+    }),
+  })
+  .openapi({ description: "Create an API-key control profile." });
+
+export const createApiKeyControlProfileRevisionRequestSchema =
+  apiKeyControlProfileRevisionCreateSchemaBase
+    .extend({
+      rules: z.array(apiKeyPolicyRuleSchema).max(100).openapi({
+        description: "Complete rule snapshot for the new immutable revision.",
+      }),
+      defaultAction: withOpenApi(apiKeyControlProfileRevisionCreateSchemaBase.shape.defaultAction, {
+        description: "Decision used when no rule matches.",
+        example: "deny",
+      }),
+    })
+    .openapi({ description: "Create a new immutable API-key control profile revision." });
+
+const writeSelectedApiKeyPolicyBindingSchema = z
+  .object({
+    bindingScope: z.literal("selected"),
+    walletId: z.string().openapi({ description: "Selected custody wallet ID." }),
+    walletControlProfileId: z.string().optional().openapi({
+      description: "Optional active wallet control profile for this wallet.",
+    }),
+    apiKeyControlProfileId: z.string().optional().openapi({
+      description: "Optional active API-key control profile for this wallet.",
+    }),
+  })
+  .openapi({ description: "Selected-wallet policy binding replacement." });
+
+const writeAllApiKeyPolicyBindingSchema = z
+  .object({
+    bindingScope: z.literal("all"),
+    apiKeyControlProfileId: z.string().openapi({
+      description: "Active API-key control profile shared by all wallets in key scope.",
+    }),
+  })
+  .openapi({ description: "All-wallet policy binding replacement." });
+
+export const writeApiKeyPolicyBindingsRequestSchema = z
+  .discriminatedUnion("mode", [
+    z.object({
+      mode: z.literal("replace"),
+      bindings: z
+        .array(z.union([writeAllApiKeyPolicyBindingSchema, writeSelectedApiKeyPolicyBindingSchema]))
+        .min(1)
+        .max(100),
+    }),
+    z.object({ mode: z.literal("clear") }),
+  ])
+  .openapi({
+    description:
+      "Explicitly replace the complete API-key policy binding set, or clear every policy binding.",
+  });
+
+export const apiKeyControlProfileResponseSchema = z.object({
+  profile: apiKeyControlProfileSchema,
+});
+
+export const apiKeyControlProfileRevisionResponseSchema = z.object({
+  revision: apiKeyControlProfileRevisionSchema,
+});
+
+export const apiKeyControlProfileActivationResponseSchema = z.object({
+  profile: apiKeyControlProfileSchema,
+  revision: apiKeyControlProfileRevisionSchema,
+});
+
+export const apiKeyPolicyBindingsResponseSchema = z.object({
+  policyBindings: z.array(apiKeyWalletPolicyBindingSchema),
+});
 
 export const apiKeyListItemSchema = z
   .object({

--- a/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
@@ -667,6 +667,65 @@ describe("API key wallet scope routes", () => {
     }
   });
 
+  it("rejects revision authoring and activation for archived profiles", async () => {
+    const apiKeyId = await createManagedApiKey({
+      name: "Archived policy key",
+      walletScope: "all",
+    });
+    const profileResponse = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-profiles`,
+      {
+        method: "POST",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({ name: "Archived controls" }),
+      },
+      env
+    );
+    expect(profileResponse.status).toBe(201);
+    const profileBody = (await profileResponse.json()) as { data: { profile: { id: string } } };
+    const profileId = profileBody.data.profile.id;
+
+    const revisionResponse = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-profiles/${profileId}/revisions`,
+      {
+        method: "POST",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({ rules: [], defaultAction: "deny" }),
+      },
+      env
+    );
+    expect(revisionResponse.status).toBe(201);
+    const revisionBody = (await revisionResponse.json()) as {
+      data: { revision: { id: string } };
+    };
+
+    await getDb(env)
+      .prepare("UPDATE api_key_control_profiles SET status = 'archived' WHERE id = ?")
+      .bind(profileId)
+      .run();
+
+    const appendResponse = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-profiles/${profileId}/revisions`,
+      {
+        method: "POST",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({ rules: [], defaultAction: "allow" }),
+      },
+      env
+    );
+    expect(appendResponse.status).toBe(404);
+
+    const activationResponse = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-profiles/${profileId}/revisions/${revisionBody.data.revision.id}/activate`,
+      {
+        method: "POST",
+        headers: authenticatedJsonHeaders(),
+      },
+      env
+    );
+    expect(activationResponse.status).toBe(404);
+  });
+
   it("authors revisions, activates and clears an all-wallet policy binding explicitly", async () => {
     const apiKeyId = await createManagedApiKey({
       name: "All-wallet policy key",

--- a/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
@@ -144,6 +144,112 @@ async function seedAuthAndWallets(): Promise<void> {
   ]);
 }
 
+function authenticatedJsonHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${TEST_API_KEY.raw}`,
+  };
+}
+
+async function createManagedApiKey(input: {
+  name: string;
+  walletScope: "all" | "selected";
+  walletIds?: string[];
+}): Promise<string> {
+  const walletIds = input.walletIds ?? [];
+  const response = await app.request(
+    "/v1/api-keys",
+    {
+      method: "POST",
+      headers: authenticatedJsonHeaders(),
+      body: JSON.stringify({
+        name: input.name,
+        walletScope: input.walletScope,
+        ...(input.walletScope === "selected"
+          ? {
+              signingWalletId: walletIds[0],
+              signingWalletIds: walletIds,
+            }
+          : {}),
+      }),
+    },
+    env
+  );
+  expect(response.status).toBe(201);
+  const body = (await response.json()) as { data: { apiKey: { id: string } } };
+  return body.data.apiKey.id;
+}
+
+async function createAndActivateApiKeyPolicy(apiKeyId: string): Promise<{
+  profileId: string;
+  revisionId: string;
+}> {
+  const profileResponse = await app.request(
+    `/v1/api-keys/${apiKeyId}/policy-profiles`,
+    {
+      method: "POST",
+      headers: authenticatedJsonHeaders(),
+      body: JSON.stringify({ name: "Managed key controls" }),
+    },
+    env
+  );
+  expect(profileResponse.status).toBe(201);
+  const profileBody = (await profileResponse.json()) as { data: { profile: { id: string } } };
+  const profileId = profileBody.data.profile.id;
+
+  const firstRevisionResponse = await app.request(
+    `/v1/api-keys/${apiKeyId}/policy-profiles/${profileId}/revisions`,
+    {
+      method: "POST",
+      headers: authenticatedJsonHeaders(),
+      body: JSON.stringify({
+        rules: [{ id: "allow-payments", kind: "operation_family", family: "payment" }],
+        defaultAction: "allow",
+      }),
+    },
+    env
+  );
+  expect(firstRevisionResponse.status).toBe(201);
+
+  const secondRevisionResponse = await app.request(
+    `/v1/api-keys/${apiKeyId}/policy-profiles/${profileId}/revisions`,
+    {
+      method: "POST",
+      headers: authenticatedJsonHeaders(),
+      body: JSON.stringify({
+        rules: [
+          { id: "deny-raw-sign", kind: "operation_family", family: "raw_sign", action: "deny" },
+        ],
+        defaultAction: "review",
+      }),
+    },
+    env
+  );
+  expect(secondRevisionResponse.status).toBe(201);
+  const revisionBody = (await secondRevisionResponse.json()) as {
+    data: { revision: { id: string; revisionNumber: number } };
+  };
+  expect(revisionBody.data.revision.revisionNumber).toBe(2);
+
+  const revisionId = revisionBody.data.revision.id;
+  const activationResponse = await app.request(
+    `/v1/api-keys/${apiKeyId}/policy-profiles/${profileId}/revisions/${revisionId}/activate`,
+    {
+      method: "POST",
+      headers: authenticatedJsonHeaders(),
+    },
+    env
+  );
+  expect(activationResponse.status).toBe(200);
+  const activationBody = (await activationResponse.json()) as {
+    data: { profile: { activeRevisionId: string }; revision: { id: string } };
+  };
+  expect(activationBody.data.profile.activeRevisionId).toBe(revisionId);
+  expect(activationBody.data.revision.id).toBe(revisionId);
+
+  return { profileId, revisionId };
+}
+
 describe("API key wallet scope routes", () => {
   beforeEach(async () => {
     await seedTestDatabase(env);
@@ -241,6 +347,12 @@ describe("API key wallet scope routes", () => {
       .bind(body.data.apiKey.id)
       .all<{ wallet_id: string }>();
     expect(bindings.results?.map((row) => row.wallet_id)).toEqual(["wal_scope_a", "wal_scope_b"]);
+
+    const policyBindings = await getDb(env)
+      .prepare("SELECT COUNT(*) AS count FROM api_key_wallet_policy_bindings WHERE api_key_id = ?")
+      .bind(body.data.apiKey.id)
+      .first<{ count: number }>();
+    expect(Number(policyBindings?.count)).toBe(0);
   });
 
   it("lists wallet access and policy binding metadata for selected-wallet keys", async () => {
@@ -461,5 +573,263 @@ describe("API key wallet scope routes", () => {
       .bind(TEST_API_KEY.id)
       .first<{ count: number }>();
     expect(bindings?.count).toBe(0);
+  });
+
+  it("hides API keys outside the authenticated project and organization", async () => {
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          "prj_other_api_key_policy",
+          TEST_ORG.id,
+          "Other Project",
+          "other-api-key-policy",
+          "sandbox",
+          "active",
+          TEST_USER.id
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO api_keys
+             (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          "key_other_project_policy",
+          TEST_ORG.id,
+          "prj_other_api_key_policy",
+          TEST_USER.id,
+          "Other project key",
+          "sk_other_prj",
+          "hash_other_project_policy",
+          "api_admin",
+          JSON.stringify(["*"]),
+          "active"
+        ),
+      getDb(env)
+        .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+        .bind(
+          "org_other_api_key_policy",
+          "Other Organization",
+          "other-api-key-policy",
+          "individual",
+          "active"
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          "prj_other_org_api_key_policy",
+          "org_other_api_key_policy",
+          "Other Organization Project",
+          "other-org-api-key-policy",
+          "sandbox",
+          "active",
+          TEST_USER.id
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO api_keys
+             (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          "key_other_org_policy",
+          "org_other_api_key_policy",
+          "prj_other_org_api_key_policy",
+          TEST_USER.id,
+          "Other organization key",
+          "sk_other_org",
+          "hash_other_org_policy",
+          "api_admin",
+          JSON.stringify(["*"]),
+          "active"
+        ),
+    ]);
+
+    for (const keyId of ["key_other_project_policy", "key_other_org_policy"]) {
+      const response = await app.request(
+        `/v1/api-keys/${keyId}/policy-profiles`,
+        {
+          method: "POST",
+          headers: authenticatedJsonHeaders(),
+          body: JSON.stringify({ name: "Out-of-scope controls" }),
+        },
+        env
+      );
+
+      expect(response.status).toBe(404);
+    }
+  });
+
+  it("authors revisions, activates and clears an all-wallet policy binding explicitly", async () => {
+    const apiKeyId = await createManagedApiKey({
+      name: "All-wallet policy key",
+      walletScope: "all",
+    });
+    const { profileId, revisionId } = await createAndActivateApiKeyPolicy(apiKeyId);
+
+    const bindingResponse = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-bindings`,
+      {
+        method: "PUT",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          mode: "replace",
+          bindings: [{ bindingScope: "all", apiKeyControlProfileId: profileId }],
+        }),
+      },
+      env
+    );
+    expect(bindingResponse.status).toBe(200);
+    const bindingBody = (await bindingResponse.json()) as {
+      data: {
+        policyBindings: Array<{
+          bindingScope: string;
+          apiKeyControlProfileRevisionId: string | null;
+        }>;
+      };
+    };
+    expect(bindingBody.data.policyBindings).toEqual([
+      expect.objectContaining({
+        bindingScope: "all",
+        apiKeyControlProfileRevisionId: revisionId,
+      }),
+    ]);
+
+    const walletAccessUpdate = await app.request(
+      `/v1/api-keys/${apiKeyId}`,
+      {
+        method: "PATCH",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          walletScope: "selected",
+          signingWalletId: "wal_scope_a",
+          signingWalletIds: ["wal_scope_a"],
+        }),
+      },
+      env
+    );
+    expect(walletAccessUpdate.status).toBe(200);
+    const preserved = await getDb(env)
+      .prepare("SELECT COUNT(*) AS count FROM api_key_wallet_policy_bindings WHERE api_key_id = ?")
+      .bind(apiKeyId)
+      .first<{ count: number }>();
+    expect(Number(preserved?.count)).toBe(1);
+
+    const clearResponse = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-bindings`,
+      {
+        method: "PUT",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({ mode: "clear" }),
+      },
+      env
+    );
+    expect(clearResponse.status).toBe(200);
+    expect(await clearResponse.json()).toMatchObject({ data: { policyBindings: [] } });
+  });
+
+  it("replaces selected-wallet policy bindings and preserves the prior set on scope failure", async () => {
+    const apiKeyId = await createManagedApiKey({
+      name: "Selected-wallet policy key",
+      walletScope: "selected",
+      walletIds: ["wal_scope_a"],
+    });
+    const { profileId } = await createAndActivateApiKeyPolicy(apiKeyId);
+
+    const firstReplace = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-bindings`,
+      {
+        method: "PUT",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          mode: "replace",
+          bindings: [
+            {
+              bindingScope: "selected",
+              walletId: "wal_scope_a",
+              apiKeyControlProfileId: profileId,
+            },
+          ],
+        }),
+      },
+      env
+    );
+    expect(firstReplace.status).toBe(200);
+
+    const outOfScopeReplace = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-bindings`,
+      {
+        method: "PUT",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          mode: "replace",
+          bindings: [
+            {
+              bindingScope: "selected",
+              walletId: "wal_scope_b",
+              apiKeyControlProfileId: profileId,
+            },
+          ],
+        }),
+      },
+      env
+    );
+    expect(outOfScopeReplace.status).toBe(403);
+
+    const preserved = await getDb(env)
+      .prepare(
+        "SELECT wallet_id FROM api_key_wallet_policy_bindings WHERE api_key_id = ? ORDER BY wallet_id"
+      )
+      .bind(apiKeyId)
+      .all<{ wallet_id: string }>();
+    expect(preserved.results.map((row) => row.wallet_id)).toEqual(["wal_scope_a"]);
+
+    const walletAccessUpdate = await app.request(
+      `/v1/api-keys/${apiKeyId}`,
+      {
+        method: "PATCH",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          walletScope: "selected",
+          signingWalletId: "wal_scope_b",
+          signingWalletIds: ["wal_scope_a", "wal_scope_b"],
+        }),
+      },
+      env
+    );
+    expect(walletAccessUpdate.status).toBe(200);
+
+    const secondReplace = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-bindings`,
+      {
+        method: "PUT",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          mode: "replace",
+          bindings: [
+            {
+              bindingScope: "selected",
+              walletId: "wal_scope_b",
+              apiKeyControlProfileId: profileId,
+            },
+          ],
+        }),
+      },
+      env
+    );
+    expect(secondReplace.status).toBe(200);
+    const secondBody = (await secondReplace.json()) as {
+      data: { policyBindings: Array<{ walletId: string | null }> };
+    };
+    expect(secondBody.data.policyBindings.map((binding) => binding.walletId)).toEqual([
+      "wal_scope_b",
+    ]);
   });
 });

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -4,11 +4,16 @@ import type {
   CreateApiKeyResponse,
   ListApiKeysResponse,
   Permission,
+  PolicyRule,
   RotateApiKeyResponse,
 } from "@sdp/types";
 import type { Context } from "hono";
 import { z } from "zod";
 import { getDb } from "@/db";
+import {
+  createPolicyRepository,
+  type UpsertApiKeyWalletPolicyBindingInput,
+} from "@/db/repositories";
 import { requireProjectId } from "@/lib/auth";
 import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
@@ -21,10 +26,18 @@ import {
 import { replaceApiKeyWalletBindings } from "@/services/api-key-wallets.service";
 import { AuditService } from "@/services/audit.service";
 import { createSigningService } from "@/services/domain/signing.service";
+import { PolicyFoundationService } from "@/services/policy-foundation.service";
 import type { WalletPurpose } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { buildApiKeyAccessSummaries } from "./access-response";
-import { apiKeyCreateSchema, apiKeyRotateSchema, apiKeyUpdateSchema } from "./schemas";
+import {
+  apiKeyControlProfileCreateSchema,
+  apiKeyControlProfileRevisionCreateSchema,
+  apiKeyCreateSchema,
+  apiKeyPolicyBindingsWriteSchema,
+  apiKeyRotateSchema,
+  apiKeyUpdateSchema,
+} from "./schemas";
 
 type AppContext = Context<{ Bindings: Env }>;
 
@@ -393,6 +406,143 @@ export const updateApiKey = async (c: AppContext) => {
   });
 
   return success(c, { success: true });
+};
+
+export const createApiKeyControlProfile = async (c: AppContext) => {
+  const { keyId } = c.req.param();
+  const actor = resolveActor(c);
+  const projectId = requireProjectId(c);
+  const parsed = apiKeyControlProfileCreateSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const profile = await new PolicyFoundationService(
+    createPolicyRepository(c.env)
+  ).createApiKeyControlProfile({
+    organizationId: actor.organizationId,
+    projectId,
+    apiKeyId: keyId,
+    name: parsed.data.name,
+    createdBy: actor.userId ?? actor.apiKeyId,
+  });
+
+  await new AuditService(getDb(c.env)).log(c, {
+    action: "create",
+    resourceType: "api_key",
+    resourceId: keyId,
+    metadata: { action: "create_control_profile", profileId: profile.id, name: profile.name },
+  });
+
+  return created(c, { profile });
+};
+
+export const createApiKeyControlProfileRevision = async (c: AppContext) => {
+  const { keyId, profileId } = c.req.param();
+  const actor = resolveActor(c);
+  const projectId = requireProjectId(c);
+  const parsed = apiKeyControlProfileRevisionCreateSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const revision = await new PolicyFoundationService(
+    createPolicyRepository(c.env)
+  ).createApiKeyControlProfileRevision({
+    organizationId: actor.organizationId,
+    projectId,
+    apiKeyId: keyId,
+    profileId,
+    rules: parsed.data.rules as PolicyRule[],
+    defaultAction: parsed.data.defaultAction,
+    createdBy: actor.userId ?? actor.apiKeyId,
+  });
+
+  await new AuditService(getDb(c.env)).log(c, {
+    action: "create",
+    resourceType: "api_key",
+    resourceId: keyId,
+    metadata: {
+      action: "create_control_profile_revision",
+      profileId,
+      revisionId: revision.id,
+      revisionNumber: revision.revisionNumber,
+    },
+  });
+
+  return created(c, { revision });
+};
+
+export const activateApiKeyControlProfileRevision = async (c: AppContext) => {
+  const { keyId, profileId, revisionId } = c.req.param();
+  const actor = resolveActor(c);
+  const projectId = requireProjectId(c);
+  const active = await new PolicyFoundationService(
+    createPolicyRepository(c.env)
+  ).activateApiKeyControlProfileRevision({
+    organizationId: actor.organizationId,
+    projectId,
+    apiKeyId: keyId,
+    profileId,
+    revisionId,
+  });
+
+  await new AuditService(getDb(c.env)).log(c, {
+    action: "update",
+    resourceType: "api_key",
+    resourceId: keyId,
+    metadata: { action: "activate_control_profile_revision", profileId, revisionId },
+  });
+
+  return success(c, active);
+};
+
+export const writeApiKeyPolicyBindings = async (c: AppContext) => {
+  const { keyId } = c.req.param();
+  const actor = resolveActor(c);
+  const projectId = requireProjectId(c);
+  const parsed = apiKeyPolicyBindingsWriteSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const bindings: UpsertApiKeyWalletPolicyBindingInput[] =
+    parsed.data.mode === "clear"
+      ? []
+      : parsed.data.bindings.map((binding) => ({
+          apiKeyId: keyId,
+          ...binding,
+        }));
+
+  await new PolicyFoundationService(
+    createPolicyRepository(c.env)
+  ).replaceApiKeyWalletPolicyBindings({
+    organizationId: actor.organizationId,
+    projectId,
+    apiKeyId: keyId,
+    bindings,
+  });
+
+  const accessSummary = (await buildApiKeyAccessSummaries(c.env, getDb(c.env), [keyId])).get(keyId);
+  const policyBindings = accessSummary?.policyBindings ?? [];
+
+  await new AuditService(getDb(c.env)).log(c, {
+    action: "update",
+    resourceType: "api_key",
+    resourceId: keyId,
+    metadata: {
+      action: `${parsed.data.mode}_policy_bindings`,
+      bindingCount: policyBindings.length,
+    },
+  });
+
+  return success(c, { policyBindings });
 };
 
 export const rotateApiKey = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/api-keys/index.ts
+++ b/apps/sdp-api/src/routes/api-keys/index.ts
@@ -7,12 +7,16 @@ import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
+  activateApiKeyControlProfileRevision,
   createApiKey,
+  createApiKeyControlProfile,
+  createApiKeyControlProfileRevision,
   getApiKey,
   listApiKeys,
   revokeApiKey,
   rotateApiKey,
   updateApiKey,
+  writeApiKeyPolicyBindings,
 } from "./handlers";
 
 const apiKeys = new Hono<{ Bindings: Env }>();
@@ -25,6 +29,26 @@ apiKeys.get("/", requirePermissions("api-keys:read"), listApiKeys);
 apiKeys.post("/", requirePermissions("api-keys:write"), createApiKey);
 apiKeys.get("/:keyId", requirePermissions("api-keys:read"), getApiKey);
 apiKeys.patch("/:keyId", requirePermissions("api-keys:write"), updateApiKey);
+apiKeys.post(
+  "/:keyId/policy-profiles",
+  requirePermissions("api-keys:write"),
+  createApiKeyControlProfile
+);
+apiKeys.post(
+  "/:keyId/policy-profiles/:profileId/revisions",
+  requirePermissions("api-keys:write"),
+  createApiKeyControlProfileRevision
+);
+apiKeys.post(
+  "/:keyId/policy-profiles/:profileId/revisions/:revisionId/activate",
+  requirePermissions("api-keys:write"),
+  activateApiKeyControlProfileRevision
+);
+apiKeys.put(
+  "/:keyId/policy-bindings",
+  requirePermissions("api-keys:write"),
+  writeApiKeyPolicyBindings
+);
 apiKeys.post("/:keyId/rotate", requirePermissions("api-keys:write"), rotateApiKey);
 apiKeys.delete("/:keyId", requirePermissions("api-keys:write"), revokeApiKey);
 

--- a/apps/sdp-api/src/routes/api-keys/schemas.ts
+++ b/apps/sdp-api/src/routes/api-keys/schemas.ts
@@ -39,3 +39,78 @@ export const apiKeyUpdateSchema = z.object({
 export const apiKeyRotateSchema = z.object({
   gracePeriodHours: z.number().min(0).max(168).optional(), // Max 7 days
 });
+
+const policyDefaultActionSchema = z.enum(["allow", "deny", "approval_required", "review"]);
+
+const apiKeyPolicyRuleSchema = z
+  .object({
+    id: z.string().min(1).max(120).optional(),
+    name: z.string().min(1).max(120).optional(),
+    description: z.string().max(500).optional(),
+    action: z
+      .enum(["allow", "deny", "approval_required", "provider_approval_required", "review"])
+      .optional(),
+    kind: z.enum([
+      "operation_family",
+      "operation_type",
+      "asset",
+      "destination",
+      "amount",
+      "approval",
+      "always",
+    ]),
+  })
+  .passthrough();
+
+export const apiKeyControlProfileCreateSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
+export const apiKeyControlProfileRevisionCreateSchema = z.object({
+  rules: z.array(apiKeyPolicyRuleSchema).max(100),
+  defaultAction: policyDefaultActionSchema,
+});
+
+const allWalletPolicyBindingSchema = z.object({
+  bindingScope: z.literal("all"),
+  apiKeyControlProfileId: z.string().min(1),
+});
+
+const selectedWalletPolicyBindingSchema = z
+  .object({
+    bindingScope: z.literal("selected"),
+    walletId: z.string().min(1),
+    walletControlProfileId: z.string().min(1).optional(),
+    apiKeyControlProfileId: z.string().min(1).optional(),
+  })
+  .refine(
+    (binding) => binding.walletControlProfileId || binding.apiKeyControlProfileId,
+    "Selected-wallet policy bindings must reference at least one control profile"
+  );
+
+const replacePolicyBindingsSchema = z.object({
+  mode: z.literal("replace"),
+  bindings: z
+    .array(z.union([allWalletPolicyBindingSchema, selectedWalletPolicyBindingSchema]))
+    .min(1)
+    .max(100)
+    .superRefine((bindings, ctx) => {
+      const targets = new Set<string>();
+      for (const [index, binding] of bindings.entries()) {
+        const target = binding.bindingScope === "all" ? "all" : `selected:${binding.walletId}`;
+        if (targets.has(target)) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Policy binding targets must be unique",
+            path: [index],
+          });
+        }
+        targets.add(target);
+      }
+    }),
+});
+
+export const apiKeyPolicyBindingsWriteSchema = z.discriminatedUnion("mode", [
+  replacePolicyBindingsSchema,
+  z.object({ mode: z.literal("clear") }),
+]);

--- a/apps/sdp-api/src/services/policy-foundation.service.ts
+++ b/apps/sdp-api/src/services/policy-foundation.service.ts
@@ -4,7 +4,9 @@ import type {
   ApiKeyWalletPolicyBinding,
   EffectiveApiKeyPolicy,
   EffectiveWalletPolicy,
+  PolicyDefaultAction,
   PolicyEvaluation,
+  PolicyRule,
   WalletControlProfile,
   WalletControlProfileRevision,
   WalletOperationActor,
@@ -29,7 +31,7 @@ import type {
   WalletControlProfileRow,
   WalletOperationRow,
 } from "@/db/repositories";
-import { badRequest, forbidden } from "@/lib/errors";
+import { badRequest, forbidden, notFound } from "@/lib/errors";
 import {
   createPolicyEvaluationInput,
   evaluateWalletOperationPolicies,
@@ -69,8 +71,116 @@ export interface ResolvedApiKeyWalletPolicyScope {
   apiKeyPolicy: EffectiveApiKeyPolicy;
 }
 
+interface ApiKeyPolicyAuthoringScope {
+  organizationId: string;
+  projectId: string;
+  apiKeyId: string;
+}
+
+interface CreateApiKeyControlProfileInput extends ApiKeyPolicyAuthoringScope {
+  name: string;
+  createdBy?: string | null;
+}
+
+interface CreateApiKeyControlProfileRevisionInput extends ApiKeyPolicyAuthoringScope {
+  profileId: string;
+  rules: PolicyRule[];
+  defaultAction: PolicyDefaultAction;
+  createdBy?: string | null;
+}
+
+interface ActivateApiKeyControlProfileRevisionInput extends ApiKeyPolicyAuthoringScope {
+  profileId: string;
+  revisionId: string;
+}
+
+interface ReplaceApiKeyWalletPolicyBindingsInput extends ApiKeyPolicyAuthoringScope {
+  bindings: UpsertApiKeyWalletPolicyBindingInput[];
+}
+
 export class PolicyFoundationService {
   constructor(private readonly repository: PolicyRepository) {}
+
+  async createApiKeyControlProfile(
+    input: CreateApiKeyControlProfileInput
+  ): Promise<ApiKeyControlProfile> {
+    await this.assertScopedApiKeyPolicySubject(input);
+    const row = await this.repository.createApiKeyControlProfile({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      apiKeyId: input.apiKeyId,
+      name: input.name,
+      createdBy: input.createdBy,
+    });
+
+    if (!row) {
+      throw new Error("Failed to create API key control profile");
+    }
+    return mapApiKeyControlProfile(row);
+  }
+
+  async createApiKeyControlProfileRevision(
+    input: CreateApiKeyControlProfileRevisionInput
+  ): Promise<ApiKeyControlProfileRevision> {
+    const subject = await this.assertScopedApiKeyPolicySubject(input);
+    await this.assertScopedApiKeyControlProfile(input.profileId, subject);
+    const row = await this.repository.createApiKeyControlProfileRevision({
+      profileId: input.profileId,
+      rules: input.rules,
+      defaultAction: input.defaultAction,
+      createdBy: input.createdBy,
+    });
+
+    if (!row) {
+      throw notFound("API key control profile");
+    }
+    return mapApiKeyControlProfileRevision(row);
+  }
+
+  async activateApiKeyControlProfileRevision(
+    input: ActivateApiKeyControlProfileRevisionInput
+  ): Promise<{ profile: ApiKeyControlProfile; revision: ApiKeyControlProfileRevision }> {
+    const subject = await this.assertScopedApiKeyPolicySubject(input);
+    await this.assertScopedApiKeyControlProfile(input.profileId, subject);
+    const revision = await this.repository.getApiKeyControlProfileRevisionById(input.revisionId);
+    if (!revision || revision.profile_id !== input.profileId) {
+      throw notFound("API key control profile revision");
+    }
+
+    const active = await this.repository.activateApiKeyControlProfileRevision({
+      profileId: input.profileId,
+      revisionId: input.revisionId,
+    });
+    if (!active?.revision) {
+      throw notFound("API key control profile revision");
+    }
+
+    return {
+      profile: mapApiKeyControlProfile(active.profile),
+      revision: mapApiKeyControlProfileRevision(active.revision),
+    };
+  }
+
+  async replaceApiKeyWalletPolicyBindings(
+    input: ReplaceApiKeyWalletPolicyBindingsInput
+  ): Promise<ApiKeyWalletPolicyBinding[]> {
+    await this.assertScopedApiKeyPolicySubject(input);
+    this.assertUniquePolicyBindingTargets(input.bindings);
+
+    const bindings: UpsertApiKeyWalletPolicyBindingInput[] = [];
+    for (const binding of input.bindings) {
+      if (binding.apiKeyId !== input.apiKeyId) {
+        throw badRequest("Policy bindings must target the requested API key");
+      }
+      bindings.push(await this.validateApiKeyWalletPolicyBinding(binding));
+    }
+
+    const rows = await this.repository.replaceApiKeyWalletPolicyBindings({
+      apiKeyId: input.apiKeyId,
+      bindings,
+    });
+    return rows.map(mapApiKeyWalletPolicyBinding);
+  }
 
   async resolveEffectiveWalletPolicy(custodyWalletId: string): Promise<EffectiveWalletPolicy> {
     const active =
@@ -111,6 +221,21 @@ export class PolicyFoundationService {
   async upsertApiKeyWalletPolicyBinding(
     input: UpsertApiKeyWalletPolicyBindingInput
   ): Promise<ApiKeyWalletPolicyBinding> {
+    const normalized = await this.validateApiKeyWalletPolicyBinding(input);
+    const row = await this.repository.upsertApiKeyWalletPolicyBinding(normalized);
+    if (!row) {
+      throw new Error("Failed to upsert API key wallet policy binding");
+    }
+    return mapApiKeyWalletPolicyBinding(row);
+  }
+
+  private async validateApiKeyWalletPolicyBinding(
+    input: UpsertApiKeyWalletPolicyBindingInput
+  ): Promise<UpsertApiKeyWalletPolicyBindingInput> {
+    if (!input.apiKeyControlProfileId && !input.walletControlProfileId) {
+      throw badRequest("Policy bindings must reference at least one control profile");
+    }
+
     if (input.bindingScope === "selected") {
       const target = await this.assertApiKeyWalletPolicyTarget({
         apiKeyId: input.apiKeyId,
@@ -129,14 +254,10 @@ export class PolicyFoundationService {
         await this.resolveWalletPolicyProfileForBinding(input.walletControlProfileId, target);
       }
 
-      const row = await this.repository.upsertApiKeyWalletPolicyBinding({
+      return {
         ...input,
         custodyWalletId: target.custody_wallet_id,
-      });
-      if (!row) {
-        throw new Error("Failed to upsert API key wallet policy binding");
-      }
-      return mapApiKeyWalletPolicyBinding(row);
+      };
     }
 
     const subject = await this.assertApiKeyPolicySubject(input.apiKeyId);
@@ -152,11 +273,7 @@ export class PolicyFoundationService {
       );
     }
 
-    const row = await this.repository.upsertApiKeyWalletPolicyBinding(input);
-    if (!row) {
-      throw new Error("Failed to upsert API key wallet policy binding");
-    }
-    return mapApiKeyWalletPolicyBinding(row);
+    return input;
   }
 
   async resolveApiKeyWalletPolicyScope(
@@ -298,6 +415,47 @@ export class PolicyFoundationService {
     }
 
     return subject;
+  }
+
+  private async assertScopedApiKeyPolicySubject(
+    input: ApiKeyPolicyAuthoringScope
+  ): Promise<ApiKeyPolicySubjectRow> {
+    const subject = await this.repository.getApiKeyPolicySubject(input.apiKeyId);
+    if (
+      !subject ||
+      subject.organization_id !== input.organizationId ||
+      subject.project_id !== input.projectId
+    ) {
+      throw notFound("API key");
+    }
+    return subject;
+  }
+
+  private async assertScopedApiKeyControlProfile(
+    profileId: string,
+    subject: ApiKeyPolicySubjectRow
+  ): Promise<ApiKeyControlProfileRow> {
+    const profile = await this.repository.getApiKeyControlProfileById(profileId);
+    if (
+      !profile ||
+      profile.api_key_id !== subject.api_key_id ||
+      profile.organization_id !== subject.organization_id ||
+      profile.project_id !== subject.project_id
+    ) {
+      throw notFound("API key control profile");
+    }
+    return profile;
+  }
+
+  private assertUniquePolicyBindingTargets(bindings: UpsertApiKeyWalletPolicyBindingInput[]): void {
+    const targets = new Set<string>();
+    for (const binding of bindings) {
+      const target = binding.bindingScope === "all" ? "all" : `selected:${binding.walletId}`;
+      if (targets.has(target)) {
+        throw badRequest("Policy binding targets must be unique");
+      }
+      targets.add(target);
+    }
   }
 
   private assertApplicablePolicyBindingExists(

--- a/apps/sdp-api/src/services/policy-foundation.service.ts
+++ b/apps/sdp-api/src/services/policy-foundation.service.ts
@@ -440,7 +440,8 @@ export class PolicyFoundationService {
       !profile ||
       profile.api_key_id !== subject.api_key_id ||
       profile.organization_id !== subject.organization_id ||
-      profile.project_id !== subject.project_id
+      profile.project_id !== subject.project_id ||
+      profile.status === "archived"
     ) {
       throw notFound("API key control profile");
     }


### PR DESCRIPTION
## Summary
- add API-key control profile, immutable revision authoring, and activation routes
- add explicit atomic replace/clear writes for all-wallet and selected-wallet policy bindings
- enforce API-key, profile, project, organization, endpoint-wallet, and active-profile boundaries
- publish the authoring surface in OpenAPI and cover no-policy fallback and rotation preservation

## Local validation
- API repository tests: 20 passed
- API-key route integration tests: 9 passed
- API typecheck: passed
- API lint: passed with 2 pre-existing Clerk constructor warnings
- API Worker dry-run build: passed
- OpenAPI generation and route inventory: passed
- Live local Worker: /health returned 200; authoring route mounted behind auth
- Ponytail simplification pass: complete

## Local limitation
The repository-wide worker test command runs database-backed files concurrently against one shared schema and produced cross-suite fixture deletion failures across unrelated API areas. The two policy files pass independently in fresh processes; CI remains the authoritative broad-suite check.

Closes PRO-1534