### PR TITLE
fix(web): prevent API key menu layout shift

### DIFF
--- a/apps/sdp-web/playwright/tests/api-keys.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/api-keys.e2e.spec.ts
@@ -55,6 +55,23 @@ test.describe
       await expect(keyRow).toContainText("Developer access");
       await expect(keyRow).toContainText("1 selected");
       await expect(keyRow).toContainText("No API-key policy");
+
+      const tableBeforeMenu = await page.getByRole("table").boundingBox();
+      const bodyOverflowBeforeMenu = await page.evaluate(
+        () => window.getComputedStyle(document.body).overflow
+      );
+
+      await keyRow.getByRole("button", { name: "Actions" }).click();
+      await expect(page.getByRole("menuitem", { name: "Edit API key" })).toBeVisible();
+
+      const tableAfterMenu = await page.getByRole("table").boundingBox();
+      expect(tableBeforeMenu).not.toBeNull();
+      expect(tableAfterMenu).not.toBeNull();
+      expect(tableAfterMenu?.x).toBe(tableBeforeMenu?.x);
+      expect(tableAfterMenu?.width).toBe(tableBeforeMenu?.width);
+      expect(await page.evaluate(() => window.getComputedStyle(document.body).overflow)).toBe(
+        bodyOverflowBeforeMenu
+      );
     });
 
     test("user can replace and clear a restricted all-wallet binding without rotation loss", async ({

--- a/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
+++ b/apps/sdp-web/src/app/dashboard/api-keys/api-key-actions-menu.tsx
@@ -41,7 +41,7 @@ export function ApiKeyActionsMenu({
         <input type="hidden" name="grace" value={String(DEFAULT_ROTATION_GRACE_HOURS)} />
       </form>
 
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"


### PR DESCRIPTION
## Summary
- make API-key action dropdowns non-modal so opening them does not apply page scroll-lock or scrollbar compensation
- match the existing wallet action-menu behavior
- add a dashboard E2E regression check for stable table position, width, and body overflow

## Root cause
Radix dropdown menus default to modal behavior. Opening the API-key action menu locked page scrolling and changed scrollbar compensation, shifting the table horizontally.

## Validation
- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web test:unit` (392 tests)
- `pnpm --filter sdp-web build`
- `pnpm check:module-boundaries`
- focused dashboard Playwright spec discovery (`--list`)

The secret-backed dashboard E2E execution is left to CI because the local API environment does not have the Clerk configuration used by that job.