### PR TITLE
fix(api): unify list-endpoint pagination envelopes and paginate /wallets

### DIFF
--- a/apps/sdp-api/src/openapi/paths/custody.ts
+++ b/apps/sdp-api/src/openapi/paths/custody.ts
@@ -8,6 +8,7 @@ import {
   errorResponseSchema,
   initializeSigningRequestSchema,
   initializeSigningResponseSchema,
+  listWalletsQuerySchema,
   orgCustodyProviderSchema,
   setDefaultWalletRequestSchema,
   setDefaultWalletResponseSchema,
@@ -210,6 +211,8 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
         includeAllProviders: z.boolean().optional(),
         includeBalances: z.boolean().optional(),
         view: z.enum(["summary"]).optional(),
+        page: listWalletsQuerySchema.shape.page,
+        pageSize: listWalletsQuerySchema.shape.pageSize,
       }),
     },
     responses: {
@@ -217,7 +220,7 @@ export function registerCustodyPaths(registry: OpenAPIRegistry) {
         description: "Wallets",
         content: jsonContent(custodyWalletsResponse),
       },
-      ...errorResponses(errorResponseSchema, [401, 403, 500]),
+      ...errorResponses(errorResponseSchema, [400, 401, 403, 500]),
     },
   });
 

--- a/apps/sdp-api/src/openapi/paths/responses.ts
+++ b/apps/sdp-api/src/openapi/paths/responses.ts
@@ -17,13 +17,14 @@ import {
   counterpartyFieldOptionsResponseSchema,
   counterpartyRequirementsResponseSchema,
   counterpartyResponseSchema,
+  counterpartySchema,
   currentUserResponseSchema,
   custodyConfigResponseSchema,
   custodyConfigsResponseSchema,
   custodyWalletAggregateResponseSchema,
   custodyWalletByIdResponseSchema,
   custodyWalletResponseSchema,
-  custodyWalletsResponseSchema,
+  custodyWalletSchema,
   deleteWalletResponseSchema,
   executeBurnResponseSchema,
   executeForceBurnResponseSchema,
@@ -37,7 +38,6 @@ import {
   inviteMemberResponseSchema,
   listApiKeysResponseSchema,
   listAssetProfilesResponseSchema,
-  listCounterpartiesResponseSchema,
   listCounterpartyAccountsResponseSchema,
   listMembersResponseSchema,
   listProjectApiKeysResponseSchema,
@@ -141,7 +141,7 @@ export const counterpartyFieldOptionsResponse = successResponseSchema(
 export const counterpartyRequirementsResponse = successResponseSchema(
   counterpartyRequirementsResponseSchema
 );
-export const listCounterpartiesResponse = successResponseSchema(listCounterpartiesResponseSchema);
+export const listCounterpartiesResponse = paginatedResponseSchema(counterpartySchema);
 export const counterpartyAccountResponse = successResponseSchema(counterpartyAccountResponseSchema);
 export const listCounterpartyAccountsResponse = successResponseSchema(
   listCounterpartyAccountsResponseSchema
@@ -193,7 +193,7 @@ export const listSessionsResponse = successResponseSchema(listSessionsResponseSc
 export const custodyConfigResponse = successResponseSchema(custodyConfigResponseSchema);
 export const custodyConfigsResponse = successResponseSchema(custodyConfigsResponseSchema);
 export const custodyWalletResponse = successResponseSchema(custodyWalletResponseSchema);
-export const custodyWalletsResponse = successResponseSchema(custodyWalletsResponseSchema);
+export const custodyWalletsResponse = paginatedResponseSchema(custodyWalletSchema);
 export const custodyWalletAggregateResponse = successResponseSchema(
   custodyWalletAggregateResponseSchema
 );

--- a/apps/sdp-api/src/openapi/schemas/counterparties.ts
+++ b/apps/sdp-api/src/openapi/schemas/counterparties.ts
@@ -391,27 +391,6 @@ export const listCounterpartyAccountsResponseSchema = withOpenApi(
   { description: "Paginated list of counterparty accounts." }
 );
 
-export const listCounterpartiesResponseSchema = withOpenApi(
-  z.object({
-    counterparties: withOpenApi(z.array(counterpartySchema), {
-      description: "Counterparties.",
-    }),
-    total: withOpenApi(z.number().int().nonnegative(), {
-      description: "Total counterparties matching the query.",
-      example: 42,
-    }),
-    page: withOpenApi(z.number().int().positive(), {
-      description: "Current page number.",
-      example: 1,
-    }),
-    pageSize: withOpenApi(z.number().int().positive(), {
-      description: "Items per page.",
-      example: 20,
-    }),
-  }),
-  { description: "Paginated list of counterparties." }
-);
-
 const countrySchema = withOpenApi(
   z.object({
     code: withOpenApi(z.string(), { description: "ISO 3166-1 alpha-2 code.", example: "US" }),

--- a/apps/sdp-api/src/openapi/schemas/custody.ts
+++ b/apps/sdp-api/src/openapi/schemas/custody.ts
@@ -3,6 +3,7 @@ import {
   createWalletSchema as createWalletSchemaBase,
   deleteWalletSchema as deleteWalletSchemaBase,
   initializeSigningSchema as initializeSigningSchemaBase,
+  listWalletsQuerySchema as listWalletsQuerySchemaBase,
   setDefaultWalletSchema as setDefaultWalletSchemaBase,
   signerCheckSchema as signerCheckSchemaBase,
   switchSigningSchema as switchSigningSchemaBase,
@@ -95,6 +96,17 @@ export const deleteWalletRequestSchema = deleteWalletSchemaBase
     }),
   })
   .openapi({ description: "Delete wallet request body." });
+
+export const listWalletsQuerySchema = listWalletsQuerySchemaBase.extend({
+  page: withOpenApi(listWalletsQuerySchemaBase.shape.page, {
+    description: "Page number (1-based).",
+    example: 1,
+  }),
+  pageSize: withOpenApi(listWalletsQuerySchemaBase.shape.pageSize, {
+    description: "Items per page (max 100).",
+    example: 20,
+  }),
+});
 
 export const updateCustodyWalletRequestSchema = updateWalletSchemaBase
   .extend({
@@ -200,12 +212,6 @@ export const custodyWalletResponseSchema = z
     wallet: custodyWalletSchema,
   })
   .openapi({ description: "Created wallet response payload." });
-
-export const custodyWalletsResponseSchema = z
-  .object({
-    wallets: z.array(custodyWalletSchema).openapi({ description: "Wallets." }),
-  })
-  .openapi({ description: "Wallets list response payload." });
 
 export const custodyWalletAggregateResponseSchema = z
   .object({

--- a/apps/sdp-api/src/routes/counterparties.test.ts
+++ b/apps/sdp-api/src/routes/counterparties.test.ts
@@ -5,6 +5,7 @@ import app from "@/index";
 import { createKVStoreSet } from "@/runtime/factory";
 import { TEST_API_KEY, TEST_CACHED_API_KEY } from "@/test/fixtures/api-keys";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 
@@ -248,9 +249,9 @@ describe("Counterparties Routes", () => {
       );
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.data.total).toBe(2);
-      expect(body.data.counterparties).toHaveLength(2);
-      expect(body.data.page).toBe(1);
+      expect(body.meta.total).toBe(2);
+      expect(body.data).toHaveLength(2);
+      expect(body.meta.page).toBe(1);
     });
 
     it("excludes archived by default", async () => {
@@ -268,7 +269,96 @@ describe("Counterparties Routes", () => {
         env
       );
       const body = await res.json();
-      expect(body.data.total).toBe(0);
+      expect(body.meta.total).toBe(0);
+    });
+
+    it("paginates results and reports the full total across pages", async () => {
+      await createCounterparty({ externalId: "page_1", displayName: "Aaa" });
+      await createCounterparty({ externalId: "page_2", displayName: "Bbb" });
+      await createCounterparty({ externalId: "page_3", displayName: "Ccc" });
+
+      const page1Res = await app.request(
+        "/v1/counterparties?page=1&pageSize=2",
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(page1Res.status).toBe(200);
+      const page1Body = await page1Res.json();
+      expect(page1Body.data).toHaveLength(2);
+      expect(page1Body.meta).toMatchObject({ total: 3, page: 1, pageSize: 2, hasMore: true });
+
+      const page2Res = await app.request(
+        "/v1/counterparties?page=2&pageSize=2",
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(page2Res.status).toBe(200);
+      const page2Body = await page2Res.json();
+      expect(page2Body.data).toHaveLength(1);
+      expect(page2Body.meta).toMatchObject({ total: 3, page: 2, pageSize: 2, hasMore: false });
+
+      const allExternalIds = [...page1Body.data, ...page2Body.data].map(
+        (cp: { externalId: string }) => cp.externalId
+      );
+      expect(new Set(allExternalIds)).toEqual(new Set(["page_1", "page_2", "page_3"]));
+    });
+  });
+
+  describe("GET /v1/counterparties/accounts", () => {
+    async function createAccount(counterpartyId: string, address: string, label?: string) {
+      const res = await app.request(
+        `/v1/counterparties/${counterpartyId}/accounts`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: authHeader },
+          body: JSON.stringify({
+            accountKind: "crypto_wallet",
+            ...(label ? { label } : {}),
+            details: { network: "solana", address },
+          }),
+        },
+        env
+      );
+      expect(res.status).toBe(201);
+    }
+
+    it("paginates project-wide recipient accounts and reports the full total across pages", async () => {
+      const aRes = await createCounterparty({ externalId: "recipients_a", displayName: "Aaa" });
+      const bRes = await createCounterparty({ externalId: "recipients_b", displayName: "Bbb" });
+      const cRes = await createCounterparty({ externalId: "recipients_c", displayName: "Ccc" });
+
+      const aCp = (await aRes.json()).data.counterparty;
+      const bCp = (await bRes.json()).data.counterparty;
+      const cCp = (await cRes.json()).data.counterparty;
+
+      await createAccount(aCp.id, TEST_SOLANA_ADDRESSES.wallet1, "Aaa wallet");
+      await createAccount(bCp.id, TEST_SOLANA_ADDRESSES.wallet2, "Bbb wallet");
+      await createAccount(cCp.id, TEST_SOLANA_ADDRESSES.wallet3, "Ccc wallet");
+
+      const page1Res = await app.request(
+        "/v1/counterparties/accounts?page=1&pageSize=2",
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(page1Res.status).toBe(200);
+      const page1Body = await page1Res.json();
+      expect(page1Body.data).toHaveLength(2);
+      expect(page1Body.meta).toMatchObject({ total: 3, page: 1, pageSize: 2, hasMore: true });
+
+      const page2Res = await app.request(
+        "/v1/counterparties/accounts?page=2&pageSize=2",
+        { headers: { Authorization: authHeader } },
+        env
+      );
+      expect(page2Res.status).toBe(200);
+      const page2Body = await page2Res.json();
+      expect(page2Body.data).toHaveLength(1);
+      expect(page2Body.meta).toMatchObject({ total: 3, page: 2, pageSize: 2, hasMore: false });
+
+      const allNames = [...page1Body.data, ...page2Body.data].map(
+        (account: { name: string }) => account.name
+      );
+      expect(new Set(allNames)).toEqual(new Set(["Aaa", "Bbb", "Ccc"]));
     });
   });
 

--- a/apps/sdp-api/src/routes/counterparties/handlers.ts
+++ b/apps/sdp-api/src/routes/counterparties/handlers.ts
@@ -8,8 +8,6 @@ import {
   type CounterpartyFieldOptionsResponse,
   type CounterpartyIdentity,
   type CounterpartyResponse,
-  type ListCounterpartiesResponse,
-  type ListProjectCounterpartyAccountsResponse,
   US_STATES,
 } from "@sdp/types";
 import { z } from "zod";
@@ -25,7 +23,7 @@ import {
   internalError,
   notFound,
 } from "@/lib/errors";
-import { created, noContent, success } from "@/lib/response";
+import { created, noContent, paginated, success } from "@/lib/response";
 import {
   advanceCounterpartyRequirements,
   assertRampProviderAvailable,
@@ -99,14 +97,7 @@ export const listCounterparties = async (c: AppContext) => {
     offset: (page - 1) * pageSize,
   });
 
-  const response: ListCounterpartiesResponse = {
-    counterparties: rows.map(mapToCounterparty),
-    total,
-    page,
-    pageSize,
-  };
-
-  return success(c, response);
+  return paginated(c, rows.map(mapToCounterparty), { total, page, pageSize });
 };
 
 export const listProjectCounterpartyAccounts = async (c: AppContext) => {
@@ -137,20 +128,15 @@ export const listProjectCounterpartyAccounts = async (c: AppContext) => {
     offset: resolvingIds ? 0 : (page - 1) * pageSize,
   });
 
-  const response: ListProjectCounterpartyAccountsResponse = {
-    accounts: rows.map((row) => ({
-      counterpartyId: row.counterparty_id,
-      counterpartyAccountId: row.account_id,
-      name: row.counterparty_display_name,
-      address: row.address,
-      label: row.account_label,
-    })),
-    total,
-    page,
-    pageSize,
-  };
+  const accounts = rows.map((row) => ({
+    counterpartyId: row.counterparty_id,
+    counterpartyAccountId: row.account_id,
+    name: row.counterparty_display_name,
+    address: row.address,
+    label: row.account_label,
+  }));
 
-  return success(c, response);
+  return paginated(c, accounts, { total, page, pageSize });
 };
 
 export const getCounterparty = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/custody-multi-provider.test.ts
+++ b/apps/sdp-api/src/routes/custody-multi-provider.test.ts
@@ -269,19 +269,15 @@ describe("Custody multi-provider routes", () => {
 
     expect(defaultRes.status).toBe(200);
     const defaultBody = (await defaultRes.json()) as {
-      data: {
-        wallets: Array<{ provider?: string; isDefaultProvider?: boolean; walletId: string }>;
-      };
+      data: Array<{ provider?: string; isDefaultProvider?: boolean; walletId: string }>;
     };
 
-    expect(defaultBody.data.wallets).toHaveLength(4);
-    expect(new Set(defaultBody.data.wallets.map((wallet) => wallet.provider))).toEqual(
+    expect(defaultBody.data).toHaveLength(4);
+    expect(new Set(defaultBody.data.map((wallet) => wallet.provider))).toEqual(
       new Set(["privy", "para"])
     );
     expect(
-      defaultBody.data.wallets
-        .filter((wallet) => wallet.isDefaultProvider)
-        .map((wallet) => wallet.provider)
+      defaultBody.data.filter((wallet) => wallet.isDefaultProvider).map((wallet) => wallet.provider)
     ).toEqual(["privy", "privy"]);
 
     const defaultProviderOnlyQuery = new URLSearchParams({
@@ -301,18 +297,14 @@ describe("Custody multi-provider routes", () => {
 
     expect(defaultProviderOnlyRes.status).toBe(200);
     const defaultProviderOnlyBody = (await defaultProviderOnlyRes.json()) as {
-      data: {
-        wallets: Array<{ provider?: string; isDefaultProvider?: boolean; walletId: string }>;
-      };
+      data: Array<{ provider?: string; isDefaultProvider?: boolean; walletId: string }>;
     };
 
-    expect(defaultProviderOnlyBody.data.wallets).toHaveLength(2);
-    expect(
-      defaultProviderOnlyBody.data.wallets.every((wallet) => wallet.provider === "privy")
-    ).toBe(true);
-    expect(
-      defaultProviderOnlyBody.data.wallets.every((wallet) => wallet.isDefaultProvider === true)
-    ).toBe(true);
+    expect(defaultProviderOnlyBody.data).toHaveLength(2);
+    expect(defaultProviderOnlyBody.data.every((wallet) => wallet.provider === "privy")).toBe(true);
+    expect(defaultProviderOnlyBody.data.every((wallet) => wallet.isDefaultProvider === true)).toBe(
+      true
+    );
   });
 
   it("returns active configs and defaultConfigId from /v1/wallets/configs", async () => {

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -257,11 +257,9 @@ describe("Custody wallet scope routes", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      data: {
-        wallets: Array<{ walletId: string }>;
-      };
+      data: Array<{ walletId: string }>;
     };
-    expect(body.data.wallets.map((wallet) => wallet.walletId)).toEqual(["para_wallet_a"]);
+    expect(body.data.map((wallet) => wallet.walletId)).toEqual(["para_wallet_a"]);
   });
 
   it("excludes bound wallets that lack wallets:read from the summary view", async () => {
@@ -282,11 +280,9 @@ describe("Custody wallet scope routes", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      data: {
-        wallets: Array<{ walletId: string }>;
-      };
+      data: Array<{ walletId: string }>;
     };
-    expect(body.data.wallets).toEqual([]);
+    expect(body.data).toEqual([]);
   });
 
   it("returns summary wallets without hydrating balances", async () => {
@@ -303,15 +299,58 @@ describe("Custody wallet scope routes", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      data: {
-        wallets: Array<{ walletId: string; balances?: unknown[] }>;
-      };
+      data: Array<{ walletId: string; balances?: unknown[] }>;
     };
 
-    expect(body.data.wallets).toHaveLength(3);
-    expect(body.data.wallets.every((wallet) => wallet.balances === undefined)).toBe(true);
+    expect(body.data).toHaveLength(3);
+    expect(body.data.every((wallet) => wallet.balances === undefined)).toBe(true);
     expect(getAccountInfoMock).not.toHaveBeenCalled();
     expect(getSplTokenBalancesMock).not.toHaveBeenCalled();
+  });
+
+  it("paginates listed wallets and reports the full total across pages", async () => {
+    const page1 = await app.request(
+      "/v1/wallets?includeAllProviders=true&view=summary&pageSize=2&page=1",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(page1.status).toBe(200);
+    const page1Body = (await page1.json()) as {
+      data: Array<{ walletId: string }>;
+      meta: { total: number; page: number; pageSize: number; hasMore: boolean };
+    };
+    expect(page1Body.data).toHaveLength(2);
+    expect(page1Body.meta).toMatchObject({ total: 3, page: 1, pageSize: 2, hasMore: true });
+
+    const page2 = await app.request(
+      "/v1/wallets?includeAllProviders=true&view=summary&pageSize=2&page=2",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+      },
+      env
+    );
+
+    expect(page2.status).toBe(200);
+    const page2Body = (await page2.json()) as {
+      data: Array<{ walletId: string }>;
+      meta: { total: number; page: number; pageSize: number; hasMore: boolean };
+    };
+    expect(page2Body.data).toHaveLength(1);
+    expect(page2Body.meta).toMatchObject({ total: 3, page: 2, pageSize: 2, hasMore: false });
+
+    const allWalletIds = [...page1Body.data, ...page2Body.data].map((wallet) => wallet.walletId);
+    expect(new Set(allWalletIds)).toEqual(
+      new Set(["privy_wallet_a", "privy_wallet_b", "para_wallet_a"])
+    );
   });
 
   it("filters aggregate wallets to the API key bindings", async () => {

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -11,8 +11,8 @@ import type { Address } from "@solana/kit";
 import { z } from "zod";
 import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
-import { AppError, badRequest } from "@/lib/errors";
-import { created, success } from "@/lib/response";
+import { AppError, badRequest, badRequestQuery, internalError } from "@/lib/errors";
+import { created, paginated, success } from "@/lib/response";
 import * as tokenAccounts from "@/routes/payments/token-accounts";
 import { resolveIssuedTokenLabelsByMint } from "@/routes/payments/token-labels";
 import {
@@ -34,10 +34,10 @@ import {
   type CustodyWalletAggregateResponse,
   type CustodyWalletByIdResponse,
   type CustodyWalletResponse,
-  type CustodyWalletsResponse,
   createWalletSchema,
   type DeleteWalletResponse,
   deleteWalletSchema,
+  listWalletsQuerySchema,
   setDefaultWalletSchema,
   updateWalletSchema,
 } from "../schemas";
@@ -716,13 +716,23 @@ export const updateWallet = async (c: AppContext) => {
 };
 
 export const listWallets = async (c: AppContext) => {
+  const parsedQuery = listWalletsQuerySchema.safeParse(c.req.query());
+  if (!parsedQuery.success) {
+    throw badRequestQuery({ errors: z.treeifyError(parsedQuery.error) });
+  }
+  const { page, pageSize } = parsedQuery.data;
+
   const filters = resolveWalletFilters(c, { defaultIncludeAllProviders: true });
   const wallets = await getCachedWalletSummaries(c, filters, "list_wallets");
+  const total = wallets.length;
+  const offset = (page - 1) * pageSize;
+  const pageWallets = wallets.slice(offset, offset + pageSize);
+
   const balancesStartedAt = performance.now();
   const balancesByWalletId = filters.includeBalances
     ? await getBalancesByWalletId(
         c,
-        wallets.map((wallet) => ({
+        pageWallets.map((wallet) => ({
           walletId: wallet.walletId,
           publicKey: wallet.publicKey,
         }))
@@ -731,12 +741,12 @@ export const listWallets = async (c: AppContext) => {
 
   if (filters.includeBalances) {
     logWalletStep(c, "list_wallets", "fetch_wallet_balances", balancesStartedAt, {
-      walletCount: wallets.length,
+      walletCount: pageWallets.length,
     });
   }
 
-  const response: CustodyWalletsResponse = {
-    wallets: wallets.map((wallet) => ({
+  const walletsResponse = pageWallets.map((wallet) => {
+    const walletSummary = {
       id: wallet.id,
       custodyConfigId: wallet.custodyConfigId,
       provider: wallet.provider,
@@ -747,15 +757,23 @@ export const listWallets = async (c: AppContext) => {
       purpose: wallet.purpose,
       status: wallet.status,
       createdAt: wallet.createdAt,
-      ...(filters.includeBalances
-        ? {
-            balances: balancesByWalletId.get(wallet.walletId) ?? [],
-          }
-        : {}),
-    })),
-  };
+    };
 
-  return success(c, response);
+    if (!filters.includeBalances) {
+      return walletSummary;
+    }
+
+    const balances = balancesByWalletId.get(wallet.walletId);
+    if (!balances) {
+      throw internalError(
+        `Missing fetched balances for wallet ${wallet.walletId} in the current page`
+      );
+    }
+
+    return { ...walletSummary, balances };
+  });
+
+  return paginated(c, walletsResponse, { total, page, pageSize });
 };
 
 export const getWalletAggregate = async (c: AppContext) => {

--- a/apps/sdp-api/src/routes/custody/schemas.ts
+++ b/apps/sdp-api/src/routes/custody/schemas.ts
@@ -9,7 +9,6 @@ import type {
   CustodyWalletAggregateResponse,
   CustodyWalletByIdResponse,
   CustodyWalletResponse,
-  CustodyWalletsResponse,
   DeleteWalletResponse,
   InitializeSigningResponse,
   SignerCheckResponse,
@@ -212,6 +211,15 @@ export const approvalRequestParamsSchema = z.object({
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// List Wallets
+// ═══════════════════════════════════════════════════════════════════════════
+
+export const listWalletsQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Response Types
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -221,7 +229,6 @@ export type {
   CustodyWalletAggregateResponse,
   CustodyWalletByIdResponse,
   CustodyWalletResponse,
-  CustodyWalletsResponse,
   DeleteWalletResponse,
   InitializeSigningResponse,
   SignerCheckResponse,

--- a/apps/sdp-docs/content/docs/tutorials/issue-a-regulated-stablecoin.mdx
+++ b/apps/sdp-docs/content/docs/tutorials/issue-a-regulated-stablecoin.mdx
@@ -175,7 +175,7 @@ Now confirm the setup by listing the wallets bound to your project:
 
 ```javascript
 const { data } = await sdp.get("/v1/wallets");
-console.log(`Custody wallets configured: ${data.wallets.length}`);
+console.log(`Custody wallets configured: ${data.length}`);
 ```
 
 A working setup prints:
@@ -603,7 +603,7 @@ Transfers run on the `/v1/payments/transfers` endpoint family, separate from the
 
 ```javascript
 const { data } = await sdp.get("/v1/wallets");
-const sourceWalletId = data.wallets[0].walletId;
+const sourceWalletId = data[0].walletId;
 
 const screening = await sdpAdmin.post("/v1/compliance/address-screenings", {
   address: destinationAddress,

--- a/apps/sdp-docs/content/docs/tutorials/tokenize-a-treasury-fund.mdx
+++ b/apps/sdp-docs/content/docs/tutorials/tokenize-a-treasury-fund.mdx
@@ -118,7 +118,7 @@ Confirm the setup by listing wallets:
 
 ```javascript
 const { data } = await sdp.get("/v1/wallets");
-console.log(`Custody wallets configured: ${data.wallets.length}`);
+console.log(`Custody wallets configured: ${data.length}`);
 ```
 
 A working setup prints at least one wallet.

--- a/apps/sdp-docs/public/llms-full.txt
+++ b/apps/sdp-docs/public/llms-full.txt
@@ -3544,7 +3544,7 @@ Now confirm the setup by listing the wallets bound to your project:
 
 ```javascript
 const { data } = await sdp.get("/v1/wallets");
-console.log(`Custody wallets configured: ${data.wallets.length}`);
+console.log(`Custody wallets configured: ${data.length}`);
 ```
 
 A working setup prints:
@@ -3971,7 +3971,7 @@ Transfers run on the `/v1/payments/transfers` endpoint family, separate from the
 
 ```javascript
 const { data } = await sdp.get("/v1/wallets");
-const sourceWalletId = data.wallets[0].walletId;
+const sourceWalletId = data[0].walletId;
 
 const screening = await sdpAdmin.post("/v1/compliance/address-screenings", {
   address: destinationAddress,

--- a/apps/sdp-web/messages/en/dashboard-payments.json
+++ b/apps/sdp-web/messages/en/dashboard-payments.json
@@ -9,6 +9,7 @@
     },
     "workspace": {
       "walletListRequestFailed": "Wallet list request failed ({status}).",
+      "walletListMissing": "Wallet list response is missing wallet data.",
       "walletAggregateRequestFailed": "Wallet aggregate request failed ({status}).",
       "walletAggregateMissing": "Wallet aggregate response is missing aggregate details.",
       "walletPolicyRequestFailed": "Wallet policy request failed ({status}).",

--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -58,16 +58,19 @@ async function getCustodyWallets(
 ): Promise<CustodyWalletSummary[]> {
   // Wallet cards refresh balances client-side; avoid blocking the overview render on balance RPCs.
   // biome-ignore lint/security/noSecrets: Public API path with query flags for wallet listing.
-  const res = await request("/v1/wallets?includeAllProviders=true");
+  const res = await request("/v1/wallets?includeAllProviders=true&pageSize=100");
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`SDP API request failed (${res.status}): ${body}`);
   }
 
   const json = (await res.json()) as {
-    data?: { wallets?: CustodyWalletSummary[] };
+    data?: CustodyWalletSummary[];
   };
-  return json.data?.wallets ?? [];
+  if (!json.data) {
+    throw new Error("Wallet list response is missing wallet data.");
+  }
+  return json.data;
 }
 
 async function getClerkOrganizationSummary(

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-playground-config.ts
@@ -89,23 +89,27 @@ export function buildWalletsPlaygroundEndpointConfigs({
       pathFields: [],
       bodyFields: [],
       expectedResponse: {
-        data: {
-          wallets:
-            wallets.length > 0
-              ? wallets.map((wallet) => ({
-                  walletId: wallet.walletId,
-                  label: wallet.label,
-                  provider: wallet.provider,
-                  publicKey: wallet.publicKey,
-                }))
-              : [
-                  {
-                    walletId: exampleWalletId,
-                    label: exampleWalletLabel,
-                    provider: "privy",
-                    publicKey: examplePublicKey,
-                  },
-                ],
+        data:
+          wallets.length > 0
+            ? wallets.map((wallet) => ({
+                walletId: wallet.walletId,
+                label: wallet.label,
+                provider: wallet.provider,
+                publicKey: wallet.publicKey,
+              }))
+            : [
+                {
+                  walletId: exampleWalletId,
+                  label: exampleWalletLabel,
+                  provider: "privy",
+                  publicKey: examplePublicKey,
+                },
+              ],
+        meta: {
+          total: wallets.length || 1,
+          page: 1,
+          pageSize: 20,
+          hasMore: false,
         },
       },
     },

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-page.data.ts
@@ -1,9 +1,4 @@
-import type {
-  Counterparty,
-  CounterpartyResponse,
-  ListCounterpartiesResponse,
-  PaginatedResponse,
-} from "@sdp/types";
+import type { Counterparty, CounterpartyResponse, PaginatedResponse } from "@sdp/types";
 import type { SdpApiClient } from "@/lib/sdp-api";
 
 export const COUNTERPARTY_PAGE_SIZE = 10;
@@ -25,11 +20,17 @@ export async function fetchCounterparties(
       const body = await response.text();
       return { ok: false, data: [], total: 0, error: body };
     }
-    const json = (await response.json()) as { data?: ListCounterpartiesResponse };
+    const json = (await response.json()) as {
+      data?: Counterparty[];
+      meta?: { total: number };
+    };
+    if (!json.data || !json.meta) {
+      throw new Error("Counterparty list response is missing data or meta.");
+    }
     return {
       ok: true,
-      data: json.data?.counterparties ?? [],
-      total: json.data?.total ?? 0,
+      data: json.data,
+      total: json.meta.total,
     };
   } catch (error) {
     return {

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-playground-config.ts
@@ -75,13 +75,16 @@ export function buildCounterpartyPlaygroundEndpointConfigs(
       pathFields: [],
       bodyFields: [],
       expectedResponse: {
-        counterparties:
+        data:
           counterparties.length > 0
             ? counterparties.map((cp) => ({ id: cp.id, displayName: cp.displayName }))
             : [{ id: exampleCounterpartyId, displayName: exampleDisplayName, email: exampleEmail }],
-        total: counterparties.length || 1,
-        page: 1,
-        pageSize: 100,
+        meta: {
+          total: counterparties.length || 1,
+          page: 1,
+          pageSize: 20,
+          hasMore: false,
+        },
       },
     },
     {

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/use-counterparty-directory.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/use-counterparty-directory.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Counterparty, ListCounterpartiesResponse } from "@sdp/types";
+import type { Counterparty } from "@sdp/types";
 import { useEffect, useRef, useState } from "react";
 import { dashboardFetch } from "@/lib/dashboard-fetch";
 import { COUNTERPARTY_PAGE_SIZE } from "./counterparty-page.data";
@@ -52,13 +52,13 @@ export function useCounterpartyDirectory(
     setLoading(true);
     setError(null);
 
-    void dashboardFetch<{ data: ListCounterpartiesResponse }>(
+    void dashboardFetch<{ data: Counterparty[]; meta: { total: number } }>(
       `/api/dashboard/counterparty?page=${page}&pageSize=${pageSize}`
     ).then((result) => {
       if (aborted) return;
       if (result.ok) {
-        setCounterparties(result.data.data.counterparties);
-        setTotal(result.data.data.total);
+        setCounterparties(result.data.data);
+        setTotal(result.data.meta.total);
         loadedPageRef.current = page;
       } else {
         setError(result.error);

--- a/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-page.data.ts
@@ -30,6 +30,7 @@ export async function fetchPaymentsWallets(
   try {
     const query = new URLSearchParams({
       includeAllProviders: "true",
+      pageSize: "100",
       ...(options.view === "summary" ? { view: "summary" } : {}),
       ...(options.includeBalances ? { includeBalances: "true" } : {}),
     }).toString();
@@ -44,25 +45,27 @@ export async function fetchPaymentsWallets(
     }
 
     const json = (await response.json()) as {
-      data?: {
-        wallets?: Array<{
-          id?: string;
-          walletId?: string;
-          publicKey?: string;
-          label?: string | null;
-          balances?: PaymentsDashboardWallet["balances"];
-        }>;
-      };
+      data?: Array<{
+        id?: string;
+        walletId?: string;
+        publicKey?: string;
+        label?: string | null;
+        balances?: PaymentsDashboardWallet["balances"];
+      }>;
     };
 
-    type WalletSummary = NonNullable<NonNullable<typeof json.data>["wallets"]>[number];
+    type WalletSummary = NonNullable<typeof json.data>[number];
     type ValidWalletSummary = WalletSummary & {
       id: string;
       walletId: string;
       publicKey: string;
     };
 
-    const wallets = (json?.data?.wallets ?? [])
+    if (!json.data) {
+      throw new Error("Wallet list response is missing wallet data.");
+    }
+
+    const wallets = json.data
       .filter(
         (wallet): wallet is ValidWalletSummary =>
           typeof wallet?.id === "string" &&

--- a/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-workspace.data.ts
@@ -4,12 +4,10 @@ import type {
   CoinbaseRampEvent,
   Counterparty,
   CounterpartyAccount,
+  CounterpartyAccountSummary,
   CryptoRailId,
   CustodyWalletAggregate,
-  ListCounterpartiesResponse,
   ListCounterpartyAccountsResponse,
-  ListProjectCounterpartyAccountsEnvelope,
-  ListProjectCounterpartyAccountsResponse,
   MoneygramRampEvent,
   MuralSandboxPayinCurrency,
   PaymentRampEstimateEnvelope,
@@ -194,6 +192,7 @@ export async function fetchWallets(
 ): Promise<WalletRecord[]> {
   const query = new URLSearchParams({
     view: "summary",
+    pageSize: "100",
   });
   if (options.includeBalances) {
     query.set("includeBalances", "true");
@@ -212,7 +211,10 @@ export async function fetchWallets(
       )
     );
   }
-  return body.data?.wallets ?? [];
+  if (!body.data) {
+    throw new Error(t("DashboardPayments.workspace.walletListMissing"));
+  }
+  return body.data;
 }
 
 export async function fetchWalletAggregate(
@@ -587,6 +589,13 @@ export async function createTransfer(
   return body.data.transfer;
 }
 
+export interface BatchRecipientsPage {
+  accounts: CounterpartyAccountSummary[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 export async function fetchBatchRecipients(
   input: {
     page?: number;
@@ -596,7 +605,7 @@ export async function fetchBatchRecipients(
     signal?: AbortSignal;
   },
   t: Translate
-): Promise<ListProjectCounterpartyAccountsResponse> {
+): Promise<BatchRecipientsPage> {
   const query = new URLSearchParams({
     ...(input.page ? { page: String(input.page) } : {}),
     ...(input.pageSize ? { pageSize: String(input.pageSize) } : {}),
@@ -608,7 +617,11 @@ export async function fetchBatchRecipients(
     cache: "no-store",
     signal: input.signal,
   });
-  const body = (await response.json().catch(() => ({}))) as ListProjectCounterpartyAccountsEnvelope;
+  const body = (await response.json().catch(() => ({}))) as {
+    data?: CounterpartyAccountSummary[];
+    meta?: { total: number; page: number; pageSize: number };
+    error?: { message?: string };
+  };
   if (!response.ok) {
     throw new Error(
       getApiError(
@@ -617,10 +630,15 @@ export async function fetchBatchRecipients(
       )
     );
   }
-  if (!body.data) {
+  if (!body.data || !body.meta) {
     throw new Error(t("DashboardPayments.workspace.recipientListMissing"));
   }
-  return body.data;
+  return {
+    accounts: body.data,
+    total: body.meta.total,
+    page: body.meta.page,
+    pageSize: body.meta.pageSize,
+  };
 }
 
 export async function estimateTransferBatch(
@@ -845,12 +863,16 @@ export async function fetchAllCounterparties(): Promise<CounterpartiesResult> {
         return { ok: false, data: [], error: await response.text() };
       }
 
-      const json = (await response.json()) as { data?: ListCounterpartiesResponse };
-      const list = json.data;
-      counterparties.push(...(list?.counterparties ?? []));
+      const json = (await response.json()) as {
+        data?: Counterparty[];
+        meta?: { total: number };
+      };
+      if (!json.data || !json.meta) {
+        throw new Error("Counterparty list response is missing data or meta.");
+      }
+      counterparties.push(...json.data);
 
-      const total = list?.total ?? counterparties.length;
-      if (counterparties.length >= total || (list?.counterparties.length ?? 0) === 0) {
+      if (counterparties.length >= json.meta.total || json.data.length === 0) {
         break;
       }
     }

--- a/packages/sdp-types/src/counterparties.ts
+++ b/packages/sdp-types/src/counterparties.ts
@@ -170,13 +170,6 @@ export interface CounterpartyFieldOptionsResponse {
   fields: CounterpartyFieldOptions;
 }
 
-export interface ListCounterpartiesResponse {
-  counterparties: Counterparty[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
 export const COUNTERPARTY_ACCOUNT_KINDS = ["bank_account", "crypto_wallet"] as const;
 export type CounterpartyAccountKind = (typeof COUNTERPARTY_ACCOUNT_KINDS)[number];
 

--- a/packages/sdp-types/src/custody.ts
+++ b/packages/sdp-types/src/custody.ts
@@ -332,10 +332,6 @@ export interface CustodyWalletResponse {
   wallet: CustodyWalletSummary;
 }
 
-export interface CustodyWalletsResponse {
-  wallets: CustodyWalletSummary[];
-}
-
 export interface CustodyWalletAggregate {
   walletCount: number;
   balances: CustodyWalletTokenBalance[];

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -23,9 +23,7 @@ export interface PaymentsDashboardWallet {
 }
 
 export interface PaymentsDashboardWalletsEnvelope {
-  data?: {
-    wallets?: PaymentsDashboardWallet[];
-  };
+  data?: PaymentsDashboardWallet[];
   error?: {
     message?: string;
   };
@@ -312,20 +310,6 @@ export interface CounterpartyAccountSummary {
   name: string;
   address: string;
   label: string | null;
-}
-
-export interface ListProjectCounterpartyAccountsResponse {
-  accounts: CounterpartyAccountSummary[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
-export interface ListProjectCounterpartyAccountsEnvelope {
-  data?: ListProjectCounterpartyAccountsResponse;
-  error?: {
-    message?: string;
-  };
 }
 
 export interface PaymentTransferBatchEstimate {


### PR DESCRIPTION
Fixes #676.

- `GET /v1/counterparties` and `GET /v1/counterparties/accounts` move from hand-rolled `{counterparties/accounts, total, page, pageSize}` shapes to the canonical `paginated()` envelope (`{data, meta: {total, page, pageSize, hasMore, requestId}}`) used by transfers/issuance.
- `GET /v1/wallets` gains `page`/`pageSize` (defaults and max copied from `listTransfersQuerySchema`); previously it returned every wallet with no pagination metadata. Pagination slices the cached wallet summary set in-memory (the cache stores the full filtered set — not redesigned), and balances are only fetched for the returned page.
- **Breaking response shapes** (pre-mainnet): dead envelope types deleted from `@sdp/types`; all sdp-web consumers, OpenAPI schemas, playground configs, tutorials, and generated artifacts updated.
- Not touched: nested `GET /v1/counterparties/{id}/accounts` shares the legacy shape but wasn't named in the issue — follow-up candidate.

## Testing
Multi-page integration tests (real Postgres: seed 3 rows, `pageSize=2`, assert `meta.total`/`hasMore` + page-2 remainder) for `/v1/wallets`, `/v1/counterparties`, and `/v1/counterparties/accounts`. Full sdp-api suite: 101 files / 1048 passed, 0 failed. `tsc --noEmit` clean in sdp-api, sdp-web, sdp-docs.

## Merge order
Conflicts with #778 on `llms-full.txt` + two tutorial MDX files — whichever merges second needs a rebase and a `pnpm generate:ai` re-run (regenerate, don't hand-resolve).