### PR TITLE
fix(ci): probe private Cloud Run candidate safely

### DIFF
--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -161,12 +161,6 @@ jobs:
                 // error("candidate traffic tag is missing a revision")
             ' <<<"${service_json}"
           )"
-          candidate_url="$(
-            jq -er --arg tag "${candidate_tag}" '
-              [.status.traffic[] | select(.tag == $tag)][0].url
-                // error("candidate traffic tag is missing a URL")
-            ' <<<"${service_json}"
-          )"
           revision_digest="$(
             gcloud run revisions describe "${candidate_revision}" \
               --region "${REGION}" --project "${PROJECT_ID}" \
@@ -178,28 +172,27 @@ jobs:
             exit 1
           fi
           echo "CANDIDATE_REVISION=${candidate_revision}" >> "${GITHUB_ENV}"
-          echo "CANDIDATE_URL=${candidate_url}" >> "${GITHUB_ENV}"
           echo "Candidate revision: ${candidate_revision}" >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Verify candidate readiness
+      - name: Verify candidate revision readiness
         timeout-minutes: 5
         run: |
           set -euo pipefail
           for attempt in {1..12}; do
-            if response="$(
-              curl --fail --silent --show-error --max-time 10 \
-                "${CANDIDATE_URL}/health/ready"
-            )" && jq -e --arg revision "${CANDIDATE_REVISION}" '
-              .status == "ready"
-              and .revision == $revision
-              and .checks.database == "ok"
-              and .checks.redis == "ok"
-            ' <<<"${response}" >/dev/null; then
-              echo "Candidate ${CANDIDATE_REVISION} passed Postgres and Redis readiness."
+            revision_json="$(
+              gcloud run revisions describe "${CANDIDATE_REVISION}" \
+                --region "${REGION}" --project "${PROJECT_ID}" --format=json
+            )"
+            if jq -e '
+              [.status.conditions[]
+                | select(.type == "Ready" and .status == "True")]
+              | length == 1
+            ' <<<"${revision_json}" >/dev/null; then
+              echo "Candidate ${CANDIDATE_REVISION} is ready to serve traffic."
               exit 0
             fi
             if [[ "${attempt}" -eq 12 ]]; then
-              echo "Candidate readiness check failed after ${attempt} attempts." >&2
+              echo "Candidate revision did not become ready after ${attempt} attempts." >&2
               false
             fi
             sleep 10

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -31,18 +31,23 @@ test("manual production redeploy always skips builds and migrations", () => {
   );
 });
 
-test("candidate is revision-specific and proven ready before promotion", () => {
+test("candidate is revision-specific and Cloud Run-ready before promotion", () => {
   assert.match(workflow, /echo "IMAGE=\$\{resolved_image\}" >> "\$\{GITHUB_ENV\}"/);
   assert.match(workflow, /--no-traffic --tag "\$\{candidate_tag\}"/);
   assert.match(workflow, /CANDIDATE_TAG=\$\{candidate_tag\}/);
   assert.match(workflow, /status\.imageDigest/);
-  assert.match(workflow, /"\$\{CANDIDATE_URL\}\/health\/ready"/);
+  assert.match(
+    workflow,
+    /gcloud run revisions describe "\$\{CANDIDATE_REVISION\}"[\s\S]*--format=json/
+  );
+  assert.match(workflow, /\.status\.conditions\[\]/);
+  assert.doesNotMatch(workflow, /CANDIDATE_URL/);
   assert.match(workflow, /\.revision == \$revision/);
   assert.match(workflow, /\.checks\.database == "ok"/);
   assert.match(workflow, /\.checks\.redis == "ok"/);
 
   const candidateDeploy = workflow.indexOf("- name: Deploy candidate without production traffic");
-  const candidateReadiness = workflow.indexOf("- name: Verify candidate readiness");
+  const candidateReadiness = workflow.indexOf("- name: Verify candidate revision readiness");
   const promotion = workflow.indexOf("- name: Promote service and cron with rollback");
   assert.ok(candidateDeploy !== -1 && candidateDeploy < candidateReadiness);
   assert.ok(candidateReadiness < promotion);


### PR DESCRIPTION
## Summary
- stop probing the private zero-traffic candidate through its public `run.app` tag URL
- verify the candidate revision is Ready through the Cloud Run control plane
- retain canonical `/health/ready` verification after promotion and automatic rollback

## Root cause
Production Cloud Run ingress is restricted to internal and Cloud Load Balancing traffic. The GitHub runner called the direct tagged `run.app` URL, so Cloud Run returned 404 before the request reached the API.

## Verification
- `node --test scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs`
- `git diff --check`

## Release context
Release 0.46.2 successfully applied database migration 0035 before candidate readiness failed. This forward fix unblocks promotion of the current API image.