### PR TITLE
fix(web): prevent language picker layout shift

### DIFF
--- a/apps/sdp-web/playwright/tests/auth-entry.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/auth-entry.e2e.spec.ts
@@ -9,6 +9,24 @@ test.describe("public auth entry e2e", () => {
     await expect(page.getByRole("link", { name: "Docs" })).toBeVisible();
   });
 
+  test("language picker does not shift the header when it opens or closes", async ({ page }) => {
+    await page.goto("/");
+
+    const languagePicker = page.getByRole("button", { name: "Language" });
+    const dashboardLink = page.getByRole("link", { name: "Dashboard" });
+    const dashboardLinkX = (await dashboardLink.boundingBox())?.x;
+
+    expect(dashboardLinkX).toBeDefined();
+
+    await languagePicker.click();
+    await expect(page.getByText("Choose language", { exact: true })).toBeVisible();
+    expect((await dashboardLink.boundingBox())?.x).toBe(dashboardLinkX);
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByText("Choose language", { exact: true })).toBeHidden();
+    expect((await dashboardLink.boundingBox())?.x).toBe(dashboardLinkX);
+  });
+
   test("system dark mode keeps landing artwork and Clerk sign-in legible", async ({ page }) => {
     const themeScriptErrors: string[] = [];
     page.on("console", (message) => {

--- a/apps/sdp-web/src/components/language-picker.tsx
+++ b/apps/sdp-web/src/components/language-picker.tsx
@@ -48,7 +48,7 @@ export function LanguagePicker({ variant = "topbar" }: { variant?: "topbar" | "l
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <button
           type="button"


### PR DESCRIPTION
## Summary

- make the language picker a non-modal dropdown
- add a browser regression covering both open and close transitions

## Root cause

Radix modal dropdowns apply document scroll locking while open. Combined with the app's stable scrollbar gutter, that temporarily changes the header's horizontal position when the language menu opens and restores it when the menu closes.

## Impact

Opening or closing the language picker no longer shifts the surrounding header layout. Keyboard dismissal and the existing menu behavior remain unchanged.

## Validation

- `pnpm --filter sdp-web exec playwright test --config=playwright.config.ts --project=public --grep "language picker does not shift"`
- `pnpm --filter sdp-web typecheck`
- `pnpm exec biome check apps/sdp-web/src/components/language-picker.tsx apps/sdp-web/playwright/tests/auth-entry.e2e.spec.ts`
