### PR TITLE
fix(api): close DeepSec high-severity findings

### DIFF
--- a/apps/sdp-api/src/middleware/clerk-auth.test.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.test.ts
@@ -191,6 +191,85 @@ describe("Clerk auth request cache", () => {
     expect(membership?.status).toBe("removed");
   });
 
+  it("does not link a first-time Clerk identity until its primary email is verified", async () => {
+    await getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')")
+      .bind("usr_email_collision_target", "collision-target@example.com")
+      .run();
+
+    env.CLERK_SECRET_KEY = "sk_test_clerk_auth_user_lookup";
+    env.CLERK_API_URL = "https://clerk.example.test/v1";
+    let verificationStatus = "unverified";
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      expect(url).toBe(`${env.CLERK_API_URL}/users/clerk_user_first_login`);
+      return new Response(
+        JSON.stringify({
+          id: "clerk_user_first_login",
+          primary_email_address_id: "email_primary",
+          email_addresses: [
+            {
+              id: "email_primary",
+              email_address: "collision-target@example.com",
+              verification: { status: verificationStatus },
+            },
+            {
+              id: "email_secondary",
+              email_address: "verified-secondary@example.com",
+              verification: { status: "verified" },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    });
+
+    const payload: ClerkJwtPayload = {
+      sub: "clerk_user_first_login",
+      org_id: "clerk_org_cached",
+      org_role: "org:member",
+      org_slug: TEST_ORG.slug,
+      email: "collision-target@example.com",
+      iss: "https://clerk.example.test",
+    };
+    const { app, token } = createProtectedApp(payload);
+
+    const unverified = await app.request(
+      "/protected",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env
+    );
+    expect(unverified.status).toBe(401);
+
+    const missingIdentity = await getDb(env)
+      .prepare(
+        `SELECT user_id
+         FROM auth_user_identities
+         WHERE provider = 'clerk' AND provider_user_id = ?`
+      )
+      .bind("clerk_user_first_login")
+      .first<{ user_id: string }>();
+    expect(missingIdentity).toBeNull();
+
+    verificationStatus = "verified";
+    const verified = await app.request(
+      "/protected",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env
+    );
+    expect(verified.status).toBe(200);
+
+    const linkedIdentity = await getDb(env)
+      .prepare(
+        `SELECT user_id
+         FROM auth_user_identities
+         WHERE provider = 'clerk' AND provider_user_id = ?`
+      )
+      .bind("clerk_user_first_login")
+      .first<{ user_id: string }>();
+    expect(linkedIdentity?.user_id).toBe("usr_email_collision_target");
+  });
+
   it("provisions default projects when the membership webhook has not arrived", async () => {
     await getDb(env)
       .prepare("DELETE FROM organization_members WHERE organization_id = ?")

--- a/apps/sdp-api/src/middleware/clerk-auth.test.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
+import { AppError } from "@/lib/errors";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { kvStoreMiddleware } from "@/middleware/kv-store";
 import { rateLimitMiddleware } from "@/middleware/rate-limit";
@@ -110,6 +111,12 @@ describe("Clerk auth request cache", () => {
         organizationId: c.get("clerk")?.organizationId ?? null,
       });
     });
+    app.onError((error, c) => {
+      if (error instanceof AppError) {
+        return c.json(error.toResponse(), error.statusCode as 401 | 403);
+      }
+      throw error;
+    });
 
     return { app, token };
   }
@@ -150,6 +157,38 @@ describe("Clerk auth request cache", () => {
       "default-production",
       "default-sandbox",
     ]);
+  });
+
+  it("rejects a stale Clerk JWT after the local organization membership is removed", async () => {
+    await getDb(env)
+      .prepare(
+        "UPDATE organization_members SET status = 'removed' WHERE organization_id = ? AND user_id = ?"
+      )
+      .bind(TEST_ORG.id, "usr_clerk_cached")
+      .run();
+
+    const payload: ClerkJwtPayload = {
+      sub: "clerk_user_cached",
+      org_id: "clerk_org_cached",
+      org_role: "org:admin",
+      org_slug: TEST_ORG.slug,
+      email: "clerk-cache@example.com",
+      iss: "https://clerk.example.test",
+    };
+    const { app, token } = createProtectedApp(payload);
+
+    const res = await app.request(
+      "/protected",
+      { headers: { Authorization: `Bearer ${token}` } },
+      env
+    );
+
+    expect(res.status).toBe(401);
+    const membership = await getDb(env)
+      .prepare("SELECT status FROM organization_members WHERE organization_id = ? AND user_id = ?")
+      .bind(TEST_ORG.id, "usr_clerk_cached")
+      .first<{ status: string }>();
+    expect(membership?.status).toBe("removed");
   });
 
   it("provisions default projects when the membership webhook has not arrived", async () => {

--- a/apps/sdp-api/src/middleware/clerk-auth.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.ts
@@ -22,15 +22,20 @@ import {
 import { AppError, unauthorized } from "@/lib/errors";
 import { ensureClerkOrganizationMapping } from "@/services/clerk-organization-provisioning.service";
 import { ClerkOrganizationsService } from "@/services/clerk-organizations.service";
+import {
+  ClerkUsersService,
+  verifiedPrimaryEmailFromClerkUser,
+} from "@/services/clerk-users.service";
 import { ProjectService } from "@/services/project.service";
 import type { Env } from "@/types/env";
 
 async function resolveClerkUser(db: DatabaseClient, clerkUserId: string) {
   return db
     .prepare(
-      `SELECT user_id, email
-       FROM auth_user_identities
-       WHERE provider = 'clerk' AND provider_user_id = ?`
+      `SELECT aui.user_id, COALESCE(aui.email, u.email) AS email
+       FROM auth_user_identities aui
+       LEFT JOIN users u ON u.id = aui.user_id
+       WHERE aui.provider = 'clerk' AND aui.provider_user_id = ?`
     )
     .bind(clerkUserId)
     .first<{ user_id: string; email: string | null }>();
@@ -123,16 +128,21 @@ async function resolveOrgMembership(db: DatabaseClient, userId: string, organiza
 }
 
 async function ensureClerkUser(
+  env: Env,
   db: DatabaseClient,
   clerkUserId: string,
-  email: string
+  fallbackEmail: string
 ): Promise<{ userId: string; email: string }> {
   const existing = await resolveClerkUser(db, clerkUserId);
   if (existing) {
-    return { userId: existing.user_id, email: existing.email ?? email };
+    return { userId: existing.user_id, email: existing.email ?? fallbackEmail };
   }
 
-  const normalizedEmail = email.toLowerCase();
+  const clerkUser = await new ClerkUsersService(env).getUser(clerkUserId);
+  const normalizedEmail = verifiedPrimaryEmailFromClerkUser(clerkUser);
+  if (!normalizedEmail) {
+    throw unauthorized("Clerk primary email must be verified");
+  }
   let user = await db
     .prepare("SELECT id, email FROM users WHERE email = ?")
     .bind(normalizedEmail)
@@ -330,7 +340,7 @@ async function buildClerkContext(c: Context<{ Bindings: Env }>, payload: ClerkJw
   }
 
   const [userIdentity, orgIdentity] = await Promise.all([
-    ensureClerkUser(getDb(c.env), payload.sub as string, email),
+    ensureClerkUser(c.env, getDb(c.env), payload.sub as string, email),
     resolveClerkOrganization(getDb(c.env), payload.org_id as string),
   ]);
 
@@ -353,7 +363,7 @@ async function buildClerkContext(c: Context<{ Bindings: Env }>, payload: ClerkJw
   const role = await ensureMembership(getDb(c.env), {
     organizationId: resolvedOrgIdentity.organization_id,
     userId: userIdentity.userId,
-    email,
+    email: userIdentity.email,
     clerkRole: payload.org_role,
   });
   await ensureDefaultProjects(
@@ -371,7 +381,7 @@ async function buildClerkContext(c: Context<{ Bindings: Env }>, payload: ClerkJw
     role,
     clerkUserId: payload.sub as string,
     clerkOrgId: payload.org_id as string,
-    email: email || userIdentity.email,
+    email: userIdentity.email,
     orgSlug: payload.org_slug ?? resolvedOrgIdentity.slug,
     orgRole: payload.org_role ?? null,
   };

--- a/apps/sdp-api/src/middleware/clerk-auth.ts
+++ b/apps/sdp-api/src/middleware/clerk-auth.ts
@@ -111,15 +111,15 @@ async function resolveExistingClerkContext(
     }>();
 }
 
-async function resolveOrgRole(db: DatabaseClient, userId: string, organizationId: string) {
+async function resolveOrgMembership(db: DatabaseClient, userId: string, organizationId: string) {
   return db
     .prepare(
-      `SELECT role
+      `SELECT role, status
        FROM organization_members
-       WHERE user_id = ? AND organization_id = ? AND status = 'active'`
+       WHERE user_id = ? AND organization_id = ?`
     )
     .bind(userId, organizationId)
-    .first<{ role: string }>();
+    .first<{ role: string; status: string }>();
 }
 
 async function ensureClerkUser(
@@ -180,8 +180,11 @@ async function ensureMembership(
     clerkRole?: string | null;
   }
 ): Promise<OrganizationRole> {
-  const existing = await resolveOrgRole(db, params.userId, params.organizationId);
-  if (existing?.role) {
+  const existing = await resolveOrgMembership(db, params.userId, params.organizationId);
+  if (existing && existing.status !== "active") {
+    throw unauthorized("Organization membership is inactive");
+  }
+  if (existing) {
     const normalizedRole = normalizeOrganizationRole(existing.role);
     if (normalizedRole !== existing.role) {
       await db
@@ -239,11 +242,19 @@ async function ensureMembership(
       )
       .bind(memberId, params.organizationId, params.userId, role)
       .run();
-  } catch {
-    const existingAfterInsert = await resolveOrgRole(db, params.userId, params.organizationId);
-    if (existingAfterInsert?.role) {
+  } catch (error) {
+    const existingAfterInsert = await resolveOrgMembership(
+      db,
+      params.userId,
+      params.organizationId
+    );
+    if (existingAfterInsert?.status === "active") {
       return normalizeOrganizationRole(existingAfterInsert.role);
     }
+    if (existingAfterInsert) {
+      throw unauthorized("Organization membership is inactive");
+    }
+    throw error;
   }
 
   if (pendingInvite && role === normalizeOrganizationRole(pendingInvite.role)) {

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -5140,7 +5140,6 @@ describe("Issuance Routes", () => {
               info: {
                 mint: TEST_SOLANA_ADDRESSES.mint,
                 mintAuthority: TEST_SOLANA_ADDRESSES.wallet2,
-                freezeAuthority: null,
               },
             },
           ],

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -5031,7 +5031,11 @@ describe("Issuance Routes", () => {
             {
               programId: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
               parsedType: "initializeMint2",
-              info: { mint: TEST_SOLANA_ADDRESSES.mint },
+              info: {
+                mint: TEST_SOLANA_ADDRESSES.mint,
+                mintAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+                freezeAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+              },
             },
           ],
         });
@@ -5113,6 +5117,7 @@ describe("Issuance Routes", () => {
           mintAddress: null,
           status: "pending",
           uri: null,
+          isFreezable: false,
           requiresAllowlist: false,
         });
 
@@ -5132,7 +5137,11 @@ describe("Issuance Routes", () => {
             {
               programId: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
               parsedType: "initializeMint2",
-              info: { mint: TEST_SOLANA_ADDRESSES.mint },
+              info: {
+                mint: TEST_SOLANA_ADDRESSES.mint,
+                mintAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+                freezeAuthority: null,
+              },
             },
           ],
         });
@@ -5249,6 +5258,75 @@ describe("Issuance Routes", () => {
         }
       });
 
+      it("returns 400 when the mint authority differs from the server-derived custody address", async () => {
+        ensureRpcUrl();
+
+        const token = await seedIssuedToken({
+          id: "tok_deploy_confirm_wrong_authority",
+          mintAddress: null,
+          status: "pending",
+          uri: null,
+          requiresAllowlist: false,
+        });
+
+        const createOrgSignerSpy = vi
+          .spyOn(SolanaServices, "createOrgSigner")
+          .mockResolvedValue({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
+        const getSignatureStatusesSpy = vi
+          .spyOn(SolanaRpc, "getSignatureStatuses")
+          .mockResolvedValueOnce([
+            { slot: 100n, confirmations: 10n, confirmationStatus: "confirmed", err: null },
+          ]);
+        const accountExistsSpy = vi.spyOn(SolanaRpc, "accountExists").mockResolvedValueOnce(true);
+        const getTransactionSpy = vi.spyOn(SolanaRpc, "getTransaction").mockResolvedValueOnce({
+          slot: 100n,
+          err: null,
+          instructions: [
+            {
+              programId: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+              parsedType: "initializeMint2",
+              info: {
+                mint: TEST_SOLANA_ADDRESSES.mint,
+                mintAuthority: TEST_SOLANA_ADDRESSES.wallet1,
+                freezeAuthority: null,
+              },
+            },
+          ],
+        });
+
+        try {
+          const res = await app.request(
+            `/v1/issuance/tokens/${token.id}/deploy/confirm`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              },
+              body: JSON.stringify({
+                signature: "5wrongAuthorityConfirmedSig",
+                mint: TEST_SOLANA_ADDRESSES.mint,
+              }),
+            },
+            env
+          );
+
+          expect(res.status).toBe(400);
+          const stillPending = await new TokenService(getDb(env)).getToken({
+            tokenId: token.id,
+            organizationId: TEST_PROJECT.organizationId,
+            projectId: TEST_PROJECT.id,
+          });
+          expect(stillPending?.mintAddress).toBeNull();
+          expect(stillPending?.status).toBe("pending");
+        } finally {
+          createOrgSignerSpy.mockRestore();
+          getSignatureStatusesSpy.mockRestore();
+          accountExistsSpy.mockRestore();
+          getTransactionSpy.mockRestore();
+        }
+      });
+
       it("returns a retryable error (not the wrong-tx 400) when the tx is not yet indexed", async () => {
         ensureRpcUrl();
 
@@ -5344,7 +5422,11 @@ describe("Issuance Routes", () => {
             {
               programId: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
               parsedType: "initializeMint2",
-              info: { mint: TEST_SOLANA_ADDRESSES.mint },
+              info: {
+                mint: TEST_SOLANA_ADDRESSES.mint,
+                mintAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+                freezeAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+              },
             },
           ],
         });
@@ -5437,7 +5519,11 @@ describe("Issuance Routes", () => {
             {
               programId: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
               parsedType: "initializeMint2",
-              info: { mint: TEST_SOLANA_ADDRESSES.mint },
+              info: {
+                mint: TEST_SOLANA_ADDRESSES.mint,
+                mintAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+                freezeAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+              },
             },
           ],
         });

--- a/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
@@ -12,7 +12,7 @@ import {
   type ParsedTransaction,
   simulateTransaction,
 } from "@sdp/rpc/solana";
-import type { TokenResponse } from "@sdp/types";
+import { SPL_TOKEN_PROGRAMS, type TokenResponse } from "@sdp/types";
 import type { Address, Signature } from "@solana/kit";
 import type { Context } from "hono";
 import { z } from "zod";
@@ -592,6 +592,7 @@ export const prepareDeploy = async (c: AppContext) => {
 // carries one targeting that mint. jsonParsed decodes both legacy `spl-token`
 // and `spl-token-2022` programs under the same instruction `type`.
 const MINT_INIT_INSTRUCTION_TYPES = new Set(["initializeMint", "initializeMint2"]);
+const TOKEN_PROGRAM_IDS = new Set<string>(Object.values(SPL_TOKEN_PROGRAMS));
 
 /**
  * Whether `tx` contains an instruction that initializes `mint` — i.e. the
@@ -602,9 +603,26 @@ const MINT_INIT_INSTRUCTION_TYPES = new Set(["initializeMint", "initializeMint2"
 const transactionInitializesMint = (tx: ParsedTransaction, mint: Address): boolean =>
   tx.instructions.some(
     (ix) =>
+      TOKEN_PROGRAM_IDS.has(ix.programId) &&
       ix.parsedType !== null &&
       MINT_INIT_INSTRUCTION_TYPES.has(ix.parsedType) &&
       ix.info?.mint === mint
+  );
+
+const transactionInitializesMintWithAuthorities = (
+  tx: ParsedTransaction,
+  mint: Address,
+  mintAuthority: Address,
+  freezeAuthority: Address | null
+): boolean =>
+  tx.instructions.some(
+    (ix) =>
+      TOKEN_PROGRAM_IDS.has(ix.programId) &&
+      ix.parsedType !== null &&
+      MINT_INIT_INSTRUCTION_TYPES.has(ix.parsedType) &&
+      ix.info?.mint === mint &&
+      ix.info?.mintAuthority === mintAuthority &&
+      ix.info?.freezeAuthority === freezeAuthority
   );
 
 /**
@@ -721,6 +739,12 @@ export const confirmDeploy = async (c: AppContext) => {
   const signer = await createOrgSigner(c.env, auth.organizationId, auth.projectId, signingWalletId);
   const custodyAddress = signer.address;
   const freezeAuthority = token.isFreezable ? custodyAddress : null;
+
+  if (
+    !transactionInitializesMintWithAuthorities(confirmedTx, mint, custodyAddress, freezeAuthority)
+  ) {
+    throw badRequest("Deploy transaction did not use the expected mint authorities");
+  }
 
   // Re-derive the ABL list address server-side instead of trusting the request
   // body's `listAddress`: for allowlist/blocklist tokens a wrong value would

--- a/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
@@ -594,35 +594,16 @@ export const prepareDeploy = async (c: AppContext) => {
 const MINT_INIT_INSTRUCTION_TYPES = new Set(["initializeMint", "initializeMint2"]);
 const TOKEN_PROGRAM_IDS = new Set<string>(Object.values(SPL_TOKEN_PROGRAMS));
 
-/**
- * Whether `tx` contains an instruction that initializes `mint` — i.e. the
- * transaction actually created this mint, rather than merely referencing or
- * coexisting with it. Used by `confirmDeploy` to bind a confirmed signature to
- * the mint a caller claims it produced.
- */
-const transactionInitializesMint = (tx: ParsedTransaction, mint: Address): boolean =>
-  tx.instructions.some(
+const findMintInitialization = (
+  tx: ParsedTransaction,
+  mint: Address
+): ParsedTransaction["instructions"][number] | undefined =>
+  tx.instructions.find(
     (ix) =>
       TOKEN_PROGRAM_IDS.has(ix.programId) &&
       ix.parsedType !== null &&
       MINT_INIT_INSTRUCTION_TYPES.has(ix.parsedType) &&
       ix.info?.mint === mint
-  );
-
-const transactionInitializesMintWithAuthorities = (
-  tx: ParsedTransaction,
-  mint: Address,
-  mintAuthority: Address,
-  freezeAuthority: Address | null
-): boolean =>
-  tx.instructions.some(
-    (ix) =>
-      TOKEN_PROGRAM_IDS.has(ix.programId) &&
-      ix.parsedType !== null &&
-      MINT_INIT_INSTRUCTION_TYPES.has(ix.parsedType) &&
-      ix.info?.mint === mint &&
-      ix.info?.mintAuthority === mintAuthority &&
-      ix.info?.freezeAuthority === freezeAuthority
   );
 
 /**
@@ -720,7 +701,8 @@ export const confirmDeploy = async (c: AppContext) => {
     );
   }
 
-  if (!transactionInitializesMint(confirmedTx, mint)) {
+  const mintInitialization = findMintInitialization(confirmedTx, mint);
+  if (!mintInitialization) {
     throw badRequest("Deploy transaction did not create this mint");
   }
 
@@ -741,7 +723,8 @@ export const confirmDeploy = async (c: AppContext) => {
   const freezeAuthority = token.isFreezable ? custodyAddress : null;
 
   if (
-    !transactionInitializesMintWithAuthorities(confirmedTx, mint, custodyAddress, freezeAuthority)
+    mintInitialization.info?.mintAuthority !== custodyAddress ||
+    (mintInitialization.info?.freezeAuthority ?? null) !== freezeAuthority
   ) {
     throw badRequest("Deploy transaction did not use the expected mint authorities");
   }

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -51,24 +51,38 @@ async function simulateClerkWebhook(event: { type: string; data: Record<string, 
 function mockClerkUserLookup(
   userId: string,
   email: string,
-  verificationStatus: "verified" | "unverified" = "verified"
+  verificationStatus: "verified" | "unverified" = "verified",
+  memberships: Array<{ role: string; organization: Record<string, unknown> }> = []
 ) {
   env.CLERK_SECRET_KEY = "sk_test_clerk_webhook_user_lookup";
   env.CLERK_API_URL = "https://clerk.example.test/v1";
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    expect(url).toBe(`${env.CLERK_API_URL}/users/${userId}`);
+
+    if (url === `${env.CLERK_API_URL}/users/${userId}`) {
+      return new Response(
+        JSON.stringify({
+          id: userId,
+          primary_email_address_id: "email_primary",
+          email_addresses: [
+            {
+              id: "email_primary",
+              email_address: email,
+              verification: { status: verificationStatus },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    expect(url).toBe(
+      `${env.CLERK_API_URL}/users/${userId}/organization_memberships?limit=500&offset=0`
+    );
     return new Response(
       JSON.stringify({
-        id: userId,
-        primary_email_address_id: "email_primary",
-        email_addresses: [
-          {
-            id: "email_primary",
-            email_address: email,
-            verification: { status: verificationStatus },
-          },
-        ],
+        data: memberships,
+        total_count: memberships.length,
       }),
       { status: 200, headers: { "Content-Type": "application/json" } }
     );
@@ -239,6 +253,7 @@ describe("Clerk webhooks", () => {
         )
         .bind("aui_existing", "user_clerk_existing", "usr_clerk_existing", "old@example.com"),
     ]);
+    mockClerkUserLookup("user_clerk_existing", "taken@example.com");
 
     const updated = await simulateClerkWebhook({
       type: "user.updated",
@@ -305,7 +320,16 @@ describe("Clerk webhooks", () => {
       .first<{ user_id: string }>();
     expect(identity).toBeNull();
 
-    mockClerkUserLookup("user_unverified_collision", "victim@example.com", "unverified");
+    mockClerkUserLookup("user_unverified_collision", "victim@example.com", "unverified", [
+      {
+        role: "org:admin",
+        organization: {
+          id: "org_unverified_collision",
+          name: "Unverified Collision Org",
+          slug: "unverified-collision-org",
+        },
+      },
+    ]);
     const membershipCreated = await simulateClerkWebhook({
       type: "organizationMembership.created",
       data: {
@@ -359,6 +383,17 @@ describe("Clerk webhooks", () => {
       .bind("user_unverified_collision")
       .first<{ user_id: string }>();
     expect(verifiedIdentity?.user_id).toBe("usr_verified_email_owner");
+
+    const reconciledMembership = await getDb(env)
+      .prepare(
+        `SELECT om.role, om.status
+         FROM organization_members om
+         JOIN auth_user_identities aui ON aui.user_id = om.user_id
+         WHERE aui.provider = 'clerk' AND aui.provider_user_id = ?`
+      )
+      .bind("user_unverified_collision")
+      .first<{ role: string; status: string }>();
+    expect(reconciledMembership).toEqual({ role: "admin", status: "active" });
   });
 
   it("syncs organization memberships without creating records on delete-only events", async () => {

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -422,7 +422,16 @@ describe("Clerk webhooks", () => {
 
     expect(missingOrg).toBeNull();
 
-    mockClerkUserLookup("user_clerk_member", "admin@example.com");
+    mockClerkUserLookup("user_clerk_member", "admin@example.com", "verified", [
+      {
+        role: "org:admin",
+        organization: {
+          id: "org_clerk_membership",
+          name: "Membership Org",
+          slug: "membership-org",
+        },
+      },
+    ]);
     const created = await simulateClerkWebhook({
       type: "organizationMembership.created",
       data: {
@@ -483,6 +492,61 @@ describe("Clerk webhooks", () => {
       .first<{ status: string }>();
 
     expect(removed?.status).toBe("removed");
+
+    const delayedUserUpdate = await simulateClerkWebhook({
+      type: "user.updated",
+      data: {
+        id: "user_clerk_member",
+        primary_email_address_id: "email_primary",
+        email_addresses: [
+          {
+            id: "email_primary",
+            email_address: "admin@example.com",
+            verification: { status: "verified" },
+          },
+        ],
+      },
+    });
+
+    expect(delayedUserUpdate.status).toBe(200);
+    const stillRemoved = await getDb(env)
+      .prepare(
+        `SELECT om.status
+         FROM organization_members om
+         JOIN auth_user_identities aui ON aui.user_id = om.user_id
+         WHERE aui.provider = 'clerk' AND aui.provider_user_id = ?`
+      )
+      .bind("user_clerk_member")
+      .first<{ status: string }>();
+    expect(stillRemoved?.status).toBe("removed");
+
+    const readded = await simulateClerkWebhook({
+      type: "organizationMembership.created",
+      data: {
+        organization: {
+          id: "org_clerk_membership",
+          name: "Membership Org",
+          slug: "membership-org",
+        },
+        role: "org:admin",
+        public_user_data: {
+          user_id: "user_clerk_member",
+          identifier: "admin@example.com",
+        },
+      },
+    });
+
+    expect(readded.status).toBe(200);
+    const activeAgain = await getDb(env)
+      .prepare(
+        `SELECT om.status
+         FROM organization_members om
+         JOIN auth_user_identities aui ON aui.user_id = om.user_id
+         WHERE aui.provider = 'clerk' AND aui.provider_user_id = ?`
+      )
+      .bind("user_clerk_member")
+      .first<{ status: string }>();
+    expect(activeAgain?.status).toBe("active");
   });
 
   it("syncs user lifecycle and Clerk organization deletion", async () => {

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -48,6 +48,33 @@ async function simulateClerkWebhook(event: { type: string; data: Record<string, 
   );
 }
 
+function mockClerkUserLookup(
+  userId: string,
+  email: string,
+  verificationStatus: "verified" | "unverified" = "verified"
+) {
+  env.CLERK_SECRET_KEY = "sk_test_clerk_webhook_user_lookup";
+  env.CLERK_API_URL = "https://clerk.example.test/v1";
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    expect(url).toBe(`${env.CLERK_API_URL}/users/${userId}`);
+    return new Response(
+      JSON.stringify({
+        id: userId,
+        primary_email_address_id: "email_primary",
+        email_addresses: [
+          {
+            id: "email_primary",
+            email_address: email,
+            verification: { status: verificationStatus },
+          },
+        ],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  });
+}
+
 describe("Clerk webhooks", () => {
   let originalDeploymentMode: "managed" | "self_hosted" | undefined;
 
@@ -222,6 +249,7 @@ describe("Clerk webhooks", () => {
           {
             id: "email_taken",
             email_address: "taken@example.com",
+            verification: { status: "verified" },
           },
         ],
       },
@@ -243,6 +271,94 @@ describe("Clerk webhooks", () => {
       user_email: "old@example.com",
       identity_email: "old@example.com",
     });
+  });
+
+  it("does not link an unverified Clerk email to an existing local user", async () => {
+    await getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')")
+      .bind("usr_verified_email_owner", "victim@example.com")
+      .run();
+
+    const created = await simulateClerkWebhook({
+      type: "user.created",
+      data: {
+        id: "user_unverified_collision",
+        primary_email_address_id: "email_unverified_collision",
+        email_addresses: [
+          {
+            id: "email_unverified_collision",
+            email_address: "victim@example.com",
+            verification: { status: "unverified" },
+          },
+        ],
+      },
+    });
+
+    expect(created.status).toBe(200);
+    const identity = await getDb(env)
+      .prepare(
+        `SELECT user_id
+         FROM auth_user_identities
+         WHERE provider = 'clerk' AND provider_user_id = ?`
+      )
+      .bind("user_unverified_collision")
+      .first<{ user_id: string }>();
+    expect(identity).toBeNull();
+
+    mockClerkUserLookup("user_unverified_collision", "victim@example.com", "unverified");
+    const membershipCreated = await simulateClerkWebhook({
+      type: "organizationMembership.created",
+      data: {
+        organization: {
+          id: "org_unverified_collision",
+          name: "Unverified Collision Org",
+          slug: "unverified-collision-org",
+        },
+        role: "org:admin",
+        public_user_data: {
+          user_id: "user_unverified_collision",
+          identifier: "victim@example.com",
+        },
+      },
+    });
+    expect(membershipCreated.status).toBe(200);
+
+    const unverifiedMembership = await getDb(env)
+      .prepare(
+        `SELECT om.id
+         FROM organization_members om
+         JOIN auth_user_identities aui ON aui.user_id = om.user_id
+         WHERE aui.provider = 'clerk' AND aui.provider_user_id = ?`
+      )
+      .bind("user_unverified_collision")
+      .first<{ id: string }>();
+    expect(unverifiedMembership).toBeNull();
+
+    const verified = await simulateClerkWebhook({
+      type: "user.updated",
+      data: {
+        id: "user_unverified_collision",
+        primary_email_address_id: "email_unverified_collision",
+        email_addresses: [
+          {
+            id: "email_unverified_collision",
+            email_address: "victim@example.com",
+            verification: { status: "verified" },
+          },
+        ],
+      },
+    });
+
+    expect(verified.status).toBe(200);
+    const verifiedIdentity = await getDb(env)
+      .prepare(
+        `SELECT user_id
+         FROM auth_user_identities
+         WHERE provider = 'clerk' AND provider_user_id = ?`
+      )
+      .bind("user_unverified_collision")
+      .first<{ user_id: string }>();
+    expect(verifiedIdentity?.user_id).toBe("usr_verified_email_owner");
   });
 
   it("syncs organization memberships without creating records on delete-only events", async () => {
@@ -271,6 +387,7 @@ describe("Clerk webhooks", () => {
 
     expect(missingOrg).toBeNull();
 
+    mockClerkUserLookup("user_clerk_member", "admin@example.com");
     const created = await simulateClerkWebhook({
       type: "organizationMembership.created",
       data: {
@@ -334,6 +451,7 @@ describe("Clerk webhooks", () => {
   });
 
   it("syncs user lifecycle and Clerk organization deletion", async () => {
+    mockClerkUserLookup("user_clerk_lifecycle", "member@example.com");
     await simulateClerkWebhook({
       type: "organizationMembership.created",
       data: {
@@ -361,6 +479,7 @@ describe("Clerk webhooks", () => {
           {
             id: "email_primary",
             email_address: "ada@example.com",
+            verification: { status: "verified" },
           },
         ],
       },

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -219,6 +219,7 @@ async function syncUser(c: AppContext, data: UserJSON) {
         organization: membership.organization,
         userId,
         role: membership.role,
+        reactivateRemoved: false,
       })
     )
   );
@@ -252,7 +253,12 @@ async function deleteUser(c: AppContext, data: UserDeletedJSON) {
 
 async function upsertVerifiedMembership(
   c: AppContext,
-  data: { organization: OrganizationJSON; userId: string; role: string }
+  data: {
+    organization: OrganizationJSON;
+    userId: string;
+    role: string;
+    reactivateRemoved: boolean;
+  }
 ) {
   const organizationId = await ensureOrganizationMapping(c, data.organization);
   const role = mapClerkRoleToOrgRole(data.role);
@@ -265,9 +271,13 @@ async function upsertVerifiedMembership(
        ON CONFLICT(organization_id, user_id)
        DO UPDATE SET
          role = excluded.role,
-         status = 'active'`
+         status = CASE
+           WHEN organization_members.status = 'removed' AND ? = 0
+             THEN organization_members.status
+           ELSE 'active'
+         END`
     )
-    .bind(memberId, organizationId, data.userId, role)
+    .bind(memberId, organizationId, data.userId, role, data.reactivateRemoved ? 1 : 0)
     .run();
 
   const projectService = new ProjectService(getDb(c.env));
@@ -290,6 +300,7 @@ async function upsertMembership(c: AppContext, data: OrganizationMembershipJSON)
     organization: data.organization,
     userId,
     role: data.role,
+    reactivateRemoved: true,
   });
 }
 

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -207,11 +207,21 @@ async function syncUser(c: AppContext, data: UserJSON) {
     return;
   }
   const fullName = [data.first_name, data.last_name].filter(Boolean).join(" ").trim();
-  await ensureUserMapping(c, {
+  const userId = await ensureUserMapping(c, {
     id: data.id,
     email,
     name: fullName || data.username,
   });
+  const memberships = await new ClerkUsersService(c.env).getOrganizationMemberships(data.id);
+  await Promise.all(
+    memberships.map((membership) =>
+      upsertVerifiedMembership(c, {
+        organization: membership.organization,
+        userId,
+        role: membership.role,
+      })
+    )
+  );
 }
 
 async function deleteUser(c: AppContext, data: UserDeletedJSON) {
@@ -240,16 +250,11 @@ async function deleteUser(c: AppContext, data: UserDeletedJSON) {
   ]);
 }
 
-async function upsertMembership(c: AppContext, data: OrganizationMembershipJSON) {
+async function upsertVerifiedMembership(
+  c: AppContext,
+  data: { organization: OrganizationJSON; userId: string; role: string }
+) {
   const organizationId = await ensureOrganizationMapping(c, data.organization);
-  const email = await resolveVerifiedUserEmail(c.env, data.public_user_data.user_id);
-  if (!email) {
-    return;
-  }
-  const userId = await ensureUserMapping(c, {
-    id: data.public_user_data.user_id,
-    email,
-  });
   const role = mapClerkRoleToOrgRole(data.role);
   const memberId = `mem_${crypto.randomUUID()}`;
 
@@ -262,14 +267,30 @@ async function upsertMembership(c: AppContext, data: OrganizationMembershipJSON)
          role = excluded.role,
          status = 'active'`
     )
-    .bind(memberId, organizationId, userId, role)
+    .bind(memberId, organizationId, data.userId, role)
     .run();
 
   const projectService = new ProjectService(getDb(c.env));
   await Promise.all([
-    projectService.findOrCreateDefault(organizationId, "sandbox", userId),
-    projectService.findOrCreateDefault(organizationId, "production", userId),
+    projectService.findOrCreateDefault(organizationId, "sandbox", data.userId),
+    projectService.findOrCreateDefault(organizationId, "production", data.userId),
   ]);
+}
+
+async function upsertMembership(c: AppContext, data: OrganizationMembershipJSON) {
+  const email = await resolveVerifiedUserEmail(c.env, data.public_user_data.user_id);
+  if (!email) {
+    return;
+  }
+  const userId = await ensureUserMapping(c, {
+    id: data.public_user_data.user_id,
+    email,
+  });
+  await upsertVerifiedMembership(c, {
+    organization: data.organization,
+    userId,
+    role: data.role,
+  });
 }
 
 async function deleteMembership(c: AppContext, data: OrganizationMembershipJSON) {

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -18,7 +18,10 @@ import {
   findClerkOrganizationMapping,
   syncClerkOrganization,
 } from "@/services/clerk-organization-provisioning.service";
-import { type ClerkUser, ClerkUsersService } from "@/services/clerk-users.service";
+import {
+  ClerkUsersService,
+  verifiedPrimaryEmailFromClerkUser,
+} from "@/services/clerk-users.service";
 import { ProjectService } from "@/services/project.service";
 import type { Env } from "@/types/env";
 import { BvnkWebhookProcessor } from "./ramps/bvnk";
@@ -104,15 +107,6 @@ async function deleteOrganization(c: AppContext, data: DeletedObjectJSON) {
       )
       .bind(mapping.organization_id),
   ]);
-}
-
-function verifiedPrimaryEmailFromClerkUser(user: ClerkUser): string | null {
-  const emails = user.email_addresses || [];
-  const primary = emails.find((item) => item.id === user.primary_email_address_id) || emails[0];
-  if (primary?.verification?.status !== "verified") {
-    return null;
-  }
-  return primary?.email_address?.toLowerCase() ?? null;
 }
 
 async function resolveVerifiedUserEmail(env: Env, userId: string): Promise<string | null> {

--- a/apps/sdp-api/src/routes/webhooks/handlers.ts
+++ b/apps/sdp-api/src/routes/webhooks/handlers.ts
@@ -106,33 +106,26 @@ async function deleteOrganization(c: AppContext, data: DeletedObjectJSON) {
   ]);
 }
 
-function primaryEmailFromClerkUser(user: ClerkUser): string | null {
+function verifiedPrimaryEmailFromClerkUser(user: ClerkUser): string | null {
   const emails = user.email_addresses || [];
   const primary = emails.find((item) => item.id === user.primary_email_address_id) || emails[0];
+  if (primary?.verification?.status !== "verified") {
+    return null;
+  }
   return primary?.email_address?.toLowerCase() ?? null;
 }
 
-async function resolveUserEmail(env: Env, userId: string, fallbackEmail?: string | null) {
-  if (fallbackEmail?.includes("@")) {
-    return fallbackEmail.toLowerCase();
-  }
-
+async function resolveVerifiedUserEmail(env: Env, userId: string): Promise<string | null> {
   const user = await new ClerkUsersService(env).getUser(userId);
-  const email = primaryEmailFromClerkUser(user);
-
-  if (!email) {
-    throw badRequest("Clerk user missing email");
-  }
-
-  return email;
+  return verifiedPrimaryEmailFromClerkUser(user);
 }
 
 async function ensureUserMapping(
   c: AppContext,
-  user: { id: string; email?: string | null; name?: string | null }
+  user: { id: string; email: string; name?: string | null }
 ): Promise<string> {
   const db = getDb(c.env);
-  const email = await resolveUserEmail(c.env, user.id, user.email);
+  const email = user.email.toLowerCase();
   const existing = await db
     .prepare(
       `SELECT aui.user_id, u.email
@@ -209,10 +202,14 @@ async function ensureUserMapping(
 }
 
 async function syncUser(c: AppContext, data: UserJSON) {
+  const email = verifiedPrimaryEmailFromClerkUser(data);
+  if (!email) {
+    return;
+  }
   const fullName = [data.first_name, data.last_name].filter(Boolean).join(" ").trim();
   await ensureUserMapping(c, {
     id: data.id,
-    email: primaryEmailFromClerkUser(data),
+    email,
     name: fullName || data.username,
   });
 }
@@ -245,9 +242,13 @@ async function deleteUser(c: AppContext, data: UserDeletedJSON) {
 
 async function upsertMembership(c: AppContext, data: OrganizationMembershipJSON) {
   const organizationId = await ensureOrganizationMapping(c, data.organization);
+  const email = await resolveVerifiedUserEmail(c.env, data.public_user_data.user_id);
+  if (!email) {
+    return;
+  }
   const userId = await ensureUserMapping(c, {
     id: data.public_user_data.user_id,
-    email: data.public_user_data.identifier,
+    email,
   });
   const role = mapClerkRoleToOrgRole(data.role);
   const memberId = `mem_${crypto.randomUUID()}`;

--- a/apps/sdp-api/src/services/clerk-users.service.ts
+++ b/apps/sdp-api/src/services/clerk-users.service.ts
@@ -19,6 +19,15 @@ export interface ClerkUser {
   email_addresses?: ClerkEmailAddress[];
 }
 
+export function verifiedPrimaryEmailFromClerkUser(user: ClerkUser): string | null {
+  const emails = user.email_addresses || [];
+  const primary = emails.find((item) => item.id === user.primary_email_address_id);
+  if (primary?.verification?.status !== "verified") {
+    return null;
+  }
+  return primary.email_address.toLowerCase();
+}
+
 export interface ClerkOrganizationMembership {
   role: string;
   organization: OrganizationJSON;

--- a/apps/sdp-api/src/services/clerk-users.service.ts
+++ b/apps/sdp-api/src/services/clerk-users.service.ts
@@ -1,3 +1,4 @@
+import type { OrganizationJSON } from "@clerk/backend";
 import { AppError } from "@/lib/errors";
 import type { Env } from "@/types/env";
 
@@ -16,6 +17,16 @@ export interface ClerkUser {
   username?: string | null;
   primary_email_address_id?: string | null;
   email_addresses?: ClerkEmailAddress[];
+}
+
+export interface ClerkOrganizationMembership {
+  role: string;
+  organization: OrganizationJSON;
+}
+
+interface ClerkOrganizationMembershipPage {
+  data: ClerkOrganizationMembership[];
+  total_count: number;
 }
 
 export class ClerkUsersService {
@@ -57,5 +68,21 @@ export class ClerkUsersService {
 
   async getUser(userId: string): Promise<ClerkUser> {
     return this.request<ClerkUser>(`/users/${userId}`);
+  }
+
+  async getOrganizationMemberships(userId: string): Promise<ClerkOrganizationMembership[]> {
+    const memberships: ClerkOrganizationMembership[] = [];
+    const limit = 500;
+
+    while (true) {
+      const page = await this.request<ClerkOrganizationMembershipPage>(
+        `/users/${userId}/organization_memberships?limit=${limit}&offset=${memberships.length}`
+      );
+      memberships.push(...page.data);
+
+      if (page.data.length === 0 || memberships.length >= page.total_count) {
+        return memberships;
+      }
+    }
   }
 }

--- a/apps/sdp-api/src/services/clerk-users.service.ts
+++ b/apps/sdp-api/src/services/clerk-users.service.ts
@@ -4,6 +4,9 @@ import type { Env } from "@/types/env";
 export interface ClerkEmailAddress {
   id: string;
   email_address: string;
+  verification?: {
+    status?: string | null;
+  } | null;
 }
 
 export interface ClerkUser {
@@ -19,7 +22,7 @@ export class ClerkUsersService {
   private apiBase: string;
   private secretKey: string;
 
-  constructor(private env: Env) {
+  constructor(env: Env) {
     if (!env.CLERK_SECRET_KEY) {
       throw new AppError("INTERNAL_ERROR", "CLERK_SECRET_KEY is required");
     }


### PR DESCRIPTION
## Summary

Closes all three High-severity findings validated by the GLM DeepSec pilot:

- reject stale Clerk organization JWT access when the local membership is inactive
- verify the deployed Solana mint uses the server-derived mint and freeze authorities
- require a verified Clerk primary email before linking identities or memberships

## Security impact

- removed organization members can no longer regain access from a still-valid Clerk JWT
- callers cannot register an attacker-controlled mint authority through deploy confirmation
- unverified Clerk email claims cannot collide with and take over an existing local identity

## Verification

- pnpm exec biome check on all seven changed files
- pnpm --filter @sdp/api typecheck
- pnpm --filter @sdp/api test
  - 116 test files passed
  - 1,200 tests passed, 14 skipped

Focused regression coverage was added for each exploit path, with positive controls for valid provisioning and verified identity linking.