### PR TITLE
fix(api): fail invites with an unresolved inviter instead of writing a bad FK

### DIFF
--- a/apps/sdp-api/src/routes/members/handlers.ts
+++ b/apps/sdp-api/src/routes/members/handlers.ts
@@ -112,7 +112,7 @@ async function getClerkUserId(db: DatabaseClient, userId: string): Promise<strin
  *
  * Clerk requires a `requesting_user_id` to revoke an invitation, and the more
  * specific sources can all come up empty: an API key carries no Clerk user of
- * its own, `invited_by` may be the `"system"` sentinel with no identity row,
+ * its own, legacy rows may carry a `"system"` sentinel with no identity row,
  * and Clerk's own `inviter_id` is optional on its invitation object. An
  * administrator is entitled to revoke, so attributing it to one keeps the
  * revocation possible rather than failing it. The local audit trail still
@@ -466,6 +466,14 @@ export const inviteMember = async (c: AppContext) => {
 
   const inviterUserId = userId || inviterKey?.created_by || null;
 
+  // `invitations.invited_by` is a NOT NULL foreign key onto `users`
+  // (0001_initial_schema.sql:112,118), so there is no sentinel that can stand in for a
+  // missing inviter: writing one only trades this error for an opaque constraint
+  // violation at insert time. Fail here, where the cause is still legible.
+  if (!inviterUserId) {
+    throw new AppError("UNAUTHORIZED", "Inviter identity could not be resolved");
+  }
+
   const clerkService = new ClerkOrganizationsService(c.env);
   const redirectUrl = resolveInviteRedirectUrl(c.env);
   const clerkInvitation = await clerkService.createOrganizationInvitation({
@@ -500,7 +508,7 @@ export const inviteMember = async (c: AppContext) => {
       organizationId,
       normalizedEmail,
       role,
-      inviterUserId || "system",
+      inviterUserId,
       tokenHash,
       expiresAt,
       clerkInvitation.id


### PR DESCRIPTION
`invitations.invited_by` is a NOT NULL foreign key onto `users`, but the invite handler bound `inviterUserId || "system"`. That sentinel has no user row, so it could only ever violate the constraint.

It is unreachable in practice: the Clerk middleware creates the local `users` row if it is missing and returns a non-null id, and `api_keys.created_by` is itself a NOT NULL FK onto `users`. So this is dead-code removal plus a guard, not a fix for a live failure. Worth doing because the sentinel reads as a supported fallback and previously sent a reviewer down the wrong path.

Behaviour on the working path is unchanged. If the branch is ever reached it now returns UNAUTHORIZED instead of an opaque constraint violation.

The comment on `getAnyOrgAdminClerkUserId` is reworded: legacy rows may still carry "system", so the read path keeps tolerating it, but nothing writes it anymore.

Two other items from the same ticket didn't survive investigation: the invite form is already role-gated at `settings/page.tsx:176` (withdrawn), and replacing the hand-rolled web member types is a cross-package change, so it's split out.