### PR TITLE
fix(release): patch npm in runtime images

### DIFF
--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -53,9 +53,14 @@ ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \
     MIGRATIONS_DIR=/app/migrations
 
-# Apply OS-level security patches not yet in the pinned base image.
+# Update npm for patched node-tar (CVE-2026-59873) and apply OS-level fixes
+# not yet in the pinned base image.
 # This layer is cached — rebuild with --no-cache to pick up new fixes.
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 \
+ && npm cache clean --force \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 
 # UID/GID 1001 matches sdp-web so k8s securityContext is consistent.
 RUN groupadd --system --gid 1001 nodejs \

--- a/apps/sdp-docs/Dockerfile
+++ b/apps/sdp-docs/Dockerfile
@@ -63,9 +63,14 @@ ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \
     NEXT_TELEMETRY_DISABLED=1
 
-# Apply OS-level security patches not yet in the pinned base image.
+# Update npm for patched node-tar (CVE-2026-59873) and apply OS-level fixes
+# not yet in the pinned base image.
 # This layer is cached — rebuild with --no-cache to pick up new fixes.
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 \
+ && npm cache clean --force \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --system --gid 1001 nodejs \
  && useradd --system --uid 1001 --gid nodejs nextjs

--- a/apps/sdp-web/Dockerfile
+++ b/apps/sdp-web/Dockerfile
@@ -133,9 +133,14 @@ ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \
     NEXT_TELEMETRY_DISABLED=1
 
-# Apply OS-level security patches not yet in the pinned base image.
+# Update npm for patched node-tar (CVE-2026-59873) and apply OS-level fixes
+# not yet in the pinned base image.
 # This layer is cached — rebuild with --no-cache to pick up new fixes.
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 \
+ && npm cache clean --force \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 
 # Run as an unprivileged user. UID/GID 1001 matches the convention used by
 # the upstream Next.js Docker example to make k8s securityContext predictable.


### PR DESCRIPTION
## Summary

- pin npm 12.0.2 in the final API, web, and docs runtime images
- retain the existing pinned Node base image and Debian security-upgrade step
- update npm's bundled `tar` from 7.5.11 to 7.5.19

## Root cause

The `v0.50.0` Release Images workflow stopped before publishing any GHCR images because Trivy detected critical `CVE-2026-59873` in npm's bundled `tar` 7.5.11. All three runtime Dockerfiles inherit the same affected npm package. The current floating `node:22-slim` image still contains 7.5.11, so refreshing only the Node digest would not close the finding.

## Impact

This restores the existing CRITICAL image-scan gate without weakening it and allows the next patch release to publish API, web, and docs images. Application code, dependencies, runtime users, entrypoints, and commands are unchanged.

## Validation

On the authenticated Linux builder, for each of `sdp-api`, `sdp-web`, and `sdp-docs`:

- built the final `linux/amd64` image successfully
- verified `/usr/local/lib/node_modules/npm/node_modules/tar/package.json` reports 7.5.19
- ran `trivy image --scanners vuln --severity CRITICAL --ignore-unfixed --exit-code 1`
- result: 0 CRITICAL vulnerabilities for every image
- verified the configured runtime user, entrypoint, and command remained unchanged

The builder does not currently have arm64 emulation configured. The npm package change is architecture-independent; release-platform validation remains responsible for the arm64 build and scan.
