### PR TITLE
feat: support business counterparties on Lightspark on-ramp

### DIFF
--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/client.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/client.test.ts
@@ -429,6 +429,25 @@ describe("LightsparkRampClient", () => {
     ]);
   });
 
+  it("treats a replayed verification for an approved customer as approved", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: "INVALID_INPUT",
+          reason: "Customer KYC status is already APPROVED",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const client = new LightsparkRampClient();
+    const verification = await client.submitVerification(LIGHTSPARK_CONTEXT, {
+      customerId: "Customer:cus_123",
+    });
+
+    expect(verification).toEqual({ verificationStatus: "APPROVED", errors: [] });
+  });
+
   it("derives content-addressed payout account keys", async () => {
     const key = await lightsparkPayoutAccountKey("USD", {
       paymentRails: "ACH",

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/client.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/client.test.ts
@@ -393,6 +393,42 @@ describe("LightsparkRampClient", () => {
     expect(account).toEqual({ id: "ExternalAccount:acc_existing_123", status: "ACTIVE" });
   });
 
+  it("submits a customer for verification and returns the outcome", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "Verification:ver_123",
+          customerId: "Customer:cus_123",
+          verificationStatus: "RESOLVE_ERRORS",
+          errors: [
+            {
+              type: "MISSING_FIELD",
+              field: "businessInfo.address",
+              reason: "Business address is required",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const client = new LightsparkRampClient();
+    const verification = await client.submitVerification(LIGHTSPARK_CONTEXT, {
+      customerId: "Customer:cus_123",
+    });
+
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      `${LIGHTSPARK_GRID_API_BASE_URL}/verifications`
+    );
+    expect(JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body))).toEqual({
+      customerId: "Customer:cus_123",
+    });
+    expect(verification.verificationStatus).toBe("RESOLVE_ERRORS");
+    expect(verification.errors.map((error) => error.reason)).toEqual([
+      "Business address is required",
+    ]);
+  });
+
   it("derives content-addressed payout account keys", async () => {
     const key = await lightsparkPayoutAccountKey("USD", {
       paymentRails: "ACH",

--- a/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
+++ b/apps/sdp-api/src/lib/ramps/providers/lightspark/counterparty.test.ts
@@ -165,13 +165,29 @@ describe("lightsparkCounterpartyRequirements", () => {
     expect(requirements.status).toBe("unsupported");
   });
 
-  it("returns unsupported for business on-ramp", () => {
+  it("collects businessInfo fields for a business on-ramp without a Grid customer", () => {
     const requirements = lightsparkCounterpartyRequirements(businessCounterparty(), {
       direction: "onramp",
       providerData: {},
     });
 
-    expect(requirements.status).toBe("unsupported");
+    if (requirements.status !== "collect") {
+      throw new Error("Expected collect requirements");
+    }
+    expect(requirements.fields.map((field) => field.key)).toEqual([
+      "businessLegalName",
+      "businessTaxId",
+      "businessIncorporatedOn",
+    ]);
+  });
+
+  it("returns ready for a business on-ramp once the Grid customer exists", () => {
+    const requirements = lightsparkCounterpartyRequirements(businessCounterparty(), {
+      direction: "onramp",
+      providerData: { lightspark: { customerId: "Customer:cus_123" } },
+    });
+
+    expect(requirements).toEqual({ provider: "lightspark", direction: "onramp", status: "ready" });
   });
 
   it("collects businessInfo fields before the payout fields for a business without a Grid customer", () => {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -330,7 +330,7 @@ export async function advanceCounterpartyRequirements(
       const customer = await ensureLightsparkCustomer(c, {
         counterparty: input.counterparty,
         projectId: input.projectId,
-        collectedData: input.direction === "offramp" ? input.collectedData : undefined,
+        collectedData: input.collectedData,
       });
       if (input.direction === "offramp") {
         await ensureLightsparkPayoutAccount(c, {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/lightspark.ts
@@ -66,8 +66,11 @@ async function persistLightsparkData(
 /**
  * Returns the Grid customer id for a counterparty, lazily creating the native
  * Lightspark customer (via the provider) and persisting it into provider_data
- * on first use. Business counterparties require collected businessInfo fields;
- * the collected values flow to Grid only and are never persisted.
+ * on first use. Business counterparties require collected businessInfo fields
+ * and KYB approval — the customer id is persisted only once verified, so a
+ * pending verification re-runs on the next requirements advance (creation is
+ * idempotent by platformCustomerId). Collected values flow to Grid only and
+ * are never persisted.
  */
 export async function ensureLightsparkCustomer(
   c: AppContext,
@@ -100,6 +103,17 @@ export async function ensureLightsparkCustomer(
     rampRuntime(c),
     input
   );
+  if (input.customerType === "BUSINESS") {
+    const verification = await RAMP_PROVIDER_CLIENTS.lightspark.submitVerification(rampRuntime(c), {
+      customerId: customer.id,
+    });
+    if (verification.verificationStatus !== "APPROVED") {
+      const outstanding = verification.errors.map((error) => error.reason).join("; ");
+      throw badRequest(
+        `Lightspark KYB verification is ${verification.verificationStatus}. Outstanding requirements: ${outstanding}`
+      );
+    }
+  }
 
   const row = await freshCounterpartyRow(c, counterparty, projectId);
   await persistLightsparkData(c, row, projectId, { customerId: customer.id });

--- a/apps/sdp-api/src/routes/payments/schemas.ts
+++ b/apps/sdp-api/src/routes/payments/schemas.ts
@@ -648,6 +648,8 @@ export const createOnrampQuoteSchema = z.object({
   domain: z.string().min(1).optional(),
 });
 
+const collectedDataSchema = z.record(z.string(), z.string()).optional();
+
 export const submitCounterpartyRequirementsSchema = z.discriminatedUnion("provider", [
   z.object({ provider: z.literal("moonpay"), direction: rampDirectionSchema }),
   z.object({ provider: z.literal("moneygram"), direction: rampDirectionSchema }),
@@ -658,23 +660,27 @@ export const submitCounterpartyRequirementsSchema = z.discriminatedUnion("provid
       cryptoToken: rampCurrencyCodeSchema,
       destinationWallet: z.string().min(1),
       fiatCurrency: rampFiatCurrencySchema,
-      collectedData: z.record(z.string(), z.string()).optional(),
+      collectedData: collectedDataSchema,
     }),
     z.object({
       provider: z.literal("bvnk"),
       direction: z.literal("offramp"),
       cryptoToken: rampCurrencyCodeSchema,
       fiatCurrency: rampFiatCurrencySchema,
-      collectedData: z.record(z.string(), z.string()).optional(),
+      collectedData: collectedDataSchema,
     }),
   ]),
   z.discriminatedUnion("direction", [
-    z.object({ provider: z.literal("lightspark"), direction: z.literal("onramp") }),
+    z.object({
+      provider: z.literal("lightspark"),
+      direction: z.literal("onramp"),
+      collectedData: collectedDataSchema,
+    }),
     z.object({
       provider: z.literal("lightspark"),
       direction: z.literal("offramp"),
       fiatCurrency: rampFiatCurrencySchema,
-      collectedData: z.record(z.string(), z.string()).optional(),
+      collectedData: collectedDataSchema,
     }),
   ]),
   z.object({ provider: z.literal("coinbase"), direction: rampDirectionSchema }),

--- a/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
@@ -609,17 +609,32 @@ export class LightsparkRampClient implements RampProvider {
    * Submits a customer for Grid KYC/KYB verification. Business customers are
    * created UNVERIFIED and cannot quote in either direction until approved;
    * sandbox approves synchronously, production returns the outstanding
-   * requirements in `errors`.
+   * requirements in `errors`. Grid rejects a replayed submission for an
+   * already-approved customer with 400 "Customer KYC status is already
+   * APPROVED"; we normalize that to an approved result so concurrent or
+   * retried provisioning converges instead of surfacing the rejection.
    */
   async submitVerification(
     { env, mode }: RampRuntimeContext,
     input: { customerId: string }
   ): Promise<LightsparkVerification> {
     const config = readLightsparkConfig(env, mode);
-    return this.request<LightsparkVerification, { customerId: string }>(config, "verifications", {
-      method: "POST",
-      body: { customerId: input.customerId },
-    });
+    try {
+      return await this.request<LightsparkVerification, { customerId: string }>(
+        config,
+        "verifications",
+        { method: "POST", body: { customerId: input.customerId } }
+      );
+    } catch (error) {
+      if (
+        error instanceof SdpPaymentsError &&
+        error.code === "BAD_REQUEST" &&
+        error.message.includes("already APPROVED")
+      ) {
+        return { verificationStatus: "APPROVED", errors: [] };
+      }
+      throw error;
+    }
   }
 
   /** Looks up an existing Grid customer by the platform-side id we assigned. */

--- a/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/client.ts
@@ -57,7 +57,7 @@ const LIGHTSPARK_DEFAULT_GRID_API_URL = "https://api.lightspark.com/grid/2025-10
 export const LIGHTSPARK_DECLARED_RAIL_SUPPORT = {
   onramp: {
     countrySupport: UNREPORTED_COUNTRY_SUPPORT,
-    entityTypes: ["individual"],
+    entityTypes: ["individual", "business"],
   },
   offramp: {
     countrySupport: UNREPORTED_COUNTRY_SUPPORT,
@@ -252,6 +252,11 @@ interface GridCreateCustomerBody {
 
 interface GridCustomerResponse {
   id: string;
+}
+
+export interface LightsparkVerification {
+  verificationStatus: string;
+  errors: { reason: string }[];
 }
 
 interface GridCustomerListResponse {
@@ -598,6 +603,23 @@ export class LightsparkRampClient implements RampProvider {
     );
 
     return { id: response.id };
+  }
+
+  /**
+   * Submits a customer for Grid KYC/KYB verification. Business customers are
+   * created UNVERIFIED and cannot quote in either direction until approved;
+   * sandbox approves synchronously, production returns the outstanding
+   * requirements in `errors`.
+   */
+  async submitVerification(
+    { env, mode }: RampRuntimeContext,
+    input: { customerId: string }
+  ): Promise<LightsparkVerification> {
+    const config = readLightsparkConfig(env, mode);
+    return this.request<LightsparkVerification, { customerId: string }>(config, "verifications", {
+      method: "POST",
+      body: { customerId: input.customerId },
+    });
   }
 
   /** Looks up an existing Grid customer by the platform-side id we assigned. */

--- a/packages/sdp-payments/src/ramps/providers/lightspark/counterparty.ts
+++ b/packages/sdp-payments/src/ramps/providers/lightspark/counterparty.ts
@@ -479,20 +479,21 @@ export function lightsparkCounterpartyRequirements(
   counterparty: Counterparty,
   { direction, providerData, fiatCurrency }: ValidateCounterpartyOptions
 ): CounterpartyRequirements {
-  if (direction === "onramp") {
-    if (counterparty.entityType === "business") {
-      return unsupportedCounterparty(
-        "lightspark",
-        direction,
-        "Lightspark on-ramp does not support business counterparties."
-      );
-    }
-    return readyCounterparty("lightspark", direction);
-  }
   const businessInfoFields =
     counterparty.entityType === "business" && !readLightsparkCustomerId(providerData)
       ? LIGHTSPARK_BUSINESS_INFO_FIELDS
       : [];
+  if (direction === "onramp") {
+    if (businessInfoFields.length > 0) {
+      return {
+        provider: "lightspark",
+        direction,
+        status: "collect",
+        fields: [...businessInfoFields],
+      };
+    }
+    return readyCounterparty("lightspark", direction);
+  }
   if (!fiatCurrency) {
     throw badRequest("fiatCurrency is required for Lightspark off-ramp requirements.");
   }

--- a/packages/sdp-types/src/generated/ramp-support.generated.ts
+++ b/packages/sdp-types/src/generated/ramp-support.generated.ts
@@ -13,13 +13,13 @@ import type { RampProviderId } from "../provider-access";
 
 export const RAMP_SUPPORT_HASH =
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
-  "15487789a8d6a0c0bd3957391bbc54416947b417691839bcedd044aed38b81bb" as const;
+  "454c8d8c1c594289497fa7d285a1bc992ba1d8f7f4c23593d395847cee864f5c" as const;
 
 export const RAMP_PROVIDER_SUPPORT_HASHES = {
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
   moonpay: "1bae9f40aaee0402594dbe2d72babb8c38032e7300131dc3edee1fe543931d41",
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
-  lightspark: "53a29135bd76f818d513f02097bc2ee3e2ad0d3eff1a6149fcd58a69ecbe5974",
+  lightspark: "0a65054262fee18de1322bc9f1c6b5bb0656e26d5ca458bd0344a9e01d437aa6",
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
   bvnk: "a81bc9617d867fd16e8fc9b91444ae968bddf32724be7a393a9b3c3a739b81f0",
   // biome-ignore lint/security/noSecrets: deterministic support hash, not a secret.
@@ -906,7 +906,7 @@ export const RAMP_PROVIDER_SUPPORT_DETAILS = {
         USD: { min: "1", max: "10000" },
       },
       countrySupport: { coverage: "unreported" },
-      entityTypes: ["individual"],
+      entityTypes: ["business", "individual"],
     },
     offramp: {
       currencies: {


### PR DESCRIPTION
## Summary

Grid supports both ramp directions for `BUSINESS` customers once KYB is approved — verified live against the Grid sandbox. The gate is verification status, not ramp direction: business customers are created `UNVERIFIED` and get `CUSTOMER_NOT_VERIFIED` on quotes in **both** directions until `POST /verifications` approves them (sandbox approves synchronously; individuals are auto-approved on create).

This removes the hard-coded "business on-ramp unsupported" gate and wires KYB verification into business customer provisioning — which also fixes the existing business off-ramp path, since it never submitted verification and would hit `CUSTOMER_NOT_VERIFIED` against today's Grid API.

## Changes

- `lightsparkCounterpartyRequirements`: business on-ramp now returns `collect` with the businessInfo fields (`businessLegalName`, `businessTaxId`, `businessIncorporatedOn`) until a Grid customer exists, then `ready` — same JIT pattern the off-ramp already used
- `LightsparkRampClient.submitVerification`: `POST /verifications`; production returns the outstanding KYB requirements in `errors`
- `ensureLightsparkCustomer`: submits KYB after business customer creation and persists the customer id **only after approval**, so a pending verification re-runs on the next requirements advance (creation is idempotent by `platformCustomerId`); throws with Grid's outstanding requirements when not approved
- Requirements advance now threads `collectedData` on the lightspark on-ramp arm (schema + handler)
- Declared on-ramp `entityTypes` now include `business`; ramp-support snapshot regenerated

## Live verification (Grid sandbox)

- Unverified BUSINESS customer → on-ramp and off-ramp quotes both fail `CUSTOMER_NOT_VERIFIED`
- After `POST /verifications` (auto-approves in sandbox) → both quote directions succeed with locked rates and payment instructions
- INDIVIDUAL customers are auto-approved on create — existing individual flows unaffected

## Notes / deferred

- Production KYB needs far more than the 3 collected fields (registration number, business type, address, beneficial owners, 4 document types). Sandbox auto-approves, so the non-approved path is unreachable today; when production KYB is built, the throw should graduate to typed `customer_verifying` / `customer_verification_failed` requirements statuses like BVNK/Mural (plus `kybStatus` cached in provider_data)
- Left the 409-then-lookup retry path in `getOrCreateCustomer` as-is; it only costs an extra call on explicit user retry after a failed verification

## Test plan

- `vitest` lightspark provider + counterparties + payments route suites pass (236 tests)
- `tsc` clean on sdp-api and sdp-payments; biome clean