### PR TITLE
feat(web): ff for AlphaLedger integration for tokenization 

### DIFF
--- a/apps/sdp-web/src/app/dashboard/issuance/create/issuance-draft-wizard.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/issuance-draft-wizard.tsx
@@ -290,7 +290,7 @@ function WizardShell({ signerWallets, signerWalletsError }: IssuanceDraftWizardP
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="shrink-0 px-4 pt-2 pb-6 md:px-6">
+      <div className="shrink-0 px-4 pt-8 pb-6 md:px-6">
         <div className="mx-auto w-full max-w-6xl">
           <WizardProgress currentStep={currentStep} />
         </div>

--- a/apps/sdp-web/src/app/dashboard/issuance/create/selection-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/selection-card.tsx
@@ -28,10 +28,10 @@ export function SelectionCard({
       // "advance" instead of skipping it like other buttons.
       data-enter-advance
       className={cn(
-        "flex flex-col rounded-2xl border p-3.5 text-left transition-colors",
+        "flex flex-col rounded-2xl border border-border-default p-3.5 text-left outline outline-2 -outline-offset-2 transition-colors",
         selected
-          ? "border-primary bg-fill-subtle"
-          : "border-border-default bg-surface-raised hover:bg-fill-subtle"
+          ? "bg-fill-subtle outline-border-strong ring-2 ring-tertiary ring-offset-2 ring-offset-white"
+          : "bg-surface-raised outline-transparent hover:bg-fill-subtle"
       )}
     >
       <div className="flex items-start justify-between gap-3">

--- a/apps/sdp-web/src/app/dashboard/issuance/create/steps/step-classification.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/create/steps/step-classification.tsx
@@ -29,9 +29,9 @@ export function StepClassification() {
       className="space-y-6"
     >
       <div>
-        <h2 className="text-xl font-medium text-primary">
+        <h1 className="text-2xl font-medium tracking-tight text-primary">
           {t("DashboardIssuance.classification.title")}
-        </h2>
+        </h1>
         <p className="mt-1 text-sm text-secondary">
           {t("DashboardIssuance.classification.description")}
         </p>
@@ -48,9 +48,11 @@ export function StepClassification() {
         <p className="text-sm text-tertiary">{t("DashboardIssuance.classification.nameHint")}</p>
       </div>
 
-      <div className="space-y-3">
+      <div className="space-y-4">
         <div className="flex items-center justify-between gap-3">
-          <Label>{t("DashboardIssuance.classification.chooseClassification")}</Label>
+          <Label className="text-base">
+            {t("DashboardIssuance.classification.chooseClassification")}
+          </Label>
           <a
             href="https://platform.solana.com/docs/reference/issuance-token-types#selecting-a-template"
             target="_blank"
@@ -93,15 +95,16 @@ export function StepClassification() {
       </div>
 
       {category ? (
-        // Keyed by category so switching classifications re-runs the reveal with
-        // the new category's sub types.
+        // Unkeyed on purpose: the reveal runs once when a category is first
+        // chosen, not on every classification swap.
         <motion.div
-          key={category.category}
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
-          className="space-y-3"
+          className="space-y-4"
         >
-          <Label>{t("DashboardIssuance.classification.chooseAssetType")}</Label>
+          <Label className="text-base">
+            {t("DashboardIssuance.classification.chooseAssetType")}
+          </Label>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
             {category.subTypes.map((subType) => (
               <SelectionCard

--- a/apps/sdp-web/src/flags.ts
+++ b/apps/sdp-web/src/flags.ts
@@ -53,6 +53,18 @@ export const organizationOnboarding = flag<boolean, DashboardFlagEntities>({
   ],
 });
 
+export const alphaledgerTokenizationEngine = flag<boolean, DashboardFlagEntities>({
+  key: "alphaledger-tokenization-engine",
+  adapter: vercelAdapter(),
+  identify: identifyDashboardEntities,
+  defaultValue: false,
+  description: "Offer the AlphaLedger tokenization engine as an issuance provider option.",
+  options: [
+    { value: false, label: "Mosaic only" },
+    { value: true, label: "AlphaLedger available" },
+  ],
+});
+
 export const assetProfiles = flag<boolean, DashboardFlagEntities>({
   key: "asset-profiles",
   adapter: vercelAdapter(),


### PR DESCRIPTION
Groundwork for the AlphaLedger tokenization-engine integration:

- Adds the `alphaledger-tokenization-engine` dashboard feature flag (default off, "Mosaic only") to gate offering AlphaLedger as an issuance provider option.
- Small polish on the issuance wizard classification step: page-level heading, larger section labels, refined selection-card selected state, and the sub-type reveal no longer re-animates on every classification swap.