### PR TITLE
feat(payments): enable MoneyGram on-ramp with self-hosted pinned widget SDK

### DIFF
--- a/apps/sdp-api/.ramp-rails/moneygram.support.json
+++ b/apps/sdp-api/.ramp-rails/moneygram.support.json
@@ -1,7 +1,12 @@
 {
   "onramp": {
-    "currencies": {},
-    "cryptos": []
+    "currencies": {
+      "USD": {
+        "min": null,
+        "max": null
+      }
+    },
+    "cryptos": ["usdc.solana"]
   },
   "offramp": {
     "currencies": {

--- a/apps/sdp-api/src/routes/counterparties/schemas.ts
+++ b/apps/sdp-api/src/routes/counterparties/schemas.ts
@@ -41,9 +41,12 @@ export const counterpartyIdParamsSchema = z.object({
 
 export const counterpartyRequirementsQuerySchema = z.discriminatedUnion("direction", [
   z.object({
-    provider: z.enum(["moonpay", "lightspark", "bvnk", "coinbase", "mural", "stripe"], {
-      error: "provider does not support onramp requirements",
-    }),
+    provider: z.enum(
+      ["moonpay", "lightspark", "bvnk", "moneygram", "coinbase", "mural", "stripe"],
+      {
+        error: "provider does not support onramp requirements",
+      }
+    ),
     direction: z.literal("onramp"),
     cryptoToken: rampCurrencyCodeSchema,
     fiatCurrency: rampFiatCurrencySchema,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -600,8 +600,16 @@ export async function createOnrampQuote(c: AppContext): Promise<Response> {
       quote = muralOnrampQuote({ account, fiatCurrency: input.fiatCurrency });
       break;
     }
-    case "moneygram":
-      throw badRequest("MoneyGram on-ramp is not available.");
+    case "moneygram": {
+      quote = await RAMP_PROVIDER_CLIENTS.moneygram.createOnrampQuote(rampRuntime(c), {
+        cryptoToken: input.cryptoToken,
+        fiatCurrency: input.fiatCurrency,
+        fiatAmount: input.fiatAmount,
+        destinationWalletAddress,
+        externalCustomerId: counterparty.external_id ?? counterparty.id,
+      });
+      break;
+    }
     case "coinbase": {
       quote = await RAMP_PROVIDER_CLIENTS.coinbase.createOnrampQuote(rampRuntime(c), {
         cryptoToken: input.cryptoToken,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
@@ -1,4 +1,5 @@
 import { isRampEventProvider } from "@sdp/payments/ramps/shared";
+import type { MoneygramRampEvent } from "@sdp/types";
 import { z } from "zod";
 import type { PaymentTransferRow, PaymentTransferStatus } from "@/db/repositories";
 import { getAuth, requireProjectId } from "@/lib/auth";
@@ -142,6 +143,14 @@ async function recordCoinbaseRampEvent(c: AppContext, body: unknown) {
   }
 }
 
+const MONEYGRAM_EVENT_DIRECTION = {
+  onramp_completed: "onramp",
+  signed: "offramp",
+  completed: "offramp",
+  errored: null,
+  closed: null,
+} as const satisfies Record<MoneygramRampEvent["kind"], "onramp" | "offramp" | null>;
+
 async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
   const parsed = moneygramRampEventSchema.safeParse(body);
   if (!parsed.success) {
@@ -164,17 +173,38 @@ async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
   if (!transfer) {
     throw notFound("Ramp transfer");
   }
-  if (transfer.type !== "offramp") {
-    throw badRequest("MoneyGram events only apply to off-ramp transfers.");
-  }
   if (isTerminalRampStatus(transfer.status)) {
     return success(c, { transfer: mapTransferRow(transfer) });
+  }
+
+  const expectedDirection = MONEYGRAM_EVENT_DIRECTION[event.kind];
+  if (expectedDirection !== null && transfer.type !== expectedDirection) {
+    throw badRequest(
+      `MoneyGram ${event.kind} events only apply to ${expectedDirection} transfers.`
+    );
   }
 
   const moneygramData = readMoneygramData(transfer);
   const now = new Date().toISOString();
 
   switch (event.kind) {
+    case "onramp_completed": {
+      const updated = await repo.updateTransfer({
+        transferId: transfer.id,
+        status: "completed",
+        providerData: {
+          ...transfer.provider_data,
+          moneygram: {
+            ...moneygramData,
+            transactionId: event.transactionId,
+            payoutStatus: event.status,
+            ...(event.referenceNumber ? { referenceNumber: event.referenceNumber } : {}),
+          },
+        },
+        updatedAt: now,
+      });
+      return transferResponse(c, updated);
+    }
     case "signed": {
       if (transfer.status === "settling") {
         if (moneygramData.cryptoTransferId === event.cryptoTransferId) {
@@ -237,52 +267,8 @@ async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
       });
       return transferResponse(c, updated);
     }
-    case "errored": {
-      const moneygram = {
-        ...moneygramData,
-        ...(event.transactionId ? { transactionId: event.transactionId } : {}),
-      };
-      if (transfer.status === "settling") {
-        const updated = await repo.updateTransfer({
-          transferId: transfer.id,
-          providerData: {
-            ...transfer.provider_data,
-            moneygram: { ...moneygram, lastWidgetError: event.reason },
-          },
-          updatedAt: now,
-        });
-        return transferResponse(c, updated);
-      }
-      if (event.cryptoTransferId) {
-        const leg = await requireVerifiedCryptoLeg(c, transfer, event.cryptoTransferId, {
-          requireConfirmed: false,
-        });
-        const updated = await repo.updateTransfer({
-          transferId: transfer.id,
-          status: "settling",
-          amount: leg.amount,
-          providerData: {
-            ...transfer.provider_data,
-            moneygram: {
-              ...moneygram,
-              cryptoTransferId: leg.id,
-              solanaTxSignature: leg.signature,
-              lastWidgetError: event.reason,
-            },
-          },
-          updatedAt: now,
-        });
-        return transferResponse(c, updated);
-      }
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "failed",
-        error: event.reason,
-        providerData: { ...transfer.provider_data, moneygram },
-        updatedAt: now,
-      });
-      return transferResponse(c, updated);
-    }
+    case "errored":
+      return recordMoneygramErroredEvent(c, transfer, moneygramData, event, now);
     case "closed": {
       if (transfer.status !== "pending") {
         return success(c, { transfer: mapTransferRow(transfer) });
@@ -299,4 +285,58 @@ async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
       throw internalError(`Unhandled MoneyGram ramp event: ${JSON.stringify(exhaustive)}`);
     }
   }
+}
+
+async function recordMoneygramErroredEvent(
+  c: AppContext,
+  transfer: PaymentTransferRow,
+  moneygramData: Record<string, unknown>,
+  event: Extract<MoneygramRampEvent, { kind: "errored" }>,
+  now: string
+) {
+  const repo = getPaymentsRepository(c);
+  const moneygram = {
+    ...moneygramData,
+    ...(event.transactionId ? { transactionId: event.transactionId } : {}),
+  };
+  if (transfer.type === "offramp" && transfer.status === "settling") {
+    const updated = await repo.updateTransfer({
+      transferId: transfer.id,
+      providerData: {
+        ...transfer.provider_data,
+        moneygram: { ...moneygram, lastWidgetError: event.reason },
+      },
+      updatedAt: now,
+    });
+    return transferResponse(c, updated);
+  }
+  if (transfer.type === "offramp" && event.cryptoTransferId) {
+    const leg = await requireVerifiedCryptoLeg(c, transfer, event.cryptoTransferId, {
+      requireConfirmed: false,
+    });
+    const updated = await repo.updateTransfer({
+      transferId: transfer.id,
+      status: "settling",
+      amount: leg.amount,
+      providerData: {
+        ...transfer.provider_data,
+        moneygram: {
+          ...moneygram,
+          cryptoTransferId: leg.id,
+          solanaTxSignature: leg.signature,
+          lastWidgetError: event.reason,
+        },
+      },
+      updatedAt: now,
+    });
+    return transferResponse(c, updated);
+  }
+  const updated = await repo.updateTransfer({
+    transferId: transfer.id,
+    status: "failed",
+    error: event.reason,
+    providerData: { ...transfer.provider_data, moneygram },
+    updatedAt: now,
+  });
+  return transferResponse(c, updated);
 }

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
@@ -197,6 +197,7 @@ async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
           moneygram: {
             ...moneygramData,
             transactionId: event.transactionId,
+            payoutAmount: event.amount,
             payoutStatus: event.status,
             ...(event.referenceNumber ? { referenceNumber: event.referenceNumber } : {}),
           },

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -708,6 +708,13 @@ export const createOfframpQuoteSchema = z.object({
 
 export const moneygramRampEventSchema = z.discriminatedUnion("kind", [
   z.object({
+    kind: z.literal("onramp_completed"),
+    sessionId: z.string().min(1),
+    transactionId: z.string().min(1),
+    status: z.string().min(1),
+    referenceNumber: z.string().min(1).optional(),
+  }),
+  z.object({
     kind: z.literal("signed"),
     sessionId: z.string().min(1),
     cryptoTransferId: z.string().min(1),

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -712,6 +712,7 @@ export const moneygramRampEventSchema = z.discriminatedUnion("kind", [
     sessionId: z.string().min(1),
     transactionId: z.string().min(1),
     status: z.string().min(1),
+    amount: z.number().positive(),
     referenceNumber: z.string().min(1).optional(),
   }),
   z.object({

--- a/apps/sdp-web/src/app/api/vendor/moneygram/sdk/[version]/route.ts
+++ b/apps/sdp-web/src/app/api/vendor/moneygram/sdk/[version]/route.ts
@@ -5,24 +5,26 @@ const MONEYGRAM_SDK_UPSTREAM_URL = "https://playground.xramps.moneygram.com/sdk/
 
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, s-maxage=31536000, immutable";
 
-let verifiedSdk: ArrayBuffer | null = null;
+let verifiedSdkPromise: Promise<ArrayBuffer> | null = null;
 
-/** Fetches the upstream SDK once per server instance; the URL is keyed by content hash, so a verified buffer never goes stale. */
-async function fetchVerifiedSdk(): Promise<ArrayBuffer> {
-  if (verifiedSdk) {
-    return verifiedSdk;
-  }
-  const upstream = await fetch(MONEYGRAM_SDK_UPSTREAM_URL, { cache: "no-store" });
-  if (!upstream.ok) {
-    throw new Error("MoneyGram SDK is unavailable.");
-  }
-  const sdk = await upstream.arrayBuffer();
-  const digest = createHash("sha256").update(new Uint8Array(sdk)).digest("hex");
-  if (digest !== MONEYGRAM_SDK_VERSION) {
-    throw new Error("MoneyGram SDK integrity check failed.");
-  }
-  verifiedSdk = sdk;
-  return sdk;
+/** Fetches the upstream SDK once per server instance; concurrent cold-start requests coalesce onto the in-flight fetch, and the URL is keyed by content hash so a verified buffer never goes stale. */
+function fetchVerifiedSdk(): Promise<ArrayBuffer> {
+  verifiedSdkPromise ??= (async () => {
+    const upstream = await fetch(MONEYGRAM_SDK_UPSTREAM_URL, { cache: "no-store" });
+    if (!upstream.ok) {
+      throw new Error("MoneyGram SDK is unavailable.");
+    }
+    const sdk = await upstream.arrayBuffer();
+    const digest = createHash("sha256").update(new Uint8Array(sdk)).digest("hex");
+    if (digest !== MONEYGRAM_SDK_VERSION) {
+      throw new Error("MoneyGram SDK integrity check failed.");
+    }
+    return sdk;
+  })();
+  verifiedSdkPromise.catch(() => {
+    verifiedSdkPromise = null;
+  });
+  return verifiedSdkPromise;
 }
 
 export async function GET(

--- a/apps/sdp-web/src/app/api/vendor/moneygram/sdk/[version]/route.ts
+++ b/apps/sdp-web/src/app/api/vendor/moneygram/sdk/[version]/route.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { MONEYGRAM_SDK_VERSION } from "@/lib/moneygram-sdk";
+
+const MONEYGRAM_SDK_UPSTREAM_URL = "https://playground.xramps.moneygram.com/sdk/index.global.js";
+
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, s-maxage=31536000, immutable";
+
+let verifiedSdk: ArrayBuffer | null = null;
+
+/** Fetches the upstream SDK once per server instance; the URL is keyed by content hash, so a verified buffer never goes stale. */
+async function fetchVerifiedSdk(): Promise<ArrayBuffer> {
+  if (verifiedSdk) {
+    return verifiedSdk;
+  }
+  const upstream = await fetch(MONEYGRAM_SDK_UPSTREAM_URL, { cache: "no-store" });
+  if (!upstream.ok) {
+    throw new Error("MoneyGram SDK is unavailable.");
+  }
+  const sdk = await upstream.arrayBuffer();
+  const digest = createHash("sha256").update(new Uint8Array(sdk)).digest("hex");
+  if (digest !== MONEYGRAM_SDK_VERSION) {
+    throw new Error("MoneyGram SDK integrity check failed.");
+  }
+  verifiedSdk = sdk;
+  return sdk;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ version: string }> }
+): Promise<Response> {
+  const { version } = await params;
+  if (version !== MONEYGRAM_SDK_VERSION) {
+    return new Response("MoneyGram SDK version not found.", { status: 404 });
+  }
+
+  let sdk: ArrayBuffer;
+  try {
+    sdk = await fetchVerifiedSdk();
+  } catch (error) {
+    return new Response(error instanceof Error ? error.message : "MoneyGram SDK is unavailable.", {
+      status: 502,
+    });
+  }
+
+  return new Response(sdk, {
+    headers: {
+      "Cache-Control": IMMUTABLE_CACHE_CONTROL,
+      "Content-Type": "text/javascript; charset=utf-8",
+      ETag: `"${MONEYGRAM_SDK_VERSION}"`,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
@@ -11,6 +11,7 @@ import {
   postMoneygramRampEvent,
 } from "@/app/dashboard/payments/payments-workspace.data";
 import { useTranslations } from "@/i18n/provider";
+import { MONEYGRAM_SDK_URL } from "@/lib/moneygram-sdk";
 
 const SESSION_REFRESH_MS = 50 * 60 * 1000;
 
@@ -225,7 +226,19 @@ function buildOfframpTransactionPrefill(
   };
 }
 
+function buildOnrampTransactionPrefill(
+  fiatAmount: string,
+  cryptoAsset: CryptoAssetSymbol
+): MoneygramRampsConfig["transaction"] {
+  return {
+    type: "on-ramp",
+    amount: toNumberAmount(fiatAmount),
+    asset: cryptoAsset,
+  };
+}
+
 export interface MoneygramRampWidgetProps {
+  direction: "onramp" | "offramp";
   quote: Extract<PaymentRampQuote, { provider: "moneygram" }>;
   counterparty: Counterparty | null;
   sourceWalletId: string;
@@ -239,6 +252,7 @@ export interface MoneygramRampWidgetProps {
 }
 
 export function MoneygramRampWidget({
+  direction,
   quote,
   counterparty,
   sourceWalletId,
@@ -273,7 +287,7 @@ export function MoneygramRampWidget({
     if (!container) {
       return;
     }
-    const { sessionId, sessionToken, widgetUrl, sdkUrl } = quote;
+    const { sessionId, sessionToken, widgetUrl } = quote;
     const mountPoint = document.createElement("div");
     mountPoint.className = "h-full w-full";
     container.appendChild(mountPoint);
@@ -292,7 +306,7 @@ export function MoneygramRampWidget({
       });
     };
 
-    loadRampsSdk(sdkUrl)
+    loadRampsSdk(MONEYGRAM_SDK_URL)
       .then((sdk) => {
         if (cancelled) {
           return;
@@ -310,12 +324,15 @@ export function MoneygramRampWidget({
             displayName: sourceWalletName,
           },
           customer: buildCustomerPrefill(counterparty),
-          transaction: buildOfframpTransactionPrefill(
-            fiatCurrency,
-            cryptoAsset,
-            cryptoAmount,
-            counterparty
-          ),
+          transaction:
+            direction === "onramp"
+              ? buildOnrampTransactionPrefill(cryptoAmount, cryptoAsset)
+              : buildOfframpTransactionPrefill(
+                  fiatCurrency,
+                  cryptoAsset,
+                  cryptoAmount,
+                  counterparty
+                ),
           onSignTransaction: async (tx) => {
             if (tx.chain !== "solana" || tx.asset !== cryptoAsset) {
               throw new Error(
@@ -357,6 +374,18 @@ export function MoneygramRampWidget({
             return transfer.signature;
           },
           onComplete: (transaction) => {
+            if (direction === "onramp") {
+              post({
+                kind: "onramp_completed",
+                sessionId,
+                transactionId: transaction.id,
+                status: transaction.status,
+                ...(transaction.referenceNumber
+                  ? { referenceNumber: transaction.referenceNumber }
+                  : {}),
+              });
+              return;
+            }
             const cryptoTransferId = signedTransferIdRef.current;
             if (!cryptoTransferId) {
               toast.error(t("DashboardPayments.ramps.moneygramCompletionBeforeTransfer"), {
@@ -410,6 +439,7 @@ export function MoneygramRampWidget({
   }, [
     quote,
     counterparty,
+    direction,
     fiatCurrency,
     cryptoAsset,
     sourceWalletId,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/moneygram-ramp-widget.tsx
@@ -380,6 +380,7 @@ export function MoneygramRampWidget({
                 sessionId,
                 transactionId: transaction.id,
                 status: transaction.status,
+                amount: transaction.amount,
                 ...(transaction.referenceNumber
                   ? { referenceNumber: transaction.referenceNumber }
                   : {}),

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/offramp-step-content.tsx
@@ -220,6 +220,7 @@ export function OfframpStepContent({ wizard }: { wizard: OfframpWizard }) {
     return (
       <div className="space-y-6">
         <MoneygramRampWidget
+          direction="offramp"
           quote={quote}
           counterparty={selectedCounterparty}
           sourceWalletId={fields.walletId}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { isMuralSandboxPayinCurrency } from "@sdp/types";
+import { getCryptoRailAssetLabel } from "@sdp/types/payment-rails";
 import { DollarSignIcon } from "lucide-react";
 import { useTranslations } from "@/i18n/provider";
 import { hasEnabledRampProvider } from "@/lib/provider-availability";
@@ -8,6 +9,7 @@ import { toRampCryptoToken } from "@/lib/ramps";
 import type { OnrampWizard } from "../hooks/use-onramp-wizard";
 import { CoinbaseRampFrame } from "./coinbase/ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
+import { MoneygramRampWidget } from "./moneygram-ramp-widget";
 import { MoonpayRampFrame } from "./moonpay-ramp-frame";
 import { hasOnboardingLifecycle, simulateActionLabels } from "./providers";
 import { RampCompleteScreen } from "./ramp-complete-screen";
@@ -42,6 +44,7 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     collectedData,
     setCollectedField,
     requirementsBlocker,
+    refreshQuote,
   } = wizard;
 
   if (currentStepId === "DEPOSIT") {
@@ -112,6 +115,32 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
         <StripeOnrampFrame
           clientSecret={quote.clientSecret}
           publishableKey={quote.publishableKey}
+        />
+        <div className="border-t border-border-default pt-5">
+          <RampStatusPanel direction="onramp" transfer={transferStatus} />
+        </div>
+      </div>
+    );
+  }
+
+  if (currentStepId === "PROVIDER" && quote?.provider === "moneygram") {
+    if (!selectedWallet) {
+      return <RampQuoteSkeleton />;
+    }
+    return (
+      <div className="space-y-6">
+        <MoneygramRampWidget
+          direction="onramp"
+          quote={quote}
+          counterparty={selectedCounterparty}
+          sourceWalletId={fields.walletId}
+          sourceWalletName={selectedWallet.label ?? selectedWallet.walletId}
+          sourceWalletAddress={selectedWallet.publicKey}
+          sourceTokenMint={null}
+          cryptoAsset={getCryptoRailAssetLabel(selectedRampPair.assetRail)}
+          cryptoAmount={fields.amount.trim()}
+          fiatCurrency={selectedRampPair.fiatCurrency}
+          onSessionExpiring={refreshQuote}
         />
         <div className="border-t border-border-default pt-5">
           <RampStatusPanel direction="onramp" transfer={transferStatus} />

--- a/apps/sdp-web/src/lib/moneygram-sdk.ts
+++ b/apps/sdp-web/src/lib/moneygram-sdk.ts
@@ -1,0 +1,4 @@
+export const MONEYGRAM_SDK_VERSION =
+  "7fb658f3553036d8eaf1788ea9ad6ef4b51b27e922c212d54d84c0c454c534c6";
+
+export const MONEYGRAM_SDK_URL = `/api/vendor/moneygram/sdk/${MONEYGRAM_SDK_VERSION}`;

--- a/packages/sdp-payments/src/ramps/providers/moneygram/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/moneygram/client.ts
@@ -24,6 +24,7 @@ import type {
   RampEstimateOfframpInput,
   RampEstimateOnrampInput,
   RampOfframpQuoteInput,
+  RampOnrampQuoteInput,
   RampProvider,
   RampRawDumpReader,
   RampRuntimeContext,
@@ -35,7 +36,7 @@ const MONEYGRAM_SANDBOX_BASE_URL = "https://playground.xramps.moneygram.com";
 export const MONEYGRAM_DECLARED_RAIL_SUPPORT = {
   onramp: {
     countrySupport: UNREPORTED_COUNTRY_SUPPORT,
-    entityTypes: [],
+    entityTypes: ["individual"],
   },
   offramp: {
     countrySupport: UNREPORTED_COUNTRY_SUPPORT,
@@ -49,6 +50,11 @@ const MONEYGRAM_OFFRAMP_DESTINATION: Partial<Record<RampFiatCurrency, string>> =
 };
 
 const MONEYGRAM_ORIGINATING_COUNTRY = "USA";
+
+const MONEYGRAM_ONRAMP_DESTINATION = {
+  country: "USA",
+  subdivision: "US-TX",
+} as const;
 
 const moneygramCurrencyEntrySchema = z.object({
   code: z.string(),
@@ -69,6 +75,24 @@ const withdrawEstimateSchema = z.object({
     fxRate: z.number(),
     totalAmount: amountDetailSchema,
   }),
+});
+
+const cashInQuoteSchema = z.object({
+  serviceOptions: z.array(
+    z.object({
+      serviceOptionCode: z.string(),
+      quote: z.object({
+        sendAmount: z.object({ value: z.string(), currency: z.string() }),
+        receiveAmount: z.object({ value: z.string(), currency: z.string() }),
+        fees: z.object({
+          mgi: z.object({ value: z.string(), currency: z.string() }),
+          partner: z.object({ value: z.string(), currency: z.string() }),
+          total: z.object({ value: z.string(), currency: z.string() }),
+        }),
+        exchangeRate: z.number(),
+      }),
+    })
+  ),
 });
 
 const sessionSchema = z.object({
@@ -108,8 +132,8 @@ export function distillMoneygramRailSupport(raw: unknown): ProviderRailSupportDi
   return {
     snapshot: {
       onramp: {
-        currencies: {},
-        cryptos: [],
+        currencies: { USD: unreportedCurrencyLimit() },
+        cryptos: ["usdc.solana"],
       },
       offramp: {
         currencies: offrampCurrencies,
@@ -158,10 +182,75 @@ export class MoneygramRampClient implements RampProvider {
   }
 
   async estimateOnramp(
-    _ctx: RampRuntimeContext,
-    _input: RampEstimateOnrampInput
+    { env, mode }: RampRuntimeContext,
+    input: RampEstimateOnrampInput
   ): Promise<PaymentRampEstimate> {
-    throw estimateNotAvailable("MoneyGram does not support on-ramp.", { provider: this.id });
+    if (input.fiatCurrency !== "USD") {
+      throw estimateNotAvailable("MoneyGram on-ramp is limited to USD during the pilot.", {
+        provider: this.id,
+      });
+    }
+    const secretKey = requireMoneygramSecretKey(env, mode);
+    const asset = getCryptoRailAssetLabel(input.assetRail);
+    const response = await providerFetchJson<unknown, Record<string, unknown>>(
+      this.id,
+      `${MONEYGRAM_SANDBOX_BASE_URL}/api/v1/quotes`,
+      {
+        method: "POST",
+        headers: { "x-api-key": secretKey, "User-Agent": "sdp-api/ramps" },
+        body: {
+          destinationCountry: MONEYGRAM_ONRAMP_DESTINATION.country,
+          destinationSubdivision: MONEYGRAM_ONRAMP_DESTINATION.subdivision,
+          sendAmount: Number(input.fiatAmount),
+          asset,
+          chain: "solana",
+          transactionType: "cash-in",
+          serviceOptionCode: "DIRECT_TO_ACCT",
+          receiveCurrencyCode: input.fiatCurrency,
+        },
+      }
+    );
+    const parsed = cashInQuoteSchema.safeParse(response);
+    if (!parsed.success) {
+      throw providerUnavailable("MoneyGram on-ramp estimate response is malformed.", {
+        provider: this.id,
+        issues: z.flattenError(parsed.error).fieldErrors,
+      });
+    }
+    const option = parsed.data.serviceOptions.find(
+      ({ serviceOptionCode }) => serviceOptionCode === "DIRECT_TO_ACCT"
+    );
+    if (!option) {
+      throw estimateNotAvailable("MoneyGram did not return a cash-in service option.", {
+        provider: this.id,
+      });
+    }
+    if (option.quote.fees.total.currency !== input.fiatCurrency) {
+      throw providerUnavailable("MoneyGram returned on-ramp fees outside the fiat send currency.", {
+        provider: this.id,
+      });
+    }
+    return {
+      provider: this.id,
+      direction: "onramp",
+      fiatCurrency: input.fiatCurrency,
+      assetRail: input.assetRail,
+      fiatAmount: option.quote.sendAmount.value,
+      cryptoAmount: option.quote.receiveAmount.value,
+      exchangeRate: String(option.quote.exchangeRate),
+      fees: {
+        currency: input.fiatCurrency,
+        total: option.quote.fees.total.value,
+        provider: option.quote.fees.mgi.value,
+      },
+    };
+  }
+
+  async createOnrampQuote(
+    ctx: RampRuntimeContext,
+    _input: RampOnrampQuoteInput
+  ): Promise<PaymentRampQuote> {
+    return this.createSessionQuote(ctx, "on-ramp");
   }
 
   async estimateOfframp(
@@ -221,8 +310,19 @@ export class MoneygramRampClient implements RampProvider {
   }
 
   async createOfframpQuote(
-    { env, mode }: RampRuntimeContext,
+    ctx: RampRuntimeContext,
     _input: RampOfframpQuoteInput
+  ): Promise<PaymentRampQuote> {
+    return this.createSessionQuote(ctx, "off-ramp");
+  }
+
+  /**
+   * The sessions API always returns a widgetUrl pinned to mode=off-ramp; the widget
+   * reads its direction solely from that query param, so rewrite it per direction.
+   */
+  private async createSessionQuote(
+    { env, mode }: RampRuntimeContext,
+    widgetMode: "on-ramp" | "off-ramp"
   ): Promise<PaymentRampQuote> {
     const secretKey = requireMoneygramSecretKey(env, mode);
     const session = await providerFetchJson<unknown, Record<never, never>>(
@@ -243,6 +343,9 @@ export class MoneygramRampClient implements RampProvider {
       });
     }
 
+    const widgetUrl = new URL(parsed.data.widgetUrl);
+    widgetUrl.searchParams.set("mode", widgetMode);
+
     return {
       provider: this.id,
       id: parsed.data.sessionId,
@@ -250,8 +353,7 @@ export class MoneygramRampClient implements RampProvider {
       deliveryMode: "session_widget",
       sessionToken: parsed.data.sessionToken,
       sessionId: parsed.data.sessionId,
-      widgetUrl: parsed.data.widgetUrl,
-      sdkUrl: `${MONEYGRAM_SANDBOX_BASE_URL}/sdk/index.global.js`,
+      widgetUrl: widgetUrl.toString(),
     };
   }
 }

--- a/packages/sdp-payments/src/ramps/providers/moneygram/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/moneygram/client.ts
@@ -230,6 +230,12 @@ export class MoneygramRampClient implements RampProvider {
         provider: this.id,
       });
     }
+    if (option.quote.receiveAmount.currency !== asset) {
+      throw providerUnavailable(
+        "MoneyGram returned an on-ramp receive amount outside the crypto asset.",
+        { provider: this.id }
+      );
+    }
     return {
       provider: this.id,
       direction: "onramp",

--- a/packages/sdp-types/src/generated/ramp-support.generated.ts
+++ b/packages/sdp-types/src/generated/ramp-support.generated.ts
@@ -13,7 +13,7 @@ import type { RampProviderId } from "../provider-access";
 
 export const RAMP_SUPPORT_HASH =
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
-  "b890004c2e13336753f5b4f61a7c11f82059c9528d80e4c3c6be2baf9a182431" as const;
+  "15487789a8d6a0c0bd3957391bbc54416947b417691839bcedd044aed38b81bb" as const;
 
 export const RAMP_PROVIDER_SUPPORT_HASHES = {
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
@@ -23,7 +23,7 @@ export const RAMP_PROVIDER_SUPPORT_HASHES = {
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
   bvnk: "a81bc9617d867fd16e8fc9b91444ae968bddf32724be7a393a9b3c3a739b81f0",
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
-  moneygram: "82b3a873f199075bb8a93c61d05556c5d039d36aab492ab2f873549035c57a6e",
+  moneygram: "3805404b4918db354043d364dbbb26f224d30e16b0039f2e639647621de922f4",
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
   coinbase: "5f01258d98e8d8402ea69e349823315744598c38a7e1ee075ea806983f3fe138",
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
@@ -36,7 +36,7 @@ export const RAMP_PROVIDER_SUPPORT_COUNTS = {
   moonpay: { onramp: 66, offramp: 25 },
   lightspark: { onramp: 1, offramp: 1 },
   bvnk: { onramp: 8, offramp: 400 },
-  moneygram: { onramp: 0, offramp: 153 },
+  moneygram: { onramp: 1, offramp: 153 },
   coinbase: { onramp: 3, offramp: 0 },
   mural: { onramp: 11, offramp: 0 },
   stripe: { onramp: 2, offramp: 0 },
@@ -1034,9 +1034,11 @@ export const RAMP_PROVIDER_SUPPORT_DETAILS = {
   },
   moneygram: {
     onramp: {
-      currencies: {},
+      currencies: {
+        USD: { min: null, max: null },
+      },
       countrySupport: { coverage: "unreported" },
-      entityTypes: [],
+      entityTypes: ["individual"],
     },
     offramp: {
       currencies: {
@@ -1401,7 +1403,7 @@ export const ONRAMP_SUPPORT = [
   {
     source: "USD",
     dest: "usdc.solana",
-    providers: ["lightspark", "bvnk", "coinbase", "mural", "stripe"],
+    providers: ["lightspark", "bvnk", "moneygram", "coinbase", "mural", "stripe"],
   },
   { source: "USD", dest: "usdt.solana", providers: ["bvnk"] },
   { source: "USD", dest: "usdg.solana", providers: ["bvnk"] },

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -923,6 +923,7 @@ export type MoneygramRampEvent =
       sessionId: string;
       transactionId: string;
       status: string;
+      amount: number;
       referenceNumber?: string;
     }
   | {

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -891,7 +891,6 @@ export type PaymentRampQuote =
       sessionToken: string;
       sessionId: string;
       widgetUrl: string;
-      sdkUrl: string;
     })
   | (BasePaymentRampQuote & {
       provider: "stripe";
@@ -919,6 +918,13 @@ export type CoinbaseRampEvent =
 
 export type MoneygramRampEvent =
   | { kind: "signed"; sessionId: string; cryptoTransferId: string }
+  | {
+      kind: "onramp_completed";
+      sessionId: string;
+      transactionId: string;
+      status: string;
+      referenceNumber?: string;
+    }
   | {
       kind: "completed";
       sessionId: string;


### PR DESCRIPTION
## Changes

- **MoneyGram now shows as a USD → USDC deposit provider** — the committed rail-support snapshot was stale (0 on-ramp pairs); re-distilled and regenerated the matrix.
- **On-ramp estimates** via `POST /api/v1/quotes` (cash-in, `DIRECT_TO_ACCT`, USD pilot), with a fee-currency match guard.
- **On-ramp quotes** reuse the shared session flow. Their sessions API always returns `widgetUrl?mode=off-ramp` and the widget reads its direction *only* from that URL param (`transaction.type` is ignored — raised with MoneyGram), so we rewrite `mode` per direction.
- **Counterparty requirements**: moneygram added to the on-ramp arm, immediately ready (`readyCounterparty`) — no KYC collection on our side, the widget handles it.
- **Ramp events**: new `onramp_completed` kind marks the transfer completed; per-case direction guards collapsed into one kind → direction table.
- **Web**: onramp wizard renders the MoneyGram widget with on-ramp prefill; session refresh wired same as off-ramp.

## SDK caching & versioning

- The widget SDK is no longer loaded from MoneyGram's origin — it's served same-origin from `/api/vendor/moneygram/sdk/<version>`.
- `<version>` **is the SHA-256 of the SDK bundle**, pinned in `lib/moneygram-sdk.ts`. The route 404s unknown versions and 502s if the upstream bytes don't hash to the pinned value, so MoneyGram can't silently ship us different code.
- Verified bytes are cached in-memory per server instance and served with `immutable, max-age=1y`. The URL is content-addressed, so it can never go stale — upgrading the SDK means updating the pinned hash, which mints a new URL and busts every cache.
- The dead `sdkUrl` field was dropped from the MoneyGram quote type; the client uses the pinned proxy URL.

<img width="1726" height="1304" alt="CleanShot 2026-07-21 at 17 15 09@2x" src="https://github.com/user-attachments/assets/56e73ec8-8bb8-47e1-8a52-4a4128bad971" />
