### PR TITLE
fix(web): harmonize payments list tables

### DIFF
--- a/apps/sdp-web/messages/en/dashboard-payments.json
+++ b/apps/sdp-web/messages/en/dashboard-payments.json
@@ -239,7 +239,7 @@
       "searchWallets": "Search wallets",
       "amount": "Amount",
       "asset": "Asset",
-      "selectAsset": "Select an asset",
+      "selectAsset": "Select",
       "memoOptional": "Memo (optional)",
       "memoPlaceholder": "Add a note for this transfer",
       "to": "To",

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-workspace.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DashboardWorkspaceTabShell } from "@/components/dashboard-workspace-tab-shell";
 import { ArrowPagination } from "@/components/ui/arrow-pagination";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -238,7 +239,10 @@ export function CounterpartyWorkspace({
                       </button>
                     ))}
                   </div>
-                  <Table className="hidden [&_table]:table-fixed md:block">
+                  <Table
+                    className="hidden rounded-none border-0 [&_table]:min-w-[880px] [&_table]:table-fixed md:block"
+                    data-counterparty-directory-table
+                  >
                     <TableHeader>
                       <TableRow>
                         <TableHead className="w-[30%]">
@@ -265,17 +269,17 @@ export function CounterpartyWorkspace({
                           <TableCell className="font-medium">
                             <span className="block truncate">{cp.displayName}</span>
                           </TableCell>
-                          <TableCell className="text-sm">
-                            <span className="block truncate">
+                          <TableCell>
+                            <Badge>
                               {cp.entityType === "individual"
                                 ? t("DashboardPayments.counterparty.individual")
                                 : t("DashboardPayments.counterparty.business")}
-                            </span>
+                            </Badge>
                           </TableCell>
-                          <TableCell className="text-sm">
+                          <TableCell className="text-sm text-secondary">
                             <span className="block truncate">{cp.email}</span>
                           </TableCell>
-                          <TableCell className="font-mono text-sm">
+                          <TableCell className="font-mono text-xs text-secondary">
                             <span className="block truncate">{cp.externalId ?? "—"}</span>
                           </TableCell>
                           <TableCell className="text-sm text-secondary">

--- a/apps/sdp-web/src/app/dashboard/payments/payments-route-skeletons.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-route-skeletons.tsx
@@ -105,7 +105,7 @@ const TABLE_SKELETON_CONFIGS: Record<TableSkeletonVariant, TableSkeletonConfig> 
         id: "type",
         headerClassName: "w-[12%]",
         headerSkeletonClassName: "h-4 w-12",
-        cellSkeletonClassName: "h-4 w-16 max-w-full",
+        cellSkeletonClassName: "h-4 w-16 max-w-full rounded-full",
       },
       {
         id: "email",

--- a/apps/sdp-web/src/app/dashboard/payments/payments-route-skeletons.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-route-skeletons.tsx
@@ -56,7 +56,7 @@ interface TableSkeletonConfig {
 
 const TABLE_SKELETON_CONFIGS: Record<TableSkeletonVariant, TableSkeletonConfig> = {
   "payment-requests": {
-    tableClassName: "[&_table]:table-fixed",
+    tableClassName: "rounded-none border-0 [&_table]:min-w-[800px] [&_table]:table-fixed",
     containerClassName: "min-h-0 flex-1 overflow-y-auto",
     columns: [
       {

--- a/apps/sdp-web/src/app/dashboard/payments/payments-route-skeletons.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-route-skeletons.tsx
@@ -92,7 +92,7 @@ const TABLE_SKELETON_CONFIGS: Record<TableSkeletonVariant, TableSkeletonConfig> 
     ],
   },
   "counterparty-directory": {
-    tableClassName: "[&_table]:table-fixed",
+    tableClassName: "rounded-none border-0 [&_table]:min-w-[880px] [&_table]:table-fixed",
     containerClassName: "min-h-0 flex-1 overflow-y-auto",
     columns: [
       {

--- a/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/requests/payment-requests-workspace.tsx
@@ -601,7 +601,7 @@ export function PaymentRequestsWorkspace({
                       );
                     })}
                   </div>
-                  <Table className="hidden [&_table]:table-fixed md:block">
+                  <Table className="hidden rounded-none border-0 [&_table]:min-w-[800px] [&_table]:table-fixed md:block">
                     <TableHeader>
                       <TableRow>
                         <TableHead className="w-[16%]">{t("DashboardPayments.status")}</TableHead>


### PR DESCRIPTION
## What changed
- align Counterparty and Payment Requests list tables with the newer payments/policies single-border table treatment
- use restrained entity badges and muted secondary metadata in Counterparty
- keep both route skeletons visually consistent with their loaded tables
- shorten the single-send asset picker placeholder to `Select` so it stays on one line

## Local validation
- focused Biome checks on every changed file
- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web test:unit` (48 files, 264 tests)
- booted the app with Doppler and verified authenticated Counterparty and Pay routes render without runtime errors

## Visual QA
- Counterparty and Requests tables no longer add a second rounded border inside their page card
- Counterparty type uses the shared badge treatment
- Pay asset picker uses the one-line `Select` placeholder