### PR TITLE
fix(e2e): assert the signer UI the wallet fixtures dictate

### DIFF
--- a/apps/sdp-web/playwright/support/issuance-fixtures.ts
+++ b/apps/sdp-web/playwright/support/issuance-fixtures.ts
@@ -27,6 +27,7 @@ export interface IssuanceFixtures {
   wallets: {
     treasury: IssuanceFixtureWallet;
     delegated: IssuanceFixtureWallet;
+    custodySignerWalletCount: number;
   };
   tokens: {
     pending: IssuanceFixtureToken;

--- a/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
+++ b/apps/sdp-web/playwright/support/local-issuance-bootstrap.ts
@@ -227,6 +227,7 @@ export async function bootstrapLocalIssuanceFixtures({
     wallets: {
       treasury: treasuryWallet,
       delegated: delegatedWallet,
+      custodySignerWalletCount: walletBootstrap.wallets.length,
     },
     tokens: {
       pending: toFixtureToken(pendingToken),

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -263,7 +263,7 @@ async function createDraftViaWizard(page: Page, options: CreateDraftOptions): Pr
   // exactly one custody signer wallet (an identity card, no combobox) and
   // renders a select otherwise. Assert the branch the fixtures dictate.
   if (options.custodySignerWalletCount === 1) {
-    await expect(page.getByText(options.treasuryWalletId, { exact: true }).first()).toBeVisible();
+    await expect(page.getByTestId("wallet-identity-card")).toContainText(options.treasuryWalletId);
   } else {
     await page.getByRole("combobox").click();
     await page.getByRole("option").filter({ hasText: options.treasuryWalletId }).click();

--- a/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/issuance.e2e.spec.ts
@@ -217,6 +217,7 @@ interface CreateDraftOptions {
   symbol: string;
   decimals: string;
   treasuryWalletId: string;
+  custodySignerWalletCount: number;
 }
 
 // Creating a draft goes through one of two UIs depending on the
@@ -258,8 +259,15 @@ async function createDraftViaWizard(page: Page, options: CreateDraftOptions): Pr
     .getByPlaceholder("Describe what this asset represents.")
     .fill("Created by Playwright issuance e2e.");
   await page.getByRole("tab", { name: "Operational", exact: true }).click();
-  await page.getByRole("combobox").click();
-  await page.getByRole("option").filter({ hasText: options.treasuryWalletId }).click();
+  // The signing-wallet field locks to the only wallet when the project has
+  // exactly one custody signer wallet (an identity card, no combobox) and
+  // renders a select otherwise. Assert the branch the fixtures dictate.
+  if (options.custodySignerWalletCount === 1) {
+    await expect(page.getByText(options.treasuryWalletId, { exact: true }).first()).toBeVisible();
+  } else {
+    await page.getByRole("combobox").click();
+    await page.getByRole("option").filter({ hasText: options.treasuryWalletId }).click();
+  }
   await page.getByRole("button", { name: "Continue", exact: true }).click();
 
   // Public information — defaults are fine.
@@ -350,6 +358,7 @@ test.describe
         symbol: draftSymbol,
         decimals: "7",
         treasuryWalletId: fixtures.wallets.treasury.walletId,
+        custodySignerWalletCount: fixtures.wallets.custodySignerWalletCount,
       });
 
       // Verify via the overview list, which is identical under either create UI

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-signer-select.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-signer-select.unit.test.tsx
@@ -1,0 +1,60 @@
+import type { PaymentsDashboardWallet } from "@sdp/types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { TokenSignerSelect } from "@/app/dashboard/issuance/[tokenId]/token-signer-select";
+
+vi.mock("@/i18n/provider", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+function makeWallet(index: number): PaymentsDashboardWallet {
+  return {
+    id: `cw_${index}`,
+    walletId: `wal_${index}`,
+    publicKey: `PubKey${index}`,
+    label: `Wallet ${index}`,
+  };
+}
+
+function render(
+  wallets: PaymentsDashboardWallet[],
+  signerUnavailableReason: string | null = null
+): string {
+  return renderToStaticMarkup(
+    <TokenSignerSelect
+      signerWallets={wallets}
+      signerWalletId=""
+      signerUnavailableReason={signerUnavailableReason}
+      onSignerWalletIdChange={() => {}}
+      optional
+    />
+  );
+}
+
+describe("TokenSignerSelect", () => {
+  it("locks to an identity card showing the only wallet, without a select", () => {
+    const markup = render([makeWallet(1)]);
+    expect(markup).toContain('data-testid="wallet-identity-card"');
+    expect(markup).toContain("wal_1");
+    expect(markup).toContain("PubKey1");
+    expect(markup).not.toContain("DashboardIssuance.signer.select");
+  });
+
+  it("renders a select instead of a locked card when several wallets exist", () => {
+    const markup = render([makeWallet(1), makeWallet(2)]);
+    expect(markup).not.toContain('data-testid="wallet-identity-card"');
+    expect(markup).toContain("DashboardIssuance.signer.select");
+  });
+
+  it("renders the optional-signer hint instead of a locked card when no wallets exist", () => {
+    const markup = render([]);
+    expect(markup).not.toContain('data-testid="wallet-identity-card"');
+    expect(markup).toContain("DashboardIssuance.signer.defaultSignerHint");
+  });
+
+  it("surfaces the unavailable reason over the wallet list", () => {
+    const markup = render([makeWallet(1)], "custody offline");
+    expect(markup).not.toContain('data-testid="wallet-identity-card"');
+    expect(markup).toContain("custody offline");
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-wallet-identity-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/[tokenId]/token-wallet-identity-card.tsx
@@ -22,7 +22,10 @@ export function TokenWalletIdentityCard({
     const label = wallet.label?.trim() || t("DashboardIssuance.wallet.unlabeled");
 
     return (
-      <div className="rounded-[12px] border border-border-default bg-fill-subtle px-4 py-3">
+      <div
+        data-testid="wallet-identity-card"
+        className="rounded-[12px] border border-border-default bg-fill-subtle px-4 py-3"
+      >
         <p className="text-sm font-medium text-primary">{label}</p>
         <div className="mt-3 space-y-2">
           <IdentityRow label={t("DashboardIssuance.wallet.walletId")} value={wallet.walletId} />

--- a/apps/sdp-web/src/app/dashboard/issuance/create/issuance-draft-wizard.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/issuance-draft-wizard.tsx
@@ -170,9 +170,16 @@ function WizardShell({ signerWallets, signerWalletsError }: IssuanceDraftWizardP
     const toastId = toast.loading(t("DashboardIssuance.wizard.creatingDraft"), {
       position: "bottom-right",
     });
+    // TokenSignerSelect locks to the only wallet when exactly one exists, but a
+    // locked field never fires onChange — mirror that rule at submit so the
+    // payload carries the wallet the UI shows as selected.
+    const submittedDraft =
+      !signerWalletsError && signerWallets.length === 1
+        ? { ...draft, signingWalletId: signerWallets[0].walletId }
+        : draft;
     try {
       const result = await createAssetDraftAction({
-        token: buildTokenInput(draft),
+        token: buildTokenInput(submittedDraft),
         assetCategory: draft.assetCategory,
         assetType: draft.assetType,
         issuanceMetadata: buildIssuanceMetadata(draft),


### PR DESCRIPTION
PR #847 added unconditional combobox clicks to the issuance create wizard spec, but TokenSignerSelect locks to an identity card when the project has exactly one custody signer wallet. which is what the local-custody CI bootstrap provisions, so the Issuance E2E shard has been red on main since. The bootstrap now records
custodySignerWalletCount in the fixtures and the spec asserts the matching branch: locked card showing the treasury wallet at one wallet, combobox selection otherwise.