### PR TITLE
perf(web): defer wallet activity below viewport

### DIFF
--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -562,8 +562,11 @@ test.describe
       await page.waitForTimeout(1_000);
       expect(activityRequestCount).toBe(requestCountBeforeReconnect);
 
-      failNextActivityRequest = true;
       await page.getByRole("heading", { name: "Recent activity" }).scrollIntoViewIfNeeded();
+      await expect(activityRegion).toHaveAttribute("data-wallet-activity-visible", "true");
+      await expect.poll(() => activityRequestCount).toBe(requestCountBeforeReconnect + 1);
+
+      failNextActivityRequest = true;
       const refreshButton = page.getByRole("button", { name: "Refresh" });
       await expect(refreshButton).toBeEnabled({ timeout: E2E_POLL_TIMEOUT_MS });
       await refreshButton.click();

--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -439,6 +439,7 @@ test.describe
       await session.page.close();
 
       await page.goto(`/dashboard/wallets/${wallet.walletId}`, { waitUntil: "domcontentloaded" });
+      await page.getByRole("heading", { name: "Recent activity" }).scrollIntoViewIfNeeded();
 
       const expectedActivityRows = [
         { operationLabel: "Burn", token: deployedToken.symbol, amount: "2" },
@@ -482,7 +483,9 @@ test.describe
       }
 
       let failNextActivityRequest = false;
+      let activityRequestCount = 0;
       await page.route(/\/api\/dashboard\/wallets\/[^/]+\/activity$/, async (route) => {
+        activityRequestCount += 1;
         if (failNextActivityRequest) {
           await route.fulfill({
             status: 503,
@@ -520,7 +523,27 @@ test.describe
         });
       });
 
+      await page.setViewportSize({ width: 1280, height: 500 });
       await page.goto(`/dashboard/wallets/${wallet.walletId}`, { waitUntil: "domcontentloaded" });
+      await expect(page.getByRole("heading", { name: wallet.label ?? "Treasury" })).toBeVisible({
+        timeout: E2E_POLL_TIMEOUT_MS,
+      });
+      await expect(page.getByRole("button", { name: "Actions" })).toBeEnabled();
+      const activityRegion = page.locator("[data-wallet-activity-state]");
+      await expect(activityRegion).not.toBeInViewport();
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          })
+      );
+      await expect(activityRegion).toHaveAttribute("data-wallet-activity-state", "deferred");
+      expect(activityRequestCount).toBe(0);
+
+      await page.getByRole("heading", { name: "Recent activity" }).scrollIntoViewIfNeeded();
+      await expect(activityRegion).toHaveAttribute("data-wallet-activity-state", "mounted");
+      await expect.poll(() => activityRequestCount).toBe(1);
+
       const activityRow = page.locator("tr").filter({ hasText: "5.00 USDC" });
       await expect(activityRow).toBeVisible({ timeout: 120_000 });
       await expect(activityRow).toContainText("Incoming");

--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -549,7 +549,21 @@ test.describe
       await expect(activityRow).toContainText("Incoming");
       await expect(activityRow.getByRole("link")).toHaveCount(1);
 
+      await page
+        .getByRole("heading", { name: wallet.label ?? "Treasury" })
+        .scrollIntoViewIfNeeded();
+      await expect(activityRegion).not.toBeInViewport();
+      await expect(activityRegion).toHaveAttribute("data-wallet-activity-visible", "false");
+      const requestCountBeforeReconnect = activityRequestCount;
+      await page.evaluate(() => {
+        window.dispatchEvent(new Event("offline"));
+        window.dispatchEvent(new Event("online"));
+      });
+      await page.waitForTimeout(1_000);
+      expect(activityRequestCount).toBe(requestCountBeforeReconnect);
+
       failNextActivityRequest = true;
+      await page.getByRole("heading", { name: "Recent activity" }).scrollIntoViewIfNeeded();
       const refreshButton = page.getByRole("button", { name: "Refresh" });
       await expect(refreshButton).toBeEnabled({ timeout: E2E_POLL_TIMEOUT_MS });
       await refreshButton.click();

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
@@ -1,13 +1,13 @@
 import { auth } from "@clerk/nextjs/server";
 import type {
-  CustodyWalletByIdResponse,
+  CustodyWalletMetadataResponse,
   CustodyWalletTokenBalance,
   PaymentWalletPolicy,
 } from "@sdp/types";
 import { SlidersHorizontal } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import type { ReactNode } from "react";
+import { type ReactNode, Suspense } from "react";
 import {
   formatCustodyProviderName,
   getCustodyProviderCategory,
@@ -15,20 +15,22 @@ import {
   isKnownCustodyProvider,
 } from "@/app/dashboard/custody/provider-catalog";
 import { WalletActionsMenu } from "@/app/dashboard/custody/wallet-actions-menu";
-import {
-  loadWalletActivity,
-  type WalletActivityPayload,
-} from "@/app/dashboard/custody/wallet-activity.data";
-import { WalletActivitySection } from "@/app/dashboard/custody/wallet-activity-section";
+import { WalletActivityViewport } from "@/app/dashboard/custody/wallet-activity-viewport";
 import { WalletAddressCopyButton } from "@/app/dashboard/custody/wallet-address-copy-button";
 import { WalletCategoryBadge } from "@/app/dashboard/custody/wallet-category-badge";
 import { formatPurpose, truncateMiddle } from "@/app/dashboard/custody/wallet-format-utils";
 import { WalletProviderMark } from "@/app/dashboard/custody/wallet-provider-mark";
+import {
+  WalletBalanceSummarySkeleton,
+  WalletBalancesSkeleton,
+  WalletControlsSkeleton,
+} from "@/app/dashboard/wallets/wallet-route-skeletons";
 import { DashboardWorkspaceOverviewPanel } from "@/components/dashboard-workspace-panel";
 import { Button } from "@/components/ui/button";
 import { getTranslations } from "@/i18n/server";
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { createSdpApiClient, type SdpApiClient } from "@/lib/sdp-api";
+import { getWalletMetadataPath } from "@/lib/sdp-api-paths";
 import { formatDisplayLabel } from "@/lib/utils";
 import {
   formatCurrencyAmount,
@@ -63,8 +65,8 @@ interface OwnedTokenRoute {
 async function getWalletDetail(
   request: SdpApiClient["request"],
   walletId: string
-): Promise<CustodyWalletByIdResponse["wallet"]> {
-  const response = await request(`/v1/wallets/${encodeURIComponent(walletId)}`);
+): Promise<CustodyWalletMetadataResponse["wallet"]> {
+  const response = await request(getWalletMetadataPath(walletId));
   if (response.status === 404) {
     notFound();
   }
@@ -73,7 +75,7 @@ async function getWalletDetail(
     throw new Error(`SDP API request failed (${response.status}): ${body}`);
   }
 
-  const json = (await response.json()) as { data?: CustodyWalletByIdResponse };
+  const json = (await response.json()) as { data?: CustodyWalletMetadataResponse };
   const wallet = json.data?.wallet;
   if (!wallet) {
     notFound();
@@ -176,28 +178,16 @@ async function getOwnedTokenRoutes(
   }
 }
 
-async function getWalletActivity(
-  request: SdpApiClient["request"],
-  walletId: string,
-  t: Awaited<ReturnType<typeof getTranslations>>
-): Promise<WalletActivityPayload> {
-  const result = await loadWalletActivity(request, walletId, t);
-  return (
-    result.data ?? {
-      activityRows: [],
-      activityError: result.error ?? t("DashboardCustody.walletActivityUnavailable"),
-      activityNotice: null,
-    }
-  );
-}
-
 export default async function WalletDetailPage({
   params,
 }: {
   params: Promise<{ walletId: string }>;
 }) {
-  const t = await getTranslations();
-  const { userId, orgId } = await auth();
+  const [t, { userId, orgId }, { walletId }] = await Promise.all([
+    getTranslations(),
+    auth(),
+    params,
+  ]);
   if (!userId) {
     redirect(await getAuthEntryPath());
   }
@@ -205,25 +195,21 @@ export default async function WalletDetailPage({
     redirect("/dashboard");
   }
 
-  const { walletId } = await params;
   const resolvedWalletId = decodeURIComponent(walletId);
   const apiClient = await createSdpApiClient();
-  const [wallet, trackedBalancesResult, walletPolicyResult, ownedTokensByMint, walletActivity] =
-    await Promise.all([
-      getWalletDetail(apiClient.request, resolvedWalletId),
-      getWalletTrackedBalances(
-        apiClient.request,
-        resolvedWalletId,
-        t("DashboardCustody.trackedBalancesUnavailable")
-      ),
-      getWalletPolicy(
-        apiClient.request,
-        resolvedWalletId,
-        t("DashboardCustody.walletControlsUnavailable")
-      ),
-      getOwnedTokenRoutes(apiClient.request),
-      getWalletActivity(apiClient.request, resolvedWalletId, t),
-    ]);
+  const walletPromise = getWalletDetail(apiClient.request, resolvedWalletId);
+  const trackedBalancesPromise = getWalletTrackedBalances(
+    apiClient.request,
+    resolvedWalletId,
+    t("DashboardCustody.trackedBalancesUnavailable")
+  );
+  const walletPolicyPromise = getWalletPolicy(
+    apiClient.request,
+    resolvedWalletId,
+    t("DashboardCustody.walletControlsUnavailable")
+  );
+  const ownedTokensByMintPromise = getOwnedTokenRoutes(apiClient.request);
+  const wallet = await walletPromise;
 
   const provider =
     wallet.provider && isKnownCustodyProvider(wallet.provider) ? wallet.provider : null;
@@ -231,10 +217,10 @@ export default async function WalletDetailPage({
   const supportsSignerCheck = provider
     ? getCustodyProviderEntry(provider).supportsSigning
     : !wallet.provider;
-  const balances =
-    trackedBalancesResult.balances.length > 0 ? trackedBalancesResult.balances : [wallet.balance];
-  const totalBalance = resolveTotalBalance(balances);
   const purposeLabel = formatPurpose(wallet.purpose, t);
+  const providerLabel = provider
+    ? formatCustodyProviderName(provider)
+    : t("DashboardCustody.unknown");
 
   return (
     <DashboardWorkspaceOverviewPanel className="space-y-6">
@@ -304,77 +290,138 @@ export default async function WalletDetailPage({
           </div>
         </section>
 
-        <section className="overflow-hidden rounded-2xl border border-border-default bg-white">
-          <div className="space-y-6 p-6">
-            <div>
-              <p className="text-xs font-medium tracking-[0.14em] text-muted uppercase">
-                {t("DashboardCustody.totalBalance")}
-              </p>
-              <p className="mt-3 text-[38px] leading-none font-medium tracking-[-0.05em] text-primary">
-                {formatCurrencyAmount(totalBalance)}
-              </p>
-            </div>
-
-            <div className="overflow-hidden rounded-2xl border border-border-subtle bg-fill-subtle">
-              <WalletInfoRow
-                label={t("DashboardCustody.address")}
-                value={truncateMiddle(wallet.publicKey)}
-                monospace
-              />
-              <WalletInfoRow
-                label={t("DashboardCustody.provider")}
-                value={
-                  provider ? formatCustodyProviderName(provider) : t("DashboardCustody.unknown")
-                }
-              />
-              {purposeLabel ? (
-                <WalletInfoRow label={t("DashboardCustody.purpose")} value={purposeLabel} />
-              ) : null}
-            </div>
-          </div>
-        </section>
+        <Suspense fallback={<WalletBalanceSummarySkeleton />}>
+          <WalletBalanceSummary
+            balancesPromise={trackedBalancesPromise}
+            providerLabel={providerLabel}
+            publicKey={wallet.publicKey}
+            purposeLabel={purposeLabel}
+            t={t}
+          />
+        </Suspense>
       </div>
 
-      <WalletControlsPanel
-        walletId={resolvedWalletId}
-        policy={walletPolicyResult.policy}
-        policyError={walletPolicyResult.error}
-      />
+      <Suspense fallback={<WalletControlsSkeleton />}>
+        <WalletControlsPanel
+          walletId={resolvedWalletId}
+          policyPromise={walletPolicyPromise}
+          t={t}
+        />
+      </Suspense>
 
-      <section className="space-y-3">
-        <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-primary">
-          {t("DashboardCustody.balances")}
-        </h3>
-        {trackedBalancesResult.error ? (
-          <p className="text-sm text-tertiary">{trackedBalancesResult.error}</p>
-        ) : null}
+      <Suspense fallback={<WalletBalancesSkeleton />}>
+        <WalletBalancesSection
+          balancesPromise={trackedBalancesPromise}
+          ownedTokensByMintPromise={ownedTokensByMintPromise}
+          t={t}
+        />
+      </Suspense>
 
-        {balances.length > 0 ? (
-          <div className="overflow-hidden rounded-2xl border border-border-default bg-white">
-            {balances.map((balance) => {
-              const ownedToken =
-                balance.token === "SOL" ? null : (ownedTokensByMint.get(balance.mint) ?? null);
-
-              return (
-                <WalletBalanceRow
-                  key={`${balance.mint}-${balance.token}`}
-                  label={ownedToken?.name ?? balance.token}
-                  value={formatDisplayAmount(balance.uiAmount, balance.token)}
-                  mint={balance.mint}
-                  href={ownedToken ? `/dashboard/issuance/${ownedToken.id}` : null}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="rounded-2xl border border-border-default bg-white px-4 py-4 text-sm text-secondary">
-            {t("DashboardCustody.noTrackedBalances")}
-          </div>
-        )}
-      </section>
-
-      <WalletActivitySection walletId={resolvedWalletId} initialActivity={walletActivity} />
+      <WalletActivityViewport walletId={resolvedWalletId} />
     </DashboardWorkspaceOverviewPanel>
+  );
+}
+
+async function WalletBalanceSummary({
+  balancesPromise,
+  providerLabel,
+  publicKey,
+  purposeLabel,
+  t,
+}: {
+  balancesPromise: Promise<WalletTrackedBalancesResult>;
+  providerLabel: string;
+  publicKey: string;
+  purposeLabel: string | null;
+  t: Awaited<ReturnType<typeof getTranslations>>;
+}) {
+  const balancesResult = await balancesPromise;
+  const totalBalance = balancesResult.error ? null : resolveTotalBalance(balancesResult.balances);
+
+  return (
+    <section className="overflow-hidden rounded-2xl border border-border-default bg-white">
+      <div className="space-y-6 p-6">
+        <div>
+          <p className="text-xs font-medium tracking-[0.14em] text-muted uppercase">
+            {t("DashboardCustody.totalBalance")}
+          </p>
+          {balancesResult.error ? (
+            <div className="mt-3 space-y-2">
+              <p className="text-[38px] leading-none font-medium tracking-[-0.05em] text-primary">
+                —
+              </p>
+              <p className="text-sm text-tertiary">{balancesResult.error}</p>
+            </div>
+          ) : (
+            <p className="mt-3 text-[38px] leading-none font-medium tracking-[-0.05em] text-primary">
+              {formatCurrencyAmount(totalBalance)}
+            </p>
+          )}
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-border-subtle bg-fill-subtle">
+          <WalletInfoRow
+            label={t("DashboardCustody.address")}
+            value={truncateMiddle(publicKey)}
+            monospace
+          />
+          <WalletInfoRow label={t("DashboardCustody.provider")} value={providerLabel} />
+          {purposeLabel ? (
+            <WalletInfoRow label={t("DashboardCustody.purpose")} value={purposeLabel} />
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+async function WalletBalancesSection({
+  balancesPromise,
+  ownedTokensByMintPromise,
+  t,
+}: {
+  balancesPromise: Promise<WalletTrackedBalancesResult>;
+  ownedTokensByMintPromise: Promise<Map<string, { id: string; name: string | null }>>;
+  t: Awaited<ReturnType<typeof getTranslations>>;
+}) {
+  const [trackedBalancesResult, ownedTokensByMint] = await Promise.all([
+    balancesPromise,
+    ownedTokensByMintPromise,
+  ]);
+  const balances = trackedBalancesResult.balances;
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-[36px] leading-[40px] font-medium tracking-[-0.3px] text-primary">
+        {t("DashboardCustody.balances")}
+      </h3>
+      {trackedBalancesResult.error ? (
+        <p className="text-sm text-tertiary">{trackedBalancesResult.error}</p>
+      ) : null}
+
+      {balances.length > 0 ? (
+        <div className="overflow-hidden rounded-2xl border border-border-default bg-white">
+          {balances.map((balance) => {
+            const ownedToken =
+              balance.token === "SOL" ? null : (ownedTokensByMint.get(balance.mint) ?? null);
+
+            return (
+              <WalletBalanceRow
+                key={`${balance.mint}-${balance.token}`}
+                label={ownedToken?.name ?? balance.token}
+                value={formatDisplayAmount(balance.uiAmount, balance.token)}
+                mint={balance.mint}
+                href={ownedToken ? `/dashboard/issuance/${ownedToken.id}` : null}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-border-default bg-white px-4 py-4 text-sm text-secondary">
+          {t("DashboardCustody.noTrackedBalances")}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -389,14 +436,14 @@ function walletPolicyHasRestrictions(policy: PaymentWalletPolicy | null): boolea
 
 async function WalletControlsPanel({
   walletId,
-  policy,
-  policyError,
+  policyPromise,
+  t,
 }: {
   walletId: string;
-  policy: PaymentWalletPolicy | null;
-  policyError: string | null;
+  policyPromise: Promise<WalletPolicyResult>;
+  t: Awaited<ReturnType<typeof getTranslations>>;
 }) {
-  const t = await getTranslations();
+  const { policy, error: policyError } = await policyPromise;
   const hasRestrictions = walletPolicyHasRestrictions(policy);
   const destinationCount = policy?.destinationAllowlist.length ?? 0;
   const policyHref = `/dashboard/wallets/${encodeURIComponent(walletId)}/policy`;

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/policy-audit.data.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/policy-audit.data.unit.test.ts
@@ -297,7 +297,7 @@ describe("policy audit data", () => {
 
   it("loads revision pages without the unused API-key directory request", async () => {
     const request = vi.fn(async (path: string) => {
-      if (path === "/v1/wallets/wallet-1") {
+      if (path === "/v1/wallets/wallet-1?includeBalance=false") {
         return Response.json({
           data: {
             wallet: {
@@ -321,7 +321,7 @@ describe("policy audit data", () => {
       revisionHistory: { profile: null, revisions: [] },
     });
     expect(request.mock.calls.map(([path]) => path)).toEqual([
-      "/v1/wallets/wallet-1",
+      "/v1/wallets/wallet-1?includeBalance=false",
       "/v1/payments/wallets/wallet-1/policies/revisions",
     ]);
   });

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/wallet-detail-page.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/wallet-detail-page.unit.test.tsx
@@ -1,0 +1,152 @@
+import type { CustodyWalletTokenBalance } from "@sdp/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAuth, mockLoadWalletActivity, mockRequest } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockLoadWalletActivity: vi.fn(),
+  mockRequest: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mockAuth,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("not found");
+  }),
+  redirect: vi.fn(() => {
+    throw new Error("redirected");
+  }),
+}));
+
+vi.mock("@/i18n/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock("@/lib/sdp-api", () => ({
+  createSdpApiClient: vi.fn(async () => ({ request: mockRequest })),
+}));
+
+vi.mock("@/app/dashboard/custody/wallet-activity.data", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/app/dashboard/custody/wallet-activity.data")>();
+  return {
+    ...actual,
+    loadWalletActivity: mockLoadWalletActivity,
+  };
+});
+
+import WalletDetailPage from "./page";
+
+const solBalance: CustodyWalletTokenBalance = {
+  token: "SOL",
+  mint: "So11111111111111111111111111111111111111112",
+  amount: "0",
+  uiAmount: "0",
+  decimals: 9,
+};
+
+function walletMetadataResponse(): Response {
+  return Response.json({
+    data: {
+      wallet: {
+        id: "wallet_record",
+        custodyConfigId: "config_test",
+        provider: "privy",
+        isDefaultProvider: true,
+        walletId: "wallet/one",
+        publicKey: "11111111111111111111111111111111",
+        label: "Fast wallet",
+        purpose: null,
+        status: "active",
+        createdAt: "2026-07-18T00:00:00.000Z",
+      },
+    },
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockLoadWalletActivity.mockReset();
+  mockRequest.mockReset();
+
+  mockAuth.mockResolvedValue({ userId: "user_test", orgId: "org_test" });
+  mockLoadWalletActivity.mockResolvedValue({
+    ok: true,
+    data: {
+      activityRows: [],
+      activityError: null,
+      activityNotice: null,
+    },
+  });
+  mockRequest.mockImplementation(async (path: string) => {
+    if (path.startsWith("/v1/wallets/wallet%2Fone")) {
+      return walletMetadataResponse();
+    }
+
+    if (path.includes("/balances")) {
+      return Response.json({ data: { walletBalances: { balances: [solBalance] } } });
+    }
+
+    if (path.includes("/policies")) {
+      return new Response(null, { status: 404 });
+    }
+
+    if (path.startsWith("/v1/issuance/tokens")) {
+      return Response.json({ data: [] });
+    }
+
+    throw new Error(`Unexpected request: ${path}`);
+  });
+});
+
+describe("WalletDetailPage critical path", () => {
+  it("loads metadata only and leaves wallet activity off the initial render path", async () => {
+    await WalletDetailPage({ params: Promise.resolve({ walletId: "wallet%2Fone" }) });
+
+    expect(mockLoadWalletActivity).not.toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith("/v1/wallets/wallet%2Fone?includeBalance=false");
+  });
+
+  it("resolves the identity shell while lower wallet sections are still pending", async () => {
+    const balances = deferred<Response>();
+    const policy = deferred<Response>();
+    const ownedTokens = deferred<Response>();
+    mockRequest.mockImplementation((path: string) => {
+      if (path === "/v1/wallets/wallet%2Fone?includeBalance=false") {
+        return Promise.resolve(walletMetadataResponse());
+      }
+      if (path.includes("/balances")) return balances.promise;
+      if (path.includes("/policies")) return policy.promise;
+      if (path.startsWith("/v1/issuance/tokens")) return ownedTokens.promise;
+      return Promise.reject(new Error(`Unexpected request: ${path}`));
+    });
+
+    const pagePromise = WalletDetailPage({
+      params: Promise.resolve({ walletId: "wallet%2Fone" }),
+    });
+
+    try {
+      const result = await Promise.race([
+        pagePromise.then(() => "resolved" as const),
+        new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+      ]);
+
+      expect(result).toBe("resolved");
+    } finally {
+      balances.resolve(Response.json({ data: { walletBalances: { balances: [solBalance] } } }));
+      policy.resolve(new Response(null, { status: 404 }));
+      ownedTokens.resolve(Response.json({ data: [] }));
+      await pagePromise;
+    }
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
@@ -90,6 +90,7 @@ export function WalletActivitySection({ walletId, isVisible = true }: WalletActi
     mutate,
   } = useSWR(`wallet-activity-${walletId}`, () => fetchWalletActivity(walletId), {
     revalidateOnFocus: isVisible,
+    revalidateOnReconnect: isVisible,
     refreshWhenHidden: false,
     refreshInterval: isVisible ? 20_000 : 0,
   });

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExternalLink, RefreshCwIcon } from "lucide-react";
+import { useEffect, useRef } from "react";
 import useSWR from "swr";
 import {
   fetchWalletActivity,
@@ -94,6 +95,14 @@ export function WalletActivitySection({ walletId, isVisible = true }: WalletActi
     refreshWhenHidden: false,
     refreshInterval: isVisible ? 20_000 : 0,
   });
+  const previousIsVisible = useRef(isVisible);
+
+  useEffect(() => {
+    if (isVisible && !previousIsVisible.current) {
+      void mutate();
+    }
+    previousIsVisible.current = isVisible;
+  }, [isVisible, mutate]);
 
   if (!swrActivity && !requestError) {
     return (

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-section.tsx
@@ -7,6 +7,10 @@ import {
   type WalletActivityPayload,
   type WalletActivityRow,
 } from "@/app/dashboard/custody/wallet-activity.data";
+import {
+  WALLET_ACTIVITY_HEADING_ID,
+  WalletActivitySkeleton,
+} from "@/app/dashboard/custody/wallet-activity-skeleton";
 import { getDevnetExplorerUrl } from "@/app/dashboard/payments/payments-workspace.data";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -23,9 +27,15 @@ import { useLocale, useTranslations } from "@/i18n/provider";
 import { formatDisplayAmount } from "../payments/payments-overview.utils";
 
 interface WalletActivitySectionProps {
+  isVisible?: boolean;
   walletId: string;
-  initialActivity: WalletActivityPayload;
 }
+
+const EMPTY_WALLET_ACTIVITY: WalletActivityPayload = {
+  activityRows: [],
+  activityError: null,
+  activityNotice: null,
+};
 
 function formatTimestamp(value: string | undefined, locale: string): string {
   if (!value) {
@@ -70,24 +80,31 @@ function TruncatedText({ value, className }: { value: string; className?: string
   );
 }
 
-export function WalletActivitySection({ walletId, initialActivity }: WalletActivitySectionProps) {
+export function WalletActivitySection({ walletId, isVisible = true }: WalletActivitySectionProps) {
   const t = useTranslations();
   const locale = useLocale();
-  const hasInitialActivity = initialActivity.activityError === null;
   const {
     data: swrActivity,
     error: requestError,
     isValidating,
     mutate,
   } = useSWR(`wallet-activity-${walletId}`, () => fetchWalletActivity(walletId), {
-    fallbackData: initialActivity,
-    revalidateOnMount: hasInitialActivity ? false : undefined,
-    revalidateIfStale: hasInitialActivity ? false : undefined,
-    revalidateOnFocus: true,
+    revalidateOnFocus: isVisible,
     refreshWhenHidden: false,
-    refreshInterval: 20_000,
+    refreshInterval: isVisible ? 20_000 : 0,
   });
-  const liveActivity = swrActivity ?? initialActivity;
+
+  if (!swrActivity && !requestError) {
+    return (
+      <WalletActivitySkeleton
+        title={t("DashboardCustody.recentActivity")}
+        description={t("DashboardCustody.recentActivityDescription")}
+        headingId={WALLET_ACTIVITY_HEADING_ID}
+      />
+    );
+  }
+
+  const liveActivity = swrActivity ?? EMPTY_WALLET_ACTIVITY;
   const liveRows = Array.isArray(liveActivity.activityRows) ? liveActivity.activityRows : [];
   const requestErrorMessage = requestError
     ? requestError instanceof Error
@@ -100,10 +117,15 @@ export function WalletActivitySection({ walletId, initialActivity }: WalletActiv
     requestErrorMessage && liveRows.length > 0 ? requestErrorMessage : liveActivity.activityNotice;
 
   return (
-    <Card className="min-w-0 overflow-hidden">
+    <Card
+      aria-labelledby={WALLET_ACTIVITY_HEADING_ID}
+      className="min-h-[22rem] min-w-0 overflow-hidden"
+    >
       <CardHeader className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
-          <CardTitle>{t("DashboardCustody.recentActivity")}</CardTitle>
+          <CardTitle>
+            <h3 id={WALLET_ACTIVITY_HEADING_ID}>{t("DashboardCustody.recentActivity")}</h3>
+          </CardTitle>
           <CardDescription>{t("DashboardCustody.recentActivityDescription")}</CardDescription>
         </div>
         <Button

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-skeleton.tsx
@@ -1,0 +1,73 @@
+import { SkeletonBlock } from "@/components/ui/skeleton-block";
+
+const SKELETON_ROWS = ["one", "two", "three"] as const;
+const SKELETON_COLUMNS = [
+  "status",
+  "asset",
+  "direction",
+  "counterparty",
+  "signature",
+  "created",
+] as const;
+export const WALLET_ACTIVITY_HEADING_ID = "wallet-activity-heading";
+
+interface WalletActivitySkeletonProps {
+  description?: string;
+  headingId?: string;
+  title?: string;
+}
+
+export function WalletActivitySkeleton({
+  description,
+  headingId,
+  title,
+}: WalletActivitySkeletonProps = {}) {
+  return (
+    <div
+      aria-busy="true"
+      className="min-h-[22rem] min-w-0 overflow-hidden rounded-[var(--sdp-surface-radius)] bg-surface-raised py-6 text-primary shadow-sm ring-1 ring-border-default"
+      data-skeleton-section="wallet-activity"
+    >
+      <div className="flex min-w-0 flex-col gap-3 px-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          {title ? (
+            <h3 id={headingId} className="text-[19px] leading-6 font-medium text-primary">
+              {title}
+            </h3>
+          ) : (
+            <SkeletonBlock className="h-6 w-40" />
+          )}
+          {description ? (
+            <p className="text-sm text-secondary">{description}</p>
+          ) : (
+            <SkeletonBlock className="h-4 w-72 max-w-full" />
+          )}
+        </div>
+        <SkeletonBlock className="h-9 w-24 shrink-0 rounded-lg" />
+      </div>
+
+      <div className="mt-6 px-6">
+        <div className="overflow-hidden rounded-xl border border-border-subtle">
+          <div className="hidden grid-cols-[9rem_1fr_8rem_1fr_1fr_10rem] gap-4 bg-fill-subtle px-4 py-3 md:grid">
+            {SKELETON_COLUMNS.map((column) => (
+              <SkeletonBlock key={column} className="h-3 w-full max-w-20" />
+            ))}
+          </div>
+          {SKELETON_ROWS.map((row) => (
+            <div
+              key={row}
+              className="grid min-h-14 grid-cols-[7rem_minmax(0,1fr)] items-center gap-4 border-t border-border-subtle px-4 py-3 first:border-t-0 md:grid-cols-[9rem_minmax(0,1fr)_8rem_minmax(0,1fr)_minmax(0,1fr)_10rem]"
+            >
+              <SkeletonBlock className="h-6 w-20 rounded-full" />
+              <SkeletonBlock className="h-4 w-full max-w-28" />
+              <SkeletonBlock className="hidden h-4 w-16 md:block" />
+              <SkeletonBlock className="hidden h-4 w-full max-w-32 md:block" />
+              <SkeletonBlock className="hidden h-4 w-full max-w-28 md:block" />
+              <SkeletonBlock className="hidden h-4 w-20 md:block" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-viewport.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-viewport.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { WalletActivitySection } from "@/app/dashboard/custody/wallet-activity-section";
+import {
+  WALLET_ACTIVITY_HEADING_ID,
+  WalletActivitySkeleton,
+} from "@/app/dashboard/custody/wallet-activity-skeleton";
+import { useTranslations } from "@/i18n/provider";
+
+export const WALLET_ACTIVITY_ROOT_MARGIN = "256px 0px";
+
+interface WalletActivityViewportContentProps {
+  isVisible: boolean;
+  isNearViewport: boolean;
+  walletId: string;
+}
+
+export function WalletActivityViewportContent({
+  isVisible,
+  isNearViewport,
+  walletId,
+}: WalletActivityViewportContentProps) {
+  const t = useTranslations();
+
+  if (isNearViewport) {
+    return (
+      <div data-wallet-activity-loader="mounted">
+        <WalletActivitySection walletId={walletId} isVisible={isVisible} />
+      </div>
+    );
+  }
+
+  return (
+    <WalletActivitySkeleton
+      title={t("DashboardCustody.recentActivity")}
+      description={t("DashboardCustody.recentActivityDescription")}
+      headingId={WALLET_ACTIVITY_HEADING_ID}
+    />
+  );
+}
+
+export function WalletActivityViewport({ walletId }: { walletId: string }) {
+  const regionRef = useRef<HTMLElement>(null);
+  const [isNearViewport, setIsNearViewport] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const region = regionRef.current;
+    if (!region) return;
+
+    if (!("IntersectionObserver" in window)) {
+      setIsNearViewport(true);
+      setIsVisible(true);
+      return;
+    }
+
+    const loadObserver = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+
+        loadObserver.disconnect();
+        setIsNearViewport(true);
+      },
+      { rootMargin: WALLET_ACTIVITY_ROOT_MARGIN }
+    );
+    const visibilityObserver = new IntersectionObserver((entries) => {
+      const nextIsVisible = entries.some((entry) => entry.isIntersecting);
+      setIsVisible(nextIsVisible);
+      if (nextIsVisible) setIsNearViewport(true);
+    });
+
+    loadObserver.observe(region);
+    visibilityObserver.observe(region);
+    return () => {
+      loadObserver.disconnect();
+      visibilityObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <section
+      ref={regionRef}
+      id="recent-activity"
+      aria-labelledby={WALLET_ACTIVITY_HEADING_ID}
+      className="scroll-mt-6"
+      data-wallet-activity-state={isNearViewport ? "mounted" : "deferred"}
+      data-wallet-activity-visible={isVisible ? "true" : "false"}
+    >
+      <WalletActivityViewportContent
+        isNearViewport={isNearViewport}
+        isVisible={isVisible}
+        walletId={walletId}
+      />
+    </section>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/custody/wallet-activity-viewport.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/wallet-activity-viewport.unit.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/i18n/provider", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/app/dashboard/custody/wallet-activity-section", () => ({
+  WalletActivitySection: ({ isVisible }: { isVisible: boolean }) => (
+    <div data-activity-fetcher="mounted" data-activity-fetcher-visible={String(isVisible)} />
+  ),
+}));
+
+import { WalletActivityViewportContent } from "./wallet-activity-viewport";
+
+describe("WalletActivityViewportContent", () => {
+  it("keeps the fetcher unmounted until the near-viewport observer latches", () => {
+    const deferredMarkup = renderToStaticMarkup(
+      <WalletActivityViewportContent
+        isNearViewport={false}
+        isVisible={false}
+        walletId="wallet-one"
+      />
+    );
+    const mountedMarkup = renderToStaticMarkup(
+      <WalletActivityViewportContent isNearViewport isVisible={false} walletId="wallet-one" />
+    );
+
+    expect(deferredMarkup).not.toContain('data-activity-fetcher="mounted"');
+    expect(deferredMarkup).toContain("DashboardCustody.recentActivity");
+    expect(mountedMarkup.match(/data-activity-fetcher="mounted"/g)).toHaveLength(1);
+    expect(mountedMarkup).toContain('data-activity-fetcher-visible="false"');
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/wallets/wallet-route-skeletons.tsx
+++ b/apps/sdp-web/src/app/dashboard/wallets/wallet-route-skeletons.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from "lucide-react";
+import { WalletActivitySkeleton } from "@/app/dashboard/custody/wallet-activity-skeleton";
 import { DashboardWorkspaceOverviewPanel } from "@/components/dashboard-workspace-panel";
 import { SkeletonBlock } from "@/components/ui/skeleton-block";
 import {
@@ -167,7 +168,7 @@ function WalletSummaryCardSkeleton({ compact = false }: { compact?: boolean }) {
   );
 }
 
-function WalletControlsSkeleton() {
+export function WalletControlsSkeleton() {
   return (
     <section
       className="overflow-hidden rounded-2xl border border-border-default bg-surface-raised"
@@ -195,6 +196,32 @@ function WalletControlsSkeleton() {
   );
 }
 
+export function WalletBalanceSummarySkeleton() {
+  return <WalletSummaryCardSkeleton compact />;
+}
+
+export function WalletBalancesSkeleton() {
+  return (
+    <section className="space-y-3" data-skeleton-section="wallet-balances">
+      <Pulse className="h-10 w-36" />
+      <div className="overflow-hidden rounded-2xl border border-border-default bg-surface-raised">
+        {THREE_ITEMS.map((row) => (
+          <div
+            key={row}
+            className="flex min-h-[58px] items-center justify-between gap-4 border-b border-border-subtle px-4 py-3 last:border-b-0"
+          >
+            <div className="space-y-2">
+              <Pulse className="h-5 w-20" />
+              <Pulse className="h-3 w-48 sm:w-56" />
+            </div>
+            <Pulse className="h-4 w-24" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function WalletDetailSkeleton() {
   return (
     <DashboardWorkspaceOverviewPanel className="space-y-6">
@@ -204,43 +231,11 @@ export function WalletDetailSkeleton() {
         </div>
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
           <WalletSummaryCardSkeleton />
-          <WalletSummaryCardSkeleton compact />
+          <WalletBalanceSummarySkeleton />
         </div>
         <WalletControlsSkeleton />
-        <section className="space-y-3" data-skeleton-section="wallet-balances">
-          <Pulse className="h-10 w-36" />
-          <div className="overflow-hidden rounded-2xl border border-border-default bg-surface-raised">
-            {THREE_ITEMS.map((row) => (
-              <div
-                key={row}
-                className="flex min-h-[58px] items-center justify-between gap-4 border-b border-border-subtle px-4 py-3 last:border-b-0"
-              >
-                <div className="space-y-2">
-                  <Pulse className="h-5 w-20" />
-                  <Pulse className="h-3 w-48 sm:w-56" />
-                </div>
-                <Pulse className="h-4 w-24" />
-              </div>
-            ))}
-          </div>
-        </section>
-        <section
-          className="rounded-2xl border border-border-default bg-surface-raised p-6"
-          data-skeleton-section="wallet-activity"
-        >
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="space-y-2">
-              <Pulse className="h-7 w-40" />
-              <Pulse className="h-4 w-72 max-w-full" />
-            </div>
-            <Pulse className="h-9 w-24 rounded-lg" />
-          </div>
-          <div className="mt-6 space-y-3">
-            {THREE_ITEMS.map((row) => (
-              <Pulse key={row} className="h-10 w-full rounded-[10px]" />
-            ))}
-          </div>
-        </section>
+        <WalletBalancesSkeleton />
+        <WalletActivitySkeleton />
       </LoadingRegion>
     </DashboardWorkspaceOverviewPanel>
   );


### PR DESCRIPTION
## Summary

- stream the wallet detail shell from metadata-only identity data while balances, policy controls, and token links resolve in independent Suspense boundaries
- defer Recent activity until it approaches the viewport, then pause polling, focus revalidation, and reconnect revalidation whenever it is offscreen
- preserve layout with route-specific skeletons and retain existing activity rows when a refresh fails

## Verification

- pnpm --filter sdp-web test:unit (33 files, 153 tests passed)
- pnpm --filter sdp-web typecheck
- pnpm exec biome check on all 9 changed files
- pnpm --filter sdp-web build (42 static pages generated)
- authenticated Playwright wallet activity regression (2 passed in 30.4s)
  - no activity request before the section approaches the viewport
  - exactly one request after scrolling it into view
  - no additional request after scrolling away and dispatching offline/online
  - refresh failure keeps the existing activity row visible

## Notes

- rebased onto c3c41b59 (latest origin/main at verification time)
- intentionally left as a draft pending review