### PR TITLE
perf(api): reduce Node/GCP request latency

### DIFF
--- a/apps/sdp-api/src/db/client.node.test.ts
+++ b/apps/sdp-api/src/db/client.node.test.ts
@@ -191,7 +191,36 @@ describe("database client connection management", () => {
       expect.objectContaining({ text: "UPDATE wallets SET updated_at = sdp_datetime_now()" }),
       "ROLLBACK",
     ]);
-    expect(client?.release).toHaveBeenCalledOnce();
+    expect(client?.release).toHaveBeenCalledWith(undefined);
+  });
+
+  it("discards the pooled connection when rollback fails", async () => {
+    const transactionFailure = new Error("write failed");
+    const rollbackFailure = new Error("connection reset during rollback");
+    let queryCount = 0;
+    pgMock.poolClientQuery = async () => {
+      queryCount += 1;
+      if (queryCount === 3) {
+        throw rollbackFailure;
+      }
+      return { rows: [], rowCount: 0 };
+    };
+    const db = createDatabaseClient("postgresql://node-rollback-connection-error/sdp");
+
+    await expect(
+      db.transaction(async (tx) => {
+        await tx.execute("UPDATE wallets SET updated_at = datetime('now')");
+        throw transactionFailure;
+      })
+    ).rejects.toBe(transactionFailure);
+
+    const client = pgMock.pools[0]?.connectedClients[0];
+    expect(client?.queries.map(([query]) => query)).toEqual([
+      "BEGIN",
+      expect.objectContaining({ text: "UPDATE wallets SET updated_at = sdp_datetime_now()" }),
+      "ROLLBACK",
+    ]);
+    expect(client?.release).toHaveBeenCalledWith(rollbackFailure);
   });
 
   it("keeps Hyperdrive on a fresh connection for each query", async () => {

--- a/apps/sdp-api/src/db/client.node.test.ts
+++ b/apps/sdp-api/src/db/client.node.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockQueryResult {
+  rows: Record<string, unknown>[];
+  rowCount: number;
+}
+
+interface MockPoolClient {
+  queries: unknown[][];
+  release: ReturnType<typeof vi.fn>;
+}
+
+interface MockPool {
+  config: Record<string, unknown>;
+  queries: unknown[];
+  connectedClients: MockPoolClient[];
+  end: ReturnType<typeof vi.fn>;
+}
+
+interface MockClient {
+  config: Record<string, unknown>;
+  queries: unknown[][];
+  connect: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+}
+
+const pgMock = vi.hoisted(() => ({
+  clients: [] as MockClient[],
+  pools: [] as MockPool[],
+  clientQuery: async (): Promise<MockQueryResult> => ({ rows: [], rowCount: 0 }),
+  poolQuery: async (): Promise<MockQueryResult> => ({ rows: [], rowCount: 0 }),
+  poolClientQuery: async (): Promise<MockQueryResult> => ({ rows: [], rowCount: 0 }),
+  poolEnd: async (): Promise<void> => {},
+}));
+
+vi.mock("pg", () => {
+  class Client {
+    readonly config: Record<string, unknown>;
+    readonly queries: unknown[][] = [];
+    readonly connect = vi.fn(async () => {});
+    readonly end = vi.fn(async () => {});
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      pgMock.clients.push(this);
+    }
+
+    async query(...args: unknown[]): Promise<MockQueryResult> {
+      this.queries.push(args);
+      return pgMock.clientQuery();
+    }
+  }
+
+  class Pool {
+    readonly config: Record<string, unknown>;
+    readonly queries: unknown[] = [];
+    readonly connectedClients: MockPoolClient[] = [];
+    readonly end = vi.fn(() => pgMock.poolEnd());
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      pgMock.pools.push(this);
+    }
+
+    on(): this {
+      return this;
+    }
+
+    async query(args: unknown): Promise<MockQueryResult> {
+      this.queries.push(args);
+      return pgMock.poolQuery();
+    }
+
+    async connect(): Promise<
+      MockPoolClient & { query: (...args: unknown[]) => Promise<MockQueryResult> }
+    > {
+      const client = {
+        queries: [] as unknown[][],
+        query: async (...args: unknown[]): Promise<MockQueryResult> => {
+          client.queries.push(args);
+          return pgMock.poolClientQuery();
+        },
+        release: vi.fn(),
+      };
+      this.connectedClients.push(client);
+      return client;
+    }
+  }
+
+  return {
+    Client,
+    Pool,
+    types: { setTypeParser: vi.fn() },
+  };
+});
+
+let closeDatabasePools: typeof import("./client").closeDatabasePools;
+let createDatabaseClient: typeof import("./client").createDatabaseClient;
+let getDb: typeof import("./client").getDb;
+
+describe("database client connection management", () => {
+  beforeAll(async () => {
+    // vitest.node.config.ts intentionally shares a module cache between files.
+    // Reload this module after installing the pg mock so targeted runs are not
+    // order-dependent on another test importing the real client first.
+    vi.resetModules();
+    const database = await import("./client");
+    closeDatabasePools = database.closeDatabasePools;
+    createDatabaseClient = database.createDatabaseClient;
+    getDb = database.getDb;
+  });
+
+  beforeEach(async () => {
+    await closeDatabasePools();
+    pgMock.clients.length = 0;
+    pgMock.pools.length = 0;
+    pgMock.clientQuery = async () => ({ rows: [], rowCount: 0 });
+    pgMock.poolQuery = async () => ({ rows: [], rowCount: 0 });
+    pgMock.poolClientQuery = async () => ({ rows: [], rowCount: 0 });
+    pgMock.poolEnd = async () => {};
+  });
+
+  afterEach(async () => {
+    pgMock.poolEnd = async () => {};
+    await closeDatabasePools();
+  });
+
+  it("reuses one configured pool and starts independent Node queries concurrently", async () => {
+    const pendingQueries: Array<() => void> = [];
+    pgMock.poolQuery = () =>
+      new Promise<MockQueryResult>((resolve) => {
+        pendingQueries.push(() => resolve({ rows: [], rowCount: 0 }));
+      });
+
+    const db = createDatabaseClient("postgresql://node-database/sdp");
+    const sameDb = createDatabaseClient("postgresql://node-database/sdp");
+    const queries = Array.from({ length: 4 }, () => db.queryOne("SELECT 1"));
+
+    await vi.waitFor(() => {
+      expect(pendingQueries).toHaveLength(4);
+    });
+    expect(sameDb).toBe(db);
+    expect(pgMock.pools).toHaveLength(1);
+    expect(pgMock.pools[0]?.config).toMatchObject({
+      max: 10,
+      connectionTimeoutMillis: 5_000,
+      idleTimeoutMillis: 30_000,
+      maxLifetimeSeconds: 300,
+      keepAlive: true,
+    });
+
+    for (const resolve of pendingQueries) {
+      resolve();
+    }
+    await Promise.all(queries);
+  });
+
+  it("checks out one pooled connection and commits a successful transaction", async () => {
+    const db = createDatabaseClient("postgresql://node-transaction/sdp");
+
+    await db.transaction(async (tx) => {
+      await tx.execute("UPDATE wallets SET updated_at = datetime('now')");
+      await tx.queryOne("SELECT 1");
+    });
+
+    const client = pgMock.pools[0]?.connectedClients[0];
+    expect(pgMock.pools[0]?.connectedClients).toHaveLength(1);
+    expect(client?.queries.map(([query]) => query)).toEqual([
+      "BEGIN",
+      expect.objectContaining({ text: "UPDATE wallets SET updated_at = sdp_datetime_now()" }),
+      expect.objectContaining({ text: "SELECT 1" }),
+      "COMMIT",
+    ]);
+    expect(client?.release).toHaveBeenCalledOnce();
+  });
+
+  it("rolls back and releases the pooled connection when a transaction fails", async () => {
+    const db = createDatabaseClient("postgresql://node-rollback/sdp");
+    const failure = new Error("write failed");
+
+    await expect(
+      db.transaction(async (tx) => {
+        await tx.execute("UPDATE wallets SET updated_at = datetime('now')");
+        throw failure;
+      })
+    ).rejects.toBe(failure);
+
+    const client = pgMock.pools[0]?.connectedClients[0];
+    expect(client?.queries.map(([query]) => query)).toEqual([
+      "BEGIN",
+      expect.objectContaining({ text: "UPDATE wallets SET updated_at = sdp_datetime_now()" }),
+      "ROLLBACK",
+    ]);
+    expect(client?.release).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Hyperdrive on a fresh connection for each query", async () => {
+    const db = getDb({
+      HYPERDRIVE: { connectionString: "postgresql://hyperdrive/sdp" },
+      DATABASE_URL: "postgresql://node-database/sdp",
+    });
+
+    await db.queryOne("SELECT 1");
+    await db.queryOne("SELECT 2");
+
+    expect(pgMock.pools).toHaveLength(0);
+    expect(pgMock.clients).toHaveLength(2);
+    expect(pgMock.clients.every((client) => client.connect.mock.calls.length === 1)).toBe(true);
+    expect(pgMock.clients.every((client) => client.end.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("waits for every pool to close before shutdown completes", async () => {
+    let resolveEnd: (() => void) | undefined;
+    pgMock.poolEnd = () =>
+      new Promise<void>((resolve) => {
+        resolveEnd = resolve;
+      });
+
+    createDatabaseClient("postgresql://node-shutdown/sdp");
+    let closed = false;
+    const closing = closeDatabasePools().then(() => {
+      closed = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(resolveEnd).toBeTypeOf("function");
+    });
+    expect(closed).toBe(false);
+    resolveEnd?.();
+    await closing;
+
+    expect(pgMock.pools[0]?.end).toHaveBeenCalledOnce();
+    expect(closed).toBe(true);
+  });
+
+  it("surfaces pool shutdown failures", async () => {
+    pgMock.poolEnd = async () => {
+      throw new Error("pool close failed");
+    };
+    createDatabaseClient("postgresql://node-shutdown-error/sdp");
+
+    await expect(closeDatabasePools()).rejects.toThrow("Failed to close PostgreSQL pools");
+  });
+});

--- a/apps/sdp-api/src/db/client.ts
+++ b/apps/sdp-api/src/db/client.ts
@@ -341,6 +341,7 @@ class PooledPostgresClient extends BasePostgresClient {
 
   async transaction<T>(callback: (tx: DatabaseExecutor) => Promise<T>): Promise<T> {
     const client = await this.pool.connect();
+    let releaseError: Error | undefined;
 
     try {
       await client.query("BEGIN");
@@ -349,10 +350,15 @@ class PooledPostgresClient extends BasePostgresClient {
       await client.query("COMMIT");
       return result;
     } catch (error) {
-      await client.query("ROLLBACK").catch(() => {});
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackError) {
+        releaseError =
+          rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError));
+      }
       throw error;
     } finally {
-      client.release();
+      client.release(releaseError);
     }
   }
 

--- a/apps/sdp-api/src/db/client.ts
+++ b/apps/sdp-api/src/db/client.ts
@@ -1,4 +1,4 @@
-import { Client, type QueryResult, types } from "pg";
+import { Client, Pool, type QueryResult, types } from "pg";
 
 types.setTypeParser(20, (value) => Number.parseInt(value, 10));
 
@@ -47,7 +47,17 @@ type Queryable = {
   query: (args: QueryArgs) => Promise<QueryResult>;
 };
 
-const clients = new Map<string, DatabaseClient>();
+const pooledClients = new Map<string, PooledPostgresClient>();
+const hyperdriveClients = new Map<string, HyperdrivePostgresClient>();
+
+const NODE_POOL_OPTIONS = {
+  max: 10,
+  connectionTimeoutMillis: 5_000,
+  idleTimeoutMillis: 30_000,
+  maxLifetimeSeconds: 300,
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10_000,
+} as const;
 
 class ConnectionCoordinator implements Queryable {
   private pending: Promise<void> = Promise.resolve();
@@ -261,15 +271,7 @@ class PostgresExecutor implements DatabaseExecutor {
   }
 }
 
-class PostgresClient extends PostgresExecutor implements DatabaseClient {
-  private readonly coordinator: ConnectionCoordinator;
-
-  constructor(private readonly connectionString: string) {
-    const coordinator = new ConnectionCoordinator(connectionString);
-    super(coordinator);
-    this.coordinator = coordinator;
-  }
-
+abstract class BasePostgresClient extends PostgresExecutor implements DatabaseClient {
   async batch(statements: readonly PreparedStatement[]): Promise<number[]> {
     return this.transaction(async (tx) => {
       const results: number[] = [];
@@ -282,6 +284,18 @@ class PostgresClient extends PostgresExecutor implements DatabaseClient {
       }
       return results;
     });
+  }
+
+  abstract transaction<T>(callback: (tx: DatabaseExecutor) => Promise<T>): Promise<T>;
+}
+
+class HyperdrivePostgresClient extends BasePostgresClient {
+  private readonly coordinator: ConnectionCoordinator;
+
+  constructor(private readonly connectionString: string) {
+    const coordinator = new ConnectionCoordinator(connectionString);
+    super(coordinator);
+    this.coordinator = coordinator;
   }
 
   async transaction<T>(callback: (tx: DatabaseExecutor) => Promise<T>): Promise<T> {
@@ -304,6 +318,46 @@ class PostgresClient extends PostgresExecutor implements DatabaseClient {
         await client.end().catch(() => {});
       }
     });
+  }
+}
+
+class PooledPostgresClient extends BasePostgresClient {
+  private readonly pool: Pool;
+
+  constructor(connectionString: string) {
+    const pool = new Pool({
+      connectionString,
+      ...NODE_POOL_OPTIONS,
+    });
+    super(pool);
+    this.pool = pool;
+
+    // Idle pool errors are EventEmitter errors; without a listener Node treats
+    // them as uncaught exceptions and terminates the process.
+    this.pool.on("error", (error) => {
+      console.error("Idle PostgreSQL pool client error:", error);
+    });
+  }
+
+  async transaction<T>(callback: (tx: DatabaseExecutor) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+      const executor = new PostgresExecutor(client);
+      const result = await callback(executor);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  close(): Promise<void> {
+    return this.pool.end();
   }
 }
 
@@ -358,20 +412,40 @@ export function getConnectionString(bindings: DatabaseBindings): string {
 }
 
 export function createDatabaseClient(connectionString: string): DatabaseClient {
-  const existing = clients.get(connectionString);
+  const existing = pooledClients.get(connectionString);
   if (existing) {
     return existing;
   }
 
-  const client = new PostgresClient(connectionString);
-  clients.set(connectionString, client);
+  const client = new PooledPostgresClient(connectionString);
+  pooledClients.set(connectionString, client);
   return client;
 }
 
 export function getDb(bindings: DatabaseBindings): DatabaseClient {
+  const hyperdriveUrl = bindings.HYPERDRIVE?.connectionString?.trim();
+  if (hyperdriveUrl) {
+    const existing = hyperdriveClients.get(hyperdriveUrl);
+    if (existing) {
+      return existing;
+    }
+
+    const client = new HyperdrivePostgresClient(hyperdriveUrl);
+    hyperdriveClients.set(hyperdriveUrl, client);
+    return client;
+  }
+
   return createDatabaseClient(getConnectionString(bindings));
 }
 
 export async function closeDatabasePools(): Promise<void> {
-  clients.clear();
+  const pools = [...pooledClients.values()];
+  pooledClients.clear();
+  hyperdriveClients.clear();
+
+  const results = await Promise.allSettled(pools.map((client) => client.close()));
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Failed to close PostgreSQL pools");
+  }
 }

--- a/apps/sdp-api/src/middleware/auth-last-used.node.test.ts
+++ b/apps/sdp-api/src/middleware/auth-last-used.node.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DatabaseClient } from "@/db";
+import { scheduleApiKeyLastUsedUpdate } from "./auth";
+
+function createDatabase(run: ReturnType<typeof vi.fn>) {
+  const boundStatement = { run };
+  const preparedStatement = {
+    bind: vi.fn(() => boundStatement),
+  };
+  const db = {
+    prepare: vi.fn(() => preparedStatement),
+  } as unknown as DatabaseClient;
+
+  return { db, preparedStatement };
+}
+
+describe("API key last-used write scheduling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("coalesces successful Node writes for five minutes per key", async () => {
+    const run = vi.fn(async () => 1);
+    const { db, preparedStatement } = createDatabase(run);
+    const startedAt = 1_000_000;
+
+    const first = scheduleApiKeyLastUsedUpdate(db, "key-node-success", "node", startedAt);
+    const concurrent = scheduleApiKeyLastUsedUpdate(db, "key-node-success", "node", startedAt + 1);
+    expect(concurrent).toBe(first);
+    await Promise.all([first, concurrent]);
+
+    await scheduleApiKeyLastUsedUpdate(db, "key-node-success", "node", startedAt + 5 * 60_000 - 1);
+    expect(run).toHaveBeenCalledOnce();
+    expect(preparedStatement.bind).toHaveBeenCalledWith("key-node-success");
+
+    await scheduleApiKeyLastUsedUpdate(db, "key-node-success", "node", startedAt + 5 * 60_000);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not coalesce the same key id across different databases", async () => {
+    const firstRun = vi.fn(async () => 1);
+    const secondRun = vi.fn(async () => 1);
+    const firstDb = createDatabase(firstRun).db;
+    const secondDb = createDatabase(secondRun).db;
+
+    await Promise.all([
+      scheduleApiKeyLastUsedUpdate(firstDb, "shared-key", "node", 2_000_000),
+      scheduleApiKeyLastUsedUpdate(secondDb, "shared-key", "node", 2_000_000),
+    ]);
+
+    expect(firstRun).toHaveBeenCalledOnce();
+    expect(secondRun).toHaveBeenCalledOnce();
+  });
+
+  it("allows the next Node request to retry after a failed write", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary database error"))
+      .mockResolvedValue(1);
+    const { db } = createDatabase(run);
+
+    await scheduleApiKeyLastUsedUpdate(db, "key-node-retry", "node", 3_000_000);
+    await scheduleApiKeyLastUsedUpdate(db, "key-node-retry", "node", 3_000_001);
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a write for every Cloudflare request", async () => {
+    const run = vi.fn(async () => 1);
+    const { db } = createDatabase(run);
+
+    await scheduleApiKeyLastUsedUpdate(db, "key-cloudflare", "cloudflare", 4_000_000);
+    await scheduleApiKeyLastUsedUpdate(db, "key-cloudflare", "cloudflare", 4_000_001);
+
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/sdp-api/src/middleware/auth.ts
+++ b/apps/sdp-api/src/middleware/auth.ts
@@ -21,10 +21,24 @@ import {
   parsePostgresJsonOr,
 } from "@/db/postgres-utils";
 import { AppError } from "@/lib/errors";
+import { getRuntime, type SdpRuntime } from "@/lib/runtime-env";
 import type { KVStore } from "@/runtime/kv";
 import type { Env } from "@/types/env";
 
 const KV_TTL_SECONDS = 3600; // 1 hour cache
+const NODE_LAST_USED_WRITE_INTERVAL_MS = 5 * 60_000;
+
+interface LastUsedWriteState {
+  lastSucceededAt: number | null;
+  inFlight: Promise<void> | null;
+}
+
+interface LastUsedWriteCache {
+  writes: Map<string, LastUsedWriteState>;
+  nextSweepAt: number;
+}
+
+const nodeLastUsedWrites = new WeakMap<DatabaseClient, LastUsedWriteCache>();
 
 interface ApiKeyContext {
   id: string;
@@ -171,14 +185,107 @@ async function getFromDatabaseAndCache(
   return cached;
 }
 
-/**
- * Update last_used_at timestamp (fire and forget)
- */
-function updateLastUsed(db: DatabaseClient, keyId: string) {
-  db.prepare(`UPDATE api_keys SET last_used_at = datetime('now') WHERE id = ?`)
+function writeLastUsed(db: DatabaseClient, keyId: string): Promise<void> {
+  return db
+    .prepare(`UPDATE api_keys SET last_used_at = datetime('now') WHERE id = ?`)
     .bind(keyId)
     .run()
-    .catch((err) => console.error("Failed to update last_used_at:", err));
+    .then(() => {});
+}
+
+function logLastUsedWriteError(error: unknown): void {
+  console.error("Failed to update last_used_at:", error);
+}
+
+function getLastUsedWriteCache(db: DatabaseClient): LastUsedWriteCache {
+  const existing = nodeLastUsedWrites.get(db);
+  if (existing) {
+    return existing;
+  }
+
+  const cache: LastUsedWriteCache = {
+    writes: new Map(),
+    nextSweepAt: 0,
+  };
+  nodeLastUsedWrites.set(db, cache);
+  return cache;
+}
+
+function sweepExpiredLastUsedWrites(cache: LastUsedWriteCache, now: number): void {
+  if (now < cache.nextSweepAt) {
+    return;
+  }
+
+  for (const [keyId, state] of cache.writes) {
+    if (
+      !state.inFlight &&
+      state.lastSucceededAt !== null &&
+      now - state.lastSucceededAt >= NODE_LAST_USED_WRITE_INTERVAL_MS
+    ) {
+      cache.writes.delete(keyId);
+    }
+  }
+
+  cache.nextSweepAt = now + NODE_LAST_USED_WRITE_INTERVAL_MS;
+}
+
+/**
+ * Updates last_used_at without putting a write on every Node request. Workers
+ * keep their existing per-request behavior because their isolate lifetime is
+ * not a useful process-local coalescing boundary.
+ */
+export function scheduleApiKeyLastUsedUpdate(
+  db: DatabaseClient,
+  keyId: string,
+  runtime: SdpRuntime,
+  now = Date.now()
+): Promise<void> {
+  if (runtime === "cloudflare") {
+    return writeLastUsed(db, keyId).catch(logLastUsedWriteError);
+  }
+
+  const cache = getLastUsedWriteCache(db);
+  sweepExpiredLastUsedWrites(cache, now);
+  const existing = cache.writes.get(keyId);
+  if (existing?.inFlight) {
+    return existing.inFlight;
+  }
+  const lastSucceededAt = existing?.lastSucceededAt;
+  if (
+    lastSucceededAt !== null &&
+    lastSucceededAt !== undefined &&
+    now - lastSucceededAt < NODE_LAST_USED_WRITE_INTERVAL_MS
+  ) {
+    return Promise.resolve();
+  }
+
+  const state: LastUsedWriteState = existing ?? {
+    lastSucceededAt: null,
+    inFlight: null,
+  };
+  const pending = Promise.resolve()
+    .then(() => writeLastUsed(db, keyId))
+    .then(
+      () => {
+        if (cache.writes.get(keyId) === state) {
+          state.lastSucceededAt = now;
+          state.inFlight = null;
+        }
+      },
+      (error) => {
+        if (cache.writes.get(keyId) === state) {
+          state.inFlight = null;
+          if (state.lastSucceededAt === null) {
+            cache.writes.delete(keyId);
+          }
+        }
+        logLastUsedWriteError(error);
+      }
+    );
+
+  state.inFlight = pending;
+  cache.writes.set(keyId, state);
+  return pending;
 }
 
 function safeParsePermissionsArray(value: string | null | undefined): Permission[] {
@@ -290,8 +397,8 @@ export function authMiddleware() {
 
     c.set("apiKey", authContext);
 
-    // Update last used (fire and forget)
-    updateLastUsed(getDb(c.env), cachedKey.id);
+    // Update last used (fire and forget). Node coalesces this write per key.
+    void scheduleApiKeyLastUsedUpdate(getDb(c.env), cachedKey.id, getRuntime(c.env));
 
     await next();
   };

--- a/apps/sdp-api/src/routes/openapi.test.ts
+++ b/apps/sdp-api/src/routes/openapi.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "@/app";
+import type { MonitorOptions, Observability } from "@/runtime/observability";
+import type { Env } from "@/types/env";
+import openapi from "./openapi";
+
+const observability: Observability = {
+  captureException: () => {},
+  withScope: () => {},
+  withMonitor: <T>(_slug: string, fn: () => Promise<T>, _opts: MonitorOptions) => fn(),
+};
+
+const appEnv = {
+  ENVIRONMENT: "development",
+  API_VERSION: "v1",
+  SDP_RUNTIME: "node",
+} as Env;
+
+describe("OpenAPI response delivery", () => {
+  it("serves the pre-serialized document with aggressive cache validators", async () => {
+    const response = await openapi.request("/");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/json; charset=UTF-8");
+    expect(response.headers.get("Content-Length")).toBeNull();
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800, stale-if-error=604800"
+    );
+    expect(response.headers.get("ETag")).toMatch(/^W\/"[a-f0-9]+-[0-9]+"$/);
+    expect((await response.json()).openapi).toBe("3.0.3");
+  });
+
+  it("returns 304 for a matching document validator", async () => {
+    const initial = await openapi.request("/");
+    const etag = initial.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    const response = await openapi.request("/", {
+      headers: { "If-None-Match": `W/"not-current", ${etag?.replace(/^W\//, "")}` },
+    });
+
+    expect(response.status).toBe(304);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("ETag")).toBe(etag);
+    expect(response.headers.get("Cache-Control")).toContain("s-maxage=86400");
+  });
+
+  it("lets the real app pretty-print /openapi.json without a stale body length", async () => {
+    const app = createApp({ observability });
+    const response = await app.request("http://local.test/openapi.json?pretty", {}, appEnv);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBeNull();
+    const body = await response.text();
+    expect(body).toContain('\n  "openapi": "3.0.3"');
+    expect(JSON.parse(body).openapi).toBe("3.0.3");
+  });
+});

--- a/apps/sdp-api/src/routes/openapi.test.ts
+++ b/apps/sdp-api/src/routes/openapi.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createApp } from "@/app";
 import type { MonitorOptions, Observability } from "@/runtime/observability";
 import type { Env } from "@/types/env";
-import openapi from "./openapi";
+import openapi, { createWeakEtag } from "./openapi";
 
 const observability: Observability = {
   captureException: () => {},
@@ -17,6 +17,10 @@ const appEnv = {
 } as Env;
 
 describe("OpenAPI response delivery", () => {
+  it("hashes UTF-8 bytes for portable validators", () => {
+    expect(createWeakEtag("café → api")).toBe('W/"b8f938af-13"');
+  });
+
   it("serves the pre-serialized document with aggressive cache validators", async () => {
     const response = await openapi.request("/");
 

--- a/apps/sdp-api/src/routes/openapi.ts
+++ b/apps/sdp-api/src/routes/openapi.ts
@@ -11,13 +11,14 @@ const openapi = new Hono<{ Bindings: Env }>();
 const document = createPublicOpenApiDocument();
 const documentBody = JSON.stringify(document);
 
-function createWeakEtag(value: string): string {
+export function createWeakEtag(value: string): string {
   let hash = 2_166_136_261;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
+  const bytes = new TextEncoder().encode(value);
+  for (const byte of bytes) {
+    hash ^= byte;
     hash = Math.imul(hash, 16_777_619);
   }
-  return `W/"${(hash >>> 0).toString(16)}-${value.length}"`;
+  return `W/"${(hash >>> 0).toString(16)}-${bytes.length}"`;
 }
 
 const documentEtag = createWeakEtag(documentBody);

--- a/apps/sdp-api/src/routes/openapi.ts
+++ b/apps/sdp-api/src/routes/openapi.ts
@@ -9,10 +9,50 @@ import type { Env } from "@/types/env";
 const openapi = new Hono<{ Bindings: Env }>();
 
 const document = createPublicOpenApiDocument();
+const documentBody = JSON.stringify(document);
+
+function createWeakEtag(value: string): string {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return `W/"${(hash >>> 0).toString(16)}-${value.length}"`;
+}
+
+const documentEtag = createWeakEtag(documentBody);
+const documentOpaqueTag = documentEtag.replace(/^W\//, "");
+const OPENAPI_CACHE_CONTROL = [
+  "public",
+  `max-age=${60 * 60}`,
+  `s-maxage=${24 * 60 * 60}`,
+  `stale-while-revalidate=${7 * 24 * 60 * 60}`,
+  `stale-if-error=${7 * 24 * 60 * 60}`,
+].join(", ");
+
+function hasMatchingEtag(ifNoneMatch: string | undefined): boolean {
+  if (!ifNoneMatch) {
+    return false;
+  }
+
+  return ifNoneMatch.split(",").some((candidate) => {
+    const normalized = candidate.trim();
+    return normalized === "*" || normalized.replace(/^W\//i, "") === documentOpaqueTag;
+  });
+}
 
 openapi.get("/", (c) => {
-  c.header("Cache-Control", "public, max-age=300");
-  return c.json(document);
+  c.header("Cache-Control", OPENAPI_CACHE_CONTROL);
+  c.header("ETag", documentEtag);
+
+  if (hasMatchingEtag(c.req.header("If-None-Match"))) {
+    return c.body(null, 304);
+  }
+
+  // Do not set Content-Length here: development pretty-printing and Node
+  // compression both transform this body later in the middleware stack.
+  c.header("Content-Type", "application/json; charset=UTF-8");
+  return c.body(documentBody);
 });
 
 export default openapi;

--- a/apps/sdp-api/src/runtime/http-node.node.test.ts
+++ b/apps/sdp-api/src/runtime/http-node.node.test.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import { prettyJSON } from "hono/pretty-json";
+import { describe, expect, it } from "vitest";
+import openapi from "@/routes/openapi";
+import type { Env } from "@/types/env";
+import { createNodeHttpApp } from "./http-node";
+
+async function readGzipJson(response: Response): Promise<unknown> {
+  const decompressed = response.body?.pipeThrough(new DecompressionStream("gzip"));
+  return new Response(decompressed).json();
+}
+
+describe("Node HTTP response compression", () => {
+  it("compresses a large response and preserves existing Vary dimensions", async () => {
+    const app = new Hono<{ Bindings: Env }>();
+    app.get("/large", (c) => {
+      c.header("Vary", "Origin");
+      return c.json({ payload: "x".repeat(8_000) });
+    });
+
+    const response = await createNodeHttpApp(app).request("http://local.test/large", {
+      headers: { "Accept-Encoding": "gzip" },
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBe("gzip");
+    expect(response.headers.get("Content-Length")).toBeNull();
+    expect(response.headers.get("Vary")).toBe("Origin, Accept-Encoding");
+    expect(await readGzipJson(response)).toEqual({ payload: "x".repeat(8_000) });
+  });
+
+  it("compresses OpenAPI after development pretty-printing", async () => {
+    const app = new Hono<{ Bindings: Env }>();
+    app.use("*", prettyJSON());
+    app.route("/openapi.json", openapi);
+    const response = await createNodeHttpApp(app).request("http://local.test/openapi.json?pretty", {
+      headers: { "Accept-Encoding": "gzip" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Encoding")).toBe("gzip");
+    expect(response.headers.get("Content-Length")).toBeNull();
+    expect(response.headers.get("Vary")).toBe("Accept-Encoding");
+    expect((await readGzipJson(response)) as { openapi: string }).toMatchObject({
+      openapi: "3.0.3",
+    });
+  });
+
+  it("leaves responses uncompressed when the client does not advertise support", async () => {
+    const app = new Hono<{ Bindings: Env }>();
+    app.get("/large", (c) => c.json({ payload: "x".repeat(8_000) }));
+
+    const response = await createNodeHttpApp(app).request("http://local.test/large");
+
+    expect(response.headers.get("Content-Encoding")).toBeNull();
+    expect(response.headers.get("Vary")).toBe("Accept-Encoding");
+    expect(await response.json()).toEqual({ payload: "x".repeat(8_000) });
+  });
+});

--- a/apps/sdp-api/src/runtime/http-node.node.test.ts
+++ b/apps/sdp-api/src/runtime/http-node.node.test.ts
@@ -55,4 +55,16 @@ describe("Node HTTP response compression", () => {
     expect(response.headers.get("Vary")).toBe("Accept-Encoding");
     expect(await response.json()).toEqual({ payload: "x".repeat(8_000) });
   });
+
+  it("preserves a wildcard Vary header without appending redundant dimensions", async () => {
+    const app = new Hono<{ Bindings: Env }>();
+    app.get("/varies-on-everything", (c) => {
+      c.header("Vary", "*");
+      return c.text("uncacheable");
+    });
+
+    const response = await createNodeHttpApp(app).request("http://local.test/varies-on-everything");
+
+    expect(response.headers.get("Vary")).toBe("*");
+  });
 });

--- a/apps/sdp-api/src/runtime/http-node.ts
+++ b/apps/sdp-api/src/runtime/http-node.ts
@@ -11,6 +11,10 @@ function appendVary(headers: Headers, value: string): void {
     .map((entry) => entry.trim())
     .filter(Boolean);
 
+  if (values.includes("*")) {
+    return;
+  }
+
   if (!values.some((entry) => entry.toLowerCase() === value.toLowerCase())) {
     values.push(value);
   }

--- a/apps/sdp-api/src/runtime/http-node.ts
+++ b/apps/sdp-api/src/runtime/http-node.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+import { compress } from "hono/compress";
+
+import type { Env } from "@/types/env";
+
+const compression = compress({ threshold: 1024 });
+
+function appendVary(headers: Headers, value: string): void {
+  const values = (headers.get("Vary") ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (!values.some((entry) => entry.toLowerCase() === value.toLowerCase())) {
+    values.push(value);
+  }
+
+  headers.set("Vary", values.join(", "));
+}
+
+/**
+ * Adds transport behavior needed by the Node/Cloud Run entrypoint without
+ * changing the legacy Cloudflare request path.
+ */
+export function createNodeHttpApp(app: Hono<{ Bindings: Env }>): Hono<{ Bindings: Env }> {
+  const nodeApp = new Hono<{ Bindings: Env }>();
+
+  nodeApp.use("*", async (c, next) => {
+    await next();
+    appendVary(c.res.headers, "Accept-Encoding");
+  });
+  nodeApp.use("*", compression);
+  nodeApp.route("/", app);
+
+  return nodeApp;
+}

--- a/apps/sdp-api/src/runtime/shutdown-node.ts
+++ b/apps/sdp-api/src/runtime/shutdown-node.ts
@@ -16,8 +16,8 @@
  *      warned) rather than silently leaked.
  *   4. closeAllRedisClients — only after bg drain, so in-flight Redis
  *      commands aren't racing a client.quit() call.
- *   5. closeDatabasePools — last; the pg client is per-query so this is
- *      a cache clear, not a connection drain.
+ *   5. closeDatabasePools — last; waits for the Node pg pools to close after
+ *      every request and background task has released its connection.
  */
 
 import type { CronHandle } from "@/cron/runner";

--- a/apps/sdp-api/src/server.ts
+++ b/apps/sdp-api/src/server.ts
@@ -16,6 +16,7 @@ import { createApp } from "@/app";
 import { startCron } from "@/cron/runner";
 import { withProcessEnvFallback } from "@/lib/runtime-env";
 import { NodeBackgroundRunner } from "@/runtime/background-node";
+import { createNodeHttpApp } from "@/runtime/http-node";
 import { getSentryOptions, isSentryEnabled } from "@/runtime/observability";
 import { initNodeSentry, nodeObservability } from "@/runtime/observability-node";
 import { shutdown } from "@/runtime/shutdown-node";
@@ -116,7 +117,7 @@ async function main(): Promise<void> {
 
   initNodeSentry(getSentryOptions(env));
 
-  const app = createApp({ observability: nodeObservability });
+  const app = createNodeHttpApp(createApp({ observability: nodeObservability }));
   const bg = new NodeBackgroundRunner();
   const cron = startCron({
     env,


### PR DESCRIPTION
## Summary

- Reuse bounded PostgreSQL pools for the Node/GCP runtime while preserving the existing Hyperdrive path, with correct transaction checkout/release and graceful pool shutdown.
- Coalesce API-key last-used writes per key on Node so authenticated reads do not create a database write on every request.
- Gzip Node responses and pre-serialize the public OpenAPI document with aggressive cache directives, validators, and zero-body 304 responses.

## Measured impact

- With a deterministic 60 ms PostgreSQL fixture, 4 concurrent queries fell from about 249 ms to 64 ms and 8 fell from about 494 ms to 65 ms. The pool reached 8 concurrent connections instead of serializing requests.
- The production OpenAPI response fell from 1,614,244 bytes to about 69,315 bytes with gzip, a 95.7% transfer reduction. Conditional requests return 304 with no body.

## Validation

- Full API tests: Workers 1,044 passed / 14 skipped; Node 95 passed.
- API typecheck and lint pass. Lint retains one pre-existing warning in clerk-users.service.ts.
- Cloudflare Worker dry-run build and production Node build pass.
- Production-built Node smoke covers readiness, 8-way database concurrency, OpenAPI gzip, pretty JSON, ETag/304, and graceful shutdown.
- Existing Solana test organization dashboard smoke passes against the production-built Node API and real local PostgreSQL/Redis: 2 Playwright tests passed.

## Scope notes

- The legacy Cloudflare and Hyperdrive behavior is preserved; these optimizations target the GCP/Node path.
- The private dev Cloud SQL endpoint is not reachable directly from the local Mac, so database validation used real local PostgreSQL plus a deterministic wire-level latency fixture. No pre-review GCP deployment was performed.