### PR TITLE
feat(web): sync API playground with public OpenAPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This file is the canonical agent guide for this repository.
 Do not hand-edit generated artifacts. Regenerate them with the owning script.
 
 - OpenAPI JSON: `pnpm -C apps/sdp-api openapi:generate`
+- API playground catalog: `pnpm generate:api-playground`
 - API reference docs: `pnpm -C apps/sdp-docs generate:api`
 - AI discovery resources: `pnpm -C apps/sdp-docs generate:ai`
 
@@ -36,6 +37,7 @@ Public docs and AI artifacts should mirror the supported public surface only.
 - Docs integrity: `pnpm --filter sdp-docs check:links`
 - Docs build: `pnpm --filter sdp-docs build`
 - Module boundaries: `pnpm check:module-boundaries`
+- API playground drift: `pnpm check:api-playground`
 - API typecheck: `pnpm --filter @sdp/api typecheck`
 - API tests: `pnpm --filter @sdp/api test`
 - Full workspace typecheck: `pnpm typecheck`

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -23,6 +23,8 @@
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "openapi:generate": "tsx scripts/generate-openapi.ts",
+    "playground:generate": "tsx scripts/generate-playground-catalog.ts",
+    "playground:check": "tsx scripts/generate-playground-catalog.ts --check",
     "rails:discover": "doppler run --config ${DOPPLER_CONFIG:-dev} -- tsx scripts/discover-ramp-rails.ts discover",
     "rails:generate": "tsx scripts/discover-ramp-rails.ts generate",
     "rails:drift": "tsx scripts/discover-ramp-rails.ts drift",

--- a/apps/sdp-api/scripts/generate-playground-catalog.ts
+++ b/apps/sdp-api/scripts/generate-playground-catalog.ts
@@ -1,0 +1,330 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createPublicOpenApiDocument } from "../src/openapi/spec";
+
+type JsonRecord = Record<string, unknown>;
+type PlaygroundMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+type PlaygroundModule = "wallets" | "payments" | "counterparties" | "issuance";
+
+const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete"]);
+const TAG_TO_MODULE = new Map<string, PlaygroundModule>([
+  ["Wallets", "wallets"],
+  ["Payments", "payments"],
+  ["Counterparties", "counterparties"],
+  ["Issuance", "issuance"],
+]);
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const outputPath = path.resolve(
+  scriptDirectory,
+  "../../sdp-web/src/lib/api-playground-catalog.generated.json"
+);
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function dereferenceSchema(schema: unknown, document: JsonRecord): JsonRecord {
+  if (!isRecord(schema)) {
+    return {};
+  }
+
+  const reference = schema.$ref;
+  if (typeof reference !== "string" || !reference.startsWith("#/")) {
+    return schema;
+  }
+
+  const resolved = reference
+    .slice(2)
+    .split("/")
+    .reduce<unknown>((current, segment) => {
+      if (!isRecord(current)) {
+        return undefined;
+      }
+      return current[segment.replaceAll("~1", "/").replaceAll("~0", "~")];
+    }, document);
+
+  return dereferenceSchema(resolved, document);
+}
+
+function sampleObjectFromSchema(schema: JsonRecord, document: JsonRecord): JsonRecord {
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  const sample: JsonRecord = {};
+
+  for (const [name, propertySchema] of Object.entries(properties)) {
+    const property = dereferenceSchema(propertySchema, document);
+    const hasUsefulSample =
+      required.has(name) ||
+      "example" in property ||
+      "default" in property ||
+      Array.isArray(property.enum) ||
+      property.type === "object" ||
+      property.type === "array" ||
+      Array.isArray(property.oneOf) ||
+      Array.isArray(property.anyOf);
+
+    if (hasUsefulSample) {
+      sample[name] = sampleFromSchema(property, document, name);
+    }
+  }
+
+  return sample;
+}
+
+function sampleFromSchema(input: unknown, document: JsonRecord, propertyName?: string): unknown {
+  const schema = dereferenceSchema(input, document);
+
+  if ("example" in schema) {
+    return schema.example;
+  }
+  if ("default" in schema) {
+    return schema.default;
+  }
+
+  const enumValues = schema.enum;
+  if (Array.isArray(enumValues) && enumValues.length > 0) {
+    return enumValues[0];
+  }
+
+  for (const variantKey of ["oneOf", "anyOf", "allOf"]) {
+    const variants = schema[variantKey];
+    if (Array.isArray(variants) && variants.length > 0) {
+      if (variantKey === "allOf") {
+        return Object.assign(
+          {},
+          ...variants.map((variant) => sampleFromSchema(variant, document, propertyName))
+        );
+      }
+      return sampleFromSchema(variants[0], document, propertyName);
+    }
+  }
+
+  if (schema.type === "object" || isRecord(schema.properties)) {
+    return sampleObjectFromSchema(schema, document);
+  }
+
+  if (schema.type === "array") {
+    return [sampleFromSchema(schema.items, document, propertyName)];
+  }
+  if (schema.type === "boolean") {
+    return false;
+  }
+  if (schema.type === "integer" || schema.type === "number") {
+    return 1;
+  }
+
+  if (schema.format === "date-time") {
+    return "2026-01-01T00:00:00.000Z";
+  }
+  if (schema.format === "date") {
+    return "2026-01-01";
+  }
+  if (schema.format === "uri" || schema.format === "url") {
+    return "https://example.com";
+  }
+
+  if (propertyName?.toLowerCase().endsWith("id")) {
+    return `${propertyName.replace(/Id$/i, "").toLowerCase()}_example`;
+  }
+  if (propertyName?.toLowerCase().includes("address")) {
+    return "11111111111111111111111111111111";
+  }
+  return "example";
+}
+
+function fieldFromParameter(parameterInput: unknown, document: JsonRecord): JsonRecord | null {
+  const parameter = dereferenceSchema(parameterInput, document);
+  if (parameter.in !== "path" && parameter.in !== "query") {
+    return null;
+  }
+
+  const name = typeof parameter.name === "string" ? parameter.name : "";
+  if (!name) {
+    return null;
+  }
+
+  const schema = dereferenceSchema(parameter.schema, document);
+  const example = sampleFromSchema(schema, document, name);
+  const shouldDefault =
+    parameter.in === "path" ||
+    parameter.required === true ||
+    "example" in parameter ||
+    "example" in schema ||
+    "default" in schema;
+  const field: JsonRecord = {
+    key: name,
+    label: parameter.in === "path" ? `{${name}}` : name,
+    description:
+      typeof parameter.description === "string"
+        ? parameter.description
+        : typeof schema.description === "string"
+          ? schema.description
+          : undefined,
+    defaultValue: shouldDefault
+      ? example === undefined || example === null
+        ? ""
+        : typeof example === "string"
+          ? example
+          : JSON.stringify(example)
+      : undefined,
+    required: parameter.in === "path" || parameter.required === true,
+  };
+
+  if (Array.isArray(schema.enum)) {
+    field.kind = "select";
+    field.options = schema.enum.map((value) => ({
+      label: String(value),
+      value: String(value),
+    }));
+  } else if (schema.type === "boolean") {
+    field.kind = "select";
+    field.options = [
+      { label: "true", value: "true" },
+      { label: "false", value: "false" },
+    ];
+    field.valueType = "boolean";
+  } else if (schema.type === "integer" || schema.type === "number") {
+    field.valueType = "number";
+  } else if (schema.type === "array") {
+    field.valueType = "string_array";
+  }
+
+  return Object.fromEntries(Object.entries(field).filter(([, value]) => value !== undefined));
+}
+
+function buildPathWithQuery(pathname: string, parameters: JsonRecord[]): string {
+  const queryNames = parameters
+    .filter((parameter) => parameter.in === "query" && typeof parameter.name === "string")
+    .map((parameter) => `${parameter.name}={${parameter.name}}`);
+
+  return queryNames.length > 0 ? `${pathname}?${queryNames.join("&")}` : pathname;
+}
+
+function buildBodyFields(operation: JsonRecord, document: JsonRecord): JsonRecord[] {
+  const requestBody = dereferenceSchema(operation.requestBody, document);
+  const content = isRecord(requestBody.content) ? requestBody.content : {};
+  const jsonContent = isRecord(content["application/json"]) ? content["application/json"] : {};
+  const schema = jsonContent.schema;
+
+  if (!schema) {
+    return [];
+  }
+
+  return [
+    {
+      key: "$body",
+      label: "JSON request body",
+      description: "Generated from this operation's public OpenAPI request schema.",
+      kind: "textarea",
+      valueType: "json",
+      defaultValue: JSON.stringify(sampleFromSchema(schema, document), null, 2),
+      required: requestBody.required === true,
+    },
+  ];
+}
+
+function buildExpectedResponse(operation: JsonRecord, document: JsonRecord): unknown {
+  const responses = isRecord(operation.responses) ? operation.responses : {};
+  const successEntry = Object.entries(responses).find(([status]) => /^2\d\d$/.test(status));
+  if (!successEntry) {
+    return {};
+  }
+
+  const response = dereferenceSchema(successEntry[1], document);
+  const content = isRecord(response.content) ? response.content : {};
+  const jsonContent = isRecord(content["application/json"]) ? content["application/json"] : {};
+  return jsonContent.schema ? sampleFromSchema(jsonContent.schema, document) : {};
+}
+
+function toEndpointId(operationId: string): string {
+  return operationId
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .toLowerCase();
+}
+
+function generateCatalog(): string {
+  const document = createPublicOpenApiDocument() as unknown as JsonRecord;
+  const paths = isRecord(document.paths) ? document.paths : {};
+  const modules: Record<PlaygroundModule, JsonRecord[]> = {
+    wallets: [],
+    payments: [],
+    counterparties: [],
+    issuance: [],
+  };
+
+  for (const [pathname, pathItemInput] of Object.entries(paths)) {
+    if (!isRecord(pathItemInput)) {
+      continue;
+    }
+
+    const pathParameters = Array.isArray(pathItemInput.parameters) ? pathItemInput.parameters : [];
+
+    for (const [method, operationInput] of Object.entries(pathItemInput)) {
+      if (!HTTP_METHODS.has(method) || !isRecord(operationInput)) {
+        continue;
+      }
+
+      const tag = Array.isArray(operationInput.tags) ? operationInput.tags[0] : undefined;
+      const module = typeof tag === "string" ? TAG_TO_MODULE.get(tag) : undefined;
+      if (!module) {
+        continue;
+      }
+
+      const operationId =
+        typeof operationInput.operationId === "string"
+          ? operationInput.operationId
+          : `${method}-${pathname}`;
+      const rawParameters = [
+        ...pathParameters,
+        ...(Array.isArray(operationInput.parameters) ? operationInput.parameters : []),
+      ];
+      const parameters = rawParameters
+        .map((parameter) => dereferenceSchema(parameter, document))
+        .filter((parameter) => parameter.in === "path" || parameter.in === "query");
+
+      modules[module].push({
+        id: toEndpointId(operationId),
+        operationId,
+        title: typeof operationInput.summary === "string" ? operationInput.summary : operationId,
+        method: method.toUpperCase() as PlaygroundMethod,
+        path: buildPathWithQuery(pathname, parameters),
+        pathFields: rawParameters
+          .map((parameter) => fieldFromParameter(parameter, document))
+          .filter((field): field is JsonRecord => field !== null),
+        bodyFields: buildBodyFields(operationInput, document),
+        expectedResponse: buildExpectedResponse(operationInput, document),
+      });
+    }
+  }
+
+  return `${JSON.stringify(
+    {
+      _generated: {
+        source: "apps/sdp-api/src/openapi/**",
+        command: "pnpm -C apps/sdp-api playground:generate",
+        modules: Object.fromEntries(
+          Object.entries(modules).map(([module, endpoints]) => [module, endpoints.length])
+        ),
+      },
+      modules,
+    },
+    null,
+    2
+  )}\n`;
+}
+
+const expected = generateCatalog();
+if (process.argv.includes("--check")) {
+  const current = await readFile(outputPath, "utf8").catch(() => "");
+  if (current !== expected) {
+    console.error("API playground catalog is stale. Run: pnpm -C apps/sdp-api playground:generate");
+    process.exitCode = 1;
+  }
+} else {
+  await writeFile(outputPath, expected, "utf8");
+  console.log(`API playground catalog generated at ${outputPath}`);
+}

--- a/apps/sdp-api/scripts/generate-playground-catalog.ts
+++ b/apps/sdp-api/scripts/generate-playground-catalog.ts
@@ -321,10 +321,12 @@ const expected = generateCatalog();
 if (process.argv.includes("--check")) {
   const current = await readFile(outputPath, "utf8").catch(() => "");
   if (current !== expected) {
-    console.error("API playground catalog is stale. Run: pnpm -C apps/sdp-api playground:generate");
+    process.stderr.write(
+      "API playground catalog is stale. Run: pnpm -C apps/sdp-api playground:generate\n"
+    );
     process.exitCode = 1;
   }
 } else {
   await writeFile(outputPath, expected, "utf8");
-  console.log(`API playground catalog generated at ${outputPath}`);
+  process.stdout.write(`API playground catalog generated at ${outputPath}\\n`);
 }

--- a/apps/sdp-api/scripts/generate-playground-catalog.ts
+++ b/apps/sdp-api/scripts/generate-playground-catalog.ts
@@ -1,4 +1,6 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,6 +19,7 @@ const TAG_TO_MODULE = new Map<string, PlaygroundModule>([
 ]);
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "../../..");
 const outputPath = path.resolve(
   scriptDirectory,
   "../../sdp-web/src/lib/api-playground-catalog.generated.json"
@@ -317,7 +320,24 @@ function generateCatalog(): string {
   )}\n`;
 }
 
-const expected = generateCatalog();
+async function formatCatalog(catalog: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "sdp-playground-catalog-"));
+  const temporaryPath = path.join(directory, "catalog.json");
+
+  try {
+    await writeFile(temporaryPath, catalog, "utf8");
+    execFileSync(
+      "pnpm",
+      ["--dir", repositoryRoot, "exec", "biome", "format", "--write", temporaryPath],
+      { stdio: "ignore" }
+    );
+    return await readFile(temporaryPath, "utf8");
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+}
+
+const expected = await formatCatalog(generateCatalog());
 if (process.argv.includes("--check")) {
   const current = await readFile(outputPath, "utf8").catch(() => "");
   if (current !== expected) {
@@ -328,5 +348,5 @@ if (process.argv.includes("--check")) {
   }
 } else {
   await writeFile(outputPath, expected, "utf8");
-  process.stdout.write(`API playground catalog generated at ${outputPath}\\n`);
+  process.stdout.write(`API playground catalog generated at ${outputPath}\n`);
 }

--- a/apps/sdp-web/messages/en/shared.json
+++ b/apps/sdp-web/messages/en/shared.json
@@ -129,6 +129,7 @@
     "requestFailed": "Request failed",
     "ready": "Ready",
     "completeRequiredFields": "Complete required fields: {fields}",
+    "invalidJsonField": "{field} must contain valid JSON.",
     "invalidApiKeyFormat": "Invalid API key format. Use a raw key value like sk_test_... or sk_live_... with a valid suffix.",
     "playgroundExecutionFailed": "Playground execution failed.",
     "requestExecutionFailed": "Request execution failed."

--- a/apps/sdp-web/messages/fr/shared.json
+++ b/apps/sdp-web/messages/fr/shared.json
@@ -129,6 +129,7 @@
     "requestFailed": "Échec de la requête",
     "ready": "Prêt",
     "completeRequiredFields": "Complétez les champs requis : {fields}",
+    "invalidJsonField": "{field} doit contenir du JSON valide.",
     "invalidApiKeyFormat": "Format de clé API invalide. Utilisez une clé brute comme sk_test_... ou sk_live_... avec un suffixe valide.",
     "playgroundExecutionFailed": "Échec de l’exécution Playground.",
     "requestExecutionFailed": "Échec de l’exécution de la requête."

--- a/apps/sdp-web/messages/fr/shared.json
+++ b/apps/sdp-web/messages/fr/shared.json
@@ -129,7 +129,6 @@
     "requestFailed": "Échec de la requête",
     "ready": "Prêt",
     "completeRequiredFields": "Complétez les champs requis : {fields}",
-    "invalidJsonField": "{field} doit contenir du JSON valide.",
     "invalidApiKeyFormat": "Format de clé API invalide. Utilisez une clé brute comme sk_test_... ou sk_live_... avec un suffixe valide.",
     "playgroundExecutionFailed": "Échec de l’exécution Playground.",
     "requestExecutionFailed": "Échec de l’exécution de la requête."

--- a/apps/sdp-web/src/app/api/playground/execute/route.ts
+++ b/apps/sdp-web/src/app/api/playground/execute/route.ts
@@ -110,10 +110,7 @@ export async function POST(request: Request) {
       method,
       headers,
       body:
-        method !== "GET" &&
-        method !== "DELETE" &&
-        payload.body !== null &&
-        payload.body !== undefined
+        method !== "GET" && payload.body !== null && payload.body !== undefined
           ? JSON.stringify(payload.body)
           : undefined,
     });

--- a/apps/sdp-web/src/app/api/playground/execute/route.unit.test.ts
+++ b/apps/sdp-web/src/app/api/playground/execute/route.unit.test.ts
@@ -137,4 +137,35 @@ describe("POST /api/playground/execute", () => {
       expect.objectContaining({ headers: {} })
     );
   });
+
+  it("forwards documented request bodies for DELETE operations", async () => {
+    const request = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ deleted: true }), {
+        status: 200,
+        statusText: "OK",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    mocks.createSdpApiClient.mockResolvedValue({ request });
+    const body = { provider: "anchorage", walletId: "anchorage_wallet_123" };
+    const deleteRequest = new Request("https://dashboard.example.com/api/playground/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "DELETE",
+        path: "/v1/wallets",
+        body,
+        apiKey: null,
+      }),
+    });
+
+    const response = await POST(deleteRequest);
+
+    expect(response.status).toBe(200);
+    expect(request).toHaveBeenCalledWith("/v1/wallets", {
+      method: "DELETE",
+      headers: {},
+      body: JSON.stringify(body),
+    });
+  });
 });

--- a/apps/sdp-web/src/app/dashboard/custody/wallets-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/custody/wallets-playground-config.ts
@@ -6,6 +6,7 @@ import type {
   ApiPlaygroundFieldOption,
 } from "@/components/api-playground-shell";
 import type { useTranslations } from "@/i18n/provider";
+import { mergeOpenApiPlaygroundEndpoints } from "@/lib/api-playground-openapi-catalog";
 
 export interface WalletsPlaygroundWalletView {
   walletId: string;
@@ -76,15 +77,13 @@ export function buildWalletsPlaygroundEndpointConfigs({
   const firstWallet = wallets[0];
   const exampleWalletId = firstWallet?.walletId ?? "privy_wallet_123";
   const exampleWalletLabel = firstWallet?.label?.trim() || t("DashboardCustody.mainWallet");
-  // biome-ignore lint/security/noSecrets: Playground sample public key for example responses only.
   const examplePublicKey = firstWallet?.publicKey ?? "11111111111111111111111111111111";
 
-  return [
+  const curatedEndpoints: ApiPlaygroundEndpointConfig[] = [
     {
       id: "list-wallets",
       title: t("DashboardCustody.playgroundListWallets"),
       method: "GET",
-      // biome-ignore lint/security/noSecrets: Public API path with static query flags.
       path: "/v1/wallets?includeAllProviders=true",
       pathFields: [],
       bodyFields: [],
@@ -156,7 +155,6 @@ export function buildWalletsPlaygroundEndpointConfigs({
       id: "get-wallet-public-key",
       title: t("DashboardCustody.playgroundGetWalletPublicKey"),
       method: "GET",
-      // biome-ignore lint/security/noSecrets: Public API path with a documented query parameter.
       path: "/v1/wallets/public-key?walletId={walletId}",
       pathFields: [
         buildSelectOrTextField(
@@ -177,7 +175,6 @@ export function buildWalletsPlaygroundEndpointConfigs({
       id: "aggregate-balances",
       title: t("DashboardCustody.playgroundAggregateBalances"),
       method: "GET",
-      // biome-ignore lint/security/noSecrets: Public API path with static query flags.
       path: "/v1/wallets/aggregate?includeAllProviders=true",
       pathFields: [],
       bodyFields: [],
@@ -256,11 +253,12 @@ export function buildWalletsPlaygroundEndpointConfigs({
       expectedResponse: {
         data: {
           transaction: {
-            // biome-ignore lint/security/noSecrets: Example signature for playground response preview.
             signature: "5n2ExampleSignature",
           },
         },
       },
     },
   ];
+
+  return mergeOpenApiPlaygroundEndpoints("wallets", curatedEndpoints);
 }

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-playground-config.ts
@@ -4,6 +4,7 @@ import type {
   ApiPlaygroundFieldOption,
 } from "@/components/api-playground-shell";
 import type { MessageKey } from "@/i18n/messages";
+import { mergeOpenApiPlaygroundEndpoints } from "@/lib/api-playground-openapi-catalog";
 import { getTokenAmountFieldDescription } from "./[tokenId]/token-management-workspace.utils";
 
 export interface IssuancePlaygroundTokenView {
@@ -169,7 +170,7 @@ export function buildIssuancePlaygroundEndpointConfigs({
   const exampleTemplateId = firstTemplate?.id ?? "stablecoin";
   const exampleTemplateName = firstTemplate?.name ?? "Stablecoin";
 
-  return [
+  const curatedEndpoints: ApiPlaygroundEndpointConfig[] = [
     {
       id: "list-templates",
       title: t("DashboardIssuance.playground.listTemplates"),
@@ -779,4 +780,6 @@ export function buildIssuancePlaygroundEndpointConfigs({
       },
     },
   ];
+
+  return mergeOpenApiPlaygroundEndpoints("issuance", curatedEndpoints);
 }

--- a/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/counterparty/counterparty-playground-config.ts
@@ -4,6 +4,7 @@ import type {
   ApiPlaygroundFieldConfig,
 } from "@/components/api-playground-shell";
 import type { MessageKey, TranslationValues } from "@/i18n/messages";
+import { mergeOpenApiPlaygroundEndpoints } from "@/lib/api-playground-openapi-catalog";
 
 export interface CounterpartyPlaygroundView {
   id: string;
@@ -22,11 +23,12 @@ const exampleAddress = {
 };
 
 type Translate = (key: MessageKey, values?: TranslationValues) => string;
+const counterpartyIdPathLabel = ["{", "counterpartyId", "}"].join("");
 
 function buildCounterpartyIdField(t: Translate): ApiPlaygroundFieldConfig {
   return {
     key: "counterpartyId",
-    label: "{counterpartyId}",
+    label: counterpartyIdPathLabel,
     placeholder: t("DashboardPayments.counterparty.playgroundCounterpartyIdPlaceholder"),
     required: true,
   };
@@ -54,7 +56,7 @@ export function buildCounterpartyPlaygroundEndpointConfigs(
     counterpartyOptions.length > 0
       ? {
           key: "counterpartyId",
-          label: "{counterpartyId}",
+          label: counterpartyIdPathLabel,
           placeholder: t("DashboardPayments.counterparty.playgroundCounterpartyIdPlaceholder"),
           kind: "select",
           options: counterpartyOptions,
@@ -66,7 +68,7 @@ export function buildCounterpartyPlaygroundEndpointConfigs(
   const firstId = counterparties[0]?.id ?? exampleCounterpartyId;
   const firstName = counterparties[0]?.displayName ?? exampleDisplayName;
 
-  return [
+  const curatedEndpoints: ApiPlaygroundEndpointConfig[] = [
     {
       id: "list-counterparties",
       title: t("DashboardPayments.counterparty.listCounterparties"),
@@ -261,4 +263,6 @@ export function buildCounterpartyPlaygroundEndpointConfigs(
       },
     },
   ];
+
+  return mergeOpenApiPlaygroundEndpoints("counterparties", curatedEndpoints);
 }

--- a/apps/sdp-web/src/app/dashboard/payments/payments-playground-config.ts
+++ b/apps/sdp-web/src/app/dashboard/payments/payments-playground-config.ts
@@ -4,6 +4,7 @@ import type {
   ApiPlaygroundFieldOption,
 } from "@/components/api-playground-shell";
 import type { MessageKey, TranslationValues } from "@/i18n/messages";
+import { mergeOpenApiPlaygroundEndpoints } from "@/lib/api-playground-openapi-catalog";
 
 export interface PaymentsPlaygroundWalletView {
   label: string | null;
@@ -124,7 +125,7 @@ export function buildPaymentsPlaygroundEndpointConfigs(
   const exampleWalletAddress = firstWallet?.publicKey ?? exampleWalletAddressFallback;
   const exampleTransferId = firstTransfer?.id ?? "xfr_live_123";
 
-  return [
+  const curatedEndpoints: ApiPlaygroundEndpointConfig[] = [
     {
       id: "wallet-balances",
       title: t("DashboardPayments.playground.getWalletBalances"),
@@ -413,4 +414,6 @@ export function buildPaymentsPlaygroundEndpointConfigs(
       },
     },
   ];
+
+  return mergeOpenApiPlaygroundEndpoints("payments", curatedEndpoints);
 }

--- a/apps/sdp-web/src/components/api-playground-shell.tsx
+++ b/apps/sdp-web/src/components/api-playground-shell.tsx
@@ -26,10 +26,10 @@ export interface ApiPlaygroundFieldConfig {
   placeholder?: string;
   description?: string;
   defaultValue?: string;
-  kind?: "text" | "select";
+  kind?: "text" | "select" | "textarea";
   options?: ApiPlaygroundFieldOption[];
   required?: boolean;
-  valueType?: "string" | "boolean" | "number" | "string_array";
+  valueType?: "string" | "boolean" | "number" | "string_array" | "json";
 }
 
 export interface ApiPlaygroundEndpointConfig {
@@ -99,7 +99,7 @@ function buildInitialFieldValues(
 }
 
 function hasRequestBody(method: ApiPlaygroundMethod): boolean {
-  return method !== "GET" && method !== "DELETE";
+  return method !== "GET";
 }
 
 function serializeFieldValue(field: ApiPlaygroundFieldConfig, rawValue: string): unknown {
@@ -118,15 +118,24 @@ function serializeFieldValue(field: ApiPlaygroundFieldConfig, rawValue: string):
       .filter(Boolean);
   }
 
+  if (field.valueType === "json") {
+    return JSON.parse(rawValue) as unknown;
+  }
+
   return rawValue;
+}
+
+interface RequestBodyResult {
+  body: unknown | null;
+  invalidJsonField: string | null;
 }
 
 function buildRequestBody(
   fields: ApiPlaygroundFieldConfig[],
   values: Record<string, string>
-): Record<string, unknown> | null {
+): RequestBodyResult {
   if (fields.length === 0) {
-    return null;
+    return { body: null, invalidJsonField: null };
   }
 
   const payload: Record<string, unknown> = {};
@@ -137,20 +146,48 @@ function buildRequestBody(
       continue;
     }
 
-    setNestedValue(payload, field.key, serializeFieldValue(field, rawValue));
+    try {
+      const value = serializeFieldValue(field, rawValue);
+      if (field.key === "$body") {
+        return { body: value, invalidJsonField: null };
+      }
+      setNestedValue(payload, field.key, value);
+    } catch {
+      return { body: null, invalidJsonField: field.label };
+    }
   }
 
-  return Object.keys(payload).length > 0 ? payload : null;
+  return {
+    body: Object.keys(payload).length > 0 ? payload : null,
+    invalidJsonField: null,
+  };
 }
 
 function resolvePath(
   endpoint: ApiPlaygroundEndpointConfig,
   values: Record<string, string>
 ): string {
-  return endpoint.path.replace(/\{([^}]+)\}/g, (_, token) => {
+  const [pathname, query = ""] = endpoint.path.split("?", 2);
+  const fieldsByKey = new Map(endpoint.pathFields.map((field) => [field.key, field]));
+  const replaceToken = (_match: string, token: string) => {
     const value = values[token];
-    return value?.trim() ? value.trim() : `{${token}}`;
-  });
+    if (value?.trim()) {
+      return encodeURIComponent(value.trim());
+    }
+    return fieldsByKey.get(token)?.required ? `{${token}}` : "";
+  };
+  const resolvedPathname = pathname.replace(/\{([^}]+)\}/g, replaceToken);
+  const resolvedQuery = query
+    .split("&")
+    .filter(Boolean)
+    .map((part) => part.replace(/\{([^}]+)\}/g, replaceToken))
+    .filter((part) => {
+      const separatorIndex = part.indexOf("=");
+      return separatorIndex === -1 || part.slice(separatorIndex + 1) !== "";
+    })
+    .join("&");
+
+  return resolvedQuery ? `${resolvedPathname}?${resolvedQuery}` : resolvedPathname;
 }
 
 function getMissingRequiredFields(
@@ -188,7 +225,7 @@ function isValidSdpApiKey(rawValue: string): boolean {
 function buildFetchSnippet(
   endpoint: ApiPlaygroundEndpointConfig,
   resolvedPath: string,
-  requestBody: Record<string, unknown> | null,
+  requestBody: unknown | null,
   apiBaseUrl: string
 ): string {
   const lines = [
@@ -215,7 +252,7 @@ function buildFetchSnippet(
 function buildAiInstructions(
   endpoint: ApiPlaygroundEndpointConfig,
   fieldValues: Record<string, string>,
-  requestBody: Record<string, unknown> | null,
+  requestBody: unknown | null,
   productName: string,
   t: (key: MessageKey, values?: TranslationValues) => string
 ): string {
@@ -614,10 +651,11 @@ export function ApiPlaygroundShell({
     setExecuteError(null);
   }, [activeEndpointId, preselectedFieldValues]);
 
-  const requestBody = useMemo(
+  const requestBodyResult = useMemo(
     () => (activeEndpoint ? buildRequestBody(activeEndpoint.bodyFields, fieldValues) : null),
     [activeEndpoint, fieldValues]
   );
+  const requestBody = requestBodyResult?.body ?? null;
   const resolvedPath = useMemo(
     () => (activeEndpoint ? resolvePath(activeEndpoint, fieldValues) : ""),
     [activeEndpoint, fieldValues]
@@ -688,6 +726,16 @@ export function ApiPlaygroundShell({
     if (missingFields.length > 0) {
       setExecuteError(
         t("Shared.SharedComponents.completeRequiredFields", { fields: missingFields.join(", ") })
+      );
+      setActivePanel("response");
+      return;
+    }
+
+    if (requestBodyResult?.invalidJsonField) {
+      setExecuteError(
+        t("Shared.SharedComponents.invalidJsonField", {
+          field: requestBodyResult.invalidJsonField,
+        })
       );
       setActivePanel("response");
       return;
@@ -873,6 +921,18 @@ export function ApiPlaygroundShell({
                               </option>
                             ))}
                           </select>
+                        ) : field.kind === "textarea" ? (
+                          <textarea
+                            id={getFieldId(field.key)}
+                            value={fieldValues[field.key] ?? ""}
+                            onChange={(event) =>
+                              updateFieldValue(field.key, event.currentTarget.value)
+                            }
+                            placeholder={field.placeholder}
+                            rows={8}
+                            spellCheck={false}
+                            className="w-full resize-y rounded-[var(--sdp-field-radius)] border border-border-default bg-surface-raised px-4 py-3 font-mono text-sm text-primary shadow-none outline-none transition-[box-shadow,border-color] focus:border-border-strong focus:ring-2 focus:ring-border-default"
+                          />
                         ) : (
                           <Input
                             id={getFieldId(field.key)}
@@ -922,6 +982,18 @@ export function ApiPlaygroundShell({
                               </option>
                             ))}
                           </select>
+                        ) : field.kind === "textarea" ? (
+                          <textarea
+                            id={getFieldId(field.key)}
+                            value={fieldValues[field.key] ?? ""}
+                            onChange={(event) =>
+                              updateFieldValue(field.key, event.currentTarget.value)
+                            }
+                            placeholder={field.placeholder}
+                            rows={10}
+                            spellCheck={false}
+                            className="w-full resize-y rounded-[var(--sdp-field-radius)] border border-border-default bg-surface-raised px-4 py-3 font-mono text-sm text-primary shadow-none outline-none transition-[box-shadow,border-color] focus:border-border-strong focus:ring-2 focus:ring-border-default"
+                          />
                         ) : (
                           <Input
                             id={getFieldId(field.key)}

--- a/apps/sdp-web/src/lib/api-playground-catalog.generated.json
+++ b/apps/sdp-web/src/lib/api-playground-catalog.generated.json
@@ -623,9 +623,7 @@
                   "decision": "approval_required",
                   "reasonCode": "wallet_policy_match",
                   "reason": "example",
-                  "matchedRules": [
-                    {}
-                  ],
+                  "matchedRules": [{}],
                   "requiresApproval": true,
                   "evaluatedAt": "2025-01-01T00:00:00.000Z"
                 }
@@ -697,9 +695,7 @@
                 "decision": "approval_required",
                 "reasonCode": "wallet_policy_match",
                 "reason": "example",
-                "matchedRules": [
-                  {}
-                ],
+                "matchedRules": [{}],
                 "requiresApproval": true,
                 "evaluatedAt": "2025-01-01T00:00:00.000Z"
               }
@@ -770,9 +766,7 @@
                 "decision": "approval_required",
                 "reasonCode": "wallet_policy_match",
                 "reason": "example",
-                "matchedRules": [
-                  {}
-                ],
+                "matchedRules": [{}],
                 "requiresApproval": true,
                 "evaluatedAt": "2025-01-01T00:00:00.000Z"
               }
@@ -843,9 +837,7 @@
                 "decision": "approval_required",
                 "reasonCode": "wallet_policy_match",
                 "reason": "example",
-                "matchedRules": [
-                  {}
-                ],
+                "matchedRules": [{}],
                 "requiresApproval": true,
                 "evaluatedAt": "2025-01-01T00:00:00.000Z"
               }
@@ -916,9 +908,7 @@
                 "decision": "approval_required",
                 "reasonCode": "wallet_policy_match",
                 "reason": "example",
-                "matchedRules": [
-                  {}
-                ],
+                "matchedRules": [{}],
                 "requiresApproval": true,
                 "evaluatedAt": "2025-01-01T00:00:00.000Z"
               }
@@ -1113,9 +1103,7 @@
           "data": {
             "policy": {
               "walletId": "privy_wallet_123",
-              "destinationAllowlist": [
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
-              ],
+              "destinationAllowlist": ["7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"],
               "maxTransferAmount": "100.00",
               "maxDailyAmount": "100.00",
               "defaultAction": "allow",
@@ -1209,9 +1197,7 @@
           "data": {
             "policy": {
               "walletId": "privy_wallet_123",
-              "destinationAllowlist": [
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
-              ],
+              "destinationAllowlist": ["7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"],
               "maxTransferAmount": "100.00",
               "maxDailyAmount": "100.00",
               "defaultAction": "allow",
@@ -1503,9 +1489,7 @@
               "decision": "allow",
               "reasonCode": "example",
               "reason": "example",
-              "matchedRules": [
-                {}
-              ],
+              "matchedRules": [{}],
               "evaluationContext": {
                 "operation": {
                   "id": "_example",
@@ -1607,9 +1591,7 @@
               "decision": "allow",
               "reasonCode": "example",
               "reason": "example",
-              "matchedRules": [
-                {}
-              ],
+              "matchedRules": [{}],
               "evaluationContext": {
                 "operation": {
                   "id": "_example",
@@ -1732,9 +1714,7 @@
                 "kind": "transfer",
                 "version": "v0",
                 "instructionCount": 4,
-                "requiredSigners": [
-                  "So11111111111111111111111111111111111111112"
-                ],
+                "requiredSigners": ["So11111111111111111111111111111111111111112"],
                 "validator": "So11111111111111111111111111111111111111112"
               }
             }
@@ -2110,9 +2090,7 @@
                 "kind": "transfer",
                 "version": "v0",
                 "instructionCount": 4,
-                "requiredSigners": [
-                  "So11111111111111111111111111111111111111112"
-                ],
+                "requiredSigners": ["So11111111111111111111111111111111111111112"],
                 "validator": "So11111111111111111111111111111111111111112"
               }
             }
@@ -3237,9 +3215,7 @@
               "serialized": "AQID",
               "blockhash": "blockhash_example",
               "lastValidBlockHeight": "123456",
-              "requiredSigners": [
-                "So11111111111111111111111111111111111111112"
-              ]
+              "requiredSigners": ["So11111111111111111111111111111111111111112"]
             }
           },
           "meta": {
@@ -3555,9 +3531,7 @@
               "serialized": "AQID",
               "blockhash": "blockhash_example",
               "lastValidBlockHeight": "123456",
-              "requiredSigners": [
-                "So11111111111111111111111111111111111111112"
-              ]
+              "requiredSigners": ["So11111111111111111111111111111111111111112"]
             }
           },
           "meta": {
@@ -3618,9 +3592,7 @@
               "serialized": "AQID",
               "blockhash": "blockhash_example",
               "lastValidBlockHeight": "123456",
-              "requiredSigners": [
-                "So11111111111111111111111111111111111111112"
-              ]
+              "requiredSigners": ["So11111111111111111111111111111111111111112"]
             }
           },
           "meta": {
@@ -3681,9 +3653,7 @@
               "serialized": "AQID",
               "blockhash": "blockhash_example",
               "lastValidBlockHeight": "123456",
-              "requiredSigners": [
-                "So11111111111111111111111111111111111111112"
-              ]
+              "requiredSigners": ["So11111111111111111111111111111111111111112"]
             }
           },
           "meta": {
@@ -3744,9 +3714,7 @@
               "serialized": "AQID",
               "blockhash": "blockhash_example",
               "lastValidBlockHeight": "123456",
-              "requiredSigners": [
-                "So11111111111111111111111111111111111111112"
-              ]
+              "requiredSigners": ["So11111111111111111111111111111111111111112"]
             },
             "collectionAttempt": {
               "id": "psca_example",
@@ -4725,23 +4693,14 @@
         "expectedResponse": {
           "data": {
             "currencies": {
-              "sources": [
-                "USD",
-                "EUR"
-              ],
-              "destinations": [
-                "usdc.solana",
-                "sol.solana"
-              ]
+              "sources": ["USD", "EUR"],
+              "destinations": ["usdc.solana", "sol.solana"]
             },
             "pairs": [
               {
                 "source": "USD",
                 "dest": "usdc.solana",
-                "providers": [
-                  "moonpay",
-                  "lightspark"
-                ]
+                "providers": ["moonpay", "lightspark"]
               }
             ],
             "providerDetails": {
@@ -4754,14 +4713,9 @@
                 },
                 "countrySupport": {
                   "coverage": "all-currencies",
-                  "countries": [
-                    "AL",
-                    "US"
-                  ]
+                  "countries": ["AL", "US"]
                 },
-                "entityTypes": [
-                  "individual"
-                ]
+                "entityTypes": ["individual"]
               }
             },
             "supportHash": "sha256:example"
@@ -5482,23 +5436,14 @@
         "expectedResponse": {
           "data": {
             "currencies": {
-              "sources": [
-                "usdc.solana",
-                "sol.solana"
-              ],
-              "destinations": [
-                "USD",
-                "EUR"
-              ]
+              "sources": ["usdc.solana", "sol.solana"],
+              "destinations": ["USD", "EUR"]
             },
             "pairs": [
               {
                 "source": "usdc.solana",
                 "dest": "USD",
-                "providers": [
-                  "moonpay",
-                  "bvnk"
-                ]
+                "providers": ["moonpay", "bvnk"]
               }
             ],
             "providerDetails": {
@@ -5511,14 +5456,9 @@
                 },
                 "countrySupport": {
                   "coverage": "all-currencies",
-                  "countries": [
-                    "AL",
-                    "US"
-                  ]
+                  "countries": ["AL", "US"]
                 },
-                "entityTypes": [
-                  "individual"
-                ]
+                "entityTypes": ["individual"]
               }
             },
             "supportHash": "sha256:example"
@@ -5565,10 +5505,7 @@
                     "accountType": "USD_ACCOUNT",
                     "accountNumber": "0000000000000000",
                     "routingNumber": "000000000",
-                    "paymentRails": [
-                      "ACH",
-                      "WIRE"
-                    ],
+                    "paymentRails": ["ACH", "WIRE"],
                     "reference": "quote-reference-example",
                     "bankName": "Example Bank",
                     "address": "ExampleSolanaWalletAddress11111111111111111",
@@ -5638,9 +5575,7 @@
         "expectedResponse": {
           "data": {
             "fields": {
-              "entityTypes": [
-                "individual"
-              ],
+              "entityTypes": ["individual"],
               "countries": [
                 {
                   "code": "US",
@@ -6939,14 +6874,8 @@
                 "maxDecimals": 18,
                 "requiresAllowlist": true,
                 "allowlistOverridable": true,
-                "requiredExtensions": [
-                  "permanentDelegate",
-                  "pausable"
-                ],
-                "availableExtensions": [
-                  "scaledUiAmount",
-                  "interestBearing"
-                ],
+                "requiredExtensions": ["permanentDelegate", "pausable"],
+                "availableExtensions": ["scaledUiAmount", "interestBearing"],
                 "defaultExtensions": {
                   "defaultAccountState": "initialized"
                 }
@@ -6985,14 +6914,8 @@
               "maxDecimals": 18,
               "requiresAllowlist": true,
               "allowlistOverridable": true,
-              "requiredExtensions": [
-                "permanentDelegate",
-                "pausable"
-              ],
-              "availableExtensions": [
-                "scaledUiAmount",
-                "interestBearing"
-              ],
+              "requiredExtensions": ["permanentDelegate", "pausable"],
+              "availableExtensions": ["scaledUiAmount", "interestBearing"],
               "defaultExtensions": {
                 "defaultAccountState": "initialized"
               }
@@ -8020,9 +7943,7 @@
             },
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -8150,9 +8071,7 @@
             "uri": "https://api.example.com/v1/issuance/tokens/tok_123/metadata.json",
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -8218,9 +8137,7 @@
             "tokenAccount": "So11111111111111111111111111111111111111112",
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -8340,9 +8257,7 @@
             },
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -8461,9 +8376,7 @@
             },
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -8582,9 +8495,7 @@
             },
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -8703,9 +8614,7 @@
             },
             "simulation": {
               "success": true,
-              "logs": [
-                "Program log: success"
-              ],
+              "logs": ["Program log: success"],
               "unitsConsumed": 20000,
               "error": "Insufficient funds"
             }
@@ -9156,10 +9065,7 @@
         "bodyFields": [],
         "expectedResponse": {
           "data": {
-            "labels": [
-              "Treasury",
-              "Market maker"
-            ],
+            "labels": ["Treasury", "Market maker"],
             "total": 42
           },
           "meta": {

--- a/apps/sdp-web/src/lib/api-playground-catalog.generated.json
+++ b/apps/sdp-web/src/lib/api-playground-catalog.generated.json
@@ -6,7 +6,7 @@
       "wallets": 19,
       "payments": 40,
       "counterparties": 12,
-      "issuance": 33
+      "issuance": 35
     }
   },
   "modules": {
@@ -1696,6 +1696,10 @@
               },
               "source": "So11111111111111111111111111111111111111112",
               "destination": "So11111111111111111111111111111111111111112",
+              "rampsMemo": {
+                "invoice": "INV-123",
+                "po": "PO-9"
+              },
               "amount": "100.00",
               "provider": "moonpay",
               "counterpartyId": "counterparty_example",
@@ -1993,6 +1997,10 @@
               },
               "source": "So11111111111111111111111111111111111111112",
               "destination": "So11111111111111111111111111111111111111112",
+              "rampsMemo": {
+                "invoice": "INV-123",
+                "po": "PO-9"
+              },
               "amount": "100.00",
               "provider": "moonpay",
               "counterpartyId": "counterparty_example",
@@ -2066,6 +2074,10 @@
               },
               "source": "So11111111111111111111111111111111111111112",
               "destination": "So11111111111111111111111111111111111111112",
+              "rampsMemo": {
+                "invoice": "INV-123",
+                "po": "PO-9"
+              },
               "amount": "100.00",
               "provider": "moonpay",
               "counterpartyId": "counterparty_example",
@@ -2219,6 +2231,10 @@
                 },
                 "source": "So11111111111111111111111111111111111111112",
                 "destination": "So11111111111111111111111111111111111111112",
+                "rampsMemo": {
+                  "invoice": "INV-123",
+                  "po": "PO-9"
+                },
                 "amount": "100.00",
                 "provider": "moonpay",
                 "counterpartyId": "counterparty_example",
@@ -2429,6 +2445,10 @@
                 },
                 "source": "So11111111111111111111111111111111111111112",
                 "destination": "So11111111111111111111111111111111111111112",
+                "rampsMemo": {
+                  "invoice": "INV-123",
+                  "po": "PO-9"
+                },
                 "amount": "100.00",
                 "provider": "moonpay",
                 "counterpartyId": "counterparty_example",
@@ -2947,6 +2967,10 @@
               },
               "source": "So11111111111111111111111111111111111111112",
               "destination": "So11111111111111111111111111111111111111112",
+              "rampsMemo": {
+                "invoice": "INV-123",
+                "po": "PO-9"
+              },
               "amount": "100.00",
               "provider": "moonpay",
               "counterpartyId": "counterparty_example",
@@ -7068,12 +7092,35 @@
         "operationId": "listTokens",
         "title": "List tokens",
         "method": "GET",
-        "path": "/v1/issuance/tokens?status={status}&page={page}&pageSize={pageSize}",
+        "path": "/v1/issuance/tokens?page={page}&pageSize={pageSize}&search={search}&status={status}&deploymentStatus={deploymentStatus}&template={template}&createdAfter={createdAfter}&createdBefore={createdBefore}&sortBy={sortBy}&sortDirection={sortDirection}",
         "pathFields": [
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Items per page (max 100).",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "search",
+            "label": "search",
+            "description": "Contains-style, case-insensitive match over name, symbol, mint address and token id. LIKE wildcards are matched literally. A blank value is treated as no search filter.",
+            "defaultValue": "usdc",
+            "required": false
+          },
           {
             "key": "status",
             "label": "status",
-            "description": "Filter by token status.",
+            "description": "Filter by the stored lifecycle column.",
             "defaultValue": "active",
             "required": false,
             "kind": "select",
@@ -7097,20 +7144,83 @@
             ]
           },
           {
-            "key": "page",
-            "label": "page",
-            "description": "Page number (1-based).",
-            "defaultValue": "1",
+            "key": "deploymentStatus",
+            "label": "deploymentStatus",
+            "description": "Filter by derived lifecycle state: draft until the token has a mint, paused when the mint is paused, active otherwise.",
+            "defaultValue": "active",
             "required": false,
-            "valueType": "number"
+            "kind": "select",
+            "options": [
+              {
+                "label": "draft",
+                "value": "draft"
+              },
+              {
+                "label": "active",
+                "value": "active"
+              },
+              {
+                "label": "paused",
+                "value": "paused"
+              }
+            ]
           },
           {
-            "key": "pageSize",
-            "label": "pageSize",
-            "description": "Number of items per page.",
-            "defaultValue": "50",
+            "key": "template",
+            "label": "template",
+            "description": "Exact-match template id. Use GET /v1/issuance/tokens/facets for the ids present in the project (older tokens may hold legacy ids).",
+            "defaultValue": "stablecoin",
+            "required": false
+          },
+          {
+            "key": "createdAfter",
+            "label": "createdAfter",
+            "description": "Inclusive lower bound on creation time (ISO 8601).",
+            "defaultValue": "2026-01-01T00:00:00.000Z",
+            "required": false
+          },
+          {
+            "key": "createdBefore",
+            "label": "createdBefore",
+            "description": "Inclusive upper bound on creation time (ISO 8601).",
+            "defaultValue": "2026-06-30T23:59:59.999Z",
+            "required": false
+          },
+          {
+            "key": "sortBy",
+            "label": "sortBy",
+            "description": "Field used to sort the token list.",
+            "defaultValue": "createdAt",
             "required": false,
-            "valueType": "number"
+            "kind": "select",
+            "options": [
+              {
+                "label": "createdAt",
+                "value": "createdAt"
+              },
+              {
+                "label": "name",
+                "value": "name"
+              }
+            ]
+          },
+          {
+            "key": "sortDirection",
+            "label": "sortDirection",
+            "description": "Sort direction.",
+            "defaultValue": "desc",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "asc",
+                "value": "asc"
+              },
+              {
+                "label": "desc",
+                "value": "desc"
+              }
+            ]
           }
         ],
         "bodyFields": [],
@@ -7179,6 +7289,35 @@
             "pageSize": 1,
             "hasMore": false,
             "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "list-token-facets",
+        "operationId": "listTokenFacets",
+        "title": "List token filter facets",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/facets",
+        "pathFields": [],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "templates": [
+              {
+                "template": "stablecoin",
+                "count": 12
+              }
+            ],
+            "deploymentStatuses": {
+              "draft": 3,
+              "active": 8,
+              "paused": 1
+            },
+            "total": 12
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
           }
         }
       },
@@ -7570,7 +7709,7 @@
         "operationId": "listTokenTransactions",
         "title": "List token transactions",
         "method": "GET",
-        "path": "/v1/issuance/tokens/{tokenId}/transactions?status={status}&page={page}&pageSize={pageSize}",
+        "path": "/v1/issuance/tokens/{tokenId}/transactions?type={type}&status={status}&page={page}&pageSize={pageSize}",
         "pathFields": [
           {
             "key": "tokenId",
@@ -7578,6 +7717,56 @@
             "description": "Token identifier.",
             "defaultValue": "tok_example",
             "required": true
+          },
+          {
+            "key": "type",
+            "label": "type",
+            "description": "Filter by token transaction type.",
+            "defaultValue": "burn",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "mint",
+                "value": "mint"
+              },
+              {
+                "label": "burn",
+                "value": "burn"
+              },
+              {
+                "label": "freeze",
+                "value": "freeze"
+              },
+              {
+                "label": "unfreeze",
+                "value": "unfreeze"
+              },
+              {
+                "label": "seize",
+                "value": "seize"
+              },
+              {
+                "label": "force_burn",
+                "value": "force_burn"
+              },
+              {
+                "label": "update_authority",
+                "value": "update_authority"
+              },
+              {
+                "label": "pause",
+                "value": "pause"
+              },
+              {
+                "label": "unpause",
+                "value": "unpause"
+              },
+              {
+                "label": "deploy",
+                "value": "deploy"
+              }
+            ]
           },
           {
             "key": "status",
@@ -8841,7 +9030,7 @@
         "operationId": "listTokenAllowlist",
         "title": "List token allowlist",
         "method": "GET",
-        "path": "/v1/issuance/tokens/{tokenId}/allowlist?page={page}&pageSize={pageSize}",
+        "path": "/v1/issuance/tokens/{tokenId}/allowlist?page={page}&pageSize={pageSize}&search={search}&label={label}",
         "pathFields": [
           {
             "key": "tokenId",
@@ -8865,6 +9054,20 @@
             "defaultValue": "50",
             "required": false,
             "valueType": "number"
+          },
+          {
+            "key": "search",
+            "label": "search",
+            "description": "Contains-style search over the entry address and label. A blank value is treated as no search filter.",
+            "defaultValue": "So1",
+            "required": false
+          },
+          {
+            "key": "label",
+            "label": "label",
+            "description": "Filter to entries with this exact label (values come from the labels endpoint).",
+            "defaultValue": "Treasury",
+            "required": false
           }
         ],
         "bodyFields": [],
@@ -8928,6 +9131,36 @@
               "createdAt": "2025-01-01T00:00:00.000Z",
               "revokedAt": "2025-02-01T00:00:00.000Z"
             }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-token-allowlist-labels",
+        "operationId": "listTokenAllowlistLabels",
+        "title": "List token allowlist labels",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}/allowlist/labels",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "labels": [
+              "Treasury",
+              "Market maker"
+            ],
+            "total": 42
           },
           "meta": {
             "requestId": "req_example",

--- a/apps/sdp-web/src/lib/api-playground-catalog.generated.json
+++ b/apps/sdp-web/src/lib/api-playground-catalog.generated.json
@@ -1,0 +1,8965 @@
+{
+  "_generated": {
+    "source": "apps/sdp-api/src/openapi/**",
+    "command": "pnpm -C apps/sdp-api playground:generate",
+    "modules": {
+      "wallets": 19,
+      "payments": 40,
+      "counterparties": 12,
+      "issuance": 33
+    }
+  },
+  "modules": {
+    "wallets": [
+      {
+        "id": "initialize-wallet-signing",
+        "operationId": "initializeWalletSigning",
+        "title": "Initialize wallet signing",
+        "method": "POST",
+        "path": "/v1/wallets/initialize",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"local\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "configId": "cfg_example",
+          "publicKey": "So11111111111111111111111111111111111111112",
+          "walletId": "privy_wallet_123"
+        }
+      },
+      {
+        "id": "switch-wallet-signing-provider",
+        "operationId": "switchWalletSigningProvider",
+        "title": "Switch wallet signing provider",
+        "method": "POST",
+        "path": "/v1/wallets/switch",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"local\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "configId": "cfg_example",
+          "publicKey": "So11111111111111111111111111111111111111112",
+          "walletId": "privy_wallet_123"
+        }
+      },
+      {
+        "id": "create-wallet",
+        "operationId": "createWallet",
+        "title": "Create wallet",
+        "method": "POST",
+        "path": "/v1/wallets",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"privy\",\n  \"label\": \"Mint authority wallet\",\n  \"purpose\": \"mint_authority\",\n  \"setDefault\": true\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "wallet": {
+              "id": "cw_example",
+              "custodyConfigId": "cfg_example",
+              "provider": "privy",
+              "isDefaultProvider": true,
+              "walletId": "privy_wallet_123",
+              "publicKey": "So11111111111111111111111111111111111111112",
+              "label": "Root Signing Wallet",
+              "purpose": "root",
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "balances": [
+                {
+                  "token": "USDC",
+                  "mint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                  "amount": "1250000",
+                  "uiAmount": "1.25",
+                  "decimals": 6,
+                  "usdPrice": 1,
+                  "usdValue": 125.5
+                }
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "delete-wallet",
+        "operationId": "deleteWallet",
+        "title": "Delete wallet",
+        "method": "DELETE",
+        "path": "/v1/wallets",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"anchorage\",\n  \"walletId\": \"anchorage_wallet_123\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "walletId": "anchorage_wallet_123",
+            "deleted": true
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-wallets",
+        "operationId": "listWallets",
+        "title": "List wallets",
+        "method": "GET",
+        "path": "/v1/wallets?provider={provider}&includeAllProviders={includeAllProviders}&includeBalances={includeBalances}&view={view}",
+        "pathFields": [
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Wallet signing provider.",
+            "defaultValue": "privy",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "local",
+                "value": "local"
+              },
+              {
+                "label": "fireblocks",
+                "value": "fireblocks"
+              },
+              {
+                "label": "privy",
+                "value": "privy"
+              },
+              {
+                "label": "coinbase_cdp",
+                "value": "coinbase_cdp"
+              },
+              {
+                "label": "para",
+                "value": "para"
+              },
+              {
+                "label": "turnkey",
+                "value": "turnkey"
+              },
+              {
+                "label": "dfns",
+                "value": "dfns"
+              },
+              {
+                "label": "ibm_haven",
+                "value": "ibm_haven"
+              },
+              {
+                "label": "anchorage",
+                "value": "anchorage"
+              }
+            ]
+          },
+          {
+            "key": "includeAllProviders",
+            "label": "includeAllProviders",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ],
+            "valueType": "boolean"
+          },
+          {
+            "key": "includeBalances",
+            "label": "includeBalances",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ],
+            "valueType": "boolean"
+          },
+          {
+            "key": "view",
+            "label": "view",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "summary",
+                "value": "summary"
+              }
+            ]
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "wallets": [
+              {
+                "id": "cw_example",
+                "custodyConfigId": "cfg_example",
+                "provider": "privy",
+                "isDefaultProvider": true,
+                "walletId": "privy_wallet_123",
+                "publicKey": "So11111111111111111111111111111111111111112",
+                "label": "Root Signing Wallet",
+                "purpose": "root",
+                "status": "active",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "balances": [
+                  {
+                    "token": "USDC",
+                    "mint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                    "amount": "1250000",
+                    "uiAmount": "1.25",
+                    "decimals": 6,
+                    "usdPrice": 1,
+                    "usdValue": 125.5
+                  }
+                ]
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "set-default-wallet",
+        "operationId": "setDefaultWallet",
+        "title": "Set default wallet",
+        "method": "POST",
+        "path": "/v1/wallets/default-wallet",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"privy\",\n  \"walletId\": \"privy_wallet_123\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "defaultWalletId": "privy_wallet_123"
+        }
+      },
+      {
+        "id": "get-wallet-config",
+        "operationId": "getWalletConfig",
+        "title": "Get wallet signing config",
+        "method": "GET",
+        "path": "/v1/wallets/config",
+        "pathFields": [],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "config": {
+              "id": "cfg_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "provider": "privy",
+              "publicKey": "So11111111111111111111111111111111111111112",
+              "defaultWalletId": "privy_wallet_123",
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-wallet-configs",
+        "operationId": "listWalletConfigs",
+        "title": "List wallet signing configs",
+        "method": "GET",
+        "path": "/v1/wallets/configs",
+        "pathFields": [],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "configs": [
+              {
+                "id": "cfg_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "provider": "privy",
+                "publicKey": "So11111111111111111111111111111111111111112",
+                "defaultWalletId": "privy_wallet_123",
+                "status": "active",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "isDefault": true
+              }
+            ],
+            "defaultConfigId": "cfg_example"
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "aggregate-wallet-balances",
+        "operationId": "aggregateWalletBalances",
+        "title": "Aggregate wallet balances",
+        "method": "GET",
+        "path": "/v1/wallets/aggregate?provider={provider}&includeAllProviders={includeAllProviders}",
+        "pathFields": [
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Wallet signing provider.",
+            "defaultValue": "privy",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "local",
+                "value": "local"
+              },
+              {
+                "label": "fireblocks",
+                "value": "fireblocks"
+              },
+              {
+                "label": "privy",
+                "value": "privy"
+              },
+              {
+                "label": "coinbase_cdp",
+                "value": "coinbase_cdp"
+              },
+              {
+                "label": "para",
+                "value": "para"
+              },
+              {
+                "label": "turnkey",
+                "value": "turnkey"
+              },
+              {
+                "label": "dfns",
+                "value": "dfns"
+              },
+              {
+                "label": "ibm_haven",
+                "value": "ibm_haven"
+              },
+              {
+                "label": "anchorage",
+                "value": "anchorage"
+              }
+            ]
+          },
+          {
+            "key": "includeAllProviders",
+            "label": "includeAllProviders",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ],
+            "valueType": "boolean"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "aggregate": {
+              "walletCount": 3,
+              "balances": [
+                {
+                  "token": "USDC",
+                  "mint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                  "amount": "1250000",
+                  "uiAmount": "1.25",
+                  "decimals": 6,
+                  "usdPrice": 1,
+                  "usdValue": 125.5
+                }
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-switch-provider-options",
+        "operationId": "listSwitchProviderOptions",
+        "title": "List switch provider options",
+        "method": "GET",
+        "path": "/v1/wallets/switch-options",
+        "pathFields": [],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "providers": [
+              {
+                "provider": "privy",
+                "hasReusableWallet": true,
+                "needsWalletLabel": false,
+                "isActive": true,
+                "isDefault": false
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-wallet-public-key",
+        "operationId": "getWalletPublicKey",
+        "title": "Get wallet public key",
+        "method": "GET",
+        "path": "/v1/wallets/public-key?walletId={walletId}",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "walletId",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets.",
+            "defaultValue": "privy_wallet_123",
+            "required": false
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "publicKey": "So11111111111111111111111111111111111111112"
+        }
+      },
+      {
+        "id": "check-wallet-signer",
+        "operationId": "checkWalletSigner",
+        "title": "Check signer via memo transaction",
+        "method": "POST",
+        "path": "/v1/wallets/signer-check",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{}",
+            "required": false
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "walletId": "privy_wallet_123",
+            "walletAddress": "So11111111111111111111111111111111111111112",
+            "feePayer": "So11111111111111111111111111111111111111112",
+            "memo": "SDP signer check 2026-02-20T00:00:00.000Z",
+            "signature": "sig_example",
+            "slot": 123456789,
+            "blockTime": "2026-02-20T00:00:00.000Z"
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-wallet-approval-requests",
+        "operationId": "listWalletApprovalRequests",
+        "title": "List wallet approval requests",
+        "method": "GET",
+        "path": "/v1/wallets/approval-requests?status={status}&limit={limit}",
+        "pathFields": [
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Filter by approval request status.",
+            "defaultValue": "pending",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending",
+                "value": "pending"
+              },
+              {
+                "label": "approved",
+                "value": "approved"
+              },
+              {
+                "label": "rejected",
+                "value": "rejected"
+              },
+              {
+                "label": "canceled",
+                "value": "canceled"
+              },
+              {
+                "label": "expired",
+                "value": "expired"
+              },
+              {
+                "label": "failed",
+                "value": "failed"
+              }
+            ]
+          },
+          {
+            "key": "limit",
+            "label": "limit",
+            "description": "Maximum approval requests to return.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "approvalRequests": [
+              {
+                "id": "appr_example",
+                "organizationId": "organization_example",
+                "projectId": "prj_example",
+                "walletOperationId": "walletoperation_example",
+                "approvalGroupId": "approvalgroup_example",
+                "status": "pending",
+                "provider": "fireblocks",
+                "providerReference": "fb_tx_123",
+                "requestedBy": "example",
+                "resolvedBy": "example",
+                "expiresAt": "2025-01-01T00:00:00.000Z",
+                "resolvedAt": "2025-01-01T00:00:00.000Z",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z",
+                "wallet": {
+                  "custodyWalletId": "custodywallet_example",
+                  "walletId": "privy_wallet_123",
+                  "publicKey": "So11111111111111111111111111111111111111112",
+                  "label": "example"
+                },
+                "operation": {
+                  "id": "_example",
+                  "custodyWalletId": "custodywallet_example",
+                  "walletId": "privy_wallet_123",
+                  "apiKeyId": "apikey_example",
+                  "source": "api",
+                  "operationFamily": "payment",
+                  "operationType": "payment_transfer",
+                  "asset": "example",
+                  "amount": "example",
+                  "destination": "example",
+                  "status": "pending_approval",
+                  "createdAt": "2025-01-01T00:00:00.000Z",
+                  "updatedAt": "2025-01-01T00:00:00.000Z"
+                },
+                "policyEvaluation": {
+                  "id": "_example",
+                  "decision": "approval_required",
+                  "reasonCode": "wallet_policy_match",
+                  "reason": "example",
+                  "matchedRules": [
+                    {}
+                  ],
+                  "requiresApproval": true,
+                  "evaluatedAt": "2025-01-01T00:00:00.000Z"
+                }
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-wallet-approval-request",
+        "operationId": "getWalletApprovalRequest",
+        "title": "Get wallet approval request",
+        "method": "GET",
+        "path": "/v1/wallets/approval-requests/{approvalRequestId}",
+        "pathFields": [
+          {
+            "key": "approvalRequestId",
+            "label": "{approvalRequestId}",
+            "description": "Approval request ID.",
+            "defaultValue": "appr_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "approvalRequest": {
+              "id": "appr_example",
+              "organizationId": "organization_example",
+              "projectId": "prj_example",
+              "walletOperationId": "walletoperation_example",
+              "approvalGroupId": "approvalgroup_example",
+              "status": "pending",
+              "provider": "fireblocks",
+              "providerReference": "fb_tx_123",
+              "requestedBy": "example",
+              "resolvedBy": "example",
+              "expiresAt": "2025-01-01T00:00:00.000Z",
+              "resolvedAt": "2025-01-01T00:00:00.000Z",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z",
+              "wallet": {
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "publicKey": "So11111111111111111111111111111111111111112",
+                "label": "example"
+              },
+              "operation": {
+                "id": "_example",
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "apiKeyId": "apikey_example",
+                "source": "api",
+                "operationFamily": "payment",
+                "operationType": "payment_transfer",
+                "asset": "example",
+                "amount": "example",
+                "destination": "example",
+                "status": "pending_approval",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "policyEvaluation": {
+                "id": "_example",
+                "decision": "approval_required",
+                "reasonCode": "wallet_policy_match",
+                "reason": "example",
+                "matchedRules": [
+                  {}
+                ],
+                "requiresApproval": true,
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "approve-wallet-approval-request",
+        "operationId": "approveWalletApprovalRequest",
+        "title": "Approve wallet approval request",
+        "method": "POST",
+        "path": "/v1/wallets/approval-requests/{approvalRequestId}/approve",
+        "pathFields": [
+          {
+            "key": "approvalRequestId",
+            "label": "{approvalRequestId}",
+            "description": "Approval request ID.",
+            "defaultValue": "appr_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "approvalRequest": {
+              "id": "appr_example",
+              "organizationId": "organization_example",
+              "projectId": "prj_example",
+              "walletOperationId": "walletoperation_example",
+              "approvalGroupId": "approvalgroup_example",
+              "status": "pending",
+              "provider": "fireblocks",
+              "providerReference": "fb_tx_123",
+              "requestedBy": "example",
+              "resolvedBy": "example",
+              "expiresAt": "2025-01-01T00:00:00.000Z",
+              "resolvedAt": "2025-01-01T00:00:00.000Z",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z",
+              "wallet": {
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "publicKey": "So11111111111111111111111111111111111111112",
+                "label": "example"
+              },
+              "operation": {
+                "id": "_example",
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "apiKeyId": "apikey_example",
+                "source": "api",
+                "operationFamily": "payment",
+                "operationType": "payment_transfer",
+                "asset": "example",
+                "amount": "example",
+                "destination": "example",
+                "status": "pending_approval",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "policyEvaluation": {
+                "id": "_example",
+                "decision": "approval_required",
+                "reasonCode": "wallet_policy_match",
+                "reason": "example",
+                "matchedRules": [
+                  {}
+                ],
+                "requiresApproval": true,
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "reject-wallet-approval-request",
+        "operationId": "rejectWalletApprovalRequest",
+        "title": "Reject wallet approval request",
+        "method": "POST",
+        "path": "/v1/wallets/approval-requests/{approvalRequestId}/reject",
+        "pathFields": [
+          {
+            "key": "approvalRequestId",
+            "label": "{approvalRequestId}",
+            "description": "Approval request ID.",
+            "defaultValue": "appr_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "approvalRequest": {
+              "id": "appr_example",
+              "organizationId": "organization_example",
+              "projectId": "prj_example",
+              "walletOperationId": "walletoperation_example",
+              "approvalGroupId": "approvalgroup_example",
+              "status": "pending",
+              "provider": "fireblocks",
+              "providerReference": "fb_tx_123",
+              "requestedBy": "example",
+              "resolvedBy": "example",
+              "expiresAt": "2025-01-01T00:00:00.000Z",
+              "resolvedAt": "2025-01-01T00:00:00.000Z",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z",
+              "wallet": {
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "publicKey": "So11111111111111111111111111111111111111112",
+                "label": "example"
+              },
+              "operation": {
+                "id": "_example",
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "apiKeyId": "apikey_example",
+                "source": "api",
+                "operationFamily": "payment",
+                "operationType": "payment_transfer",
+                "asset": "example",
+                "amount": "example",
+                "destination": "example",
+                "status": "pending_approval",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "policyEvaluation": {
+                "id": "_example",
+                "decision": "approval_required",
+                "reasonCode": "wallet_policy_match",
+                "reason": "example",
+                "matchedRules": [
+                  {}
+                ],
+                "requiresApproval": true,
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "cancel-wallet-approval-request",
+        "operationId": "cancelWalletApprovalRequest",
+        "title": "Cancel wallet approval request",
+        "method": "POST",
+        "path": "/v1/wallets/approval-requests/{approvalRequestId}/cancel",
+        "pathFields": [
+          {
+            "key": "approvalRequestId",
+            "label": "{approvalRequestId}",
+            "description": "Approval request ID.",
+            "defaultValue": "appr_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "approvalRequest": {
+              "id": "appr_example",
+              "organizationId": "organization_example",
+              "projectId": "prj_example",
+              "walletOperationId": "walletoperation_example",
+              "approvalGroupId": "approvalgroup_example",
+              "status": "pending",
+              "provider": "fireblocks",
+              "providerReference": "fb_tx_123",
+              "requestedBy": "example",
+              "resolvedBy": "example",
+              "expiresAt": "2025-01-01T00:00:00.000Z",
+              "resolvedAt": "2025-01-01T00:00:00.000Z",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z",
+              "wallet": {
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "publicKey": "So11111111111111111111111111111111111111112",
+                "label": "example"
+              },
+              "operation": {
+                "id": "_example",
+                "custodyWalletId": "custodywallet_example",
+                "walletId": "privy_wallet_123",
+                "apiKeyId": "apikey_example",
+                "source": "api",
+                "operationFamily": "payment",
+                "operationType": "payment_transfer",
+                "asset": "example",
+                "amount": "example",
+                "destination": "example",
+                "status": "pending_approval",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "policyEvaluation": {
+                "id": "_example",
+                "decision": "approval_required",
+                "reasonCode": "wallet_policy_match",
+                "reason": "example",
+                "matchedRules": [
+                  {}
+                ],
+                "requiresApproval": true,
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-wallet-by-id",
+        "operationId": "getWalletById",
+        "title": "Get wallet by ID",
+        "method": "GET",
+        "path": "/v1/wallets/{walletId}?includeBalance={includeBalance}",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          },
+          {
+            "key": "includeBalance",
+            "label": "includeBalance",
+            "description": "Whether to resolve the current SOL balance. Defaults to true; false returns metadata without balance RPC or pricing calls.",
+            "defaultValue": "false",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ]
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "wallet": {
+              "id": "cw_example",
+              "custodyConfigId": "cfg_example",
+              "provider": "privy",
+              "isDefaultProvider": true,
+              "walletId": "privy_wallet_123",
+              "publicKey": "So11111111111111111111111111111111111111112",
+              "label": "Root Signing Wallet",
+              "purpose": "root",
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "balance": {
+                "token": "SOL",
+                "mint": "So11111111111111111111111111111111111111112",
+                "amount": "123456789",
+                "uiAmount": "0.123456789",
+                "decimals": 9
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-wallet",
+        "operationId": "updateWallet",
+        "title": "Update wallet",
+        "method": "PATCH",
+        "path": "/v1/wallets/{walletId}",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"label\": \"Treasury signer\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "wallet": {
+              "id": "cw_example",
+              "custodyConfigId": "cfg_example",
+              "provider": "privy",
+              "isDefaultProvider": true,
+              "walletId": "privy_wallet_123",
+              "publicKey": "So11111111111111111111111111111111111111112",
+              "label": "Root Signing Wallet",
+              "purpose": "root",
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "balances": [
+                {
+                  "token": "USDC",
+                  "mint": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+                  "amount": "1250000",
+                  "uiAmount": "1.25",
+                  "decimals": 6,
+                  "usdPrice": 1,
+                  "usdValue": 125.5
+                }
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      }
+    ],
+    "payments": [
+      {
+        "id": "get-payment-wallet-balances",
+        "operationId": "getPaymentWalletBalances",
+        "title": "Get wallet balances",
+        "method": "GET",
+        "path": "/v1/payments/wallets/{walletId}/balances",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets. The wallet record `id` and the public key are not accepted.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "walletBalances": {
+              "walletId": "privy_wallet_123",
+              "address": "So11111111111111111111111111111111111111112",
+              "balances": [
+                {
+                  "token": "USDC",
+                  "mint": "So11111111111111111111111111111111111111112",
+                  "amount": "100000000",
+                  "uiAmount": "100.00",
+                  "decimals": 6,
+                  "usdPrice": 1,
+                  "usdValue": 100,
+                  "confidential": false
+                }
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-payment-wallet-policy",
+        "operationId": "getPaymentWalletPolicy",
+        "title": "Get wallet policy",
+        "method": "GET",
+        "path": "/v1/payments/wallets/{walletId}/policies",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets. The wallet record `id` and the public key are not accepted.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "policy": {
+              "walletId": "privy_wallet_123",
+              "destinationAllowlist": [
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+              ],
+              "maxTransferAmount": "100.00",
+              "maxDailyAmount": "100.00",
+              "defaultAction": "allow",
+              "rules": [
+                {
+                  "id": "deny-raw-signing",
+                  "kind": "operation_family",
+                  "family": "raw_sign",
+                  "action": "deny"
+                }
+              ],
+              "controlProfile": {
+                "id": "_example",
+                "status": "draft",
+                "activeRevisionId": "activerevision_example",
+                "revisionId": "revision_example",
+                "revisionNumber": 1,
+                "defaultAction": "allow",
+                "rules": [
+                  {
+                    "id": "deny-raw-signing",
+                    "kind": "operation_family",
+                    "family": "raw_sign",
+                    "action": "deny"
+                  }
+                ],
+                "providerMappingStatus": "not_applicable",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z",
+                "activatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "audit": {
+                "recentEvaluations": [
+                  {
+                    "walletOperationId": "wop_example",
+                    "policyEvaluationId": "peval_example",
+                    "operationFamily": "transfer",
+                    "operationType": "payment_transfer_execute",
+                    "asset": "USDC",
+                    "amount": "100.00",
+                    "destination": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                    "status": "created",
+                    "decision": "allow",
+                    "reasonCode": "wallet_policy_match",
+                    "reason": "Operation family payment matched policy.",
+                    "requiresApproval": false,
+                    "approvalRequestId": "appr_example",
+                    "operationCreatedAt": "2025-01-01T00:00:00.000Z",
+                    "operationUpdatedAt": "2025-01-01T00:00:00.000Z",
+                    "evaluatedAt": "2025-01-01T00:00:00.000Z"
+                  }
+                ]
+              },
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-payment-wallet-policy",
+        "operationId": "updatePaymentWalletPolicy",
+        "title": "Update wallet policy",
+        "method": "PUT",
+        "path": "/v1/payments/wallets/{walletId}/policies",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets. The wallet record `id` and the public key are not accepted.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"destinationAllowlist\": [\n    \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\"\n  ],\n  \"maxTransferAmount\": \"100.00\",\n  \"maxDailyAmount\": \"1000.00\",\n  \"defaultAction\": \"allow\",\n  \"rules\": [\n    {\n      \"id\": \"deny-raw-signing\",\n      \"kind\": \"operation_family\",\n      \"family\": \"raw_sign\",\n      \"action\": \"deny\"\n    }\n  ]\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "policy": {
+              "walletId": "privy_wallet_123",
+              "destinationAllowlist": [
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+              ],
+              "maxTransferAmount": "100.00",
+              "maxDailyAmount": "100.00",
+              "defaultAction": "allow",
+              "rules": [
+                {
+                  "id": "deny-raw-signing",
+                  "kind": "operation_family",
+                  "family": "raw_sign",
+                  "action": "deny"
+                }
+              ],
+              "controlProfile": {
+                "id": "_example",
+                "status": "draft",
+                "activeRevisionId": "activerevision_example",
+                "revisionId": "revision_example",
+                "revisionNumber": 1,
+                "defaultAction": "allow",
+                "rules": [
+                  {
+                    "id": "deny-raw-signing",
+                    "kind": "operation_family",
+                    "family": "raw_sign",
+                    "action": "deny"
+                  }
+                ],
+                "providerMappingStatus": "not_applicable",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z",
+                "activatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "audit": {
+                "recentEvaluations": [
+                  {
+                    "walletOperationId": "wop_example",
+                    "policyEvaluationId": "peval_example",
+                    "operationFamily": "transfer",
+                    "operationType": "payment_transfer_execute",
+                    "asset": "USDC",
+                    "amount": "100.00",
+                    "destination": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                    "status": "created",
+                    "decision": "allow",
+                    "reasonCode": "wallet_policy_match",
+                    "reason": "Operation family payment matched policy.",
+                    "requiresApproval": false,
+                    "approvalRequestId": "appr_example",
+                    "operationCreatedAt": "2025-01-01T00:00:00.000Z",
+                    "operationUpdatedAt": "2025-01-01T00:00:00.000Z",
+                    "evaluatedAt": "2025-01-01T00:00:00.000Z"
+                  }
+                ]
+              },
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-wallet-policy-revisions",
+        "operationId": "listPaymentWalletPolicyRevisions",
+        "title": "List wallet policy revisions",
+        "method": "GET",
+        "path": "/v1/payments/wallets/{walletId}/policies/revisions",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets. The wallet record `id` and the public key are not accepted.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "profile": {
+              "id": "_example",
+              "organizationId": "organization_example",
+              "projectId": "project_example",
+              "custodyWalletId": "custodywallet_example",
+              "name": "example",
+              "status": "draft",
+              "activeRevisionId": "activerevision_example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z",
+              "activatedAt": "2025-01-01T00:00:00.000Z",
+              "archivedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "revisions": [
+              {
+                "id": "_example",
+                "profileId": "profile_example",
+                "revisionNumber": 1,
+                "rules": [
+                  {
+                    "id": "deny-raw-signing",
+                    "kind": "operation_family",
+                    "family": "raw_sign",
+                    "action": "deny"
+                  }
+                ],
+                "defaultAction": "allow",
+                "createdBy": "example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "activatedAt": "2025-01-01T00:00:00.000Z",
+                "isActive": false
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-wallet-policy-evaluations",
+        "operationId": "listPaymentWalletPolicyEvaluations",
+        "title": "List wallet policy evaluations",
+        "method": "GET",
+        "path": "/v1/payments/wallets/{walletId}/policies/evaluations?page={page}&pageSize={pageSize}&decision={decision}&status={status}&operationFamily={operationFamily}&reasonCode={reasonCode}",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets. The wallet record `id` and the public key are not accepted.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (default 1).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Items per page (default 25, maximum 100).",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "decision",
+            "label": "decision",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "allow",
+                "value": "allow"
+              },
+              {
+                "label": "deny",
+                "value": "deny"
+              },
+              {
+                "label": "approval_required",
+                "value": "approval_required"
+              },
+              {
+                "label": "provider_approval_required",
+                "value": "provider_approval_required"
+              },
+              {
+                "label": "review",
+                "value": "review"
+              },
+              {
+                "label": "not_evaluated",
+                "value": "not_evaluated"
+              }
+            ]
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "created",
+                "value": "created"
+              },
+              {
+                "label": "evaluated",
+                "value": "evaluated"
+              },
+              {
+                "label": "pending_approval",
+                "value": "pending_approval"
+              },
+              {
+                "label": "executing",
+                "value": "executing"
+              },
+              {
+                "label": "completed",
+                "value": "completed"
+              },
+              {
+                "label": "failed",
+                "value": "failed"
+              },
+              {
+                "label": "canceled",
+                "value": "canceled"
+              }
+            ]
+          },
+          {
+            "key": "operationFamily",
+            "label": "operationFamily",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "transfer",
+                "value": "transfer"
+              },
+              {
+                "label": "payment",
+                "value": "payment"
+              },
+              {
+                "label": "ramp",
+                "value": "ramp"
+              },
+              {
+                "label": "issuance",
+                "value": "issuance"
+              },
+              {
+                "label": "raw_sign",
+                "value": "raw_sign"
+              },
+              {
+                "label": "program",
+                "value": "program"
+              },
+              {
+                "label": "provider_admin",
+                "value": "provider_admin"
+              }
+            ]
+          },
+          {
+            "key": "reasonCode",
+            "label": "reasonCode",
+            "required": false
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "_example",
+              "walletOperation": {
+                "id": "_example",
+                "operationFamily": "transfer",
+                "operationType": "example",
+                "asset": "example",
+                "amount": "example",
+                "destination": "example",
+                "status": "created",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "policyRevisions": {
+                "wallet": {
+                  "evaluatedRevisionId": "evaluatedrevision_example",
+                  "activeRevisionId": "activerevision_example"
+                },
+                "apiKey": {
+                  "evaluatedRevisionId": "evaluatedrevision_example",
+                  "activeRevisionId": "activerevision_example"
+                }
+              },
+              "decision": "allow",
+              "reasonCode": "example",
+              "reason": "example",
+              "matchedRules": [
+                {}
+              ],
+              "evaluationContext": {
+                "operation": {
+                  "id": "_example",
+                  "organizationId": "organization_example",
+                  "projectId": "project_example",
+                  "custodyWalletId": "custodywallet_example",
+                  "walletId": "wallet_example",
+                  "apiKeyId": "apikey_example",
+                  "actor": {},
+                  "source": "example",
+                  "operationFamily": "transfer",
+                  "operationType": "example",
+                  "asset": "example",
+                  "amount": "example",
+                  "destination": "example",
+                  "context": {},
+                  "idempotencyKey": "example",
+                  "createdAt": "2025-01-01T00:00:00.000Z"
+                },
+                "walletPolicy": {
+                  "source": "implicit_default_allow",
+                  "profileId": "profile_example",
+                  "revisionId": "revision_example",
+                  "defaultAction": "allow",
+                  "decision": "allow",
+                  "requiresApproval": false
+                },
+                "apiKeyPolicy": {
+                  "source": "implicit_default_allow",
+                  "profileId": "profile_example",
+                  "revisionId": "revision_example",
+                  "defaultAction": "allow",
+                  "decision": "allow",
+                  "requiresApproval": false
+                }
+              },
+              "requiresApproval": false,
+              "approvalRequestId": "approvalrequest_example",
+              "evaluatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "get-payment-wallet-policy-evaluation",
+        "operationId": "getPaymentWalletPolicyEvaluation",
+        "title": "Get wallet policy evaluation",
+        "method": "GET",
+        "path": "/v1/payments/wallets/{walletId}/policies/evaluations/{policyEvaluationId}",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "{walletId}",
+            "description": "Provider wallet ID — the `walletId` field returned by GET /v1/wallets. The wallet record `id` and the public key are not accepted.",
+            "defaultValue": "privy_wallet_123",
+            "required": true
+          },
+          {
+            "key": "policyEvaluationId",
+            "label": "{policyEvaluationId}",
+            "description": "Policy evaluation ID.",
+            "defaultValue": "policyevaluation_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "policyEvaluation": {
+              "id": "_example",
+              "walletOperation": {
+                "id": "_example",
+                "operationFamily": "transfer",
+                "operationType": "example",
+                "asset": "example",
+                "amount": "example",
+                "destination": "example",
+                "status": "created",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "policyRevisions": {
+                "wallet": {
+                  "evaluatedRevisionId": "evaluatedrevision_example",
+                  "activeRevisionId": "activerevision_example"
+                },
+                "apiKey": {
+                  "evaluatedRevisionId": "evaluatedrevision_example",
+                  "activeRevisionId": "activerevision_example"
+                }
+              },
+              "decision": "allow",
+              "reasonCode": "example",
+              "reason": "example",
+              "matchedRules": [
+                {}
+              ],
+              "evaluationContext": {
+                "operation": {
+                  "id": "_example",
+                  "organizationId": "organization_example",
+                  "projectId": "project_example",
+                  "custodyWalletId": "custodywallet_example",
+                  "walletId": "wallet_example",
+                  "apiKeyId": "apikey_example",
+                  "actor": {},
+                  "source": "example",
+                  "operationFamily": "transfer",
+                  "operationType": "example",
+                  "asset": "example",
+                  "amount": "example",
+                  "destination": "example",
+                  "context": {},
+                  "idempotencyKey": "example",
+                  "createdAt": "2025-01-01T00:00:00.000Z"
+                },
+                "walletPolicy": {
+                  "source": "implicit_default_allow",
+                  "profileId": "profile_example",
+                  "revisionId": "revision_example",
+                  "defaultAction": "allow",
+                  "decision": "allow",
+                  "requiresApproval": false
+                },
+                "apiKeyPolicy": {
+                  "source": "implicit_default_allow",
+                  "profileId": "profile_example",
+                  "revisionId": "revision_example",
+                  "defaultAction": "allow",
+                  "decision": "allow",
+                  "requiresApproval": false
+                }
+              },
+              "requiresApproval": false,
+              "approvalRequestId": "approvalrequest_example",
+              "evaluatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-transfer",
+        "operationId": "createPaymentTransfer",
+        "title": "Execute transfer (custody)",
+        "method": "POST",
+        "path": "/v1/payments/transfers",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"projectId\": \"prj_example\",\n  \"source\": \"privy_wallet_123\",\n  \"destination\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\",\n  \"token\": \"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\n  \"amount\": \"100.00\",\n  \"privateTransfer\": {\n    \"provider\": \"magicblock\",\n    \"magicBlock\": {\n      \"initIfMissing\": true,\n      \"initAtasIfMissing\": true,\n      \"maxDelayMs\": \"1000\"\n    }\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transfer": {
+              "id": "xfr_example",
+              "organizationId": "org_example",
+              "walletId": "privy_wallet_123",
+              "projectId": "prj_example",
+              "type": "transfer",
+              "direction": "outbound",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "serializedTx": "base64_tx_example",
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedBy": {
+                "type": "api_key"
+              },
+              "source": "So11111111111111111111111111111111111111112",
+              "destination": "So11111111111111111111111111111111111111112",
+              "amount": "100.00",
+              "provider": "moonpay",
+              "counterpartyId": "counterparty_example",
+              "counterpartyDisplayName": "Acme Studio",
+              "providerReference": "ramp_quote_example",
+              "deliveryMode": "session_widget",
+              "fiatCurrency": "USD",
+              "fiatAmount": "100.00",
+              "risk": {
+                "provider": "trm",
+                "score": "0.12",
+                "level": "low",
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "moneygram": {
+                "transactionId": "mgi_tx_example",
+                "referenceNumber": "12345678",
+                "payoutAmount": 25,
+                "payoutStatus": "completed",
+                "cryptoTransferId": "xfr_moneygram_crypto_leg_example",
+                "solanaTxSignature": "sig_moneygram_usdc_transfer_example",
+                "lastWidgetError": "Transaction cancelled by user"
+              },
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "privateTransfer": {
+              "provider": "magicblock",
+              "magicBlock": {
+                "kind": "transfer",
+                "version": "v0",
+                "instructionCount": 4,
+                "requiredSigners": [
+                  "So11111111111111111111111111111111111111112"
+                ],
+                "validator": "So11111111111111111111111111111111111111112"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-transfers",
+        "operationId": "listPaymentTransfers",
+        "title": "List transfers",
+        "method": "GET",
+        "path": "/v1/payments/transfers?wallet={wallet}&walletAddress={walletAddress}&search={search}&token={token}&direction={direction}&status={status}&category={category}&type={type}&counterpartyId={counterpartyId}&provider={provider}&providerReference={providerReference}&from={from}&to={to}&includeObserved={includeObserved}&sortBy={sortBy}&sortDirection={sortDirection}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "wallet",
+            "label": "wallet",
+            "description": "Filter by wallet `walletId`.",
+            "defaultValue": "privy_wallet_123",
+            "required": false
+          },
+          {
+            "key": "walletAddress",
+            "label": "walletAddress",
+            "description": "Filter by wallet address.",
+            "defaultValue": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "required": false
+          },
+          {
+            "key": "search",
+            "label": "search",
+            "description": "Search transfer ID, signature, provider reference, source or destination address, memo, counterparty ID, or counterparty display name. Use at least 3 non-whitespace characters; a blank value is treated as no search filter.",
+            "defaultValue": "xfr_example",
+            "required": false
+          },
+          {
+            "key": "token",
+            "label": "token",
+            "description": "Filter by token symbol or mint.",
+            "defaultValue": "USDC",
+            "required": false
+          },
+          {
+            "key": "direction",
+            "label": "direction",
+            "description": "Filter by transfer direction.",
+            "defaultValue": "outbound",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "inbound",
+                "value": "inbound"
+              },
+              {
+                "label": "outbound",
+                "value": "outbound"
+              }
+            ]
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Filter by transfer status. Accepts a comma-separated list of statuses.",
+            "defaultValue": "completed,confirmed,finalized",
+            "required": false
+          },
+          {
+            "key": "category",
+            "label": "category",
+            "description": "Filter by wallet transfers or ramp transfers.",
+            "defaultValue": "ramp",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "wallet",
+                "value": "wallet"
+              },
+              {
+                "label": "ramp",
+                "value": "ramp"
+              }
+            ]
+          },
+          {
+            "key": "type",
+            "label": "type",
+            "description": "Filter by one or more comma-separated transfer types.",
+            "defaultValue": "transfer,transfer_batch",
+            "required": false
+          },
+          {
+            "key": "counterpartyId",
+            "label": "counterpartyId",
+            "description": "Filter transfers tied to a specific counterparty.",
+            "defaultValue": "counterparty_example",
+            "required": false
+          },
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Filter ramp transfers by provider.",
+            "defaultValue": "lightspark",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "moonpay",
+                "value": "moonpay"
+              },
+              {
+                "label": "lightspark",
+                "value": "lightspark"
+              },
+              {
+                "label": "bvnk",
+                "value": "bvnk"
+              },
+              {
+                "label": "moneygram",
+                "value": "moneygram"
+              },
+              {
+                "label": "coinbase",
+                "value": "coinbase"
+              },
+              {
+                "label": "mural",
+                "value": "mural"
+              },
+              {
+                "label": "stripe",
+                "value": "stripe"
+              }
+            ]
+          },
+          {
+            "key": "providerReference",
+            "label": "providerReference",
+            "description": "Provider quote or transaction reference. Must be supplied with provider for exact ramp transfer lookup.",
+            "defaultValue": "Quote:019e979c-f660-5246-0000-c0588496b9ce",
+            "required": false
+          },
+          {
+            "key": "from",
+            "label": "from",
+            "description": "Filter from timestamp.",
+            "defaultValue": "2025-01-01T00:00:00.000Z",
+            "required": false
+          },
+          {
+            "key": "to",
+            "label": "to",
+            "description": "Filter to timestamp.",
+            "defaultValue": "2025-01-02T00:00:00.000Z",
+            "required": false
+          },
+          {
+            "key": "includeObserved",
+            "label": "includeObserved",
+            "description": "When filtering a wallet, include RPC-observed on-chain activity that has not been recorded by SDP. Disable for stable database-backed pagination.",
+            "defaultValue": "false",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ]
+          },
+          {
+            "key": "sortBy",
+            "label": "sortBy",
+            "description": "Field used to sort the transfer list.",
+            "defaultValue": "createdAt",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "createdAt",
+                "value": "createdAt"
+              },
+              {
+                "label": "updatedAt",
+                "value": "updatedAt"
+              },
+              {
+                "label": "amount",
+                "value": "amount"
+              },
+              {
+                "label": "status",
+                "value": "status"
+              }
+            ]
+          },
+          {
+            "key": "sortDirection",
+            "label": "sortDirection",
+            "description": "Sort direction.",
+            "defaultValue": "desc",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "asc",
+                "value": "asc"
+              },
+              {
+                "label": "desc",
+                "value": "desc"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Items per page.",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "xfr_example",
+              "organizationId": "org_example",
+              "walletId": "privy_wallet_123",
+              "projectId": "prj_example",
+              "type": "transfer",
+              "direction": "outbound",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "serializedTx": "base64_tx_example",
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedBy": {
+                "type": "api_key"
+              },
+              "source": "So11111111111111111111111111111111111111112",
+              "destination": "So11111111111111111111111111111111111111112",
+              "amount": "100.00",
+              "provider": "moonpay",
+              "counterpartyId": "counterparty_example",
+              "counterpartyDisplayName": "Acme Studio",
+              "providerReference": "ramp_quote_example",
+              "deliveryMode": "session_widget",
+              "fiatCurrency": "USD",
+              "fiatAmount": "100.00",
+              "risk": {
+                "provider": "trm",
+                "score": "0.12",
+                "level": "low",
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "moneygram": {
+                "transactionId": "mgi_tx_example",
+                "referenceNumber": "12345678",
+                "payoutAmount": 25,
+                "payoutStatus": "completed",
+                "cryptoTransferId": "xfr_moneygram_crypto_leg_example",
+                "solanaTxSignature": "sig_moneygram_usdc_transfer_example",
+                "lastWidgetError": "Transaction cancelled by user"
+              },
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "get-payment-transfer",
+        "operationId": "getPaymentTransfer",
+        "title": "Get transfer",
+        "method": "GET",
+        "path": "/v1/payments/transfers/{transferId}",
+        "pathFields": [
+          {
+            "key": "transferId",
+            "label": "{transferId}",
+            "description": "Transfer identifier (SDP record ID, not the on-chain signature).",
+            "defaultValue": "xfr_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "transfer": {
+              "id": "xfr_example",
+              "organizationId": "org_example",
+              "walletId": "privy_wallet_123",
+              "projectId": "prj_example",
+              "type": "transfer",
+              "direction": "outbound",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "serializedTx": "base64_tx_example",
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedBy": {
+                "type": "api_key"
+              },
+              "source": "So11111111111111111111111111111111111111112",
+              "destination": "So11111111111111111111111111111111111111112",
+              "amount": "100.00",
+              "provider": "moonpay",
+              "counterpartyId": "counterparty_example",
+              "counterpartyDisplayName": "Acme Studio",
+              "providerReference": "ramp_quote_example",
+              "deliveryMode": "session_widget",
+              "fiatCurrency": "USD",
+              "fiatAmount": "100.00",
+              "risk": {
+                "provider": "trm",
+                "score": "0.12",
+                "level": "low",
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "moneygram": {
+                "transactionId": "mgi_tx_example",
+                "referenceNumber": "12345678",
+                "payoutAmount": 25,
+                "payoutStatus": "completed",
+                "cryptoTransferId": "xfr_moneygram_crypto_leg_example",
+                "solanaTxSignature": "sig_moneygram_usdc_transfer_example",
+                "lastWidgetError": "Transaction cancelled by user"
+              },
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "privateTransfer": {
+              "provider": "magicblock",
+              "magicBlock": {
+                "kind": "transfer",
+                "version": "v0",
+                "instructionCount": 4,
+                "requiredSigners": [
+                  "So11111111111111111111111111111111111111112"
+                ],
+                "validator": "So11111111111111111111111111111111111111112"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "estimate-payment-transfer-batch",
+        "operationId": "estimatePaymentTransferBatch",
+        "title": "Estimate transfer batch",
+        "method": "POST",
+        "path": "/v1/payments/transfer-batches/estimate",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"projectId\": \"prj_example\",\n  \"externalId\": \"payroll_2026_06_30\",\n  \"source\": \"privy_wallet_123\",\n  \"token\": \"SOL\",\n  \"recipients\": [\n    {\n      \"externalId\": \"payroll_row_001\",\n      \"counterpartyId\": \"cp_example\",\n      \"counterpartyAccountId\": \"cpa_example\",\n      \"amount\": \"25.00\"\n    }\n  ],\n  \"options\": {\n    \"maxRecipientsPerTransaction\": 20,\n    \"priorityFee\": \"auto\",\n    \"preflight\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "estimate": {
+              "recipientCount": 1,
+              "transactionCount": 1,
+              "estimatedFees": {
+                "networkFeeLamports": "5000",
+                "priorityFeeLamports": "0",
+                "tokenAccountRentLamports": "0",
+                "sponsored": true
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-transfer-batch",
+        "operationId": "createPaymentTransferBatch",
+        "title": "Create transfer batch",
+        "method": "POST",
+        "path": "/v1/payments/transfer-batches",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"projectId\": \"prj_example\",\n  \"externalId\": \"payroll_2026_06_30\",\n  \"source\": \"privy_wallet_123\",\n  \"token\": \"SOL\",\n  \"recipients\": [\n    {\n      \"externalId\": \"payroll_row_001\",\n      \"counterpartyId\": \"cp_example\",\n      \"counterpartyAccountId\": \"cpa_example\",\n      \"amount\": \"25.00\"\n    }\n  ],\n  \"options\": {\n    \"maxRecipientsPerTransaction\": 20,\n    \"priorityFee\": \"auto\",\n    \"preflight\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "batch": {
+              "id": "xbatch_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "externalId": "payroll_2026_06_30",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "token": "SOL",
+              "status": "processing",
+              "totalAmount": "1000.00",
+              "recipientCount": 20,
+              "transactionCount": 1,
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "recipients": [
+              {
+                "id": "_example",
+                "batchId": "batch_example",
+                "transferId": "xfr_example",
+                "externalId": "payroll_row_001",
+                "counterpartyId": "cp_example",
+                "counterpartyAccountId": "cpa_example",
+                "destination": "So11111111111111111111111111111111111111112",
+                "amount": "100.00",
+                "status": "pending",
+                "error": "example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            ],
+            "transfers": [
+              {
+                "id": "xfr_example",
+                "organizationId": "org_example",
+                "walletId": "privy_wallet_123",
+                "projectId": "prj_example",
+                "type": "transfer",
+                "direction": "outbound",
+                "status": "confirmed",
+                "signature": "sig_example",
+                "serializedTx": "base64_tx_example",
+                "slot": 123456,
+                "blockTime": "2025-01-01T00:00:00.000Z",
+                "fee": 5000,
+                "error": "Signature failed",
+                "initiatedBy": {
+                  "type": "api_key"
+                },
+                "source": "So11111111111111111111111111111111111111112",
+                "destination": "So11111111111111111111111111111111111111112",
+                "amount": "100.00",
+                "provider": "moonpay",
+                "counterpartyId": "counterparty_example",
+                "counterpartyDisplayName": "Acme Studio",
+                "providerReference": "ramp_quote_example",
+                "deliveryMode": "session_widget",
+                "fiatCurrency": "USD",
+                "fiatAmount": "100.00",
+                "risk": {
+                  "provider": "trm",
+                  "score": "0.12",
+                  "level": "low",
+                  "evaluatedAt": "2025-01-01T00:00:00.000Z"
+                },
+                "moneygram": {
+                  "transactionId": "mgi_tx_example",
+                  "referenceNumber": "12345678",
+                  "payoutAmount": 25,
+                  "payoutStatus": "completed",
+                  "cryptoTransferId": "xfr_moneygram_crypto_leg_example",
+                  "solanaTxSignature": "sig_moneygram_usdc_transfer_example",
+                  "lastWidgetError": "Transaction cancelled by user"
+                },
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-02T00:00:00.000Z"
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-transfer-batches",
+        "operationId": "listPaymentTransferBatches",
+        "title": "List transfer batches",
+        "method": "GET",
+        "path": "/v1/payments/transfer-batches?wallet={wallet}&token={token}&status={status}&externalId={externalId}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "wallet",
+            "label": "wallet",
+            "description": "Filter by source wallet `walletId`.",
+            "defaultValue": "privy_wallet_123",
+            "required": false
+          },
+          {
+            "key": "token",
+            "label": "token",
+            "description": "Filter by token symbol or mint.",
+            "defaultValue": "SOL",
+            "required": false
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Filter by transfer batch status.",
+            "defaultValue": "processing",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending",
+                "value": "pending"
+              },
+              {
+                "label": "processing",
+                "value": "processing"
+              },
+              {
+                "label": "confirmed",
+                "value": "confirmed"
+              },
+              {
+                "label": "failed",
+                "value": "failed"
+              },
+              {
+                "label": "partially_failed",
+                "value": "partially_failed"
+              },
+              {
+                "label": "archived",
+                "value": "archived"
+              }
+            ]
+          },
+          {
+            "key": "externalId",
+            "label": "externalId",
+            "description": "Filter by caller-provided batch correlation ID.",
+            "defaultValue": "payroll_2026_06_30",
+            "required": false
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of batches per page.",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "xbatch_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "externalId": "payroll_2026_06_30",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "token": "SOL",
+              "status": "processing",
+              "totalAmount": "1000.00",
+              "recipientCount": 20,
+              "transactionCount": 1,
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "get-payment-transfer-batch",
+        "operationId": "getPaymentTransferBatch",
+        "title": "Get transfer batch",
+        "method": "GET",
+        "path": "/v1/payments/transfer-batches/{batchId}",
+        "pathFields": [
+          {
+            "key": "batchId",
+            "label": "{batchId}",
+            "description": "Transfer batch identifier.",
+            "defaultValue": "xbatch_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "batch": {
+              "id": "xbatch_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "externalId": "payroll_2026_06_30",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "token": "SOL",
+              "status": "processing",
+              "totalAmount": "1000.00",
+              "recipientCount": 20,
+              "transactionCount": 1,
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "recipients": [
+              {
+                "id": "_example",
+                "batchId": "batch_example",
+                "transferId": "xfr_example",
+                "externalId": "payroll_row_001",
+                "counterpartyId": "cp_example",
+                "counterpartyAccountId": "cpa_example",
+                "destination": "So11111111111111111111111111111111111111112",
+                "amount": "100.00",
+                "status": "pending",
+                "error": "example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            ],
+            "transfers": [
+              {
+                "id": "xfr_example",
+                "organizationId": "org_example",
+                "walletId": "privy_wallet_123",
+                "projectId": "prj_example",
+                "type": "transfer",
+                "direction": "outbound",
+                "status": "confirmed",
+                "signature": "sig_example",
+                "serializedTx": "base64_tx_example",
+                "slot": 123456,
+                "blockTime": "2025-01-01T00:00:00.000Z",
+                "fee": 5000,
+                "error": "Signature failed",
+                "initiatedBy": {
+                  "type": "api_key"
+                },
+                "source": "So11111111111111111111111111111111111111112",
+                "destination": "So11111111111111111111111111111111111111112",
+                "amount": "100.00",
+                "provider": "moonpay",
+                "counterpartyId": "counterparty_example",
+                "counterpartyDisplayName": "Acme Studio",
+                "providerReference": "ramp_quote_example",
+                "deliveryMode": "session_widget",
+                "fiatCurrency": "USD",
+                "fiatAmount": "100.00",
+                "risk": {
+                  "provider": "trm",
+                  "score": "0.12",
+                  "level": "low",
+                  "evaluatedAt": "2025-01-01T00:00:00.000Z"
+                },
+                "moneygram": {
+                  "transactionId": "mgi_tx_example",
+                  "referenceNumber": "12345678",
+                  "payoutAmount": 25,
+                  "payoutStatus": "completed",
+                  "cryptoTransferId": "xfr_moneygram_crypto_leg_example",
+                  "solanaTxSignature": "sig_moneygram_usdc_transfer_example",
+                  "lastWidgetError": "Transaction cancelled by user"
+                },
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-02T00:00:00.000Z"
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-recurring-payment",
+        "operationId": "createPaymentRecurringPayment",
+        "title": "Create recurring payment",
+        "method": "POST",
+        "path": "/v1/payments/recurring-payments",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"sourceWalletId\": \"privy_wallet_123\",\n  \"counterpartyId\": \"cp_example\",\n  \"counterpartyAccountId\": \"cpa_example\",\n  \"token\": \"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\n  \"amount\": \"25.00\",\n  \"periodHours\": 720,\n  \"firstCollectionAt\": \"2099-01-01T00:00:00.000Z\",\n  \"metadataUri\": \"https://example.com/subscriptions/monthly-usdc.json\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-recurring-payments",
+        "operationId": "listPaymentRecurringPayments",
+        "title": "List recurring payments",
+        "method": "GET",
+        "path": "/v1/payments/recurring-payments?counterpartyId={counterpartyId}&status={status}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "counterpartyId",
+            "description": "Filter recurring payments by counterparty.",
+            "defaultValue": "cp_example",
+            "required": false
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Recurring payment status.",
+            "defaultValue": "active",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending_activation",
+                "value": "pending_activation"
+              },
+              {
+                "label": "activating",
+                "value": "activating"
+              },
+              {
+                "label": "active",
+                "value": "active"
+              },
+              {
+                "label": "updating",
+                "value": "updating"
+              },
+              {
+                "label": "canceling",
+                "value": "canceling"
+              },
+              {
+                "label": "resuming",
+                "value": "resuming"
+              },
+              {
+                "label": "paused",
+                "value": "paused"
+              },
+              {
+                "label": "canceled",
+                "value": "canceled"
+              },
+              {
+                "label": "expired",
+                "value": "expired"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "recurringPayments": [
+              {
+                "id": "prp_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "sourceWalletId": "privy_wallet_123",
+                "sourceAddress": "So11111111111111111111111111111111111111112",
+                "counterpartyId": "cp_example",
+                "counterpartyAccountId": "cpa_example",
+                "destinationAddress": "So11111111111111111111111111111111111111112",
+                "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+                "token": "example",
+                "amount": "100.00",
+                "periodHours": 720,
+                "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+                "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+                "planId": "plan_example",
+                "subscriptionId": "subscription_example",
+                "planPda": "So11111111111111111111111111111111111111112",
+                "planCreatedAt": "example",
+                "planCreationSignature": "example",
+                "subscriptionPda": "So11111111111111111111111111111111111111112",
+                "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+                "authorizationSignature": "example",
+                "status": "active",
+                "metadataUri": "example",
+                "createdBy": "example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            ],
+            "total": 1,
+            "page": 1,
+            "pageSize": 1
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-payment-recurring-payment",
+        "operationId": "updatePaymentRecurringPayment",
+        "title": "Update recurring payment",
+        "method": "PATCH",
+        "path": "/v1/payments/recurring-payments/{id}",
+        "pathFields": [
+          {
+            "key": "id",
+            "label": "{id}",
+            "description": "SDP recurring payment record ID.",
+            "defaultValue": "prp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"sourceWalletId\": \"privy_wallet_123\",\n  \"counterpartyId\": \"cp_example\",\n  \"counterpartyAccountId\": \"cpa_example\",\n  \"token\": \"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\n  \"amount\": \"25.00\",\n  \"periodHours\": 720,\n  \"firstCollectionAt\": \"2099-01-01T00:00:00.000Z\",\n  \"nextCollectionDueAt\": \"2099-02-01T00:00:00.000Z\",\n  \"metadataUri\": \"https://example.com/subscriptions/monthly-usdc.json\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-payment-recurring-payment",
+        "operationId": "getPaymentRecurringPayment",
+        "title": "Get recurring payment",
+        "method": "GET",
+        "path": "/v1/payments/recurring-payments/{id}",
+        "pathFields": [
+          {
+            "key": "id",
+            "label": "{id}",
+            "description": "SDP recurring payment record ID.",
+            "defaultValue": "prp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "activate-payment-recurring-payment",
+        "operationId": "activatePaymentRecurringPayment",
+        "title": "Activate recurring payment",
+        "method": "POST",
+        "path": "/v1/payments/recurring-payments/{id}/activate",
+        "pathFields": [
+          {
+            "key": "id",
+            "label": "{id}",
+            "description": "SDP recurring payment record ID.",
+            "defaultValue": "prp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "cancel-payment-recurring-payment",
+        "operationId": "cancelPaymentRecurringPayment",
+        "title": "Cancel recurring payment",
+        "method": "POST",
+        "path": "/v1/payments/recurring-payments/{id}/cancel",
+        "pathFields": [
+          {
+            "key": "id",
+            "label": "{id}",
+            "description": "SDP recurring payment record ID.",
+            "defaultValue": "prp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "collect-payment-recurring-payment",
+        "operationId": "collectPaymentRecurringPayment",
+        "title": "Collect recurring payment",
+        "method": "POST",
+        "path": "/v1/payments/recurring-payments/{id}/collect",
+        "pathFields": [
+          {
+            "key": "id",
+            "label": "{id}",
+            "description": "SDP recurring payment record ID.",
+            "defaultValue": "prp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "collectionAttempt": {
+              "id": "psca_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "subscriptionId": "subscription_example",
+              "transferId": "xfr_example",
+              "token": "example",
+              "amount": "100.00",
+              "dueAt": "2025-01-01T00:00:00.000Z",
+              "attemptedAt": "2025-01-01T00:00:00.000Z",
+              "status": "pending",
+              "signature": "example",
+              "error": "example",
+              "metadata": {},
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "transfer": {
+              "id": "xfr_example",
+              "organizationId": "org_example",
+              "walletId": "privy_wallet_123",
+              "projectId": "prj_example",
+              "type": "transfer",
+              "direction": "outbound",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "serializedTx": "base64_tx_example",
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedBy": {
+                "type": "api_key"
+              },
+              "source": "So11111111111111111111111111111111111111112",
+              "destination": "So11111111111111111111111111111111111111112",
+              "amount": "100.00",
+              "provider": "moonpay",
+              "counterpartyId": "counterparty_example",
+              "counterpartyDisplayName": "Acme Studio",
+              "providerReference": "ramp_quote_example",
+              "deliveryMode": "session_widget",
+              "fiatCurrency": "USD",
+              "fiatAmount": "100.00",
+              "risk": {
+                "provider": "trm",
+                "score": "0.12",
+                "level": "low",
+                "evaluatedAt": "2025-01-01T00:00:00.000Z"
+              },
+              "moneygram": {
+                "transactionId": "mgi_tx_example",
+                "referenceNumber": "12345678",
+                "payoutAmount": 25,
+                "payoutStatus": "completed",
+                "cryptoTransferId": "xfr_moneygram_crypto_leg_example",
+                "solanaTxSignature": "sig_moneygram_usdc_transfer_example",
+                "lastWidgetError": "Transaction cancelled by user"
+              },
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "resume-payment-recurring-payment",
+        "operationId": "resumePaymentRecurringPayment",
+        "title": "Resume recurring payment",
+        "method": "POST",
+        "path": "/v1/payments/recurring-payments/{id}/resume",
+        "pathFields": [
+          {
+            "key": "id",
+            "label": "{id}",
+            "description": "SDP recurring payment record ID.",
+            "defaultValue": "prp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "recurringPayment": {
+              "id": "prp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "sourceWalletId": "privy_wallet_123",
+              "sourceAddress": "So11111111111111111111111111111111111111112",
+              "counterpartyId": "cp_example",
+              "counterpartyAccountId": "cpa_example",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "destinationTokenAccount": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "firstCollectionAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "planId": "plan_example",
+              "subscriptionId": "subscription_example",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "planCreatedAt": "example",
+              "planCreationSignature": "example",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "metadataUri": "example",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-subscription-plan",
+        "operationId": "createPaymentSubscriptionPlan",
+        "title": "Create subscription plan",
+        "method": "POST",
+        "path": "/v1/payments/subscription-plans",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"ownerWalletId\": \"wal_merchant\",\n  \"token\": \"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v\",\n  \"amount\": \"25.00\",\n  \"periodHours\": 720,\n  \"programPlanId\": \"17014118346046923173\",\n  \"planPda\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\",\n  \"destinationAddress\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\",\n  \"pullerWalletId\": \"wal_collector\",\n  \"metadataUri\": \"https://example.com/subscriptions/monthly-usdc.json\",\n  \"status\": \"active\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscriptionPlan": {
+              "id": "psp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "ownerWalletId": "privy_wallet_123",
+              "ownerAddress": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "programPlanId": "17014118346046923173",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "pullerWalletId": "privy_wallet_123",
+              "pullerAddress": "So11111111111111111111111111111111111111112",
+              "metadataUri": "example",
+              "status": "active",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-subscription-plans",
+        "operationId": "listPaymentSubscriptionPlans",
+        "title": "List subscription plans",
+        "method": "GET",
+        "path": "/v1/payments/subscription-plans?status={status}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Subscription plan status.",
+            "defaultValue": "active",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "draft",
+                "value": "draft"
+              },
+              {
+                "label": "active",
+                "value": "active"
+              },
+              {
+                "label": "archived",
+                "value": "archived"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "subscriptionPlans": [
+              {
+                "id": "psp_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "ownerWalletId": "privy_wallet_123",
+                "ownerAddress": "So11111111111111111111111111111111111111112",
+                "token": "example",
+                "amount": "100.00",
+                "periodHours": 720,
+                "programPlanId": "17014118346046923173",
+                "planPda": "So11111111111111111111111111111111111111112",
+                "destinationAddress": "So11111111111111111111111111111111111111112",
+                "pullerWalletId": "privy_wallet_123",
+                "pullerAddress": "So11111111111111111111111111111111111111112",
+                "metadataUri": "example",
+                "status": "active",
+                "createdBy": "example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            ],
+            "total": 1,
+            "page": 1,
+            "pageSize": 1
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-payment-subscription-plan-create",
+        "operationId": "preparePaymentSubscriptionPlanCreate",
+        "title": "Prepare subscription plan creation",
+        "method": "POST",
+        "path": "/v1/payments/subscription-plans/{planId}/prepare-create",
+        "pathFields": [
+          {
+            "key": "planId",
+            "label": "{planId}",
+            "description": "SDP subscription plan record ID.",
+            "defaultValue": "psp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"destinations\": [\n    \"example\"\n  ],\n  \"pullers\": [\n    \"example\"\n  ],\n  \"endTs\": \"1770000000\",\n  \"metadataUri\": \"https://example.com/subscriptions/monthly-usdc.json\"\n}",
+            "required": false
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscriptionPlan": {
+              "id": "psp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "ownerWalletId": "privy_wallet_123",
+              "ownerAddress": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "programPlanId": "17014118346046923173",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "pullerWalletId": "privy_wallet_123",
+              "pullerAddress": "So11111111111111111111111111111111111111112",
+              "metadataUri": "example",
+              "status": "active",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "planPda": "So11111111111111111111111111111111111111112",
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456",
+              "requiredSigners": [
+                "So11111111111111111111111111111111111111112"
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-payment-subscription-plan",
+        "operationId": "getPaymentSubscriptionPlan",
+        "title": "Get subscription plan",
+        "method": "GET",
+        "path": "/v1/payments/subscription-plans/{planId}",
+        "pathFields": [
+          {
+            "key": "planId",
+            "label": "{planId}",
+            "description": "SDP subscription plan record ID.",
+            "defaultValue": "psp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "subscriptionPlan": {
+              "id": "psp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "ownerWalletId": "privy_wallet_123",
+              "ownerAddress": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "programPlanId": "17014118346046923173",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "pullerWalletId": "privy_wallet_123",
+              "pullerAddress": "So11111111111111111111111111111111111111112",
+              "metadataUri": "example",
+              "status": "active",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-payment-subscription-plan",
+        "operationId": "updatePaymentSubscriptionPlan",
+        "title": "Update subscription plan",
+        "method": "PATCH",
+        "path": "/v1/payments/subscription-plans/{planId}",
+        "pathFields": [
+          {
+            "key": "planId",
+            "label": "{planId}",
+            "description": "SDP subscription plan record ID.",
+            "defaultValue": "psp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"planPda\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\",\n  \"pullerWalletId\": \"wal_collector\",\n  \"status\": \"active\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscriptionPlan": {
+              "id": "psp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "ownerWalletId": "privy_wallet_123",
+              "ownerAddress": "So11111111111111111111111111111111111111112",
+              "token": "example",
+              "amount": "100.00",
+              "periodHours": 720,
+              "programPlanId": "17014118346046923173",
+              "planPda": "So11111111111111111111111111111111111111112",
+              "destinationAddress": "So11111111111111111111111111111111111111112",
+              "pullerWalletId": "privy_wallet_123",
+              "pullerAddress": "So11111111111111111111111111111111111111112",
+              "metadataUri": "example",
+              "status": "active",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-subscription",
+        "operationId": "createPaymentSubscription",
+        "title": "Create subscription",
+        "method": "POST",
+        "path": "/v1/payments/subscriptions",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"planId\": \"psp_example\",\n  \"counterpartyId\": \"counterparty_example\",\n  \"subscriberAddress\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\",\n  \"authorizationSignature\": \"sig_example\",\n  \"status\": \"active\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-subscriptions",
+        "operationId": "listPaymentSubscriptions",
+        "title": "List subscriptions",
+        "method": "GET",
+        "path": "/v1/payments/subscriptions?planId={planId}&counterpartyId={counterpartyId}&status={status}&dueBefore={dueBefore}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "planId",
+            "label": "planId",
+            "required": false
+          },
+          {
+            "key": "counterpartyId",
+            "label": "counterpartyId",
+            "required": false
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Subscription status.",
+            "defaultValue": "active",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending_authorization",
+                "value": "pending_authorization"
+              },
+              {
+                "label": "active",
+                "value": "active"
+              },
+              {
+                "label": "paused",
+                "value": "paused"
+              },
+              {
+                "label": "canceling",
+                "value": "canceling"
+              },
+              {
+                "label": "canceled",
+                "value": "canceled"
+              },
+              {
+                "label": "expired",
+                "value": "expired"
+              }
+            ]
+          },
+          {
+            "key": "dueBefore",
+            "label": "dueBefore",
+            "required": false
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "subscriptions": [
+              {
+                "id": "psub_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "planId": "plan_example",
+                "counterpartyId": "counterparty_example",
+                "subscriberAddress": "So11111111111111111111111111111111111111112",
+                "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+                "subscriptionPda": "So11111111111111111111111111111111111111112",
+                "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+                "authorizationSignature": "example",
+                "status": "active",
+                "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+                "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+                "cancelAt": "2025-01-01T00:00:00.000Z",
+                "canceledAt": "2025-01-01T00:00:00.000Z",
+                "createdBy": "example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            ],
+            "total": 1,
+            "page": 1,
+            "pageSize": 1
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-payment-subscription-authorization",
+        "operationId": "preparePaymentSubscriptionAuthorization",
+        "title": "Prepare subscription authorization",
+        "method": "POST",
+        "path": "/v1/payments/subscriptions/{subscriptionId}/prepare-authorization",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"subscriberTokenAccount\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\",\n  \"expectedPlanCreatedAt\": \"0\",\n  \"expectedSubscriptionAuthorityInitId\": \"0\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "subscriptionPda": "So11111111111111111111111111111111111111112",
+            "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456",
+              "requiredSigners": [
+                "So11111111111111111111111111111111111111112"
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-payment-subscription-cancel",
+        "operationId": "preparePaymentSubscriptionCancel",
+        "title": "Prepare subscription cancellation",
+        "method": "POST",
+        "path": "/v1/payments/subscriptions/{subscriptionId}/prepare-cancel",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{}",
+            "required": false
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456",
+              "requiredSigners": [
+                "So11111111111111111111111111111111111111112"
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-payment-subscription-resume",
+        "operationId": "preparePaymentSubscriptionResume",
+        "title": "Prepare subscription resume",
+        "method": "POST",
+        "path": "/v1/payments/subscriptions/{subscriptionId}/prepare-resume",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{}",
+            "required": false
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456",
+              "requiredSigners": [
+                "So11111111111111111111111111111111111111112"
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-payment-subscription-collection",
+        "operationId": "preparePaymentSubscriptionCollection",
+        "title": "Prepare subscription collection",
+        "method": "POST",
+        "path": "/v1/payments/subscriptions/{subscriptionId}/prepare-collection",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"amount\": \"25.00\",\n  \"receiverTokenAccount\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456",
+              "requiredSigners": [
+                "So11111111111111111111111111111111111111112"
+              ]
+            },
+            "collectionAttempt": {
+              "id": "psca_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "subscriptionId": "subscription_example",
+              "transferId": "xfr_example",
+              "token": "example",
+              "amount": "100.00",
+              "dueAt": "2025-01-01T00:00:00.000Z",
+              "attemptedAt": "2025-01-01T00:00:00.000Z",
+              "status": "pending",
+              "signature": "example",
+              "error": "example",
+              "metadata": {},
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-payment-subscription",
+        "operationId": "getPaymentSubscription",
+        "title": "Get subscription",
+        "method": "GET",
+        "path": "/v1/payments/subscriptions/{subscriptionId}",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-payment-subscription",
+        "operationId": "updatePaymentSubscription",
+        "title": "Update subscription",
+        "method": "PATCH",
+        "path": "/v1/payments/subscriptions/{subscriptionId}",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"status\": \"active\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "subscription": {
+              "id": "psub_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "planId": "plan_example",
+              "counterpartyId": "counterparty_example",
+              "subscriberAddress": "So11111111111111111111111111111111111111112",
+              "subscriberTokenAccount": "So11111111111111111111111111111111111111112",
+              "subscriptionPda": "So11111111111111111111111111111111111111112",
+              "subscriptionAuthorityAddress": "So11111111111111111111111111111111111111112",
+              "authorizationSignature": "example",
+              "status": "active",
+              "currentPeriodStartAt": "2025-01-01T00:00:00.000Z",
+              "nextCollectionDueAt": "2025-01-01T00:00:00.000Z",
+              "cancelAt": "2025-01-01T00:00:00.000Z",
+              "canceledAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-subscription-collection-attempt",
+        "operationId": "createPaymentSubscriptionCollectionAttempt",
+        "title": "Create subscription collection attempt",
+        "method": "POST",
+        "path": "/v1/payments/subscriptions/{subscriptionId}/collection-attempts",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"status\": \"pending\",\n  \"metadata\": {}\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "collectionAttempt": {
+              "id": "psca_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "subscriptionId": "subscription_example",
+              "transferId": "xfr_example",
+              "token": "example",
+              "amount": "100.00",
+              "dueAt": "2025-01-01T00:00:00.000Z",
+              "attemptedAt": "2025-01-01T00:00:00.000Z",
+              "status": "pending",
+              "signature": "example",
+              "error": "example",
+              "metadata": {},
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-subscription-collection-attempts",
+        "operationId": "listPaymentSubscriptionCollectionAttempts",
+        "title": "List subscription collection attempts",
+        "method": "GET",
+        "path": "/v1/payments/subscriptions/{subscriptionId}/collection-attempts?status={status}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "subscriptionId",
+            "label": "{subscriptionId}",
+            "description": "SDP subscription record ID.",
+            "defaultValue": "psub_example",
+            "required": true
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Collection attempt status.",
+            "defaultValue": "pending",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending",
+                "value": "pending"
+              },
+              {
+                "label": "processing",
+                "value": "processing"
+              },
+              {
+                "label": "confirmed",
+                "value": "confirmed"
+              },
+              {
+                "label": "failed",
+                "value": "failed"
+              },
+              {
+                "label": "skipped",
+                "value": "skipped"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "collectionAttempts": [
+              {
+                "id": "psca_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "subscriptionId": "subscription_example",
+                "transferId": "xfr_example",
+                "token": "example",
+                "amount": "100.00",
+                "dueAt": "2025-01-01T00:00:00.000Z",
+                "attemptedAt": "2025-01-01T00:00:00.000Z",
+                "status": "pending",
+                "signature": "example",
+                "error": "example",
+                "metadata": {},
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-01T00:00:00.000Z"
+              }
+            ],
+            "total": 1,
+            "page": 1,
+            "pageSize": 1
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-onramp-currencies",
+        "operationId": "listPaymentOnrampCurrencies",
+        "title": "List on-ramp currency support",
+        "method": "GET",
+        "path": "/v1/payments/ramps/onramp/currency?source={source}&dest={dest}&provider={provider}",
+        "pathFields": [
+          {
+            "key": "source",
+            "label": "source",
+            "description": "Optional fiat source currency filter.",
+            "defaultValue": "USD",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "AED",
+                "value": "AED"
+              },
+              {
+                "label": "AFN",
+                "value": "AFN"
+              },
+              {
+                "label": "ALL",
+                "value": "ALL"
+              },
+              {
+                "label": "AMD",
+                "value": "AMD"
+              },
+              {
+                "label": "ANG",
+                "value": "ANG"
+              },
+              {
+                "label": "AOA",
+                "value": "AOA"
+              },
+              {
+                "label": "ARS",
+                "value": "ARS"
+              },
+              {
+                "label": "AUD",
+                "value": "AUD"
+              },
+              {
+                "label": "AWG",
+                "value": "AWG"
+              },
+              {
+                "label": "AZN",
+                "value": "AZN"
+              },
+              {
+                "label": "BAM",
+                "value": "BAM"
+              },
+              {
+                "label": "BBD",
+                "value": "BBD"
+              },
+              {
+                "label": "BDT",
+                "value": "BDT"
+              },
+              {
+                "label": "BGN",
+                "value": "BGN"
+              },
+              {
+                "label": "BHD",
+                "value": "BHD"
+              },
+              {
+                "label": "BIF",
+                "value": "BIF"
+              },
+              {
+                "label": "BMD",
+                "value": "BMD"
+              },
+              {
+                "label": "BND",
+                "value": "BND"
+              },
+              {
+                "label": "BOB",
+                "value": "BOB"
+              },
+              {
+                "label": "BRL",
+                "value": "BRL"
+              },
+              {
+                "label": "BSD",
+                "value": "BSD"
+              },
+              {
+                "label": "BTN",
+                "value": "BTN"
+              },
+              {
+                "label": "BWP",
+                "value": "BWP"
+              },
+              {
+                "label": "BZD",
+                "value": "BZD"
+              },
+              {
+                "label": "CAD",
+                "value": "CAD"
+              },
+              {
+                "label": "CDF",
+                "value": "CDF"
+              },
+              {
+                "label": "CHF",
+                "value": "CHF"
+              },
+              {
+                "label": "CLP",
+                "value": "CLP"
+              },
+              {
+                "label": "CNY",
+                "value": "CNY"
+              },
+              {
+                "label": "COP",
+                "value": "COP"
+              },
+              {
+                "label": "CRC",
+                "value": "CRC"
+              },
+              {
+                "label": "CUC",
+                "value": "CUC"
+              },
+              {
+                "label": "CUP",
+                "value": "CUP"
+              },
+              {
+                "label": "CVE",
+                "value": "CVE"
+              },
+              {
+                "label": "CZK",
+                "value": "CZK"
+              },
+              {
+                "label": "DJF",
+                "value": "DJF"
+              },
+              {
+                "label": "DKK",
+                "value": "DKK"
+              },
+              {
+                "label": "DOP",
+                "value": "DOP"
+              },
+              {
+                "label": "DZD",
+                "value": "DZD"
+              },
+              {
+                "label": "EGP",
+                "value": "EGP"
+              },
+              {
+                "label": "ERN",
+                "value": "ERN"
+              },
+              {
+                "label": "ETB",
+                "value": "ETB"
+              },
+              {
+                "label": "EUR",
+                "value": "EUR"
+              },
+              {
+                "label": "FJD",
+                "value": "FJD"
+              },
+              {
+                "label": "FKP",
+                "value": "FKP"
+              },
+              {
+                "label": "GBP",
+                "value": "GBP"
+              },
+              {
+                "label": "GEL",
+                "value": "GEL"
+              },
+              {
+                "label": "GHS",
+                "value": "GHS"
+              },
+              {
+                "label": "GIP",
+                "value": "GIP"
+              },
+              {
+                "label": "GMD",
+                "value": "GMD"
+              },
+              {
+                "label": "GNF",
+                "value": "GNF"
+              },
+              {
+                "label": "GTQ",
+                "value": "GTQ"
+              },
+              {
+                "label": "GYD",
+                "value": "GYD"
+              },
+              {
+                "label": "HKD",
+                "value": "HKD"
+              },
+              {
+                "label": "HNL",
+                "value": "HNL"
+              },
+              {
+                "label": "HRK",
+                "value": "HRK"
+              },
+              {
+                "label": "HTG",
+                "value": "HTG"
+              },
+              {
+                "label": "HUF",
+                "value": "HUF"
+              },
+              {
+                "label": "IDR",
+                "value": "IDR"
+              },
+              {
+                "label": "ILS",
+                "value": "ILS"
+              },
+              {
+                "label": "INR",
+                "value": "INR"
+              },
+              {
+                "label": "IQD",
+                "value": "IQD"
+              },
+              {
+                "label": "IRR",
+                "value": "IRR"
+              },
+              {
+                "label": "ISK",
+                "value": "ISK"
+              },
+              {
+                "label": "JMD",
+                "value": "JMD"
+              },
+              {
+                "label": "JOD",
+                "value": "JOD"
+              },
+              {
+                "label": "JPY",
+                "value": "JPY"
+              },
+              {
+                "label": "KES",
+                "value": "KES"
+              },
+              {
+                "label": "KGS",
+                "value": "KGS"
+              },
+              {
+                "label": "KHR",
+                "value": "KHR"
+              },
+              {
+                "label": "KMF",
+                "value": "KMF"
+              },
+              {
+                "label": "KPW",
+                "value": "KPW"
+              },
+              {
+                "label": "KRW",
+                "value": "KRW"
+              },
+              {
+                "label": "KWD",
+                "value": "KWD"
+              },
+              {
+                "label": "KYD",
+                "value": "KYD"
+              },
+              {
+                "label": "KZT",
+                "value": "KZT"
+              },
+              {
+                "label": "LAK",
+                "value": "LAK"
+              },
+              {
+                "label": "LBP",
+                "value": "LBP"
+              },
+              {
+                "label": "LKR",
+                "value": "LKR"
+              },
+              {
+                "label": "LRD",
+                "value": "LRD"
+              },
+              {
+                "label": "LSL",
+                "value": "LSL"
+              },
+              {
+                "label": "LYD",
+                "value": "LYD"
+              },
+              {
+                "label": "MAD",
+                "value": "MAD"
+              },
+              {
+                "label": "MDL",
+                "value": "MDL"
+              },
+              {
+                "label": "MGA",
+                "value": "MGA"
+              },
+              {
+                "label": "MKD",
+                "value": "MKD"
+              },
+              {
+                "label": "MMK",
+                "value": "MMK"
+              },
+              {
+                "label": "MNT",
+                "value": "MNT"
+              },
+              {
+                "label": "MOP",
+                "value": "MOP"
+              },
+              {
+                "label": "MRU",
+                "value": "MRU"
+              },
+              {
+                "label": "MUR",
+                "value": "MUR"
+              },
+              {
+                "label": "MVR",
+                "value": "MVR"
+              },
+              {
+                "label": "MWK",
+                "value": "MWK"
+              },
+              {
+                "label": "MXN",
+                "value": "MXN"
+              },
+              {
+                "label": "MYR",
+                "value": "MYR"
+              },
+              {
+                "label": "MZN",
+                "value": "MZN"
+              },
+              {
+                "label": "NAD",
+                "value": "NAD"
+              },
+              {
+                "label": "NGN",
+                "value": "NGN"
+              },
+              {
+                "label": "NIO",
+                "value": "NIO"
+              },
+              {
+                "label": "NOK",
+                "value": "NOK"
+              },
+              {
+                "label": "NPR",
+                "value": "NPR"
+              },
+              {
+                "label": "NZD",
+                "value": "NZD"
+              },
+              {
+                "label": "OMR",
+                "value": "OMR"
+              },
+              {
+                "label": "PAB",
+                "value": "PAB"
+              },
+              {
+                "label": "PEN",
+                "value": "PEN"
+              },
+              {
+                "label": "PGK",
+                "value": "PGK"
+              },
+              {
+                "label": "PHP",
+                "value": "PHP"
+              },
+              {
+                "label": "PKR",
+                "value": "PKR"
+              },
+              {
+                "label": "PLN",
+                "value": "PLN"
+              },
+              {
+                "label": "PYG",
+                "value": "PYG"
+              },
+              {
+                "label": "QAR",
+                "value": "QAR"
+              },
+              {
+                "label": "RON",
+                "value": "RON"
+              },
+              {
+                "label": "RSD",
+                "value": "RSD"
+              },
+              {
+                "label": "RUB",
+                "value": "RUB"
+              },
+              {
+                "label": "RWF",
+                "value": "RWF"
+              },
+              {
+                "label": "SAR",
+                "value": "SAR"
+              },
+              {
+                "label": "SBD",
+                "value": "SBD"
+              },
+              {
+                "label": "SCR",
+                "value": "SCR"
+              },
+              {
+                "label": "SDG",
+                "value": "SDG"
+              },
+              {
+                "label": "SEK",
+                "value": "SEK"
+              },
+              {
+                "label": "SGD",
+                "value": "SGD"
+              },
+              {
+                "label": "SHP",
+                "value": "SHP"
+              },
+              {
+                "label": "SLE",
+                "value": "SLE"
+              },
+              {
+                "label": "SLL",
+                "value": "SLL"
+              },
+              {
+                "label": "SOS",
+                "value": "SOS"
+              },
+              {
+                "label": "SRD",
+                "value": "SRD"
+              },
+              {
+                "label": "SSP",
+                "value": "SSP"
+              },
+              {
+                "label": "STN",
+                "value": "STN"
+              },
+              {
+                "label": "SVC",
+                "value": "SVC"
+              },
+              {
+                "label": "SYP",
+                "value": "SYP"
+              },
+              {
+                "label": "SZL",
+                "value": "SZL"
+              },
+              {
+                "label": "THB",
+                "value": "THB"
+              },
+              {
+                "label": "TJS",
+                "value": "TJS"
+              },
+              {
+                "label": "TMT",
+                "value": "TMT"
+              },
+              {
+                "label": "TND",
+                "value": "TND"
+              },
+              {
+                "label": "TOP",
+                "value": "TOP"
+              },
+              {
+                "label": "TRY",
+                "value": "TRY"
+              },
+              {
+                "label": "TTD",
+                "value": "TTD"
+              },
+              {
+                "label": "TWD",
+                "value": "TWD"
+              },
+              {
+                "label": "TZS",
+                "value": "TZS"
+              },
+              {
+                "label": "UAH",
+                "value": "UAH"
+              },
+              {
+                "label": "UGX",
+                "value": "UGX"
+              },
+              {
+                "label": "USD",
+                "value": "USD"
+              },
+              {
+                "label": "UYU",
+                "value": "UYU"
+              },
+              {
+                "label": "UZS",
+                "value": "UZS"
+              },
+              {
+                "label": "VND",
+                "value": "VND"
+              },
+              {
+                "label": "VUV",
+                "value": "VUV"
+              },
+              {
+                "label": "WST",
+                "value": "WST"
+              },
+              {
+                "label": "XAF",
+                "value": "XAF"
+              },
+              {
+                "label": "XCD",
+                "value": "XCD"
+              },
+              {
+                "label": "XOF",
+                "value": "XOF"
+              },
+              {
+                "label": "XPF",
+                "value": "XPF"
+              },
+              {
+                "label": "YER",
+                "value": "YER"
+              },
+              {
+                "label": "ZAR",
+                "value": "ZAR"
+              },
+              {
+                "label": "ZMW",
+                "value": "ZMW"
+              }
+            ]
+          },
+          {
+            "key": "dest",
+            "label": "dest",
+            "description": "Optional Solana crypto rail destination filter.",
+            "defaultValue": "usdc.solana",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "sol.solana",
+                "value": "sol.solana"
+              },
+              {
+                "label": "usdc.solana",
+                "value": "usdc.solana"
+              },
+              {
+                "label": "usdt.solana",
+                "value": "usdt.solana"
+              },
+              {
+                "label": "usdg.solana",
+                "value": "usdg.solana"
+              },
+              {
+                "label": "pyusd.solana",
+                "value": "pyusd.solana"
+              }
+            ]
+          },
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Optional ramp provider filter.",
+            "defaultValue": "moonpay",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "moonpay",
+                "value": "moonpay"
+              },
+              {
+                "label": "lightspark",
+                "value": "lightspark"
+              },
+              {
+                "label": "bvnk",
+                "value": "bvnk"
+              },
+              {
+                "label": "moneygram",
+                "value": "moneygram"
+              },
+              {
+                "label": "coinbase",
+                "value": "coinbase"
+              },
+              {
+                "label": "mural",
+                "value": "mural"
+              },
+              {
+                "label": "stripe",
+                "value": "stripe"
+              }
+            ]
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "currencies": {
+              "sources": [
+                "USD",
+                "EUR"
+              ],
+              "destinations": [
+                "usdc.solana",
+                "sol.solana"
+              ]
+            },
+            "pairs": [
+              {
+                "source": "USD",
+                "dest": "usdc.solana",
+                "providers": [
+                  "moonpay",
+                  "lightspark"
+                ]
+              }
+            ],
+            "providerDetails": {
+              "moonpay": {
+                "currencies": {
+                  "USD": {
+                    "min": "20",
+                    "max": "30000"
+                  }
+                },
+                "countrySupport": {
+                  "coverage": "all-currencies",
+                  "countries": [
+                    "AL",
+                    "US"
+                  ]
+                },
+                "entityTypes": [
+                  "individual"
+                ]
+              }
+            },
+            "supportHash": "sha256:example"
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-payment-offramp-currencies",
+        "operationId": "listPaymentOfframpCurrencies",
+        "title": "List off-ramp currency support",
+        "method": "GET",
+        "path": "/v1/payments/ramps/offramp/currency?source={source}&dest={dest}&provider={provider}",
+        "pathFields": [
+          {
+            "key": "source",
+            "label": "source",
+            "description": "Optional Solana crypto rail source filter.",
+            "defaultValue": "usdc.solana",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "sol.solana",
+                "value": "sol.solana"
+              },
+              {
+                "label": "usdc.solana",
+                "value": "usdc.solana"
+              },
+              {
+                "label": "usdt.solana",
+                "value": "usdt.solana"
+              },
+              {
+                "label": "usdg.solana",
+                "value": "usdg.solana"
+              },
+              {
+                "label": "pyusd.solana",
+                "value": "pyusd.solana"
+              }
+            ]
+          },
+          {
+            "key": "dest",
+            "label": "dest",
+            "description": "Optional fiat destination currency filter.",
+            "defaultValue": "USD",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "AED",
+                "value": "AED"
+              },
+              {
+                "label": "AFN",
+                "value": "AFN"
+              },
+              {
+                "label": "ALL",
+                "value": "ALL"
+              },
+              {
+                "label": "AMD",
+                "value": "AMD"
+              },
+              {
+                "label": "ANG",
+                "value": "ANG"
+              },
+              {
+                "label": "AOA",
+                "value": "AOA"
+              },
+              {
+                "label": "ARS",
+                "value": "ARS"
+              },
+              {
+                "label": "AUD",
+                "value": "AUD"
+              },
+              {
+                "label": "AWG",
+                "value": "AWG"
+              },
+              {
+                "label": "AZN",
+                "value": "AZN"
+              },
+              {
+                "label": "BAM",
+                "value": "BAM"
+              },
+              {
+                "label": "BBD",
+                "value": "BBD"
+              },
+              {
+                "label": "BDT",
+                "value": "BDT"
+              },
+              {
+                "label": "BGN",
+                "value": "BGN"
+              },
+              {
+                "label": "BHD",
+                "value": "BHD"
+              },
+              {
+                "label": "BIF",
+                "value": "BIF"
+              },
+              {
+                "label": "BMD",
+                "value": "BMD"
+              },
+              {
+                "label": "BND",
+                "value": "BND"
+              },
+              {
+                "label": "BOB",
+                "value": "BOB"
+              },
+              {
+                "label": "BRL",
+                "value": "BRL"
+              },
+              {
+                "label": "BSD",
+                "value": "BSD"
+              },
+              {
+                "label": "BTN",
+                "value": "BTN"
+              },
+              {
+                "label": "BWP",
+                "value": "BWP"
+              },
+              {
+                "label": "BZD",
+                "value": "BZD"
+              },
+              {
+                "label": "CAD",
+                "value": "CAD"
+              },
+              {
+                "label": "CDF",
+                "value": "CDF"
+              },
+              {
+                "label": "CHF",
+                "value": "CHF"
+              },
+              {
+                "label": "CLP",
+                "value": "CLP"
+              },
+              {
+                "label": "CNY",
+                "value": "CNY"
+              },
+              {
+                "label": "COP",
+                "value": "COP"
+              },
+              {
+                "label": "CRC",
+                "value": "CRC"
+              },
+              {
+                "label": "CUC",
+                "value": "CUC"
+              },
+              {
+                "label": "CUP",
+                "value": "CUP"
+              },
+              {
+                "label": "CVE",
+                "value": "CVE"
+              },
+              {
+                "label": "CZK",
+                "value": "CZK"
+              },
+              {
+                "label": "DJF",
+                "value": "DJF"
+              },
+              {
+                "label": "DKK",
+                "value": "DKK"
+              },
+              {
+                "label": "DOP",
+                "value": "DOP"
+              },
+              {
+                "label": "DZD",
+                "value": "DZD"
+              },
+              {
+                "label": "EGP",
+                "value": "EGP"
+              },
+              {
+                "label": "ERN",
+                "value": "ERN"
+              },
+              {
+                "label": "ETB",
+                "value": "ETB"
+              },
+              {
+                "label": "EUR",
+                "value": "EUR"
+              },
+              {
+                "label": "FJD",
+                "value": "FJD"
+              },
+              {
+                "label": "FKP",
+                "value": "FKP"
+              },
+              {
+                "label": "GBP",
+                "value": "GBP"
+              },
+              {
+                "label": "GEL",
+                "value": "GEL"
+              },
+              {
+                "label": "GHS",
+                "value": "GHS"
+              },
+              {
+                "label": "GIP",
+                "value": "GIP"
+              },
+              {
+                "label": "GMD",
+                "value": "GMD"
+              },
+              {
+                "label": "GNF",
+                "value": "GNF"
+              },
+              {
+                "label": "GTQ",
+                "value": "GTQ"
+              },
+              {
+                "label": "GYD",
+                "value": "GYD"
+              },
+              {
+                "label": "HKD",
+                "value": "HKD"
+              },
+              {
+                "label": "HNL",
+                "value": "HNL"
+              },
+              {
+                "label": "HRK",
+                "value": "HRK"
+              },
+              {
+                "label": "HTG",
+                "value": "HTG"
+              },
+              {
+                "label": "HUF",
+                "value": "HUF"
+              },
+              {
+                "label": "IDR",
+                "value": "IDR"
+              },
+              {
+                "label": "ILS",
+                "value": "ILS"
+              },
+              {
+                "label": "INR",
+                "value": "INR"
+              },
+              {
+                "label": "IQD",
+                "value": "IQD"
+              },
+              {
+                "label": "IRR",
+                "value": "IRR"
+              },
+              {
+                "label": "ISK",
+                "value": "ISK"
+              },
+              {
+                "label": "JMD",
+                "value": "JMD"
+              },
+              {
+                "label": "JOD",
+                "value": "JOD"
+              },
+              {
+                "label": "JPY",
+                "value": "JPY"
+              },
+              {
+                "label": "KES",
+                "value": "KES"
+              },
+              {
+                "label": "KGS",
+                "value": "KGS"
+              },
+              {
+                "label": "KHR",
+                "value": "KHR"
+              },
+              {
+                "label": "KMF",
+                "value": "KMF"
+              },
+              {
+                "label": "KPW",
+                "value": "KPW"
+              },
+              {
+                "label": "KRW",
+                "value": "KRW"
+              },
+              {
+                "label": "KWD",
+                "value": "KWD"
+              },
+              {
+                "label": "KYD",
+                "value": "KYD"
+              },
+              {
+                "label": "KZT",
+                "value": "KZT"
+              },
+              {
+                "label": "LAK",
+                "value": "LAK"
+              },
+              {
+                "label": "LBP",
+                "value": "LBP"
+              },
+              {
+                "label": "LKR",
+                "value": "LKR"
+              },
+              {
+                "label": "LRD",
+                "value": "LRD"
+              },
+              {
+                "label": "LSL",
+                "value": "LSL"
+              },
+              {
+                "label": "LYD",
+                "value": "LYD"
+              },
+              {
+                "label": "MAD",
+                "value": "MAD"
+              },
+              {
+                "label": "MDL",
+                "value": "MDL"
+              },
+              {
+                "label": "MGA",
+                "value": "MGA"
+              },
+              {
+                "label": "MKD",
+                "value": "MKD"
+              },
+              {
+                "label": "MMK",
+                "value": "MMK"
+              },
+              {
+                "label": "MNT",
+                "value": "MNT"
+              },
+              {
+                "label": "MOP",
+                "value": "MOP"
+              },
+              {
+                "label": "MRU",
+                "value": "MRU"
+              },
+              {
+                "label": "MUR",
+                "value": "MUR"
+              },
+              {
+                "label": "MVR",
+                "value": "MVR"
+              },
+              {
+                "label": "MWK",
+                "value": "MWK"
+              },
+              {
+                "label": "MXN",
+                "value": "MXN"
+              },
+              {
+                "label": "MYR",
+                "value": "MYR"
+              },
+              {
+                "label": "MZN",
+                "value": "MZN"
+              },
+              {
+                "label": "NAD",
+                "value": "NAD"
+              },
+              {
+                "label": "NGN",
+                "value": "NGN"
+              },
+              {
+                "label": "NIO",
+                "value": "NIO"
+              },
+              {
+                "label": "NOK",
+                "value": "NOK"
+              },
+              {
+                "label": "NPR",
+                "value": "NPR"
+              },
+              {
+                "label": "NZD",
+                "value": "NZD"
+              },
+              {
+                "label": "OMR",
+                "value": "OMR"
+              },
+              {
+                "label": "PAB",
+                "value": "PAB"
+              },
+              {
+                "label": "PEN",
+                "value": "PEN"
+              },
+              {
+                "label": "PGK",
+                "value": "PGK"
+              },
+              {
+                "label": "PHP",
+                "value": "PHP"
+              },
+              {
+                "label": "PKR",
+                "value": "PKR"
+              },
+              {
+                "label": "PLN",
+                "value": "PLN"
+              },
+              {
+                "label": "PYG",
+                "value": "PYG"
+              },
+              {
+                "label": "QAR",
+                "value": "QAR"
+              },
+              {
+                "label": "RON",
+                "value": "RON"
+              },
+              {
+                "label": "RSD",
+                "value": "RSD"
+              },
+              {
+                "label": "RUB",
+                "value": "RUB"
+              },
+              {
+                "label": "RWF",
+                "value": "RWF"
+              },
+              {
+                "label": "SAR",
+                "value": "SAR"
+              },
+              {
+                "label": "SBD",
+                "value": "SBD"
+              },
+              {
+                "label": "SCR",
+                "value": "SCR"
+              },
+              {
+                "label": "SDG",
+                "value": "SDG"
+              },
+              {
+                "label": "SEK",
+                "value": "SEK"
+              },
+              {
+                "label": "SGD",
+                "value": "SGD"
+              },
+              {
+                "label": "SHP",
+                "value": "SHP"
+              },
+              {
+                "label": "SLE",
+                "value": "SLE"
+              },
+              {
+                "label": "SLL",
+                "value": "SLL"
+              },
+              {
+                "label": "SOS",
+                "value": "SOS"
+              },
+              {
+                "label": "SRD",
+                "value": "SRD"
+              },
+              {
+                "label": "SSP",
+                "value": "SSP"
+              },
+              {
+                "label": "STN",
+                "value": "STN"
+              },
+              {
+                "label": "SVC",
+                "value": "SVC"
+              },
+              {
+                "label": "SYP",
+                "value": "SYP"
+              },
+              {
+                "label": "SZL",
+                "value": "SZL"
+              },
+              {
+                "label": "THB",
+                "value": "THB"
+              },
+              {
+                "label": "TJS",
+                "value": "TJS"
+              },
+              {
+                "label": "TMT",
+                "value": "TMT"
+              },
+              {
+                "label": "TND",
+                "value": "TND"
+              },
+              {
+                "label": "TOP",
+                "value": "TOP"
+              },
+              {
+                "label": "TRY",
+                "value": "TRY"
+              },
+              {
+                "label": "TTD",
+                "value": "TTD"
+              },
+              {
+                "label": "TWD",
+                "value": "TWD"
+              },
+              {
+                "label": "TZS",
+                "value": "TZS"
+              },
+              {
+                "label": "UAH",
+                "value": "UAH"
+              },
+              {
+                "label": "UGX",
+                "value": "UGX"
+              },
+              {
+                "label": "USD",
+                "value": "USD"
+              },
+              {
+                "label": "UYU",
+                "value": "UYU"
+              },
+              {
+                "label": "UZS",
+                "value": "UZS"
+              },
+              {
+                "label": "VND",
+                "value": "VND"
+              },
+              {
+                "label": "VUV",
+                "value": "VUV"
+              },
+              {
+                "label": "WST",
+                "value": "WST"
+              },
+              {
+                "label": "XAF",
+                "value": "XAF"
+              },
+              {
+                "label": "XCD",
+                "value": "XCD"
+              },
+              {
+                "label": "XOF",
+                "value": "XOF"
+              },
+              {
+                "label": "XPF",
+                "value": "XPF"
+              },
+              {
+                "label": "YER",
+                "value": "YER"
+              },
+              {
+                "label": "ZAR",
+                "value": "ZAR"
+              },
+              {
+                "label": "ZMW",
+                "value": "ZMW"
+              }
+            ]
+          },
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Optional ramp provider filter.",
+            "defaultValue": "moonpay",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "moonpay",
+                "value": "moonpay"
+              },
+              {
+                "label": "lightspark",
+                "value": "lightspark"
+              },
+              {
+                "label": "bvnk",
+                "value": "bvnk"
+              },
+              {
+                "label": "moneygram",
+                "value": "moneygram"
+              },
+              {
+                "label": "coinbase",
+                "value": "coinbase"
+              },
+              {
+                "label": "mural",
+                "value": "mural"
+              },
+              {
+                "label": "stripe",
+                "value": "stripe"
+              }
+            ]
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "currencies": {
+              "sources": [
+                "usdc.solana",
+                "sol.solana"
+              ],
+              "destinations": [
+                "USD",
+                "EUR"
+              ]
+            },
+            "pairs": [
+              {
+                "source": "usdc.solana",
+                "dest": "USD",
+                "providers": [
+                  "moonpay",
+                  "bvnk"
+                ]
+              }
+            ],
+            "providerDetails": {
+              "moonpay": {
+                "currencies": {
+                  "USD": {
+                    "min": "20",
+                    "max": "30000"
+                  }
+                },
+                "countrySupport": {
+                  "coverage": "all-currencies",
+                  "countries": [
+                    "AL",
+                    "US"
+                  ]
+                },
+                "entityTypes": [
+                  "individual"
+                ]
+              }
+            },
+            "supportHash": "sha256:example"
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-payment-onramp-quote",
+        "operationId": "createPaymentOnrampQuote",
+        "title": "Create on-ramp quote",
+        "method": "POST",
+        "path": "/v1/payments/ramps/onramp/quote",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"moonpay\",\n  \"counterpartyId\": \"counterparty_example\",\n  \"destinationWallet\": \"privy_wallet_123\",\n  \"cryptoToken\": \"USDC\",\n  \"fiatCurrency\": \"USD\",\n  \"fiatAmount\": \"100.00\",\n  \"redirectUrl\": \"https://example.com/onramp/complete\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "quote": {
+              "id": "ramp_quote_example",
+              "provider": "moonpay",
+              "status": "pending",
+              "deliveryMode": "hosted",
+              "paymentInstructions": [
+                {
+                  "provider": "lightspark",
+                  "kind": "crypto_deposit",
+                  "destinationAddress": "So11111111111111111111111111111111111111112",
+                  "cryptoCurrency": "USDC",
+                  "network": "SOLANA",
+                  "accountOrWalletInfo": {
+                    "accountType": "USD_ACCOUNT",
+                    "accountNumber": "0000000000000000",
+                    "routingNumber": "000000000",
+                    "paymentRails": [
+                      "ACH",
+                      "WIRE"
+                    ],
+                    "reference": "quote-reference-example",
+                    "bankName": "Example Bank",
+                    "address": "ExampleSolanaWalletAddress11111111111111111",
+                    "assetType": "USDC"
+                  }
+                }
+              ],
+              "sendingCurrency": {
+                "code": "USDC",
+                "decimals": 2
+              },
+              "receivingCurrency": {
+                "code": "USDC",
+                "decimals": 2
+              },
+              "feeCurrency": {
+                "code": "USDC",
+                "decimals": 2
+              },
+              "expiresAt": "2025-01-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "simulate-sandbox-transfer",
+        "operationId": "simulateSandboxTransfer",
+        "title": "Simulate sandbox transfer",
+        "method": "POST",
+        "path": "/v1/payments/ramps/sandbox/simulate",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"provider\": \"lightspark\",\n  \"payload\": {\n    \"quoteId\": \"quote_example\",\n    \"currencyCode\": \"USD\"\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {}
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      }
+    ],
+    "counterparties": [
+      {
+        "id": "get-counterparty-field-options",
+        "operationId": "getCounterpartyFieldOptions",
+        "title": "Get counterparty field options",
+        "method": "GET",
+        "path": "/v1/counterparties/metadata",
+        "pathFields": [],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "fields": {
+              "entityTypes": [
+                "individual"
+              ],
+              "countries": [
+                {
+                  "code": "US",
+                  "name": "United States"
+                }
+              ],
+              "usStates": [
+                {
+                  "code": "US",
+                  "name": "United States"
+                }
+              ]
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-counterparties",
+        "operationId": "listCounterparties",
+        "title": "List counterparties",
+        "method": "GET",
+        "path": "/v1/counterparties?page={page}&pageSize={pageSize}&includeArchived={includeArchived}",
+        "pathFields": [
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Items per page (max 100).",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "includeArchived",
+            "label": "includeArchived",
+            "description": "Include archived counterparties in results.",
+            "defaultValue": "false",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ],
+            "valueType": "boolean"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "counterparties": [
+              {
+                "id": "cp_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "externalId": "customer_42",
+                "entityType": "individual",
+                "displayName": "Jane Doe",
+                "email": "jane@example.com",
+                "identity": {
+                  "firstName": "Jane",
+                  "middleName": "Q",
+                  "lastName": "Doe",
+                  "secondLastName": "Garcia",
+                  "dateOfBirth": "1990-01-15",
+                  "phone": "+14155551234",
+                  "address": {
+                    "line1": "123 Main St",
+                    "line2": "Apt 4B",
+                    "city": "San Francisco",
+                    "postalCode": "94105",
+                    "countryCode": "US",
+                    "subdivisionCode": "CA"
+                  }
+                },
+                "status": "active",
+                "createdBy": "usr_example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-02T00:00:00.000Z"
+              }
+            ],
+            "total": 42,
+            "page": 1,
+            "pageSize": 20
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-counterparty",
+        "operationId": "createCounterparty",
+        "title": "Create counterparty",
+        "method": "POST",
+        "path": "/v1/counterparties",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"externalId\": \"customer_42\",\n  \"displayName\": \"Jane Doe\",\n  \"email\": \"jane@example.com\",\n  \"entityType\": \"individual\",\n  \"identity\": {\n    \"firstName\": \"Jane\",\n    \"middleName\": \"Q\",\n    \"lastName\": \"Doe\",\n    \"secondLastName\": \"Garcia\",\n    \"dateOfBirth\": \"1990-01-15\",\n    \"phone\": \"+14155551234\",\n    \"address\": {\n      \"line1\": \"123 Main St\",\n      \"line2\": \"Apt 4B\",\n      \"city\": \"San Francisco\",\n      \"postalCode\": \"94105\",\n      \"countryCode\": \"US\",\n      \"subdivisionCode\": \"CA\"\n    }\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "counterparty": {
+              "id": "cp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "externalId": "customer_42",
+              "entityType": "individual",
+              "displayName": "Jane Doe",
+              "email": "jane@example.com",
+              "identity": {
+                "firstName": "Jane",
+                "middleName": "Q",
+                "lastName": "Doe",
+                "secondLastName": "Garcia",
+                "dateOfBirth": "1990-01-15",
+                "phone": "+14155551234",
+                "address": {
+                  "line1": "123 Main St",
+                  "line2": "Apt 4B",
+                  "city": "San Francisco",
+                  "postalCode": "94105",
+                  "countryCode": "US",
+                  "subdivisionCode": "CA"
+                }
+              },
+              "status": "active",
+              "createdBy": "usr_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-counterparty",
+        "operationId": "getCounterparty",
+        "title": "Get counterparty",
+        "method": "GET",
+        "path": "/v1/counterparties/{counterpartyId}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "counterparty": {
+              "id": "cp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "externalId": "customer_42",
+              "entityType": "individual",
+              "displayName": "Jane Doe",
+              "email": "jane@example.com",
+              "identity": {
+                "firstName": "Jane",
+                "middleName": "Q",
+                "lastName": "Doe",
+                "secondLastName": "Garcia",
+                "dateOfBirth": "1990-01-15",
+                "phone": "+14155551234",
+                "address": {
+                  "line1": "123 Main St",
+                  "line2": "Apt 4B",
+                  "city": "San Francisco",
+                  "postalCode": "94105",
+                  "countryCode": "US",
+                  "subdivisionCode": "CA"
+                }
+              },
+              "status": "active",
+              "createdBy": "usr_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-counterparty",
+        "operationId": "updateCounterparty",
+        "title": "Update counterparty",
+        "method": "PATCH",
+        "path": "/v1/counterparties/{counterpartyId}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"externalId\": \"customer_42\",\n  \"entityType\": \"business\",\n  \"displayName\": \"Jane Q. Doe\",\n  \"email\": \"jane.doe@example.com\",\n  \"identity\": {\n    \"firstName\": \"Jane\",\n    \"middleName\": \"Q\",\n    \"lastName\": \"Doe\",\n    \"secondLastName\": \"Garcia\",\n    \"dateOfBirth\": \"1990-01-15\",\n    \"phone\": \"+14155551234\",\n    \"address\": {\n      \"line1\": \"123 Main St\",\n      \"line2\": \"Apt 4B\",\n      \"city\": \"San Francisco\",\n      \"postalCode\": \"94105\",\n      \"countryCode\": \"US\",\n      \"subdivisionCode\": \"CA\"\n    }\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "counterparty": {
+              "id": "cp_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "externalId": "customer_42",
+              "entityType": "individual",
+              "displayName": "Jane Doe",
+              "email": "jane@example.com",
+              "identity": {
+                "firstName": "Jane",
+                "middleName": "Q",
+                "lastName": "Doe",
+                "secondLastName": "Garcia",
+                "dateOfBirth": "1990-01-15",
+                "phone": "+14155551234",
+                "address": {
+                  "line1": "123 Main St",
+                  "line2": "Apt 4B",
+                  "city": "San Francisco",
+                  "postalCode": "94105",
+                  "countryCode": "US",
+                  "subdivisionCode": "CA"
+                }
+              },
+              "status": "active",
+              "createdBy": "usr_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "archive-counterparty",
+        "operationId": "archiveCounterparty",
+        "title": "Archive counterparty",
+        "method": "DELETE",
+        "path": "/v1/counterparties/{counterpartyId}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {}
+      },
+      {
+        "id": "get-counterparty-requirements",
+        "operationId": "getCounterpartyRequirements",
+        "title": "Get counterparty ramp requirements",
+        "method": "GET",
+        "path": "/v1/counterparties/{counterpartyId}/requirements?provider={provider}&direction={direction}&cryptoToken={cryptoToken}&fiatCurrency={fiatCurrency}&destinationWallet={destinationWallet}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          },
+          {
+            "key": "provider",
+            "label": "provider",
+            "description": "Ramp provider to evaluate.",
+            "defaultValue": "moonpay",
+            "required": true
+          },
+          {
+            "key": "direction",
+            "label": "direction",
+            "description": "Ramp direction.",
+            "defaultValue": "onramp",
+            "required": true,
+            "kind": "select",
+            "options": [
+              {
+                "label": "onramp",
+                "value": "onramp"
+              },
+              {
+                "label": "offramp",
+                "value": "offramp"
+              }
+            ]
+          },
+          {
+            "key": "cryptoToken",
+            "label": "cryptoToken",
+            "description": "Crypto asset symbol.",
+            "defaultValue": "USDC",
+            "required": true
+          },
+          {
+            "key": "fiatCurrency",
+            "label": "fiatCurrency",
+            "description": "Fiat currency code.",
+            "defaultValue": "USD",
+            "required": true,
+            "kind": "select",
+            "options": [
+              {
+                "label": "AED",
+                "value": "AED"
+              },
+              {
+                "label": "AFN",
+                "value": "AFN"
+              },
+              {
+                "label": "ALL",
+                "value": "ALL"
+              },
+              {
+                "label": "AMD",
+                "value": "AMD"
+              },
+              {
+                "label": "ANG",
+                "value": "ANG"
+              },
+              {
+                "label": "AOA",
+                "value": "AOA"
+              },
+              {
+                "label": "ARS",
+                "value": "ARS"
+              },
+              {
+                "label": "AUD",
+                "value": "AUD"
+              },
+              {
+                "label": "AWG",
+                "value": "AWG"
+              },
+              {
+                "label": "AZN",
+                "value": "AZN"
+              },
+              {
+                "label": "BAM",
+                "value": "BAM"
+              },
+              {
+                "label": "BBD",
+                "value": "BBD"
+              },
+              {
+                "label": "BDT",
+                "value": "BDT"
+              },
+              {
+                "label": "BGN",
+                "value": "BGN"
+              },
+              {
+                "label": "BHD",
+                "value": "BHD"
+              },
+              {
+                "label": "BIF",
+                "value": "BIF"
+              },
+              {
+                "label": "BMD",
+                "value": "BMD"
+              },
+              {
+                "label": "BND",
+                "value": "BND"
+              },
+              {
+                "label": "BOB",
+                "value": "BOB"
+              },
+              {
+                "label": "BRL",
+                "value": "BRL"
+              },
+              {
+                "label": "BSD",
+                "value": "BSD"
+              },
+              {
+                "label": "BTN",
+                "value": "BTN"
+              },
+              {
+                "label": "BWP",
+                "value": "BWP"
+              },
+              {
+                "label": "BZD",
+                "value": "BZD"
+              },
+              {
+                "label": "CAD",
+                "value": "CAD"
+              },
+              {
+                "label": "CDF",
+                "value": "CDF"
+              },
+              {
+                "label": "CHF",
+                "value": "CHF"
+              },
+              {
+                "label": "CLP",
+                "value": "CLP"
+              },
+              {
+                "label": "CNY",
+                "value": "CNY"
+              },
+              {
+                "label": "COP",
+                "value": "COP"
+              },
+              {
+                "label": "CRC",
+                "value": "CRC"
+              },
+              {
+                "label": "CUC",
+                "value": "CUC"
+              },
+              {
+                "label": "CUP",
+                "value": "CUP"
+              },
+              {
+                "label": "CVE",
+                "value": "CVE"
+              },
+              {
+                "label": "CZK",
+                "value": "CZK"
+              },
+              {
+                "label": "DJF",
+                "value": "DJF"
+              },
+              {
+                "label": "DKK",
+                "value": "DKK"
+              },
+              {
+                "label": "DOP",
+                "value": "DOP"
+              },
+              {
+                "label": "DZD",
+                "value": "DZD"
+              },
+              {
+                "label": "EGP",
+                "value": "EGP"
+              },
+              {
+                "label": "ERN",
+                "value": "ERN"
+              },
+              {
+                "label": "ETB",
+                "value": "ETB"
+              },
+              {
+                "label": "EUR",
+                "value": "EUR"
+              },
+              {
+                "label": "FJD",
+                "value": "FJD"
+              },
+              {
+                "label": "FKP",
+                "value": "FKP"
+              },
+              {
+                "label": "GBP",
+                "value": "GBP"
+              },
+              {
+                "label": "GEL",
+                "value": "GEL"
+              },
+              {
+                "label": "GHS",
+                "value": "GHS"
+              },
+              {
+                "label": "GIP",
+                "value": "GIP"
+              },
+              {
+                "label": "GMD",
+                "value": "GMD"
+              },
+              {
+                "label": "GNF",
+                "value": "GNF"
+              },
+              {
+                "label": "GTQ",
+                "value": "GTQ"
+              },
+              {
+                "label": "GYD",
+                "value": "GYD"
+              },
+              {
+                "label": "HKD",
+                "value": "HKD"
+              },
+              {
+                "label": "HNL",
+                "value": "HNL"
+              },
+              {
+                "label": "HRK",
+                "value": "HRK"
+              },
+              {
+                "label": "HTG",
+                "value": "HTG"
+              },
+              {
+                "label": "HUF",
+                "value": "HUF"
+              },
+              {
+                "label": "IDR",
+                "value": "IDR"
+              },
+              {
+                "label": "ILS",
+                "value": "ILS"
+              },
+              {
+                "label": "INR",
+                "value": "INR"
+              },
+              {
+                "label": "IQD",
+                "value": "IQD"
+              },
+              {
+                "label": "IRR",
+                "value": "IRR"
+              },
+              {
+                "label": "ISK",
+                "value": "ISK"
+              },
+              {
+                "label": "JMD",
+                "value": "JMD"
+              },
+              {
+                "label": "JOD",
+                "value": "JOD"
+              },
+              {
+                "label": "JPY",
+                "value": "JPY"
+              },
+              {
+                "label": "KES",
+                "value": "KES"
+              },
+              {
+                "label": "KGS",
+                "value": "KGS"
+              },
+              {
+                "label": "KHR",
+                "value": "KHR"
+              },
+              {
+                "label": "KMF",
+                "value": "KMF"
+              },
+              {
+                "label": "KPW",
+                "value": "KPW"
+              },
+              {
+                "label": "KRW",
+                "value": "KRW"
+              },
+              {
+                "label": "KWD",
+                "value": "KWD"
+              },
+              {
+                "label": "KYD",
+                "value": "KYD"
+              },
+              {
+                "label": "KZT",
+                "value": "KZT"
+              },
+              {
+                "label": "LAK",
+                "value": "LAK"
+              },
+              {
+                "label": "LBP",
+                "value": "LBP"
+              },
+              {
+                "label": "LKR",
+                "value": "LKR"
+              },
+              {
+                "label": "LRD",
+                "value": "LRD"
+              },
+              {
+                "label": "LSL",
+                "value": "LSL"
+              },
+              {
+                "label": "LYD",
+                "value": "LYD"
+              },
+              {
+                "label": "MAD",
+                "value": "MAD"
+              },
+              {
+                "label": "MDL",
+                "value": "MDL"
+              },
+              {
+                "label": "MGA",
+                "value": "MGA"
+              },
+              {
+                "label": "MKD",
+                "value": "MKD"
+              },
+              {
+                "label": "MMK",
+                "value": "MMK"
+              },
+              {
+                "label": "MNT",
+                "value": "MNT"
+              },
+              {
+                "label": "MOP",
+                "value": "MOP"
+              },
+              {
+                "label": "MRU",
+                "value": "MRU"
+              },
+              {
+                "label": "MUR",
+                "value": "MUR"
+              },
+              {
+                "label": "MVR",
+                "value": "MVR"
+              },
+              {
+                "label": "MWK",
+                "value": "MWK"
+              },
+              {
+                "label": "MXN",
+                "value": "MXN"
+              },
+              {
+                "label": "MYR",
+                "value": "MYR"
+              },
+              {
+                "label": "MZN",
+                "value": "MZN"
+              },
+              {
+                "label": "NAD",
+                "value": "NAD"
+              },
+              {
+                "label": "NGN",
+                "value": "NGN"
+              },
+              {
+                "label": "NIO",
+                "value": "NIO"
+              },
+              {
+                "label": "NOK",
+                "value": "NOK"
+              },
+              {
+                "label": "NPR",
+                "value": "NPR"
+              },
+              {
+                "label": "NZD",
+                "value": "NZD"
+              },
+              {
+                "label": "OMR",
+                "value": "OMR"
+              },
+              {
+                "label": "PAB",
+                "value": "PAB"
+              },
+              {
+                "label": "PEN",
+                "value": "PEN"
+              },
+              {
+                "label": "PGK",
+                "value": "PGK"
+              },
+              {
+                "label": "PHP",
+                "value": "PHP"
+              },
+              {
+                "label": "PKR",
+                "value": "PKR"
+              },
+              {
+                "label": "PLN",
+                "value": "PLN"
+              },
+              {
+                "label": "PYG",
+                "value": "PYG"
+              },
+              {
+                "label": "QAR",
+                "value": "QAR"
+              },
+              {
+                "label": "RON",
+                "value": "RON"
+              },
+              {
+                "label": "RSD",
+                "value": "RSD"
+              },
+              {
+                "label": "RUB",
+                "value": "RUB"
+              },
+              {
+                "label": "RWF",
+                "value": "RWF"
+              },
+              {
+                "label": "SAR",
+                "value": "SAR"
+              },
+              {
+                "label": "SBD",
+                "value": "SBD"
+              },
+              {
+                "label": "SCR",
+                "value": "SCR"
+              },
+              {
+                "label": "SDG",
+                "value": "SDG"
+              },
+              {
+                "label": "SEK",
+                "value": "SEK"
+              },
+              {
+                "label": "SGD",
+                "value": "SGD"
+              },
+              {
+                "label": "SHP",
+                "value": "SHP"
+              },
+              {
+                "label": "SLE",
+                "value": "SLE"
+              },
+              {
+                "label": "SLL",
+                "value": "SLL"
+              },
+              {
+                "label": "SOS",
+                "value": "SOS"
+              },
+              {
+                "label": "SRD",
+                "value": "SRD"
+              },
+              {
+                "label": "SSP",
+                "value": "SSP"
+              },
+              {
+                "label": "STN",
+                "value": "STN"
+              },
+              {
+                "label": "SVC",
+                "value": "SVC"
+              },
+              {
+                "label": "SYP",
+                "value": "SYP"
+              },
+              {
+                "label": "SZL",
+                "value": "SZL"
+              },
+              {
+                "label": "THB",
+                "value": "THB"
+              },
+              {
+                "label": "TJS",
+                "value": "TJS"
+              },
+              {
+                "label": "TMT",
+                "value": "TMT"
+              },
+              {
+                "label": "TND",
+                "value": "TND"
+              },
+              {
+                "label": "TOP",
+                "value": "TOP"
+              },
+              {
+                "label": "TRY",
+                "value": "TRY"
+              },
+              {
+                "label": "TTD",
+                "value": "TTD"
+              },
+              {
+                "label": "TWD",
+                "value": "TWD"
+              },
+              {
+                "label": "TZS",
+                "value": "TZS"
+              },
+              {
+                "label": "UAH",
+                "value": "UAH"
+              },
+              {
+                "label": "UGX",
+                "value": "UGX"
+              },
+              {
+                "label": "USD",
+                "value": "USD"
+              },
+              {
+                "label": "UYU",
+                "value": "UYU"
+              },
+              {
+                "label": "UZS",
+                "value": "UZS"
+              },
+              {
+                "label": "VND",
+                "value": "VND"
+              },
+              {
+                "label": "VUV",
+                "value": "VUV"
+              },
+              {
+                "label": "WST",
+                "value": "WST"
+              },
+              {
+                "label": "XAF",
+                "value": "XAF"
+              },
+              {
+                "label": "XCD",
+                "value": "XCD"
+              },
+              {
+                "label": "XOF",
+                "value": "XOF"
+              },
+              {
+                "label": "XPF",
+                "value": "XPF"
+              },
+              {
+                "label": "YER",
+                "value": "YER"
+              },
+              {
+                "label": "ZAR",
+                "value": "ZAR"
+              },
+              {
+                "label": "ZMW",
+                "value": "ZMW"
+              }
+            ]
+          },
+          {
+            "key": "destinationWallet",
+            "label": "destinationWallet",
+            "description": "Destination wallet ID. Required when direction is onramp.",
+            "defaultValue": "privy_wallet_123",
+            "required": false
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "direction": "onramp",
+            "provider": "moonpay",
+            "status": "ready"
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-counterparty-accounts",
+        "operationId": "listCounterpartyAccounts",
+        "title": "List counterparty accounts",
+        "method": "GET",
+        "path": "/v1/counterparties/{counterpartyId}/accounts?page={page}&pageSize={pageSize}&includeArchived={includeArchived}&accountKind={accountKind}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Items per page (max 100).",
+            "defaultValue": "20",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "includeArchived",
+            "label": "includeArchived",
+            "description": "Include archived counterparty accounts in results.",
+            "defaultValue": "false",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "true",
+                "value": "true"
+              },
+              {
+                "label": "false",
+                "value": "false"
+              }
+            ],
+            "valueType": "boolean"
+          },
+          {
+            "key": "accountKind",
+            "label": "accountKind",
+            "description": "Filter accounts by account kind.",
+            "defaultValue": "crypto_wallet",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "bank_account",
+                "value": "bank_account"
+              },
+              {
+                "label": "crypto_wallet",
+                "value": "crypto_wallet"
+              }
+            ]
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "accounts": [
+              {
+                "id": "cpa_example",
+                "organizationId": "org_example",
+                "projectId": "prj_example",
+                "counterpartyId": "cp_example",
+                "accountKind": "crypto_wallet",
+                "label": "USDC wallet",
+                "details": {
+                  "network": "solana",
+                  "address": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+                },
+                "providerAccountData": {},
+                "status": "active",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-02T00:00:00.000Z"
+              }
+            ],
+            "total": 2,
+            "page": 1,
+            "pageSize": 20
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-counterparty-account",
+        "operationId": "createCounterpartyAccount",
+        "title": "Create counterparty account",
+        "method": "POST",
+        "path": "/v1/counterparties/{counterpartyId}/accounts",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"accountKind\": \"crypto_wallet\",\n  \"label\": \"USDC wallet\",\n  \"details\": {\n    \"network\": \"solana\",\n    \"address\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\"\n  },\n  \"providerAccountData\": {}\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "account": {
+              "id": "cpa_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "counterpartyId": "cp_example",
+              "accountKind": "crypto_wallet",
+              "label": "USDC wallet",
+              "details": {
+                "network": "solana",
+                "address": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+              },
+              "providerAccountData": {},
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-counterparty-account",
+        "operationId": "getCounterpartyAccount",
+        "title": "Get counterparty account",
+        "method": "GET",
+        "path": "/v1/counterparties/{counterpartyId}/accounts/{counterpartyAccountId}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          },
+          {
+            "key": "counterpartyAccountId",
+            "label": "{counterpartyAccountId}",
+            "description": "Counterparty account identifier.",
+            "defaultValue": "cpa_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "account": {
+              "id": "cpa_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "counterpartyId": "cp_example",
+              "accountKind": "crypto_wallet",
+              "label": "USDC wallet",
+              "details": {
+                "network": "solana",
+                "address": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+              },
+              "providerAccountData": {},
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-counterparty-account",
+        "operationId": "updateCounterpartyAccount",
+        "title": "Update counterparty account",
+        "method": "PATCH",
+        "path": "/v1/counterparties/{counterpartyId}/accounts/{counterpartyAccountId}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          },
+          {
+            "key": "counterpartyAccountId",
+            "label": "{counterpartyAccountId}",
+            "description": "Counterparty account identifier.",
+            "defaultValue": "cpa_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"label\": \"Primary USDC wallet\",\n  \"details\": {\n    \"network\": \"solana\",\n    \"address\": \"7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU\"\n  },\n  \"providerAccountData\": {}\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "account": {
+              "id": "cpa_example",
+              "organizationId": "org_example",
+              "projectId": "prj_example",
+              "counterpartyId": "cp_example",
+              "accountKind": "crypto_wallet",
+              "label": "USDC wallet",
+              "details": {
+                "network": "solana",
+                "address": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"
+              },
+              "providerAccountData": {},
+              "status": "active",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "archive-counterparty-account",
+        "operationId": "archiveCounterpartyAccount",
+        "title": "Archive counterparty account",
+        "method": "DELETE",
+        "path": "/v1/counterparties/{counterpartyId}/accounts/{counterpartyAccountId}",
+        "pathFields": [
+          {
+            "key": "counterpartyId",
+            "label": "{counterpartyId}",
+            "description": "Counterparty identifier.",
+            "defaultValue": "cp_example",
+            "required": true
+          },
+          {
+            "key": "counterpartyAccountId",
+            "label": "{counterpartyAccountId}",
+            "description": "Counterparty account identifier.",
+            "defaultValue": "cpa_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {}
+      }
+    ],
+    "issuance": [
+      {
+        "id": "list-token-templates",
+        "operationId": "listTokenTemplates",
+        "title": "List token templates",
+        "method": "GET",
+        "path": "/v1/issuance/templates",
+        "pathFields": [],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "templates": [
+              {
+                "id": "stablecoin",
+                "name": "Stablecoin",
+                "description": "USD-backed stablecoins with compliance controls and privacy features",
+                "decimals": 6,
+                "maxDecimals": 18,
+                "requiresAllowlist": true,
+                "allowlistOverridable": true,
+                "requiredExtensions": [
+                  "permanentDelegate",
+                  "pausable"
+                ],
+                "availableExtensions": [
+                  "scaledUiAmount",
+                  "interestBearing"
+                ],
+                "defaultExtensions": {
+                  "defaultAccountState": "initialized"
+                }
+              }
+            ]
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-token-template",
+        "operationId": "getTokenTemplate",
+        "title": "Get token template",
+        "method": "GET",
+        "path": "/v1/issuance/templates/{templateId}",
+        "pathFields": [
+          {
+            "key": "templateId",
+            "label": "{templateId}",
+            "description": "Template identifier.",
+            "defaultValue": "stablecoin",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "template": {
+              "id": "stablecoin",
+              "name": "Stablecoin",
+              "description": "USD-backed stablecoins with compliance controls and privacy features",
+              "decimals": 6,
+              "maxDecimals": 18,
+              "requiresAllowlist": true,
+              "allowlistOverridable": true,
+              "requiredExtensions": [
+                "permanentDelegate",
+                "pausable"
+              ],
+              "availableExtensions": [
+                "scaledUiAmount",
+                "interestBearing"
+              ],
+              "defaultExtensions": {
+                "defaultAccountState": "initialized"
+              }
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "create-token",
+        "operationId": "createToken",
+        "title": "Create token",
+        "method": "POST",
+        "path": "/v1/issuance/tokens",
+        "pathFields": [],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"name\": \"Example Token\",\n  \"symbol\": \"EXM\",\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"decimals\": 6,\n  \"description\": \"Example token description.\",\n  \"uri\": \"https://example.com/metadata.json\",\n  \"imageUrl\": \"https://example.com/token.png\",\n  \"maxSupply\": \"1000000\",\n  \"template\": \"stablecoin\",\n  \"overrides\": {\n    \"extensions\": {\n      \"transferFee\": {\n        \"basisPoints\": 50,\n        \"maxFee\": \"0.5\"\n      }\n    }\n  },\n  \"requiresAllowlist\": true,\n  \"isMintable\": true,\n  \"isFreezable\": true\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "token": {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-tokens",
+        "operationId": "listTokens",
+        "title": "List tokens",
+        "method": "GET",
+        "path": "/v1/issuance/tokens?status={status}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Filter by token status.",
+            "defaultValue": "active",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending",
+                "value": "pending"
+              },
+              {
+                "label": "active",
+                "value": "active"
+              },
+              {
+                "label": "paused",
+                "value": "paused"
+              },
+              {
+                "label": "revoked",
+                "value": "revoked"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of items per page.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "list-issuance-transactions",
+        "operationId": "listIssuanceTransactions",
+        "title": "List issuance transactions",
+        "method": "GET",
+        "path": "/v1/issuance/transactions?walletId={walletId}&type={type}&status={status}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "walletId",
+            "label": "walletId",
+            "description": "Filter to transactions associated with a wallet. Selected-wallet API keys must have wallet-level tokens:read for the requested wallet.",
+            "defaultValue": "privy_wallet_123",
+            "required": false
+          },
+          {
+            "key": "type",
+            "label": "type",
+            "description": "Filter by transaction type. Repeat this query parameter for multiple values, for example type=burn&type=force_burn.",
+            "defaultValue": "[\"burn\",\"force_burn\"]",
+            "required": false,
+            "valueType": "string_array"
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Filter by token transaction status.",
+            "defaultValue": "confirmed",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending",
+                "value": "pending"
+              },
+              {
+                "label": "processing",
+                "value": "processing"
+              },
+              {
+                "label": "confirmed",
+                "value": "confirmed"
+              },
+              {
+                "label": "finalized",
+                "value": "finalized"
+              },
+              {
+                "label": "failed",
+                "value": "failed"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of items per page.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "token": {
+                "id": "tok_example",
+                "name": "Example Token",
+                "symbol": "EXM",
+                "mintAddress": null
+              },
+              "transaction": {
+                "id": "ttx_example",
+                "tokenId": "tok_example",
+                "organizationId": "org_example",
+                "type": "mint",
+                "status": "confirmed",
+                "signature": "sig_example",
+                "idempotencyKey": "idem_example_12345",
+                "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+                "serializedTx": "AQID",
+                "params": {},
+                "slot": 123456,
+                "blockTime": "2025-01-01T00:00:00.000Z",
+                "fee": 5000,
+                "error": "Signature failed",
+                "initiatedByKeyId": "key_example",
+                "createdAt": "2025-01-01T00:00:00.000Z",
+                "updatedAt": "2025-01-02T00:00:00.000Z"
+              }
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "get-token",
+        "operationId": "getToken",
+        "title": "Get token",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "token": {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "update-token",
+        "operationId": "updateToken",
+        "title": "Update token",
+        "method": "PATCH",
+        "path": "/v1/issuance/tokens/{tokenId}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"name\": \"Example Token Updated\",\n  \"description\": \"Updated token description.\",\n  \"uri\": \"https://example.com/metadata.json\",\n  \"imageUrl\": \"https://example.com/token.png\",\n  \"status\": \"active\",\n  \"requiresAllowlist\": true\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "token": {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "get-token-metadata-json",
+        "operationId": "getTokenMetadataJson",
+        "title": "Get public token metadata JSON",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}/metadata.json",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "name": "example",
+          "symbol": "example"
+        }
+      },
+      {
+        "id": "refresh-token-supply",
+        "operationId": "refreshTokenSupply",
+        "title": "Refresh cached token supply",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/supply/refresh",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "token": {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-token-transactions",
+        "operationId": "listTokenTransactions",
+        "title": "List token transactions",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}/transactions?status={status}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          },
+          {
+            "key": "status",
+            "label": "status",
+            "description": "Filter by token transaction status.",
+            "defaultValue": "confirmed",
+            "required": false,
+            "kind": "select",
+            "options": [
+              {
+                "label": "pending",
+                "value": "pending"
+              },
+              {
+                "label": "processing",
+                "value": "processing"
+              },
+              {
+                "label": "confirmed",
+                "value": "confirmed"
+              },
+              {
+                "label": "finalized",
+                "value": "finalized"
+              },
+              {
+                "label": "failed",
+                "value": "failed"
+              }
+            ]
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of items per page.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "get-asset-audit-history",
+        "operationId": "getAssetAuditHistory",
+        "title": "Get asset audit history",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}/audit?action={action}&page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          },
+          {
+            "key": "action",
+            "label": "action",
+            "description": "Filter by audit action.",
+            "required": false
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of items per page.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "_example",
+              "action": "freeze",
+              "resourceType": "frozen_account",
+              "resourceId": "resource_example",
+              "actorType": "user",
+              "actorLabel": "Jordan Lee",
+              "status": "success",
+              "createdAt": "2026-07-19T12:00:00.000Z",
+              "metadata": {}
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "deploy-token",
+        "operationId": "deployToken",
+        "title": "Deploy token",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/deploy",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "token": {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-deploy-token",
+        "operationId": "prepareDeployToken",
+        "title": "Prepare token deploy transaction",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/deploy/prepare",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "mint": "So11111111111111111111111111111111111111112",
+            "listAddress": "So11111111111111111111111111111111111111112",
+            "metadataUriFollowUp": {
+              "required": true,
+              "uri": "https://example.com"
+            },
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "confirm-deploy",
+        "operationId": "confirmDeploy",
+        "title": "Confirm non-custodial deploy",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/deploy/confirm",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signature\": \"5x...signature\",\n  \"mint\": \"So11111111111111111111111111111111111111112\",\n  \"listAddress\": \"So11111111111111111111111111111111111111112\",\n  \"signingWalletId\": \"privy_wallet_123\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "token": {
+              "id": "tok_example",
+              "projectId": "prj_example",
+              "organizationId": "org_example",
+              "signingWalletId": "privy_wallet_123",
+              "mintAddress": "So11111111111111111111111111111111111111112",
+              "mintAuthority": "So11111111111111111111111111111111111111112",
+              "freezeAuthority": "So11111111111111111111111111111111111111112",
+              "ablListAddress": "So11111111111111111111111111111111111111112",
+              "name": "Example Token",
+              "symbol": "EXM",
+              "decimals": 9,
+              "description": "Example token description.",
+              "uri": "https://example.com/metadata.json",
+              "imageUrl": "https://example.com/token.png",
+              "template": "stablecoin",
+              "extensions": {
+                "transferFee": {
+                  "basisPoints": 25,
+                  "maxFee": "0.5",
+                  "transferFeeConfigAuthority": "So11111111111111111111111111111111111111112",
+                  "withdrawWithheldAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "interestBearing": {
+                  "rate": 2.5,
+                  "rateAuthority": "So11111111111111111111111111111111111111112"
+                },
+                "permanentDelegate": "So11111111111111111111111111111111111111112",
+                "pausable": {
+                  "authority": "So11111111111111111111111111111111111111112"
+                },
+                "nonTransferable": false,
+                "defaultAccountState": "initialized",
+                "scaledUiAmount": {
+                  "authority": "So11111111111111111111111111111111111111112",
+                  "multiplier": 1,
+                  "newMultiplier": 2,
+                  "newMultiplierEffectiveTimestamp": 1735689600
+                },
+                "transferHook": {
+                  "programId": "So11111111111111111111111111111111111111112",
+                  "authority": "So11111111111111111111111111111111111111112"
+                }
+              },
+              "totalSupply": "1000000",
+              "totalSupplyUpdatedAt": null,
+              "maxSupply": "10000000",
+              "isMintable": true,
+              "isFreezable": true,
+              "requiresAllowlist": false,
+              "status": "active",
+              "deployedAt": "2025-01-05T00:00:00.000Z",
+              "createdBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-deploy-metadata",
+        "operationId": "prepareDeployMetadata",
+        "title": "Prepare metadata-URI follow-up transaction",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/deploy/prepare-metadata",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "uri": "https://api.example.com/v1/issuance/tokens/tok_123/metadata.json",
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-mint",
+        "operationId": "prepareMint",
+        "title": "Prepare mint transaction",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/mint/prepare",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"mint\": {\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Payout\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "tokenAccount": "So11111111111111111111111111111111111111112",
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "execute-mint",
+        "operationId": "executeMint",
+        "title": "Execute mint",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/mint",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"mint\": {\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Payout\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "tokenAccount": "So11111111111111111111111111111111111111112"
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-burn",
+        "operationId": "prepareBurn",
+        "title": "Prepare burn transaction",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/burn/prepare",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"burn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Correction\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "execute-burn",
+        "operationId": "executeBurn",
+        "title": "Execute burn",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/burn",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"burn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"1000\",\n    \"memo\": \"Correction\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-seize",
+        "operationId": "prepareSeize",
+        "title": "Prepare seize transaction",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/seize/prepare",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"seize\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance seizure\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "execute-seize",
+        "operationId": "executeSeize",
+        "title": "Execute seize",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/seize",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"seize\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"destination\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance seizure\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-force-burn",
+        "operationId": "prepareForceBurn",
+        "title": "Prepare force burn transaction",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/force-burn/prepare",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"forceBurn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance burn\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "execute-force-burn",
+        "operationId": "executeForceBurn",
+        "title": "Execute force burn",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/force-burn",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"forceBurn\": {\n    \"source\": \"So11111111111111111111111111111111111111112\",\n    \"amount\": \"250\",\n    \"delegateAuthority\": \"So11111111111111111111111111111111111111112\",\n    \"memo\": \"Compliance burn\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "prepare-update-authority",
+        "operationId": "prepareUpdateAuthority",
+        "title": "Prepare authority update",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/authority/prepare",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"authority\": {\n    \"role\": \"mint\",\n    \"newAuthority\": \"So11111111111111111111111111111111111111112\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            },
+            "preparedTransaction": {
+              "serialized": "AQID",
+              "blockhash": "blockhash_example",
+              "lastValidBlockHeight": "123456"
+            },
+            "simulation": {
+              "success": true,
+              "logs": [
+                "Program log: success"
+              ],
+              "unitsConsumed": 20000,
+              "error": "Insufficient funds"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "execute-update-authority",
+        "operationId": "executeUpdateAuthority",
+        "title": "Execute authority update",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/authority",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"signingWalletId\": \"privy_wallet_123\",\n  \"authority\": {\n    \"role\": \"mint\",\n    \"newAuthority\": \"So11111111111111111111111111111111111111112\"\n  },\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "pause-token",
+        "operationId": "pauseToken",
+        "title": "Pause token transfers",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/pause",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "unpause-token",
+        "operationId": "unpauseToken",
+        "title": "Unpause token transfers",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/unpause",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"options\": {\n    \"priorityFee\": \"low\",\n    \"simulate\": true\n  }\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "transaction": {
+              "id": "ttx_example",
+              "tokenId": "tok_example",
+              "organizationId": "org_example",
+              "type": "mint",
+              "status": "confirmed",
+              "signature": "sig_example",
+              "idempotencyKey": "idem_example_12345",
+              "idempotencyFingerprint": "4f2d9c7a5e6f1c...",
+              "serializedTx": "AQID",
+              "params": {},
+              "slot": 123456,
+              "blockTime": "2025-01-01T00:00:00.000Z",
+              "fee": 5000,
+              "error": "Signature failed",
+              "initiatedByKeyId": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "updatedAt": "2025-01-02T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "freeze-account",
+        "operationId": "freezeAccount",
+        "title": "Freeze account",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/freeze",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"accountAddress\": \"So11111111111111111111111111111111111111112\",\n  \"reason\": \"Compliance hold\",\n  \"signingWalletId\": \"privy_abcd1234\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "frozenAccount": {
+              "id": "frz_example",
+              "tokenId": "tok_example",
+              "accountAddress": "So11111111111111111111111111111111111111112",
+              "reason": "Compliance hold",
+              "frozenAt": "2025-01-05T00:00:00.000Z",
+              "frozenBy": "key_example",
+              "unfrozenAt": "2025-01-10T00:00:00.000Z",
+              "unfrozenBy": "example",
+              "signature": "sig_example"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "unfreeze-account",
+        "operationId": "unfreezeAccount",
+        "title": "Unfreeze account",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/unfreeze",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"accountAddress\": \"So11111111111111111111111111111111111111112\",\n  \"signingWalletId\": \"privy_abcd1234\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "frozenAccount": {
+              "id": "frz_example",
+              "tokenId": "tok_example",
+              "accountAddress": "So11111111111111111111111111111111111111112",
+              "reason": "Compliance hold",
+              "frozenAt": "2025-01-05T00:00:00.000Z",
+              "frozenBy": "key_example",
+              "unfrozenAt": "2025-01-10T00:00:00.000Z",
+              "unfrozenBy": "example",
+              "signature": "sig_example"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "list-frozen-accounts",
+        "operationId": "listFrozenAccounts",
+        "title": "List frozen accounts",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}/frozen?page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of items per page.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "frz_example",
+              "tokenId": "tok_example",
+              "accountAddress": "So11111111111111111111111111111111111111112",
+              "reason": "Compliance hold",
+              "frozenAt": "2025-01-05T00:00:00.000Z",
+              "frozenBy": "key_example",
+              "unfrozenAt": "2025-01-10T00:00:00.000Z",
+              "unfrozenBy": "example",
+              "signature": "sig_example"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "list-token-allowlist",
+        "operationId": "listTokenAllowlist",
+        "title": "List token allowlist",
+        "method": "GET",
+        "path": "/v1/issuance/tokens/{tokenId}/allowlist?page={page}&pageSize={pageSize}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          },
+          {
+            "key": "page",
+            "label": "page",
+            "description": "Page number (1-based).",
+            "defaultValue": "1",
+            "required": false,
+            "valueType": "number"
+          },
+          {
+            "key": "pageSize",
+            "label": "pageSize",
+            "description": "Number of items per page.",
+            "defaultValue": "50",
+            "required": false,
+            "valueType": "number"
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {
+          "data": [
+            {
+              "id": "tal_example",
+              "tokenId": "tok_example",
+              "address": "So11111111111111111111111111111111111111112",
+              "label": "Treasury",
+              "status": "active",
+              "addedBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "revokedAt": "2025-02-01T00:00:00.000Z"
+            }
+          ],
+          "meta": {
+            "total": 1,
+            "page": 1,
+            "pageSize": 1,
+            "hasMore": false,
+            "requestId": "req_example"
+          }
+        }
+      },
+      {
+        "id": "add-token-allowlist-entry",
+        "operationId": "addTokenAllowlistEntry",
+        "title": "Add token allowlist entry",
+        "method": "POST",
+        "path": "/v1/issuance/tokens/{tokenId}/allowlist",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [
+          {
+            "key": "$body",
+            "label": "JSON request body",
+            "description": "Generated from this operation's public OpenAPI request schema.",
+            "kind": "textarea",
+            "valueType": "json",
+            "defaultValue": "{\n  \"address\": \"So11111111111111111111111111111111111111112\",\n  \"label\": \"Treasury\"\n}",
+            "required": true
+          }
+        ],
+        "expectedResponse": {
+          "data": {
+            "entry": {
+              "id": "tal_example",
+              "tokenId": "tok_example",
+              "address": "So11111111111111111111111111111111111111112",
+              "label": "Treasury",
+              "status": "active",
+              "addedBy": "key_example",
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "revokedAt": "2025-02-01T00:00:00.000Z"
+            }
+          },
+          "meta": {
+            "requestId": "req_example",
+            "timestamp": "2025-01-01T00:00:00.000Z"
+          }
+        }
+      },
+      {
+        "id": "remove-token-allowlist-entry",
+        "operationId": "removeTokenAllowlistEntry",
+        "title": "Remove token allowlist entry",
+        "method": "DELETE",
+        "path": "/v1/issuance/tokens/{tokenId}/allowlist/{entryId}",
+        "pathFields": [
+          {
+            "key": "tokenId",
+            "label": "{tokenId}",
+            "description": "Token identifier.",
+            "defaultValue": "tok_example",
+            "required": true
+          },
+          {
+            "key": "entryId",
+            "label": "{entryId}",
+            "description": "Allowlist entry identifier.",
+            "defaultValue": "al_example",
+            "required": true
+          }
+        ],
+        "bodyFields": [],
+        "expectedResponse": {}
+      }
+    ]
+  }
+}

--- a/apps/sdp-web/src/lib/api-playground-openapi-catalog.ts
+++ b/apps/sdp-web/src/lib/api-playground-openapi-catalog.ts
@@ -1,0 +1,36 @@
+import type { ApiPlaygroundEndpointConfig } from "@/components/api-playground-shell";
+import generatedCatalog from "./api-playground-catalog.generated.json";
+
+type PlaygroundModule = "wallets" | "payments" | "counterparties" | "issuance";
+
+interface GeneratedPlaygroundCatalog {
+  modules: Record<PlaygroundModule, ApiPlaygroundEndpointConfig[]>;
+}
+
+const catalog = generatedCatalog as GeneratedPlaygroundCatalog;
+
+function operationKey(endpoint: ApiPlaygroundEndpointConfig): string {
+  return `${endpoint.method} ${endpoint.path.split("?", 1)[0]}`;
+}
+
+/**
+ * Keeps the hand-authored forms for existing endpoints and fills every missing
+ * operation from the public OpenAPI module catalog.
+ */
+export function mergeOpenApiPlaygroundEndpoints(
+  module: PlaygroundModule,
+  curatedEndpoints: ApiPlaygroundEndpointConfig[]
+): ApiPlaygroundEndpointConfig[] {
+  const curatedKeys = new Set(curatedEndpoints.map(operationKey));
+  const missingEndpoints = catalog.modules[module].filter(
+    (endpoint) => !curatedKeys.has(operationKey(endpoint))
+  );
+
+  return [...curatedEndpoints, ...missingEndpoints];
+}
+
+export function getOpenApiPlaygroundEndpoints(
+  module: PlaygroundModule
+): ApiPlaygroundEndpointConfig[] {
+  return catalog.modules[module];
+}

--- a/apps/sdp-web/src/lib/api-playground-openapi-catalog.unit.test.ts
+++ b/apps/sdp-web/src/lib/api-playground-openapi-catalog.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWalletsPlaygroundEndpointConfigs } from "@/app/dashboard/custody/wallets-playground-config";
+import { buildIssuancePlaygroundEndpointConfigs } from "@/app/dashboard/issuance/issuance-playground-config";
+import { buildCounterpartyPlaygroundEndpointConfigs } from "@/app/dashboard/payments/counterparty/counterparty-playground-config";
+import { buildPaymentsPlaygroundEndpointConfigs } from "@/app/dashboard/payments/payments-playground-config";
+import type { ApiPlaygroundEndpointConfig } from "@/components/api-playground-shell";
+import { getMessages, translate } from "@/i18n/messages";
+import { getOpenApiPlaygroundEndpoints } from "./api-playground-openapi-catalog";
+
+function operationKey(endpoint: ApiPlaygroundEndpointConfig): string {
+  return `${endpoint.method} ${endpoint.path.split("?", 1)[0]}`;
+}
+
+describe("API playground module coverage", () => {
+  it("exposes every public operation only through its owning product builder", () => {
+    const messages = getMessages("en");
+    const t = (
+      key: Parameters<typeof translate<typeof messages>>[1],
+      values?: Record<string, string | number>
+    ) => translate(messages, key, values);
+    const configsByModule = {
+      wallets: buildWalletsPlaygroundEndpointConfigs({
+        connectedProviders: [],
+        wallets: [],
+        t,
+      }),
+      payments: buildPaymentsPlaygroundEndpointConfigs({ transfers: [], wallets: [] }, t),
+      counterparties: buildCounterpartyPlaygroundEndpointConfigs([], t),
+      issuance: buildIssuancePlaygroundEndpointConfigs({ templates: [], tokens: [], t }),
+    };
+
+    for (const [module, configs] of Object.entries(configsByModule)) {
+      const configuredKeys = new Set(configs.map(operationKey));
+      const publicKeys = getOpenApiPlaygroundEndpoints(module as keyof typeof configsByModule).map(
+        operationKey
+      );
+
+      expect(configuredKeys.size).toBe(configs.length);
+      expect(publicKeys.every((key) => configuredKeys.has(key))).toBe(true);
+      for (const [otherModule, otherConfigs] of Object.entries(configsByModule)) {
+        if (otherModule !== module) {
+          const otherKeys = new Set(otherConfigs.map(operationKey));
+          expect(publicKeys.some((key) => otherKeys.has(key))).toBe(false);
+        }
+      }
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "check:env-configurator-drift": "node scripts/check-env-configurator-drift.mjs",
     "check:module-boundaries": "node scripts/check-module-boundaries.mjs",
     "check:well-known-mints": "pnpm --filter @sdp/api exec tsx ../../scripts/check-well-known-mints.mjs",
+    "check:api-playground": "pnpm -C apps/sdp-api playground:check",
+    "generate:api-playground": "pnpm -C apps/sdp-api playground:generate",
     "generate:module-map": "node scripts/check-module-boundaries.mjs --write",
     "typecheck": "turbo run typecheck",
     "typecheck:all": "turbo run typecheck",


### PR DESCRIPTION
## Summary

- generate a module-owned API Playground catalog from the public OpenAPI contract
- merge missing operations into the Wallets, Payments, Counterparties, and Issuance tabs while preserving curated forms
- add validated JSON request-body editing, optional query handling, and DELETE request-body forwarding
- add drift and module-ownership coverage so future OpenAPI additions cannot silently disappear from the playground

## Why

The playground endpoint lists had drifted behind the public contract. Only 39 of the 104 public operations owned by these four modules were represented. Manual inventories also made it easy to classify endpoints by URL prefix instead of their actual OpenAPI module.

The generated catalog now uses exact OpenAPI tags as the ownership boundary. This exposes 19 Wallets, 40 Payments, 12 Counterparties, and 33 Issuance operations without folding sibling modules such as Asset Profiles into Issuance.

## Impact

Developers can discover and execute the complete public API surface from the appropriate dashboard tab. Complex generated payloads remain editable as JSON, and documented DELETE bodies now reach the API correctly.

## Validation

- `pnpm --filter sdp-web build`
- `pnpm --filter sdp-web test:unit` (394 tests)
- `pnpm --filter sdp-web typecheck`
- `pnpm --filter @sdp/api typecheck`
- `pnpm check:module-boundaries`
- `pnpm check:api-playground`
- targeted Biome checks

## Note

`pnpm --filter sdp-web check:i18n` still reports unrelated pre-existing findings in `not-found.tsx`, the public payment loading state, and `flags.ts`; this change introduces no new playground findings.
