### PR TITLE
fix(i18n): sign automated translation commits

### DIFF
--- a/.github/scripts/github-commit-on-branch.mjs
+++ b/.github/scripts/github-commit-on-branch.mjs
@@ -1,0 +1,80 @@
+const graphqlEndpoint = "https://api.github.com/graphql";
+
+export async function githubGraphqlRequest({ query, variables, token, fetchImpl = fetch }) {
+  if (!token) {
+    throw new Error("GITHUB_TOKEN is required to call the GitHub GraphQL API");
+  }
+
+  const response = await fetchImpl(graphqlEndpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const text = await response.text();
+  let payload = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`GraphQL request failed: ${response.status} ${text}`);
+  }
+
+  if (!response.ok || payload.errors?.length) {
+    const message = payload.errors?.map((error) => error.message).join("; ") || text;
+    throw new Error(`GraphQL request failed: ${response.status} ${message}`);
+  }
+
+  return payload.data;
+}
+
+export async function createCommitOnBranch({
+  repository,
+  branch,
+  expectedHeadOid,
+  headline,
+  additions,
+  token,
+  fetchImpl = fetch,
+}) {
+  if (!repository || !token) {
+    throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required to create a commit");
+  }
+
+  const query = `
+    mutation CreateCommitOnBranch($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit {
+          oid
+          url
+        }
+      }
+    }
+  `;
+  const data = await githubGraphqlRequest({
+    query,
+    variables: {
+      input: {
+        branch: {
+          repositoryNameWithOwner: repository,
+          branchName: branch,
+        },
+        expectedHeadOid,
+        message: { headline },
+        fileChanges: { additions },
+      },
+    },
+    token,
+    fetchImpl,
+  });
+
+  const commit = data?.createCommitOnBranch?.commit;
+  if (!commit?.oid) {
+    throw new Error("GraphQL request did not return a created commit");
+  }
+
+  return commit;
+}

--- a/.github/scripts/release-flow.mjs
+++ b/.github/scripts/release-flow.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { createCommitOnBranch, githubGraphqlRequest } from "./github-commit-on-branch.mjs";
 
 const mode = process.argv[2];
 const dryRun = process.argv.includes("--dry-run");
@@ -300,33 +301,6 @@ async function githubRequest(method, resourcePath, body) {
   return response.json();
 }
 
-async function githubGraphqlRequest(query, variables) {
-  const response = await fetch("https://api.github.com/graphql", {
-    method: "POST",
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  const text = await response.text();
-  let payload = {};
-  try {
-    payload = text ? JSON.parse(text) : {};
-  } catch {
-    throw new Error(`GraphQL request failed: ${response.status} ${text}`);
-  }
-
-  if (!response.ok || payload.errors?.length) {
-    const message = payload.errors?.map((error) => error.message).join("; ") || text;
-    throw new Error(`GraphQL request failed: ${response.status} ${message}`);
-  }
-
-  return payload.data;
-}
-
 async function githubReleaseExists(tagName) {
   try {
     await githubRequest("GET", `/repos/${repo}/releases/tags/${encodeURIComponent(tagName)}`);
@@ -414,38 +388,19 @@ async function createReleaseBranchCommit(version) {
   const expectedHeadOid = git(["rev-parse", "HEAD"]);
   await resetReleaseBranch(expectedHeadOid);
 
-  const query = `
-    mutation CreateReleaseBranchCommit($input: CreateCommitOnBranchInput!) {
-      createCommitOnBranch(input: $input) {
-        commit {
-          oid
-          url
-        }
-      }
-    }
-  `;
-
-  const data = await githubGraphqlRequest(query, {
-    input: {
-      branch: {
-        repositoryNameWithOwner: repo,
-        branchName: releaseBranch,
-      },
-      expectedHeadOid,
-      message: {
-        headline: `chore(main): release ${version}`,
-      },
-      fileChanges: {
-        additions: [
-          releaseFileAddition("package.json"),
-          releaseFileAddition("CHANGELOG.md"),
-          releaseFileAddition(".github/.release-please-manifest.json"),
-        ],
-      },
-    },
+  const commit = await createCommitOnBranch({
+    repository: repo,
+    branch: releaseBranch,
+    expectedHeadOid,
+    headline: `chore(main): release ${version}`,
+    additions: [
+      releaseFileAddition("package.json"),
+      releaseFileAddition("CHANGELOG.md"),
+      releaseFileAddition(".github/.release-please-manifest.json"),
+    ],
+    token,
   });
 
-  const commit = data.createCommitOnBranch.commit;
   console.log(`Created release branch commit ${commit.oid}`);
   return commit.oid;
 }
@@ -469,9 +424,13 @@ async function enableAutoMerge(pullRequestId, version) {
   `;
 
   try {
-    await githubGraphqlRequest(query, {
-      pullRequestId,
-      commitHeadline: `chore(main): release ${version}`,
+    await githubGraphqlRequest({
+      query,
+      variables: {
+        pullRequestId,
+        commitHeadline: `chore(main): release ${version}`,
+      },
+      token,
     });
   } catch (error) {
     if (error.message.includes("Auto merge is already enabled")) {

--- a/.github/scripts/translate-missing.mjs
+++ b/.github/scripts/translate-missing.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { createCommitOnBranch } from "./github-commit-on-branch.mjs";
 import {
   agentHost,
   applyTranslations,
@@ -177,6 +178,24 @@ async function updateReleasePrComment(markdown) {
   }
 }
 
+async function createTranslationCommit(files) {
+  const additions = files.map((relativePath) => ({
+    path: relativePath,
+    contents: fs.readFileSync(path.resolve(relativePath)).toString("base64"),
+  }));
+  const commit = await createCommitOnBranch({
+    repository: repo,
+    branch: releaseBranch,
+    expectedHeadOid: git(["rev-parse", "HEAD"]),
+    headline: "chore(i18n): translate missing release strings",
+    additions,
+    token,
+  });
+
+  console.log(`Created translation commit ${commit.oid}`);
+  return commit.oid;
+}
+
 async function main() {
   const inventory = collectMissingTranslations({ messagesDir, sourceLocale });
   const impactedLocales = [...new Set(inventory.missing.map((entry) => entry.locale))].sort();
@@ -220,14 +239,7 @@ async function main() {
       result.translations.map((entry) => path.join(messagesRelativeDir, entry.targetFile))
     ),
   ].sort();
-  git(["add", ...files]);
-  git(["config", "user.name", process.env.GIT_COMMIT_NAME ?? "github-actions[bot]"]);
-  git([
-    "config",
-    "user.email",
-    process.env.GIT_COMMIT_EMAIL ?? "github-actions[bot]@users.noreply.github.com",
-  ]);
-  git(["commit", "-m", "chore(i18n): translate missing release strings"]);
+  await createTranslationCommit(files);
 
   const summary = summaryMarkdown({
     missing: inventory.missing,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,7 +91,6 @@ jobs:
           git fetch origin codex/release-main
           git checkout -B codex/release-main origin/codex/release-main
           node .github/scripts/translate-missing.mjs
-          git push origin HEAD:codex/release-main
 
   publish-release:
     if: "${{ startsWith(github.event.head_commit.message, 'chore(main): release ') }}"

--- a/scripts/release-translations.test.mjs
+++ b/scripts/release-translations.test.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { createCommitOnBranch } from "../.github/scripts/github-commit-on-branch.mjs";
 import {
   applyTranslations,
   collectMissingTranslations,
@@ -302,4 +303,78 @@ test("preserves ICU selectors and markup while allowing translated branch text",
 
   assert.deepEqual(extractPlaceholderTokens(source), extractPlaceholderTokens(translation));
   assert.notDeepEqual(extractPlaceholderTokens(source), extractPlaceholderTokens(changedSelector));
+});
+
+test("creates translation commits through GitHub without overriding the app identity", async () => {
+  let request;
+  const encodedContents = Buffer.from('{"test":true}').toString("base64");
+  const commit = await createCommitOnBranch({
+    repository: "solana-foundation/solana-developer-platform",
+    branch: "codex/release-main",
+    expectedHeadOid: "abc123",
+    headline: "chore(i18n): translate missing release strings",
+    additions: [{ path: "apps/sdp-web/messages/fr.json", contents: encodedContents }],
+    token: "test-token",
+    fetchImpl: async (url, options) => {
+      request = { url, options };
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            data: {
+              createCommitOnBranch: {
+                commit: { oid: "def456", url: "https://github.test/commit/def456" },
+              },
+            },
+          }),
+      };
+    },
+  });
+
+  assert.equal(commit.oid, "def456");
+  assert.equal(request.url, "https://api.github.com/graphql");
+  assert.equal(request.options.headers.Authorization, "Bearer test-token");
+  const input = JSON.parse(request.options.body).variables.input;
+  assert.deepEqual(input, {
+    branch: {
+      repositoryNameWithOwner: "solana-foundation/solana-developer-platform",
+      branchName: "codex/release-main",
+    },
+    expectedHeadOid: "abc123",
+    message: { headline: "chore(i18n): translate missing release strings" },
+    fileChanges: {
+      additions: [{ path: "apps/sdp-web/messages/fr.json", contents: encodedContents }],
+    },
+  });
+  assert.equal("author" in input, false);
+  assert.equal("committer" in input, false);
+});
+
+test("surfaces GraphQL commit errors returned with HTTP 200", async () => {
+  await assert.rejects(
+    createCommitOnBranch({
+      repository: "solana-foundation/solana-developer-platform",
+      branch: "codex/release-main",
+      expectedHeadOid: "stale-head",
+      headline: "chore(i18n): translate missing release strings",
+      additions: [],
+      token: "test-token",
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ errors: [{ message: "Expected head oid mismatch" }] }),
+      }),
+    }),
+    /Expected head oid mismatch/
+  );
+});
+
+test("translation workflow does not push a locally created commit", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(import.meta.dirname, "../.github/workflows/release-please.yml"),
+    "utf8"
+  );
+
+  assert.doesNotMatch(workflow, /git push origin HEAD:codex\/release-main/);
 });


### PR DESCRIPTION
## Summary

- extract the release bot's existing GraphQL transport into a shared helper
- create both release and translation commits with the same `createCommitOnBranch` implementation
- use the release GitHub App token without overriding author or committer identity, allowing GitHub to sign the commit
- remove the local `git commit` and `git push` path from the release workflow
- add regression coverage for the GraphQL payload, stale-head errors, and workflow push behavior

## Root cause

`translate-missing.mjs` created a local Git commit and pushed it over the Git protocol. That commit had no verified signature, so release PRs containing generated translations could not satisfy the repository's signed-commit rule.

## Impact

Future release PR translation commits are created and signed by GitHub using the same App token as the signed release commit. Merging this fix to `main` will rerun Release Flow and reconstruct `codex/release-main`, replacing the unsigned translation commit currently blocking release 0.53.0.

## Checks

- `pnpm test:scripts` — 50 passed
- `pnpm lint` — passed (pre-existing warnings only)
- focused Biome checks for all changed JavaScript files
- local commit signature verified with the configured SSH signing key
