### PR TITLE
fix: backfill existing organizations as enterprise approved

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0035_backfill_existing_organizations_enterprise.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0035_backfill_existing_organizations_enterprise.sql
@@ -1,0 +1,10 @@
+-- Organizations present when open signup launches were already approved for
+-- production access. Preserve that entitlement and keep them out of the new
+-- organization setup flow. Organizations created after this migration retain
+-- the normal tier and onboarding defaults.
+UPDATE organizations
+SET tier = 'enterprise',
+    onboarding_completed_at = COALESCE(onboarding_completed_at, sdp_datetime_now()),
+    updated_at = sdp_datetime_now()
+WHERE tier <> 'enterprise'
+   OR onboarding_completed_at IS NULL;


### PR DESCRIPTION
## Summary
- upgrade every organization present at migration time to the enterprise tier
- mark those organizations onboarding-complete so existing production users skip the new sandbox setup splash
- leave organizations created after the migration on the normal onboarding path

## Root cause
The onboarding schema migration only covered organizations already present when that earlier migration ran. Existing production organizations that were provisioned or remained incomplete afterward can still have a null onboarding completion timestamp and be routed into the new setup flow.

## Validation
- `pnpm --filter @sdp/api typecheck`
- `git diff --check`

Local Postgres migration execution was not available because Docker Desktop is offline; CI will execute the complete migration chain against Postgres.