### PR TITLE
feat(sdp-api): Dry-Run header plumbing [PART-1]

### DIFF
--- a/apps/sdp-api/src/app.ts
+++ b/apps/sdp-api/src/app.ts
@@ -18,6 +18,7 @@ import { secureHeaders } from "hono/secure-headers";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { AppError } from "@/lib/errors";
 import { corsMiddleware } from "@/middleware/cors";
+import { dryRunMiddleware } from "@/middleware/dry-run";
 import { idempotencyKeyMiddleware } from "@/middleware/idempotency-key";
 import { kvStoreMiddleware } from "@/middleware/kv-store";
 import { skipRateLimitPaths } from "@/middleware/rate-limit";
@@ -285,6 +286,7 @@ export function createApp(deps: AppDeps): Hono<{ Bindings: Env }> {
 
   // Idempotency-Key validation + response echo (public API only)
   app.use("/v1/*", idempotencyKeyMiddleware());
+  app.use("/v1/*", dryRunMiddleware());
 
   // Request trace + duration logging
   app.use("*", requestTracingMiddleware());

--- a/apps/sdp-api/src/middleware/dry-run.test.ts
+++ b/apps/sdp-api/src/middleware/dry-run.test.ts
@@ -1,0 +1,52 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { AppError } from "@/lib/errors";
+import { env } from "@/test/helpers/env";
+import type { Env } from "@/types/env";
+import { dryRunMiddleware, isDryRunRequest } from "./dry-run";
+
+function buildApp() {
+  const app = new Hono<{ Bindings: Env }>();
+  app.use("*", dryRunMiddleware());
+  app.all("*", (c) => c.json({ dryRun: isDryRunRequest(c) }));
+  app.onError((error, c) => {
+    if (error instanceof AppError) {
+      return c.json(error.toResponse(), 400);
+    }
+    throw error;
+  });
+  return app;
+}
+
+describe("dryRunMiddleware", () => {
+  it("passes requests without the Dry-Run header", async () => {
+    const response = await buildApp().request("/preview", {}, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ dryRun: false });
+  });
+
+  it.each([
+    ["true", true],
+    ["false", false],
+    [" true ", true],
+    [" false ", false],
+  ])("accepts %j", async (value, expected) => {
+    const response = await buildApp().request("/preview", { headers: { "Dry-Run": value } }, env);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ dryRun: expected });
+  });
+
+  it.each(["TRUE", "1", "yes", ""])("rejects %j", async (value) => {
+    const response = await buildApp().request("/preview", { headers: { "Dry-Run": value } }, env);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Dry-Run must be exactly true or false",
+      },
+    });
+  });
+});

--- a/apps/sdp-api/src/middleware/dry-run.ts
+++ b/apps/sdp-api/src/middleware/dry-run.ts
@@ -1,0 +1,36 @@
+import type { Context, Next } from "hono";
+import { badRequest } from "@/lib/errors";
+import type { Env } from "@/types/env";
+
+const DRY_RUN_HEADER = "Dry-Run";
+
+/**
+ * Validates the optional Dry-Run header (exactly "true" or "false" after
+ * trimming, rejected with 400 otherwise).
+ *
+ * @returns Hono middleware enforcing the Dry-Run header vocabulary.
+ */
+export function dryRunMiddleware() {
+  return async (c: Context<{ Bindings: Env }>, next: Next) => {
+    const value = c.req.header(DRY_RUN_HEADER);
+    if (value !== undefined) {
+      const normalized = value.trim();
+      if (normalized !== "true" && normalized !== "false") {
+        throw badRequest(`${DRY_RUN_HEADER} must be exactly true or false`);
+      }
+    }
+    await next();
+  };
+}
+
+/**
+ * Reports whether the request opted into a policy dry-run via the Dry-Run
+ * header, assuming dryRunMiddleware already rejected invalid values.
+ *
+ * @param c - Request context.
+ * @returns True when the Dry-Run header is set to "true".
+ */
+export function isDryRunRequest(c: Context<{ Bindings: Env }>): boolean {
+  const value = c.req.header(DRY_RUN_HEADER);
+  return value !== undefined && value.trim() === "true";
+}


### PR DESCRIPTION
Validates an optional `Dry-Run` header on `/v1/*`: exactly `true` or `false` after trimming (mirroring `Idempotency-Key`), 400 otherwise. Nothing consumes the header yet, `isDryRunRequest` exists for gated endpoints to adopt.

```mermaid
flowchart TD
    E["Gated endpoint<br/>/transfers · /mint · /ramps/…/quote"] --> V["Auth + validation<br/>+ resource resolution"]
    V --> P["Policy evaluation<br/>wallet + API-key profiles<br/>(strictest wins)"]
    P -- "Dry-Run: true" --> D["200 preview<br/>decision + criteria<br/>zero writes"]
    P -- "no header · allow" --> X["Execute<br/>201 resource"]
    P -- "no header · approval_required" --> W["202 pending<br/>poll GET /:id"]
    P -- "no header · deny" --> N["403"]
```

Rollout continues one module per PR (preview service + types next, then custody signer-check → ramp quotes → issuance → transfers/batches). The transfers/batches PR folds the legacy `payment_wallet_policies` checks into the preview decision so a preview can never say allow where the real call would 403.