### PR TITLE
feat(payments): reconcile Coinbase onramp webhooks and surface order economics

### DIFF
--- a/apps/sdp-api/scripts/register-coinbase-webhook.mjs
+++ b/apps/sdp-api/scripts/register-coinbase-webhook.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { generateJwt } from "@coinbase/cdp-sdk/auth";
+
+const [webhookUrl, description = "SDP onramp events"] = process.argv.slice(2);
+const apiKeyId = process.env.COINBASE_CDP_API_KEY_ID;
+const apiKeySecret = process.env.COINBASE_CDP_API_KEY_SECRET;
+
+if (!webhookUrl || !apiKeyId || !apiKeySecret) {
+  console.error("usage: doppler run -- node register-coinbase-webhook.mjs <webhook-url>");
+  console.error("arguments:");
+  console.error("<webhook-url> the deployed /webhooks/payments/ramps/<mode>/coinbase endpoint");
+  console.error("description optional");
+  console.error("requires COINBASE_CDP_API_KEY_ID and COINBASE_CDP_API_KEY_SECRET in the env");
+  process.exit(1);
+}
+
+const EVENT_TYPES = [
+  "onramp.transaction.created",
+  "onramp.transaction.updated",
+  "onramp.transaction.success",
+  "onramp.transaction.failed",
+];
+
+const HOST = "api.cdp.coinbase.com";
+const SUBSCRIPTIONS_PATH = "/platform/v2/data/webhooks/subscriptions";
+
+async function cdpApi(method, path, body) {
+  const jwt = await generateJwt({
+    apiKeyId,
+    apiKeySecret,
+    requestMethod: method,
+    requestHost: HOST,
+    requestPath: path,
+  });
+  const response = await fetch(`https://${HOST}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${method} ${path} -> ${response.status}: ${text}`);
+  }
+  return text ? JSON.parse(text) : undefined;
+}
+
+const subscriptionBody = {
+  description,
+  eventTypes: EVENT_TYPES,
+  isEnabled: true,
+  target: { url: webhookUrl },
+};
+
+const { subscriptions } = await cdpApi("GET", SUBSCRIPTIONS_PATH);
+const existing = subscriptions.find(
+  (entry) => entry.target.url.replace(/\/$/, "") === webhookUrl.replace(/\/$/, "")
+);
+
+let subscription;
+if (existing) {
+  console.log(
+    `Reusing existing subscription ${existing.subscriptionId} for ${webhookUrl}; syncing event types`
+  );
+  subscription = await cdpApi(
+    "PUT",
+    `${SUBSCRIPTIONS_PATH}/${existing.subscriptionId}`,
+    subscriptionBody
+  );
+} else {
+  subscription = await cdpApi("POST", SUBSCRIPTIONS_PATH, subscriptionBody);
+  console.log(`Created subscription ${subscription.subscriptionId}`);
+}
+
+console.log(`Subscription ${subscription.subscriptionId} -> ${subscription.target.url}`);
+console.log(`Event types: ${subscription.eventTypes.join(", ")}`);
+console.log("\nStore this in your secret store as COINBASE_CDP_RAMPS_WEBHOOK_SECRET:");
+console.log("------------------------------------------------------------");
+console.log(subscription.secret);
+console.log("------------------------------------------------------------");

--- a/apps/sdp-api/src/routes/webhooks/ramps/coinbase.test.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/coinbase.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { CoinbaseWebhookProcessor } from "./coinbase";
+
+const processor = new CoinbaseWebhookProcessor();
+
+/** Real sandbox delivery captured 2026-07-21 via ngrok; success events add txHash. */
+function sandboxOrderEvent(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    createdAt: "2026-07-21T10:40:23.439Z",
+    destinationAddress: "sWzzJyQjbqh5bmPcHdmGEnggfrkGmqWxE43GPjZ9GFD",
+    destinationNetwork: "solana",
+    exchangeRate: "1",
+    fees: [
+      { feeAmount: "0", feeCurrency: "USD", feeType: "FEE_TYPE_NETWORK" },
+      { feeAmount: "0.05", feeCurrency: "USD", feeType: "FEE_TYPE_EXCHANGE" },
+    ],
+    orderId: "1f184f09-3d65-690d-b3b1-ba4a77af2429",
+    partnerUserRef: "sandbox-counterparty_c8e2e54c-60b6-4f4b-8d50-1f76cb64b2a8",
+    paymentCurrency: "USD",
+    paymentMethod: "GUEST_CHECKOUT_APPLE_PAY",
+    paymentSubtotal: "2",
+    paymentTotal: "2.05",
+    purchaseAmount: "2",
+    purchaseCurrency: "USDC",
+    updatedAt: "2026-07-21T10:40:28.704Z",
+    ...overrides,
+  };
+}
+
+describe("CoinbaseWebhookProcessor.parse", () => {
+  it("maps a created order awaiting payment to awaiting_payment", () => {
+    expect(
+      processor.parse(
+        sandboxOrderEvent({
+          eventType: "onramp.transaction.created",
+          status: "ONRAMP_ORDER_STATUS_PENDING_PAYMENT",
+        })
+      )
+    ).toEqual({
+      provider: "coinbase",
+      kind: "awaiting_payment",
+      reference: "1f184f09-3d65-690d-b3b1-ba4a77af2429",
+    });
+  });
+
+  it("maps a processing update to settling", () => {
+    expect(
+      processor.parse(
+        sandboxOrderEvent({
+          eventType: "onramp.transaction.updated",
+          status: "ONRAMP_ORDER_STATUS_PROCESSING",
+        })
+      )
+    ).toEqual({
+      provider: "coinbase",
+      kind: "settling",
+      reference: "1f184f09-3d65-690d-b3b1-ba4a77af2429",
+    });
+  });
+
+  it("maps a success event to settled with delivered amount and economics", () => {
+    expect(
+      processor.parse(
+        sandboxOrderEvent({
+          eventType: "onramp.transaction.success",
+          status: "ONRAMP_ORDER_STATUS_COMPLETED",
+          txHash: "sandbox_tx_hash",
+        })
+      )
+    ).toEqual({
+      provider: "coinbase",
+      kind: "settled",
+      reference: "1f184f09-3d65-690d-b3b1-ba4a77af2429",
+      receivedAmount: "2",
+      settlement: {
+        provider: "coinbase",
+        status: "completed",
+        paymentCurrency: "USD",
+        paymentSubtotal: "2",
+        paymentTotal: "2.05",
+        purchaseCurrency: "USDC",
+        purchaseAmount: "2",
+        exchangeRate: "1",
+        fees: [
+          { feeAmount: "0", feeCurrency: "USD", feeType: "FEE_TYPE_NETWORK" },
+          { feeAmount: "0.05", feeCurrency: "USD", feeType: "FEE_TYPE_EXCHANGE" },
+        ],
+        txHash: "sandbox_tx_hash",
+      },
+    });
+  });
+
+  it("maps a failed event to failed with the failure reason", () => {
+    expect(
+      processor.parse(
+        sandboxOrderEvent({
+          eventType: "onramp.transaction.failed",
+          status: "ONRAMP_ORDER_STATUS_FAILED",
+          failureReason: "card_declined",
+        })
+      )
+    ).toMatchObject({
+      provider: "coinbase",
+      kind: "failed",
+      reference: "1f184f09-3d65-690d-b3b1-ba4a77af2429",
+      error: "card_declined",
+      settlement: { provider: "coinbase", status: "failed", failureReason: "card_declined" },
+    });
+  });
+
+  it("ignores event types outside the onramp order lifecycle", () => {
+    expect(
+      processor.parse(sandboxOrderEvent({ eventType: "offramp.transaction.created" }))
+    ).toEqual({
+      provider: "coinbase",
+      kind: "ignore",
+      reason: "unsupported_event:offramp.transaction.created",
+    });
+  });
+
+  it("ignores lifecycle events with an unrecognized status", () => {
+    expect(
+      processor.parse(
+        sandboxOrderEvent({
+          eventType: "onramp.transaction.updated",
+          status: "ONRAMP_ORDER_STATUS_SOMETHING_NEW",
+        })
+      )
+    ).toEqual({
+      provider: "coinbase",
+      kind: "ignore",
+      reason: "unhandled:onramp.transaction.updated:ONRAMP_ORDER_STATUS_SOMETHING_NEW",
+    });
+  });
+
+  it("throws on payloads violating the event envelope", () => {
+    expect(() =>
+      processor.parse(
+        sandboxOrderEvent({ eventType: "onramp.transaction.created", orderId: undefined })
+      )
+    ).toThrow("Coinbase webhook payload violates the onramp event envelope");
+    expect(() => processor.parse(sandboxOrderEvent({}))).toThrow(
+      "Coinbase webhook payload violates the onramp event envelope"
+    );
+    expect(() => processor.parse("not an object")).toThrow(
+      "Coinbase webhook payload violates the onramp event envelope"
+    );
+  });
+});

--- a/apps/sdp-api/src/routes/webhooks/ramps/coinbase.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/coinbase.ts
@@ -1,36 +1,151 @@
+import { readRecord, readString } from "@sdp/payments/json";
 import type { RampSettlementEvent, RampWebhookValidationContext } from "@sdp/payments/ramps/types";
-import type { SdpEnvironment } from "@sdp/types";
+import type { CoinbaseRampSettlement, SdpEnvironment } from "@sdp/types";
+import { z } from "zod";
 import { AppError, badRequest, providerNotConfigured } from "@/lib/errors";
 import { verifyWebhookSignature } from "@/lib/webhook-signature";
 import type { AppContext, WebhookProcessor } from "./processor";
 import { applyRampSettlementEvent } from "./settlements";
 
-interface CoinbaseAmount {
-  value: string;
-}
-
 const COINBASE_ORDER_STATUS = {
+  ONRAMP_ORDER_STATUS_PENDING_PAYMENT: "awaiting_payment",
   ONRAMP_ORDER_STATUS_PENDING_AUTH: "settling",
-  ONRAMP_ORDER_STATUS_PENDING_PAYMENT: "settling",
   ONRAMP_ORDER_STATUS_PROCESSING: "settling",
   ONRAMP_ORDER_STATUS_COMPLETED: "settled",
   ONRAMP_ORDER_STATUS_FAILED: "failed",
 } as const satisfies Record<string, RampSettlementEvent["kind"]>;
+type CoinbaseOrderStatus = keyof typeof COINBASE_ORDER_STATUS;
 
+const coinbaseOnrampOrderSnapshot = z.object({
+  orderId: z.string(),
+  status: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  destinationAddress: z.string(),
+  destinationNetwork: z.string(),
+  partnerUserRef: z.string(),
+  paymentMethod: z.string(),
+  paymentCurrency: z.string(),
+  paymentSubtotal: z.string(),
+  paymentTotal: z.string(),
+  purchaseCurrency: z.string(),
+  purchaseAmount: z.string(),
+  exchangeRate: z.string(),
+  fees: z.array(z.object({ feeAmount: z.string(), feeCurrency: z.string(), feeType: z.string() })),
+  failureReason: z.string().optional(),
+});
+
+const coinbaseOnrampWebhookSchema = z.discriminatedUnion("eventType", [
+  coinbaseOnrampOrderSnapshot.extend({ eventType: z.literal("onramp.transaction.created") }),
+  coinbaseOnrampOrderSnapshot.extend({ eventType: z.literal("onramp.transaction.updated") }),
+  coinbaseOnrampOrderSnapshot.extend({
+    eventType: z.literal("onramp.transaction.success"),
+    txHash: z.string().optional(),
+  }),
+  coinbaseOnrampOrderSnapshot.extend({ eventType: z.literal("onramp.transaction.failed") }),
+]);
+type CoinbaseOnrampOrderEvent = z.infer<typeof coinbaseOnrampWebhookSchema>;
+type CoinbaseOnrampEventType = CoinbaseOnrampOrderEvent["eventType"];
+
+const COINBASE_ONRAMP_EVENT_TYPES = coinbaseOnrampWebhookSchema.options.map(
+  (option) => option.shape.eventType.value
+);
+
+function isCoinbaseOnrampEventType(value: string): value is CoinbaseOnrampEventType {
+  return (COINBASE_ONRAMP_EVENT_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Resolves the settlement kind: terminal event types are authoritative,
+ * lifecycle events defer to the order status.
+ */
 function coinbaseSettlementKind(
-  eventType: string,
-  status: string | undefined
-): "settling" | "settled" | "failed" | undefined {
-  switch (eventType) {
+  event: CoinbaseOnrampOrderEvent
+): (typeof COINBASE_ORDER_STATUS)[CoinbaseOrderStatus] | undefined {
+  switch (event.eventType) {
     case "onramp.transaction.success":
       return "settled";
     case "onramp.transaction.failed":
       return "failed";
-    default:
-      return status
-        ? COINBASE_ORDER_STATUS[status as keyof typeof COINBASE_ORDER_STATUS]
-        : undefined;
+    case "onramp.transaction.created":
+    case "onramp.transaction.updated":
+      return COINBASE_ORDER_STATUS[event.status as CoinbaseOrderStatus];
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
   }
+}
+
+/**
+ * Captures the order economics verbatim from a terminal event.
+ */
+function buildCoinbaseSettlement(
+  event: CoinbaseOnrampOrderEvent,
+  status: CoinbaseRampSettlement["status"]
+): CoinbaseRampSettlement {
+  return {
+    provider: "coinbase",
+    status,
+    paymentCurrency: event.paymentCurrency,
+    paymentSubtotal: event.paymentSubtotal,
+    paymentTotal: event.paymentTotal,
+    purchaseCurrency: event.purchaseCurrency,
+    purchaseAmount: event.purchaseAmount,
+    exchangeRate: event.exchangeRate,
+    fees: event.fees,
+    ...(event.eventType === "onramp.transaction.success" && event.txHash
+      ? { txHash: event.txHash }
+      : {}),
+    ...(event.failureReason ? { failureReason: event.failureReason } : {}),
+  };
+}
+
+/**
+ * Maps a Coinbase onramp webhook payload to a provider-agnostic settlement event.
+ */
+function parseCoinbaseWebhookEvent(payload: unknown): RampSettlementEvent {
+  const eventType = readString(readRecord(payload)?.eventType);
+  if (eventType !== undefined && !isCoinbaseOnrampEventType(eventType)) {
+    return { provider: "coinbase", kind: "ignore", reason: `unsupported_event:${eventType}` };
+  }
+
+  const parsed = coinbaseOnrampWebhookSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw badRequest("Coinbase webhook payload violates the onramp event envelope", {
+      provider: "coinbase",
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+  const event = parsed.data;
+
+  const kind = coinbaseSettlementKind(event);
+  if (!kind) {
+    return {
+      provider: "coinbase",
+      kind: "ignore",
+      reason: `unhandled:${event.eventType}:${event.status}`,
+    };
+  }
+  if (kind === "failed") {
+    return {
+      provider: "coinbase",
+      kind,
+      reference: event.orderId,
+      ...(event.failureReason ? { error: event.failureReason } : {}),
+      settlement: buildCoinbaseSettlement(event, "failed"),
+    };
+  }
+  if (kind === "settled") {
+    return {
+      provider: "coinbase",
+      kind,
+      reference: event.orderId,
+      receivedAmount: event.purchaseAmount,
+      settlement: buildCoinbaseSettlement(event, "completed"),
+    };
+  }
+  return { provider: "coinbase", kind, reference: event.orderId };
 }
 
 interface CoinbaseWebhookSignatureFields {
@@ -39,7 +154,7 @@ interface CoinbaseWebhookSignatureFields {
 }
 
 /**
- * Parses the comma-separated `t=<timestamp>,v0=<signature>` X-Hook0-Signature header.
+ * Parses the comma-separated `t=<timestamp>,v0=<signature>,...` X-Hook0-Signature header.
  */
 function parseCoinbaseSignatureHeader(header: string): CoinbaseWebhookSignatureFields | undefined {
   const fields = new Map(
@@ -54,57 +169,6 @@ function parseCoinbaseSignatureHeader(header: string): CoinbaseWebhookSignatureF
     return undefined;
   }
   return { timestamp, signature };
-}
-
-// TODO(coinbase): type against real onramp.transaction.* samples before production.
-interface CoinbaseOnrampWebhookEvent {
-  eventType: string;
-  data: {
-    orderId: string;
-    status?: string;
-    purchaseAmount?: CoinbaseAmount;
-    failureReason?: string;
-  };
-}
-
-/**
- * Maps a Coinbase onramp webhook payload to a provider-agnostic settlement event.
- */
-function parseCoinbaseWebhookEvent(payload: unknown): RampSettlementEvent {
-  const { eventType, data } = payload as CoinbaseOnrampWebhookEvent;
-  if (!eventType?.startsWith("onramp.transaction.")) {
-    return { provider: "coinbase", kind: "ignore", reason: `unsupported_event:${eventType}` };
-  }
-  if (!data?.orderId) {
-    return { provider: "coinbase", kind: "ignore", reason: "missing_order_id" };
-  }
-
-  const kind = coinbaseSettlementKind(eventType, data.status);
-  if (!kind) {
-    return {
-      provider: "coinbase",
-      kind: "ignore",
-      reason: `unhandled:${eventType}:${data.status}`,
-    };
-  }
-  const reference = data.orderId;
-  if (kind === "failed") {
-    return {
-      provider: "coinbase",
-      kind,
-      reference,
-      ...(data.failureReason ? { error: data.failureReason } : {}),
-    };
-  }
-  if (kind === "settled") {
-    return {
-      provider: "coinbase",
-      kind,
-      reference,
-      ...(data.purchaseAmount ? { receivedAmount: data.purchaseAmount.value } : {}),
-    };
-  }
-  return { provider: "coinbase", kind, reference };
 }
 
 export class CoinbaseWebhookProcessor implements WebhookProcessor<unknown, RampSettlementEvent> {

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-detail-workspace.tsx
@@ -485,6 +485,31 @@ function RampSettlementRows({ settlement }: { settlement: RampTransferSettlement
     );
   }
 
+  if (settlement.provider === "coinbase") {
+    const providerFee = settlement.fees.find((fee) => fee.feeType === "FEE_TYPE_EXCHANGE");
+    const networkFee = settlement.fees.find((fee) => fee.feeType === "FEE_TYPE_NETWORK");
+    return (
+      <>
+        {providerFee ? (
+          <DetailRow
+            label={t("DashboardPayments.transferDetails.providerFee")}
+            value={formatDisplayAmount(providerFee.feeAmount, providerFee.feeCurrency)}
+          />
+        ) : null}
+        {networkFee && Number(networkFee.feeAmount) > 0 ? (
+          <DetailRow
+            label={t("DashboardPayments.transferDetails.networkFee")}
+            value={formatDisplayAmount(networkFee.feeAmount, networkFee.feeCurrency)}
+          />
+        ) : null}
+        <DetailRow
+          label={t("DashboardPayments.transferDetails.exchangeRate")}
+          value={`1 ${settlement.purchaseCurrency} = ${formatDisplayAmount(settlement.exchangeRate, settlement.paymentCurrency)}`}
+        />
+      </>
+    );
+  }
+
   const sentDecimal = settlement.sentAmount.amount / 10 ** settlement.sentAmount.decimals;
   const receivedDecimal =
     settlement.receivedAmount.amount / 10 ** settlement.receivedAmount.decimals;

--- a/apps/sdp-web/src/app/dashboard/payments/payments-wizard-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-wizard-frame.tsx
@@ -27,7 +27,7 @@ export function PaymentsWizardFrame({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col" data-payments-wizard-frame>
-      <div className="shrink-0 px-4 pt-2 pb-6 md:px-6" data-payments-wizard-stepper>
+      <div className="shrink-0 px-4 pt-8 pb-6 md:px-6" data-payments-wizard-stepper>
         <div className={cn("mx-auto w-full", maxWidthClassName)}>
           <WizardStepProgress
             currentStep={currentStep}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/frame-events.ts
@@ -31,7 +31,7 @@ const coinbaseFrameEventSchema = z.discriminatedUnion("eventName", [
   }),
 ]);
 
-type CoinbaseFrameEvent = z.infer<typeof coinbaseFrameEventSchema>;
+export type CoinbaseFrameEvent = z.infer<typeof coinbaseFrameEventSchema>;
 type Translate = (key: MessageKey, values?: TranslationValues) => string;
 
 /**
@@ -85,12 +85,19 @@ function reportRampEvent(event: CoinbaseRampEvent, t: Translate): void {
  * ERROR_CODE_GUEST_APPLE_PAY_NOT_SUPPORTED is followed by a successful QR-code fallback
  * render on web.
  *
+ * Returns the parsed event (null for foreign messages) so the frame can react to
+ * UI-phase transitions like `apple_pay_button_pressed` and `cancel`.
+ *
  * @see https://docs.cdp.coinbase.com/onramp/headless-onramp/overview#post-message-events
  */
-export function handleCoinbaseFrameEvent(orderId: string, raw: unknown, t: Translate): void {
+export function handleCoinbaseFrameEvent(
+  orderId: string,
+  raw: unknown,
+  t: Translate
+): CoinbaseFrameEvent | null {
   const event = parseCoinbaseFrameEvent(raw);
   if (!event) {
-    return;
+    return null;
   }
   switch (event.eventName) {
     case "onramp_api.commit_success":
@@ -115,4 +122,5 @@ export function handleCoinbaseFrameEvent(orderId: string, raw: unknown, t: Trans
       throw new Error(`Unhandled Coinbase frame event: ${JSON.stringify(exhaustive)}`);
     }
   }
+  return event;
 }

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/quote-summary.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/quote-summary.tsx
@@ -14,7 +14,9 @@ type CoinbaseQuote = Extract<PaymentRampQuote, { provider: "coinbase" }>;
  */
 export function CoinbaseQuoteSummary({ quote }: { quote: CoinbaseQuote }) {
   const t = useTranslations();
-  const feesIncluded = quote.fees.reduce((total, fee) => total + Number(fee.feeAmount), 0);
+  const feesIncluded = quote.fees
+    .filter((fee) => fee.feeCurrency === quote.paymentCurrency)
+    .reduce((total, fee) => total + Number(fee.feeAmount), 0);
   return (
     <div className="grid gap-3 lg:grid-cols-2">
       <QuoteSummaryField

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/quote-summary.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/quote-summary.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { PaymentRampQuote } from "@sdp/types";
+import { ArrowDownLeft, CoinsIcon, DollarSignIcon, WalletIcon } from "lucide-react";
+import { formatDisplayAmount } from "@/app/dashboard/payments/payments-overview.utils";
+import { useTranslations } from "@/i18n/provider";
+import { QuoteSummaryField } from "../manual-instructions-quote";
+
+type CoinbaseQuote = Extract<PaymentRampQuote, { provider: "coinbase" }>;
+
+/**
+ * Locked order economics shown above the Apple Pay button, mirroring the
+ * Lightspark quote-summary grid.
+ */
+export function CoinbaseQuoteSummary({ quote }: { quote: CoinbaseQuote }) {
+  const t = useTranslations();
+  const feesIncluded = quote.fees.reduce((total, fee) => total + Number(fee.feeAmount), 0);
+  return (
+    <div className="grid gap-3 lg:grid-cols-2">
+      <QuoteSummaryField
+        icon={<CoinsIcon className="size-4" />}
+        label={t("DashboardPayments.manualInstructions.finalAmount")}
+        value={formatDisplayAmount(quote.purchaseAmount, quote.purchaseCurrency)}
+      />
+      <QuoteSummaryField
+        icon={<WalletIcon className="size-4" />}
+        label={t("DashboardPayments.manualInstructions.depositAmount")}
+        value={formatDisplayAmount(quote.paymentTotal, quote.paymentCurrency)}
+      />
+      <QuoteSummaryField
+        icon={<DollarSignIcon className="size-4" />}
+        label={t("DashboardPayments.manualInstructions.feesIncluded")}
+        value={formatDisplayAmount(String(feesIncluded), quote.paymentCurrency)}
+      />
+      <QuoteSummaryField
+        icon={<ArrowDownLeft className="size-4" />}
+        label={t("DashboardPayments.manualInstructions.exchangeRate")}
+        value={`1 ${quote.purchaseCurrency} = ${formatDisplayAmount(quote.exchangeRate, quote.paymentCurrency)}`}
+      />
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "@/i18n/provider";
 import { handleCoinbaseFrameEvent } from "./frame-events";
 
@@ -9,9 +9,11 @@ import { handleCoinbaseFrameEvent } from "./frame-events";
  * events (`onramp_api.*`) to the SDP ramp-events endpoint.
  *
  * Coinbase-specific by design: the payment link requires the exact
- * `sandbox`/`referrerPolicy` attributes below to render in an iframe, and the
- * Apple Pay sheet takes over the screen on its own when pressed, so the frame
- * deliberately has no fullscreen affordance.
+ * `sandbox`/`referrerPolicy` attributes below to render in an iframe. The
+ * framed page renders only the Apple Pay button until it is pressed, then
+ * expands a payment sheet inside the same frame — so the frame is sized like
+ * a button and grows to a panel on `apple_pay_button_pressed`, shrinking back
+ * on `cancel`.
  *
  * The `allow-scripts allow-same-origin` pair is mandated verbatim by Coinbase's
  * embedding docs. The known sandbox escape for that pair (the framed script
@@ -23,24 +25,33 @@ import { handleCoinbaseFrameEvent } from "./frame-events";
  */
 export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: string }) {
   const t = useTranslations();
+  const [expanded, setExpanded] = useState(false);
   useEffect(() => {
     const expectedOrigin = new URL(src).origin;
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== expectedOrigin) {
         return;
       }
-      handleCoinbaseFrameEvent(orderId, event.data, t);
+      const frameEvent = handleCoinbaseFrameEvent(orderId, event.data, t);
+      if (frameEvent?.eventName === "onramp_api.apple_pay_button_pressed") {
+        setExpanded(true);
+      }
+      if (frameEvent?.eventName === "onramp_api.cancel") {
+        setExpanded(false);
+      }
     };
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
   }, [src, orderId, t]);
 
   return (
-    <div className="overflow-hidden rounded-2xl">
+    <div
+      className={`overflow-hidden rounded-lg transition-all duration-300 ${expanded ? "max-w-lg" : "max-w-xs"}`}
+    >
       <iframe
         title={t("DashboardPayments.ramps.coinbaseOnramp")}
         src={src}
-        className="h-[480px] w-full border-0"
+        className={`w-full border-0 transition-all duration-300 ${expanded ? "h-96" : "h-12"}`}
         allow="payment"
         sandbox="allow-scripts allow-same-origin"
         referrerPolicy="no-referrer"

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslations } from "@/i18n/provider";
 import { handleCoinbaseFrameEvent } from "./frame-events";
@@ -23,9 +24,11 @@ import { handleCoinbaseFrameEvent } from "./frame-events";
  *
  * @see https://docs.cdp.coinbase.com/onramp/headless-onramp/overview#web-app-testing
  */
+type CoinbaseFramePhase = "button" | "sheet" | "processing";
+
 export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: string }) {
   const t = useTranslations();
-  const [expanded, setExpanded] = useState(false);
+  const [phase, setPhase] = useState<CoinbaseFramePhase>("button");
   useEffect(() => {
     const expectedOrigin = new URL(src).origin;
     const handleMessage = (event: MessageEvent) => {
@@ -34,24 +37,35 @@ export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: stri
       }
       const frameEvent = handleCoinbaseFrameEvent(orderId, event.data, t);
       if (frameEvent?.eventName === "onramp_api.apple_pay_button_pressed") {
-        setExpanded(true);
+        setPhase("sheet");
       }
       if (frameEvent?.eventName === "onramp_api.cancel") {
-        setExpanded(false);
+        setPhase("button");
+      }
+      if (frameEvent?.eventName === "onramp_api.commit_success") {
+        setPhase("processing");
       }
     };
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
   }, [src, orderId, t]);
 
+  if (phase === "processing") {
+    return (
+      <div className="flex h-12 items-center justify-center">
+        <Loader2 className="size-5 animate-spin text-secondary" />
+      </div>
+    );
+  }
+
   return (
     <div
-      className={`mx-auto overflow-hidden rounded-lg transition-all duration-300 ${expanded ? "max-w-lg" : "max-w-xs"}`}
+      className={`mx-auto overflow-hidden rounded-lg transition-all duration-300 ${phase === "sheet" ? "max-w-lg" : "max-w-xs"}`}
     >
       <iframe
         title={t("DashboardPayments.ramps.coinbaseOnramp")}
         src={src}
-        className={`w-full border-0 transition-all duration-300 ${expanded ? "h-96" : "h-12"}`}
+        className={`w-full border-0 transition-all duration-300 ${phase === "sheet" ? "h-96" : "h-12"}`}
         allow="payment"
         sandbox="allow-scripts allow-same-origin"
         referrerPolicy="no-referrer"

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslations } from "@/i18n/provider";
 import { handleCoinbaseFrameEvent } from "./frame-events";
@@ -51,11 +50,7 @@ export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: stri
   }, [src, orderId, t]);
 
   if (phase === "processing") {
-    return (
-      <div className="flex h-12 items-center justify-center">
-        <Loader2 className="size-5 animate-spin text-secondary" />
-      </div>
-    );
+    return null;
   }
 
   return (

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/coinbase/ramp-frame.tsx
@@ -46,7 +46,7 @@ export function CoinbaseRampFrame({ orderId, src }: { orderId: string; src: stri
 
   return (
     <div
-      className={`overflow-hidden rounded-lg transition-all duration-300 ${expanded ? "max-w-lg" : "max-w-xs"}`}
+      className={`mx-auto overflow-hidden rounded-lg transition-all duration-300 ${expanded ? "max-w-lg" : "max-w-xs"}`}
     >
       <iframe
         title={t("DashboardPayments.ramps.coinbaseOnramp")}

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/manual-instructions-quote.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/manual-instructions-quote.tsx
@@ -82,7 +82,7 @@ function PaymentInstructionField({
   );
 }
 
-function QuoteSummaryField({
+export function QuoteSummaryField({
   icon,
   label,
   value,

--- a/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
+++ b/apps/sdp-web/src/app/dashboard/payments/ramps/components/onramp-step-content.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "@/i18n/provider";
 import { hasEnabledRampProvider } from "@/lib/provider-availability";
 import { toRampCryptoToken } from "@/lib/ramps";
 import type { OnrampWizard } from "../hooks/use-onramp-wizard";
+import { CoinbaseQuoteSummary } from "./coinbase/quote-summary";
 import { CoinbaseRampFrame } from "./coinbase/ramp-frame";
 import { ManualInstructionsQuote } from "./manual-instructions-quote";
 import { MoneygramRampWidget } from "./moneygram-ramp-widget";
@@ -153,7 +154,10 @@ export function OnrampStepContent({ wizard }: { wizard: OnrampWizard }) {
     return (
       <div className="space-y-6">
         {quote.provider === "coinbase" ? (
-          <CoinbaseRampFrame orderId={quote.id} src={quote.hostedUrl} />
+          <>
+            <CoinbaseQuoteSummary quote={quote} />
+            <CoinbaseRampFrame orderId={quote.id} src={quote.hostedUrl} />
+          </>
         ) : (
           <MoonpayRampFrame
             title={t("DashboardPayments.ramps.providerDeposit", { provider: quote.provider })}

--- a/packages/sdp-payments/src/ramps/providers/coinbase/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/coinbase/client.ts
@@ -144,8 +144,24 @@ interface CoinbaseBuyQuoteResponse {
   network_fee: CoinbaseAmount;
 }
 
+interface CoinbaseOrderFee {
+  amount: string;
+  currency: string;
+  type: string;
+}
+
 interface CoinbaseCreateOrderResponse {
-  order: { orderId: string; status: string };
+  order: {
+    orderId: string;
+    status: string;
+    paymentCurrency: string;
+    paymentSubtotal: string;
+    paymentTotal: string;
+    purchaseCurrency: string;
+    purchaseAmount: string;
+    exchangeRate: string;
+    fees: CoinbaseOrderFee[];
+  };
   paymentLink: { url: string; paymentLinkType: string };
 }
 
@@ -326,6 +342,17 @@ export class CoinbaseRampClient implements RampProvider {
       status: "pending",
       deliveryMode: "hosted",
       hostedUrl: hostedUrl.href,
+      paymentCurrency: order.paymentCurrency,
+      paymentSubtotal: order.paymentSubtotal,
+      paymentTotal: order.paymentTotal,
+      purchaseCurrency: order.purchaseCurrency,
+      purchaseAmount: order.purchaseAmount,
+      exchangeRate: order.exchangeRate,
+      fees: order.fees.map((fee) => ({
+        feeAmount: fee.amount,
+        feeCurrency: fee.currency,
+        feeType: fee.type,
+      })),
     };
   }
 

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -149,7 +149,31 @@ export interface LightsparkRampSettlement {
   failureReason?: string;
 }
 
-export type RampTransferSettlement = MoonpayRampSettlement | LightsparkRampSettlement;
+export interface CoinbaseRampFee {
+  feeAmount: string;
+  feeCurrency: string;
+  feeType: string;
+}
+
+/** Coinbase onramp order economics, captured verbatim from a terminal webhook. */
+export interface CoinbaseRampSettlement {
+  provider: "coinbase";
+  status: "completed" | "failed";
+  paymentCurrency: string;
+  paymentSubtotal: string;
+  paymentTotal: string;
+  purchaseCurrency: string;
+  purchaseAmount: string;
+  exchangeRate: string;
+  fees: CoinbaseRampFee[];
+  txHash?: string;
+  failureReason?: string;
+}
+
+export type RampTransferSettlement =
+  | MoonpayRampSettlement
+  | LightsparkRampSettlement
+  | CoinbaseRampSettlement;
 
 export interface MoneygramTransferDetails {
   transactionId?: string;
@@ -880,9 +904,22 @@ export type PaymentRampQuote =
       paymentInstructions: MuralPaymentRampInstruction[];
     })
   | (BasePaymentRampQuote & {
-      provider: "moonpay" | "bvnk" | "coinbase";
+      provider: "moonpay" | "bvnk";
       deliveryMode: "hosted";
       hostedUrl: string;
+    })
+  | (BasePaymentRampQuote & {
+      provider: "coinbase";
+      deliveryMode: "hosted";
+      hostedUrl: string;
+      /** Order economics captured verbatim from the Coinbase create-order response. */
+      paymentCurrency: string;
+      paymentSubtotal: string;
+      paymentTotal: string;
+      purchaseCurrency: string;
+      purchaseAmount: string;
+      exchangeRate: string;
+      fees: CoinbaseRampFee[];
     })
   | (BasePaymentRampQuote & {
       provider: "moneygram";


### PR DESCRIPTION
**Add completeness to Coinbase headless onramps**

1. Give coinbase onramps more information around what's the exchange
2. Added dynamic height to rendering coinbase ramps iframe for apply pay button 
3. Added script to configure webhook via api instead of through CDP Platform
4. Gave coinbase webhooks definite types

<img width="3448" height="2002" alt="CleanShot 2026-07-21 at 21 43 39@2x" src="https://github.com/user-attachments/assets/119c0ca9-01a1-4c64-b944-604af22e2654" />

<img width="3448" height="2000" alt="CleanShot 2026-07-21 at 21 51 06@2x" src="https://github.com/user-attachments/assets/f8468dc3-ed7c-48aa-a7a5-cf010256a036" />

<img width="3444" height="2000" alt="CleanShot 2026-07-21 at 21 52 10@2x" src="https://github.com/user-attachments/assets/7d0e60aa-dac8-42da-a515-4d622426eb5b" />