### PR TITLE
fix(tests): standardize test runs on TEST_DATABASE_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
-      DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
+      TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379
-      DOPPLER_PRESERVE_ENV: DATABASE_URL,REDIS_URL
+      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL
     services:
       postgres:
         image: postgres:16-alpine
@@ -455,9 +455,9 @@ jobs:
             custody_provider: local
     env:
       CI_HAS_DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_CI != '' }}
-      DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp
+      TEST_DATABASE_URL: postgresql://sdp:sdp@127.0.0.1:5432/sdp_test
       REDIS_URL: redis://127.0.0.1:6379
-      DOPPLER_PRESERVE_ENV: DATABASE_URL,REDIS_URL,SOLANA_NETWORK
+      DOPPLER_PRESERVE_ENV: TEST_DATABASE_URL,REDIS_URL,SOLANA_NETWORK
       SOLANA_NETWORK: devnet
       INTEGRATION_SHARD_NAME: ${{ matrix.name }}
       INTEGRATION_TEST_FILES: ${{ matrix.test_files }}

--- a/apps/sdp-api/scripts/migrate-postgres-test.mjs
+++ b/apps/sdp-api/scripts/migrate-postgres-test.mjs
@@ -5,23 +5,10 @@ import { ensureDatabaseExists, runPostgresMigrations } from "./lib/run-postgres-
 // biome-ignore lint/security/noSecrets: Local Docker Postgres fallback for isolated tests.
 const TEST_DATABASE_URL_FALLBACK = "postgresql://sdp:sdp@127.0.0.1:5432/sdp_test";
 
-// Keep the `_test` derivation stable for callers that run this migration
-// helper outside the Testcontainers-backed Vitest suite.
-function deriveTestDatabaseUrl(baseUrl) {
-  const url = new URL(baseUrl);
-  const dbName = decodeURIComponent(url.pathname.replace(/^\//, "")) || "sdp";
-  url.pathname = `/${encodeURIComponent(`${dbName}_test`)}`;
-  return url.toString();
-}
-
 const appDir = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const migrationsDir = path.join(appDir, "src/db/migrations/postgres");
 
-const explicitTestDatabaseUrl = process.env.TEST_DATABASE_URL?.trim();
-const baseDatabaseUrl = process.env.DATABASE_URL?.trim();
-const databaseUrl =
-  explicitTestDatabaseUrl ||
-  (baseDatabaseUrl ? deriveTestDatabaseUrl(baseDatabaseUrl) : TEST_DATABASE_URL_FALLBACK);
+const databaseUrl = process.env.TEST_DATABASE_URL?.trim() || TEST_DATABASE_URL_FALLBACK;
 
 try {
   await ensureDatabaseExists({ databaseUrl });

--- a/apps/sdp-api/scripts/migrate-postgres-test.mjs
+++ b/apps/sdp-api/scripts/migrate-postgres-test.mjs
@@ -2,13 +2,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDatabaseExists, runPostgresMigrations } from "./lib/run-postgres-migrations.mjs";
 
-// biome-ignore lint/security/noSecrets: Local Docker Postgres fallback for isolated tests.
-const TEST_DATABASE_URL_FALLBACK = "postgresql://sdp:sdp@127.0.0.1:5432/sdp_test";
-
 const appDir = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
 const migrationsDir = path.join(appDir, "src/db/migrations/postgres");
 
-const databaseUrl = process.env.TEST_DATABASE_URL?.trim() || TEST_DATABASE_URL_FALLBACK;
+const databaseUrl = process.env.TEST_DATABASE_URL?.trim();
+if (!databaseUrl) {
+  console.error("db:migrate:test requires TEST_DATABASE_URL to be set.");
+  process.exit(1);
+}
 
 try {
   await ensureDatabaseExists({ databaseUrl });

--- a/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.test.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority-resolution.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiKeyContext } from "@/lib/auth";
 import * as solanaServices from "@/services/solana";
 import { CustodyConfigStore } from "@/services/stores/custody-config.store";
+import { env as testEnv } from "@/test/helpers/env";
 import {
   getInitialPermanentDelegateAuthority,
   resolveAuthoritySigner,
@@ -199,7 +200,7 @@ describe("authority-resolution", () => {
 
     const result = await resolveAuthoritySigner({
       env: {
-        DATABASE_URL: "postgresql://sdp:sdp@127.0.0.1:5432/sdp",
+        DATABASE_URL: testEnv.DATABASE_URL,
         CUSTODY_ENCRYPTION_KEY: "test",
       } as never,
       auth,

--- a/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/services/custody/provisioning";
 import { type SigningRequestStore, SigningService } from "@/services/domain/signing.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import { env as testEnv } from "@/test/helpers/env";
 import type { Env } from "@/types/env";
 
 vi.mock("@/services/custody/provisioning", () => ({
@@ -231,7 +232,7 @@ function createService(params: {
   };
 
   const env: Env = {
-    DATABASE_URL: "postgresql://sdp:sdp@127.0.0.1:5432/sdp",
+    DATABASE_URL: testEnv.DATABASE_URL,
     CUSTODY_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString("base64"),
     ENVIRONMENT: "development",
     API_VERSION: "v1",

--- a/apps/sdp-api/src/test/helpers/env.ts
+++ b/apps/sdp-api/src/test/helpers/env.ts
@@ -6,7 +6,7 @@ import type { Env } from "@/types/env";
 const providedEnv: Env = {
   ENVIRONMENT: "development",
   API_VERSION: "v1",
-  DATABASE_URL: process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL,
+  DATABASE_URL: process.env.TEST_DATABASE_URL,
   REDIS_URL: process.env.REDIS_URL,
   API_KEY_PEPPER: "test-pepper-for-unit-tests",
   SOLANA_MOCK: "true",
@@ -18,7 +18,7 @@ const providedEnv: Env = {
 };
 
 if (!providedEnv.DATABASE_URL) {
-  throw new Error("Test environment requires TEST_DATABASE_URL or DATABASE_URL.");
+  throw new Error("Test environment requires TEST_DATABASE_URL.");
 }
 if (!providedEnv.REDIS_URL) {
   throw new Error("Test environment requires REDIS_URL.");

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "kora:surfpool:integration": "scripts/kora-surfpool/integration.sh",
     "kora:surfpool:test": "scripts/kora-surfpool/test.sh",
     "kora:devnet:check": "infra/kora/cloud-run/check.sh",
-    "kora:devnet:test": "DATABASE_URL=${KORA_DEVNET_DATABASE_URL:-${DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp}} node scripts/run-workspace-tests.mjs integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
+    "kora:devnet:test": "TEST_DATABASE_URL=${KORA_DEVNET_DATABASE_URL:-${TEST_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp_test}} node scripts/run-workspace-tests.mjs integration -- src/tests/kora.test.ts src/tests/kora-flow.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/packages/sdp-api-integration/src/helpers/env.node.ts
+++ b/packages/sdp-api-integration/src/helpers/env.node.ts
@@ -4,14 +4,14 @@ const { getDb } = apiTestSupport;
 
 function readEnvFromProcess(): ApiTestEnv {
   const proc: Record<string, string | undefined> = { ...process.env };
-  proc.DATABASE_URL = proc.TEST_DATABASE_URL ?? proc.DATABASE_URL;
+  proc.DATABASE_URL = proc.TEST_DATABASE_URL;
   return proc as unknown as ApiTestEnv;
 }
 
 const providedEnv = readEnvFromProcess();
 
 if (!providedEnv.DATABASE_URL) {
-  throw new Error("env requires DATABASE_URL or TEST_DATABASE_URL to be set.");
+  throw new Error("env requires TEST_DATABASE_URL to be set.");
 }
 
 export const env = {

--- a/packages/sdp-api-integration/vitest.config.ts
+++ b/packages/sdp-api-integration/vitest.config.ts
@@ -32,10 +32,6 @@ for (const [key, value] of Object.entries(loadEnvFile(LOCAL_ENV_PATH))) {
 
 process.env.ENVIRONMENT ??= "development";
 process.env.API_VERSION ??= "v1";
-if (!process.env.TEST_DATABASE_URL) {
-  throw new Error("Integration tests require TEST_DATABASE_URL to be set.");
-}
-process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
 process.env.REDIS_URL ??= "redis://127.0.0.1:6379";
 process.env.RUN_INTEGRATION_TESTS = "true";
 process.env.SOLANA_MOCK = "false";

--- a/packages/sdp-api-integration/vitest.config.ts
+++ b/packages/sdp-api-integration/vitest.config.ts
@@ -32,8 +32,9 @@ for (const [key, value] of Object.entries(loadEnvFile(LOCAL_ENV_PATH))) {
 
 process.env.ENVIRONMENT ??= "development";
 process.env.API_VERSION ??= "v1";
-// biome-ignore lint/security/noSecrets: Local Docker Postgres fallback for integration tests.
-process.env.DATABASE_URL ??= "postgresql://sdp:sdp@127.0.0.1:5432/sdp";
+// biome-ignore lint/security/noSecrets: Local Docker Postgres fallback for isolated integration tests.
+const TEST_DATABASE_URL_FALLBACK = "postgresql://sdp:sdp@127.0.0.1:5432/sdp_test";
+process.env.DATABASE_URL = process.env.TEST_DATABASE_URL ?? TEST_DATABASE_URL_FALLBACK;
 process.env.REDIS_URL ??= "redis://127.0.0.1:6379";
 process.env.RUN_INTEGRATION_TESTS = "true";
 process.env.SOLANA_MOCK = "false";

--- a/packages/sdp-api-integration/vitest.config.ts
+++ b/packages/sdp-api-integration/vitest.config.ts
@@ -32,9 +32,10 @@ for (const [key, value] of Object.entries(loadEnvFile(LOCAL_ENV_PATH))) {
 
 process.env.ENVIRONMENT ??= "development";
 process.env.API_VERSION ??= "v1";
-// biome-ignore lint/security/noSecrets: Local Docker Postgres fallback for isolated integration tests.
-const TEST_DATABASE_URL_FALLBACK = "postgresql://sdp:sdp@127.0.0.1:5432/sdp_test";
-process.env.DATABASE_URL = process.env.TEST_DATABASE_URL ?? TEST_DATABASE_URL_FALLBACK;
+if (!process.env.TEST_DATABASE_URL) {
+  throw new Error("Integration tests require TEST_DATABASE_URL to be set.");
+}
+process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
 process.env.REDIS_URL ??= "redis://127.0.0.1:6379";
 process.env.RUN_INTEGRATION_TESTS = "true";
 process.env.SOLANA_MOCK = "false";

--- a/scripts/kora-surfpool/integration.sh
+++ b/scripts/kora-surfpool/integration.sh
@@ -75,7 +75,7 @@ export KORA_SURFPOOL_SHIM="${KORA_SURFPOOL_SHIM:-true}"
 export SOLANA_RPC_DEFAULT_PROVIDER=default
 export SDP_INTEGRATION_CUSTODY_PROVIDER="${SDP_INTEGRATION_CUSTODY_PROVIDER:-local}"
 configure_local_custody
-export DATABASE_URL="${KORA_SURFPOOL_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp}"
+export TEST_DATABASE_URL="${KORA_SURFPOOL_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp_test}"
 export REDIS_URL="${REDIS_URL:-redis://127.0.0.1:6379}"
 
 "${ROOT_DIR}/scripts/kora-surfpool/up.sh"
@@ -89,9 +89,9 @@ fi
 # Re-derive DB bindings after runtime.env is sourced; up.sh may write a
 # KORA_SURFPOOL_DATABASE_URL override for the active harness.
 export SOLANA_RPC_DEFAULT_PROVIDER=default
-export DATABASE_URL="${KORA_SURFPOOL_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp}"
+export TEST_DATABASE_URL="${KORA_SURFPOOL_DATABASE_URL:-postgresql://sdp:sdp@127.0.0.1:5432/sdp_test}"
 export REDIS_URL="${REDIS_URL:-redis://127.0.0.1:6379}"
 
-pnpm --filter @sdp/api db:postgres:bootstrap
+pnpm --filter @sdp/api db:migrate:test
 
 pnpm --filter @sdp/api-integration exec vitest run --no-file-parallelism --hookTimeout 240000 "$@"

--- a/scripts/run-workspace-tests.mjs
+++ b/scripts/run-workspace-tests.mjs
@@ -44,17 +44,16 @@ function loadLocalEnvFile(filePath) {
 }
 
 const localEnv = loadLocalEnvFile(localApiEnvPath);
-const localDatabaseUrl = new URL("postgresql://127.0.0.1:5432/sdp");
-localDatabaseUrl.username = "sdp";
-localDatabaseUrl.password = "sdp";
-const databaseUrl =
-  process.env.DATABASE_URL ?? localEnv.DATABASE_URL ?? localDatabaseUrl.toString();
+// biome-ignore lint/security/noSecrets: Local Docker Postgres fallback for isolated tests.
+const localTestDatabaseUrl = "postgresql://sdp:sdp@127.0.0.1:5432/sdp_test";
+const testDatabaseUrl =
+  process.env.TEST_DATABASE_URL ?? localEnv.TEST_DATABASE_URL ?? localTestDatabaseUrl;
 const redisUrl = process.env.REDIS_URL ?? localEnv.REDIS_URL ?? "redis://127.0.0.1:6379";
 
 const resolvedEnv = {
   ...localEnv,
   ...process.env,
-  DATABASE_URL: databaseUrl,
+  TEST_DATABASE_URL: testDatabaseUrl,
   REDIS_URL: redisUrl,
 };
 
@@ -89,9 +88,7 @@ try {
     await configureIntegrationSolanaRpc(resolvedEnv);
   }
 
-  await run("pnpm", ["--filter", "@sdp/api", "db:postgres:bootstrap"]);
-
-  if (mode === "unit") {
+  if (mode === "integration") {
     await run("pnpm", ["--filter", "@sdp/api", "db:migrate:test"]);
   }
 


### PR DESCRIPTION
- Integration test runs used to resolve `DATABASE_URL` (falling back to the local dev `sdp` database) and wipe it during suite cleanup — running integration tests locally destroyed your dev data.
- Every test entry point (`run-workspace-tests.mjs`, `kora-surfpool/integration.sh`, integration vitest config, `env.node.ts`, `kora:devnet:test`) now reads only `TEST_DATABASE_URL`, defaulting to `sdp_test`; `db:migrate:test` creates and migrates that database automatically.
- The integration vitest config now hard-assigns `DATABASE_URL` from `TEST_DATABASE_URL` instead of `??=`, so an ambient/`.env.local` `DATABASE_URL` can never leak into the suite.
- Removed the derive-`_test`-from-`DATABASE_URL` arm in `migrate-postgres-test.mjs` and a duplicate `db:migrate:test` run in unit mode.
- CI unit + integration-shard jobs now pass `TEST_DATABASE_URL` (and preserve it through Doppler) instead of `DATABASE_URL`; browser e2e keeps `DATABASE_URL` since it runs the live API, not the test suite.
- Verified: full `@sdp/api` suite green locally (117 files / 1212 tests).