### PR TITLE
fix(sdp-web): repair policy search and table responsiveness

### DIFF
--- a/apps/sdp-web/playwright/tests/policies.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/policies.e2e.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+import { getPlaywrightAdminSession } from "../support/auth-session";
+import { createLocalApiClient } from "../support/local-api-client";
+import {
+  bootstrapLocalWalletFixtures,
+  ensureLinkedOrg,
+  getBootstrapApiBaseUrl,
+  resolvePlaywrightProjectId,
+  seedProjectCookie,
+} from "../support/local-dashboard-bootstrap";
+
+const E2E_TIMEOUT_MS = 180_000;
+
+test.describe("policies responsive table", () => {
+  let projectId = "";
+
+  test.beforeAll(async ({ browser }) => {
+    const session = await getPlaywrightAdminSession(browser);
+
+    try {
+      await ensureLinkedOrg(session.identity, { tier: "enterprise" });
+      const fixtures = await bootstrapLocalWalletFixtures({
+        identity: session.identity,
+        bearerToken: session.getBearerToken,
+        provider: "privy",
+        walletCount: 1,
+        walletLabel: `Policies responsive ${Date.now().toString(36).toUpperCase()}`,
+        tier: "enterprise",
+      });
+      const wallet = fixtures.wallets[0];
+      if (!wallet) {
+        throw new Error("Failed to create a wallet for Policies responsive coverage");
+      }
+
+      projectId = await resolvePlaywrightProjectId(
+        getBootstrapApiBaseUrl(),
+        session.getBearerToken
+      );
+      const api = createLocalApiClient(getBootstrapApiBaseUrl(), session.getBearerToken, projectId);
+      await api.put(`/v1/payments/wallets/${encodeURIComponent(wallet.walletId)}/policies`, {
+        destinationAllowlist: [],
+        maxTransferAmount: "25",
+      });
+    } finally {
+      await session.page.close();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await seedProjectCookie(page, projectId);
+  });
+
+  test("uses cards on phones and progressively reveals table columns without overflow", async ({
+    page,
+  }) => {
+    const desktopInventory = page.locator("[data-desktop-inventory]");
+    const mobileInventory = page.locator("[data-mobile-inventory]");
+    const column = (name: string) => page.locator("th").filter({ hasText: name });
+    const expectNoOverflow = async () => {
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
+        .toBe(true);
+    };
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/dashboard/policies", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: "Policies" })).toBeVisible({
+      timeout: E2E_TIMEOUT_MS,
+    });
+    await expect(mobileInventory).toBeVisible({ timeout: E2E_TIMEOUT_MS });
+    await expect(desktopInventory).toBeHidden();
+    await expectNoOverflow();
+
+    await page.setViewportSize({ width: 1024, height: 900 });
+    await expect(desktopInventory).toBeVisible();
+    await expect(mobileInventory).toBeHidden();
+    await expect(column("Rules")).toBeHidden();
+    await expect(column("Bindings")).toBeHidden();
+    await expect(column("Last updated")).toBeHidden();
+    await expectNoOverflow();
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expect(column("Rules")).toBeVisible();
+    await expect(column("Bindings")).toBeHidden();
+    await expect(column("Last updated")).toBeHidden();
+    await expectNoOverflow();
+
+    await page.setViewportSize({ width: 1536, height: 900 });
+    await expect(column("Rules")).toBeVisible();
+    await expect(column("Bindings")).toBeVisible();
+    await expect(column("Last updated")).toBeVisible();
+    await expectNoOverflow();
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/policies/policies-overview.tsx
+++ b/apps/sdp-web/src/app/dashboard/policies/policies-overview.tsx
@@ -302,13 +302,13 @@ function LoadingRows() {
       <TableCell>
         <SkeletonBlock className="h-4 w-16" />
       </TableCell>
-      <TableCell>
+      <TableCell className="hidden xl:table-cell 2xl:w-[12%]">
         <SkeletonBlock className="h-4 w-20" />
       </TableCell>
-      <TableCell>
+      <TableCell className="hidden 2xl:table-cell 2xl:w-[15%]">
         <SkeletonBlock className="h-4 w-20" />
       </TableCell>
-      <TableCell>
+      <TableCell className="hidden 2xl:table-cell 2xl:w-[15%]">
         <SkeletonBlock className="h-4 w-20" />
       </TableCell>
       <TableCell>
@@ -370,16 +370,28 @@ function InventoryTable({
   }
   return (
     <div data-desktop-inventory className="hidden lg:block">
-      <Table className="rounded-none border-0 [&::after]:hidden [&::before]:hidden [&_table]:min-w-[1160px] [&_table]:table-fixed [&_td]:whitespace-nowrap [&_td]:py-4 [&_th]:whitespace-nowrap">
+      <Table className="rounded-none border-0 [&::after]:hidden [&::before]:hidden [&_table]:min-w-0 [&_table]:table-fixed [&_td]:whitespace-nowrap [&_td]:py-4 [&_th]:whitespace-nowrap">
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[22%]">{t("DashboardPolicies.target")}</TableHead>
-            <TableHead className="w-[13%]">{t("DashboardPolicies.status")}</TableHead>
-            <TableHead className="w-[15%]">{t("DashboardPolicies.defaultAction")}</TableHead>
-            <TableHead className="w-[12%]">{t("DashboardPolicies.rules")}</TableHead>
-            <TableHead className="w-[15%]">{t("DashboardPolicies.bindings")}</TableHead>
-            <TableHead className="w-[15%]">{t("DashboardPolicies.lastUpdated")}</TableHead>
-            <TableHead className="w-[8%] text-right">{t("DashboardPolicies.actions")}</TableHead>
+            <TableHead className="w-[45%] xl:w-[35%] 2xl:w-[22%]">
+              {t("DashboardPolicies.target")}
+            </TableHead>
+            <TableHead className="w-[17%] xl:w-[16%] 2xl:w-[13%]">
+              {t("DashboardPolicies.status")}
+            </TableHead>
+            <TableHead className="w-[28%] xl:w-[22%] 2xl:w-[15%]">
+              {t("DashboardPolicies.defaultAction")}
+            </TableHead>
+            <TableHead className="hidden xl:table-cell xl:w-[17%] 2xl:w-[12%]">
+              {t("DashboardPolicies.rules")}
+            </TableHead>
+            <TableHead className="hidden 2xl:table-cell 2xl:w-[15%]">
+              {t("DashboardPolicies.bindings")}
+            </TableHead>
+            <TableHead className="hidden 2xl:table-cell 2xl:w-[15%]">
+              {t("DashboardPolicies.lastUpdated")}
+            </TableHead>
+            <TableHead className="w-[10%] text-right">{t("DashboardPolicies.actions")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -396,11 +408,13 @@ function InventoryTable({
                   <TableCell className="text-sm text-secondary">
                     {formatDefaultAction(item.defaultAction, t)}
                   </TableCell>
-                  <TableCell className="text-sm text-secondary">{formatRules(item, t)}</TableCell>
-                  <TableCell className="text-sm text-secondary">
+                  <TableCell className="hidden text-sm text-secondary xl:table-cell">
+                    {formatRules(item, t)}
+                  </TableCell>
+                  <TableCell className="hidden text-sm text-secondary 2xl:table-cell">
                     {formatBindings(item, t)}
                   </TableCell>
-                  <TableCell className="text-sm text-secondary">
+                  <TableCell className="hidden text-sm text-secondary 2xl:table-cell">
                     <time
                       dateTime={item.updatedAt}
                       title={new Date(item.updatedAt).toLocaleString(locale)}
@@ -527,15 +541,15 @@ export function PoliciesOverviewSurface({
               placeholder={t("DashboardPolicies.searchPlaceholder")}
               aria-label={t("DashboardPolicies.searchPlaceholder")}
               iconLeft={<SearchIcon />}
-              iconRight={
+              action={
                 searchValue ? (
                   <button
                     type="button"
                     aria-label={t("DashboardPolicies.clearSearch")}
                     onClick={() => onSearchChange("")}
-                    className="rounded text-tertiary hover:text-primary"
+                    className="rounded text-tertiary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-default"
                   >
-                    <XIcon />
+                    <XIcon className="size-5" />
                   </button>
                 ) : undefined
               }

--- a/apps/sdp-web/src/app/dashboard/policies/policies-overview.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/policies/policies-overview.unit.test.tsx
@@ -117,6 +117,21 @@ describe("PoliciesOverviewSurface", () => {
     expect(markup).toContain("No restrictions");
   });
 
+  it("renders the clear-search control in the input action slot", () => {
+    const markup = renderSurface({
+      inventory: inventory([wallet("active", "active")]),
+      searchValue: "treasury",
+    });
+    const clearButtonIndex = markup.indexOf('aria-label="Clear search"');
+    const actionSlotIndex = markup.lastIndexOf(
+      "relative z-10 inline-flex shrink-0 items-center justify-center",
+      clearButtonIndex
+    );
+
+    expect(clearButtonIndex).toBeGreaterThan(-1);
+    expect(actionSlotIndex).toBeGreaterThan(-1);
+  });
+
   it("renders five table skeleton rows while loading", () => {
     const markup = renderSurface({ inventory: null, loading: true });
     expect(markup.match(/data-policy-skeleton-row/g)).toHaveLength(5);
@@ -144,6 +159,14 @@ describe("PoliciesOverviewSurface", () => {
     const markup = renderSurface({ inventory: inventory([wallet("active", "active")]) });
     expect(markup).toMatch(/data-desktop-inventory="true"[^>]*hidden lg:block/);
     expect(markup).toMatch(/data-mobile-inventory="true"[^>]*lg:hidden/);
+  });
+
+  it("progressively hides lower-priority table columns on compact desktops", () => {
+    const markup = renderSurface({ inventory: inventory([wallet("active", "active")]) });
+
+    expect(markup).toContain("hidden xl:table-cell xl:w-[17%] 2xl:w-[12%]");
+    expect(markup).toContain("hidden 2xl:table-cell 2xl:w-[15%]");
+    expect(markup).not.toContain("min-w-[1160px]");
   });
 });
 


### PR DESCRIPTION
## Summary

- Make the Policies search clear control interactive by using the input action slot.
- Remove the forced 1160px table minimum and progressively hide lower-priority columns:
  - 1024px+: Target, Status, Default action, Actions
  - 1280px+: add Rules
  - 1536px+: add Bindings and Last updated
- Add unit and authenticated dashboard E2E regression coverage for the clear control and responsive table.

## Why

The clear-search icon was rendered in the design-system icon slot, which disables pointer events. The Policies table also forced horizontal scrolling at narrower desktop widths.

## Validation

- `pnpm --filter sdp-web test:unit -- src/app/dashboard/policies/policies-overview.unit.test.tsx`
- `pnpm --filter sdp-web typecheck`
- `pnpm --filter sdp-web build`
- `pnpm exec biome check …`

The new responsive E2E test covers 390, 1024, 1280, and 1536px widths. It could not run locally because the Docker daemon is unavailable, so the test Postgres and Redis services cannot start.
