### PR TITLE
fix(api): harden CORS origin matching against regex bypass

### DIFF
--- a/apps/sdp-api/src/middleware/cors.test.ts
+++ b/apps/sdp-api/src/middleware/cors.test.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { corsMiddleware, createOriginMatcher } from "./cors";
+
+describe("createOriginMatcher", () => {
+  it("allows an exact origin", () => {
+    const matches = createOriginMatcher(["https://solana.com"], []);
+    expect(matches("https://solana.com")).toBe(true);
+  });
+
+  it("does not treat exact origins as regular expressions", () => {
+    const matches = createOriginMatcher(["https://solana.com"], []);
+    expect(matches("https://solanaXcom")).toBe(false);
+  });
+
+  it("allows a single-label wildcard subdomain", () => {
+    const matches = createOriginMatcher([], ["https://*.vercel.app"]);
+    expect(matches("https://preview-git-main-team.vercel.app")).toBe(true);
+  });
+
+  it("rejects a look-alike domain abusing the unescaped dot", () => {
+    const matches = createOriginMatcher([], ["https://*.vercel.app"]);
+    expect(matches("https://evil-vercel.app")).toBe(false);
+  });
+
+  it("rejects a domain that merely suffixes the wildcard host", () => {
+    const matches = createOriginMatcher([], ["https://*.vercel.app"]);
+    expect(matches("https://vercel.app.evil.com")).toBe(false);
+  });
+
+  it("rejects nested subdomains for a single-label wildcard", () => {
+    const matches = createOriginMatcher([], ["https://*.vercel.app"]);
+    expect(matches("https://a.b.vercel.app")).toBe(false);
+  });
+});
+
+describe("corsMiddleware", () => {
+  function buildApp(environment: "production" | "development") {
+    const app = new Hono();
+    app.use("*", corsMiddleware(environment));
+    app.all("*", (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it("echoes an allowed production origin", async () => {
+    const app = buildApp("production");
+    const res = await app.request("/x", { headers: { Origin: "https://solana.com" } });
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://solana.com");
+  });
+
+  it("rejects a disallowed production origin", async () => {
+    const app = buildApp("production");
+    const res = await app.request("/x", { headers: { Origin: "https://evil.com" } });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("rejects a wildcard look-alike origin in production", async () => {
+    const app = buildApp("production");
+    const res = await app.request("/x", { headers: { Origin: "https://evil-vercel.app" } });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("allows any origin in development", async () => {
+    const app = buildApp("development");
+    const res = await app.request("/x", { headers: { Origin: "https://anything.example" } });
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://anything.example");
+  });
+});

--- a/apps/sdp-api/src/middleware/cors.ts
+++ b/apps/sdp-api/src/middleware/cors.ts
@@ -1,54 +1,48 @@
-/**
- * CORS Middleware Configuration
- */
-
 import { getSdpDocsOrigin } from "@sdp/types";
 import { cors } from "hono/cors";
 import type { Env } from "@/types/env";
 
-/**
- * CORS middleware with environment-aware configuration
- */
+const PRODUCTION_ORIGINS = [
+  "https://solana.com",
+  "https://www.solana.com",
+  "https://developer.solana.com",
+];
+
+const DEVELOPMENT_ORIGINS = [
+  "http://localhost:3000",
+  "http://localhost:3001",
+  "http://localhost:5173",
+];
+
+const DEVELOPMENT_ORIGIN_PATTERNS = ["https://*.vercel.app"];
+
+function wildcardToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replace(/\\\*/g, "[^.]*")}$`);
+}
+
+export function createOriginMatcher(
+  exactOrigins: string[],
+  wildcardPatterns: string[]
+): (origin: string) => boolean {
+  const exact = new Set(exactOrigins);
+  const patterns = wildcardPatterns.map(wildcardToRegExp);
+  return (origin) => exact.has(origin) || patterns.some((pattern) => pattern.test(origin));
+}
+
 export function corsMiddleware(env: Env["ENVIRONMENT"]) {
-  const allowedOrigins =
-    env === "production"
-      ? [
-          "https://solana.com",
-          "https://www.solana.com",
-          "https://developer.solana.com",
-          getSdpDocsOrigin(),
-        ]
-      : [
-          "http://localhost:3000",
-          "http://localhost:3001",
-          "http://localhost:5173",
-          "https://*.vercel.app",
-        ];
+  const isProduction = env === "production";
+  const exactOrigins = isProduction
+    ? [...PRODUCTION_ORIGINS, getSdpDocsOrigin()]
+    : DEVELOPMENT_ORIGINS;
+  const wildcardPatterns = isProduction ? [] : DEVELOPMENT_ORIGIN_PATTERNS;
+  const isAllowedOrigin = createOriginMatcher(exactOrigins, wildcardPatterns);
 
   return cors({
     origin: (origin) => {
       if (!origin) return null;
-
-      // Check exact matches
-      if (allowedOrigins.includes(origin)) {
-        return origin;
-      }
-
-      // Check wildcard patterns
-      for (const pattern of allowedOrigins) {
-        if (pattern.includes("*")) {
-          const regex = new RegExp(`^${pattern.replace("*", ".*")}$`);
-          if (regex.test(origin)) {
-            return origin;
-          }
-        }
-      }
-
-      // In development, allow all origins
-      if (env !== "production") {
-        return origin;
-      }
-
+      if (isAllowedOrigin(origin)) return origin;
+      if (!isProduction) return origin;
       return null;
     },
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
@@ -61,7 +55,7 @@ export function corsMiddleware(env: Env["ENVIRONMENT"]) {
       "X-RateLimit-Remaining",
       "X-RateLimit-Reset",
     ],
-    maxAge: 86400, // 24 hours
+    maxAge: 86400,
     credentials: true,
   });
 }


### PR DESCRIPTION
## Summary

Reworks the CORS origin allowlist in `apps/sdp-api/src/middleware/cors.ts` so exact origins and wildcard patterns are matched safely, clearing 7 open CodeQL alerts.

The previous implementation pushed every allowlist entry through `new RegExp(\`^\${pattern.replace("*", ".*")}\$\`)`:
- exact origins (`https://solana.com`, …) were tainted into a regex even though they were only ever used for equality checks;
- the `*` wildcard expanded to `.*` with **unescaped dots**, so `https://*.vercel.app` compiled to `^https://.*.vercel.app$` — which also matches look-alikes like `https://evil-vercel.app`;
- `.replace("*", ".*")` only replaced the first `*`.

Now:
- `createOriginMatcher(exactOrigins, wildcardPatterns)` keeps exact origins in a `Set` (never compiled to a regex) and compiles wildcard patterns with all regex metacharacters escaped, `*` → `[^.]*` (single DNS label), anchored `^…$`.
- Exact origins no longer flow into `RegExp`, so the taint-based alerts disappear.

Runtime behaviour is unchanged: production still matches the same fixed origins; development still allows `*.vercel.app` previews (and falls back to allow-all for local dev).

## Alerts cleared
- js/regex/missing-regexp-anchor ×3 (49, 50, 51)
- js/incomplete-hostname-regexp ×2 in cors.ts (36, 37) + site.ts (38)
- js/incomplete-sanitization (34)

## Tests
`apps/sdp-api/src/middleware/cors.test.ts` (TDD): unit tests for `createOriginMatcher` (exact match is not regex, wildcard rejects `evil-vercel.app` / `vercel.app.evil.com` / nested subdomains) + middleware behaviour per environment. 10/10 pass via the repo vitest config.