### PR TITLE
fix(types): declare USDG under the Token-2022 program

### DIFF
--- a/packages/sdp-types/src/well-known-tokens.ts
+++ b/packages/sdp-types/src/well-known-tokens.ts
@@ -66,7 +66,7 @@ export const WELL_KNOWN_TOKENS = {
     symbol: "USDG",
     decimals: 6,
     isUsdStable: true,
-    tokenProgram: "spl-token",
+    tokenProgram: "token-2022",
     mints: {
       // biome-ignore lint/security/noSecrets: Devnet USDG mint address constant, not a secret.
       devnet: "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7",


### PR DESCRIPTION
## What

`WELL_KNOWN_TOKENS.USDG` declared `tokenProgram: "spl-token"`. USDG is owned by the Token-2022 program on both mainnet and devnet.

## Evidence

Queried directly against chain. The mint reports owner `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` and carries Token-2022 extensions:

```
mintCloseAuthority, permanentDelegate, transferFeeConfig,
confidentialTransferMint, confidentialTransferFeeConfig, transferHook
```

PYUSD, the other Token-2022 entry in the catalogue, was already declared correctly.

## Severity

Latent rather than live. Nothing reads this field today — the transfer path resolves the owning program from the mint account at runtime via `resolveMintTokenProgram` (`token-accounts.ts:219-228`), so no current code path trusts the constant.

It is still a trap: anyone deriving an associated token account from the declared program would build the address under the wrong program and the transfer would fail.

## Worth a separate look

USDG carries `transferFeeConfig` and `transferHook`. For a payments product that means received can differ from sent on USDG transfers. Not addressed here, flagging it for whoever owns transfer accounting.