### PR TITLE
fix(api): enforce tenant-scoped data access

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0046_signing_requests_project_scope.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0046_signing_requests_project_scope.sql
@@ -1,0 +1,12 @@
+ALTER TABLE signing_requests
+ADD COLUMN IF NOT EXISTS project_id TEXT REFERENCES projects(id) ON DELETE SET NULL;
+
+UPDATE signing_requests AS request
+SET project_id = config.project_id
+FROM custody_configs AS config
+WHERE request.custody_config_id = config.id
+  AND request.project_id IS NULL
+  AND config.project_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_signing_requests_org_project
+ON signing_requests(organization_id, project_id);

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -302,6 +302,11 @@ export {
   createPrivateChannelVerifiedWalletRepository,
   createPrivateChannelWithdrawalRepository,
   createProjectUserRepository,
+  createSystemAssetProfilesRepository,
+  createSystemCounterpartiesRepository,
+  createSystemPaymentRequestsRepository,
+  createSystemPaymentsRepository,
+  createSystemPaymentTransferBatchesRepository,
   createTokenRepository,
 } from "./repository-factory";
 export type {

--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -164,6 +164,7 @@ function mapPolicyRow(row: Record<string, unknown>): PaymentWalletPolicyRow {
 function buildTransferScopeWhere(params: {
   organizationId: string;
   projectId: string | null;
+  includeAllOrganizationProjects?: boolean;
   tableAlias?: string;
   extraClauses?: string[];
   extraValues?: unknown[];
@@ -172,8 +173,10 @@ function buildTransferScopeWhere(params: {
   const clauses = [`${prefix}organization_id = ?`];
   const values: unknown[] = [params.organizationId];
 
-  clauses.push(`${prefix}project_id IS NOT DISTINCT FROM ?`);
-  values.push(params.projectId);
+  if (!params.includeAllOrganizationProjects) {
+    clauses.push(`${prefix}project_id IS NOT DISTINCT FROM ?`);
+    values.push(params.projectId);
+  }
 
   if (params.extraClauses?.length) {
     clauses.push(...params.extraClauses);
@@ -210,17 +213,24 @@ export function createPostgresPaymentsRepository(
   db: DatabaseExecutor,
   tenantScope?: TenantScope
 ): PaymentsRepository {
+  const canAccessAllOrganizationProjects = tenantScope?.projectId === null;
   const assertScope = (claim: { organizationId: string; projectId: string | null }) => {
     if (tenantScope) {
       assertTenantClaim(tenantScope, claim, "PaymentsRepository");
     }
   };
-  const ownsCustodyWallet = async (custodyWalletId: string): Promise<boolean> => {
+  const ownsCustodyWallet = async (
+    custodyWalletId: string,
+    access: "read" | "write"
+  ): Promise<boolean> => {
     if (!tenantScope) return true;
-    const projectClause = tenantScope.projectId
-      ? "(cc.project_id = ? OR cc.project_id IS NULL)"
-      : "cc.project_id IS NULL";
-    const projectValues = tenantScope.projectId ? [tenantScope.projectId] : [];
+    const projectClause =
+      tenantScope.projectId === null
+        ? ""
+        : access === "read"
+          ? "AND (cc.project_id = ? OR cc.project_id IS NULL)"
+          : "AND cc.project_id = ?";
+    const projectValues = tenantScope.projectId === null ? [] : [tenantScope.projectId];
     const row = await db
       .prepare(
         `SELECT cw.id
@@ -228,7 +238,7 @@ export function createPostgresPaymentsRepository(
          JOIN custody_configs cc ON cc.id = cw.custody_config_id
          WHERE cw.id = ?
            AND cc.organization_id = ?
-           AND ${projectClause}`
+           ${projectClause}`
       )
       .bind(custodyWalletId, tenantScope.organizationId, ...projectValues)
       .first<{ id: string }>();
@@ -335,7 +345,7 @@ export function createPostgresPaymentsRepository(
         input = {
           ...input,
           organizationId: tenantScope.organizationId,
-          projectId: tenantScope.projectId,
+          projectId: canAccessAllOrganizationProjects ? undefined : tenantScope.projectId,
         };
       }
       const clauses = ["id = ?"];
@@ -410,6 +420,7 @@ export function createPostgresPaymentsRepository(
       const scope = buildTransferScopeWhere({
         organizationId: input.organizationId,
         projectId: input.projectId,
+        includeAllOrganizationProjects: canAccessAllOrganizationProjects,
         extraClauses: ["id = ?", "status = ANY(?)"],
         extraValues: [input.transferId, [...input.fromStatuses]],
       });
@@ -434,6 +445,7 @@ export function createPostgresPaymentsRepository(
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
+        includeAllOrganizationProjects: canAccessAllOrganizationProjects,
         extraClauses: ["id = ?"],
         extraValues: [params.transferId],
       });
@@ -451,6 +463,7 @@ export function createPostgresPaymentsRepository(
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
+        includeAllOrganizationProjects: canAccessAllOrganizationProjects,
         extraClauses: ["signature = ?"],
         extraValues: [params.signature],
       });
@@ -472,6 +485,7 @@ export function createPostgresPaymentsRepository(
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
+        includeAllOrganizationProjects: canAccessAllOrganizationProjects,
         extraClauses: ["id = ANY(?)"],
         extraValues: [params.transferIds],
       });
@@ -497,6 +511,7 @@ export function createPostgresPaymentsRepository(
         ? buildTransferScopeWhere({
             organizationId: effectiveOrganizationId,
             projectId: effectiveProjectId ?? null,
+            includeAllOrganizationProjects: canAccessAllOrganizationProjects,
             extraClauses: ["provider = ?", "provider_reference = ?"],
             extraValues: [params.provider, params.providerReference],
           })
@@ -522,6 +537,7 @@ export function createPostgresPaymentsRepository(
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
+        includeAllOrganizationProjects: canAccessAllOrganizationProjects,
         tableAlias: "pt",
         extraClauses: [`pt.signature IN (${buildInClause(params.signatures.length)})`],
         extraValues: params.signatures,
@@ -596,6 +612,7 @@ export function createPostgresPaymentsRepository(
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
+        includeAllOrganizationProjects: canAccessAllOrganizationProjects,
         extraClauses: [
           "wallet_id = ?",
           "token = ?",
@@ -677,7 +694,7 @@ export function createPostgresPaymentsRepository(
     },
 
     async getWalletPoliciesByCustodyWalletId(custodyWalletId) {
-      if (!(await ownsCustodyWallet(custodyWalletId))) {
+      if (!(await ownsCustodyWallet(custodyWalletId, "read"))) {
         return [];
       }
       return getWalletPoliciesInternal(db, custodyWalletId);
@@ -689,7 +706,7 @@ export function createPostgresPaymentsRepository(
       }
 
       for (const input of inputs) {
-        if (!(await ownsCustodyWallet(input.custodyWalletId))) {
+        if (!(await ownsCustodyWallet(input.custodyWalletId, "write"))) {
           throw new TenantScopeViolationError(
             "PaymentsRepository.upsertWalletPolicies rejected a foreign custody wallet"
           );

--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -217,6 +217,10 @@ export function createPostgresPaymentsRepository(
   };
   const ownsCustodyWallet = async (custodyWalletId: string): Promise<boolean> => {
     if (!tenantScope) return true;
+    const projectClause = tenantScope.projectId
+      ? "(cc.project_id = ? OR cc.project_id IS NULL)"
+      : "cc.project_id IS NULL";
+    const projectValues = tenantScope.projectId ? [tenantScope.projectId] : [];
     const row = await db
       .prepare(
         `SELECT cw.id
@@ -224,17 +228,9 @@ export function createPostgresPaymentsRepository(
          JOIN custody_configs cc ON cc.id = cw.custody_config_id
          WHERE cw.id = ?
            AND cc.organization_id = ?
-           AND (
-             cc.project_id IS NOT DISTINCT FROM ?
-             OR (? IS NOT NULL AND cc.project_id IS NULL)
-           )`
+           AND ${projectClause}`
       )
-      .bind(
-        custodyWalletId,
-        tenantScope.organizationId,
-        tenantScope.projectId,
-        tenantScope.projectId
-      )
+      .bind(custodyWalletId, tenantScope.organizationId, ...projectValues)
       .first<{ id: string }>();
     return row !== null;
   };

--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -1,4 +1,5 @@
 import type { DatabaseExecutor } from "@/db";
+import { assertTenantClaim, type TenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import type {
   CreatePaymentTransferInput,
   ListTransfersByStatusInput,
@@ -171,10 +172,8 @@ function buildTransferScopeWhere(params: {
   const clauses = [`${prefix}organization_id = ?`];
   const values: unknown[] = [params.organizationId];
 
-  if (params.projectId) {
-    clauses.push(`${prefix}project_id = ?`);
-    values.push(params.projectId);
-  }
+  clauses.push(`${prefix}project_id IS NOT DISTINCT FROM ?`);
+  values.push(params.projectId);
 
   if (params.extraClauses?.length) {
     clauses.push(...params.extraClauses);
@@ -207,9 +206,42 @@ async function getWalletPoliciesInternal(
   return rows.results.map(mapPolicyRow);
 }
 
-export function createPostgresPaymentsRepository(db: DatabaseExecutor): PaymentsRepository {
+export function createPostgresPaymentsRepository(
+  db: DatabaseExecutor,
+  tenantScope?: TenantScope
+): PaymentsRepository {
+  const assertScope = (claim: { organizationId: string; projectId: string | null }) => {
+    if (tenantScope) {
+      assertTenantClaim(tenantScope, claim, "PaymentsRepository");
+    }
+  };
+  const ownsCustodyWallet = async (custodyWalletId: string): Promise<boolean> => {
+    if (!tenantScope) return true;
+    const row = await db
+      .prepare(
+        `SELECT cw.id
+         FROM custody_wallets cw
+         JOIN custody_configs cc ON cc.id = cw.custody_config_id
+         WHERE cw.id = ?
+           AND cc.organization_id = ?
+           AND (
+             cc.project_id IS NOT DISTINCT FROM ?
+             OR (? IS NOT NULL AND cc.project_id IS NULL)
+           )`
+      )
+      .bind(
+        custodyWalletId,
+        tenantScope.organizationId,
+        tenantScope.projectId,
+        tenantScope.projectId
+      )
+      .first<{ id: string }>();
+    return row !== null;
+  };
+
   return {
     async createTransfer(input: CreatePaymentTransferInput) {
+      assertScope(input);
       const row = await db
         .prepare(
           `INSERT INTO payment_transfers (
@@ -278,6 +310,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async findTransferByIdempotency({ organizationId, projectId, idempotencyKey }) {
+      assertScope({ organizationId, projectId });
       const row = await db
         .prepare(
           `SELECT * FROM payment_transfers
@@ -292,6 +325,23 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async updateTransfer(input: UpdatePaymentTransferInput) {
+      if (tenantScope) {
+        if (input.organizationId !== undefined) {
+          assertTenantClaim(
+            tenantScope,
+            {
+              organizationId: input.organizationId,
+              projectId: input.projectId ?? tenantScope.projectId,
+            },
+            "PaymentsRepository"
+          );
+        }
+        input = {
+          ...input,
+          organizationId: tenantScope.organizationId,
+          projectId: tenantScope.projectId,
+        };
+      }
       const clauses = ["id = ?"];
       const values: unknown[] = [input.transferId];
 
@@ -360,6 +410,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async updateTransferStatusGuarded(input) {
+      assertScope(input);
       const scope = buildTransferScopeWhere({
         organizationId: input.organizationId,
         projectId: input.projectId,
@@ -383,6 +434,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async getTransferById(params) {
+      assertScope(params);
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
@@ -399,6 +451,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async getTransferBySignature(params) {
+      assertScope(params);
       const scope = buildTransferScopeWhere({
         organizationId: params.organizationId,
         projectId: params.projectId,
@@ -415,6 +468,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async listTransfersByIds(params) {
+      assertScope(params);
       if (params.transferIds.length === 0) {
         return [];
       }
@@ -435,10 +489,18 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async getTransferByProviderReference(params) {
-      const scope = params.organizationId
+      if (tenantScope && params.organizationId !== undefined) {
+        assertScope({
+          organizationId: params.organizationId,
+          projectId: params.projectId,
+        });
+      }
+      const effectiveOrganizationId = tenantScope?.organizationId ?? params.organizationId;
+      const effectiveProjectId = tenantScope?.projectId ?? params.projectId;
+      const scope = effectiveOrganizationId
         ? buildTransferScopeWhere({
-            organizationId: params.organizationId,
-            projectId: params.projectId,
+            organizationId: effectiveOrganizationId,
+            projectId: effectiveProjectId ?? null,
             extraClauses: ["provider = ?", "provider_reference = ?"],
             extraValues: [params.provider, params.providerReference],
           })
@@ -456,6 +518,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async listTransfersBySignatures(params) {
+      assertScope(params);
       if (params.signatures.length === 0) {
         return [];
       }
@@ -485,6 +548,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async listTransfers(params: ListTransfersInput): Promise<ListTransfersResult> {
+      assertScope(params);
       const { whereClause, values } = buildTransferListWhere(params);
       const paginationValues = [...values, params.limit, params.offset];
       const sort = {
@@ -528,6 +592,7 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async listTransferAmounts(params) {
+      assertScope(params);
       if (params.statuses.length === 0) {
         return [];
       }
@@ -570,6 +635,11 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
       limit,
       offset,
     }: ListTransfersByStatusInput) {
+      if (tenantScope) {
+        throw new TenantScopeViolationError(
+          "PaymentsRepository.listTransfersByStatus is system-only"
+        );
+      }
       if (statuses.length === 0) {
         return [];
       }
@@ -611,6 +681,9 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
     },
 
     async getWalletPoliciesByCustodyWalletId(custodyWalletId) {
+      if (!(await ownsCustodyWallet(custodyWalletId))) {
+        return [];
+      }
       return getWalletPoliciesInternal(db, custodyWalletId);
     },
 
@@ -620,6 +693,11 @@ export function createPostgresPaymentsRepository(db: DatabaseExecutor): Payments
       }
 
       for (const input of inputs) {
+        if (!(await ownsCustodyWallet(input.custodyWalletId))) {
+          throw new TenantScopeViolationError(
+            "PaymentsRepository.upsertWalletPolicies rejected a foreign custody wallet"
+          );
+        }
         await db
           .prepare(
             `INSERT INTO payment_wallet_policies (

--- a/apps/sdp-api/src/db/repositories/payments.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import { isPostgresUniqueViolation } from "@/db/postgres-utils";
+import { createTenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
@@ -194,6 +195,64 @@ describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
 
     expect(updated).toBeNull();
     expect(await readStatus("xfr_guard_project")).toBe("awaiting_payment");
+  });
+
+  it("makes a valid foreign transfer id indistinguishable from a missing row", async () => {
+    await seedTransfer({
+      id: "xfr_foreign_valid_id",
+      status: "awaiting_payment",
+      projectId: OTHER_PROJECT_ID,
+    });
+    const scoped = createPostgresPaymentsRepository(
+      getDb(env),
+      createTenantScope({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      })
+    );
+
+    await expect(
+      scoped.updateTransfer({
+        transferId: "xfr_foreign_valid_id",
+        status: "confirmed",
+        updatedAt: new Date().toISOString(),
+      })
+    ).resolves.toBeNull();
+    await expect(
+      scoped.getTransferById({
+        transferId: "xfr_foreign_valid_id",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      })
+    ).resolves.toBeNull();
+    expect(await readStatus("xfr_foreign_valid_id")).toBe("awaiting_payment");
+  });
+
+  it("rejects forged tenant claims before querying and preserves same-tenant writes", async () => {
+    await seedTransfer({ id: "xfr_owned_valid_id", status: "awaiting_payment" });
+    const scoped = createPostgresPaymentsRepository(
+      getDb(env),
+      createTenantScope({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT_ID,
+      })
+    );
+
+    await expect(
+      scoped.getTransferById({
+        transferId: "xfr_owned_valid_id",
+        organizationId: TEST_ORG.id,
+        projectId: OTHER_PROJECT_ID,
+      })
+    ).rejects.toBeInstanceOf(TenantScopeViolationError);
+
+    await expect(
+      scoped.updateTransfer({
+        transferId: "xfr_owned_valid_id",
+        status: "confirmed",
+        updatedAt: new Date().toISOString(),
+      })
+    ).resolves.toMatchObject({ id: "xfr_owned_valid_id", status: "confirmed" });
   });
 
   it("persists idempotency metadata and looks it up by (org, key)", async () => {

--- a/apps/sdp-api/src/db/repositories/payments.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.test.ts
@@ -11,6 +11,10 @@ import { createPostgresPaymentsRepository } from "./payments.repository.postgres
 const TEST_PROJECT_ID = "prj_payments_repo_test";
 const OTHER_PROJECT_ID = "prj_payments_repo_test_other";
 const TEST_WALLET_ID = "wallet_payments_repo_test";
+const ORG_CUSTODY_CONFIG_ID = "ccfg_payments_repo_org";
+const PROJECT_CUSTODY_CONFIG_ID = "ccfg_payments_repo_project";
+const ORG_CUSTODY_WALLET_ID = "cwal_payments_repo_org";
+const PROJECT_CUSTODY_WALLET_ID = "cwal_payments_repo_project";
 const CANCELABLE = ["pending", "awaiting_payment"] as const;
 
 describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
@@ -26,6 +30,10 @@ describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
 
   beforeEach(async () => {
     const db = getDb(env);
+    await db.prepare("DELETE FROM payment_wallet_policies").run();
+    await db.prepare("DELETE FROM custody_scope_defaults").run();
+    await db.prepare("DELETE FROM custody_wallets").run();
+    await db.prepare("DELETE FROM custody_configs").run();
     await db.prepare("DELETE FROM payment_transfers").run();
     await db.prepare("DELETE FROM projects").run();
 
@@ -88,7 +96,7 @@ describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
   async function seedTransfer(input: {
     id: string;
     status: string;
-    projectId?: string;
+    projectId?: string | null;
   }): Promise<void> {
     const now = new Date().toISOString();
     await getDb(env)
@@ -100,7 +108,7 @@ describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
       .bind(
         input.id,
         TEST_ORG.id,
-        input.projectId ?? TEST_PROJECT_ID,
+        input.projectId === undefined ? TEST_PROJECT_ID : input.projectId,
         TEST_WALLET_ID,
         "USDC",
         "offramp",
@@ -226,6 +234,110 @@ describe("PaymentsRepository.updateTransferStatusGuarded (postgres)", () => {
       })
     ).resolves.toBeNull();
     expect(await readStatus("xfr_foreign_valid_id")).toBe("awaiting_payment");
+  });
+
+  it("lets an organization-scoped repository read and update project transfers", async () => {
+    await seedTransfer({ id: "xfr_org_admin", status: "awaiting_payment" });
+    const scoped = createPostgresPaymentsRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: null })
+    );
+
+    await expect(
+      scoped.getTransferById({
+        transferId: "xfr_org_admin",
+        organizationId: TEST_ORG.id,
+        projectId: null,
+      })
+    ).resolves.toMatchObject({ id: "xfr_org_admin", project_id: TEST_PROJECT_ID });
+    await expect(
+      scoped.updateTransfer({
+        transferId: "xfr_org_admin",
+        status: "confirmed",
+        updatedAt: new Date().toISOString(),
+      })
+    ).resolves.toMatchObject({ id: "xfr_org_admin", status: "confirmed" });
+  });
+
+  it("allows inherited wallet-policy reads but reserves organization-wallet writes", async () => {
+    const db = getDb(env);
+    for (const [configId, projectId, walletId, custodyWalletId, publicKey] of [
+      [ORG_CUSTODY_CONFIG_ID, null, "wallet_org", ORG_CUSTODY_WALLET_ID, "OrgWallet111"],
+      [
+        PROJECT_CUSTODY_CONFIG_ID,
+        TEST_PROJECT_ID,
+        "wallet_project",
+        PROJECT_CUSTODY_WALLET_ID,
+        "ProjectWallet111",
+      ],
+    ] as const) {
+      await db
+        .prepare(
+          `INSERT INTO custody_configs
+             (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES (?, ?, ?, 'local', 'encrypted', 'active')`
+        )
+        .bind(configId, TEST_ORG.id, projectId)
+        .run();
+      await db
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+           VALUES (?, ?, ?, ?, 'Payments repository wallet', 'transfer', 'active')`
+        )
+        .bind(custodyWalletId, configId, walletId, publicKey)
+        .run();
+    }
+
+    const now = new Date().toISOString();
+    await db
+      .prepare(
+        `INSERT INTO payment_wallet_policies
+           (id, custody_wallet_id, policy_type, policy, created_at, updated_at)
+         VALUES ('pwp_org', ?, 'transfer', 'deny', ?, ?)`
+      )
+      .bind(ORG_CUSTODY_WALLET_ID, now, now)
+      .run();
+
+    const projectScoped = createPostgresPaymentsRepository(
+      db,
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID })
+    );
+    await expect(
+      projectScoped.getWalletPoliciesByCustodyWalletId(ORG_CUSTODY_WALLET_ID)
+    ).resolves.toHaveLength(1);
+    await expect(
+      projectScoped.upsertWalletPolicies([
+        {
+          id: "pwp_project_attack",
+          custodyWalletId: ORG_CUSTODY_WALLET_ID,
+          policyType: "transfer",
+          policy: "allow",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ])
+    ).rejects.toBeInstanceOf(TenantScopeViolationError);
+
+    const organizationScoped = createPostgresPaymentsRepository(
+      db,
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: null })
+    );
+    await expect(
+      organizationScoped.getWalletPoliciesByCustodyWalletId(PROJECT_CUSTODY_WALLET_ID)
+    ).resolves.toEqual([]);
+    await expect(
+      organizationScoped.upsertWalletPolicies([
+        {
+          id: "pwp_org_admin",
+          custodyWalletId: PROJECT_CUSTODY_WALLET_ID,
+          policyType: "transfer",
+          policy: "allow",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ])
+    ).resolves.toHaveLength(1);
   });
 
   it("rejects forged tenant claims before querying and preserves same-tenant writes", async () => {

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -5,6 +5,7 @@ import {
   parseOptionalPostgresJson,
 } from "@/db/postgres-utils";
 import { badRequest } from "@/lib/errors";
+import { assertTenantClaim, type TenantScope } from "@/lib/tenant-scope";
 import type {
   ActivateApiKeyControlProfileRevisionInput,
   ActivateWalletControlProfileRevisionInput,
@@ -919,9 +920,79 @@ function walletPolicyEvaluationAuditFilters(input: ListWalletPolicyEvaluationAud
   return { conditions, params };
 }
 
-export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
+async function tenantOwnsRow(
+  db: DatabaseExecutor,
+  scope: TenantScope,
+  table:
+    | "api_key_control_profiles"
+    | "api_keys"
+    | "approval_requests"
+    | "wallet_control_profiles"
+    | "wallet_operations",
+  id: string
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT id
+       FROM ${table}
+       WHERE id = ?
+         AND organization_id = ?
+         AND project_id IS NOT DISTINCT FROM ?
+       LIMIT 1`
+    )
+    .bind(id, scope.organizationId, scope.projectId)
+    .first<{ id: string }>();
+  return Boolean(row);
+}
+
+async function tenantOwnsWallet(
+  db: DatabaseExecutor,
+  scope: TenantScope,
+  walletId: string
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT w.id
+       FROM custody_wallets w
+       INNER JOIN custody_configs c ON c.id = w.custody_config_id
+       WHERE (w.id = ? OR w.wallet_id = ?)
+         AND c.organization_id = ?
+         AND (c.project_id IS NOT DISTINCT FROM ? OR c.project_id IS NULL)
+         AND w.status = 'active'
+         AND c.status = 'active'
+       LIMIT 1`
+    )
+    .bind(walletId, walletId, scope.organizationId, scope.projectId)
+    .first<{ id: string }>();
+  return Boolean(row);
+}
+
+async function tenantOwnsPolicyRevision(
+  db: DatabaseExecutor,
+  scope: TenantScope,
+  revisionTable: "api_key_control_profile_revisions" | "wallet_control_profile_revisions",
+  profileTable: "api_key_control_profiles" | "wallet_control_profiles",
+  revisionId: string
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT r.id
+       FROM ${revisionTable} r
+       INNER JOIN ${profileTable} p ON p.id = r.profile_id
+       WHERE r.id = ?
+         AND p.organization_id = ?
+         AND p.project_id IS NOT DISTINCT FROM ?
+       LIMIT 1`
+    )
+    .bind(revisionId, scope.organizationId, scope.projectId)
+    .first<{ id: string }>();
+  return Boolean(row);
+}
+
+export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): PolicyRepository {
   return {
     async listPolicyControlInventory(input: ListPolicyControlInventoryInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.listPolicyControlInventory");
       const page = Math.max(input.page ?? 1, 1);
       const pageSize = Math.min(Math.max(input.pageSize ?? 25, 1), 100);
       const offset = (page - 1) * pageSize;
@@ -989,6 +1060,10 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async createWalletControlProfile(input: CreateWalletControlProfileInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.createWalletControlProfile");
+      if (!(await tenantOwnsWallet(db, scope, input.custodyWalletId))) {
+        return null;
+      }
       const id = generateWalletControlProfileId();
 
       await db
@@ -1018,6 +1093,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async createWalletControlProfileRevision(input: CreateWalletControlProfileRevisionInput) {
+      if (!(await tenantOwnsRow(db, scope, "wallet_control_profiles", input.profileId))) {
+        return null;
+      }
       const id = generateWalletControlProfileRevisionId();
       const row = await db.transaction(async (tx) => {
         const profile = await tx
@@ -1065,6 +1143,18 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async activateWalletControlProfileRevision(input: ActivateWalletControlProfileRevisionInput) {
+      if (
+        !(await tenantOwnsRow(db, scope, "wallet_control_profiles", input.profileId)) ||
+        !(await tenantOwnsPolicyRevision(
+          db,
+          scope,
+          "wallet_control_profile_revisions",
+          "wallet_control_profiles",
+          input.revisionId
+        ))
+      ) {
+        return null;
+      }
       const activatedAt = input.activatedAt ?? new Date().toISOString();
 
       const profile = await db.transaction(async (tx) => {
@@ -1108,16 +1198,21 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getActiveWalletControlProfileByCustodyWalletId(custodyWalletId: string) {
+      if (!(await tenantOwnsWallet(db, scope, custodyWalletId))) {
+        return null;
+      }
       const profile = await db
         .prepare(
           `SELECT *
            FROM wallet_control_profiles
            WHERE custody_wallet_id = ?
+             AND organization_id = ?
+             AND project_id IS NOT DISTINCT FROM ?
              AND status = 'active'
            ORDER BY activated_at DESC NULLS LAST, created_at DESC
            LIMIT 1`
         )
-        .bind(custodyWalletId)
+        .bind(custodyWalletId, scope.organizationId, scope.projectId)
         .first<Record<string, unknown>>();
 
       if (!profile) {
@@ -1136,6 +1231,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getActiveWalletControlProfileByProfileId(profileId: string) {
+      if (!(await tenantOwnsRow(db, scope, "wallet_control_profiles", profileId))) {
+        return null;
+      }
       const profile = await db
         .prepare(
           `SELECT *
@@ -1165,6 +1263,7 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     async getWalletControlProfileRevisionHistory(
       input: GetWalletControlProfileRevisionHistoryInput
     ) {
+      assertTenantClaim(scope, input, "PolicyRepository.getWalletControlProfileRevisionHistory");
       const profile = await db
         .prepare(
           `SELECT *
@@ -1203,6 +1302,10 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async createApiKeyControlProfile(input: CreateApiKeyControlProfileInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.createApiKeyControlProfile");
+      if (!(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
+        return null;
+      }
       const id = generateApiKeyControlProfileId();
 
       await db
@@ -1232,10 +1335,16 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getApiKeyControlProfileById(profileId: string) {
+      if (!(await tenantOwnsRow(db, scope, "api_key_control_profiles", profileId))) {
+        return null;
+      }
       return getApiKeyControlProfileById(db, profileId);
     },
 
     async createApiKeyControlProfileRevision(input: CreateApiKeyControlProfileRevisionInput) {
+      if (!(await tenantOwnsRow(db, scope, "api_key_control_profiles", input.profileId))) {
+        return null;
+      }
       const id = generateApiKeyControlProfileRevisionId();
       const row = await db.transaction(async (tx) => {
         const profile = await tx
@@ -1283,10 +1392,33 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getApiKeyControlProfileRevisionById(revisionId: string) {
+      if (
+        !(await tenantOwnsPolicyRevision(
+          db,
+          scope,
+          "api_key_control_profile_revisions",
+          "api_key_control_profiles",
+          revisionId
+        ))
+      ) {
+        return null;
+      }
       return getApiKeyControlProfileRevisionById(db, revisionId);
     },
 
     async activateApiKeyControlProfileRevision(input: ActivateApiKeyControlProfileRevisionInput) {
+      if (
+        !(await tenantOwnsRow(db, scope, "api_key_control_profiles", input.profileId)) ||
+        !(await tenantOwnsPolicyRevision(
+          db,
+          scope,
+          "api_key_control_profile_revisions",
+          "api_key_control_profiles",
+          input.revisionId
+        ))
+      ) {
+        return null;
+      }
       const activatedAt = input.activatedAt ?? new Date().toISOString();
 
       const profile = await db.transaction(async (tx) => {
@@ -1330,16 +1462,21 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getActiveApiKeyControlProfileByApiKeyId(apiKeyId: string) {
+      if (!(await tenantOwnsRow(db, scope, "api_keys", apiKeyId))) {
+        return null;
+      }
       const profile = await db
         .prepare(
           `SELECT *
            FROM api_key_control_profiles
            WHERE api_key_id = ?
+             AND organization_id = ?
+             AND project_id IS NOT DISTINCT FROM ?
              AND status = 'active'
            ORDER BY activated_at DESC NULLS LAST, created_at DESC
            LIMIT 1`
         )
-        .bind(apiKeyId)
+        .bind(apiKeyId, scope.organizationId, scope.projectId)
         .first<Record<string, unknown>>();
 
       if (!profile) {
@@ -1358,6 +1495,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getActiveApiKeyControlProfileByProfileId(profileId: string) {
+      if (!(await tenantOwnsRow(db, scope, "api_key_control_profiles", profileId))) {
+        return null;
+      }
       const profile = await db
         .prepare(
           `SELECT *
@@ -1385,6 +1525,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getApiKeyPolicySubject(apiKeyId: string) {
+      if (!(await tenantOwnsRow(db, scope, "api_keys", apiKeyId))) {
+        return null;
+      }
       const row = await db
         .prepare(
           `SELECT
@@ -1403,11 +1546,53 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async upsertApiKeyWalletPolicyBinding(input: UpsertApiKeyWalletPolicyBindingInput) {
+      if (!(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
+        return null;
+      }
+      if (
+        input.walletControlProfileId &&
+        !(await tenantOwnsRow(db, scope, "wallet_control_profiles", input.walletControlProfileId))
+      ) {
+        return null;
+      }
+      if (
+        input.apiKeyControlProfileId &&
+        !(await tenantOwnsRow(db, scope, "api_key_control_profiles", input.apiKeyControlProfileId))
+      ) {
+        return null;
+      }
+      if (input.walletId && !(await tenantOwnsWallet(db, scope, input.walletId))) {
+        return null;
+      }
       validateApiKeyWalletPolicyBindingInput(input);
       return upsertApiKeyWalletPolicyBindingInternal(db, input);
     },
 
     async replaceApiKeyWalletPolicyBindings(input: ReplaceApiKeyWalletPolicyBindingsInput) {
+      if (!(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
+        return [];
+      }
+      for (const binding of input.bindings) {
+        if (
+          (binding.walletControlProfileId &&
+            !(await tenantOwnsRow(
+              db,
+              scope,
+              "wallet_control_profiles",
+              binding.walletControlProfileId
+            ))) ||
+          (binding.apiKeyControlProfileId &&
+            !(await tenantOwnsRow(
+              db,
+              scope,
+              "api_key_control_profiles",
+              binding.apiKeyControlProfileId
+            ))) ||
+          (binding.walletId && !(await tenantOwnsWallet(db, scope, binding.walletId)))
+        ) {
+          return [];
+        }
+      }
       if (input.bindings.some((binding) => binding.apiKeyId !== input.apiKeyId)) {
         throw badRequest("Policy bindings must target the requested API key");
       }
@@ -1434,6 +1619,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async listApiKeyWalletPolicyBindings(apiKeyId: string) {
+      if (!(await tenantOwnsRow(db, scope, "api_keys", apiKeyId))) {
+        return [];
+      }
       const rows = await db
         .prepare(
           `SELECT *
@@ -1454,12 +1642,15 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
 
       const rows = await db
         .prepare(
-          `SELECT *
-           FROM api_key_wallet_policy_bindings
-           WHERE api_key_id = ANY(?::text[])
+          `SELECT b.*
+           FROM api_key_wallet_policy_bindings b
+           INNER JOIN api_keys ak ON ak.id = b.api_key_id
+           WHERE b.api_key_id = ANY(?::text[])
+             AND ak.organization_id = ?
+             AND ak.project_id IS NOT DISTINCT FROM ?
            ORDER BY api_key_id ASC, created_at ASC`
         )
-        .bind(apiKeyIds)
+        .bind(apiKeyIds, scope.organizationId, scope.projectId)
         .all<Record<string, unknown>>();
 
       return rows.results.map(mapApiKeyWalletPolicyBindingRow);
@@ -1475,9 +1666,11 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
           `SELECT id AS profile_id, active_revision_id
            FROM wallet_control_profiles
            WHERE id = ANY(?::text[])
+             AND organization_id = ?
+             AND project_id IS NOT DISTINCT FROM ?
              AND status = 'active'`
         )
-        .bind(profileIds)
+        .bind(profileIds, scope.organizationId, scope.projectId)
         .all<ActivePolicyProfileRevisionRefRow>();
 
       return rows.results;
@@ -1493,15 +1686,26 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
           `SELECT id AS profile_id, active_revision_id
            FROM api_key_control_profiles
            WHERE id = ANY(?::text[])
+             AND organization_id = ?
+             AND project_id IS NOT DISTINCT FROM ?
              AND status = 'active'`
         )
-        .bind(profileIds)
+        .bind(profileIds, scope.organizationId, scope.projectId)
         .all<ActivePolicyProfileRevisionRefRow>();
 
       return rows.results;
     },
 
     async getApiKeyWalletPolicyBindingResolution(apiKeyId: string, walletId: string) {
+      if (
+        !(await tenantOwnsRow(db, scope, "api_keys", apiKeyId)) ||
+        !(await tenantOwnsWallet(db, scope, walletId))
+      ) {
+        return {
+          total_binding_count: 0,
+          binding: null,
+        };
+      }
       const row = await db
         .prepare(
           `WITH binding_count AS (
@@ -1536,6 +1740,12 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getApiKeyWalletPolicyTarget(apiKeyId: string, walletId: string) {
+      if (
+        !(await tenantOwnsRow(db, scope, "api_keys", apiKeyId)) ||
+        !(await tenantOwnsWallet(db, scope, walletId))
+      ) {
+        return null;
+      }
       const row = await db
         .prepare(
           `WITH target_api_key AS (
@@ -1587,6 +1797,13 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async createWalletOperation(input: CreateWalletOperationInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.createWalletOperation");
+      if (!(await tenantOwnsWallet(db, scope, input.custodyWalletId ?? input.walletId))) {
+        return null;
+      }
+      if (input.apiKeyId && !(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
+        return null;
+      }
       const id = generateWalletOperationId();
 
       await db
@@ -1632,6 +1849,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getWalletOperationById(walletOperationId: string) {
+      if (!(await tenantOwnsRow(db, scope, "wallet_operations", walletOperationId))) {
+        return null;
+      }
       return getWalletOperationByIdInternal(db, walletOperationId);
     },
 
@@ -1639,6 +1859,9 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
       walletOperationId: string,
       status: WalletOperationRow["status"]
     ) {
+      if (!(await tenantOwnsRow(db, scope, "wallet_operations", walletOperationId))) {
+        return null;
+      }
       const row = await db
         .prepare(
           `UPDATE wallet_operations
@@ -1654,6 +1877,33 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async createPolicyEvaluation(input: CreatePolicyEvaluationInput) {
+      if (!(await tenantOwnsRow(db, scope, "wallet_operations", input.walletOperationId))) {
+        return null;
+      }
+      if (
+        input.walletPolicyRevisionId &&
+        !(await tenantOwnsPolicyRevision(
+          db,
+          scope,
+          "wallet_control_profile_revisions",
+          "wallet_control_profiles",
+          input.walletPolicyRevisionId
+        ))
+      ) {
+        return null;
+      }
+      if (
+        input.apiKeyPolicyRevisionId &&
+        !(await tenantOwnsPolicyRevision(
+          db,
+          scope,
+          "api_key_control_profile_revisions",
+          "api_key_control_profiles",
+          input.apiKeyPolicyRevisionId
+        ))
+      ) {
+        return null;
+      }
       const id = generatePolicyEvaluationId();
 
       await db
@@ -1691,10 +1941,14 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async listPolicyEvaluationsForOperation(walletOperationId: string) {
+      if (!(await tenantOwnsRow(db, scope, "wallet_operations", walletOperationId))) {
+        return [];
+      }
       return listPolicyEvaluationsForOperationInternal(db, walletOperationId);
     },
 
     async listWalletPolicyEvaluationAudits(input: ListWalletPolicyEvaluationAuditsInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.listWalletPolicyEvaluationAudits");
       const page = Math.max(input.page ?? 1, 1);
       const pageSize = Math.min(Math.max(input.pageSize ?? 25, 1), 100);
       const offset = (page - 1) * pageSize;
@@ -1728,6 +1982,7 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async getWalletPolicyEvaluationAudit(input: GetWalletPolicyEvaluationAuditInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.getWalletPolicyEvaluationAudit");
       const { conditions, params } = walletPolicyEvaluationAuditFilters(input);
       conditions.push("pe.id = ?");
       params.push(input.policyEvaluationId);
@@ -1745,6 +2000,10 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async createApprovalRequest(input: CreateApprovalRequestInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.createApprovalRequest");
+      if (!(await tenantOwnsRow(db, scope, "wallet_operations", input.walletOperationId))) {
+        return null;
+      }
       const id = generateApprovalRequestId();
       const row = await db
         .prepare(
@@ -1784,15 +2043,15 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async updateApprovalRequestStatus(input: UpdateApprovalRequestStatusInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.updateApprovalRequestStatus");
+      if (!(await tenantOwnsRow(db, scope, "approval_requests", input.approvalRequestId))) {
+        return null;
+      }
       const resolvedAt = input.resolvedAt ?? new Date().toISOString();
 
       const row = await db.transaction(async (tx) => {
-        const conditions = ["id = ?", "organization_id = ?"];
-        const params: unknown[] = [input.approvalRequestId, input.organizationId];
-        if (input.projectId) {
-          conditions.push("project_id = ?");
-          params.push(input.projectId);
-        }
+        const conditions = ["id = ?", "organization_id = ?", "project_id IS NOT DISTINCT FROM ?"];
+        const params: unknown[] = [input.approvalRequestId, scope.organizationId, scope.projectId];
 
         const current = await tx
           .prepare(`SELECT * FROM approval_requests WHERE ${conditions.join(" AND ")} FOR UPDATE`)
@@ -1815,6 +2074,7 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
                  updated_at = ?
              WHERE id = ?
                AND organization_id = ?
+               AND project_id IS NOT DISTINCT FROM ?
              RETURNING *`
           )
           .bind(
@@ -1823,7 +2083,8 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
             resolvedAt,
             resolvedAt,
             input.approvalRequestId,
-            input.organizationId
+            scope.organizationId,
+            scope.projectId
           )
           .first<Record<string, unknown>>();
 
@@ -1844,13 +2105,15 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
                    updated_at = ?
                WHERE id = ?
                  AND organization_id = ?
+                 AND project_id IS NOT DISTINCT FROM ?
                  AND ${currentOperationStatus}`
             )
             .bind(
               input.operationStatus,
               resolvedAt,
               current.wallet_operation_id,
-              input.organizationId
+              scope.organizationId,
+              scope.projectId
             )
             .run();
         }
@@ -1862,10 +2125,12 @@ export function createPostgresPolicyRepository(db: AppDb): PolicyRepository {
     },
 
     async listApprovalRequestDetails(input: ListApprovalRequestDetailsInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.listApprovalRequestDetails");
       return listApprovalRequestDetailsInternal(db, input);
     },
 
     async getApprovalRequestDetail(input: GetApprovalRequestDetailInput) {
+      assertTenantClaim(scope, input, "PolicyRepository.getApprovalRequestDetail");
       const rows = await listApprovalRequestDetailsInternal(db, {
         ...input,
         approvalRequestId: input.approvalRequestId,

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -1585,6 +1585,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
     },
 
     async upsertApiKeyWalletPolicyBinding(input: UpsertApiKeyWalletPolicyBindingInput) {
+      validateApiKeyWalletPolicyBindingInput(input);
       if (!(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
         return null;
       }
@@ -1606,11 +1607,16 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
       ) {
         return null;
       }
-      validateApiKeyWalletPolicyBindingInput(input);
       return upsertApiKeyWalletPolicyBindingInternal(db, input);
     },
 
     async replaceApiKeyWalletPolicyBindings(input: ReplaceApiKeyWalletPolicyBindingsInput) {
+      if (input.bindings.some((binding) => binding.apiKeyId !== input.apiKeyId)) {
+        throw badRequest("Policy bindings must target the requested API key");
+      }
+      for (const binding of input.bindings) {
+        validateApiKeyWalletPolicyBindingInput(binding);
+      }
       if (!(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
         return [];
       }
@@ -1635,12 +1641,6 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
         ) {
           return [];
         }
-      }
-      if (input.bindings.some((binding) => binding.apiKeyId !== input.apiKeyId)) {
-        throw badRequest("Policy bindings must target the requested API key");
-      }
-      for (const binding of input.bindings) {
-        validateApiKeyWalletPolicyBindingInput(binding);
       }
 
       return db.transaction(async (tx) => {

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -662,15 +662,16 @@ async function getWalletControlProfileById(
 
 async function listApprovalRequestDetailsInternal(
   db: AppDb,
+  scope: TenantScope,
   input: ListApprovalRequestDetailsInput & { approvalRequestId?: string }
 ): Promise<ApprovalRequestDetailRow[]> {
   const limit = Math.min(Math.max(input.limit ?? 50, 1), 100);
   const conditions = ["ar.organization_id = ?"];
-  const params: unknown[] = [input.organizationId];
+  const params: unknown[] = [scope.organizationId];
 
-  if (input.projectId) {
+  if (scope.projectId !== null) {
     conditions.push("ar.project_id = ?");
-    params.push(input.projectId);
+    params.push(scope.projectId);
   }
   if (input.status) {
     conditions.push("ar.status = ?");
@@ -889,7 +890,10 @@ LEFT JOIN wallet_control_profiles wcp ON wcp.id = wcpr.profile_id
 LEFT JOIN api_key_control_profile_revisions akcpr ON akcpr.id = pe.api_key_policy_revision_id
 LEFT JOIN api_key_control_profiles akcp ON akcp.id = akcpr.profile_id`;
 
-function walletPolicyEvaluationAuditFilters(input: ListWalletPolicyEvaluationAuditsInput): {
+function walletPolicyEvaluationAuditFilters(
+  scope: TenantScope,
+  input: ListWalletPolicyEvaluationAuditsInput
+): {
   conditions: string[];
   params: unknown[];
 } {
@@ -898,7 +902,7 @@ function walletPolicyEvaluationAuditFilters(input: ListWalletPolicyEvaluationAud
     "wo.project_id IS NOT DISTINCT FROM ?",
     "wo.custody_wallet_id = ?",
   ];
-  const params: unknown[] = [input.organizationId, input.projectId, input.custodyWalletId];
+  const params: unknown[] = [scope.organizationId, scope.projectId, input.custodyWalletId];
 
   if (input.decision) {
     conditions.push("pe.decision = ?");
@@ -967,6 +971,37 @@ async function tenantOwnsWallet(
   return Boolean(row);
 }
 
+async function tenantOwnsWalletTarget(
+  db: DatabaseExecutor,
+  scope: TenantScope,
+  walletId: string,
+  custodyWalletId?: string | null
+): Promise<boolean> {
+  const hasCustodyWalletId = custodyWalletId !== undefined && custodyWalletId !== null;
+  const custodyPredicate = hasCustodyWalletId ? "AND w.id = ?" : "";
+  const row = await db
+    .prepare(
+      `SELECT w.id
+       FROM custody_wallets w
+       INNER JOIN custody_configs c ON c.id = w.custody_config_id
+       WHERE w.wallet_id = ?
+         ${custodyPredicate}
+         AND c.organization_id = ?
+         AND (c.project_id IS NOT DISTINCT FROM ? OR c.project_id IS NULL)
+         AND w.status = 'active'
+         AND c.status = 'active'
+       LIMIT 1`
+    )
+    .bind(
+      walletId,
+      ...(hasCustodyWalletId ? [custodyWalletId] : []),
+      scope.organizationId,
+      scope.projectId
+    )
+    .first<{ id: string }>();
+  return Boolean(row);
+}
+
 async function tenantOwnsPolicyRevision(
   db: DatabaseExecutor,
   scope: TenantScope,
@@ -1015,8 +1050,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
            WHERE ${summaryWhere}`
         )
         .bind(
-          input.organizationId,
-          input.projectId,
+          scope.organizationId,
+          scope.projectId,
           input.walletIds ?? null,
           ...(input.status ? [input.status] : []),
           ...summaryFilters.params
@@ -1036,8 +1071,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
            LIMIT ? OFFSET ?`
         )
         .bind(
-          input.organizationId,
-          input.projectId,
+          scope.organizationId,
+          scope.projectId,
           input.walletIds ?? null,
           ...rowFilters.params,
           pageSize,
@@ -1080,8 +1115,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
         )
         .bind(
           id,
-          input.organizationId,
-          input.projectId,
+          scope.organizationId,
+          scope.projectId,
           input.custodyWalletId,
           input.name,
           input.status ?? "draft",
@@ -1207,12 +1242,14 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
            FROM wallet_control_profiles
            WHERE custody_wallet_id = ?
              AND organization_id = ?
-             AND project_id IS NOT DISTINCT FROM ?
+             AND (project_id IS NOT DISTINCT FROM ? OR project_id IS NULL)
              AND status = 'active'
-           ORDER BY activated_at DESC NULLS LAST, created_at DESC
+           ORDER BY CASE WHEN project_id IS NOT DISTINCT FROM ? THEN 0 ELSE 1 END,
+                    activated_at DESC NULLS LAST,
+                    created_at DESC
            LIMIT 1`
         )
-        .bind(custodyWalletId, scope.organizationId, scope.projectId)
+        .bind(custodyWalletId, scope.organizationId, scope.projectId, scope.projectId)
         .first<Record<string, unknown>>();
 
       if (!profile) {
@@ -1276,7 +1313,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
                     id DESC
            LIMIT 1`
         )
-        .bind(input.organizationId, input.projectId, input.custodyWalletId)
+        .bind(scope.organizationId, scope.projectId, input.custodyWalletId)
         .first<Record<string, unknown>>();
 
       if (!profile) {
@@ -1322,8 +1359,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
         )
         .bind(
           id,
-          input.organizationId,
-          input.projectId,
+          scope.organizationId,
+          scope.projectId,
           input.apiKeyId,
           input.name,
           input.status ?? "draft",
@@ -1471,12 +1508,14 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
            FROM api_key_control_profiles
            WHERE api_key_id = ?
              AND organization_id = ?
-             AND project_id IS NOT DISTINCT FROM ?
+             AND (project_id IS NOT DISTINCT FROM ? OR project_id IS NULL)
              AND status = 'active'
-           ORDER BY activated_at DESC NULLS LAST, created_at DESC
+           ORDER BY CASE WHEN project_id IS NOT DISTINCT FROM ? THEN 0 ELSE 1 END,
+                    activated_at DESC NULLS LAST,
+                    created_at DESC
            LIMIT 1`
         )
-        .bind(apiKeyId, scope.organizationId, scope.projectId)
+        .bind(apiKeyId, scope.organizationId, scope.projectId, scope.projectId)
         .first<Record<string, unknown>>();
 
       if (!profile) {
@@ -1561,7 +1600,10 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
       ) {
         return null;
       }
-      if (input.walletId && !(await tenantOwnsWallet(db, scope, input.walletId))) {
+      if (
+        input.bindingScope === "selected" &&
+        !(await tenantOwnsWalletTarget(db, scope, input.walletId, input.custodyWalletId))
+      ) {
         return null;
       }
       validateApiKeyWalletPolicyBindingInput(input);
@@ -1588,7 +1630,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
               "api_key_control_profiles",
               binding.apiKeyControlProfileId
             ))) ||
-          (binding.walletId && !(await tenantOwnsWallet(db, scope, binding.walletId)))
+          (binding.bindingScope === "selected" &&
+            !(await tenantOwnsWalletTarget(db, scope, binding.walletId, binding.custodyWalletId)))
         ) {
           return [];
         }
@@ -1798,7 +1841,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
 
     async createWalletOperation(input: CreateWalletOperationInput) {
       assertTenantClaim(scope, input, "PolicyRepository.createWalletOperation");
-      if (!(await tenantOwnsWallet(db, scope, input.custodyWalletId ?? input.walletId))) {
+      if (!(await tenantOwnsWalletTarget(db, scope, input.walletId, input.custodyWalletId))) {
         return null;
       }
       if (input.apiKeyId && !(await tenantOwnsRow(db, scope, "api_keys", input.apiKeyId))) {
@@ -1828,8 +1871,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
         )
         .bind(
           id,
-          input.organizationId,
-          input.projectId,
+          scope.organizationId,
+          scope.projectId,
           input.custodyWalletId ?? null,
           input.walletId,
           input.apiKeyId ?? null,
@@ -1952,7 +1995,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
       const page = Math.max(input.page ?? 1, 1);
       const pageSize = Math.min(Math.max(input.pageSize ?? 25, 1), 100);
       const offset = (page - 1) * pageSize;
-      const { conditions, params } = walletPolicyEvaluationAuditFilters(input);
+      const { conditions, params } = walletPolicyEvaluationAuditFilters(scope, input);
       const where = conditions.join(" AND ");
 
       const count = await db
@@ -1983,7 +2026,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
 
     async getWalletPolicyEvaluationAudit(input: GetWalletPolicyEvaluationAuditInput) {
       assertTenantClaim(scope, input, "PolicyRepository.getWalletPolicyEvaluationAudit");
-      const { conditions, params } = walletPolicyEvaluationAuditFilters(input);
+      const { conditions, params } = walletPolicyEvaluationAuditFilters(scope, input);
       conditions.push("pe.id = ?");
       params.push(input.policyEvaluationId);
 
@@ -2027,8 +2070,8 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
         )
         .bind(
           id,
-          input.organizationId,
-          input.projectId,
+          scope.organizationId,
+          scope.projectId,
           input.walletOperationId,
           input.approvalGroupId ?? null,
           input.provider ?? null,
@@ -2126,12 +2169,12 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
 
     async listApprovalRequestDetails(input: ListApprovalRequestDetailsInput) {
       assertTenantClaim(scope, input, "PolicyRepository.listApprovalRequestDetails");
-      return listApprovalRequestDetailsInternal(db, input);
+      return listApprovalRequestDetailsInternal(db, scope, input);
     },
 
     async getApprovalRequestDetail(input: GetApprovalRequestDetailInput) {
       assertTenantClaim(scope, input, "PolicyRepository.getApprovalRequestDetail");
-      const rows = await listApprovalRequestDetailsInternal(db, {
+      const rows = await listApprovalRequestDetailsInternal(db, scope, {
         ...input,
         approvalRequestId: input.approvalRequestId,
         limit: 1,

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "@sdp/types";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { ApiKeyService } from "@/services/api-key.service";
 import { PolicyFoundationService } from "@/services/policy-foundation.service";
 import { TEST_API_KEY } from "@/test/fixtures/api-keys";
@@ -37,6 +38,10 @@ const OTHER_PROJECT = {
 };
 
 const OTHER_PROJECT_CUSTODY_CONFIG_ID = "ccfg_policy_other_project";
+const TEST_SCOPE = createTenantScope({
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT.id,
+});
 const OTHER_PROJECT_CUSTODY_WALLET = {
   id: "cw_policy_other_project",
   walletId: "wallet_policy_other_project",
@@ -59,7 +64,7 @@ describe("PolicyRepository (postgres)", () => {
   beforeEach(async () => {
     await clearTestDatabase(env as Parameters<typeof clearTestDatabase>[0]);
     await seedPolicyFoundationFixtures();
-    repo = createPostgresPolicyRepository(getDb(env));
+    repo = createPostgresPolicyRepository(getDb(env), TEST_SCOPE);
   });
 
   it("resolves implicit default allow when no customer-authored profiles exist", async () => {
@@ -530,7 +535,14 @@ describe("PolicyRepository (postgres)", () => {
       approvalRequestId: request?.id,
     });
 
-    const otherOperation = await repo.createWalletOperation({
+    const otherProjectRepo = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({
+        organizationId: TEST_ORG.id,
+        projectId: OTHER_PROJECT.id,
+      })
+    );
+    const otherOperation = await otherProjectRepo.createWalletOperation({
       organizationId: TEST_ORG.id,
       projectId: OTHER_PROJECT.id,
       custodyWalletId: OTHER_PROJECT_CUSTODY_WALLET.id,
@@ -541,7 +553,7 @@ describe("PolicyRepository (postgres)", () => {
     });
     expect(otherOperation).not.toBeNull();
 
-    const otherRequest = await repo.createApprovalRequest({
+    const otherRequest = await otherProjectRepo.createApprovalRequest({
       organizationId: TEST_ORG.id,
       projectId: OTHER_PROJECT.id,
       walletOperationId: otherOperation?.id ?? "",
@@ -1009,7 +1021,7 @@ describe("PolicyRepository (postgres)", () => {
       apiKeyControlProfileId: apiKeyProfile?.id,
     });
 
-    const rotation = await new ApiKeyService(getDb(env)).rotateApiKey(
+    const rotation = await new ApiKeyService(getDb(env), TEST_SCOPE).rotateApiKey(
       TEST_API_KEY.id,
       TEST_ORG.id,
       TEST_PROJECT.id,

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -451,7 +451,7 @@ describe("PolicyRepository (postgres)", () => {
       requested_by: TEST_USER.id,
     });
 
-    expect(() =>
+    await expect(
       repo.updateApprovalRequestStatus({
         organizationId: "org_other",
         approvalRequestId: request?.id ?? "",
@@ -459,7 +459,7 @@ describe("PolicyRepository (postgres)", () => {
         operationStatus: "executing",
         resolvedBy: TEST_USER.id,
       })
-    ).toThrowError("cannot override the repository organization scope");
+    ).rejects.toThrowError("cannot override the repository organization scope");
 
     await expect(
       repo.updateApprovalRequestStatus({

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -451,7 +451,7 @@ describe("PolicyRepository (postgres)", () => {
       requested_by: TEST_USER.id,
     });
 
-    await expect(
+    expect(() =>
       repo.updateApprovalRequestStatus({
         organizationId: "org_other",
         approvalRequestId: request?.id ?? "",
@@ -459,7 +459,7 @@ describe("PolicyRepository (postgres)", () => {
         operationStatus: "executing",
         resolvedBy: TEST_USER.id,
       })
-    ).resolves.toBeNull();
+    ).toThrowError("cannot override the repository organization scope");
 
     await expect(
       repo.updateApprovalRequestStatus({
@@ -542,6 +542,13 @@ describe("PolicyRepository (postgres)", () => {
         projectId: OTHER_PROJECT.id,
       })
     );
+    const organizationRepo = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({
+        organizationId: TEST_ORG.id,
+        projectId: null,
+      })
+    );
     const otherOperation = await otherProjectRepo.createWalletOperation({
       organizationId: TEST_ORG.id,
       projectId: OTHER_PROJECT.id,
@@ -607,7 +614,7 @@ describe("PolicyRepository (postgres)", () => {
       })
     ).resolves.toBeNull();
     await expect(
-      repo.getApprovalRequestDetail({
+      organizationRepo.getApprovalRequestDetail({
         organizationId: TEST_ORG.id,
         projectId: null,
         approvalRequestId: otherRequest?.id ?? "",
@@ -618,7 +625,7 @@ describe("PolicyRepository (postgres)", () => {
       operation_status: "pending_approval",
     });
 
-    const orgRows = await repo.listApprovalRequestDetails({
+    const orgRows = await organizationRepo.listApprovalRequestDetails({
       organizationId: TEST_ORG.id,
       projectId: null,
       status: "pending",
@@ -889,7 +896,7 @@ describe("PolicyRepository (postgres)", () => {
       })
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
-      message: "Project API keys cannot use wallets from other projects",
+      message: "API key is not authorized for the requested wallet",
     });
   });
 

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -18,6 +18,7 @@ import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 import type {
   ApiKeyControlProfileRevisionRow,
   ApiKeyControlProfileRow,
+  CreateWalletControlProfileInput,
   PolicyRepository,
 } from "./policy.repository";
 import { createPostgresPolicyRepository } from "./policy.repository.postgres";
@@ -284,6 +285,113 @@ describe("PolicyRepository (postgres)", () => {
     expect(updatedOperation?.updated_at).not.toBe(operation?.updated_at);
   });
 
+  it("rejects mismatched custody and wallet identifiers on operations and bindings", async () => {
+    await seedOtherProjectCustodyWallet();
+
+    await expect(
+      repo.createWalletOperation({
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
+        custodyWalletId: TEST_CUSTODY_WALLET.id,
+        walletId: OTHER_PROJECT_CUSTODY_WALLET.walletId,
+        operationFamily: "payment",
+        operationType: "payment_transfer",
+      })
+    ).resolves.toBeNull();
+
+    await expect(
+      repo.upsertApiKeyWalletPolicyBinding({
+        apiKeyId: TEST_API_KEY.id,
+        bindingScope: "selected",
+        walletId: TEST_CUSTODY_WALLET.walletId,
+        custodyWalletId: OTHER_PROJECT_CUSTODY_WALLET.id,
+      })
+    ).resolves.toBeNull();
+
+    await expect(
+      repo.replaceApiKeyWalletPolicyBindings({
+        apiKeyId: TEST_API_KEY.id,
+        bindings: [
+          {
+            apiKeyId: TEST_API_KEY.id,
+            bindingScope: "selected",
+            walletId: TEST_CUSTODY_WALLET.walletId,
+            custodyWalletId: OTHER_PROJECT_CUSTODY_WALLET.id,
+          },
+        ],
+      })
+    ).resolves.toEqual([]);
+
+    await expect(repo.listApiKeyWalletPolicyBindings(TEST_API_KEY.id)).resolves.toEqual([]);
+  });
+
+  it("rejects a tenant-bearing input that omits its project claim", async () => {
+    const inputWithoutProject = {
+      organizationId: TEST_ORG.id,
+      custodyWalletId: TEST_CUSTODY_WALLET.id,
+      name: "Canonical tenant scope",
+    } as unknown as CreateWalletControlProfileInput;
+
+    await expect(repo.createWalletControlProfile(inputWithoutProject)).rejects.toThrow(
+      "cannot override the repository project scope"
+    );
+  });
+
+  it("applies active organization wallet and API key policies as project fallbacks", async () => {
+    await getDb(env)
+      .prepare("UPDATE custody_configs SET project_id = NULL WHERE id = ?")
+      .bind(TEST_CUSTODY_CONFIG.id)
+      .run();
+
+    const organizationRepo = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: null })
+    );
+    const walletProfile = await organizationRepo.createWalletControlProfile({
+      organizationId: TEST_ORG.id,
+      projectId: null,
+      custodyWalletId: TEST_CUSTODY_WALLET.id,
+      name: "Organization wallet controls",
+    });
+    const walletRevision = await organizationRepo.createWalletControlProfileRevision({
+      profileId: walletProfile?.id ?? "",
+      defaultAction: "deny",
+    });
+    await organizationRepo.activateWalletControlProfileRevision({
+      profileId: walletProfile?.id ?? "",
+      revisionId: walletRevision?.id ?? "",
+    });
+
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO api_key_control_profiles (
+             id, organization_id, project_id, api_key_id, name, status, active_revision_id
+           ) VALUES ('akcp_org_fallback', ?, NULL, ?, 'Organization key controls', 'active', 'akcpr_org_fallback')`
+        )
+        .bind(TEST_ORG.id, TEST_API_KEY.id),
+      getDb(env).prepare(
+        `INSERT INTO api_key_control_profile_revisions (
+             id, profile_id, revision_number, rules, default_action, activated_at
+           ) VALUES ('akcpr_org_fallback', 'akcp_org_fallback', 1, '[]'::jsonb, 'deny', sdp_iso_now())`
+      ),
+    ]);
+
+    const service = new PolicyFoundationService(repo);
+    await expect(
+      service.resolveEffectiveWalletPolicy(TEST_CUSTODY_WALLET.id)
+    ).resolves.toMatchObject({
+      source: "customer_profile",
+      profile: { id: walletProfile?.id },
+      defaultAction: "deny",
+    });
+    await expect(service.resolveEffectiveApiKeyPolicy(TEST_API_KEY.id)).resolves.toMatchObject({
+      source: "customer_profile",
+      profile: { id: "akcp_org_fallback" },
+      defaultAction: "deny",
+    });
+  });
+
   it("lists recent policy evaluations scoped to a wallet for audit review", async () => {
     await seedAdditionalCustodyWallet();
 
@@ -454,6 +562,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       repo.updateApprovalRequestStatus({
         organizationId: "org_other",
+        projectId: TEST_PROJECT.id,
         approvalRequestId: request?.id ?? "",
         status: "approved",
         operationStatus: "executing",
@@ -464,6 +573,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       repo.updateApprovalRequestStatus({
         organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
         approvalRequestId: request?.id ?? "",
         status: "approved",
         operationStatus: "executing",
@@ -478,6 +588,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       repo.updateApprovalRequestStatus({
         organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
         approvalRequestId: request?.id ?? "",
         status: "approved",
         operationStatus: "executing",

--- a/apps/sdp-api/src/db/repositories/policy.repository.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.ts
@@ -430,7 +430,7 @@ export interface CreateApprovalRequestInput {
 
 export interface UpdateApprovalRequestStatusInput {
   organizationId: string;
-  projectId?: string | null;
+  projectId: string | null;
   approvalRequestId: string;
   status: ApprovalRequestStatus;
   operationStatus?: WalletOperationStatus;

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -1,4 +1,6 @@
+// biome-ignore-all lint/security/noSecrets: repository and method identifiers are not credentials
 import { getDb } from "@/db";
+import { bindRepositoryToTenant, type TenantScope } from "@/lib/tenant-scope";
 import { createPiiCipher, type PiiCipher } from "@/services/pii-cipher/pii-cipher";
 import type { Env } from "@/types/env";
 import type { AssetProfilesRepository } from "./asset-profile.repository";
@@ -42,50 +44,133 @@ import { createPostgresProjectUserRepository } from "./project-user.repository.p
 import type { TokenRepository } from "./token.repository";
 import { createPostgresTokenRepository } from "./token.repository.postgres";
 
-export function createPaymentsRepository(env: Env): PaymentsRepository {
+export function createPaymentsRepository(env: Env, scope: TenantScope): PaymentsRepository {
+  return bindRepositoryToTenant(
+    createPostgresPaymentsRepository(getDb(env), scope),
+    scope,
+    "PaymentsRepository",
+    ["listTransfersByStatus"]
+  );
+}
+
+export function createSystemPaymentsRepository(env: Env): PaymentsRepository {
   return createPostgresPaymentsRepository(getDb(env));
 }
 
-export function createPaymentSubscriptionsRepository(env: Env): PaymentSubscriptionsRepository {
-  return createPostgresPaymentSubscriptionsRepository(getDb(env));
+export function createPaymentSubscriptionsRepository(
+  env: Env,
+  scope: TenantScope
+): PaymentSubscriptionsRepository {
+  return bindRepositoryToTenant(
+    createPostgresPaymentSubscriptionsRepository(getDb(env)),
+    scope,
+    "PaymentSubscriptionsRepository"
+  );
 }
 
 export function createPaymentRecurringPaymentsRepository(
-  env: Env
+  env: Env,
+  scope: TenantScope
 ): PaymentRecurringPaymentsRepository {
-  return createPostgresPaymentRecurringPaymentsRepository(getDb(env));
+  return bindRepositoryToTenant(
+    createPostgresPaymentRecurringPaymentsRepository(getDb(env)),
+    scope,
+    "PaymentRecurringPaymentsRepository"
+  );
 }
 
-export function createPaymentRequestsRepository(env: Env): PaymentRequestsRepository {
+export function createPaymentRequestsRepository(
+  env: Env,
+  scope: TenantScope
+): PaymentRequestsRepository {
+  return bindRepositoryToTenant(
+    createPostgresPaymentRequestsRepository(getDb(env)),
+    scope,
+    "PaymentRequestsRepository",
+    ["getPaymentRequestByPublicToken"]
+  );
+}
+
+export function createSystemPaymentRequestsRepository(env: Env): PaymentRequestsRepository {
   return createPostgresPaymentRequestsRepository(getDb(env));
 }
 
-export function createPaymentTransferBatchesRepository(env: Env): PaymentTransferBatchesRepository {
+export function createPaymentTransferBatchesRepository(
+  env: Env,
+  scope: TenantScope
+): PaymentTransferBatchesRepository {
+  return bindRepositoryToTenant(
+    createPostgresPaymentTransferBatchesRepository(getDb(env)),
+    scope,
+    "PaymentTransferBatchesRepository",
+    ["settleTransferBatch"]
+  );
+}
+
+export function createSystemPaymentTransferBatchesRepository(
+  env: Env
+): PaymentTransferBatchesRepository {
   return createPostgresPaymentTransferBatchesRepository(getDb(env));
 }
 
-export function createCounterpartiesRepository(env: Env): CounterpartiesRepository {
+export function createCounterpartiesRepository(
+  env: Env,
+  scope: TenantScope
+): CounterpartiesRepository {
+  const testCipher = (env as Env & { counterpartyPiiCipher?: PiiCipher }).counterpartyPiiCipher;
+  return bindRepositoryToTenant(
+    createPostgresCounterpartiesRepository(getDb(env), testCipher ?? createPiiCipher(env)),
+    scope,
+    "CounterpartiesRepository",
+    [
+      "findActiveCounterpartyById",
+      "findActiveCounterpartyByBvnkCustomerReference",
+      "findCounterpartyByMuralOrganizationId",
+      "mutateProviderData",
+      "upsertBvnkCustomerProviderData",
+      "patchMuralOrganizationById",
+    ]
+  );
+}
+
+export function createSystemCounterpartiesRepository(env: Env): CounterpartiesRepository {
   const testCipher = (env as Env & { counterpartyPiiCipher?: PiiCipher }).counterpartyPiiCipher;
   return createPostgresCounterpartiesRepository(getDb(env), testCipher ?? createPiiCipher(env));
 }
 
-export function createCounterpartyAccountsRepository(env: Env): CounterpartyAccountsRepository {
+export function createCounterpartyAccountsRepository(
+  env: Env,
+  scope: TenantScope
+): CounterpartyAccountsRepository {
   const testCipher = (env as Env & { counterpartyPiiCipher?: PiiCipher }).counterpartyPiiCipher;
-  return createPostgresCounterpartyAccountsRepository(
-    getDb(env),
-    testCipher ?? createPiiCipher(env)
+  return bindRepositoryToTenant(
+    createPostgresCounterpartyAccountsRepository(getDb(env), testCipher ?? createPiiCipher(env)),
+    scope,
+    "CounterpartyAccountsRepository"
   );
 }
 
-export function createTokenRepository(env: Env): TokenRepository {
-  return createPostgresTokenRepository(getDb(env));
+export function createTokenRepository(env: Env, scope: TenantScope): TokenRepository {
+  return createPostgresTokenRepository(getDb(env), scope);
 }
 
-export function createPolicyRepository(env: Env): PolicyRepository {
-  return createPostgresPolicyRepository(getDb(env));
+export function createPolicyRepository(env: Env, scope: TenantScope): PolicyRepository {
+  return createPostgresPolicyRepository(getDb(env), scope);
 }
 
-export function createAssetProfilesRepository(env: Env): AssetProfilesRepository {
+export function createAssetProfilesRepository(
+  env: Env,
+  scope: TenantScope
+): AssetProfilesRepository {
+  return bindRepositoryToTenant(
+    createPostgresAssetProfilesRepository(getDb(env)),
+    scope,
+    "AssetProfilesRepository",
+    ["getPublicMetadataByTokenId"]
+  );
+}
+
+export function createSystemAssetProfilesRepository(env: Env): AssetProfilesRepository {
   return createPostgresAssetProfilesRepository(getDb(env));
 }
 

--- a/apps/sdp-api/src/db/repositories/token.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/token.repository.postgres.ts
@@ -2,6 +2,7 @@ import { formatDecimalAmount } from "@sdp/solana/amount";
 import type { Token, TokenExtensionsConfig, TokenStatus, TokenTemplate } from "@sdp/types";
 import type { AppDb } from "@/db";
 import { parsePostgresJsonOr } from "@/db/postgres-utils";
+import { assertTenantClaim, type TenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import type { ListTokensOptions, TokenRepository } from "./token.repository";
 
 function buildInClause(length: number): string {
@@ -56,12 +57,20 @@ function mapTokenRow(
   };
 }
 
-export function createPostgresTokenRepository(db: AppDb): TokenRepository {
+export function createPostgresTokenRepository(db: AppDb, scope: TenantScope): TokenRepository {
+  if (!scope.projectId) {
+    throw new TenantScopeViolationError("TokenRepository requires a project tenant scope");
+  }
+
   return {
     async getById(tokenId: string) {
       const row = await db
-        .prepare("SELECT * FROM issued_tokens WHERE id = ?")
-        .bind(tokenId)
+        .prepare(
+          `SELECT *
+           FROM issued_tokens
+           WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(tokenId, scope.organizationId, scope.projectId)
         .first<Record<string, unknown>>();
 
       if (!row) {
@@ -90,9 +99,14 @@ export function createPostgresTokenRepository(db: AppDb): TokenRepository {
     },
 
     async getStatusByMint(projectId: string, mintAddress: string) {
+      assertTenantClaim(scope, { projectId }, "TokenRepository.getStatusByMint");
       const row = await db
-        .prepare("SELECT status FROM issued_tokens WHERE project_id = ? AND mint_address = ?")
-        .bind(projectId, mintAddress)
+        .prepare(
+          `SELECT status
+           FROM issued_tokens
+           WHERE organization_id = ? AND project_id = ? AND mint_address = ?`
+        )
+        .bind(scope.organizationId, scope.projectId, mintAddress)
         .first<{ status: TokenStatus }>();
 
       if (!row) {
@@ -103,8 +117,9 @@ export function createPostgresTokenRepository(db: AppDb): TokenRepository {
     },
 
     async listByProject(projectId: string, options: ListTokensOptions) {
-      const clauses = ["project_id = ?"];
-      const values: unknown[] = [projectId];
+      assertTenantClaim(scope, { projectId }, "TokenRepository.listByProject");
+      const clauses = ["organization_id = ?", "project_id = ?"];
+      const values: unknown[] = [scope.organizationId, scope.projectId];
 
       if (options.status) {
         clauses.push("status = ?");

--- a/apps/sdp-api/src/db/repositories/token.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/token.repository.postgres.ts
@@ -99,7 +99,11 @@ export function createPostgresTokenRepository(db: AppDb, scope: TenantScope): To
     },
 
     async getStatusByMint(projectId: string, mintAddress: string) {
-      assertTenantClaim(scope, { projectId }, "TokenRepository.getStatusByMint");
+      assertTenantClaim(
+        scope,
+        { organizationId: scope.organizationId, projectId },
+        "TokenRepository.getStatusByMint"
+      );
       const row = await db
         .prepare(
           `SELECT status
@@ -117,7 +121,11 @@ export function createPostgresTokenRepository(db: AppDb, scope: TenantScope): To
     },
 
     async listByProject(projectId: string, options: ListTokensOptions) {
-      assertTenantClaim(scope, { projectId }, "TokenRepository.listByProject");
+      assertTenantClaim(
+        scope,
+        { organizationId: scope.organizationId, projectId },
+        "TokenRepository.listByProject"
+      );
       const clauses = ["organization_id = ?", "project_id = ?"];
       const values: unknown[] = [scope.organizationId, scope.projectId];
 

--- a/apps/sdp-api/src/lib/tenant-boundary.test.ts
+++ b/apps/sdp-api/src/lib/tenant-boundary.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = join(process.cwd(), "src");
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      return sourceFiles(path);
+    }
+    return path.endsWith(".ts") && !path.endsWith(".test.ts") ? [path] : [];
+  });
+}
+
+describe("tenant data-access boundary", () => {
+  it("keeps raw TokenService construction out of authenticated issuance handlers", () => {
+    const handlers = sourceFiles(join(sourceRoot, "routes", "issuance", "handlers"));
+    const violations = handlers
+      .filter((path) => !path.endsWith(join("handlers", "metadata.ts")))
+      .filter((path) => readFileSync(path, "utf8").includes("new TokenService("))
+      .map((path) => relative(sourceRoot, path));
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps system repository factories in explicit public, webhook, and job paths", () => {
+    const allowedPrefixes = [
+      "routes/pay.ts",
+      "routes/issuance/handlers/metadata.ts",
+      "routes/webhooks/",
+      "services/jobs/",
+      "db/repositories/index.ts",
+      "db/repositories/repository-factory.ts",
+    ];
+    const violations = sourceFiles(sourceRoot)
+      .filter((path) => readFileSync(path, "utf8").match(/createSystem[A-Z]\w+Repository/))
+      .map((path) => relative(sourceRoot, path))
+      .filter((path) => !allowedPrefixes.some((prefix) => path.startsWith(prefix)));
+
+    expect(violations).toEqual([]);
+  });
+
+  it("requires transactional payment repositories to receive a tenant scope", () => {
+    const allowedSystemFactory = join(sourceRoot, "db", "repositories", "repository-factory.ts");
+    const violations = sourceFiles(sourceRoot)
+      .filter((path) => path !== allowedSystemFactory)
+      .flatMap((path) => {
+        const source = readFileSync(path, "utf8");
+        const calls = source.matchAll(/createPostgresPaymentsRepository\(([^)]*)\)/g);
+        return Array.from(calls)
+          .filter((match) => !match[1]?.includes(","))
+          .map(() => relative(sourceRoot, path));
+      });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("requires authenticated custody handlers to construct scoped signing services", () => {
+    const violations = sourceFiles(join(sourceRoot, "routes", "custody", "handlers")).flatMap(
+      (path) => {
+        const source = readFileSync(path, "utf8");
+        const calls = source.matchAll(/createSigningService\(([^)]*)\)/g);
+        return Array.from(calls)
+          .filter((match) => !match[1]?.includes(","))
+          .map(() => relative(sourceRoot, path));
+      }
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/sdp-api/src/lib/tenant-scope.test.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.test.ts
@@ -125,6 +125,52 @@ describe("tenant repository scope", () => {
     expect(calls).toBe(0);
   });
 
+  it("rejects snake-case cross-tenant claims before repository execution", () => {
+    let calls = 0;
+    const repository = bindRepositoryToTenant(
+      {
+        create(input: { organization_id: string; project_id: string; id: string }) {
+          calls += 1;
+          return input.id;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+
+    expect(() =>
+      repository.create({
+        organization_id: "org_alpha",
+        project_id: "prj_foreign",
+        id: "foreign",
+      })
+    ).toThrow(TenantScopeViolationError);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects cross-tenant claims nested in Map and Set arguments", () => {
+    let calls = 0;
+    const repository = bindRepositoryToTenant(
+      {
+        create(input: Map<string, Set<{ organizationId: string; projectId: string }>>) {
+          calls += 1;
+          return input.size;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+
+    expect(() =>
+      repository.create(
+        new Map([
+          ["nested", new Set([{ organizationId: "org_foreign", projectId: "prj_foreign" }])],
+        ])
+      )
+    ).toThrow(TenantScopeViolationError);
+    expect(calls).toBe(0);
+  });
+
   it("keeps organization-scoped null project semantics explicit", () => {
     expect(
       createTenantScope({

--- a/apps/sdp-api/src/lib/tenant-scope.test.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  bindRepositoryToTenant,
+  createTenantScope,
+  TenantScopeViolationError,
+} from "./tenant-scope";
+
+describe("tenant repository scope", () => {
+  const scope = createTenantScope({
+    organizationId: "org_alpha",
+    projectId: "prj_alpha",
+  });
+
+  it("rejects cross-tenant organization and project claims before repository execution", async () => {
+    let calls = 0;
+    const repository = bindRepositoryToTenant(
+      {
+        async get(input: { organizationId: string; projectId: string; id: string }) {
+          calls += 1;
+          return input.id;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+
+    expect(() =>
+      repository.get({
+        organizationId: "org_foreign",
+        projectId: "prj_foreign",
+        id: "foreign",
+      })
+    ).toThrow(TenantScopeViolationError);
+    expect(calls).toBe(0);
+  });
+
+  it("preserves legitimate same-tenant access", async () => {
+    const repository = bindRepositoryToTenant(
+      {
+        async get(input: { organizationId: string; projectId: string; id: string }) {
+          return input.id;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+
+    await expect(
+      repository.get({
+        organizationId: "org_alpha",
+        projectId: "prj_alpha",
+        id: "owned",
+      })
+    ).resolves.toBe("owned");
+  });
+
+  it("keeps organization-scoped null project semantics explicit", () => {
+    expect(
+      createTenantScope({
+        organizationId: "org_alpha",
+        projectId: null,
+      })
+    ).toMatchObject({
+      organizationId: "org_alpha",
+      projectId: null,
+    });
+  });
+
+  it("blocks system-only methods from tenant repositories", () => {
+    const repository = bindRepositoryToTenant(
+      {
+        reconcile() {
+          return "unsafe";
+        },
+      },
+      scope,
+      "TestRepository",
+      ["reconcile"]
+    );
+
+    expect(() => repository.reconcile()).toThrow(TenantScopeViolationError);
+  });
+});

--- a/apps/sdp-api/src/lib/tenant-scope.test.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.test.ts
@@ -106,7 +106,7 @@ describe("tenant repository scope", () => {
     expect(calls).toBe(0);
   });
 
-  it("rejects incomplete tenant claims before repository execution", () => {
+  it("validates each tenant claim independently without rejecting legitimate partial filters", () => {
     let calls = 0;
     const repository = bindRepositoryToTenant(
       {
@@ -119,9 +119,31 @@ describe("tenant repository scope", () => {
       "TestRepository"
     );
 
-    expect(() => repository.create({ organizationId: "org_alpha", id: "incomplete" })).toThrow(
+    expect(repository.create({ organizationId: "org_alpha", id: "partial" })).toBe("partial");
+    expect(() => repository.create({ organizationId: "org_foreign", id: "foreign" })).toThrow(
       TenantScopeViolationError
     );
+    expect(calls).toBe(1);
+  });
+
+  it("rejects inherited tenant claims before repository execution", () => {
+    let calls = 0;
+    const repository = bindRepositoryToTenant(
+      {
+        create(input: { organizationId: string; projectId: string; id: string }) {
+          calls += 1;
+          return input.id;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+    const inheritedClaim = Object.assign(
+      Object.create({ organizationId: "org_foreign", projectId: "prj_foreign" }),
+      { id: "inherited" }
+    );
+
+    expect(() => repository.create(inheritedClaim)).toThrow(TenantScopeViolationError);
     expect(calls).toBe(0);
   });
 

--- a/apps/sdp-api/src/lib/tenant-scope.test.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.test.ts
@@ -54,6 +54,77 @@ describe("tenant repository scope", () => {
     ).resolves.toBe("owned");
   });
 
+  it("rejects nested cross-tenant claims before repository execution", () => {
+    let calls = 0;
+    const repository = bindRepositoryToTenant(
+      {
+        createTransferBatchWithRecipients(input: {
+          batch: { organizationId: string; projectId: string; id: string };
+          recipients: Array<{ organizationId: string; projectId: string; id: string }>;
+        }) {
+          calls += 1;
+          return input.recipients.length;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+
+    expect(() =>
+      repository.createTransferBatchWithRecipients({
+        batch: {
+          organizationId: "org_foreign",
+          projectId: "prj_foreign",
+          id: "foreign-batch",
+        },
+        recipients: [
+          {
+            organizationId: "org_alpha",
+            projectId: "prj_alpha",
+            id: "owned-recipient",
+          },
+        ],
+      })
+    ).toThrow(TenantScopeViolationError);
+
+    expect(() =>
+      repository.createTransferBatchWithRecipients({
+        batch: {
+          organizationId: "org_alpha",
+          projectId: "prj_alpha",
+          id: "owned-batch",
+        },
+        recipients: [
+          {
+            organizationId: "org_foreign",
+            projectId: "prj_foreign",
+            id: "foreign-recipient",
+          },
+        ],
+      })
+    ).toThrow(TenantScopeViolationError);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects incomplete tenant claims before repository execution", () => {
+    let calls = 0;
+    const repository = bindRepositoryToTenant(
+      {
+        create(input: { organizationId: string; projectId?: string; id: string }) {
+          calls += 1;
+          return input.id;
+        },
+      },
+      scope,
+      "TestRepository"
+    );
+
+    expect(() => repository.create({ organizationId: "org_alpha", id: "incomplete" })).toThrow(
+      TenantScopeViolationError
+    );
+    expect(calls).toBe(0);
+  });
+
   it("keeps organization-scoped null project semantics explicit", () => {
     expect(
       createTenantScope({

--- a/apps/sdp-api/src/lib/tenant-scope.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.ts
@@ -1,0 +1,112 @@
+import type { Context } from "hono";
+import { getAuth } from "@/lib/auth";
+import type { Env } from "@/types/env";
+
+declare const tenantScopeBrand: unique symbol;
+
+/**
+ * Trusted tenant identity established by authentication and project-context
+ * middleware. `projectId` remains explicitly nullable for organization-level
+ * resources; callers may not omit it.
+ */
+export interface TenantScope {
+  readonly organizationId: string;
+  readonly projectId: string | null;
+  readonly [tenantScopeBrand]: true;
+}
+
+export class TenantScopeViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TenantScopeViolationError";
+  }
+}
+
+export function createTenantScope(input: {
+  organizationId: string;
+  projectId: string | null;
+}): TenantScope {
+  const organizationId = input.organizationId.trim();
+  const projectId = input.projectId?.trim() ?? null;
+
+  if (!organizationId) {
+    throw new TenantScopeViolationError("Tenant organizationId is required");
+  }
+  if (input.projectId !== null && !projectId) {
+    throw new TenantScopeViolationError("Tenant projectId cannot be empty");
+  }
+
+  return Object.freeze({
+    organizationId,
+    projectId,
+  }) as TenantScope;
+}
+
+/**
+ * Derive scope only from authenticated middleware state. Request headers,
+ * query parameters, and bodies are deliberately not consulted.
+ */
+export function getRequestTenantScope(c: Context<{ Bindings: Env }>): TenantScope {
+  const auth = getAuth(c);
+  return createTenantScope({
+    organizationId: auth.organizationId,
+    projectId: c.get("projectId") ?? auth.projectId ?? null,
+  });
+}
+
+export function assertTenantClaim(
+  scope: TenantScope,
+  claim: { organizationId?: unknown; projectId?: unknown },
+  operation: string
+): void {
+  if (claim.organizationId !== undefined && claim.organizationId !== scope.organizationId) {
+    throw new TenantScopeViolationError(
+      `${operation} cannot override the repository organization scope`
+    );
+  }
+
+  if (claim.projectId !== undefined && claim.projectId !== scope.projectId) {
+    throw new TenantScopeViolationError(
+      `${operation} cannot override the repository project scope`
+    );
+  }
+}
+
+export function bindRepositoryToTenant<T extends object>(
+  repository: T,
+  scope: TenantScope,
+  repositoryName: string,
+  systemOnlyMethods: readonly string[] = []
+): T {
+  const denied = new Set(systemOnlyMethods);
+
+  return new Proxy(repository, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return (...args: unknown[]) => {
+        const method = String(property);
+        if (denied.has(method)) {
+          throw new TenantScopeViolationError(
+            `${repositoryName}.${method} is system-only and unavailable to tenant callers`
+          );
+        }
+
+        for (const argument of args) {
+          if (argument && typeof argument === "object" && !Array.isArray(argument)) {
+            assertTenantClaim(
+              scope,
+              argument as { organizationId?: unknown; projectId?: unknown },
+              `${repositoryName}.${method}`
+            );
+          }
+        }
+
+        return Reflect.apply(value, target, args);
+      };
+    },
+  });
+}

--- a/apps/sdp-api/src/lib/tenant-scope.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.ts
@@ -83,11 +83,43 @@ function assertNestedTenantClaims(
   }
 
   visited.add(value);
-  if (
-    !Array.isArray(value) &&
-    (Object.hasOwn(value, "organizationId") || Object.hasOwn(value, "projectId"))
-  ) {
-    assertTenantClaim(scope, value as { organizationId: unknown; projectId: unknown }, operation);
+  if (value instanceof Map) {
+    for (const [key, nested] of value) {
+      assertNestedTenantClaims(scope, key, operation, visited);
+      assertNestedTenantClaims(scope, nested, operation, visited);
+    }
+    return;
+  }
+
+  if (value instanceof Set) {
+    for (const nested of value) {
+      assertNestedTenantClaims(scope, nested, operation, visited);
+    }
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    const record = value as Record<PropertyKey, unknown>;
+    if (Object.hasOwn(record, "organizationId") || Object.hasOwn(record, "projectId")) {
+      assertTenantClaim(
+        scope,
+        {
+          organizationId: record.organizationId,
+          projectId: record.projectId,
+        },
+        operation
+      );
+    }
+    if (Object.hasOwn(record, "organization_id") || Object.hasOwn(record, "project_id")) {
+      assertTenantClaim(
+        scope,
+        {
+          organizationId: record.organization_id,
+          projectId: record.project_id,
+        },
+        operation
+      );
+    }
   }
 
   for (const nested of Object.values(value)) {

--- a/apps/sdp-api/src/lib/tenant-scope.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.ts
@@ -100,24 +100,24 @@ function assertNestedTenantClaims(
 
   if (!Array.isArray(value)) {
     const record = value as Record<PropertyKey, unknown>;
-    if (Object.hasOwn(record, "organizationId") || Object.hasOwn(record, "projectId")) {
-      assertTenantClaim(
-        scope,
-        {
-          organizationId: record.organizationId,
-          projectId: record.projectId,
-        },
-        operation
+    if ("organizationId" in record && record.organizationId !== scope.organizationId) {
+      throw new TenantScopeViolationError(
+        `${operation} cannot override the repository organization scope`
       );
     }
-    if (Object.hasOwn(record, "organization_id") || Object.hasOwn(record, "project_id")) {
-      assertTenantClaim(
-        scope,
-        {
-          organizationId: record.organization_id,
-          projectId: record.project_id,
-        },
-        operation
+    if ("projectId" in record && record.projectId !== scope.projectId) {
+      throw new TenantScopeViolationError(
+        `${operation} cannot override the repository project scope`
+      );
+    }
+    if ("organization_id" in record && record.organization_id !== scope.organizationId) {
+      throw new TenantScopeViolationError(
+        `${operation} cannot override the repository organization scope`
+      );
+    }
+    if ("project_id" in record && record.project_id !== scope.projectId) {
+      throw new TenantScopeViolationError(
+        `${operation} cannot override the repository project scope`
       );
     }
   }

--- a/apps/sdp-api/src/lib/tenant-scope.ts
+++ b/apps/sdp-api/src/lib/tenant-scope.ts
@@ -56,19 +56,42 @@ export function getRequestTenantScope(c: Context<{ Bindings: Env }>): TenantScop
 
 export function assertTenantClaim(
   scope: TenantScope,
-  claim: { organizationId?: unknown; projectId?: unknown },
+  claim: { organizationId: unknown; projectId: unknown },
   operation: string
 ): void {
-  if (claim.organizationId !== undefined && claim.organizationId !== scope.organizationId) {
+  if (claim.organizationId !== scope.organizationId) {
     throw new TenantScopeViolationError(
       `${operation} cannot override the repository organization scope`
     );
   }
 
-  if (claim.projectId !== undefined && claim.projectId !== scope.projectId) {
+  if (claim.projectId !== scope.projectId) {
     throw new TenantScopeViolationError(
       `${operation} cannot override the repository project scope`
     );
+  }
+}
+
+function assertNestedTenantClaims(
+  scope: TenantScope,
+  value: unknown,
+  operation: string,
+  visited: WeakSet<object>
+): void {
+  if (value === null || typeof value !== "object" || visited.has(value)) {
+    return;
+  }
+
+  visited.add(value);
+  if (
+    !Array.isArray(value) &&
+    (Object.hasOwn(value, "organizationId") || Object.hasOwn(value, "projectId"))
+  ) {
+    assertTenantClaim(scope, value as { organizationId: unknown; projectId: unknown }, operation);
+  }
+
+  for (const nested of Object.values(value)) {
+    assertNestedTenantClaims(scope, nested, operation, visited);
   }
 }
 
@@ -96,13 +119,7 @@ export function bindRepositoryToTenant<T extends object>(
         }
 
         for (const argument of args) {
-          if (argument && typeof argument === "object" && !Array.isArray(argument)) {
-            assertTenantClaim(
-              scope,
-              argument as { organizationId?: unknown; projectId?: unknown },
-              `${repositoryName}.${method}`
-            );
-          }
+          assertNestedTenantClaims(scope, argument, `${repositoryName}.${method}`, new WeakSet());
         }
 
         return Reflect.apply(value, target, args);

--- a/apps/sdp-api/src/routes/api-keys/access-response.ts
+++ b/apps/sdp-api/src/routes/api-keys/access-response.ts
@@ -4,6 +4,7 @@ import {
   type ApiKeyWalletPolicyBindingRow,
   createPolicyRepository,
 } from "@/db/repositories";
+import type { TenantScope } from "@/lib/tenant-scope";
 import {
   type ApiKeyWalletBinding,
   listApiKeyWalletBindingsForApiKeys,
@@ -54,6 +55,7 @@ function mapPolicyBindingSummary(
 export async function buildApiKeyAccessSummaries(
   env: Env,
   db: ApiKeyWalletBindingsDb,
+  scope: TenantScope,
   apiKeyIds: string[]
 ): Promise<Map<string, ApiKeyAccessSummary>> {
   const uniqueApiKeyIds = uniqueStrings(apiKeyIds);
@@ -61,7 +63,7 @@ export async function buildApiKeyAccessSummaries(
     return new Map();
   }
 
-  const policyRepository = createPolicyRepository(env);
+  const policyRepository = createPolicyRepository(env, scope);
 
   const [walletBindings, policyBindings] = await Promise.all([
     listApiKeyWalletBindingsForApiKeys(db, uniqueApiKeyIds),

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -17,6 +17,7 @@ import {
 import { requireProjectId } from "@/lib/auth";
 import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { ApiKeyService } from "@/services/api-key.service";
 import {
   assertWalletBindingsInScope,
@@ -85,11 +86,12 @@ export const listApiKeys = async (c: AppContext) => {
   const projectId = requireProjectId(c);
 
   const db = getDb(c.env);
-  const apiKeyService = new ApiKeyService(db);
+  const apiKeyService = new ApiKeyService(db, getRequestTenantScope(c));
   const apiKeys = await apiKeyService.listForProject(projectId);
   const accessSummaryByKeyId = await buildApiKeyAccessSummaries(
     c.env,
     db,
+    getRequestTenantScope(c),
     apiKeys.map((key) => key.id)
   );
 
@@ -230,7 +232,7 @@ export const createApiKey = async (c: AppContext) => {
     throw new AppError("UNAUTHORIZED", "Could not resolve authenticated user for API key creation");
   }
 
-  const apiKeyService = new ApiKeyService(getDb(c.env));
+  const apiKeyService = new ApiKeyService(getDb(c.env), getRequestTenantScope(c));
   const createdKey = await apiKeyService.createApiKey({
     organizationId: orgId,
     projectId,
@@ -289,14 +291,19 @@ export const getApiKey = async (c: AppContext) => {
   const actor = resolveActor(c);
   const projectId = requireProjectId(c);
 
-  const apiKeyService = new ApiKeyService(getDb(c.env));
+  const apiKeyService = new ApiKeyService(getDb(c.env), getRequestTenantScope(c));
   const key = await apiKeyService.getDetails(keyId, actor.organizationId, projectId);
 
   if (!key) {
     throw notFound("API key");
   }
 
-  const accessSummaryByKeyId = await buildApiKeyAccessSummaries(c.env, getDb(c.env), [key.id]);
+  const accessSummaryByKeyId = await buildApiKeyAccessSummaries(
+    c.env,
+    getDb(c.env),
+    getRequestTenantScope(c),
+    [key.id]
+  );
   const accessSummary = accessSummaryByKeyId.get(key.id);
   const walletBindings = accessSummary?.walletBindings ?? [];
 
@@ -366,7 +373,7 @@ export const updateApiKey = async (c: AppContext) => {
     );
   }
 
-  const apiKeyService = new ApiKeyService(getDb(c.env));
+  const apiKeyService = new ApiKeyService(getDb(c.env), getRequestTenantScope(c));
   await apiKeyService.updateApiKey({
     keyId,
     organizationId: actor.organizationId,
@@ -420,7 +427,7 @@ export const createApiKeyControlProfile = async (c: AppContext) => {
   }
 
   const profile = await new PolicyFoundationService(
-    createPolicyRepository(c.env)
+    createPolicyRepository(c.env, getRequestTenantScope(c))
   ).createApiKeyControlProfile({
     organizationId: actor.organizationId,
     projectId,
@@ -451,7 +458,7 @@ export const createApiKeyControlProfileRevision = async (c: AppContext) => {
   }
 
   const revision = await new PolicyFoundationService(
-    createPolicyRepository(c.env)
+    createPolicyRepository(c.env, getRequestTenantScope(c))
   ).createApiKeyControlProfileRevision({
     organizationId: actor.organizationId,
     projectId,
@@ -482,7 +489,7 @@ export const activateApiKeyControlProfileRevision = async (c: AppContext) => {
   const actor = resolveActor(c);
   const projectId = requireProjectId(c);
   const active = await new PolicyFoundationService(
-    createPolicyRepository(c.env)
+    createPolicyRepository(c.env, getRequestTenantScope(c))
   ).activateApiKeyControlProfileRevision({
     organizationId: actor.organizationId,
     projectId,
@@ -521,7 +528,7 @@ export const writeApiKeyPolicyBindings = async (c: AppContext) => {
         }));
 
   await new PolicyFoundationService(
-    createPolicyRepository(c.env)
+    createPolicyRepository(c.env, getRequestTenantScope(c))
   ).replaceApiKeyWalletPolicyBindings({
     organizationId: actor.organizationId,
     projectId,
@@ -529,7 +536,9 @@ export const writeApiKeyPolicyBindings = async (c: AppContext) => {
     bindings,
   });
 
-  const accessSummary = (await buildApiKeyAccessSummaries(c.env, getDb(c.env), [keyId])).get(keyId);
+  const accessSummary = (
+    await buildApiKeyAccessSummaries(c.env, getDb(c.env), getRequestTenantScope(c), [keyId])
+  ).get(keyId);
   const policyBindings = accessSummary?.policyBindings ?? [];
 
   await new AuditService(getDb(c.env)).log(c, {
@@ -566,7 +575,7 @@ export const rotateApiKey = async (c: AppContext) => {
 
   const gracePeriodHours = parsed.data.gracePeriodHours ?? 24;
 
-  const apiKeyService = new ApiKeyService(getDb(c.env));
+  const apiKeyService = new ApiKeyService(getDb(c.env), getRequestTenantScope(c));
   const rotation = await apiKeyService.rotateApiKey(
     keyId,
     actor.organizationId,
@@ -643,7 +652,7 @@ export const revokeApiKey = async (c: AppContext) => {
     throw badRequest("Confirmation did not match the key name");
   }
 
-  const apiKeyService = new ApiKeyService(getDb(c.env));
+  const apiKeyService = new ApiKeyService(getDb(c.env), getRequestTenantScope(c));
   const revokedKey = await apiKeyService.revokeApiKey(keyId, actor.organizationId, projectId);
 
   if (!revokedKey) {

--- a/apps/sdp-api/src/routes/asset-profiles/context.ts
+++ b/apps/sdp-api/src/routes/asset-profiles/context.ts
@@ -1,13 +1,14 @@
 import type { Context } from "hono";
 import { createAssetProfilesRepository, createTokenRepository } from "@/db/repositories";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
 
 export function getAssetProfilesRepository(c: AppContext) {
-  return createAssetProfilesRepository(c.env);
+  return createAssetProfilesRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getTokenRepository(c: AppContext) {
-  return createTokenRepository(c.env);
+  return createTokenRepository(c.env, getRequestTenantScope(c));
 }

--- a/apps/sdp-api/src/routes/asset-profiles/create.ts
+++ b/apps/sdp-api/src/routes/asset-profiles/create.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/issuance/advanced-settings";
 import { projectPublicMetadata } from "@/lib/issuance/public-metadata";
 import { created } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { createOrgSigner } from "@/services/solana";
@@ -110,10 +111,11 @@ export const createTokenWithAssetProfile = async (c: AppContext) => {
   const createdBy = await resolveCreatorUserId(c);
 
   const db = getDb(c.env);
+  const tenantScope = getRequestTenantScope(c);
 
   const { token, profileRow } = await db.transaction(async (tx) => {
     const client = asTransactionalClient(tx);
-    const tokenService = new TokenService(client);
+    const tokenService = new TokenService(client, tenantScope);
     const assetProfilesRepo = createPostgresAssetProfilesRepository(client);
 
     const token = await tokenService.createToken({

--- a/apps/sdp-api/src/routes/counterparties/context.ts
+++ b/apps/sdp-api/src/routes/counterparties/context.ts
@@ -3,14 +3,15 @@ import {
   createCounterpartiesRepository,
   createCounterpartyAccountsRepository,
 } from "@/db/repositories";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
 
 export function getCounterpartiesRepository(c: AppContext) {
-  return createCounterpartiesRepository(c.env);
+  return createCounterpartiesRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getCounterpartyAccountsRepository(c: AppContext) {
-  return createCounterpartyAccountsRepository(c.env);
+  return createCounterpartyAccountsRepository(c.env, getRequestTenantScope(c));
 }

--- a/apps/sdp-api/src/routes/counterparty-accounts/context.ts
+++ b/apps/sdp-api/src/routes/counterparty-accounts/context.ts
@@ -3,14 +3,15 @@ import {
   createCounterpartiesRepository,
   createCounterpartyAccountsRepository,
 } from "@/db/repositories";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
 
 export function getCounterpartyAccountsRepository(c: AppContext) {
-  return createCounterpartyAccountsRepository(c.env);
+  return createCounterpartyAccountsRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getCounterpartiesRepository(c: AppContext) {
-  return createCounterpartiesRepository(c.env);
+  return createCounterpartiesRepository(c.env, getRequestTenantScope(c));
 }

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -453,6 +453,56 @@ describe("Custody wallet scope routes", () => {
     expect(res.status).toBe(404);
   });
 
+  it("prevents a project-scoped caller from changing an organization default wallet", async () => {
+    const res = await app.request(
+      "/v1/wallets/default-wallet",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "privy",
+          walletId: "privy_wallet_b",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(409);
+    const config = await getDb(env)
+      .prepare("SELECT default_wallet_id FROM custody_configs WHERE id = ?")
+      .bind(PRIVY_CONFIG_ID)
+      .first<{ default_wallet_id: string | null }>();
+    expect(config?.default_wallet_id).toBe("privy_wallet_a");
+  });
+
+  it("prevents a project-scoped caller from deleting an organization wallet", async () => {
+    const res = await app.request(
+      "/v1/wallets",
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "privy",
+          walletId: "privy_wallet_b",
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(404);
+    const wallet = await getDb(env)
+      .prepare("SELECT status FROM custody_wallets WHERE wallet_id = ?")
+      .bind("privy_wallet_b")
+      .first<{ status: string }>();
+    expect(wallet?.status).toBe("active");
+  });
+
   it("excludes custody configs from a different project in the same org", async () => {
     const otherProjectId = "prj_custody_config_cross_project";
     const otherConfigId = "cust_cfg_scope_other_project";

--- a/apps/sdp-api/src/routes/custody/handlers/approval-requests.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/approval-requests.ts
@@ -4,6 +4,7 @@ import { type ApprovalRequestDetailRow, createPolicyRepository } from "@/db/repo
 import { type ApiKeyContext, getAuth } from "@/lib/auth";
 import { badRequestParams, badRequestQuery, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { WalletPolicyEnforcementService } from "@/services/policy-enforcement.service";
 import type { AppContext } from "../context";
 import { approvalRequestListQuerySchema, approvalRequestParamsSchema } from "../schemas";
@@ -80,7 +81,7 @@ function actorId(auth: ApiKeyContext): string {
 
 async function readApprovalRequest(c: AppContext, approvalRequestId: string) {
   const auth = getAuth(c);
-  const repository = createPolicyRepository(c.env);
+  const repository = createPolicyRepository(c.env, getRequestTenantScope(c));
   const row = await repository.getApprovalRequestDetail({
     organizationId: auth.organizationId,
     projectId: auth.projectId,
@@ -105,7 +106,10 @@ export const listApprovalRequests = async (c: AppContext) => {
     throw badRequestQuery({ errors: z.flattenError(parsed.error).fieldErrors });
   }
 
-  const rows = await createPolicyRepository(c.env).listApprovalRequestDetails({
+  const rows = await createPolicyRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).listApprovalRequestDetails({
     organizationId: auth.organizationId,
     projectId: auth.projectId,
     status: parsed.data.status,
@@ -127,7 +131,7 @@ export const getApprovalRequest = async (c: AppContext) => {
 export const approveApprovalRequest = async (c: AppContext) => {
   const { approvalRequestId } = parseApprovalRequestParams(c);
   const auth = getAuth(c);
-  const repository = createPolicyRepository(c.env);
+  const repository = createPolicyRepository(c.env, getRequestTenantScope(c));
   const approvalRequest = await new WalletPolicyEnforcementService(
     repository
   ).approveApprovalRequest(auth.organizationId, approvalRequestId, actorId(auth), auth.projectId);
@@ -144,7 +148,7 @@ export const approveApprovalRequest = async (c: AppContext) => {
 export const rejectApprovalRequest = async (c: AppContext) => {
   const { approvalRequestId } = parseApprovalRequestParams(c);
   const auth = getAuth(c);
-  const repository = createPolicyRepository(c.env);
+  const repository = createPolicyRepository(c.env, getRequestTenantScope(c));
   const approvalRequest = await new WalletPolicyEnforcementService(
     repository
   ).rejectApprovalRequest(auth.organizationId, approvalRequestId, actorId(auth), auth.projectId);
@@ -161,7 +165,7 @@ export const rejectApprovalRequest = async (c: AppContext) => {
 export const cancelApprovalRequest = async (c: AppContext) => {
   const { approvalRequestId } = parseApprovalRequestParams(c);
   const auth = getAuth(c);
-  const repository = createPolicyRepository(c.env);
+  const repository = createPolicyRepository(c.env, getRequestTenantScope(c));
   const approvalRequest = await new WalletPolicyEnforcementService(
     repository
   ).cancelApprovalRequest(auth.organizationId, approvalRequestId, actorId(auth), auth.projectId);

--- a/apps/sdp-api/src/routes/custody/handlers/configs.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/configs.ts
@@ -1,6 +1,7 @@
 import { getDb } from "@/db";
 import { AppError } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { createSigningService } from "@/services/domain/signing.service";
 import { type AppContext, getPreferredWalletForConfig, resolveActor } from "../context";
 import type { CustodyConfigResponse, CustodyConfigsResponse } from "../schemas";
@@ -9,7 +10,7 @@ export const getConfig = async (c: AppContext) => {
   const actor = resolveActor(c);
   const projectId = c.get("projectId");
 
-  const signingService = createSigningService(c.env);
+  const signingService = createSigningService(c.env, getRequestTenantScope(c));
   const config = await signingService.getConfiguration(actor.organizationId, projectId);
 
   if (!config) {
@@ -40,7 +41,7 @@ export const getConfig = async (c: AppContext) => {
 export const getConfigs = async (c: AppContext) => {
   const actor = resolveActor(c);
   const projectId = c.get("projectId");
-  const signingService = createSigningService(c.env);
+  const signingService = createSigningService(c.env, getRequestTenantScope(c));
   const { configs, defaultConfigId } = await signingService.getConfigurations(
     actor.organizationId,
     projectId

--- a/apps/sdp-api/src/routes/custody/handlers/provider.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/provider.ts
@@ -6,6 +6,7 @@ import { getDb } from "@/db";
 import { AppError, badRequest, conflict, forbidden } from "@/lib/errors";
 import { isPrivyByokProvisioningEnabled } from "@/lib/feature-flags";
 import { created, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { clearWalletCaches } from "@/routes/custody/handlers/wallets";
 import { AuditService } from "@/services/audit.service";
 import { provisionFireblocksVaultAccount } from "@/services/custody/provisioning";
@@ -81,7 +82,7 @@ export const initializeSigning = async (c: AppContext) => {
     });
   }
 
-  const signingService = createSigningService(c.env);
+  const signingService = createSigningService(c.env, getRequestTenantScope(c));
 
   try {
     const result = await initializeProviderConnection(
@@ -127,7 +128,7 @@ export const switchSigning = async (c: AppContext) => {
     });
   }
 
-  const signingService = createSigningService(c.env);
+  const signingService = createSigningService(c.env, getRequestTenantScope(c));
   const auditService = new AuditService(getDb(c.env));
   const projectId = c.get("projectId");
   const targetProvider = parsed.data.provider;
@@ -213,7 +214,7 @@ export const switchSigning = async (c: AppContext) => {
 export const getSwitchProviderOptions = async (c: AppContext) => {
   const actor = resolveActor(c);
   const projectId = c.get("projectId");
-  const signingService = createSigningService(c.env);
+  const signingService = createSigningService(c.env, getRequestTenantScope(c));
   const enabledProviders = (await getEnabledProviders(c.env, getDb(c.env), actor.organizationId))
     .custody;
   const [reuseState, configurations] = await Promise.all([

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -20,6 +20,7 @@ import { getAuth } from "@/lib/auth";
 import { AppError, badRequest } from "@/lib/errors";
 import { resolveKoraUserId } from "@/lib/kora-user";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import {
   enforceWalletOperationPolicy,
@@ -69,7 +70,7 @@ export const signerCheck = async (c: AppContext) => {
   }
 
   const policyWallet = await resolvePolicyCustodyWallet(c.env, auth, resolvedWalletId);
-  await enforceWalletOperationPolicy(c.env, {
+  await enforceWalletOperationPolicy(c.env, getRequestTenantScope(c), {
     organizationId: auth.organizationId,
     projectId: auth.projectId,
     custodyWalletId: policyWallet?.id ?? null,

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -13,6 +13,7 @@ import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
 import { AppError, badRequest } from "@/lib/errors";
 import { created, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import * as tokenAccounts from "@/routes/payments/token-accounts";
 import { resolveIssuedTokenLabelsByMint } from "@/routes/payments/token-labels";
 import { getLogger } from "@/runtime/logger";
@@ -472,7 +473,7 @@ export const createWallet = async (c: AppContext) => {
     });
   }
 
-  const signingService = signingServiceModule.createSigningService(c.env);
+  const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
 
   try {
     const wallet = await signingService.createWallet(actor.organizationId, projectId, {
@@ -521,7 +522,7 @@ export const deleteWallet = async (c: AppContext) => {
   }
 
   const projectId = c.get("projectId");
-  const signingService = signingServiceModule.createSigningService(c.env);
+  const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
 
   try {
     await signingService.deleteWallet(actor.organizationId, projectId, {
@@ -574,7 +575,7 @@ export const setDefaultWallet = async (c: AppContext) => {
   }
 
   const projectId = c.get("projectId");
-  const signingService = signingServiceModule.createSigningService(c.env);
+  const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
   const config = parsed.data.provider
     ? await signingService.getConfigurationByProvider(
         actor.organizationId,
@@ -655,7 +656,7 @@ export const updateWallet = async (c: AppContext) => {
     });
   }
 
-  const signingService = signingServiceModule.createSigningService(c.env);
+  const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
   const wallet = await signingService.getWalletById(actor.organizationId, projectId, walletId);
 
   if (!wallet) {
@@ -825,7 +826,7 @@ export const getWalletById = async (c: AppContext) => {
     throw badRequest("Invalid wallet ID");
   }
 
-  const signingService = signingServiceModule.createSigningService(c.env);
+  const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
   const wallet = await signingService.getWalletById(actor.organizationId, projectId, walletId);
 
   if (!wallet) {
@@ -918,7 +919,7 @@ export const getPublicKey = async (c: AppContext) => {
   const projectId = c.get("projectId");
   const requestedWalletId = c.req.query("walletId");
 
-  const signingService = signingServiceModule.createSigningService(c.env);
+  const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
 
   try {
     const walletId = resolveApiKeySigningWalletId(auth, requestedWalletId, ["wallets:read"]);

--- a/apps/sdp-api/src/routes/custody/handlers/wallets.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/wallets.ts
@@ -576,13 +576,11 @@ export const setDefaultWallet = async (c: AppContext) => {
 
   const projectId = c.get("projectId");
   const signingService = signingServiceModule.createSigningService(c.env, getRequestTenantScope(c));
-  const config = parsed.data.provider
-    ? await signingService.getConfigurationByProvider(
-        actor.organizationId,
-        projectId,
-        parsed.data.provider
-      )
-    : await signingService.getConfiguration(actor.organizationId, projectId);
+  const config = await signingService.getConfigurationForMutation(
+    actor.organizationId,
+    projectId,
+    parsed.data.provider
+  );
 
   if (!config?.id) {
     throw new AppError("CONFLICT", "Wallet signing is not initialized");

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -2553,7 +2553,7 @@ describe("Issuance Routes", () => {
         }
       });
 
-      it("restores the database entry if on-chain control-list removal fails", async () => {
+      it("keeps the database entry revoked and retries a failed on-chain removal", async () => {
         await app.request(
           `/v1/issuance/tokens/${tokenId}/allowlist`,
           {
@@ -2585,10 +2585,14 @@ describe("Issuance Routes", () => {
 
         const createOrgSignerSpy = vi
           .spyOn(SolanaServices, "createOrgSigner")
-          .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
+          .mockResolvedValue({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
         const removeFromListSpy = vi
           .spyOn(MosaicService.prototype, "removeFromList")
-          .mockRejectedValueOnce(new Error("mosaic removal failed"));
+          .mockRejectedValueOnce(new Error("mosaic removal failed"))
+          .mockResolvedValueOnce(undefined as never);
+        const isWalletOnListSpy = vi
+          .spyOn(MosaicService.prototype, "isWalletOnList")
+          .mockResolvedValueOnce(true);
 
         try {
           const res = await app.request(
@@ -2602,23 +2606,30 @@ describe("Issuance Routes", () => {
 
           expect(res.status).toBe(500);
 
-          const restoredListRes = await app.request(
-            `/v1/issuance/tokens/${tokenId}/allowlist`,
+          const revoked = await db
+            .prepare("SELECT status FROM token_allowlists WHERE id = ?")
+            .bind(entryId)
+            .first<{ status: string }>();
+          expect(revoked?.status).toBe("revoked");
+
+          const retry = await app.request(
+            `/v1/issuance/tokens/${tokenId}/allowlist/${entryId}`,
             {
+              method: "DELETE",
               headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
             },
             env
           );
-          const restoredListBody = await restoredListRes.json();
-          expect(restoredListBody.data).toHaveLength(1);
-          expect(restoredListBody.data[0].id).toBe(entryId);
+          expect(retry.status).toBe(204);
+          expect(removeFromListSpy).toHaveBeenCalledTimes(2);
         } finally {
           createOrgSignerSpy.mockRestore();
           removeFromListSpy.mockRestore();
+          isWalletOnListSpy.mockRestore();
         }
       });
 
-      it("restores a pending entry as pending when on-chain removal fails", async () => {
+      it("treats a timed-out removal as success when on-chain absence is confirmed", async () => {
         const db = getDb(env);
         await db
           .prepare("UPDATE issued_tokens SET abl_list_address = ? WHERE id = ?")
@@ -2637,7 +2648,10 @@ describe("Issuance Routes", () => {
           .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
         const removeFromListSpy = vi
           .spyOn(MosaicService.prototype, "removeFromList")
-          .mockRejectedValueOnce(new Error("pending entry was never confirmed on-chain"));
+          .mockRejectedValueOnce(new Error("RPC confirmation timeout"));
+        const isWalletOnListSpy = vi
+          .spyOn(MosaicService.prototype, "isWalletOnList")
+          .mockResolvedValueOnce(false);
 
         try {
           const res = await app.request(
@@ -2649,15 +2663,16 @@ describe("Issuance Routes", () => {
             env
           );
 
-          expect(res.status).toBe(500);
-          const restored = await db
+          expect(res.status).toBe(204);
+          const revoked = await db
             .prepare("SELECT status FROM token_allowlists WHERE id = ?")
             .bind(entry.id)
             .first<{ status: string }>();
-          expect(restored?.status).toBe("pending");
+          expect(revoked?.status).toBe("revoked");
         } finally {
           createOrgSignerSpy.mockRestore();
           removeFromListSpy.mockRestore();
+          isWalletOnListSpy.mockRestore();
         }
       });
     });

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -2170,7 +2170,7 @@ describe("Issuance Routes", () => {
 
         const createOrgSignerSpy = vi
           .spyOn(SolanaServices, "createOrgSigner")
-          .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
+          .mockResolvedValue({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
         const addToListSpy = vi
           .spyOn(MosaicService.prototype, "addToList")
           .mockRejectedValueOnce(new Error("on-chain add failed"))

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -1466,6 +1466,33 @@ describe("Issuance Routes", () => {
       expect(body.data.token.description).toBe("New description");
     });
 
+    it("rejects metadata updates while token deployment is in progress", async () => {
+      await getDb(env)
+        .prepare("UPDATE issued_tokens SET status = 'deploying' WHERE id = ?")
+        .bind(tokenId)
+        .run();
+
+      const res = await app.request(
+        `/v1/issuance/tokens/${tokenId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({ name: "Divergent metadata" }),
+        },
+        env
+      );
+
+      expect(res.status).toBe(409);
+      const row = await getDb(env)
+        .prepare("SELECT name FROM issued_tokens WHERE id = ?")
+        .bind(tokenId)
+        .first<{ name: string }>();
+      expect(row?.name).toBe("Update Token");
+    });
+
     it("updates deployed token metadata on-chain before persisting local fields", async () => {
       const db = getDb(env);
       const activeTokenId = "tok_metadataupdate1";
@@ -2585,6 +2612,49 @@ describe("Issuance Routes", () => {
           const restoredListBody = await restoredListRes.json();
           expect(restoredListBody.data).toHaveLength(1);
           expect(restoredListBody.data[0].id).toBe(entryId);
+        } finally {
+          createOrgSignerSpy.mockRestore();
+          removeFromListSpy.mockRestore();
+        }
+      });
+
+      it("restores a pending entry as pending when on-chain removal fails", async () => {
+        const db = getDb(env);
+        await db
+          .prepare("UPDATE issued_tokens SET abl_list_address = ? WHERE id = ?")
+          .bind(TEST_SOLANA_ADDRESSES.wallet3, tokenId)
+          .run();
+        const tokenService = new TokenService(db);
+        const { entry } = await tokenService.addAllowlistEntry({
+          tokenId,
+          address: TEST_SOLANA_ADDRESSES.wallet1,
+          addedBy: TEST_PROJECT_API_KEY.id,
+          initialStatus: "pending",
+        });
+
+        const createOrgSignerSpy = vi
+          .spyOn(SolanaServices, "createOrgSigner")
+          .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
+        const removeFromListSpy = vi
+          .spyOn(MosaicService.prototype, "removeFromList")
+          .mockRejectedValueOnce(new Error("pending entry was never confirmed on-chain"));
+
+        try {
+          const res = await app.request(
+            `/v1/issuance/tokens/${tokenId}/allowlist/${entry.id}`,
+            {
+              method: "DELETE",
+              headers: { Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}` },
+            },
+            env
+          );
+
+          expect(res.status).toBe(500);
+          const restored = await db
+            .prepare("SELECT status FROM token_allowlists WHERE id = ?")
+            .bind(entry.id)
+            .first<{ status: string }>();
+          expect(restored?.status).toBe("pending");
         } finally {
           createOrgSignerSpy.mockRestore();
           removeFromListSpy.mockRestore();

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -2553,7 +2553,7 @@ describe("Issuance Routes", () => {
         }
       });
 
-      it("keeps the database entry revoked and retries a failed on-chain removal", async () => {
+      it("keeps the database entry active until a retry confirms on-chain removal", async () => {
         await app.request(
           `/v1/issuance/tokens/${tokenId}/allowlist`,
           {
@@ -2606,11 +2606,11 @@ describe("Issuance Routes", () => {
 
           expect(res.status).toBe(500);
 
-          const revoked = await db
+          const stillActive = await db
             .prepare("SELECT status FROM token_allowlists WHERE id = ?")
             .bind(entryId)
             .first<{ status: string }>();
-          expect(revoked?.status).toBe("revoked");
+          expect(stillActive?.status).toBe("active");
 
           const retry = await app.request(
             `/v1/issuance/tokens/${tokenId}/allowlist/${entryId}`,
@@ -2622,6 +2622,12 @@ describe("Issuance Routes", () => {
           );
           expect(retry.status).toBe(204);
           expect(removeFromListSpy).toHaveBeenCalledTimes(2);
+
+          const revoked = await db
+            .prepare("SELECT status FROM token_allowlists WHERE id = ?")
+            .bind(entryId)
+            .first<{ status: string }>();
+          expect(revoked?.status).toBe("revoked");
         } finally {
           createOrgSignerSpy.mockRestore();
           removeFromListSpy.mockRestore();

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -2161,7 +2161,7 @@ describe("Issuance Routes", () => {
         }
       });
 
-      it("surfaces both errors when add compensation fails", async () => {
+      it("keeps a pending DB row and audit trail when on-chain confirmation is ambiguous", async () => {
         const db = getDb(env);
         await db
           .prepare("UPDATE issued_tokens SET abl_list_address = ? WHERE id = ?")
@@ -2173,16 +2173,12 @@ describe("Issuance Routes", () => {
           .mockResolvedValueOnce({ address: TEST_SOLANA_ADDRESSES.wallet2 } as never);
         const addToListSpy = vi
           .spyOn(MosaicService.prototype, "addToList")
-          .mockRejectedValueOnce(new Error("on-chain add failed"));
-        // After addToList fails the handler re-checks on-chain membership; if
-        // it returns true, we'd keep the DB row and succeed — for this test we
-        // want the rollback path, so return false.
+          .mockRejectedValueOnce(new Error("on-chain add failed"))
+          .mockResolvedValueOnce(undefined as never);
         const isWalletOnListSpy = vi
           .spyOn(MosaicService.prototype, "isWalletOnList")
           .mockResolvedValueOnce(false);
-        const deleteAllowlistEntrySpy = vi
-          .spyOn(TokenService.prototype, "deleteAllowlistEntry")
-          .mockRejectedValueOnce(new Error("rollback failed"));
+        const deleteAllowlistEntrySpy = vi.spyOn(TokenService.prototype, "deleteAllowlistEntry");
 
         try {
           const res = await app.request(
@@ -2202,10 +2198,44 @@ describe("Issuance Routes", () => {
           );
 
           expect(res.status).toBe(500);
-          const body = await res.json();
-          expect(body.error.code).toBe("INTERNAL_ERROR");
-          expect(body.error.details.originalError).toBe("on-chain add failed");
-          expect(body.error.details.restoreError).toBe("rollback failed");
+          expect(deleteAllowlistEntrySpy).not.toHaveBeenCalled();
+
+          const entry = await db
+            .prepare("SELECT id, status FROM token_allowlists WHERE token_id = ? AND address = ?")
+            .bind(tokenId, TEST_SOLANA_ADDRESSES.wallet1)
+            .first<{ id: string; status: string }>();
+          expect(entry?.status).toBe("pending");
+          const audit = await db
+            .prepare(
+              `SELECT id FROM audit_logs
+               WHERE action = 'create' AND resource_type = 'token_allowlist'
+                 AND resource_id = ?`
+            )
+            .bind(entry?.id)
+            .first<{ id: string }>();
+          expect(audit).not.toBeNull();
+
+          const retry = await app.request(
+            `/v1/issuance/tokens/${tokenId}/allowlist`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              },
+              body: JSON.stringify({
+                address: TEST_SOLANA_ADDRESSES.wallet1,
+                label: "On-chain Wallet",
+              }),
+            },
+            env
+          );
+          expect(retry.status).toBe(201);
+          const reconciled = await db
+            .prepare("SELECT status FROM token_allowlists WHERE id = ?")
+            .bind(entry?.id)
+            .first<{ status: string }>();
+          expect(reconciled?.status).toBe("active");
         } finally {
           createOrgSignerSpy.mockRestore();
           addToListSpy.mockRestore();
@@ -2298,11 +2328,7 @@ describe("Issuance Routes", () => {
         expect(res.status).toBe(409);
       });
 
-      it("restores prior revoked state on rollback when re-adding a previously-revoked entry", async () => {
-        // Reactivated row (previously revoked → addAllowlistEntry promotes back
-        // to active in-place). If addToList then fails and on-chain membership
-        // is not confirmed, rollback must re-revoke (not hard-delete) so the
-        // operator's original revocation record survives.
+      it("keeps a re-added entry pending when on-chain membership is uncertain", async () => {
         const db = getDb(env);
         await db
           .prepare("UPDATE issued_tokens SET abl_list_address = ? WHERE id = ?")
@@ -2354,7 +2380,7 @@ describe("Issuance Routes", () => {
             .bind(tokenId, TEST_SOLANA_ADDRESSES.wallet1)
             .first<{ id: string; status: string }>();
           expect(row?.id).toBe(entry.id);
-          expect(row?.status).toBe("revoked");
+          expect(row?.status).toBe("pending");
         } finally {
           createOrgSignerSpy.mockRestore();
           addToListSpy.mockRestore();

--- a/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
@@ -303,14 +303,14 @@ export const removeAllowlistEntry = async (c: AppContext) => {
   if (!entry || entry.tokenId !== tokenId) {
     throw notFound("Allowlist entry");
   }
-  if (entry.status === "revoked" && !token.ablListAddress) {
+  if (entry.status === "revoked") {
     return noContent(c);
   }
 
-  if (entry.status !== "revoked") {
-    await tokenService.revokeAllowlistEntry(entryId);
-  }
-
+  // For on-chain lists, confirm authoritative removal before publishing the
+  // final DB state. The helper reconciles ambiguous submission errors by
+  // reading membership, so a timeout that landed still completes, while a
+  // definite failure leaves the entry accurately active and safely retryable.
   if (token.ablListAddress) {
     await removeExistingAllowlistEntryOnChain({
       c,
@@ -321,6 +321,8 @@ export const removeAllowlistEntry = async (c: AppContext) => {
       wallet: assertValidAddress(entry.address, "address"),
     });
   }
+
+  await tokenService.revokeAllowlistEntry(entryId);
 
   // Audit log
   const auditService = new AuditService(getDb(c.env));

--- a/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
@@ -1,5 +1,5 @@
 import { assertValidAddress } from "@sdp/solana/address";
-import type { TokenAllowlistResponse } from "@sdp/types";
+import type { TokenAllowlistEntry, TokenAllowlistResponse } from "@sdp/types";
 import type { Context } from "hono";
 import { z } from "zod";
 import { getDb } from "@/db";
@@ -56,20 +56,12 @@ async function withTimeout<T>(
 }
 
 /**
- * On-chain add for an allowlist row that was just inserted or reactivated,
- * with TOCTOU-safe rollback.
+ * On-chain add for an allowlist row that is durably recorded as pending.
  *
- * If `addToList` errors, re-checks `isWalletOnList`. When membership is
- * confirmed, the DB row is kept and success bubbles up — the RPC/confirmation
- * error was transient and the on-chain write actually landed. Otherwise the
- * rollback path depends on `wasReactivated`:
- *
- *  - `false` (freshly inserted): hard-delete the row. Soft-revoking would
- *    leave a tombstone that the mint auto-add guard treats as an operator
- *    revoke and would block every subsequent mint to the address.
- *  - `true` (reactivated from `revoked`): re-revoke to restore the operator's
- *    prior revocation record. Hard-deleting would erase the original status
- *    history (the same row was operator-revoked earlier for KYC/compliance).
+ * A failed or timed-out submission can still land on-chain, so an ambiguous
+ * failure must never delete the DB record or its audit trail. The row remains
+ * pending and a retry can reconcile it. Confirmed membership promotes it to
+ * active.
  */
 async function syncNewAllowlistEntryOnChain(opts: {
   c: AppContext;
@@ -78,10 +70,9 @@ async function syncNewAllowlistEntryOnChain(opts: {
   signingWalletId: string | null | undefined;
   tokenService: TokenService;
   entryId: string;
-  wasReactivated: boolean;
   list: ReturnType<typeof assertValidAddress>;
   wallet: ReturnType<typeof assertValidAddress>;
-}): Promise<void> {
+}): Promise<TokenAllowlistEntry> {
   const signer = await createOrgSigner(
     opts.c.env,
     opts.organizationId,
@@ -93,28 +84,12 @@ async function syncNewAllowlistEntryOnChain(opts: {
   try {
     await mosaic.addToList({ list: opts.list, wallet: opts.wallet });
   } catch (error) {
-    if (await mosaic.isWalletOnList(opts.list, opts.wallet)) {
-      return;
+    if (!(await mosaic.isWalletOnList(opts.list, opts.wallet))) {
+      throw error;
     }
-    try {
-      if (opts.wasReactivated) {
-        await opts.tokenService.revokeAllowlistEntry(opts.entryId);
-      } else {
-        await opts.tokenService.deleteAllowlistEntry(opts.entryId);
-      }
-    } catch (rollbackError) {
-      throw new AppError(
-        "INTERNAL_ERROR",
-        "Failed to roll back control-list entry after sync error",
-        {
-          originalError: error instanceof Error ? error.message : "Unknown add error",
-          restoreError:
-            rollbackError instanceof Error ? rollbackError.message : "Unknown rollback error",
-        }
-      );
-    }
-    throw error;
   }
+
+  return opts.tokenService.activateAllowlistEntry(opts.entryId);
 }
 
 async function removeExistingAllowlistEntryOnChain(opts: {
@@ -242,26 +217,13 @@ export const addAllowlistEntry = async (c: AppContext) => {
   }
 
   try {
-    const { entry, wasReactivated } = await tokenService.addAllowlistEntry({
+    let { entry } = await tokenService.addAllowlistEntry({
       tokenId,
       address: parsed.data.address,
       addedBy: auth.id,
       label: parsed.data.label,
+      initialStatus: token.ablListAddress ? "pending" : "active",
     });
-
-    if (token.ablListAddress) {
-      await syncNewAllowlistEntryOnChain({
-        c,
-        organizationId: auth.organizationId,
-        projectId,
-        signingWalletId: token.signingWalletId,
-        tokenService,
-        entryId: entry.id,
-        wasReactivated,
-        list: assertValidAddress(token.ablListAddress, "ablListAddress"),
-        wallet: assertValidAddress(parsed.data.address, "address"),
-      });
-    }
 
     const auditService = new AuditService(getDb(c.env));
     await auditService.log(c, {
@@ -273,8 +235,22 @@ export const addAllowlistEntry = async (c: AppContext) => {
         address: parsed.data.address,
         label: parsed.data.label,
         mode: token.ablListAddress ? "on-chain" : "database",
+        syncStatus: token.ablListAddress ? "pending" : "not_required",
       },
     });
+
+    if (token.ablListAddress) {
+      entry = await syncNewAllowlistEntryOnChain({
+        c,
+        organizationId: auth.organizationId,
+        projectId,
+        signingWalletId: token.signingWalletId,
+        tokenService,
+        entryId: entry.id,
+        list: assertValidAddress(token.ablListAddress, "ablListAddress"),
+        wallet: assertValidAddress(parsed.data.address, "address"),
+      });
+    }
 
     const response: TokenAllowlistResponse = { entry };
     return created(c, response);

--- a/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
@@ -112,30 +112,52 @@ async function removeExistingAllowlistEntryOnChain(opts: {
     wallet: opts.wallet,
   });
 
-  if (opts.c.env.KORA_SURFPOOL_SHIM !== "true") {
-    await removeOperation;
-    return;
-  }
-
   try {
-    await withTimeout(
-      removeOperation,
-      getSurfpoolAblRemoveTimeoutMs(opts.c.env),
-      "Surfpool control-list removal timed out"
-    );
+    if (opts.c.env.KORA_SURFPOOL_SHIM === "true") {
+      await withTimeout(
+        removeOperation,
+        getSurfpoolAblRemoveTimeoutMs(opts.c.env),
+        "Surfpool control-list removal timed out"
+      );
+    } else {
+      await removeOperation;
+    }
   } catch (error) {
-    if (!isTimeoutLikeError(error)) {
-      throw error;
+    // Submission and confirmation errors are ambiguous: the removal may have
+    // landed despite the client error, and retrying an already-absent member
+    // must remain idempotent. Verify the authoritative on-chain state before
+    // deciding whether the operation failed.
+    try {
+      if (!(await mosaic.isWalletOnList(opts.list, opts.wallet))) {
+        return;
+      }
+    } catch (verificationError) {
+      getLogger().warn(
+        {
+          list: opts.list,
+          wallet: opts.wallet,
+          error:
+            verificationError instanceof Error
+              ? verificationError.message
+              : "Unknown verification error",
+        },
+        "Unable to verify control-list state after removal error"
+      );
     }
 
-    getLogger().warn(
-      {
-        list: opts.list,
-        wallet: opts.wallet,
-        error: error.message,
-      },
-      "Surfpool control-list removal timed out; keeping DB revocation as test truth"
-    );
+    if (opts.c.env.KORA_SURFPOOL_SHIM === "true" && isTimeoutLikeError(error)) {
+      getLogger().warn(
+        {
+          list: opts.list,
+          wallet: opts.wallet,
+          error: error.message,
+        },
+        "Surfpool control-list removal timed out; keeping DB revocation as test truth"
+      );
+      return;
+    }
+
+    throw error;
   }
 }
 
@@ -281,45 +303,23 @@ export const removeAllowlistEntry = async (c: AppContext) => {
   if (!entry || entry.tokenId !== tokenId) {
     throw notFound("Allowlist entry");
   }
-  if (entry.status === "revoked") {
+  if (entry.status === "revoked" && !token.ablListAddress) {
     return noContent(c);
   }
 
-  await tokenService.revokeAllowlistEntry(entryId);
+  if (entry.status !== "revoked") {
+    await tokenService.revokeAllowlistEntry(entryId);
+  }
 
-  try {
-    if (token.ablListAddress) {
-      await removeExistingAllowlistEntryOnChain({
-        c,
-        organizationId: auth.organizationId,
-        projectId,
-        signingWalletId: token.signingWalletId,
-        list: assertValidAddress(token.ablListAddress, "ablListAddress"),
-        wallet: assertValidAddress(entry.address, "address"),
-      });
-    }
-  } catch (error) {
-    try {
-      await tokenService.addAllowlistEntry({
-        tokenId,
-        address: entry.address,
-        addedBy: entry.addedBy,
-        label: entry.label ?? undefined,
-        initialStatus: entry.status,
-      });
-    } catch (restoreError) {
-      throw new AppError(
-        "INTERNAL_ERROR",
-        "Failed to restore control-list entry after sync error",
-        {
-          originalError: error instanceof Error ? error.message : "Unknown removal error",
-          restoreError:
-            restoreError instanceof Error ? restoreError.message : "Unknown restore error",
-        }
-      );
-    }
-
-    throw error;
+  if (token.ablListAddress) {
+    await removeExistingAllowlistEntryOnChain({
+      c,
+      organizationId: auth.organizationId,
+      projectId,
+      signingWalletId: token.signingWalletId,
+      list: assertValidAddress(token.ablListAddress, "ablListAddress"),
+      wallet: assertValidAddress(entry.address, "address"),
+    });
   }
 
   // Audit log

--- a/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
@@ -281,6 +281,9 @@ export const removeAllowlistEntry = async (c: AppContext) => {
   if (!entry || entry.tokenId !== tokenId) {
     throw notFound("Allowlist entry");
   }
+  if (entry.status === "revoked") {
+    return noContent(c);
+  }
 
   await tokenService.revokeAllowlistEntry(entryId);
 
@@ -302,6 +305,7 @@ export const removeAllowlistEntry = async (c: AppContext) => {
         address: entry.address,
         addedBy: entry.addedBy,
         label: entry.label ?? undefined,
+        initialStatus: entry.status,
       });
     } catch (restoreError) {
       throw new AppError(

--- a/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/allowlist.ts
@@ -9,9 +9,9 @@ import { getLogger } from "@/runtime/logger";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
 import { createOrgSigner } from "@/services/solana";
-import { TokenService } from "@/services/token.service";
+import type { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { addAllowlistSchema, listAllowlistQuerySchema } from "../schemas";
 
 type AppContext = Context<{ Bindings: Env }>;
@@ -174,7 +174,7 @@ export const listAllowlist = async (c: AppContext) => {
   }
   const { page, pageSize, search, label } = parsed.data;
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -201,7 +201,7 @@ export const listAllowlistLabels = async (c: AppContext) => {
   const { tokenId } = c.req.param();
   const { projectId, orgId } = requireProjectScope(c);
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -230,7 +230,7 @@ export const addAllowlistEntry = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -290,7 +290,7 @@ export const removeAllowlistEntry = async (c: AppContext) => {
   const { tokenId, entryId } = c.req.param();
   const { auth, projectId, orgId } = requireProjectScope(c);
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/audit.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/audit.ts
@@ -10,9 +10,8 @@ import { getDb } from "@/db";
 import { badRequest, notFound } from "@/lib/errors";
 import { paginated } from "@/lib/response";
 import { type AuditAction, AuditService, isAuditAction } from "@/services/audit.service";
-import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 
 type AppContext = Context<{ Bindings: Env }>;
 
@@ -39,7 +38,7 @@ export const getAssetAuditHistory = async (c: AppContext) => {
   const { orgId, projectId } = requireProjectScope(c);
 
   const db = getDb(c.env);
-  const tokenService = new TokenService(db);
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({ tokenId, organizationId: orgId, projectId });
   if (!token) {
     throw notFound("Token");

--- a/apps/sdp-api/src/routes/issuance/handlers/authority.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority.ts
@@ -9,9 +9,8 @@ import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
-import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { updateAuthoritySchema } from "../schemas";
 import {
   type AuthorityRole,
@@ -58,7 +57,7 @@ export const prepareUpdateAuthority = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -167,7 +166,7 @@ export const executeUpdateAuthority = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/burn.ts
@@ -9,14 +9,13 @@ import { success } from "@/lib/response";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { createOrgSigner, createToken2022Service } from "@/services/solana";
-import { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
   parsePositiveTokenAmount,
 } from "@/services/token-operation.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { burnSchema } from "../schemas";
 import { buildIdempotencyMetadata } from "./idempotency";
 
@@ -133,7 +132,7 @@ export const prepareBurn = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -244,7 +243,7 @@ export const executeBurn = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/deploy.ts
@@ -24,9 +24,9 @@ import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService, type MosaicFeePayment } from "@/services/issuance/mosaic";
 import { createOrgSigner } from "@/services/solana";
-import { TokenService } from "@/services/token.service";
+import type { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { confirmDeploySchema, deployTokenSchema } from "../schemas";
 import { getMosaicAclMode, shouldEnableOnChainAcl } from "./access-control";
 import { getInitialPermanentDelegateAuthority } from "./authority-resolution";
@@ -257,7 +257,7 @@ export const deployToken = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   let token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -504,7 +504,7 @@ export const prepareDeploy = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -676,7 +676,7 @@ export const confirmDeploy = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -834,7 +834,7 @@ export const prepareDeployMetadata = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/force-burn.ts
@@ -7,14 +7,13 @@ import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
-import { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
   parsePositiveTokenAmount,
 } from "@/services/token-operation.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { forceBurnSchema } from "../schemas";
 import { resolveAuthoritySigner, resolvePermanentDelegateAuthority } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
@@ -34,7 +33,7 @@ export const prepareForceBurn = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -136,7 +135,7 @@ export const executeForceBurn = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/freeze.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/freeze.ts
@@ -9,9 +9,8 @@ import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, paginated, success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
-import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { freezeSchema, unfreezeSchema } from "../schemas";
 import { getTokenAccessControlMode, type TokenAccessControlMode } from "./access-control";
 import { resolveAuthoritySigner, resolveCurrentAuthorityForRole } from "./authority-resolution";
@@ -139,7 +138,7 @@ export const freezeAccount = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -306,7 +305,7 @@ export const listFrozenAccounts = async (c: AppContext) => {
   const { tokenId } = c.req.param();
   const { projectId, orgId } = requireProjectScope(c);
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -342,7 +341,7 @@ export const unfreezeAccount = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/metadata.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/metadata.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import { getDb } from "@/db";
-import { createAssetProfilesRepository } from "@/db/repositories";
+import { createSystemAssetProfilesRepository } from "@/db/repositories";
 import { isAssetProfilesEnabled } from "@/lib/feature-flags";
 import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
@@ -121,9 +121,9 @@ export const serveTokenMetadata = async (c: AppContext) => {
   // Gated by the same flag as the Asset Profiles family, so the canonical URI
   // already burned into deployed tokens serves the projection once it ships.
   if (isAssetProfilesEnabled(c.env)) {
-    const publicMetadata = await createAssetProfilesRepository(c.env).getPublicMetadataByTokenId(
-      tokenId
-    );
+    const publicMetadata = await createSystemAssetProfilesRepository(
+      c.env
+    ).getPublicMetadataByTokenId(tokenId);
     if (publicMetadata) {
       return c.json({ ...publicMetadata, ...body });
     }

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -9,10 +9,10 @@ import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
 import { createOrgSigner } from "@/services/solana";
-import { TokenService } from "@/services/token.service";
+import type { TokenService } from "@/services/token.service";
 import { resolveMintOperationAmount } from "@/services/token-operation.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { mintSchema } from "../schemas";
 import {
   assertDestinationAllowedByControlList,
@@ -195,7 +195,7 @@ export const prepareMint = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -324,7 +324,7 @@ export const executeMint = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/pause.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/pause.ts
@@ -9,9 +9,9 @@ import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
 import { createOrgSigner } from "@/services/solana";
-import { TokenService } from "@/services/token.service";
+import type { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { pauseTokenSchema } from "../schemas";
 import { buildIdempotencyMetadata } from "./idempotency";
 
@@ -38,7 +38,7 @@ export const pauseToken = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -159,7 +159,7 @@ export const unpauseToken = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/policy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/policy.ts
@@ -1,5 +1,6 @@
 import type { Token } from "@sdp/types";
 import type { ApiKeyContext } from "@/lib/auth";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import {
   enforceWalletOperationPolicy,
   resolvePolicyCustodyWallet,
@@ -27,7 +28,7 @@ export async function enforceIssuanceWalletOperationPolicy(
 
   const policyWallet = await resolvePolicyCustodyWallet(c.env, input.auth, input.walletId);
 
-  await enforceWalletOperationPolicy(c.env, {
+  await enforceWalletOperationPolicy(c.env, getRequestTenantScope(c), {
     organizationId: input.auth.organizationId,
     projectId: input.token.projectId,
     custodyWalletId: policyWallet?.id ?? null,

--- a/apps/sdp-api/src/routes/issuance/handlers/seize.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/seize.ts
@@ -7,14 +7,13 @@ import { badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
-import { TokenService } from "@/services/token.service";
 import {
   assertTokenAllowsOperation,
   assertTokenIsDeployed,
   parsePositiveTokenAmount,
 } from "@/services/token-operation.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { seizeSchema } from "../schemas";
 import { assertDestinationAllowedByControlList } from "./access-control";
 import { resolveAuthoritySigner, resolvePermanentDelegateAuthority } from "./authority-resolution";
@@ -35,7 +34,7 @@ export const prepareSeize = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -151,7 +150,7 @@ export const executeSeize = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/supply.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/supply.ts
@@ -5,9 +5,8 @@ import { getDb } from "@/db";
 import { AppError, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
 import { AuditService } from "@/services/audit.service";
-import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 
 type AppContext = Context<{ Bindings: Env }>;
 
@@ -57,7 +56,7 @@ export const refreshTokenSupply = async (c: AppContext) => {
   const { tokenId } = c.req.param();
   const { projectId, orgId } = requireProjectScope(c);
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,

--- a/apps/sdp-api/src/routes/issuance/handlers/tokens.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/tokens.ts
@@ -4,7 +4,7 @@ import type { TokenResponse } from "@sdp/types";
 import type { Context } from "hono";
 import { z } from "zod";
 import { getDb } from "@/db";
-import { badRequest, badRequestQuery, notFound } from "@/lib/errors";
+import { badRequest, badRequestQuery, conflict, notFound } from "@/lib/errors";
 import { created, paginated, success } from "@/lib/response";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
@@ -213,6 +213,13 @@ export const updateToken = async (c: AppContext) => {
     throw notFound("Token");
   }
 
+  // `deploying` is an internal transient state, so it is not part of the
+  // public TokenStatus union even though it can be observed between the claim
+  // and final deployment writes. Reject the whole PATCH during that window.
+  if (String(existing.status) === "deploying") {
+    throw conflict("Token deployment is in progress; retry after it completes");
+  }
+
   // Access-control enforcement is baked into the mint at deploy; the flag only
   // makes sense to change while the token is still an undeployed draft.
   if (
@@ -272,7 +279,10 @@ export const updateToken = async (c: AppContext) => {
       metadataUpdateSlot = result ? result.slot.toString() : null;
     }
 
-    const token = await tokenService.updateToken(tokenId, parsed.data);
+    const token = await tokenService.updateToken(tokenId, parsed.data, {
+      status: existing.status,
+      mintAddress: existing.mintAddress,
+    });
 
     // Audit log
     const auditService = new AuditService(getDb(c.env));

--- a/apps/sdp-api/src/routes/issuance/handlers/tokens.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/tokens.ts
@@ -10,9 +10,8 @@ import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { AuditService } from "@/services/audit.service";
 import { createMosaicService } from "@/services/issuance/mosaic";
 import { createOrgSigner } from "@/services/solana";
-import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { createTokenSchema, listTokensQuerySchema, updateTokenSchema } from "../schemas";
 import { resolveAuthoritySigner, resolveCurrentAuthorityForRole } from "./authority-resolution";
 
@@ -73,7 +72,7 @@ export const createToken = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const signingWalletId = resolveApiKeySigningWalletId(auth, parsed.data.signingWalletId, [
     "tokens:write",
   ]);
@@ -143,7 +142,7 @@ export const listTokens = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const { tokens, total } = await tokenService.listTokens(projectId, {
     // A blank search passes validation (an empty input isn't an error) but must
     // not become an `ILIKE '%%'` filter.
@@ -165,7 +164,7 @@ export const listTokens = async (c: AppContext) => {
 export const listTokenFacets = async (c: AppContext) => {
   const { projectId } = requireProjectScope(c);
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const facets = await tokenService.listTokenFacets(projectId);
 
   return success(c, facets);
@@ -175,7 +174,7 @@ export const getToken = async (c: AppContext) => {
   const { tokenId } = c.req.param();
   const { projectId, orgId } = requireProjectScope(c);
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -203,7 +202,7 @@ export const updateToken = async (c: AppContext) => {
     });
   }
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
 
   const existing = await tokenService.getToken({
     tokenId,

--- a/apps/sdp-api/src/routes/issuance/handlers/transactions.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/transactions.ts
@@ -10,7 +10,6 @@ import {
 import { findAssociatedTokenPda, TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
 import type { Context } from "hono";
 import { z } from "zod";
-import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
 import { badRequest, badRequestQuery, notFound, walletNotFound } from "@/lib/errors";
 import { paginated } from "@/lib/response";
@@ -19,9 +18,9 @@ import {
   getAllowedApiKeyWalletIdsForPermissions,
 } from "@/services/api-key-scope.service";
 import { createSigningService } from "@/services/domain/signing.service";
-import { TokenService } from "@/services/token.service";
+import type { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
-import { requireProjectScope } from "../helpers";
+import { getTenantTokenService, requireProjectScope } from "../helpers";
 import { listTokenTransactionsQuerySchema } from "../schemas";
 
 type AppContext = Context<{ Bindings: Env }>;
@@ -223,7 +222,7 @@ export const listTokenTransactions = async (c: AppContext) => {
   }
   const { page, pageSize, status, type } = parsed.data;
 
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
@@ -253,7 +252,7 @@ export const listTokenTransactions = async (c: AppContext) => {
 
 export const listTransactions = async (c: AppContext) => {
   const auth = getAuth(c);
-  const tokenService = new TokenService(getDb(c.env));
+  const tokenService = getTenantTokenService(c);
   const types = parseTransactionTypes(c);
   const status = parseTransactionStatus(c.req.query("status"));
   const page = parsePositiveInteger(c.req.query("page"), 1, "page");

--- a/apps/sdp-api/src/routes/issuance/helpers.ts
+++ b/apps/sdp-api/src/routes/issuance/helpers.ts
@@ -1,5 +1,8 @@
 import type { Context } from "hono";
+import { getDb } from "@/db";
 import { getAuth, requireProjectId } from "@/lib/auth";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
+import { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
@@ -15,3 +18,10 @@ export const requireProjectScope = (c: AppContext) => {
   const projectId = requireProjectId(c);
   return { auth, projectId, orgId: auth.organizationId };
 };
+
+/**
+ * The only tenant-facing TokenService construction path. Its scope comes from
+ * authenticated middleware state, never request-controlled headers or bodies.
+ */
+export const getTenantTokenService = (c: AppContext): TokenService =>
+  new TokenService(getDb(c.env), getRequestTenantScope(c));

--- a/apps/sdp-api/src/routes/pay.ts
+++ b/apps/sdp-api/src/routes/pay.ts
@@ -22,7 +22,7 @@ import { encodeURL } from "@solana/pay";
 import { getTransferSolInstruction } from "@solana-program/system";
 import { Hono } from "hono";
 import { z } from "zod";
-import { createPaymentRequestsRepository } from "@/db/repositories/repository-factory";
+import { createSystemPaymentRequestsRepository } from "@/db/repositories/repository-factory";
 import { badRequest, notFound } from "@/lib/errors";
 import {
   isPaymentRequestExpired,
@@ -43,9 +43,9 @@ const transactionRequestBodySchema = z.object({ account: z.string() });
 const pay = new Hono<{ Bindings: Env }>();
 
 pay.get("/:token", async (c) => {
-  const existing = await createPaymentRequestsRepository(c.env).getPaymentRequestByPublicToken(
-    c.req.param("token")
-  );
+  const existing = await createSystemPaymentRequestsRepository(
+    c.env
+  ).getPaymentRequestByPublicToken(c.req.param("token"));
   if (!existing) {
     throw notFound("Payment request");
   }
@@ -80,9 +80,9 @@ pay.get("/:token/tx", (c) => {
 });
 
 pay.post("/:token/tx", async (c) => {
-  const existing = await createPaymentRequestsRepository(c.env).getPaymentRequestByPublicToken(
-    c.req.param("token")
-  );
+  const existing = await createSystemPaymentRequestsRepository(
+    c.env
+  ).getPaymentRequestByPublicToken(c.req.param("token"));
   if (!existing) {
     throw notFound("Payment request");
   }

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -31,6 +31,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresPolicyRepository } from "@/db/repositories";
 import app from "@/index";
+import { createTenantScope } from "@/lib/tenant-scope";
 import * as tokenAccounts from "@/routes/payments/token-accounts";
 import * as solanaServices from "@/services/solana";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
@@ -447,7 +448,10 @@ async function seedWalletControlProfile(params: {
   rules: PolicyRule[];
   defaultAction?: PolicyDefaultAction;
 }): Promise<void> {
-  const repo = createPostgresPolicyRepository(getDb(env));
+  const repo = createPostgresPolicyRepository(
+    getDb(env),
+    createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+  );
   const profile = await repo.createWalletControlProfile({
     organizationId: TEST_ORG.id,
     projectId: TEST_PROJECT.id,

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -6025,6 +6025,11 @@ describe("Payments routes", () => {
   });
 
   it("activates immutable wallet control profile revisions from wallet policy updates", async () => {
+    await getDb(env)
+      .prepare("UPDATE custody_configs SET project_id = ? WHERE id = ?")
+      .bind(TEST_PROJECT.id, TEST_CONFIG_ID)
+      .run();
+
     const rules = [
       {
         id: "deny-raw-signing",

--- a/apps/sdp-api/src/routes/payments/context.ts
+++ b/apps/sdp-api/src/routes/payments/context.ts
@@ -13,6 +13,7 @@ import {
   createPolicyRepository,
 } from "@/db/repositories";
 import { resolveKoraUserId } from "@/lib/kora-user";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { Env } from "@/types/env";
 
 export type AppContext = Context<{ Bindings: Env }>;
@@ -38,31 +39,31 @@ export function rampRuntime(c: AppContext): RampRuntimeContext {
 }
 
 export function getPaymentsRepository(c: AppContext) {
-  return createPaymentsRepository(c.env);
+  return createPaymentsRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getCounterpartiesRepository(c: AppContext) {
-  return createCounterpartiesRepository(c.env);
+  return createCounterpartiesRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getCounterpartyAccountsRepository(c: AppContext) {
-  return createCounterpartyAccountsRepository(c.env);
+  return createCounterpartyAccountsRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getPaymentSubscriptionsRepository(c: AppContext) {
-  return createPaymentSubscriptionsRepository(c.env);
+  return createPaymentSubscriptionsRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getPaymentRecurringPaymentsRepository(c: AppContext) {
-  return createPaymentRecurringPaymentsRepository(c.env);
+  return createPaymentRecurringPaymentsRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getPaymentTransferBatchesRepository(c: AppContext) {
-  return createPaymentTransferBatchesRepository(c.env);
+  return createPaymentTransferBatchesRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getPolicyRepository(c: AppContext) {
-  return createPolicyRepository(c.env);
+  return createPolicyRepository(c.env, getRequestTenantScope(c));
 }
 
 export function getFeePayment(c: AppContext) {

--- a/apps/sdp-api/src/routes/payments/handlers/balances.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/balances.ts
@@ -20,6 +20,7 @@ import {
 } from "@/db/repositories/policy.repository";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { getLogger } from "@/runtime/logger";
 import {
   attachTokenSymbolsToBalances,
@@ -348,7 +349,7 @@ export async function updateWalletPolicy(c: AppContext) {
   let rows: Awaited<ReturnType<typeof repository.upsertWalletPolicies>>;
   if (parsed.data.rules || parsed.data.defaultAction) {
     rows = await getDb(c.env).transaction(async (tx) => {
-      const txRepository = createPostgresPaymentsRepository(tx);
+      const txRepository = createPostgresPaymentsRepository(tx, getRequestTenantScope(c));
       const savedRows = await txRepository.upsertWalletPolicies(walletPolicyInputs);
 
       if (savedRows.length === 0) {

--- a/apps/sdp-api/src/routes/payments/handlers/payment-requests.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/payment-requests.ts
@@ -7,6 +7,7 @@ import { getAuth, requireProjectId } from "@/lib/auth";
 import { resolveCreatorUserId } from "@/lib/creator";
 import { badRequest, badRequestQuery } from "@/lib/errors";
 import { created, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
 import {
   isPaymentRequestExpired,
@@ -53,7 +54,10 @@ export async function listPaymentRequests(c: AppContext) {
   if (!query.success) throw badRequestQuery();
 
   const { page, pageSize, status } = query.data;
-  const { rows, total } = await createPaymentRequestsRepository(c.env).listPaymentRequests({
+  const { rows, total } = await createPaymentRequestsRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).listPaymentRequests({
     organizationId: auth.organizationId,
     projectId,
     status,
@@ -97,7 +101,10 @@ export async function createPaymentRequest(c: AppContext) {
   const wallet = resolveWallet(scope.wallets, body.data.walletId);
   assertApiKeyWalletAccess(scope.auth, wallet.walletId, ["payments:write"]);
 
-  const row = await createPaymentRequestsRepository(c.env).createPaymentRequest({
+  const row = await createPaymentRequestsRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).createPaymentRequest({
     organizationId: scope.auth.organizationId,
     projectId,
     counterpartyId: body.data.counterpartyId,

--- a/apps/sdp-api/src/routes/payments/handlers/policy-audit.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/policy-audit.ts
@@ -14,6 +14,7 @@ import {
 } from "@/db/repositories";
 import { badRequestParams, badRequestQuery, notFound } from "@/lib/errors";
 import { paginated, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import type { AppContext } from "../context";
 import {
   walletPolicyEvaluationListQuerySchema,
@@ -128,7 +129,10 @@ function mapPolicyEvaluation(row: WalletPolicyEvaluationAuditRow): WalletPolicyE
 
 export async function listWalletControlProfileRevisions(c: AppContext) {
   const { auth, wallet } = await resolveWalletFromParams(c, ["wallets:read"]);
-  const history = await createPolicyRepository(c.env).getWalletControlProfileRevisionHistory({
+  const history = await createPolicyRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).getWalletControlProfileRevisionHistory({
     organizationId: auth.organizationId,
     projectId: auth.projectId ?? null,
     custodyWalletId: wallet.id,
@@ -151,7 +155,10 @@ export async function listWalletPolicyEvaluations(c: AppContext) {
   }
 
   const { auth, wallet } = await resolveWalletFromParams(c, ["wallets:read"]);
-  const result = await createPolicyRepository(c.env).listWalletPolicyEvaluationAudits({
+  const result = await createPolicyRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).listWalletPolicyEvaluationAudits({
     organizationId: auth.organizationId,
     projectId: auth.projectId ?? null,
     custodyWalletId: wallet.id,
@@ -172,7 +179,10 @@ export async function getWalletPolicyEvaluation(c: AppContext) {
   }
 
   const { auth, wallet } = await resolveWalletFromParams(c, ["wallets:read"]);
-  const evaluation = await createPolicyRepository(c.env).getWalletPolicyEvaluationAudit({
+  const evaluation = await createPolicyRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).getWalletPolicyEvaluationAudit({
     organizationId: auth.organizationId,
     projectId: auth.projectId ?? null,
     custodyWalletId: wallet.id,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -55,6 +55,7 @@ import {
   unsupportedRampCorridor,
 } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import {
   enforceWalletOperationPolicy,
@@ -243,7 +244,7 @@ async function enforceRampWalletOperationPolicy(
     rawPayload?: Record<string, unknown>;
   }
 ) {
-  return enforceWalletOperationPolicy(c.env, {
+  return enforceWalletOperationPolicy(c.env, getRequestTenantScope(c), {
     organizationId: input.scope.auth.organizationId,
     projectId: input.scope.auth.projectId,
     custodyWalletId: input.wallet.id,

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/bvnk.ts
@@ -42,7 +42,10 @@ import type { BvnkPaymentRampInstruction, PaymentRampQuote } from "@sdp/types";
 import type { RampFiatCurrency } from "@sdp/types/generated/ramp-support";
 import type { CollectedFieldData } from "@sdp/types/ramp-requirements";
 import { z } from "zod";
-import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
+import type {
+  CounterpartiesRepository,
+  CounterpartyRow,
+} from "@/db/repositories/counterparty.repository";
 import type {
   PaymentTransferRow,
   PaymentTransferStatus,
@@ -146,9 +149,10 @@ async function persistBvnkOnrampState(
   projectId: string,
   key: string,
   customer: BvnkCustomerResolution,
-  entry: BvnkOnrampPaymentRuleState
+  entry: BvnkOnrampPaymentRuleState,
+  repository?: CounterpartiesRepository
 ): Promise<void> {
-  const repo = getCounterpartiesRepository(c);
+  const repo = repository ?? getCounterpartiesRepository(c);
   await repo.mutateProviderData({
     counterpartyId: counterparty.id,
     organizationId: counterparty.organization_id,
@@ -435,7 +439,8 @@ export async function ensureBvnkPaymentRule(
   counterparty: CounterpartyRow,
   projectId: string,
   customer: BvnkCustomerResolution,
-  params: BvnkOnrampRequestSpec
+  params: BvnkOnrampRequestSpec,
+  repository?: CounterpartiesRepository
 ): Promise<BvnkPaymentRuleResolution> {
   const client = RAMP_PROVIDER_CLIENTS.bvnk;
   const paymentRuleKey = buildBvnkOnrampPaymentRuleKey(
@@ -456,7 +461,15 @@ export async function ensureBvnkPaymentRule(
 
   if (!entry.request) {
     entry = { ...entry, request: params };
-    await persistBvnkOnrampState(c, counterparty, projectId, paymentRuleKey, customer, entry);
+    await persistBvnkOnrampState(
+      c,
+      counterparty,
+      projectId,
+      paymentRuleKey,
+      customer,
+      entry,
+      repository
+    );
   }
 
   if (!isBvnkCustomerVerified(customer.status) || !customer.customerReference) {
@@ -496,7 +509,15 @@ export async function ensureBvnkPaymentRule(
       walletStatus: wallet.status,
       bankAccount: wallet.bankAccount,
     };
-    await persistBvnkOnrampState(c, counterparty, projectId, paymentRuleKey, customer, entry);
+    await persistBvnkOnrampState(
+      c,
+      counterparty,
+      projectId,
+      paymentRuleKey,
+      customer,
+      entry,
+      repository
+    );
   }
 
   if (entry.walletId && !isBvnkWalletActive(entry.walletStatus)) {
@@ -507,7 +528,15 @@ export async function ensureBvnkPaymentRule(
         walletStatus: wallet.status ?? entry.walletStatus,
         bankAccount: wallet.bankAccount ?? entry.bankAccount,
       };
-      await persistBvnkOnrampState(c, counterparty, projectId, paymentRuleKey, customer, entry);
+      await persistBvnkOnrampState(
+        c,
+        counterparty,
+        projectId,
+        paymentRuleKey,
+        customer,
+        entry,
+        repository
+      );
     } catch (error) {
       getLogger().warn(
         {
@@ -532,7 +561,15 @@ export async function ensureBvnkPaymentRule(
       },
     });
     entry = { ...entry, ruleId: rule.id ?? entry.ruleId, ruleStatus: rule.status };
-    await persistBvnkOnrampState(c, counterparty, projectId, paymentRuleKey, customer, entry);
+    await persistBvnkOnrampState(
+      c,
+      counterparty,
+      projectId,
+      paymentRuleKey,
+      customer,
+      entry,
+      repository
+    );
   }
 
   return {

--- a/apps/sdp-api/src/routes/payments/handlers/subscriptions.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/subscriptions.ts
@@ -50,6 +50,7 @@ import { getAuth, requireProjectId } from "@/lib/auth";
 import { resolveCreatorUserId } from "@/lib/creator";
 import { AppError, badRequest, badRequestParams, badRequestQuery } from "@/lib/errors";
 import { created, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { assertApiKeyWalletAccess } from "@/services/api-key-scope.service";
 import {
   normalizePaymentToken,
@@ -328,7 +329,7 @@ async function getSubscriptionWithPlan(
 async function requireActiveCounterparty(c: AppContext, counterpartyId: string): Promise<void> {
   const auth = getAuth(c);
   const projectId = requireProjectId(c);
-  const repo = createCounterpartiesRepository(c.env);
+  const repo = createCounterpartiesRepository(c.env, getRequestTenantScope(c));
   const counterparty = await repo.getCounterpartyById({
     counterpartyId,
     organizationId: auth.organizationId,

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/db/repositories/payments.repository";
 import { createPostgresPaymentsRepository } from "@/db/repositories/payments.repository.postgres";
 import { internalError, transactionFailed } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import {
   type AppContext,
   type getFeePayment,
@@ -174,7 +175,13 @@ export async function executeChunk(params: {
   const firstRecipient = recipientRows[0];
   const linkedTransfer = await getDb(c.env).transaction(async (tx) => {
     const txClient = asTransactionalClient(tx);
-    const created = await createPostgresPaymentsRepository(txClient).createTransfer({
+    const created = await createPostgresPaymentsRepository(
+      txClient,
+      createTenantScope({
+        organizationId: resolved.scope.auth.organizationId,
+        projectId: resolved.projectId,
+      })
+    ).createTransfer({
       organizationId: resolved.scope.auth.organizationId,
       projectId: resolved.projectId,
       walletId: resolved.sourceWallet.walletId,

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/policy.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/policy.ts
@@ -1,3 +1,4 @@
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { assertWalletPolicyAllowsTransferWithRows } from "@/services/payments/wallet-policy";
 import {
   enforceWalletOperationPolicy,
@@ -22,7 +23,7 @@ export async function enforceBatchPolicies(
   resolved: ResolvedBatchRequest,
   input: CreateTransferBatchInput
 ): Promise<void> {
-  const enforcement = await enforceWalletOperationPolicy(c.env, {
+  const enforcement = await enforceWalletOperationPolicy(c.env, getRequestTenantScope(c), {
     organizationId: resolved.scope.auth.organizationId,
     projectId: resolved.scope.auth.projectId,
     custodyWalletId: resolved.sourceWallet.id,

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -36,6 +36,7 @@ import { getAuth } from "@/lib/auth";
 import { AppError, accountFrozen, badRequest, badRequestQuery, solanaRpcError } from "@/lib/errors";
 import { buildPaymentTransferFingerprint, resolveIdempotencyReplay } from "@/lib/idempotency";
 import { paginated, success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import {
   assertApiKeyWalletAccess,
   getAllowedApiKeyWalletIdsForPermissions,
@@ -232,7 +233,7 @@ async function enforcePaymentTransferOperationPolicy(
     rawPayload?: Record<string, unknown>;
   }
 ) {
-  return enforceWalletOperationPolicy(c.env, {
+  return enforceWalletOperationPolicy(c.env, getRequestTenantScope(c), {
     organizationId: scope.auth.organizationId,
     projectId: scope.auth.projectId,
     custodyWalletId: operation.sourceWallet.id,

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -7,11 +7,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import {
   createPaymentsRepository,
-  createPaymentTransferBatchesRepository,
+  createSystemPaymentTransferBatchesRepository,
 } from "@/db/repositories";
 import * as batchesRepositoryPostgres from "@/db/repositories/payment-transfer-batches.repository.postgres";
 import * as paymentsRepositoryPostgres from "@/db/repositories/payments.repository.postgres";
 import app from "@/index";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
 import * as solanaServices from "@/services/solana";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
@@ -1809,7 +1810,7 @@ describe("payment transfer batches", () => {
     };
     expect(body.data.transfers).toHaveLength(2);
 
-    const repository = createPaymentTransferBatchesRepository(env);
+    const repository = createSystemPaymentTransferBatchesRepository(env);
     await Promise.all([
       repository.settleTransferBatch({
         transferId: body.data.transfers[0].id,
@@ -1879,7 +1880,7 @@ describe("payment transfer batches", () => {
     expect(body.data.transfers).toHaveLength(1);
     const transferId = body.data.transfers[0].id;
 
-    const repository = createPaymentTransferBatchesRepository(env);
+    const repository = createSystemPaymentTransferBatchesRepository(env);
     await repository.settleTransferBatch({
       transferId,
       organizationId: TEST_ORG.id,
@@ -1907,7 +1908,10 @@ describe("payment transfer batches", () => {
     expect(transferRow?.status).toBe("finalized");
     expect(Number(transferRow?.slot)).toBe(500);
 
-    const guarded = await createPaymentsRepository(env).updateTransfer({
+    const guarded = await createPaymentsRepository(
+      env,
+      createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+    ).updateTransfer({
       transferId,
       status: "confirmed",
       expectedStatus: "processing",

--- a/apps/sdp-api/src/routes/playground-internal/index.ts
+++ b/apps/sdp-api/src/routes/playground-internal/index.ts
@@ -4,6 +4,7 @@ import { getDb } from "@/db";
 import { requireProjectId } from "@/lib/auth";
 import { badRequest, forbidden, unauthorized } from "@/lib/errors";
 import { noContent } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import { ApiKeyService } from "@/services/api-key.service";
@@ -40,7 +41,7 @@ playgroundInternal.post("/api-key/verify", requirePermissions("api-keys:read"), 
     throw unauthorized("Dashboard session required");
   }
 
-  const owned = await new ApiKeyService(getDb(c.env)).ownsUsableApiKey({
+  const owned = await new ApiKeyService(getDb(c.env), getRequestTenantScope(c)).ownsUsableApiKey({
     apiKey: parsed.data.apiKey,
     organizationId: actor.organizationId,
     projectId: requireProjectId(c),

--- a/apps/sdp-api/src/routes/policies.test.ts
+++ b/apps/sdp-api/src/routes/policies.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresPolicyRepository } from "@/db/repositories";
 import app from "@/index";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -657,7 +658,10 @@ describe("GET /v1/policies", () => {
     expect(targetIds).not.toContain("cw_policy_inventory_foreign");
     expect(targetIds).not.toContain("key_policy_inventory_other_project");
 
-    const nullScoped = await createPostgresPolicyRepository(getDb(env)).listPolicyControlInventory({
+    const nullScoped = await createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: TEST_ORG_ID, projectId: null })
+    ).listPolicyControlInventory({
       organizationId: TEST_ORG_ID,
       projectId: null,
     });
@@ -713,7 +717,10 @@ describe("GET /v1/policies", () => {
       },
     });
 
-    const result = await createPostgresPolicyRepository(countingDb).listPolicyControlInventory({
+    const result = await createPostgresPolicyRepository(
+      countingDb,
+      createTenantScope({ organizationId: TEST_ORG_ID, projectId: TEST_PROJECT_ID })
+    ).listPolicyControlInventory({
       organizationId: TEST_ORG_ID,
       projectId: TEST_PROJECT_ID,
       pageSize: 100,

--- a/apps/sdp-api/src/routes/policies/handlers.ts
+++ b/apps/sdp-api/src/routes/policies/handlers.ts
@@ -10,6 +10,7 @@ import { createPolicyRepository, type PolicyControlInventoryRow } from "@/db/rep
 import { getAuth } from "@/lib/auth";
 import { AppError, badRequestQuery } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { getAllowedApiKeyWalletIdsForPermissions } from "@/services/api-key-scope.service";
 import type { Env } from "@/types/env";
 import { policyControlInventoryQuerySchema } from "./schemas";
@@ -98,7 +99,10 @@ export const listPolicyControlInventory = async (c: AppContext) => {
 
   assertTargetPermissions(auth.permissions, parsed.data.target);
   const allowedWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["wallets:read"]);
-  const result = await createPolicyRepository(c.env).listPolicyControlInventory({
+  const result = await createPolicyRepository(
+    c.env,
+    getRequestTenantScope(c)
+  ).listPolicyControlInventory({
     organizationId: auth.organizationId,
     projectId: c.get("projectId") ?? null,
     walletIds: allowedWalletIds ?? undefined,

--- a/apps/sdp-api/src/routes/policy-audit-details.test.ts
+++ b/apps/sdp-api/src/routes/policy-audit-details.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresPolicyRepository } from "@/db/repositories";
 import app from "@/index";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { env } from "@/test/helpers/env";
 import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
@@ -218,7 +219,10 @@ async function seedAuthAndWallet() {
 }
 
 async function seedPoliciesAndEvaluations() {
-  const repository = createPostgresPolicyRepository(getDb(env));
+  const repository = createPostgresPolicyRepository(
+    getDb(env),
+    createTenantScope({ organizationId: TEST_ORG_ID, projectId: TEST_PROJECT_ID })
+  );
   const profile = await repository.createWalletControlProfile({
     organizationId: TEST_ORG_ID,
     projectId: TEST_PROJECT_ID,
@@ -383,52 +387,68 @@ async function seedPoliciesAndEvaluations() {
       .run();
   }
 
-  const foreignOperation = await repository.createWalletOperation({
+  const seedForeignEvaluation = async (input: {
+    key: "foreign" | "crossOrganization";
+    organizationId: string;
+    projectId: string;
+    operationType: string;
+  }) => {
+    const operationId = `wop_${crypto.randomUUID()}`;
+    const evaluationId = `pev_${crypto.randomUUID()}`;
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO wallet_operations (
+             id, organization_id, project_id, custody_wallet_id, wallet_id,
+             source, operation_family, operation_type, raw_payload, status
+           ) VALUES (?, ?, ?, ?, ?, 'api', 'payment', ?, '{}'::jsonb, 'created')`
+        )
+        .bind(
+          operationId,
+          input.organizationId,
+          input.projectId,
+          TEST_CUSTODY_WALLET_ID,
+          TEST_WALLET_ID,
+          input.operationType
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO policy_evaluations (
+             id, wallet_operation_id, decision, reason_code, matched_rules,
+             evaluation_context, requires_approval
+           ) VALUES (?, ?, 'allow', 'implicit_default_allow', '[]'::jsonb, ?::jsonb, false)`
+        )
+        .bind(
+          evaluationId,
+          operationId,
+          JSON.stringify(
+            evaluationContext({
+              operationId,
+              organizationId: input.organizationId,
+              projectId: input.projectId,
+              family: "payment",
+              operationType: input.operationType,
+              walletRevisionId: null,
+              apiKeyRevisionId: null,
+            })
+          )
+        ),
+    ]);
+    evaluationIds[input.key] = evaluationId;
+  };
+
+  await seedForeignEvaluation({
+    key: "foreign",
     organizationId: TEST_ORG_ID,
     projectId: OTHER_PROJECT_ID,
-    custodyWalletId: TEST_CUSTODY_WALLET_ID,
-    walletId: TEST_WALLET_ID,
-    operationFamily: "payment",
     operationType: "foreign_project_payment",
   });
-  const foreignEvaluation = await repository.createPolicyEvaluation({
-    walletOperationId: foreignOperation?.id ?? "",
-    decision: "allow",
-    reasonCode: "implicit_default_allow",
-    evaluationContext: evaluationContext({
-      operationId: foreignOperation?.id ?? "",
-      projectId: OTHER_PROJECT_ID,
-      family: "payment",
-      operationType: "foreign_project_payment",
-      walletRevisionId: null,
-      apiKeyRevisionId: null,
-    }),
-  });
-  evaluationIds.foreign = foreignEvaluation?.id ?? "";
-
-  const crossOrganizationOperation = await repository.createWalletOperation({
+  await seedForeignEvaluation({
+    key: "crossOrganization",
     organizationId: OTHER_ORG_ID,
     projectId: TEST_PROJECT_ID,
-    custodyWalletId: TEST_CUSTODY_WALLET_ID,
-    walletId: TEST_WALLET_ID,
-    operationFamily: "payment",
     operationType: "foreign_organization_payment",
   });
-  const crossOrganizationEvaluation = await repository.createPolicyEvaluation({
-    walletOperationId: crossOrganizationOperation?.id ?? "",
-    decision: "allow",
-    reasonCode: "implicit_default_allow",
-    evaluationContext: evaluationContext({
-      operationId: crossOrganizationOperation?.id ?? "",
-      organizationId: OTHER_ORG_ID,
-      projectId: TEST_PROJECT_ID,
-      family: "payment",
-      operationType: "foreign_organization_payment",
-      walletRevisionId: null,
-      apiKeyRevisionId: null,
-    }),
-  });
-  evaluationIds.crossOrganization = crossOrganizationEvaluation?.id ?? "";
 }
 
 describe("Wallet policy audit detail routes", () => {

--- a/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
+++ b/apps/sdp-api/src/routes/projects/handlers/api-keys.ts
@@ -6,6 +6,7 @@ import { getDb } from "@/db";
 import { getAuth } from "@/lib/auth";
 import { AppError, badRequest, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { buildApiKeyAccessSummaries } from "@/routes/api-keys/access-response";
 import { apiKeyCreateSchema } from "@/routes/api-keys/schemas";
 import { ApiKeyService } from "@/services/api-key.service";
@@ -59,11 +60,21 @@ export const listProjectApiKeys = async (c: AppContext) => {
   await assertProjectAccess(c, auth, projectId);
 
   const db = getDb(c.env);
-  const apiKeyService = new ApiKeyService(db);
+  const apiKeyService = new ApiKeyService(
+    db,
+    createTenantScope({
+      organizationId: auth.organizationId,
+      projectId,
+    })
+  );
   const apiKeys = await apiKeyService.listForProject(projectId);
   const accessSummaryByKeyId = await buildApiKeyAccessSummaries(
     c.env,
     db,
+    createTenantScope({
+      organizationId: auth.organizationId,
+      projectId,
+    }),
     apiKeys.map((key) => key.id)
   );
 
@@ -166,7 +177,13 @@ export const createProjectApiKey = async (c: AppContext) => {
     );
   }
 
-  const apiKeyService = new ApiKeyService(getDb(c.env));
+  const apiKeyService = new ApiKeyService(
+    getDb(c.env),
+    createTenantScope({
+      organizationId: auth.organizationId,
+      projectId,
+    })
+  );
   const createdKey = await apiKeyService.createApiKey({
     organizationId: auth.organizationId,
     projectId,

--- a/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
@@ -17,7 +17,7 @@ import {
 import type { RampRuntimeContext, RampWebhookValidationContext } from "@sdp/payments/ramps/types";
 import type { BvnkBankFundingDetails, SdpEnvironment } from "@sdp/types";
 import { getDb } from "@/db";
-import { createCounterpartiesRepository } from "@/db/repositories";
+import { createSystemCounterpartiesRepository } from "@/db/repositories";
 import type {
   CounterpartiesRepository,
   CounterpartyRow,
@@ -185,7 +185,7 @@ async function handleProviderOnrampSettlementWebhook(
   if (event.status !== "COMPLETED" || !event.customerReference || !event.walletId) {
     return;
   }
-  const repo = createCounterpartiesRepository(c.env);
+  const repo = createSystemCounterpartiesRepository(c.env);
   const counterparty = await repo.findActiveCounterpartyByBvnkCustomerReference(
     event.customerReference
   );
@@ -335,7 +335,7 @@ async function handleProviderOnrampCounterpartyRequirementWebhook(
     }
   >
 ): Promise<void> {
-  const repo = createCounterpartiesRepository(c.env);
+  const repo = createSystemCounterpartiesRepository(c.env);
 
   switch (event.kind) {
     case "bvnk:customers:status-change":
@@ -398,7 +398,7 @@ async function handleProviderOfframpCounterpartyRequirementWebhook(
   }
   const walletStatus = event.walletStatus;
 
-  const repo = createCounterpartiesRepository(c.env);
+  const repo = createSystemCounterpartiesRepository(c.env);
   const wallet = parseBvnkOfframpWalletName(event.walletName);
   const counterparty = await repo.findActiveCounterpartyById(wallet.counterpartyId);
   if (!counterparty) {

--- a/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
@@ -311,7 +311,8 @@ async function provisionPendingBvnkOnramps(
         reloadedCounterparty,
         reloadedCounterparty.project_id,
         readBvnkCustomer(reloadedCounterparty.provider_data),
-        entry.request
+        entry.request,
+        repo
       );
     } catch (error) {
       await updateBvnkOnrampPaymentRuleState(repo, reloadedCounterparty, key, {

--- a/apps/sdp-api/src/routes/webhooks/ramps/mural.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/mural.ts
@@ -3,8 +3,8 @@ import type { MuralWebhookEvent } from "@sdp/payments/ramps/providers/mural/clie
 import type { RampWebhookValidationContext } from "@sdp/payments/ramps/types";
 import type { SdpEnvironment } from "@sdp/types";
 import {
-  createCounterpartiesRepository,
-  createPaymentsRepository,
+  createSystemCounterpartiesRepository,
+  createSystemPaymentsRepository,
   type PaymentsRepository,
   type PaymentTransferRow,
   type PaymentTransferStatus,
@@ -57,14 +57,14 @@ async function handleAccountCredited(
   getLogger().info(
     `[mural webhook] account_credited account=${event.accountId} amount=${event.tokenAmount} org=${event.organizationId}`
   );
-  const counterparty = await createCounterpartiesRepository(
+  const counterparty = await createSystemCounterpartiesRepository(
     c.env
   ).findCounterpartyByMuralOrganizationId(event.organizationId);
   if (!counterparty) {
     getLogger().warn(`[mural webhook] no counterparty for org ${event.organizationId}`);
     return;
   }
-  const payments = createPaymentsRepository(c.env);
+  const payments = createSystemPaymentsRepository(c.env);
   const transfer = await findMuralOnrampTransfer(payments, counterparty, ["awaiting_payment"]);
   if (!transfer) {
     getLogger().warn(
@@ -94,7 +94,7 @@ async function handleOrganizationLifecycleEvent(
   c: AppContext,
   event: Extract<MuralWebhookEvent, { kind: "kyc_status" | "tos_accepted" }>
 ): Promise<void> {
-  const repo = createCounterpartiesRepository(c.env);
+  const repo = createSystemCounterpartiesRepository(c.env);
   const counterparty = await repo.findCounterpartyByMuralOrganizationId(event.organizationId);
   if (!counterparty) {
     getLogger().warn(`[mural webhook] no counterparty for organization ${event.organizationId}`);

--- a/apps/sdp-api/src/routes/webhooks/ramps/settlements.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/settlements.ts
@@ -1,7 +1,7 @@
 import type { RampSettlementEvent } from "@sdp/payments/ramps";
 import type { Context } from "hono";
 import type { PaymentTransferStatus, UpdatePaymentTransferInput } from "@/db/repositories";
-import { createPaymentsRepository, isRampTransferType } from "@/db/repositories";
+import { createSystemPaymentsRepository, isRampTransferType } from "@/db/repositories";
 import type { Env } from "@/types/env";
 
 type AppContext = Context<{ Bindings: Env }>;
@@ -29,7 +29,7 @@ export async function applyRampSettlementEvent(c: AppContext, event: RampSettlem
     return;
   }
 
-  const repo = createPaymentsRepository(c.env);
+  const repo = createSystemPaymentsRepository(c.env);
   const transfer = await repo.getTransferByProviderReference({
     provider: event.provider,
     providerReference: event.reference,

--- a/apps/sdp-api/src/services/api-key.service.test.ts
+++ b/apps/sdp-api/src/services/api-key.service.test.ts
@@ -1,7 +1,10 @@
 import { hashString } from "@sdp/payments/hash";
 import { describe, expect, it } from "vitest";
 import type { DatabaseClient, PreparedStatement, QueryManyResult } from "@/db/client";
+import { createTenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import { ApiKeyService } from "./api-key.service";
+
+const TEST_SCOPE = createTenantScope({ organizationId: "org_1", projectId: "prj_1" });
 
 type RunCall = { sql: string; values: unknown[] };
 
@@ -99,9 +102,24 @@ class LookupDb extends RecordingDb {
 }
 
 describe("ApiKeyService.ownsUsableApiKey", () => {
+  it("rejects forged organization and project claims before database access", async () => {
+    const db = new LookupDb({ status: "active", expires_at: null });
+    const service = new ApiKeyService(db, TEST_SCOPE);
+
+    await expect(
+      service.ownsUsableApiKey({
+        apiKey: "sk_test_foreign_secret",
+        organizationId: "org_foreign",
+        projectId: "prj_foreign",
+        pepper: "test-pepper",
+      })
+    ).rejects.toBeInstanceOf(TenantScopeViolationError);
+    expect(db.lookups).toHaveLength(0);
+  });
+
   it("matches exact key material inside the organization and project boundary", async () => {
     const db = new LookupDb({ status: "active", expires_at: null });
-    const service = new ApiKeyService(db);
+    const service = new ApiKeyService(db, TEST_SCOPE);
     const apiKey = "sk_test_owned_secret";
     const pepper = "test-pepper";
 
@@ -120,7 +138,7 @@ describe("ApiKeyService.ownsUsableApiKey", () => {
   });
 
   it("fails closed when no scoped exact-key match exists", async () => {
-    const service = new ApiKeyService(new LookupDb(null));
+    const service = new ApiKeyService(new LookupDb(null), TEST_SCOPE);
 
     await expect(
       service.ownsUsableApiKey({
@@ -136,7 +154,7 @@ describe("ApiKeyService.ownsUsableApiKey", () => {
     ["deactivated", null],
     ["active", "2000-01-01T00:00:00.000Z"],
   ])("rejects an unusable key with status %s and expiry %s", async (status, expiresAt) => {
-    const service = new ApiKeyService(new LookupDb({ status, expires_at: expiresAt }));
+    const service = new ApiKeyService(new LookupDb({ status, expires_at: expiresAt }), TEST_SCOPE);
 
     await expect(
       service.ownsUsableApiKey({
@@ -152,7 +170,7 @@ describe("ApiKeyService.ownsUsableApiKey", () => {
 describe("ApiKeyService.createApiKey permission guard", () => {
   it("rejects a non-admin minting an api_admin key before touching the database", async () => {
     const db = new RecordingDb();
-    const service = new ApiKeyService(db);
+    const service = new ApiKeyService(db, TEST_SCOPE);
 
     await expect(
       service.createApiKey({
@@ -179,7 +197,7 @@ describe("ApiKeyService.updateApiKey", () => {
 
   it("rejects a non-admin raising permissions to a wildcard", async () => {
     const db = new RecordingDb();
-    const service = new ApiKeyService(db);
+    const service = new ApiKeyService(db, TEST_SCOPE);
 
     await expect(
       service.updateApiKey({
@@ -194,7 +212,7 @@ describe("ApiKeyService.updateApiKey", () => {
 
   it("scopes the update to organization and project", async () => {
     const db = new RecordingDb();
-    const service = new ApiKeyService(db);
+    const service = new ApiKeyService(db, TEST_SCOPE);
 
     await service.updateApiKey({
       ...base,
@@ -209,7 +227,7 @@ describe("ApiKeyService.updateApiKey", () => {
 
   it("lets a non-admin narrow permissions to a subset of its own", async () => {
     const db = new RecordingDb();
-    const service = new ApiKeyService(db);
+    const service = new ApiKeyService(db, TEST_SCOPE);
 
     await service.updateApiKey({
       ...base,
@@ -228,7 +246,7 @@ describe("ApiKeyService.updateApiKey", () => {
 
   it("throws when there are no fields to update", async () => {
     const db = new RecordingDb();
-    const service = new ApiKeyService(db);
+    const service = new ApiKeyService(db, TEST_SCOPE);
 
     await expect(
       service.updateApiKey({ ...base, actorPermissions: ["org:admin"] })

--- a/apps/sdp-api/src/services/api-key.service.ts
+++ b/apps/sdp-api/src/services/api-key.service.ts
@@ -4,6 +4,7 @@
  * Shared data access for API key operations.
  */
 
+// biome-ignore-all lint/security/noSecrets: service operation identifiers are not credentials
 import { hashString } from "@sdp/payments/hash";
 import type {
   ApiKeyEnvironment,
@@ -15,6 +16,7 @@ import type {
 import type { DatabaseExecutor } from "@/db";
 import { parseOptionalPostgresJson, parsePostgresJson } from "@/db/postgres-utils";
 import { AppError, badRequest } from "@/lib/errors";
+import { assertTenantClaim, type TenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import { createApiKeyMaterial } from "./api-key.utils";
 import { assertGrantableApiKeyPermissions } from "./api-key-scope.service";
 
@@ -142,7 +144,14 @@ function stringifyJsonb(value: unknown, fallback: unknown): string {
 }
 
 export class ApiKeyService {
-  constructor(private db: DatabaseClient) {}
+  constructor(
+    private db: DatabaseClient,
+    private scope: TenantScope
+  ) {
+    if (!scope.projectId) {
+      throw new TenantScopeViolationError("ApiKeyService requires a project tenant scope");
+    }
+  }
 
   /**
    * Verifies full API-key material against the current tenant boundary.
@@ -151,6 +160,7 @@ export class ApiKeyService {
    * and not unique. The raw key is hashed in memory and is never stored.
    */
   async ownsUsableApiKey(input: VerifyApiKeyOwnershipInput): Promise<boolean> {
+    assertTenantClaim(this.scope, input, "ApiKeyService.ownsUsableApiKey");
     const keyHash = await hashString(input.apiKey, input.pepper);
     const row = await this.db
       .prepare(
@@ -170,6 +180,7 @@ export class ApiKeyService {
   }
 
   async listForProject(projectId: string): Promise<ApiKeyListItem[]> {
+    assertTenantClaim(this.scope, { projectId }, "ApiKeyService.listForProject");
     const result = await this.db
       .prepare(
         `SELECT ak.id, ak.name, ak.description, ak.key_prefix, ak.role, p.environment, ak.status,
@@ -185,10 +196,12 @@ export class ApiKeyService {
                 ak.signing_wallet_id, ak.last_used_at, ak.expires_at, ak.created_at
          FROM api_keys ak
          JOIN projects p ON p.id = ak.project_id
-         WHERE ak.project_id = ? AND ak.status NOT IN ('revoked', 'deactivated')
+         WHERE ak.organization_id = ?
+           AND ak.project_id = ?
+           AND ak.status NOT IN ('revoked', 'deactivated')
          ORDER BY ak.created_at DESC`
       )
-      .bind(projectId)
+      .bind(this.scope.organizationId, this.scope.projectId)
       .all<ApiKeyListRow>();
 
     return result.results.map((row) => this.mapListRow(row));
@@ -199,6 +212,7 @@ export class ApiKeyService {
     organizationId: string,
     projectId: string
   ): Promise<ApiKeyDetails | null> {
+    assertTenantClaim(this.scope, { organizationId, projectId }, "ApiKeyService.getDetails");
     const row = await this.db
       .prepare(
         `SELECT ak.id, ak.name, ak.description, ak.key_prefix, ak.role, p.environment, ak.status,
@@ -236,6 +250,7 @@ export class ApiKeyService {
   }
 
   async createApiKey(input: CreateApiKeyInput): Promise<CreateApiKeyResult> {
+    assertTenantClaim(this.scope, input, "ApiKeyService.createApiKey");
     assertGrantableApiKeyPermissions(input.actorPermissions, input.role, input.permissions);
 
     const project = await this.db
@@ -255,8 +270,12 @@ export class ApiKeyService {
 
     if (!createdBy && input.createdByKeyId) {
       const creatorKey = await this.db
-        .prepare("SELECT created_by FROM api_keys WHERE id = ?")
-        .bind(input.createdByKeyId)
+        .prepare(
+          `SELECT created_by
+           FROM api_keys
+           WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(input.createdByKeyId, this.scope.organizationId, this.scope.projectId)
         .first<{ created_by: string }>();
       createdBy = creatorKey?.created_by || "";
     }
@@ -326,6 +345,7 @@ export class ApiKeyService {
   }
 
   async updateApiKey(input: UpdateApiKeyInput): Promise<void> {
+    assertTenantClaim(this.scope, input, "ApiKeyService.updateApiKey");
     if (input.permissions !== undefined) {
       assertGrantableApiKeyPermissions(
         input.actorPermissions,
@@ -382,6 +402,7 @@ export class ApiKeyService {
     gracePeriodHours: number,
     pepper?: string
   ): Promise<RotateApiKeyResult | null> {
+    assertTenantClaim(this.scope, { organizationId, projectId }, "ApiKeyService.rotateApiKey");
     const existing = await this.db
       .prepare(
         `SELECT ak.id, ak.name, ak.description, ak.key_hash, ak.role, ak.permissions,
@@ -441,8 +462,12 @@ export class ApiKeyService {
         .run();
 
       await tx
-        .prepare("UPDATE api_keys SET rotation_deadline = ? WHERE id = ?")
-        .bind(rotationDeadline, keyId)
+        .prepare(
+          `UPDATE api_keys
+           SET rotation_deadline = ?
+           WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(rotationDeadline, keyId, this.scope.organizationId, this.scope.projectId)
         .run();
 
       await tx
@@ -489,6 +514,7 @@ export class ApiKeyService {
     keyHash: string;
     revokedAt: string;
   } | null> {
+    assertTenantClaim(this.scope, { organizationId, projectId }, "ApiKeyService.revokeApiKey");
     const key = await this.db
       .prepare(
         "SELECT id, key_hash FROM api_keys WHERE id = ? AND organization_id = ? AND project_id = ?"
@@ -502,8 +528,12 @@ export class ApiKeyService {
 
     const now = new Date().toISOString();
     await this.db
-      .prepare("UPDATE api_keys SET status = 'deactivated', revoked_at = ? WHERE id = ?")
-      .bind(now, keyId)
+      .prepare(
+        `UPDATE api_keys
+         SET status = 'deactivated', revoked_at = ?
+         WHERE id = ? AND organization_id = ? AND project_id = ?`
+      )
+      .bind(now, keyId, this.scope.organizationId, this.scope.projectId)
       .run();
 
     return { keyHash: key.key_hash, revokedAt: now };

--- a/apps/sdp-api/src/services/api-key.service.ts
+++ b/apps/sdp-api/src/services/api-key.service.ts
@@ -180,7 +180,11 @@ export class ApiKeyService {
   }
 
   async listForProject(projectId: string): Promise<ApiKeyListItem[]> {
-    assertTenantClaim(this.scope, { projectId }, "ApiKeyService.listForProject");
+    assertTenantClaim(
+      this.scope,
+      { organizationId: this.scope.organizationId, projectId },
+      "ApiKeyService.listForProject"
+    );
     const result = await this.db
       .prepare(
         `SELECT ak.id, ak.name, ak.description, ak.key_prefix, ak.role, p.environment, ak.status,

--- a/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
@@ -187,21 +187,36 @@ describe("signing.service provider reuse", () => {
     expect(configStore.setDefaultConfig).toHaveBeenCalledWith(orgId, undefined, signingConfigId);
   });
 
+  it("does not let a project create wallets in an organization-scoped fallback config", async () => {
+    const orgId = "org_shared_wallet_guard";
+    const configRecord = createConfigRecord({
+      id: "cust_shared_wallet_guard",
+      orgId,
+      provider: "privy",
+      defaultWalletId: "privy_shared_default",
+    });
+    const { service, configStore } = createService({ configRecord, wallets: [] });
+    configStore.getDefaultConfig.mockResolvedValue(configRecord);
+
+    await expect(service.createWallet(orgId, "prj_attacker", {})).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    expect(configStore.createWallet).not.toHaveBeenCalled();
+  });
+
   it("does not return cached signatures outside the request tenant", async () => {
     const orgId = "org_signing_owner";
-    const configRecord = {
-      ...createConfigRecord({
-        id: "cust_signing_status",
-        orgId,
-        provider: "privy",
-        defaultWalletId: "privy_wallet_1",
-      }),
-      projectId: "prj_signing_owner",
-    };
+    const configRecord = createConfigRecord({
+      id: "cust_signing_status",
+      orgId,
+      provider: "privy",
+      defaultWalletId: "privy_wallet_1",
+    });
     const { service, signingStore } = createService({ configRecord, wallets: [] });
     signingStore.findByIdOrExternal.mockResolvedValue({
       id: "sreq_owner",
       organizationId: orgId,
+      projectId: "prj_signing_owner",
       custodyConfigId: configRecord.id,
       externalRequestId: "external_owner",
       status: "completed",
@@ -220,6 +235,9 @@ describe("signing.service provider reuse", () => {
     await expect(
       service.getSigningStatus(orgId, "prj_signing_owner", "sreq_owner")
     ).resolves.toMatchObject({ status: "completed" });
+    await expect(service.getSigningStatus(orgId, undefined, "sreq_owner")).resolves.toMatchObject({
+      status: "completed",
+    });
   });
 });
 

--- a/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.reuse.test.ts
@@ -186,6 +186,41 @@ describe("signing.service provider reuse", () => {
 
     expect(configStore.setDefaultConfig).toHaveBeenCalledWith(orgId, undefined, signingConfigId);
   });
+
+  it("does not return cached signatures outside the request tenant", async () => {
+    const orgId = "org_signing_owner";
+    const configRecord = {
+      ...createConfigRecord({
+        id: "cust_signing_status",
+        orgId,
+        provider: "privy",
+        defaultWalletId: "privy_wallet_1",
+      }),
+      projectId: "prj_signing_owner",
+    };
+    const { service, signingStore } = createService({ configRecord, wallets: [] });
+    signingStore.findByIdOrExternal.mockResolvedValue({
+      id: "sreq_owner",
+      organizationId: orgId,
+      custodyConfigId: configRecord.id,
+      externalRequestId: "external_owner",
+      status: "completed",
+      transactionMessage: "message",
+      signatures: JSON.stringify([{ publicKey: "OwnerPublicKey", signature: "AQ==" }]),
+      metadata: null,
+    });
+
+    await expect(
+      service.getSigningStatus("org_attacker", "prj_attacker", "sreq_owner")
+    ).resolves.toEqual({ status: "failed", error: "Signing request not found" });
+    await expect(service.getSigningStatus(orgId, "prj_attacker", "sreq_owner")).resolves.toEqual({
+      status: "failed",
+      error: "Signing request not found",
+    });
+    await expect(
+      service.getSigningStatus(orgId, "prj_signing_owner", "sreq_owner")
+    ).resolves.toMatchObject({ status: "completed" });
+  });
 });
 
 function createService(params: {
@@ -195,6 +230,11 @@ function createService(params: {
   defaultConfigRecord?: SigningConfigRecord | null;
 }): {
   service: SigningService;
+  signingStore: {
+    create: ReturnType<typeof vi.fn>;
+    findByIdOrExternal: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+  };
   configStore: {
     findActive: ReturnType<typeof vi.fn>;
     listActive: ReturnType<typeof vi.fn>;
@@ -225,11 +265,11 @@ function createService(params: {
     reactivateWallet: vi.fn(),
   };
 
-  const signingStore: SigningRequestStore = {
+  const signingStore = {
     create: vi.fn(),
     findByIdOrExternal: vi.fn(),
     updateStatus: vi.fn(),
-  };
+  } satisfies SigningRequestStore;
 
   const env: Env = {
     DATABASE_URL: testEnv.DATABASE_URL,
@@ -242,6 +282,7 @@ function createService(params: {
   return {
     service: new SigningService(configStore as never, signingStore, env),
     configStore,
+    signingStore,
   };
 }
 

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -119,6 +119,7 @@ export interface SigningRequestStore {
 
 export interface CreateSigningRequestParams {
   organizationId: string;
+  projectId: string | null;
   custodyConfigId: string;
   tokenTransactionId?: string | null;
   externalRequestId: string;
@@ -129,6 +130,7 @@ export interface CreateSigningRequestParams {
 export interface SigningRequestRecord {
   id: string;
   organizationId: string;
+  projectId: string | null;
   custodyConfigId: string;
   tokenTransactionId?: string | null;
   externalRequestId: string | null;
@@ -1384,9 +1386,7 @@ export class SigningService {
       provider?: SigningConfiguration["provider"];
     }
   ): Promise<CustodyWallet> {
-    const config = params.provider
-      ? await this.getConfigurationByProvider(orgId, projectId, params.provider)
-      : await this.configStore.findActive(orgId, projectId);
+    const config = await this.getConfigurationForMutation(orgId, projectId, params.provider);
     if (!config) {
       throw new SigningError(
         params.provider
@@ -1796,6 +1796,7 @@ export class SigningService {
     if (result.status === "pending" && result.requestId) {
       await this.signingStore.create({
         organizationId: orgId,
+        projectId: projectId ?? null,
         custodyConfigId: config.id,
         externalRequestId: result.requestId,
         transactionMessage: encodeBase64(request.message),
@@ -1820,10 +1821,14 @@ export class SigningService {
       return { status: "failed", error: "Signing request not found" };
     }
 
+    if (projectId !== undefined && record.projectId !== projectId) {
+      return { status: "failed", error: "Signing request not found" };
+    }
+
     const config = await this.configStore.getById(record.custodyConfigId);
     const configIsVisible =
       config?.organizationId === orgId &&
-      (projectId === undefined || config.projectId === null || config.projectId === projectId);
+      (config.projectId === null || config.projectId === record.projectId);
     if (!configIsVisible) {
       return { status: "failed", error: "Signing request not found" };
     }

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -388,6 +388,23 @@ export class SigningService {
     return this.configStore.findActiveByProvider(orgId, undefined, provider);
   }
 
+  /**
+   * Resolve an active configuration for an administrative mutation without
+   * project-to-organization fallback. Shared organization configurations may
+   * be used by project workloads, but only organization-scoped callers may
+   * mutate them.
+   */
+  async getConfigurationForMutation(
+    orgId: string,
+    projectId: string | undefined,
+    provider?: SigningConfiguration["provider"]
+  ): Promise<SigningConfigRecord | null> {
+    const config = provider
+      ? await this.configStore.findActiveByProvider(orgId, projectId, provider)
+      : await this.configStore.getDefaultConfig(orgId, projectId);
+    return config?.projectId === (projectId ?? null) ? config : null;
+  }
+
   async setDefaultConfiguration(
     orgId: string,
     projectId: string | undefined,
@@ -1446,9 +1463,7 @@ export class SigningService {
       provider?: SigningConfiguration["provider"];
     }
   ): Promise<void> {
-    const config = params.provider
-      ? await this.getConfigurationByProvider(orgId, projectId, params.provider)
-      : await this.configStore.findActive(orgId, projectId);
+    const config = await this.getConfigurationForMutation(orgId, projectId, params.provider);
     if (!config) {
       throw new SigningError(
         params.provider
@@ -1982,6 +1997,7 @@ export function createSigningService(env: Env, scope?: TenantScope): SigningServ
 
   const tenantMethods = new Set([
     "getConfigurationByProvider",
+    "getConfigurationForMutation",
     "setDefaultConfiguration",
     "setDefaultProvider",
     "getProviderReuseState",

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -30,6 +30,7 @@ import { createKeyPairSignerFromPrivateKeyBytes } from "@solana/signers";
 import { getDb } from "@/db";
 import { parsePostgresJson } from "@/db/postgres-utils";
 import { AppError } from "@/lib/errors";
+import { assertTenantClaim, type TenantScope } from "@/lib/tenant-scope";
 import {
   KeychainFireblocksAdapter,
   KeychainMemoryAdapter,
@@ -1970,9 +1971,67 @@ function decodeBase64(base64: string): Uint8Array {
  * @param env - API process environment
  * @returns Configured SigningService instance
  */
-export function createSigningService(env: Env): SigningService {
+export function createSigningService(env: Env, scope?: TenantScope): SigningService {
   const configStore = new CustodyConfigStore(getDb(env), env);
   const signingStore = new SigningRequestStorePg(getDb(env));
+  const service = new SigningService(configStore, signingStore, env);
 
-  return new SigningService(configStore, signingStore, env);
+  if (!scope) {
+    return service;
+  }
+
+  const tenantMethods = new Set([
+    "getConfigurationByProvider",
+    "setDefaultConfiguration",
+    "setDefaultProvider",
+    "getProviderReuseState",
+    "initializeLocalSigning",
+    "initializeFireblocksSigning",
+    "initializePrivySigning",
+    "initializeCoinbaseCdpSigning",
+    "initializeParaSigning",
+    "initializeTurnkeySigning",
+    "initializeDfnsSigning",
+    "initializeIbmHavenSigning",
+    "initializeAnchorageWalletLifecycle",
+    "initializeAnchorageSigning",
+    "initializeUtilaSigning",
+    "getWallets",
+    "getWalletsWithProviders",
+    // biome-ignore lint/security/noSecrets: public service method identifier, not a credential
+    "getWalletById",
+    "createWallet",
+    "deleteWallet",
+    "getAdapter",
+    "getPublicKey",
+    "getKeypairSigner",
+    "getTransactionSigner",
+    "sign",
+    "configureProvider",
+    "getConfiguration",
+    "getConfigurations",
+    "requiresApproval",
+    "invalidateCache",
+  ]);
+
+  return new Proxy(service, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof value !== "function" || !tenantMethods.has(String(property))) {
+        return value;
+      }
+
+      return (...args: unknown[]) => {
+        assertTenantClaim(
+          scope,
+          {
+            organizationId: args[0],
+            projectId: args[1] ?? null,
+          },
+          `SigningService.${String(property)}`
+        );
+        return Reflect.apply(value, target, args);
+      };
+    },
+  });
 }

--- a/apps/sdp-api/src/services/domain/signing.service.ts
+++ b/apps/sdp-api/src/services/domain/signing.service.ts
@@ -1809,10 +1809,22 @@ export class SigningService {
   /**
    * Check the status of an async signing request.
    */
-  async getSigningStatus(requestId: string): Promise<SignStatus> {
+  async getSigningStatus(
+    orgId: string,
+    projectId: string | undefined,
+    requestId: string
+  ): Promise<SignStatus> {
     const record = await this.signingStore.findByIdOrExternal(requestId);
 
-    if (!record) {
+    if (!record || record.organizationId !== orgId) {
+      return { status: "failed", error: "Signing request not found" };
+    }
+
+    const config = await this.configStore.getById(record.custodyConfigId);
+    const configIsVisible =
+      config?.organizationId === orgId &&
+      (projectId === undefined || config.projectId === null || config.projectId === projectId);
+    if (!configIsVisible) {
       return { status: "failed", error: "Signing request not found" };
     }
 
@@ -1840,16 +1852,10 @@ export class SigningService {
       return { status: "failed", error: "Signing failed" };
     }
 
-    // Query the provider for current status
-    const config = await this.configStore.getById(record.custodyConfigId);
-    if (!config) {
-      return { status: "failed", error: "Custody configuration not found" };
-    }
-
     // Use encrypted config handler to properly decrypt credentials
     const adapter = await createAdapterFromEncryptedConfig(
       this.env,
-      record.organizationId,
+      orgId,
       config,
       this.getCustodyCipher()
     );
@@ -2023,6 +2029,7 @@ export function createSigningService(env: Env, scope?: TenantScope): SigningServ
     "getKeypairSigner",
     "getTransactionSigner",
     "sign",
+    "getSigningStatus",
     "configureProvider",
     "getConfiguration",
     "getConfigurations",

--- a/apps/sdp-api/src/services/jobs/track-pending-transfers.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-transfers.ts
@@ -17,8 +17,8 @@ import type { SignatureStatusInfo } from "@sdp/rpc/solana";
 import * as solanaRpc from "@sdp/rpc/solana";
 import type { Signature } from "@solana/kit";
 import {
-  createPaymentsRepository,
-  createPaymentTransferBatchesRepository,
+  createSystemPaymentsRepository,
+  createSystemPaymentTransferBatchesRepository,
   type PaymentsRepository,
   WALLET_TRANSFER_TYPES,
 } from "@/db/repositories";
@@ -55,7 +55,7 @@ async function updateTerminalTransfer(
     if (transfer.project_id === null) {
       throw internalError("Transfer batch transfer is missing a project");
     }
-    await createPaymentTransferBatchesRepository(env).settleTransferBatch({
+    await createSystemPaymentTransferBatchesRepository(env).settleTransferBatch({
       transferId: transfer.id,
       organizationId: transfer.organization_id,
       projectId: transfer.project_id,
@@ -70,7 +70,7 @@ async function updateTerminalTransfer(
 }
 
 export async function trackPendingTransfers(env: Env): Promise<void> {
-  const repo = createPaymentsRepository(env);
+  const repo = createSystemPaymentsRepository(env);
   const now = new Date();
   const nowIso = now.toISOString();
 

--- a/apps/sdp-api/src/services/payments/counterparty-account-resolution.ts
+++ b/apps/sdp-api/src/services/payments/counterparty-account-resolution.ts
@@ -7,6 +7,7 @@ import {
 import type { CounterpartyRow } from "@/db/repositories/counterparty.repository";
 import type { CounterpartyAccountRow } from "@/db/repositories/counterparty-account.repository";
 import { AppError } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import type { Env } from "@/types/env";
 
 export interface ResolvedSolanaCounterpartyAccount {
@@ -33,7 +34,11 @@ export async function resolveSolanaCounterpartyAccount(input: {
   counterpartyId: string;
   counterpartyAccountId: string;
 }): Promise<ResolvedSolanaCounterpartyAccount> {
-  const counterparty = await createCounterpartiesRepository(input.env).getCounterpartyById({
+  const scope = createTenantScope({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  const counterparty = await createCounterpartiesRepository(input.env, scope).getCounterpartyById({
     counterpartyId: input.counterpartyId,
     organizationId: input.organizationId,
     projectId: input.projectId,
@@ -48,7 +53,10 @@ export async function resolveSolanaCounterpartyAccount(input: {
     );
   }
 
-  const account = await createCounterpartyAccountsRepository(input.env).getCounterpartyAccountById({
+  const account = await createCounterpartyAccountsRepository(
+    input.env,
+    scope
+  ).getCounterpartyAccountById({
     counterpartyAccountId: input.counterpartyAccountId,
     counterpartyId: input.counterpartyId,
     organizationId: input.organizationId,

--- a/apps/sdp-api/src/services/payments/payment-requests.test.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.test.ts
@@ -13,6 +13,7 @@ import {
 import { getDb } from "@/db";
 import type { PaymentRequestRow } from "@/db/repositories/payment-requests.repository";
 import { createPaymentRequestsRepository } from "@/db/repositories/repository-factory";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { rootLogger } from "@/runtime/logger";
 import { SOL_MINT } from "@/services/payment-operation.service";
 import { TEST_CUSTODY_PUBLIC_KEY } from "@/test/fixtures/custody";
@@ -47,7 +48,10 @@ function mockSettlementSucceeds() {
 }
 
 async function createRequest(overrides?: { token?: string; expiresAt?: string }) {
-  return createPaymentRequestsRepository(env).createPaymentRequest({
+  return createPaymentRequestsRepository(
+    env,
+    createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID })
+  ).createPaymentRequest({
     organizationId: TEST_ORG.id,
     projectId: TEST_PROJECT_ID,
     counterpartyId: null,

--- a/apps/sdp-api/src/services/payments/payment-requests.ts
+++ b/apps/sdp-api/src/services/payments/payment-requests.ts
@@ -16,6 +16,7 @@ import {
   createPaymentsRepository,
 } from "@/db/repositories/repository-factory";
 import { AppError, internalError, nullOnExpected } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { getLogger } from "@/runtime/logger";
 import type { Env } from "@/types/env";
 
@@ -111,7 +112,11 @@ async function settlePaymentRequestIfPaid(
 
   const transfer = await recordInboundTransfer(env, row, projectId, found);
 
-  const requestsRepo = createPaymentRequestsRepository(env);
+  const scope = createTenantScope({
+    organizationId: row.organization_id,
+    projectId,
+  });
+  const requestsRepo = createPaymentRequestsRepository(env, scope);
   const settled = await requestsRepo.markPaymentRequest({
     requestId: row.id,
     organizationId: row.organization_id,
@@ -151,7 +156,13 @@ async function recordInboundTransfer(
   projectId: string,
   found: Awaited<ReturnType<typeof findReference>>
 ): Promise<PaymentTransferRow> {
-  const paymentsRepo = createPaymentsRepository(env);
+  const paymentsRepo = createPaymentsRepository(
+    env,
+    createTenantScope({
+      organizationId: row.organization_id,
+      projectId,
+    })
+  );
   try {
     const transfer = await paymentsRepo.createTransfer({
       organizationId: row.organization_id,

--- a/apps/sdp-api/src/services/payments/recurring-payments/activation.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/activation.ts
@@ -27,6 +27,7 @@ import {
   type PaymentSubscriptionsRepository,
 } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import {
   resolveMintTokenProgram,
   resolveSourceTokenAccountOrAta,
@@ -42,6 +43,13 @@ import {
   generateProgramPlanId,
   sendSubscriptionInstructions,
 } from "./shared";
+
+function tenantScope(input: { organizationId: string; projectId: string }) {
+  return createTenantScope({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+}
 
 async function resetRecurringPaymentActivationUnlessAlreadyActive(input: {
   recurringRepo: ReturnType<typeof createPaymentRecurringPaymentsRepository>;
@@ -555,8 +563,8 @@ export async function activateRecurringPayment(input: {
   recurringPayment: PaymentRecurringPaymentRow;
   createdBy: string | null;
 }): Promise<PaymentRecurringPaymentRow> {
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
-  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env, tenantScope(input));
   const rpc = solanaRpc.createRpc(input.env);
   const nowIso = new Date().toISOString();
 

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -30,6 +30,7 @@ import {
   type PaymentTransferRow,
 } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import {
   resolveMintTokenProgram,
   resolveSourceTokenAccountOrAta,
@@ -50,6 +51,13 @@ import {
 } from "./shared";
 
 const COLLECTION_STALE_AFTER_MS = RECURRING_PAYMENT_OPERATION_STALE_AFTER_MS;
+
+function tenantScope(input: { organizationId: string; projectId: string }) {
+  return createTenantScope({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+}
 
 type RecurringCollectionSource = "manual" | "automated";
 
@@ -276,7 +284,13 @@ async function finalizeRecurringPaymentCollection(input: {
     // Recovery can safely re-run this transaction because the period updates below are CAS-guarded.
     const recurringRepo = createPostgresPaymentRecurringPaymentsRepository(tx);
     const subscriptionsRepo = createPostgresPaymentSubscriptionsRepository(tx);
-    const paymentsRepo = createPostgresPaymentsRepository(tx);
+    const paymentsRepo = createPostgresPaymentsRepository(
+      tx,
+      createTenantScope({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      })
+    );
 
     const updatedTransfer = await paymentsRepo.updateTransfer({
       transferId: input.transfer.id,
@@ -701,9 +715,9 @@ export async function collectRecurringPayment(input: {
   const nowIso = new Date().toISOString();
   const dueAt = input.recurringPayment.next_collection_due_at;
 
-  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
-  const paymentsRepo = createPaymentsRepository(input.env);
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env, tenantScope(input));
+  const paymentsRepo = createPaymentsRepository(input.env, tenantScope(input));
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
   const subscription = await subscriptionsRepo.getSubscriptionById({
     subscriptionId: input.recurringPayment.subscription_id,
     organizationId: input.organizationId,

--- a/apps/sdp-api/src/services/payments/recurring-payments/create.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/create.ts
@@ -4,6 +4,7 @@ import {
   type PaymentRecurringPaymentRow,
 } from "@/db/repositories";
 import { AppError } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { resolveSolanaCounterpartyAccount } from "../counterparty-account-resolution";
@@ -25,7 +26,7 @@ export async function createRecurringPayment(input: {
   createdBy: string | null;
 }): Promise<PaymentRecurringPaymentRow> {
   const [tokenMint, destination] = await Promise.all([
-    assertRecurringPaymentTokenMint(input.token, input.projectId, input.env),
+    assertRecurringPaymentTokenMint(input.token, input.organizationId, input.projectId, input.env),
     resolveSolanaCounterpartyAccount({
       env: input.env,
       organizationId: input.organizationId,
@@ -35,7 +36,11 @@ export async function createRecurringPayment(input: {
     }),
   ]);
 
-  await assertWalletPolicyAllowsTransferWithRepository(createPaymentsRepository(input.env), {
+  const scope = createTenantScope({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  await assertWalletPolicyAllowsTransferWithRepository(createPaymentsRepository(input.env, scope), {
     organizationId: input.organizationId,
     projectId: input.projectId,
     wallet: input.sourceWallet,
@@ -47,7 +52,8 @@ export async function createRecurringPayment(input: {
 
   const now = new Date().toISOString();
   const recurringPayment = await createPaymentRecurringPaymentsRepository(
-    input.env
+    input.env,
+    scope
   ).createRecurringPayment({
     id: `prp_${crypto.randomUUID()}`,
     organizationId: input.organizationId,

--- a/apps/sdp-api/src/services/payments/recurring-payments/lifecycle.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/lifecycle.ts
@@ -21,12 +21,20 @@ import {
   type PaymentSubscriptionRow,
 } from "@/db/repositories";
 import { AppError, badRequest, conflict } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { getLogger } from "@/runtime/logger";
 import * as solanaServices from "@/services/solana";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { recoverOrBlockLifecycleCollection } from "./collection";
 import { confirmSubscriptionSignature, sendSubscriptionInstructions } from "./shared";
+
+function tenantScope(input: { organizationId: string; projectId: string }) {
+  return createTenantScope({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+}
 
 function lifecycleConfirmationMessage(operation: RecurringPaymentLifecycleOperation) {
   return operation === "cancel"
@@ -292,9 +300,9 @@ async function runRecurringPaymentLifecycle(input: {
   recurringPayment: PaymentRecurringPaymentRow;
   operation: RecurringPaymentLifecycleOperation;
 }): Promise<PaymentRecurringPaymentRow> {
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
-  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
-  const paymentsRepo = createPaymentsRepository(input.env);
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env, tenantScope(input));
+  const paymentsRepo = createPaymentsRepository(input.env, tenantScope(input));
   const nowIso = new Date().toISOString();
 
   assertLifecyclePreconditions({ ...input, nowIso });
@@ -513,7 +521,7 @@ export async function cancelRecurringPayment(input: {
   recurringPayment: PaymentRecurringPaymentRow;
 }): Promise<PaymentRecurringPaymentRow> {
   if (input.recurringPayment.status === "pending_activation") {
-    const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
+    const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
     const updated = await recurringRepo.updateRecurringPaymentLifecycle({
       recurringPaymentId: input.recurringPayment.id,
       organizationId: input.organizationId,

--- a/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
@@ -19,6 +19,7 @@ import {
 import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import { createTokenRepository } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { isNativePaymentToken, normalizePaymentToken } from "@/services/payment-operation.service";
 import * as solanaServices from "@/services/solana";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -33,6 +34,7 @@ const RECURRING_PAYMENT_TOKEN_ERROR =
  */
 export async function assertRecurringPaymentTokenMint(
   token: string,
+  organizationId: string,
   projectId: string,
   env: Env
 ): Promise<string> {
@@ -50,7 +52,10 @@ export async function assertRecurringPaymentTokenMint(
     throw badRequest(RECURRING_PAYMENT_TOKEN_ERROR);
   }
 
-  const issuedTokenStatus = await createTokenRepository(env).getStatusByMint(projectId, mint);
+  const issuedTokenStatus = await createTokenRepository(
+    env,
+    createTenantScope({ organizationId, projectId })
+  ).getStatusByMint(projectId, mint);
   if (issuedTokenStatus !== "active") {
     throw badRequest(RECURRING_PAYMENT_TOKEN_ERROR);
   }

--- a/apps/sdp-api/src/services/payments/recurring-payments/update.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/update.ts
@@ -32,6 +32,7 @@ import {
   type PaymentSubscriptionsRepository,
 } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import {
   resolveMintTokenProgram,
   resolveSourceTokenAccountOrAta,
@@ -88,6 +89,13 @@ const REPLACEMENT_UPDATE_FIELDS = new Set<keyof RecurringPaymentUpdateSnapshot>(
   "amount",
   "periodHours",
 ]);
+
+function tenantScope(input: { organizationId: string; projectId: string }) {
+  return createTenantScope({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+}
 
 function recurringPaymentSnapshot(row: PaymentRecurringPaymentRow): RecurringPaymentUpdateSnapshot {
   return {
@@ -206,7 +214,12 @@ async function resolveRecurringPaymentUpdate(input: {
     counterpartyAccountId !== input.recurringPayment.counterparty_account_id;
   const [token, destination] = await Promise.all([
     input.request.token !== undefined
-      ? assertRecurringPaymentTokenMint(input.request.token, input.projectId, input.env)
+      ? assertRecurringPaymentTokenMint(
+          input.request.token,
+          input.organizationId,
+          input.projectId,
+          input.env
+        )
       : input.recurringPayment.token,
     accountChanged
       ? resolveSolanaCounterpartyAccount({
@@ -233,15 +246,18 @@ async function resolveRecurringPaymentUpdate(input: {
       ? input.request.metadataUri
       : input.recurringPayment.metadata_uri;
 
-  await assertWalletPolicyAllowsTransferWithRepository(createPaymentsRepository(input.env), {
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    wallet: finalSourceWallet,
-    destinationAddress: destination.destinationAddress,
-    enforceDailyLimit: false,
-    token,
-    amount,
-  });
+  await assertWalletPolicyAllowsTransferWithRepository(
+    createPaymentsRepository(input.env, tenantScope(input)),
+    {
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      wallet: finalSourceWallet,
+      destinationAddress: destination.destinationAddress,
+      enforceDailyLimit: false,
+      token,
+      amount,
+    }
+  );
 
   const before = recurringPaymentSnapshot(input.recurringPayment);
   const after: RecurringPaymentUpdateSnapshot = {
@@ -318,7 +334,7 @@ async function updatePendingRecurringPayment(input: {
     input.resolved.destinationAddress !== input.recurringPayment.destination_address ||
     input.resolved.token !== input.recurringPayment.token;
   const updatedAt = new Date().toISOString();
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
   const updated = await recurringRepo.updateRecurringPayment({
     recurringPaymentId: input.recurringPayment.id,
     organizationId: input.organizationId,
@@ -602,7 +618,7 @@ async function runMetadataScheduleUpdate(input: {
   request: UpdatePaymentRecurringPaymentRequest;
   createdBy: string | null;
 }): Promise<PaymentRecurringPaymentRow> {
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
   const rpc = solanaRpc.createRpc(input.env);
   let attempt = input.attempt;
   let planUpdateSignature = attempt.plan_update_signature as Signature | null;
@@ -1041,7 +1057,7 @@ async function runReplacementUpdate(input: {
   }
   const oldSubscription =
     input.subscription ??
-    (await createPaymentSubscriptionsRepository(input.env).getSubscriptionById({
+    (await createPaymentSubscriptionsRepository(input.env, tenantScope(input)).getSubscriptionById({
       subscriptionId: input.claimed.subscription_id,
       organizationId: input.organizationId,
       projectId: input.projectId,
@@ -1050,8 +1066,8 @@ async function runReplacementUpdate(input: {
     throw new AppError("NOT_FOUND", "Subscription not found");
   }
 
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
-  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env, tenantScope(input));
   const rpc = solanaRpc.createRpc(input.env);
   let attempt = input.attempt;
   let planCreationSignature = attempt.plan_creation_signature as Signature | null;
@@ -1420,9 +1436,9 @@ export async function updateRecurringPayment(input: {
     throw badRequest("firstCollectionAt can only be updated before activation");
   }
 
-  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env);
-  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env);
-  const paymentsRepo = createPaymentsRepository(input.env);
+  const recurringRepo = createPaymentRecurringPaymentsRepository(input.env, tenantScope(input));
+  const subscriptionsRepo = createPaymentSubscriptionsRepository(input.env, tenantScope(input));
+  const paymentsRepo = createPaymentsRepository(input.env, tenantScope(input));
   const settled = await recoverOrBlockLifecycleCollection({
     env: input.env,
     recurringRepo,

--- a/apps/sdp-api/src/services/policy-enforcement.service.test.ts
+++ b/apps/sdp-api/src/services/policy-enforcement.service.test.ts
@@ -571,6 +571,7 @@ describe("WalletPolicyEnforcementService", () => {
 
     expect(repository.updateApprovalRequestStatus).toHaveBeenCalledWith({
       organizationId: "org_1",
+      projectId: "prj_1",
       approvalRequestId: "appr_1",
       status: "failed",
       operationStatus: "failed",
@@ -594,6 +595,7 @@ describe("WalletPolicyEnforcementService", () => {
 
     expect(repository.updateApprovalRequestStatus).toHaveBeenCalledWith({
       organizationId: "org_1",
+      projectId: "prj_1",
       approvalRequestId: "appr_1",
       status: "failed",
       operationStatus: "failed",

--- a/apps/sdp-api/src/services/policy-enforcement.service.test.ts
+++ b/apps/sdp-api/src/services/policy-enforcement.service.test.ts
@@ -9,7 +9,12 @@ import type {
   PolicyRepository,
   WalletOperationRow,
 } from "@/db/repositories";
-import { WalletPolicyEnforcementService } from "./policy-enforcement.service";
+import { createTenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
+import type { Env } from "@/types/env";
+import {
+  enforceWalletOperationPolicy,
+  WalletPolicyEnforcementService,
+} from "./policy-enforcement.service";
 
 const baseOperation: CreateWalletOperationInput = {
   organizationId: "org_1",
@@ -263,6 +268,18 @@ function createRepository(options: {
 }
 
 describe("WalletPolicyEnforcementService", () => {
+  it("rejects operation tenant claims that differ from the trusted request scope", async () => {
+    const scope = createTenantScope({ organizationId: "org_1", projectId: "prj_1" });
+
+    await expect(
+      enforceWalletOperationPolicy({} as Env, scope, {
+        ...baseOperation,
+        organizationId: "org_foreign",
+        projectId: "prj_foreign",
+      })
+    ).rejects.toBeInstanceOf(TenantScopeViolationError);
+  });
+
   it("records default-allow operations and marks them evaluated", async () => {
     const repository = createRepository({});
     const service = new WalletPolicyEnforcementService(repository);

--- a/apps/sdp-api/src/services/policy-enforcement.service.ts
+++ b/apps/sdp-api/src/services/policy-enforcement.service.ts
@@ -16,7 +16,7 @@ import {
 } from "@/db/repositories";
 import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, conflict, internalError } from "@/lib/errors";
-import { createTenantScope } from "@/lib/tenant-scope";
+import { assertTenantClaim, createTenantScope, type TenantScope } from "@/lib/tenant-scope";
 import { getLogger } from "@/runtime/logger";
 import {
   CustodyConfigStore,
@@ -269,17 +269,11 @@ function errorMessage(error: unknown): string {
 
 export async function enforceWalletOperationPolicy(
   env: Env,
+  scope: TenantScope,
   input: CreateWalletOperationInput
 ): Promise<WalletOperationPolicyEnforcement> {
-  const service = new WalletPolicyEnforcementService(
-    createPolicyRepository(
-      env,
-      createTenantScope({
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-      })
-    )
-  );
+  assertTenantClaim(scope, input, "enforceWalletOperationPolicy");
+  const service = new WalletPolicyEnforcementService(createPolicyRepository(env, scope));
   return service.enforce(input);
 }
 

--- a/apps/sdp-api/src/services/policy-enforcement.service.ts
+++ b/apps/sdp-api/src/services/policy-enforcement.service.ts
@@ -16,6 +16,7 @@ import {
 } from "@/db/repositories";
 import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, conflict, internalError } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { getLogger } from "@/runtime/logger";
 import {
   CustodyConfigStore,
@@ -172,7 +173,13 @@ export async function recordLegacyWalletPolicyDenial(
   enforcement: WalletOperationPolicyEnforcement,
   error: unknown
 ): Promise<void> {
-  const repository = createPolicyRepository(env);
+  const repository = createPolicyRepository(
+    env,
+    createTenantScope({
+      organizationId: enforcement.operation.organizationId,
+      projectId: enforcement.operation.projectId,
+    })
+  );
   const reason =
     error instanceof Error && error.message
       ? error.message
@@ -261,7 +268,15 @@ export async function enforceWalletOperationPolicy(
   env: Env,
   input: CreateWalletOperationInput
 ): Promise<WalletOperationPolicyEnforcement> {
-  const service = new WalletPolicyEnforcementService(createPolicyRepository(env));
+  const service = new WalletPolicyEnforcementService(
+    createPolicyRepository(
+      env,
+      createTenantScope({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+      })
+    )
+  );
   return service.enforce(input);
 }
 

--- a/apps/sdp-api/src/services/policy-enforcement.service.ts
+++ b/apps/sdp-api/src/services/policy-enforcement.service.ts
@@ -91,6 +91,7 @@ export class WalletPolicyEnforcementService {
             await markApprovalRequestAndWalletOperationFailed(
               this.repository,
               operation.organizationId,
+              operation.projectId,
               approvalRequestId
             );
           } catch (cleanupError) {
@@ -121,7 +122,7 @@ export class WalletPolicyEnforcementService {
   ) {
     const approvalRequest = await this.repository.updateApprovalRequestStatus({
       organizationId,
-      projectId,
+      projectId: projectId ?? null,
       approvalRequestId,
       status: "approved",
       operationStatus: "executing",
@@ -139,7 +140,7 @@ export class WalletPolicyEnforcementService {
   ) {
     const approvalRequest = await this.repository.updateApprovalRequestStatus({
       organizationId,
-      projectId,
+      projectId: projectId ?? null,
       approvalRequestId,
       status: "canceled",
       operationStatus: "canceled",
@@ -157,7 +158,7 @@ export class WalletPolicyEnforcementService {
   ) {
     const approvalRequest = await this.repository.updateApprovalRequestStatus({
       organizationId,
-      projectId,
+      projectId: projectId ?? null,
       approvalRequestId,
       status: "rejected",
       operationStatus: "canceled",
@@ -232,10 +233,12 @@ async function markWalletOperationFailed(
 async function markApprovalRequestAndWalletOperationFailed(
   repository: PolicyRepository,
   organizationId: string,
+  projectId: string | null,
   approvalRequestId: string
 ): Promise<void> {
   await repository.updateApprovalRequestStatus({
     organizationId,
+    projectId,
     approvalRequestId,
     status: "failed",
     operationStatus: "failed",

--- a/apps/sdp-api/src/services/stores/custody-config.store.ts
+++ b/apps/sdp-api/src/services/stores/custody-config.store.ts
@@ -87,6 +87,7 @@ interface CustodyWalletLookupRow extends CustodyWalletRow {
 interface SigningRequestRow {
   id: string;
   organization_id: string;
+  project_id: string | null;
   custody_config_id: string;
   token_transaction_id: string | null;
   external_request_id: string | null;
@@ -812,12 +813,13 @@ export class SigningRequestStorePg implements SigningRequestStore {
     await this.db
       .prepare(
         `INSERT INTO signing_requests
-         (id, organization_id, custody_config_id, token_transaction_id, external_request_id, transaction_message, metadata)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+         (id, organization_id, project_id, custody_config_id, token_transaction_id, external_request_id, transaction_message, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         id,
         params.organizationId,
+        params.projectId,
         params.custodyConfigId,
         params.tokenTransactionId ?? null,
         params.externalRequestId,
@@ -906,6 +908,7 @@ export class SigningRequestStorePg implements SigningRequestStore {
     return {
       id: row.id,
       organizationId: row.organization_id,
+      projectId: row.project_id,
       custodyConfigId: row.custody_config_id,
       tokenTransactionId: row.token_transaction_id,
       externalRequestId: row.external_request_id,

--- a/apps/sdp-api/src/services/token.service.test.ts
+++ b/apps/sdp-api/src/services/token.service.test.ts
@@ -380,6 +380,59 @@ describe("TokenService", () => {
       expect(row?.decimals).toBe(9);
     });
 
+    it("blocks metadata updates while deployment is using the claimed snapshot", async () => {
+      await insertToken("tok_claim_metadata_race", { status: "pending", mintAddress: null });
+      await tokenService.beginTokenDeploy("tok_claim_metadata_race");
+
+      await expect(
+        tokenService.updateToken("tok_claim_metadata_race", {
+          name: "Divergent metadata",
+          description: "Must not persist while deployment is in flight",
+        })
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      const row = await db
+        .prepare("SELECT name, description FROM issued_tokens WHERE id = ?")
+        .bind("tok_claim_metadata_race")
+        .first<{ name: string; description: string | null }>();
+      expect(row).toEqual({ name: "Claimed Token", description: null });
+    });
+
+    it("blocks stale metadata updates after deployment completes", async () => {
+      await insertToken("tok_completed_metadata_race", { status: "pending", mintAddress: null });
+      const pendingSnapshot = await tokenService.getToken({
+        tokenId: "tok_completed_metadata_race",
+        organizationId: TEST_ORG.id,
+        projectId: TEST_PROJECT.id,
+      });
+      expect(pendingSnapshot).not.toBeNull();
+
+      await tokenService.beginTokenDeploy("tok_completed_metadata_race");
+      await tokenService.setTokenDeployed(
+        "tok_completed_metadata_race",
+        "11111111111111111111111111111111",
+        "11111111111111111111111111111111",
+        null
+      );
+
+      await expect(
+        tokenService.updateToken(
+          "tok_completed_metadata_race",
+          { name: "Stale route snapshot" },
+          {
+            status: pendingSnapshot?.status ?? "pending",
+            mintAddress: pendingSnapshot?.mintAddress ?? null,
+          }
+        )
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      const row = await db
+        .prepare("SELECT name FROM issued_tokens WHERE id = ?")
+        .bind("tok_completed_metadata_race")
+        .first<{ name: string }>();
+      expect(row?.name).toBe("Claimed Token");
+    });
+
     it("releases a deploying claim back to pending so a failed deploy stays editable", async () => {
       await insertToken("tok_claim_release", { status: "pending", mintAddress: null });
       await tokenService.beginTokenDeploy("tok_claim_release");

--- a/apps/sdp-api/src/services/token.service.test.ts
+++ b/apps/sdp-api/src/services/token.service.test.ts
@@ -475,9 +475,29 @@ describe("TokenService", () => {
         ["tok_foreign_release", "deploying"],
         ["tok_foreign_deployed", "pending"],
         ["tok_foreign_supply", "active"],
+        ["tok_foreign_child", "active"],
       ] as const) {
         await insertToken(id, { projectId: foreignProjectId, status });
       }
+
+      const { entry: foreignEntry } = await tokenService.addAllowlistEntry({
+        tokenId: "tok_foreign_child",
+        address: "ForeignAllowlist111111111111111111111111111111",
+        addedBy: TEST_USER.id,
+      });
+      await tokenService.freezeAccount({
+        tokenId: "tok_foreign_child",
+        accountAddress: "foreign_account",
+        frozenBy: TEST_USER.id,
+      });
+      const { transaction: foreignTransaction } = await tokenService.createTransaction({
+        tokenId: "tok_foreign_child",
+        organizationId: TEST_ORG.id,
+        type: "mint",
+        params: { destination: "foreign_account", amount: "1" },
+        idempotencyKey: "foreign-idempotency-key",
+        idempotencyFingerprint: "foreign-idempotency-fingerprint",
+      });
 
       const scoped = new TokenService(
         db,
@@ -498,6 +518,60 @@ describe("TokenService", () => {
         "TOKEN_NOT_FOUND"
       );
 
+      // Child resources must enforce the same boundary even when a caller has
+      // only a globally unique entry/transaction id.
+      await expect(scoped.getAllowlistEntry(foreignEntry.id)).resolves.toBeNull();
+      await expect(scoped.listAllowlistEntries("tok_foreign_child")).rejects.toThrow(
+        "TOKEN_NOT_FOUND"
+      );
+      await expect(scoped.listAllowlistLabels("tok_foreign_child")).rejects.toThrow(
+        "TOKEN_NOT_FOUND"
+      );
+      await expect(scoped.revokeAllowlistEntry(foreignEntry.id)).rejects.toThrow(
+        "ALLOWLIST_ENTRY_NOT_FOUND"
+      );
+      await expect(scoped.activateAllowlistEntry(foreignEntry.id)).rejects.toThrow(
+        "ALLOWLIST_ENTRY_NOT_FOUND"
+      );
+      await expect(scoped.deleteAllowlistEntry(foreignEntry.id)).rejects.toThrow(
+        "ALLOWLIST_ENTRY_NOT_FOUND"
+      );
+      await expect(
+        scoped.addAllowlistEntry({
+          tokenId: "tok_foreign_child",
+          address: "BlockedForeignAdd11111111111111111111111111111",
+          addedBy: TEST_USER.id,
+        })
+      ).rejects.toThrow("TOKEN_NOT_FOUND");
+
+      await expect(
+        scoped.freezeAccount({
+          tokenId: "tok_foreign_child",
+          accountAddress: "blocked_foreign_account",
+          frozenBy: TEST_USER.id,
+        })
+      ).rejects.toThrow("TOKEN_NOT_FOUND");
+      await expect(
+        scoped.unfreezeAccount("tok_foreign_child", "foreign_account", TEST_USER.id)
+      ).rejects.toThrow("TOKEN_NOT_FOUND");
+      await expect(scoped.listFrozenAccounts("tok_foreign_child")).rejects.toThrow(
+        "TOKEN_NOT_FOUND"
+      );
+
+      await expect(scoped.getTransaction(foreignTransaction.id)).resolves.toBeNull();
+      await expect(
+        scoped.updateTransaction(foreignTransaction.id, { status: "confirmed" })
+      ).rejects.toThrow("TRANSACTION_NOT_FOUND");
+      await expect(scoped.listTokenTransactions("tok_foreign_child")).rejects.toThrow(
+        "TOKEN_NOT_FOUND"
+      );
+      await expect(
+        scoped.listTransactions({
+          organizationId: TEST_ORG.id,
+          projectId: foreignProjectId,
+        })
+      ).rejects.toThrow("cannot override the repository project scope");
+
       await expect(readStatus("tok_foreign_claim")).resolves.toBe("pending");
       await expect(readStatus("tok_foreign_release")).resolves.toBe("deploying");
       const rows = await db
@@ -512,6 +586,25 @@ describe("TokenService", () => {
         { id: "tok_foreign_deployed", mint_address: null, total_supply_cached: "0" },
         { id: "tok_foreign_supply", mint_address: null, total_supply_cached: "0" },
       ]);
+
+      const childState = await db
+        .prepare(
+          `SELECT
+             (SELECT status FROM token_allowlists WHERE id = ?) AS allowlist_status,
+             (SELECT unfrozen_at FROM frozen_accounts WHERE token_id = ? AND account_address = ?) AS unfrozen_at,
+             (SELECT status FROM issuance_transactions WHERE id = ?) AS transaction_status`
+        )
+        .bind(foreignEntry.id, "tok_foreign_child", "foreign_account", foreignTransaction.id)
+        .first<{
+          allowlist_status: string;
+          unfrozen_at: string | null;
+          transaction_status: string;
+        }>();
+      expect(childState).toEqual({
+        allowlist_status: "active",
+        unfrozen_at: null,
+        transaction_status: "pending",
+      });
     });
   });
 

--- a/apps/sdp-api/src/services/token.service.test.ts
+++ b/apps/sdp-api/src/services/token.service.test.ts
@@ -5,6 +5,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getDb } from "@/db";
 import { AppError } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
 import { TokenService } from "@/services/token.service";
 import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
 import { TEST_PROJECT, TEST_PROJECT_API_KEY } from "@/test/fixtures/tokens";
@@ -225,7 +226,7 @@ describe("TokenService", () => {
   describe("updateToken undeployed guard", () => {
     async function insertToken(
       id: string,
-      overrides: { mintAddress?: string | null; status?: string }
+      overrides: { mintAddress?: string | null; projectId?: string; status?: string }
     ): Promise<void> {
       await db
         .prepare(
@@ -237,7 +238,7 @@ describe("TokenService", () => {
         )
         .bind(
           id,
-          TEST_PROJECT.id,
+          overrides.projectId ?? TEST_PROJECT.id,
           TEST_ORG.id,
           overrides.mintAddress ?? null,
           overrides.status ?? "pending",
@@ -304,7 +305,7 @@ describe("TokenService", () => {
   describe("deploy claim lifecycle (beginTokenDeploy / releaseTokenDeploy)", () => {
     async function insertToken(
       id: string,
-      overrides: { mintAddress?: string | null; status?: string }
+      overrides: { mintAddress?: string | null; projectId?: string; status?: string }
     ): Promise<void> {
       await db
         .prepare(
@@ -316,7 +317,7 @@ describe("TokenService", () => {
         )
         .bind(
           id,
-          TEST_PROJECT.id,
+          overrides.projectId ?? TEST_PROJECT.id,
           TEST_ORG.id,
           overrides.mintAddress ?? null,
           overrides.status ?? "pending",
@@ -405,6 +406,59 @@ describe("TokenService", () => {
       await tokenService.releaseTokenDeploy("tok_claim_release_noop");
 
       expect(await readStatus("tok_claim_release_noop")).toBe("active");
+    });
+
+    it("applies tenant predicates before deployment and supply mutations", async () => {
+      const foreignProjectId = "prj_token_foreign";
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Foreign Project', ?, 'sandbox', 'active', ?)`
+        )
+        .bind(foreignProjectId, TEST_ORG.id, foreignProjectId, TEST_USER.id)
+        .run();
+      for (const [id, status] of [
+        ["tok_foreign_claim", "pending"],
+        ["tok_foreign_release", "deploying"],
+        ["tok_foreign_deployed", "pending"],
+        ["tok_foreign_supply", "active"],
+      ] as const) {
+        await insertToken(id, { projectId: foreignProjectId, status });
+      }
+
+      const scoped = new TokenService(
+        db,
+        createTenantScope({ organizationId: TEST_ORG.id, projectId: TEST_PROJECT.id })
+      );
+
+      await expect(scoped.beginTokenDeploy("tok_foreign_claim")).resolves.toBeNull();
+      await scoped.releaseTokenDeploy("tok_foreign_release");
+      await expect(
+        scoped.setTokenDeployed(
+          "tok_foreign_deployed",
+          "ForeignMint111111111111111111111111111111111",
+          "ForeignAuthority11111111111111111111111111111",
+          null
+        )
+      ).rejects.toThrow("TOKEN_NOT_FOUND");
+      await expect(scoped.setSupplyFromBaseUnits("tok_foreign_supply", "999")).rejects.toThrow(
+        "TOKEN_NOT_FOUND"
+      );
+
+      await expect(readStatus("tok_foreign_claim")).resolves.toBe("pending");
+      await expect(readStatus("tok_foreign_release")).resolves.toBe("deploying");
+      const rows = await db
+        .prepare(
+          `SELECT id, mint_address, total_supply_cached
+           FROM issued_tokens
+           WHERE id IN ('tok_foreign_deployed', 'tok_foreign_supply')
+           ORDER BY id`
+        )
+        .all<{ id: string; mint_address: string | null; total_supply_cached: string }>();
+      expect(rows.results).toEqual([
+        { id: "tok_foreign_deployed", mint_address: null, total_supply_cached: "0" },
+        { id: "tok_foreign_supply", mint_address: null, total_supply_cached: "0" },
+      ]);
     });
   });
 

--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -860,15 +860,8 @@ export class TokenService {
       whereConditions.push("status <> 'deploying'");
     }
     if (expectedDeploymentState) {
-      whereConditions.push(
-        "status = ?",
-        "(mint_address = ? OR (mint_address IS NULL AND ? IS NULL))"
-      );
-      whereValues.push(
-        expectedDeploymentState.status,
-        expectedDeploymentState.mintAddress,
-        expectedDeploymentState.mintAddress
-      );
+      whereConditions.push("status = ?", "mint_address IS NOT DISTINCT FROM ?");
+      whereValues.push(expectedDeploymentState.status, expectedDeploymentState.mintAddress);
     }
 
     const rowsAffected = await this.db

--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -414,6 +414,60 @@ export class TokenService {
     };
   }
 
+  private tenantTokenScope(alias = ""): { clause: string; values: Array<string | null> } {
+    if (!this.tenantScope) {
+      return { clause: "", values: [] };
+    }
+
+    const prefix = alias ? `${alias}.` : "";
+    return {
+      clause: ` AND ${prefix}organization_id = ? AND ${prefix}project_id IS NOT DISTINCT FROM ?`,
+      values: [this.tenantScope.organizationId, this.tenantScope.projectId],
+    };
+  }
+
+  /**
+   * Enforce the service's immutable tenant boundary before touching a child
+   * resource keyed only by token id. Token ownership is immutable, so this
+   * check remains valid for the following child-row operation.
+   */
+  private async assertTokenInTenant(tokenId: string): Promise<void> {
+    if (!this.tenantScope) {
+      return;
+    }
+
+    const row = await this.db
+      .prepare(
+        `SELECT id
+         FROM issued_tokens
+         WHERE id = ? AND organization_id = ? AND project_id IS NOT DISTINCT FROM ?`
+      )
+      .bind(tokenId, this.tenantScope.organizationId, this.tenantScope.projectId)
+      .first<{ id: string }>();
+
+    if (!row) {
+      throw new Error("TOKEN_NOT_FOUND");
+    }
+  }
+
+  private assertTenantOptions(options: {
+    organizationId: string;
+    projectId?: string | null;
+  }): void {
+    if (!this.tenantScope) {
+      return;
+    }
+
+    assertTenantClaim(
+      this.tenantScope,
+      {
+        organizationId: options.organizationId,
+        projectId: options.projectId ?? null,
+      },
+      "TokenService"
+    );
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Token CRUD
   // ═══════════════════════════════════════════════════════════════════════════
@@ -637,6 +691,7 @@ export class TokenService {
   }
 
   async getTokenByMint(mintAddress: string): Promise<Token | null> {
+    const tenant = this.tenantTokenScope();
     const row = await this.db
       .prepare(
         `SELECT id, project_id, organization_id, mint_address, mint_authority, metadata_authority, freeze_authority,
@@ -645,9 +700,9 @@ export class TokenService {
                 total_supply_cached, total_supply_updated_at, max_supply, is_mintable,
                 freeze_authority_enabled, allowlist_enabled, status, deployed_at, created_by,
                 created_at, updated_at
-         FROM issued_tokens WHERE mint_address = ?`
+         FROM issued_tokens WHERE mint_address = ?${tenant.clause}`
       )
-      .bind(mintAddress)
+      .bind(mintAddress, ...tenant.values)
       .first<TokenRow>();
 
     if (!row) {
@@ -677,13 +732,16 @@ export class TokenService {
     const { limit = 50, offset = 0, sortBy = "createdAt", sortDirection = "desc" } = options;
 
     const { whereClause, values } = buildTokenListFilter(projectId, options);
+    const tenant = this.tenantTokenScope();
+    const scopedWhereClause = `${whereClause}${tenant.clause}`;
+    const scopedValues = [...values, ...tenant.values];
     const sortColumn = TOKEN_LIST_SORT_COLUMNS[sortBy] ?? TOKEN_LIST_SORT_COLUMNS.createdAt;
     const direction = sortDirection === "asc" ? "ASC" : "DESC";
 
     const [countResult, result] = await Promise.all([
       this.db
-        .prepare(`SELECT COUNT(*)::int as count FROM issued_tokens WHERE ${whereClause}`)
-        .bind(...values)
+        .prepare(`SELECT COUNT(*)::int as count FROM issued_tokens WHERE ${scopedWhereClause}`)
+        .bind(...scopedValues)
         .first<{ count: number }>(),
       this.db
         .prepare(
@@ -694,11 +752,11 @@ export class TokenService {
                   freeze_authority_enabled, allowlist_enabled, status, deployed_at, created_by,
                   created_at, updated_at
            FROM issued_tokens
-           WHERE ${whereClause}
+           WHERE ${scopedWhereClause}
            ORDER BY ${sortColumn} ${direction}, id ${direction}
            LIMIT ? OFFSET ?`
         )
-        .bind(...values, limit, offset)
+        .bind(...scopedValues, limit, offset)
         .all<TokenRow>(),
     ]);
 
@@ -730,16 +788,17 @@ export class TokenService {
     if (this.tenantScope && this.tenantScope.projectId !== projectId) {
       throw new AppError("FORBIDDEN", "Token project is outside the authenticated tenant");
     }
+    const tenant = this.tenantTokenScope();
     const [templateRows, counts] = await Promise.all([
       this.db
         .prepare(
           `SELECT template, COUNT(*)::int as count
            FROM issued_tokens
-           WHERE project_id = ?
+           WHERE project_id = ?${tenant.clause}
            GROUP BY template
            ORDER BY template ASC`
         )
-        .bind(projectId)
+        .bind(projectId, ...tenant.values)
         .all<{ template: string | null; count: number }>(),
       this.db
         .prepare(
@@ -748,9 +807,9 @@ export class TokenService {
                   COUNT(*) FILTER (WHERE ${TOKEN_DEPLOYMENT_STATUS_PREDICATES.active})::int as active,
                   COUNT(*) FILTER (WHERE ${TOKEN_DEPLOYMENT_STATUS_PREDICATES.paused})::int as paused
            FROM issued_tokens
-           WHERE project_id = ?`
+           WHERE project_id = ?${tenant.clause}`
         )
-        .bind(projectId)
+        .bind(projectId, ...tenant.values)
         .first<{ total: number; draft: number; active: number; paused: number }>(),
     ]);
 
@@ -863,6 +922,10 @@ export class TokenService {
       whereConditions.push("status = ?", "mint_address IS NOT DISTINCT FROM ?");
       whereValues.push(expectedDeploymentState.status, expectedDeploymentState.mintAddress);
     }
+    if (this.tenantScope) {
+      whereConditions.push("organization_id = ?", "project_id IS NOT DISTINCT FROM ?");
+      whereValues.push(this.tenantScope.organizationId, this.tenantScope.projectId);
+    }
 
     const rowsAffected = await this.db
       .prepare(
@@ -944,17 +1007,20 @@ export class TokenService {
       values.push(now);
       values.push(tokenId);
 
+      const tenant = this.tenantMutationScope();
+
       await this.db
-        .prepare(`UPDATE issued_tokens SET ${fields.join(", ")} WHERE id = ?`)
-        .bind(...values)
+        .prepare(`UPDATE issued_tokens SET ${fields.join(", ")} WHERE id = ?${tenant.clause}`)
+        .bind(...values, ...tenant.values)
         .run();
     }
 
     if (updates.permanentDelegate !== undefined) {
       if (fields.length === 0) {
+        const tenant = this.tenantMutationScope();
         await this.db
-          .prepare("UPDATE issued_tokens SET updated_at = ? WHERE id = ?")
-          .bind(now, tokenId)
+          .prepare(`UPDATE issued_tokens SET updated_at = ? WHERE id = ?${tenant.clause}`)
+          .bind(now, tokenId, ...tenant.values)
           .run();
       }
       await this.setTokenExtension(tokenId, "permanentDelegate", updates.permanentDelegate, now);
@@ -1099,11 +1165,14 @@ export class TokenService {
     }
 
     const now = new Date().toISOString();
+    const tenant = this.tenantMutationScope();
     await this.db
       .prepare(
-        "UPDATE issued_tokens SET total_supply_cached = ?, total_supply_updated_at = ?, updated_at = ? WHERE id = ?"
+        `UPDATE issued_tokens
+         SET total_supply_cached = ?, total_supply_updated_at = ?, updated_at = ?
+         WHERE id = ?${tenant.clause}`
       )
-      .bind(newSupply.toString(), now, now, tokenId)
+      .bind(newSupply.toString(), now, now, tokenId, ...tenant.values)
       .run();
   }
 
@@ -1140,6 +1209,14 @@ export class TokenService {
   // ═══════════════════════════════════════════════════════════════════════════
 
   async createTransaction(input: CreateTokenTransactionInput): Promise<CreateTransactionResult> {
+    if (this.tenantScope) {
+      this.assertTenantOptions({
+        organizationId: input.organizationId,
+        projectId: this.tenantScope.projectId,
+      });
+      await this.assertTokenInTenant(input.tokenId);
+    }
+
     if (input.idempotencyKey && !input.idempotencyFingerprint) {
       throw badRequest("Missing idempotency fingerprint for idempotency key");
     }
@@ -1293,44 +1370,53 @@ export class TokenService {
     values.push(now);
     values.push(txId);
 
-    await this.db
-      .prepare(`UPDATE issuance_transactions SET ${updates.join(", ")} WHERE id = ?`)
-      .bind(...values)
+    const tenant = this.tenantTokenScope("tenant_token");
+    const rowsAffected = await this.db
+      .prepare(
+        `UPDATE issuance_transactions
+         SET ${updates.join(", ")}
+         WHERE id = ?
+           AND EXISTS (
+             SELECT 1
+             FROM issued_tokens tenant_token
+             WHERE tenant_token.id = issuance_transactions.token_id${tenant.clause}
+           )`
+      )
+      .bind(...values, ...tenant.values)
       .run();
+
+    if (rowsAffected === 0) {
+      throw new Error("TRANSACTION_NOT_FOUND");
+    }
 
     if (input.status) {
       await this.insertTransactionStatus(txId, input.status, now);
     }
 
-    const row = await this.db
-      .prepare(
-        `SELECT id, token_id, organization_id, type, status, idempotency_key, idempotency_fingerprint,
-                signature, serialized_tx, operation_params, slot, block_time, fee, error, initiated_by_key_id,
-                created_at, updated_at
-         FROM issuance_transactions WHERE id = ?`
-      )
-      .bind(txId)
-      .first<TokenTransactionRow>();
-
-    if (!row) {
+    const transaction = await this.getTransaction(txId);
+    if (!transaction) {
       throw new Error("TRANSACTION_NOT_FOUND");
     }
 
-    return this.mapRowToTransaction(row);
+    return transaction;
   }
 
   /**
    * Get a token transaction by ID
    */
   async getTransaction(txId: string): Promise<TokenTransaction | null> {
+    const tenant = this.tenantTokenScope("tenant_token");
     const row = await this.db
       .prepare(
-        `SELECT id, token_id, organization_id, type, status, idempotency_key, idempotency_fingerprint,
-                signature, serialized_tx, operation_params, slot, block_time, fee, error,
-                initiated_by_key_id, created_at, updated_at
-         FROM issuance_transactions WHERE id = ?`
+        `SELECT tx.id, tx.token_id, tx.organization_id, tx.type, tx.status, tx.idempotency_key,
+                tx.idempotency_fingerprint, tx.signature, tx.serialized_tx, tx.operation_params,
+                tx.slot, tx.block_time, tx.fee, tx.error, tx.initiated_by_key_id,
+                tx.created_at, tx.updated_at
+         FROM issuance_transactions tx
+         JOIN issued_tokens tenant_token ON tenant_token.id = tx.token_id
+         WHERE tx.id = ?${tenant.clause}`
       )
-      .bind(txId)
+      .bind(txId, ...tenant.values)
       .first<TokenTransactionRow>();
 
     if (!row) {
@@ -1344,15 +1430,21 @@ export class TokenService {
     organizationId: string,
     idempotencyKey: string
   ): Promise<TokenTransaction | null> {
+    if (this.tenantScope) {
+      this.assertTenantOptions({ organizationId, projectId: this.tenantScope.projectId });
+    }
+    const tenant = this.tenantTokenScope("tenant_token");
     const row = await this.db
       .prepare(
-        `SELECT id, token_id, organization_id, type, status, idempotency_key, idempotency_fingerprint,
-                signature, serialized_tx, operation_params, slot, block_time, fee, error, initiated_by_key_id,
-                created_at, updated_at
-         FROM issuance_transactions
-         WHERE organization_id = ? AND idempotency_key = ?`
+        `SELECT tx.id, tx.token_id, tx.organization_id, tx.type, tx.status, tx.idempotency_key,
+                tx.idempotency_fingerprint, tx.signature, tx.serialized_tx, tx.operation_params,
+                tx.slot, tx.block_time, tx.fee, tx.error, tx.initiated_by_key_id,
+                tx.created_at, tx.updated_at
+         FROM issuance_transactions tx
+         JOIN issued_tokens tenant_token ON tenant_token.id = tx.token_id
+         WHERE tx.organization_id = ? AND tx.idempotency_key = ?${tenant.clause}`
       )
-      .bind(organizationId, idempotencyKey)
+      .bind(organizationId, idempotencyKey, ...tenant.values)
       .first<TokenTransactionRow>();
 
     if (!row) {
@@ -1373,6 +1465,11 @@ export class TokenService {
     } = {}
   ): Promise<{ transactions: TokenTransaction[]; total: number }> {
     const { status, type, organizationId, limit = 50, offset = 0 } = options;
+
+    await this.assertTokenInTenant(tokenId);
+    if (organizationId && this.tenantScope) {
+      this.assertTenantOptions({ organizationId, projectId: this.tenantScope.projectId });
+    }
 
     let countQuery = "SELECT COUNT(*) as count FROM issuance_transactions WHERE token_id = ?";
     let selectQuery = `SELECT id, token_id, organization_id, type, status, idempotency_key, idempotency_fingerprint,
@@ -1423,6 +1520,7 @@ export class TokenService {
     organizationId: string;
     projectId?: string | null;
   }): Promise<Array<{ tokenId: string; mintAddress: string }>> {
+    this.assertTenantOptions(options);
     const params: string[] = [options.organizationId];
     let query = `
       SELECT id, mint_address
@@ -1458,6 +1556,7 @@ export class TokenService {
     limit?: number;
     offset?: number;
   }): Promise<{ transactions: TokenTransactionListItem[]; total: number }> {
+    this.assertTenantOptions(options);
     const {
       organizationId,
       projectId,
@@ -1623,6 +1722,7 @@ export class TokenService {
   async addAllowlistEntry(
     input: AddAllowlistInput
   ): Promise<{ entry: TokenAllowlistEntry; wasReactivated: boolean }> {
+    await this.assertTokenInTenant(input.tokenId);
     const requestedStatus = input.initialStatus ?? "active";
     const existing = await this.db
       .prepare("SELECT id, status FROM token_allowlists WHERE token_id = ? AND address = ?")
@@ -1670,6 +1770,7 @@ export class TokenService {
    *   so the mint short-circuits to 403 instead of silently un-revoking.
    */
   async addAllowlistEntryStrict(input: AddAllowlistInput): Promise<TokenAllowlistEntry> {
+    await this.assertTokenInTenant(input.tokenId);
     const existing = await this.db
       .prepare("SELECT id, status FROM token_allowlists WHERE token_id = ? AND address = ?")
       .bind(input.tokenId, input.address)
@@ -1737,13 +1838,16 @@ export class TokenService {
   }
 
   async getAllowlistEntry(entryId: string): Promise<TokenAllowlistEntry | null> {
+    const tenant = this.tenantTokenScope("tenant_token");
     const row = await this.db
       .prepare(
-        `SELECT id, token_id, address, label,
-                status, added_by, created_at, revoked_at
-         FROM token_allowlists WHERE id = ?`
+        `SELECT allowlist.id, allowlist.token_id, allowlist.address, allowlist.label,
+                allowlist.status, allowlist.added_by, allowlist.created_at, allowlist.revoked_at
+         FROM token_allowlists allowlist
+         JOIN issued_tokens tenant_token ON tenant_token.id = allowlist.token_id
+         WHERE allowlist.id = ?${tenant.clause}`
       )
-      .bind(entryId)
+      .bind(entryId, ...tenant.values)
       .first<AllowlistRow>();
 
     if (!row) {
@@ -1763,6 +1867,7 @@ export class TokenService {
       offset?: number;
     } = {}
   ): Promise<{ entries: TokenAllowlistEntry[]; total: number }> {
+    await this.assertTokenInTenant(tokenId);
     const { status = "active", search, label, limit = 50, offset = 0 } = options;
 
     // Shared WHERE for the data + count queries. Search is a contains-style
@@ -1817,6 +1922,7 @@ export class TokenService {
     tokenId: string,
     options: { status?: AllowlistEntryStatus } = {}
   ): Promise<{ labels: string[]; total: number }> {
+    await this.assertTokenInTenant(tokenId);
     const { status = "active" } = options;
 
     const [labelsResult, countResult] = await Promise.all([
@@ -1842,6 +1948,7 @@ export class TokenService {
   }
 
   async isAddressAllowed(tokenId: string, address: string): Promise<boolean> {
+    await this.assertTokenInTenant(tokenId);
     const row = await this.db
       .prepare(
         "SELECT id FROM token_allowlists WHERE token_id = ? AND address = ? AND status = 'active'"
@@ -1864,6 +1971,7 @@ export class TokenService {
     tokenId: string,
     address: string
   ): Promise<AllowlistEntryStatus | null> {
+    await this.assertTokenInTenant(tokenId);
     const row = await this.db
       .prepare("SELECT status FROM token_allowlists WHERE token_id = ? AND address = ?")
       .bind(tokenId, address)
@@ -1874,21 +1982,43 @@ export class TokenService {
 
   async revokeAllowlistEntry(entryId: string): Promise<void> {
     const now = new Date().toISOString();
-    await this.db
-      .prepare("UPDATE token_allowlists SET status = 'revoked', revoked_at = ? WHERE id = ?")
-      .bind(now, entryId)
+    const tenant = this.tenantTokenScope("tenant_token");
+    const rowsAffected = await this.db
+      .prepare(
+        `UPDATE token_allowlists
+         SET status = 'revoked', revoked_at = ?
+         WHERE id = ?
+           AND EXISTS (
+             SELECT 1
+             FROM issued_tokens tenant_token
+             WHERE tenant_token.id = token_allowlists.token_id${tenant.clause}
+           )`
+      )
+      .bind(now, entryId, ...tenant.values)
       .run();
+
+    if (rowsAffected === 0) {
+      throw new Error("ALLOWLIST_ENTRY_NOT_FOUND");
+    }
 
     await this.insertAllowlistStatus(entryId, "revoked", now);
   }
 
   async activateAllowlistEntry(entryId: string): Promise<TokenAllowlistEntry> {
     const now = new Date().toISOString();
+    const tenant = this.tenantTokenScope("tenant_token");
     const rowsAffected = await this.db
       .prepare(
-        "UPDATE token_allowlists SET status = 'active', revoked_at = NULL WHERE id = ? AND status = 'pending'"
+        `UPDATE token_allowlists
+         SET status = 'active', revoked_at = NULL
+         WHERE id = ? AND status = 'pending'
+           AND EXISTS (
+             SELECT 1
+             FROM issued_tokens tenant_token
+             WHERE tenant_token.id = token_allowlists.token_id${tenant.clause}
+           )`
       )
-      .bind(entryId)
+      .bind(entryId, ...tenant.values)
       .run();
 
     if (rowsAffected > 0) {
@@ -1912,7 +2042,23 @@ export class TokenService {
    * `ON DELETE CASCADE`, so status history rows are removed by the database.
    */
   async deleteAllowlistEntry(entryId: string): Promise<void> {
-    await this.db.prepare("DELETE FROM token_allowlists WHERE id = ?").bind(entryId).run();
+    const tenant = this.tenantTokenScope("tenant_token");
+    const rowsAffected = await this.db
+      .prepare(
+        `DELETE FROM token_allowlists
+         WHERE id = ?
+           AND EXISTS (
+             SELECT 1
+             FROM issued_tokens tenant_token
+             WHERE tenant_token.id = token_allowlists.token_id${tenant.clause}
+           )`
+      )
+      .bind(entryId, ...tenant.values)
+      .run();
+
+    if (rowsAffected === 0) {
+      throw new Error("ALLOWLIST_ENTRY_NOT_FOUND");
+    }
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1920,6 +2066,7 @@ export class TokenService {
   // ═══════════════════════════════════════════════════════════════════════════
 
   async freezeAccount(input: FreezeAccountInput): Promise<FrozenAccount> {
+    await this.assertTokenInTenant(input.tokenId);
     const existing = await this.db
       .prepare(
         `SELECT id, token_id, account_address, reason, frozen_at, frozen_by, unfrozen_at, unfrozen_by
@@ -1992,6 +2139,7 @@ export class TokenService {
     accountAddress: string,
     unfrozenBy: string
   ): Promise<FrozenAccount> {
+    await this.assertTokenInTenant(tokenId);
     const row = await this.db
       .prepare(
         `SELECT id, token_id, account_address, reason, frozen_at, frozen_by, unfrozen_at, unfrozen_by
@@ -2027,6 +2175,7 @@ export class TokenService {
    * Check if an account is frozen
    */
   async isAccountFrozen(tokenId: string, accountAddress: string): Promise<boolean> {
+    await this.assertTokenInTenant(tokenId);
     const row = await this.db
       .prepare(
         "SELECT id FROM frozen_accounts WHERE token_id = ? AND account_address = ? AND unfrozen_at IS NULL"
@@ -2045,6 +2194,7 @@ export class TokenService {
     accountAddress: string,
     includeUnfrozen = false
   ): Promise<FrozenAccount | null> {
+    await this.assertTokenInTenant(tokenId);
     const row = await this.db
       .prepare(
         `SELECT id, token_id, account_address, reason, frozen_at, frozen_by, unfrozen_at, unfrozen_by
@@ -2070,6 +2220,7 @@ export class TokenService {
     tokenId: string,
     options: { includeUnfrozen?: boolean; limit?: number; offset?: number } = {}
   ): Promise<{ frozenAccounts: FrozenAccount[]; total: number }> {
+    await this.assertTokenInTenant(tokenId);
     const { includeUnfrozen = false, limit = 50, offset = 0 } = options;
 
     const unfrozenFilter = includeUnfrozen ? "" : "AND unfrozen_at IS NULL";

--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -21,6 +21,7 @@ import type {
 } from "@sdp/types";
 import { isPostgresUniqueViolation, parsePostgresJsonOr } from "@/db/postgres-utils";
 import { AppError, badRequest } from "@/lib/errors";
+import { assertTenantClaim, type TenantScope } from "@/lib/tenant-scope";
 
 // Escapes LIKE/ILIKE wildcards so operator-supplied search text matches
 // literally (mirrors the payments/policy repositories' `ESCAPE '\'` idiom).
@@ -396,13 +397,23 @@ interface WalletTransactionScope {
 // ═══════════════════════════════════════════════════════════════════════════
 
 export class TokenService {
-  constructor(private db: DatabaseClient) {}
+  constructor(
+    private db: DatabaseClient,
+    private readonly tenantScope?: TenantScope
+  ) {}
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Token CRUD
   // ═══════════════════════════════════════════════════════════════════════════
 
   async createToken(input: CreateTokenInput): Promise<Token> {
+    if (this.tenantScope) {
+      assertTenantClaim(
+        this.tenantScope,
+        { organizationId: input.organizationId, projectId: input.projectId },
+        "TokenService"
+      );
+    }
     const id = `tok_${crypto.randomUUID()}`;
     const now = new Date().toISOString();
     const decimals = input.decimals ?? 9;
@@ -514,6 +525,9 @@ export class TokenService {
     organizationId: string;
     projectId: string;
   }): Promise<Token | null> {
+    if (this.tenantScope) {
+      assertTenantClaim(this.tenantScope, params, "TokenService");
+    }
     const row = await this.db
       .prepare(
         `SELECT id, project_id, organization_id, mint_address, mint_authority, metadata_authority, freeze_authority,
@@ -536,6 +550,12 @@ export class TokenService {
   }
 
   private async _getTokenById(tokenId: string): Promise<Token | null> {
+    const tenantWhere = this.tenantScope
+      ? " AND organization_id = ? AND project_id IS NOT DISTINCT FROM ?"
+      : "";
+    const tenantValues = this.tenantScope
+      ? [this.tenantScope.organizationId, this.tenantScope.projectId]
+      : [];
     const row = await this.db
       .prepare(
         `SELECT id, project_id, organization_id, mint_address, mint_authority, metadata_authority, freeze_authority,
@@ -544,9 +564,9 @@ export class TokenService {
                 total_supply_cached, total_supply_updated_at, max_supply, is_mintable,
                 freeze_authority_enabled, allowlist_enabled, status, deployed_at, created_by,
                 created_at, updated_at
-         FROM issued_tokens WHERE id = ?`
+         FROM issued_tokens WHERE id = ?${tenantWhere}`
       )
-      .bind(tokenId)
+      .bind(tokenId, ...tenantValues)
       .first<TokenRow>();
 
     if (!row) {
@@ -639,6 +659,9 @@ export class TokenService {
     projectId: string,
     options: ListTokensOptions = {}
   ): Promise<{ tokens: Token[]; total: number }> {
+    if (this.tenantScope && this.tenantScope.projectId !== projectId) {
+      throw new AppError("FORBIDDEN", "Token project is outside the authenticated tenant");
+    }
     const { limit = 50, offset = 0, sortBy = "createdAt", sortDirection = "desc" } = options;
 
     const { whereClause, values } = buildTokenListFilter(projectId, options);
@@ -692,6 +715,9 @@ export class TokenService {
    * over-filtered one.
    */
   async listTokenFacets(projectId: string): Promise<TokenListFacets> {
+    if (this.tenantScope && this.tenantScope.projectId !== projectId) {
+      throw new AppError("FORBIDDEN", "Token project is outside the authenticated tenant");
+    }
     const [templateRows, counts] = await Promise.all([
       this.db
         .prepare(

--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -233,6 +233,7 @@ export interface AddAllowlistInput {
   address: string;
   addedBy: string;
   label?: string;
+  initialStatus?: Extract<AllowlistEntryStatus, "pending" | "active">;
 }
 
 export interface FreezeAccountInput {
@@ -401,6 +402,17 @@ export class TokenService {
     private db: DatabaseClient,
     private readonly tenantScope?: TenantScope
   ) {}
+
+  private tenantMutationScope(): { clause: string; values: Array<string | null> } {
+    if (!this.tenantScope) {
+      return { clause: "", values: [] };
+    }
+
+    return {
+      clause: " AND organization_id = ? AND project_id IS NOT DISTINCT FROM ?",
+      values: [this.tenantScope.organizationId, this.tenantScope.projectId],
+    };
+  }
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Token CRUD
@@ -955,12 +967,13 @@ export class TokenService {
    */
   async beginTokenDeploy(tokenId: string): Promise<Token | null> {
     const now = new Date().toISOString();
+    const tenant = this.tenantMutationScope();
     const rowsAffected = await this.db
       .prepare(
         `UPDATE issued_tokens SET status = 'deploying', updated_at = ?
-         WHERE id = ? AND status = 'pending' AND mint_address IS NULL`
+         WHERE id = ?${tenant.clause} AND status = 'pending' AND mint_address IS NULL`
       )
-      .bind(now, tokenId)
+      .bind(now, tokenId, ...tenant.values)
       .run();
 
     if (rowsAffected === 0) {
@@ -978,12 +991,13 @@ export class TokenService {
    */
   async releaseTokenDeploy(tokenId: string): Promise<void> {
     const now = new Date().toISOString();
+    const tenant = this.tenantMutationScope();
     await this.db
       .prepare(
         `UPDATE issued_tokens SET status = 'pending', updated_at = ?
-         WHERE id = ? AND status = 'deploying' AND mint_address IS NULL`
+         WHERE id = ?${tenant.clause} AND status = 'deploying' AND mint_address IS NULL`
       )
-      .bind(now, tokenId)
+      .bind(now, tokenId, ...tenant.values)
       .run();
   }
 
@@ -995,8 +1009,9 @@ export class TokenService {
     ablListAddress?: string | null
   ): Promise<Token> {
     const now = new Date().toISOString();
+    const tenant = this.tenantMutationScope();
 
-    await this.db
+    const rowsAffected = await this.db
       .prepare(
         `UPDATE issued_tokens SET
           mint_address = ?,
@@ -1007,7 +1022,7 @@ export class TokenService {
           status = 'active',
           deployed_at = ?,
           updated_at = ?
-         WHERE id = ?`
+         WHERE id = ?${tenant.clause}`
       )
       .bind(
         mintAddress,
@@ -1017,9 +1032,14 @@ export class TokenService {
         ablListAddress ?? null,
         now,
         now,
-        tokenId
+        tokenId,
+        ...tenant.values
       )
       .run();
+
+    if (rowsAffected === 0) {
+      throw new Error("TOKEN_NOT_FOUND");
+    }
 
     const updated = await this._getTokenById(tokenId);
     if (!updated) {
@@ -1071,12 +1091,19 @@ export class TokenService {
     }
 
     const now = new Date().toISOString();
-    await this.db
+    const tenant = this.tenantMutationScope();
+    const rowsAffected = await this.db
       .prepare(
-        "UPDATE issued_tokens SET total_supply_cached = ?, total_supply_updated_at = ?, updated_at = ? WHERE id = ?"
+        `UPDATE issued_tokens
+         SET total_supply_cached = ?, total_supply_updated_at = ?, updated_at = ?
+         WHERE id = ?${tenant.clause}`
       )
-      .bind(supplyBaseUnits, now, now, tokenId)
+      .bind(supplyBaseUnits, now, now, tokenId, ...tenant.values)
       .run();
+
+    if (rowsAffected === 0) {
+      throw new Error("TOKEN_NOT_FOUND");
+    }
 
     const updated = await this._getTokenById(tokenId);
     if (!updated) {
@@ -1566,16 +1593,15 @@ export class TokenService {
   /**
    * Add an address to the token allowlist.
    *
-   * Returns `{ entry, wasReactivated }`. `wasReactivated` is `true` when this
-   * call promoted a previously-revoked row back to `active` (vs. inserting a
-   * fresh row). Callers rolling back after a downstream on-chain failure need
-   * this to choose between `deleteAllowlistEntry` (fresh row → hard-delete)
-   * and `revokeAllowlistEntry` (reactivated row → restore the prior `revoked`
-   * state, preserving the operator's original revocation record).
+   * `initialStatus: "pending"` gives on-chain callers a durable intent record
+   * before submission. A retry reuses that pending row; confirmed membership
+   * is promoted with `activateAllowlistEntry`. Database-only callers keep the
+   * default immediate `active` status.
    */
   async addAllowlistEntry(
     input: AddAllowlistInput
   ): Promise<{ entry: TokenAllowlistEntry; wasReactivated: boolean }> {
+    const requestedStatus = input.initialStatus ?? "active";
     const existing = await this.db
       .prepare("SELECT id, status FROM token_allowlists WHERE token_id = ? AND address = ?")
       .bind(input.tokenId, input.address)
@@ -1585,21 +1611,23 @@ export class TokenService {
       if (existing.status === "active") {
         throw new Error("ADDRESS_ALREADY_ALLOWLISTED");
       }
-      // Reactivate revoked entry — operator-initiated re-add.
+      const wasReactivated = existing.status === "revoked";
       await this.db
         .prepare(
-          "UPDATE token_allowlists SET status = 'active', revoked_at = NULL, label = ?, added_by = ? WHERE id = ?"
+          "UPDATE token_allowlists SET status = ?, revoked_at = NULL, label = ?, added_by = ? WHERE id = ?"
         )
-        .bind(input.label ?? null, input.addedBy, existing.id)
+        .bind(requestedStatus, input.label ?? null, input.addedBy, existing.id)
         .run();
 
-      await this.insertAllowlistStatus(existing.id, "active", new Date().toISOString());
+      if (existing.status !== requestedStatus) {
+        await this.insertAllowlistStatus(existing.id, requestedStatus, new Date().toISOString());
+      }
 
       const entry = await this.getAllowlistEntry(existing.id);
       if (!entry) {
         throw new Error("ALLOWLIST_ENTRY_NOT_FOUND");
       }
-      return { entry, wasReactivated: true };
+      return { entry, wasReactivated };
     }
 
     const entry = await this.insertNewAllowlistEntry(input);
@@ -1644,7 +1672,7 @@ export class TokenService {
       tokenId: input.tokenId,
       address: input.address,
       label: input.label ?? null,
-      status: "active",
+      status: input.initialStatus ?? "active",
       addedBy: input.addedBy,
       createdAt: now,
       revokedAt: null,
@@ -1813,11 +1841,11 @@ export class TokenService {
   async getAllowlistEntryStatusByAddress(
     tokenId: string,
     address: string
-  ): Promise<"active" | "revoked" | null> {
+  ): Promise<AllowlistEntryStatus | null> {
     const row = await this.db
       .prepare("SELECT status FROM token_allowlists WHERE token_id = ? AND address = ?")
       .bind(tokenId, address)
-      .first<{ status: "active" | "revoked" }>();
+      .first<{ status: AllowlistEntryStatus }>();
 
     return row?.status ?? null;
   }
@@ -1830,6 +1858,25 @@ export class TokenService {
       .run();
 
     await this.insertAllowlistStatus(entryId, "revoked", now);
+  }
+
+  async activateAllowlistEntry(entryId: string): Promise<TokenAllowlistEntry> {
+    const now = new Date().toISOString();
+    const rowsAffected = await this.db
+      .prepare(
+        "UPDATE token_allowlists SET status = 'active', revoked_at = NULL WHERE id = ? AND status = 'pending'"
+      )
+      .bind(entryId)
+      .run();
+
+    if (rowsAffected > 0) {
+      await this.insertAllowlistStatus(entryId, "active", now);
+    }
+    const entry = await this.getAllowlistEntry(entryId);
+    if (!entry) {
+      throw new Error("ALLOWLIST_ENTRY_NOT_FOUND");
+    }
+    return entry;
   }
 
   /**

--- a/apps/sdp-api/src/services/token.service.ts
+++ b/apps/sdp-api/src/services/token.service.ts
@@ -769,7 +769,11 @@ export class TokenService {
     };
   }
 
-  async updateToken(tokenId: string, input: UpdateTokenInput): Promise<Token> {
+  async updateToken(
+    tokenId: string,
+    input: UpdateTokenInput,
+    expectedDeploymentState?: Pick<Token, "status" | "mintAddress">
+  ): Promise<Token> {
     const existing = await this._getTokenById(tokenId);
     if (!existing) {
       throw new Error("TOKEN_NOT_FOUND");
@@ -830,7 +834,6 @@ export class TokenService {
 
     updates.push("updated_at = ?");
     values.push(now);
-    values.push(tokenId);
 
     // symbol/decimals/requiresAllowlist are only mutable pre-deploy. The route
     // handler enforces that from a read of `existing`, but a concurrent
@@ -842,22 +845,48 @@ export class TokenService {
       input.symbol !== undefined ||
       input.decimals !== undefined ||
       input.requiresAllowlist !== undefined;
+    const requiresStableDeploymentGuard =
+      input.name !== undefined ||
+      input.description !== undefined ||
+      input.uri !== undefined ||
+      input.imageUrl !== undefined ||
+      input.status !== undefined;
 
-    const whereClause = requiresUndeployedGuard
-      ? "WHERE id = ? AND status = 'pending' AND mint_address IS NULL"
-      : "WHERE id = ?";
+    const whereConditions = ["id = ?"];
+    const whereValues: (string | null)[] = [tokenId];
+    if (requiresUndeployedGuard) {
+      whereConditions.push("status = 'pending'", "mint_address IS NULL");
+    } else if (requiresStableDeploymentGuard) {
+      whereConditions.push("status <> 'deploying'");
+    }
+    if (expectedDeploymentState) {
+      whereConditions.push(
+        "status = ?",
+        "(mint_address = ? OR (mint_address IS NULL AND ? IS NULL))"
+      );
+      whereValues.push(
+        expectedDeploymentState.status,
+        expectedDeploymentState.mintAddress,
+        expectedDeploymentState.mintAddress
+      );
+    }
 
     const rowsAffected = await this.db
-      .prepare(`UPDATE issued_tokens SET ${updates.join(", ")} ${whereClause}`)
-      .bind(...values)
+      .prepare(
+        `UPDATE issued_tokens SET ${updates.join(", ")} WHERE ${whereConditions.join(" AND ")}`
+      )
+      .bind(...values, ...whereValues)
       .run();
 
     // The row existed at the top-of-method read, so a guarded 0-row result means
     // it was deployed during the window — surface a 409 rather than a 404.
-    if (requiresUndeployedGuard && rowsAffected === 0) {
+    if (
+      (requiresUndeployedGuard || requiresStableDeploymentGuard || expectedDeploymentState) &&
+      rowsAffected === 0
+    ) {
       throw new AppError(
         "CONFLICT",
-        "Token was deployed while this update was in flight; re-fetch and retry"
+        "Token deployment state changed while this update was in flight; re-fetch and retry"
       );
     }
 

--- a/packages/sdp-api-integration/src/tests/kora-flow.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora-flow.test.ts
@@ -1,3 +1,4 @@
+import { apiTestSupport } from "@sdp/api/test-support";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { SignerCheckApiResponse } from "../helpers/api-types";
 import {
@@ -6,6 +7,8 @@ import {
   initIntegrationSuite,
   requestWithApiKey,
 } from "../helpers/integration";
+
+const { createSigningService, TEST_ORG, TEST_PROJECT } = apiTestSupport;
 
 const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
 
@@ -214,6 +217,9 @@ describe("Kora Fee Payment (Live Smoke)", () => {
   beforeAll(async () => {
     assertKoraLiveSmokeEnvConfigured();
     await initIntegrationSuite();
+    await createSigningService(env).initializePrivySigning(TEST_ORG.id, TEST_PROJECT.id, {
+      walletLabel: "Kora project root wallet",
+    });
   });
 
   afterAll(async () => {

--- a/packages/sdp-types/src/tokens.ts
+++ b/packages/sdp-types/src/tokens.ts
@@ -42,7 +42,7 @@ export const TOKEN_TRANSACTION_STATUSES = [
 ] as const;
 export type TokenTransactionStatus = (typeof TOKEN_TRANSACTION_STATUSES)[number];
 
-export type AllowlistEntryStatus = "active" | "revoked";
+export type AllowlistEntryStatus = "pending" | "active" | "revoked";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Token Templates


### PR DESCRIPTION
## What changed
- add an immutable tenant scope derived only from authenticated middleware state
- require tenant scope when constructing payments, policy, API-key, counterparty, token, asset-profile, and custody services
- split unauthenticated webhook, cron, reconciliation, and public metadata operations into explicit system factories
- enforce organization plus exact nullable-project predicates at the data layer
- add cross-tenant, forged-claim, positive-control, and static boundary regression tests

## Security invariant
A valid identifier from another organization or project must behave like a missing resource, and request-controlled org/project claims must never override the authenticated scope. Organization-level project null semantics remain supported.

## Local verification
- pnpm --filter @sdp/api lint
- pnpm --filter @sdp/api typecheck
- pnpm typecheck
- focused tenant-boundary and API-key tests: 18 passed

The full database-backed API test suite could not start locally because Testcontainers found no container runtime. CI is the required runtime verification before this PR is marked ready.