### PR TITLE
fix(scripts): strip surrounding quotes when overlaying .env.local

### DIFF
--- a/scripts/doppler/run-with-config.sh
+++ b/scripts/doppler/run-with-config.sh
@@ -14,6 +14,12 @@ done
 # consumer of these files (Next.js and dev-local.mjs): split on the
 # first "=", keep the value literal. Never `source` them — shell parsing would
 # expand/execute characters like $, #, and backticks inside secret values.
+#
+# One layer of matching surrounding quotes is stripped, because that is what
+# dotenv (Next.js) and dev-local.mjs both do when they read the same file.
+# Exporting `KEY="value"` verbatim puts literal quote characters in the value,
+# and since the process environment wins over Next.js's own .env.local parsing,
+# every quoted var reaches the app malformed — Clerk rejects such a key outright.
 load_env_files() {
   local file line key value
   for file in "$@"; do
@@ -22,6 +28,16 @@ load_env_files() {
       case "$line" in '' | '#'*) continue ;; esac
       key="${line%%=*}"
       value="${line#*=}"
+      case "$value" in
+      '"'*'"')
+        value="${value#\"}"
+        value="${value%\"}"
+        ;;
+      "'"*"'")
+        value="${value#\'}"
+        value="${value%\'}"
+        ;;
+      esac
       case "$key" in
       [A-Za-z_]*) export "$key=$value" ;;
       esac


### PR DESCRIPTION
## What

The env-file overlay in `scripts/doppler/run-with-config.sh` split each line on the first `=` and exported the value verbatim, so `KEY="value"` reached the process with literal quote characters in it.

The process environment wins over Next.js's own `.env.local` parsing, so every quoted variable arrived malformed in `sdp-web`. Clerk rejected the publishable key outright and the dashboard returned 500 on every route.

## Why it looked like a bad key

`apps/sdp-api/scripts/dev-local.mjs:34-35` already strips one layer of matching quotes, which is why `sdp-api` was unaffected. The split made this look like a Clerk credential problem rather than a parsing bug. The key was byte-identical to the one in Doppler the whole time.

133 of the 134 assignments in each `apps/*/.env.local` are quoted, so this affected effectively every variable, not just Clerk's.

## Safety

Values are still treated as inert data. Only one balanced layer of quotes is removed; lone or unbalanced quotes are left intact, and `$` and backticks are never expanded. Verified against a fixture covering unquoted values, single and double quotes, embedded `=`, embedded `#`, JSON values, `$HOME`, backticks, and unbalanced quotes.

## Verification

- `sdp-web` boots and `/` and `/sign-in` return 200 with zero Clerk errors
- `sdp-api` still boots, migrations apply, health returns 200