### PR TITLE
fix(web): use dark-mode surface for wallet setup footer

### DIFF
--- a/apps/sdp-web/src/app/dashboard/custody/setup/wallet-setup-flow.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/wallet-setup-flow.tsx
@@ -412,7 +412,7 @@ export function WalletSetupFlow({
       </div>
 
       <footer
-        className="shrink-0 border-t border-border-default bg-white/95 px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] md:px-6"
+        className="shrink-0 border-t border-border-default bg-surface-raised/95 px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] md:px-6"
         data-wallet-setup-actions="true"
       >
         <div className="mx-auto flex w-full max-w-3xl items-center justify-between gap-3">

--- a/apps/sdp-web/src/app/dashboard/custody/setup/wallet-setup-flow.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/wallet-setup-flow.unit.test.tsx
@@ -42,6 +42,8 @@ describe("WalletSetupFlow", () => {
     expect(markup.indexOf('data-wallet-setup-scroll-region="true"')).toBeLessThan(
       markup.indexOf('data-wallet-setup-actions="true"')
     );
+    expect(markup).toContain("bg-surface-raised/95");
+    expect(markup).not.toContain("bg-white/95");
     expect(markup).toContain("Cancel");
     expect(markup).toContain("Next");
     expect(markup).toContain('id="wallet-provider-form"');


### PR DESCRIPTION
## Summary

- replace the wallet setup action footer's hard-coded white background with the semantic raised-surface token
- keep the footer consistent across light and dark themes
- add a regression assertion that rejects the hard-coded white class

## Validation

- `pnpm -C apps/sdp-web exec vitest run src/app/dashboard/custody/setup/wallet-setup-flow.unit.test.tsx`
- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web build`
- `pnpm exec biome check apps/sdp-web/src/app/dashboard/custody/setup/wallet-setup-flow.tsx apps/sdp-web/src/app/dashboard/custody/setup/wallet-setup-flow.unit.test.tsx`
- `git diff --check`

## Visual QA

- verified the deployed Vercel preview at `/dashboard/wallets/setup` with dark mode enabled
- confirmed the sticky action footer uses the dark raised surface and no longer renders as a white strip
- local authenticated visual E2E was blocked by incompatible Clerk keys in the isolated worktree, so authenticated visual QA was completed against the branch deployment
