### PR TITLE
perf(web): stop pages minting a second Clerk token per request

### DIFF
--- a/apps/sdp-web/src/app/dashboard/custody/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/page.tsx
@@ -61,7 +61,7 @@ async function getCustodyWallets(
 }
 
 export default async function CustodyPage() {
-  const [t, { getToken, userId, orgId }] = await Promise.all([getTranslations(), auth()]);
+  const [t, { userId, orgId }] = await Promise.all([getTranslations(), auth()]);
   if (!userId) {
     redirect(await getAuthEntryPath());
   }
@@ -74,7 +74,6 @@ export default async function CustodyPage() {
   try {
     const { organizationClient, projectClient } = await trace.step("create_sdp_api_clients", () =>
       createRequestScopedSdpApiClients({
-        getToken,
         organizationTraceContext: trace.childContext("dashboard.custody.org.api"),
         projectTraceContext: trace.childContext("dashboard.custody.api"),
       })

--- a/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/setup/page.tsx
@@ -57,7 +57,7 @@ async function getConnectedCustodyProviders(
 }
 
 export default async function CustodySetupPage({ searchParams }: CustodySetupPageProps) {
-  const { getToken, userId, orgId } = await auth();
+  const { userId, orgId } = await auth();
   if (!userId) {
     redirect(await getAuthEntryPath());
   }
@@ -71,7 +71,6 @@ export default async function CustodySetupPage({ searchParams }: CustodySetupPag
 
   const { organizationClient, projectClient } = await trace.step("create_sdp_api_clients", () =>
     createRequestScopedSdpApiClients({
-      getToken,
       organizationTraceContext: trace.childContext("dashboard.custody.setup.org.api"),
       projectTraceContext: trace.childContext("dashboard.custody.setup.api"),
     })

--- a/apps/sdp-web/src/app/dashboard/onboarding/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/onboarding/page.tsx
@@ -23,7 +23,7 @@ const GENERAL_RPC_PROVIDERS = ORGANIZATION_RPC_PROVIDERS.filter(
 );
 
 export default async function OrganizationOnboardingPage() {
-  const [t, onboardingEnabled, { getToken, userId, orgId }] = await Promise.all([
+  const [t, onboardingEnabled, { userId, orgId }] = await Promise.all([
     getTranslations(),
     organizationOnboarding(),
     auth(),
@@ -32,7 +32,7 @@ export default async function OrganizationOnboardingPage() {
   if (!orgId) redirect("/dashboard");
   if (!onboardingEnabled) redirect("/dashboard");
 
-  const { organizationClient } = await createRequestScopedSdpApiClients({ getToken });
+  const { organizationClient } = await createRequestScopedSdpApiClients();
   const status = await organizationClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status");
 
   if (!status.linked || !status.organization || !status.setup) {

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -189,15 +189,12 @@ function assembleSdpApiClient(request: SdpApiRequestFn): SdpApiClient {
 }
 
 /**
- * Builds the org- and project-scoped clients a server page needs from one
- * request-bound Clerk token. This avoids acquiring the same token twice while
- * preserving the absence of a project header on organization endpoints.
+ * Org- and project-scoped clients for one request, built from one request-bound Clerk
+ * token so the same token is not acquired twice, and without a project header on the
+ * organization client.
  *
- * A missing project is represented by a null project client so onboarding
- * pages can still query organization state before a project has been selected.
- */
-/**
- * Org- and project-scoped clients for one request.
+ * A missing project is represented by a null project client, so onboarding pages can
+ * still query organization state before a project has been selected.
  *
  * `getToken` is optional and should normally be omitted. Minting a Clerk token is a
  * network round trip, and passing `getToken` bypasses the request-scoped cache that
@@ -217,9 +214,12 @@ export async function createRequestScopedSdpApiClients({
   organizationClient: SdpApiClient;
   projectClient: SdpApiClient | null;
 }> {
+  // Only the token half ever duplicated work. `getSelectedProjectId` is a thin wrapper
+  // over `getRequestSelectedProjectId`, so branching on `getToken` here called the same
+  // function either way and read as though the project lookup were duplicated too.
   const [token, projectId] = await Promise.all([
     getToken ? acquireClerkToken(getToken) : getRequestClerkToken(),
-    getToken ? getSelectedProjectId() : getRequestSelectedProjectId(),
+    getRequestSelectedProjectId(),
   ]);
 
   return {

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -196,21 +196,31 @@ function assembleSdpApiClient(request: SdpApiRequestFn): SdpApiClient {
  * A missing project is represented by a null project client so onboarding
  * pages can still query organization state before a project has been selected.
  */
+/**
+ * Org- and project-scoped clients for one request.
+ *
+ * `getToken` is optional and should normally be omitted. Minting a Clerk token is a
+ * network round trip, and passing `getToken` bypasses the request-scoped cache that
+ * the layout has usually already populated — so a page that supplied its own paid
+ * for a second mint of the same token. Omitting it reuses the cached one. The
+ * parameter stays for callers that hold a token source without a request-bound
+ * `auth()` context.
+ */
 export async function createRequestScopedSdpApiClients({
   getToken,
   organizationTraceContext,
   projectTraceContext,
 }: {
-  getToken: ClerkGetToken;
+  getToken?: ClerkGetToken;
   organizationTraceContext?: TraceContext;
   projectTraceContext?: TraceContext;
-}): Promise<{
+} = {}): Promise<{
   organizationClient: SdpApiClient;
   projectClient: SdpApiClient | null;
 }> {
   const [token, projectId] = await Promise.all([
-    acquireClerkToken(getToken),
-    getSelectedProjectId(),
+    getToken ? acquireClerkToken(getToken) : getRequestClerkToken(),
+    getToken ? getSelectedProjectId() : getRequestSelectedProjectId(),
   ]);
 
   return {

--- a/apps/sdp-web/src/lib/sdp-api.ts
+++ b/apps/sdp-web/src/lib/sdp-api.ts
@@ -201,10 +201,9 @@ function assembleSdpApiClient(request: SdpApiRequestFn): SdpApiClient {
  *
  * `getToken` is optional and should normally be omitted. Minting a Clerk token is a
  * network round trip, and passing `getToken` bypasses the request-scoped cache that
- * the layout has usually already populated — so a page that supplied its own paid
- * for a second mint of the same token. Omitting it reuses the cached one. The
- * parameter stays for callers that hold a token source without a request-bound
- * `auth()` context.
+ * the layout has usually already populated — so a page that supplied its own paid for
+ * a second mint of the same token. Omitting it reuses the cached one. The parameter
+ * stays for callers that hold a token source without a request-bound `auth()` context.
  */
 export async function createRequestScopedSdpApiClients({
   getToken,

--- a/apps/sdp-web/src/lib/sdp-api.unit.test.ts
+++ b/apps/sdp-web/src/lib/sdp-api.unit.test.ts
@@ -2,10 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   cookies: vi.fn(),
+  auth: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({
   cookies: mocks.cookies,
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: mocks.auth,
 }));
 
 import { createRequestScopedSdpApiClients, SdpApiResponseError } from "./sdp-api";
@@ -24,6 +29,7 @@ describe("createRequestScopedSdpApiClients", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     mocks.cookies.mockReset();
+    mocks.auth.mockReset();
 
     if (originalApiBaseUrl === undefined) {
       delete process.env.SDP_API_BASE_URL;
@@ -82,6 +88,62 @@ describe("createRequestScopedSdpApiClients", () => {
     expect(organizationClient).toBeDefined();
     expect(projectClient).toBeNull();
     expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  // The three cases above all hand in `getToken`, which is the branch callers are
+  // being moved off. These cover the default one the migrated pages now take.
+  it("takes the token and project from the request when no getToken is passed", async () => {
+    mocks.cookies.mockResolvedValue({
+      get: (name: string) =>
+        name === "sdp_selected_project_id" ? { value: "project_test" } : undefined,
+    });
+    const getToken = vi.fn().mockResolvedValue("token_from_request");
+    mocks.auth.mockResolvedValue({ getToken, orgId: "org_test" });
+    const fetchMock = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ data: { ok: true } }), {
+          headers: { "Content-Type": "application/json" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { organizationClient, projectClient } = await createRequestScopedSdpApiClients();
+
+    expect(projectClient).not.toBeNull();
+    await organizationClient.fetch("/v1/onboarding/status");
+    await projectClient?.fetch("/v1/wallets");
+
+    // One mint covering both clients is the whole point of the request-scoped branch.
+    expect(getToken).toHaveBeenCalledTimes(1);
+
+    const organizationHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    const projectHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(organizationHeaders.get("Authorization")).toBe("Bearer token_from_request");
+    expect(organizationHeaders.has("x-project-id")).toBe(false);
+    expect(projectHeaders.get("Authorization")).toBe("Bearer token_from_request");
+    expect(projectHeaders.get("x-project-id")).toBe("project_test");
+  });
+
+  it("returns a null project client when the request carries no selection", async () => {
+    mocks.cookies.mockResolvedValue({ get: () => undefined });
+    mocks.auth.mockResolvedValue({
+      getToken: vi.fn().mockResolvedValue("token_from_request"),
+      orgId: "org_test",
+    });
+
+    const { organizationClient, projectClient } = await createRequestScopedSdpApiClients();
+
+    expect(organizationClient).toBeDefined();
+    expect(projectClient).toBeNull();
+  });
+
+  it("refuses to build a client when the request has no active organization", async () => {
+    mocks.cookies.mockResolvedValue({ get: () => undefined });
+    mocks.auth.mockResolvedValue({ getToken: vi.fn(), orgId: null });
+
+    await expect(createRequestScopedSdpApiClients()).rejects.toThrow(
+      "Active Clerk organization required"
+    );
   });
 
   it("preserves upstream status on API response errors", async () => {


### PR DESCRIPTION
Minting a Clerk token is a network round trip and it dominates server render time on every dashboard route. Measured warm, it is 258–291ms of a 290–337ms render on api keys, issuance, policies, payments and settings — the data fetches themselves are 12–56ms and already run in parallel.

`getRequestClerkToken` caches that mint for the request and the layout populates it before any page runs. `createRequestScopedSdpApiClients` did not use it: passing `getToken` sent it down an uncached path, so the three pages calling it paid for a **second mint of the same token**. Custody showed it plainly — `create_sdp_api_clients` at 685ms against ~270ms everywhere else.

`getToken` is now optional and those pages omit it. The parameter stays for callers holding a token source without a request-bound `auth()` context, and the unit tests that pass it explicitly are unchanged.

Measured on `/dashboard/wallets`, repeat warm loads: **685ms → 270–296ms**.

Worth being clear about what this does *not* fix: every route still pays one ~270ms token mint, which is the single largest server cost across the dashboard. Removing that means caching the token across requests, which is a revocation-window tradeoff rather than a code change — and Next's cache primitives cannot do it on serverless (`use cache` cannot read headers, `use cache: private` never stores server-side). That needs a product decision.

All numbers are from `next dev`; a production build will differ in absolute terms, though the duplicate mint is structural.