### PR TITLE
fix(ci): stabilize Surfpool RPC setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
           - name: Surfpool / Issuance Prepare
             provider: surfpool
             test_files: src/tests/issuance-prepare.test.ts
-            rpc_provider: triton
+            rpc_provider: quicknode
             custody_provider: local
           - name: Surfpool / Issuance Execute
             provider: surfpool
@@ -459,7 +459,7 @@ jobs:
           - name: Surfpool / Mosaic
             provider: surfpool
             test_files: src/tests/mosaic-token-acl.test.ts src/tests/mosaic-token-acl-constraints.test.ts src/tests/mosaic-abl.test.ts src/tests/mosaic-templates.test.ts
-            rpc_provider: triton
+            rpc_provider: quicknode
             custody_provider: local
           - name: Surfpool / Token Flows
             provider: surfpool

--- a/packages/sdp-api-integration/src/helpers/integration.ts
+++ b/packages/sdp-api-integration/src/helpers/integration.ts
@@ -617,7 +617,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function solanaRpc<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
-  const maxRetries = 2;
+  const maxRetries = 4;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const response = await fetch(rpcUrl, {
@@ -649,6 +649,7 @@ function isRetryableSolanaRpcError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const message = error.message.toLowerCase();
   return (
+    message.includes("internal error") ||
     message.includes("unable to complete request") ||
     message.includes("request timed out") ||
     message.includes("timed out") ||

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -247,7 +247,9 @@ async function solanaGetBalance(rpcUrl: string, address: string): Promise<number
 
 async function solanaRpc<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
   const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params });
-  const maxRetries = 4;
+  // Preflight performs sequential RPC checks inside a 120-second setup hook.
+  // Keep the retry budget below that deadline while still retrying transient errors.
+  const maxRetries = 2;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -247,7 +247,7 @@ async function solanaGetBalance(rpcUrl: string, address: string): Promise<number
 
 async function solanaRpc<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
   const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params });
-  const maxRetries = 2;
+  const maxRetries = 4;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -278,6 +278,7 @@ function isRetryableSolanaRpcError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const message = error.message.toLowerCase();
   return (
+    message.includes("internal error") ||
     message.includes("unable to complete request") ||
     message.includes("request timed out") ||
     message.includes("timed out") ||

--- a/packages/sdp-api-integration/src/helpers/preflight.ts
+++ b/packages/sdp-api-integration/src/helpers/preflight.ts
@@ -146,16 +146,20 @@ async function preflightKoraSuite(): Promise<void> {
     throw new Error("Integration preflight internal error: required env vars were missing.");
   }
 
-  // Validate Solana RPC connectivity early so failures are explicit.
-  await assertSolanaRpcHealthy(solanaRpcUrl);
-
   // Validate Kora connectivity and that it can sponsor transactions (fee payer exists and is funded).
   const koraClient = new KoraClient({
     rpcUrl: koraUrl,
     ...(env.KORA_API_KEY ? { apiKey: env.KORA_API_KEY } : {}),
   });
 
-  const config = await withLabel("Kora.getConfig", () => koraClient.getConfig());
+  // These are independent read-only checks. Run them together so the two Kora
+  // requests cannot consume the setup hook budget ahead of the bounded RPC retries.
+  const [, config, payerSignerResp] = await Promise.all([
+    assertSolanaRpcHealthy(solanaRpcUrl),
+    withLabel("Kora.getConfig", () => koraClient.getConfig()),
+    withLabel("Kora.getPayerSigner", () => koraClient.getPayerSigner()),
+  ]);
+
   if (!config?.validation_config?.allowed_programs) {
     throw new Error("Kora preflight failed: missing validation_config.allowed_programs");
   }
@@ -169,7 +173,6 @@ async function preflightKoraSuite(): Promise<void> {
     );
   }
 
-  const payerSignerResp = await withLabel("Kora.getPayerSigner", () => koraClient.getPayerSigner());
   const feePayerAddress =
     (payerSignerResp as { signer_address?: string }).signer_address ??
     (payerSignerResp as { payment_address?: string }).payment_address ??


### PR DESCRIPTION
## What changed
- Routes the affected Surfpool shards through the QuickNode upstream instead of Triton.
- Retries transient JSON-RPC `Internal error` responses with bounded backoff in integration setup and preflight.

## Why
The Issuance Prepare and Mosaic CI shards repeatedly failed while Surfpool lazily fetched accounts through the Triton remote RPC. Other Surfpool shards using QuickNode and Alchemy passed.

## Local validation
- `pnpm --filter @sdp/api-integration typecheck`
- `pnpm exec biome check packages/sdp-api-integration/src/helpers/integration.ts packages/sdp-api-integration/src/helpers/preflight.ts`
- `git diff --check`

## CI-only validation
The affected integration suites require the CI Postgres, Redis, Doppler, and Surfpool service stack; the direct local run was not started without that environment.