### PR TITLE
fix(payments): verify and serialize ramp settlement events

### DIFF
--- a/apps/sdp-api/src/db/migrations/postgres/0047_ramp_settlement_integrity.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0047_ramp_settlement_integrity.sql
@@ -1,0 +1,22 @@
+-- Provider settlement references must resolve to exactly one active tenant row.
+-- The historical JSON-path indexes stop covering rows after encrypted provider
+-- data is purged, so enforce uniqueness on the denormalized lookup columns.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_counterparties_bvnk_customer_reference_denormalized_active
+    ON counterparties(bvnk_customer_reference)
+    WHERE status = 'active' AND bvnk_customer_reference IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_counterparties_mural_organization_id_denormalized_active
+    ON counterparties(mural_organization_id)
+    WHERE status = 'active' AND mural_organization_id IS NOT NULL;
+
+-- A confirmed wallet transfer can fund at most one MoneyGram off-ramp session.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_transfers_moneygram_crypto_leg
+    ON payment_transfers ((provider_data->'moneygram'->>'cryptoTransferId'))
+    WHERE provider = 'moneygram'
+      AND provider_data->'moneygram'->>'cryptoTransferId' IS NOT NULL;
+
+-- Signed Mural deliveries are consumed exactly once even when the provider retries.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_transfers_mural_account_credit_delivery
+    ON payment_transfers ((provider_data->'mural'->>'accountCreditedDeliveryId'))
+    WHERE provider = 'mural'
+      AND provider_data->'mural'->>'accountCreditedDeliveryId' IS NOT NULL;

--- a/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/counterparty.repository.postgres.ts
@@ -435,7 +435,7 @@ export function createPostgresCounterpartiesRepository(
     },
 
     async findActiveCounterpartyByBvnkCustomerReference(customerReference: string) {
-      const row = await db
+      const rows = await db
         .prepare(
           `SELECT * FROM counterparties
             WHERE status = 'active'
@@ -446,15 +446,18 @@ export function createPostgresCounterpartiesRepository(
                   AND provider_data->'bvnk'->'customer'->>'customerReference' = ?
                 )
               )
-            LIMIT 1`
+            ORDER BY id
+            LIMIT 2`
         )
         .bind(customerReference, customerReference)
-        .first<Record<string, unknown>>();
-      return row ? mapCounterpartyRow(db, cipher, row) : null;
+        .all<Record<string, unknown>>();
+      return rows.results.length === 1
+        ? mapCounterpartyRow(db, cipher, rows.results[0] as Record<string, unknown>)
+        : null;
     },
 
     async findCounterpartyByMuralOrganizationId(organizationId: string) {
-      const row = await db
+      const rows = await db
         .prepare(
           `SELECT * FROM counterparties
             WHERE status = 'active'
@@ -465,11 +468,14 @@ export function createPostgresCounterpartiesRepository(
                   AND provider_data->'mural'->'organization'->>'id' = ?
                 )
               )
-            LIMIT 1`
+            ORDER BY id
+            LIMIT 2`
         )
         .bind(organizationId, organizationId)
-        .first<Record<string, unknown>>();
-      return row ? mapCounterpartyRow(db, cipher, row) : null;
+        .all<Record<string, unknown>>();
+      return rows.results.length === 1
+        ? mapCounterpartyRow(db, cipher, rows.results[0] as Record<string, unknown>)
+        : null;
     },
 
     async mutateProviderData(params) {

--- a/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.postgres.ts
@@ -425,16 +425,32 @@ export function createPostgresPaymentsRepository(
         extraValues: [input.transferId, [...input.fromStatuses]],
       });
 
-      const amountClause = input.amount === undefined ? "" : ", amount = ?";
-      const amountValues = input.amount === undefined ? [] : [input.amount];
+      const assignments = ["status = ?", "updated_at = ?"];
+      const assignmentValues: unknown[] = [input.toStatus, input.updatedAt];
+      if (input.amount !== undefined) {
+        assignments.push("amount = ?");
+        assignmentValues.push(input.amount);
+      }
+      if (input.fiatAmount !== undefined) {
+        assignments.push("fiat_amount = ?");
+        assignmentValues.push(input.fiatAmount);
+      }
+      if (input.providerData !== undefined) {
+        assignments.push("provider_data = provider_data || ?::jsonb");
+        assignmentValues.push(JSON.stringify(input.providerData));
+      }
+      if (input.error !== undefined) {
+        assignments.push("error = ?");
+        assignmentValues.push(input.error);
+      }
       const row = await db
         .prepare(
           `UPDATE payment_transfers
-           SET status = ?, updated_at = ?${amountClause}
+           SET ${assignments.join(", ")}
            WHERE ${scope.where}
            RETURNING *`
         )
-        .bind(input.toStatus, input.updatedAt, ...amountValues, ...scope.values)
+        .bind(...assignmentValues, ...scope.values)
         .first<Record<string, unknown>>();
 
       return row ? mapTransferRow(row) : null;

--- a/apps/sdp-api/src/db/repositories/payments.repository.ts
+++ b/apps/sdp-api/src/db/repositories/payments.repository.ts
@@ -206,7 +206,10 @@ export interface PaymentsRepository {
     fromStatuses: readonly PaymentTransferStatus[];
     toStatus: PaymentTransferStatus;
     updatedAt: string;
-    amount?: string;
+    amount?: string | null;
+    fiatAmount?: string | null;
+    providerData?: Record<string, unknown>;
+    error?: string | null;
   }): Promise<PaymentTransferRow | null>;
   listTransfersByStatus(params: ListTransfersByStatusInput): Promise<PaymentTransferRow[]>;
   getTransferById(params: {

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -521,6 +521,51 @@ async function seedCounterparty(params?: {
   return id;
 }
 
+async function seedRampEventTransfer(params: {
+  id: string;
+  provider: "coinbase" | "moneygram";
+  providerReference: string;
+  type: "onramp" | "offramp";
+  amount?: string;
+}): Promise<void> {
+  const now = new Date().toISOString();
+  await getDb(env)
+    .prepare(
+      `INSERT INTO payment_transfers (
+         id, organization_id, project_id, wallet_id, source_address, destination_address,
+         token, amount, memo, type, direction, status, provider, provider_reference,
+         delivery_mode, fiat_currency, fiat_amount, provider_data, signature, serialized_tx,
+         initiated_by_key_id, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      params.id,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      TEST_WALLET_ID,
+      params.type === "offramp" ? TEST_SOLANA_ADDRESSES.wallet1 : null,
+      params.type === "onramp" ? TEST_SOLANA_ADDRESSES.wallet2 : null,
+      "USDC",
+      params.amount ?? "25",
+      null,
+      params.type,
+      params.type === "onramp" ? "inbound" : "outbound",
+      "pending",
+      params.provider,
+      params.providerReference,
+      "hosted",
+      "USD",
+      "25",
+      {},
+      null,
+      null,
+      null,
+      now,
+      now
+    )
+    .run();
+}
+
 async function seedCryptoWalletCounterpartyAccount(params: {
   counterpartyId: string;
   address: string;
@@ -8464,5 +8509,125 @@ describe("Payments routes", () => {
 
       expect(res.status).toBe(404);
     });
+  });
+
+  it("keeps browser ramp terminal callbacks advisory", async () => {
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    await seedRampEventTransfer({
+      id: "xfr_coinbase_advisory",
+      provider: "coinbase",
+      providerReference: "coinbase_order_advisory",
+      type: "onramp",
+    });
+    await seedRampEventTransfer({
+      id: "xfr_moneygram_advisory",
+      provider: "moneygram",
+      providerReference: "moneygram_session_advisory",
+      type: "onramp",
+    });
+
+    const coinbase = await app.request(
+      "/v1/payments/ramps/coinbase/events",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ kind: "committed", orderId: "coinbase_order_advisory" }),
+      },
+      env
+    );
+    const moneygram = await app.request(
+      "/v1/payments/ramps/moneygram/events",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          kind: "onramp_completed",
+          sessionId: "moneygram_session_advisory",
+          transactionId: "moneygram_transaction_advisory",
+          status: "COMPLETED",
+          amount: 25,
+        }),
+      },
+      env
+    );
+
+    expect(coinbase.status).toBe(200);
+    expect(moneygram.status).toBe(200);
+    const rows = await getDb(env)
+      .prepare(
+        `SELECT id, status, provider_data
+         FROM payment_transfers
+         WHERE id IN ('xfr_coinbase_advisory', 'xfr_moneygram_advisory')
+         ORDER BY id`
+      )
+      .all<{ id: string; status: string; provider_data: Record<string, unknown> }>();
+    expect(rows.results).toHaveLength(2);
+    for (const row of rows.results) {
+      expect(row.status).toBe("pending");
+      expect(row.provider_data).toMatchObject({ clientEvent: { advisory: true } });
+    }
+  });
+
+  it("rejects a MoneyGram crypto leg whose amount does not match the session", async () => {
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    await seedRampEventTransfer({
+      id: "xfr_moneygram_amount_guard",
+      provider: "moneygram",
+      providerReference: "moneygram_session_amount_guard",
+      type: "offramp",
+      amount: "25",
+    });
+    const now = new Date().toISOString();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers (
+           id, organization_id, project_id, wallet_id, source_address, destination_address,
+           token, amount, type, direction, status, signature, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        "xfr_moneygram_wrong_amount_leg",
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_WALLET_ID,
+        TEST_SOLANA_ADDRESSES.wallet1,
+        TEST_SOLANA_ADDRESSES.wallet2,
+        "USDC",
+        "24",
+        "transfer",
+        "outbound",
+        "confirmed",
+        "moneygram-wrong-amount-signature",
+        now,
+        now
+      )
+      .run();
+
+    const response = await app.request(
+      "/v1/payments/ramps/moneygram/events",
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          kind: "signed",
+          sessionId: "moneygram_session_amount_guard",
+          cryptoTransferId: "xfr_moneygram_wrong_amount_leg",
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    const transfer = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+      .bind("xfr_moneygram_amount_guard")
+      .first<{ status: string }>();
+    expect(transfer?.status).toBe("pending");
   });
 });

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -602,6 +602,7 @@ export async function createOnrampQuote(c: AppContext): Promise<Response> {
         throw counterpartyNotProvisioned("mural", "onramp");
       }
       quote = muralOnrampQuote({ account, fiatCurrency: input.fiatCurrency });
+      transferProviderData = { mural: { accountId: account.id } };
       break;
     }
     case "moneygram": {

--- a/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps/events.ts
@@ -1,3 +1,4 @@
+import { compareDecimalAmounts } from "@sdp/payments/decimal";
 import { isRampEventProvider } from "@sdp/payments/ramps/shared";
 import type { MoneygramRampEvent } from "@sdp/types";
 import { z } from "zod";
@@ -13,6 +14,7 @@ const TERMINAL_RAMP_STATUSES = [
   "completed",
   "failed",
   "expired",
+  "canceled",
 ] as const satisfies readonly PaymentTransferStatus[];
 
 function isTerminalRampStatus(status: PaymentTransferStatus): boolean {
@@ -53,6 +55,18 @@ async function requireVerifiedCryptoLeg(
   if (leg.source_address !== ramp.source_address) {
     throw badRequest("Crypto transfer was not sent from the off-ramp source wallet.");
   }
+  if (leg.wallet_id !== ramp.wallet_id) {
+    throw badRequest("Crypto transfer was not sent from the off-ramp wallet.");
+  }
+  if (leg.direction !== "outbound") {
+    throw badRequest("Crypto transfer must be outbound.");
+  }
+  if (leg.token !== ramp.token) {
+    throw badRequest("Crypto transfer asset does not match the off-ramp asset.");
+  }
+  if (ramp.amount !== null && compareDecimalAmounts(leg.amount ?? "0", ramp.amount) !== 0) {
+    throw badRequest("Crypto transfer amount does not match the off-ramp amount.");
+  }
   if (!leg.signature) {
     throw badRequest("Crypto transfer has no on-chain signature.");
   }
@@ -67,6 +81,35 @@ function transferResponse(c: AppContext, row: PaymentTransferRow | null) {
     throw internalError("Failed to update the ramp transfer.");
   }
   return success(c, { transfer: mapTransferRow(row) });
+}
+
+/**
+ * Browser/widget callbacks are useful telemetry, but they are not provider-authenticated
+ * settlement evidence. Keep them in an explicitly advisory namespace and never derive a
+ * transfer status from them.
+ */
+async function recordAdvisoryClientEvent(
+  c: AppContext,
+  transfer: PaymentTransferRow,
+  event: Record<string, unknown>
+) {
+  const repo = getPaymentsRepository(c);
+  const receivedAt = new Date().toISOString();
+  const updated = await repo.updateTransfer({
+    transferId: transfer.id,
+    expectedStatus: transfer.status,
+    providerData: { clientEvent: { ...event, advisory: true, receivedAt } },
+    updatedAt: receivedAt,
+  });
+  if (updated) {
+    return transferResponse(c, updated);
+  }
+  const current = await repo.getTransferById({
+    transferId: transfer.id,
+    organizationId: transfer.organization_id,
+    projectId: transfer.project_id,
+  });
+  return transferResponse(c, current);
 }
 
 export async function recordRampProviderEvent(c: AppContext) {
@@ -117,25 +160,14 @@ async function recordCoinbaseRampEvent(c: AppContext, body: unknown) {
     return success(c, { transfer: mapTransferRow(transfer) });
   }
 
-  const now = new Date().toISOString();
   switch (event.kind) {
-    case "committed": {
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "settling",
-        updatedAt: now,
+    case "committed":
+      return recordAdvisoryClientEvent(c, transfer, { kind: event.kind });
+    case "errored":
+      return recordAdvisoryClientEvent(c, transfer, {
+        kind: event.kind,
+        reason: event.reason,
       });
-      return transferResponse(c, updated);
-    }
-    case "errored": {
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "failed",
-        error: event.reason,
-        updatedAt: now,
-      });
-      return transferResponse(c, updated);
-    }
     default: {
       const exhaustive: never = event;
       throw internalError(`Unhandled Coinbase ramp event: ${JSON.stringify(exhaustive)}`);
@@ -185,56 +217,66 @@ async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
   }
 
   const moneygramData = readMoneygramData(transfer);
-  const now = new Date().toISOString();
+  if (event.kind !== "signed") {
+    return recordMoneygramAdvisoryEvent(c, transfer, moneygramData, event);
+  }
+  if (transfer.status === "settling") {
+    if (moneygramData.cryptoTransferId === event.cryptoTransferId) {
+      return success(c, { transfer: mapTransferRow(transfer) });
+    }
+    throw conflict("Off-ramp transfer is already settling a different crypto transfer.");
+  }
+  if (transfer.status !== "pending") {
+    throw conflict(`Cannot record a signed event while the transfer is ${transfer.status}.`);
+  }
+  const leg = await requireVerifiedCryptoLeg(c, transfer, event.cryptoTransferId, {
+    requireConfirmed: false,
+  });
+  const updated = await repo.updateTransferStatusGuarded({
+    transferId: transfer.id,
+    organizationId: transfer.organization_id,
+    projectId: transfer.project_id,
+    fromStatuses: ["pending"],
+    toStatus: "settling",
+    amount: leg.amount,
+    providerData: {
+      moneygram: {
+        ...moneygramData,
+        cryptoTransferId: leg.id,
+        solanaTxSignature: leg.signature,
+      },
+    },
+    updatedAt: new Date().toISOString(),
+  });
+  if (!updated) {
+    const current = await repo.getTransferById({
+      transferId: transfer.id,
+      organizationId: transfer.organization_id,
+      projectId: transfer.project_id,
+    });
+    if (current?.status === "settling" && readMoneygramData(current).cryptoTransferId === leg.id) {
+      return transferResponse(c, current);
+    }
+    throw conflict("Off-ramp transfer changed while the signed event was recorded.");
+  }
+  return transferResponse(c, updated);
+}
 
+async function recordMoneygramAdvisoryEvent(
+  c: AppContext,
+  transfer: PaymentTransferRow,
+  moneygramData: Record<string, unknown>,
+  event: Exclude<MoneygramRampEvent, { kind: "signed" }>
+) {
   switch (event.kind) {
-    case "onramp_completed": {
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "completed",
-        providerData: {
-          ...transfer.provider_data,
-          moneygram: {
-            ...moneygramData,
-            transactionId: event.transactionId,
-            payoutAmount: event.amount,
-            payoutStatus: event.status,
-            ...(event.referenceNumber ? { referenceNumber: event.referenceNumber } : {}),
-          },
-        },
-        updatedAt: now,
+    case "onramp_completed":
+      return recordAdvisoryClientEvent(c, transfer, {
+        kind: event.kind,
+        transactionId: event.transactionId,
+        amount: event.amount,
+        status: event.status,
+        ...(event.referenceNumber ? { referenceNumber: event.referenceNumber } : {}),
       });
-      return transferResponse(c, updated);
-    }
-    case "signed": {
-      if (transfer.status === "settling") {
-        if (moneygramData.cryptoTransferId === event.cryptoTransferId) {
-          return success(c, { transfer: mapTransferRow(transfer) });
-        }
-        throw conflict("Off-ramp transfer is already settling a different crypto transfer.");
-      }
-      if (transfer.status !== "pending") {
-        throw conflict(`Cannot record a signed event while the transfer is ${transfer.status}.`);
-      }
-      const leg = await requireVerifiedCryptoLeg(c, transfer, event.cryptoTransferId, {
-        requireConfirmed: false,
-      });
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "settling",
-        amount: leg.amount,
-        providerData: {
-          ...transfer.provider_data,
-          moneygram: {
-            ...moneygramData,
-            cryptoTransferId: leg.id,
-            solanaTxSignature: leg.signature,
-          },
-        },
-        updatedAt: now,
-      });
-      return transferResponse(c, updated);
-    }
     case "completed": {
       if (transfer.status !== "pending" && transfer.status !== "settling") {
         throw conflict(`Cannot record a completed event while the transfer is ${transfer.status}.`);
@@ -248,96 +290,23 @@ async function recordMoneygramRampEvent(c: AppContext, body: unknown) {
       const leg = await requireVerifiedCryptoLeg(c, transfer, event.cryptoTransferId, {
         requireConfirmed: true,
       });
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "completed",
-        amount: leg.amount,
-        providerData: {
-          ...transfer.provider_data,
-          moneygram: {
-            ...moneygramData,
-            cryptoTransferId: leg.id,
-            solanaTxSignature: leg.signature,
-            transactionId: event.transactionId,
-            payoutAmount: event.payoutAmount,
-            payoutStatus: event.payoutStatus,
-            ...(event.referenceNumber ? { referenceNumber: event.referenceNumber } : {}),
-          },
-        },
-        updatedAt: now,
+      return recordAdvisoryClientEvent(c, transfer, {
+        kind: event.kind,
+        cryptoTransferId: leg.id,
+        transactionId: event.transactionId,
+        payoutAmount: event.payoutAmount,
+        payoutStatus: event.payoutStatus,
+        ...(event.referenceNumber ? { referenceNumber: event.referenceNumber } : {}),
       });
-      return transferResponse(c, updated);
     }
     case "errored":
-      return recordMoneygramErroredEvent(c, transfer, moneygramData, event, now);
-    case "closed": {
-      if (transfer.status !== "pending") {
-        return success(c, { transfer: mapTransferRow(transfer) });
-      }
-      const updated = await repo.updateTransfer({
-        transferId: transfer.id,
-        status: "expired",
-        updatedAt: now,
+      return recordAdvisoryClientEvent(c, transfer, {
+        kind: event.kind,
+        reason: event.reason,
+        ...(event.cryptoTransferId ? { cryptoTransferId: event.cryptoTransferId } : {}),
+        ...(event.transactionId ? { transactionId: event.transactionId } : {}),
       });
-      return transferResponse(c, updated);
-    }
-    default: {
-      const exhaustive: never = event;
-      throw internalError(`Unhandled MoneyGram ramp event: ${JSON.stringify(exhaustive)}`);
-    }
+    case "closed":
+      return recordAdvisoryClientEvent(c, transfer, { kind: event.kind });
   }
-}
-
-async function recordMoneygramErroredEvent(
-  c: AppContext,
-  transfer: PaymentTransferRow,
-  moneygramData: Record<string, unknown>,
-  event: Extract<MoneygramRampEvent, { kind: "errored" }>,
-  now: string
-) {
-  const repo = getPaymentsRepository(c);
-  const moneygram = {
-    ...moneygramData,
-    ...(event.transactionId ? { transactionId: event.transactionId } : {}),
-  };
-  if (transfer.type === "offramp" && transfer.status === "settling") {
-    const updated = await repo.updateTransfer({
-      transferId: transfer.id,
-      providerData: {
-        ...transfer.provider_data,
-        moneygram: { ...moneygram, lastWidgetError: event.reason },
-      },
-      updatedAt: now,
-    });
-    return transferResponse(c, updated);
-  }
-  if (transfer.type === "offramp" && event.cryptoTransferId) {
-    const leg = await requireVerifiedCryptoLeg(c, transfer, event.cryptoTransferId, {
-      requireConfirmed: false,
-    });
-    const updated = await repo.updateTransfer({
-      transferId: transfer.id,
-      status: "settling",
-      amount: leg.amount,
-      providerData: {
-        ...transfer.provider_data,
-        moneygram: {
-          ...moneygram,
-          cryptoTransferId: leg.id,
-          solanaTxSignature: leg.signature,
-          lastWidgetError: event.reason,
-        },
-      },
-      updatedAt: now,
-    });
-    return transferResponse(c, updated);
-  }
-  const updated = await repo.updateTransfer({
-    transferId: transfer.id,
-    status: "failed",
-    error: event.reason,
-    providerData: { ...transfer.provider_data, moneygram },
-    updatedAt: now,
-  });
-  return transferResponse(c, updated);
 }

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -1378,6 +1378,70 @@ describe("BVNK ramp webhook", () => {
     expect(Number(transfer?.fiat_amount)).toBe(100);
   });
 
+  it("refuses to guess between ambiguous BVNK pay-in transfers", async () => {
+    const ruleId = "rule_webhook_payment_ambiguous";
+    for (const [index, createdAt] of [
+      [1, "2026-06-05T00:00:00.000Z"],
+      [2, "2026-06-05T00:01:00.000Z"],
+    ] as const) {
+      await getDb(env)
+        .prepare(
+          `INSERT INTO payment_transfers (
+             id, organization_id, project_id, wallet_id, counterparty_id,
+             source_address, destination_address, token, amount, memo, type,
+             direction, status, provider, provider_reference, delivery_mode,
+             fiat_currency, fiat_amount, provider_data, signature, serialized_tx,
+             initiated_by_key_id, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          `pt_bvnk_ambiguous_${index}`,
+          ORG_ID,
+          PROJECT_ID,
+          "wallet_bvnk_webhook",
+          COUNTERPARTY_ID,
+          null,
+          "dest",
+          "USDC",
+          null,
+          null,
+          "onramp",
+          "inbound",
+          "awaiting_payment",
+          "bvnk",
+          `bvnk_onramp_quote_ambiguous_${index}`,
+          "manual_instructions",
+          "USD",
+          "100.00",
+          JSON.stringify({ bvnk: { ruleId, fundingWalletId: WALLET_ID } }),
+          null,
+          null,
+          null,
+          createdAt,
+          createdAt
+        )
+        .run();
+    }
+
+    const res = await sendBvnkWebhook({
+      event: "bvnk:payment:payin:status-change",
+      data: {
+        customerReference: CUSTOMER_REFERENCE,
+        beneficiary: { walletId: WALLET_ID },
+        status: "COMPLETED",
+        amount: { value: 100, currencyCode: "USD" },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const rows = await getDb(env)
+      .prepare(
+        "SELECT status FROM payment_transfers WHERE id LIKE 'pt_bvnk_ambiguous_%' ORDER BY id"
+      )
+      .all<{ status: string }>();
+    expect(rows.results.map((row) => row.status)).toEqual(["awaiting_payment", "awaiting_payment"]);
+  });
+
   it("moves a BVNK off-ramp transfer to settling when a channel transaction is detected", async () => {
     const transferId = "xfr_d7a72b93-cd7e-405b-96b5-73ca368a7bd7";
     await getDb(env)

--- a/apps/sdp-api/src/routes/webhooks.test.ts
+++ b/apps/sdp-api/src/routes/webhooks.test.ts
@@ -1442,6 +1442,77 @@ describe("BVNK ramp webhook", () => {
     expect(rows.results.map((row) => row.status)).toEqual(["awaiting_payment", "awaiting_payment"]);
   });
 
+  it("matches a BVNK pay-in against the complete eligible transfer set", async () => {
+    const ruleId = "rule_webhook_payment_complete_set";
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers (
+           id, organization_id, project_id, wallet_id, counterparty_id,
+           destination_address, token, type, direction, status, provider,
+           provider_reference, delivery_mode, fiat_currency, fiat_amount,
+           provider_data, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)`
+      )
+      .bind(
+        "pt_bvnk_complete_set_match",
+        ORG_ID,
+        PROJECT_ID,
+        "wallet_bvnk_webhook",
+        COUNTERPARTY_ID,
+        "dest",
+        "USDC",
+        "onramp",
+        "inbound",
+        "awaiting_payment",
+        "bvnk",
+        "bvnk_onramp_quote_complete_set_match",
+        "manual_instructions",
+        "USD",
+        "100.00",
+        { bvnk: { ruleId, fundingWalletId: WALLET_ID } },
+        "2026-06-05T00:00:00.000Z",
+        "2026-06-05T00:00:00.000Z"
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers (
+           id, organization_id, project_id, wallet_id, counterparty_id,
+           destination_address, token, type, direction, status, provider,
+           provider_reference, delivery_mode, fiat_currency, fiat_amount,
+           provider_data, created_at, updated_at
+         )
+         SELECT
+           'pt_bvnk_complete_set_decoy_' || candidate,
+           ?, ?, ?, ?, 'dest', 'USDC', 'onramp', 'inbound', 'awaiting_payment',
+           'bvnk', 'bvnk_onramp_quote_complete_set_decoy_' || candidate,
+           'manual_instructions', 'USD', (100 + candidate)::text,
+           jsonb_build_object('bvnk', jsonb_build_object(
+             'ruleId', ?::text, 'fundingWalletId', ?::text
+           )),
+           '2026-06-05T01:00:00.000Z', '2026-06-05T01:00:00.000Z'
+         FROM generate_series(1, 100) AS candidate`
+      )
+      .bind(ORG_ID, PROJECT_ID, "wallet_bvnk_webhook", COUNTERPARTY_ID, ruleId, WALLET_ID)
+      .run();
+
+    const res = await sendBvnkWebhook({
+      event: "bvnk:payment:payin:status-change",
+      data: {
+        customerReference: CUSTOMER_REFERENCE,
+        beneficiary: { walletId: WALLET_ID },
+        status: "COMPLETED",
+        amount: { value: 100, currencyCode: "USD" },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const transfer = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = 'pt_bvnk_complete_set_match'")
+      .first<{ status: string }>();
+    expect(transfer?.status).toBe("completed");
+  });
+
   it("moves a BVNK off-ramp transfer to settling when a channel transaction is detected", async () => {
     const transferId = "xfr_d7a72b93-cd7e-405b-96b5-73ca368a7bd7";
     await getDb(env)

--- a/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
@@ -1,4 +1,3 @@
-import { compareDecimalAmounts } from "@sdp/payments/decimal";
 import { readRecord, readString } from "@sdp/payments/json";
 import { RAMP_PROVIDER_CLIENTS } from "@sdp/payments/ramps";
 import {
@@ -205,33 +204,50 @@ async function handleProviderOnrampSettlementWebhook(
   }
   const paymentAmount = event.amount;
   const payments = createSystemPaymentsRepository(c.env);
-  const { rows } = await payments.listTransfers({
-    organizationId: counterparty.organization_id,
-    projectId: counterparty.project_id,
-    counterpartyId: counterparty.id,
-    provider: "bvnk",
-    types: ["onramp"],
-    statuses: ["pending", "awaiting_payment", "settling"],
-    limit: 100,
-    offset: 0,
-  });
-  const matches = rows.filter((transfer) => {
-    const bvnk = readRecord(transfer.provider_data.bvnk);
-    return (
-      readString(bvnk?.fundingWalletId) === event.walletId &&
-      transfer.fiat_amount !== null &&
-      compareDecimalAmounts(transfer.fiat_amount, paymentAmount) === 0
-    );
-  });
+  const matches = await getDb(c.env)
+    .prepare(
+      `SELECT id
+       FROM payment_transfers
+       WHERE organization_id = ?
+         AND project_id IS NOT DISTINCT FROM ?
+         AND counterparty_id = ?
+         AND provider = 'bvnk'
+         AND type = 'onramp'
+         AND status IN ('pending', 'awaiting_payment', 'settling')
+         AND provider_data->'bvnk'->>'fundingWalletId' = ?
+         AND fiat_amount IS NOT NULL
+         AND fiat_amount::numeric = ?::numeric
+       ORDER BY id
+       LIMIT 2`
+    )
+    .bind(
+      counterparty.organization_id,
+      counterparty.project_id,
+      counterparty.id,
+      event.walletId,
+      paymentAmount
+    )
+    .all<{ id: string }>();
   // BVNK pay-in events do not carry the SDP quote id. Only a unique active
   // wallet+amount match is safe; choosing the newest row can settle the wrong quote.
-  if (matches.length !== 1) {
+  if (matches.results.length !== 1) {
     getLogger().warn(
-      `[bvnk webhook] refusing ambiguous pay-in settlement customer=${event.customerReference} wallet=${event.walletId} matches=${matches.length}`
+      `[bvnk webhook] refusing ambiguous pay-in settlement customer=${event.customerReference} wallet=${event.walletId} matches=${matches.results.length}`
     );
     return;
   }
-  const transfer = matches[0];
+  const match = matches.results[0];
+  if (!match) {
+    return;
+  }
+  const transfer = await payments.getTransferById({
+    transferId: match.id,
+    organizationId: counterparty.organization_id,
+    projectId: counterparty.project_id,
+  });
+  if (!transfer) {
+    return;
+  }
   await payments.updateTransferStatusGuarded({
     transferId: transfer.id,
     organizationId: transfer.organization_id,

--- a/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/bvnk.ts
@@ -1,3 +1,4 @@
+import { compareDecimalAmounts } from "@sdp/payments/decimal";
 import { readRecord, readString } from "@sdp/payments/json";
 import { RAMP_PROVIDER_CLIENTS } from "@sdp/payments/ramps";
 import {
@@ -17,7 +18,10 @@ import {
 import type { RampRuntimeContext, RampWebhookValidationContext } from "@sdp/payments/ramps/types";
 import type { BvnkBankFundingDetails, SdpEnvironment } from "@sdp/types";
 import { getDb } from "@/db";
-import { createSystemCounterpartiesRepository } from "@/db/repositories";
+import {
+  createSystemCounterpartiesRepository,
+  createSystemPaymentsRepository,
+} from "@/db/repositories";
 import type {
   CounterpartiesRepository,
   CounterpartyRow,
@@ -182,7 +186,12 @@ async function handleProviderOnrampSettlementWebhook(
   c: AppContext,
   event: Extract<BvnkWebhookEvent, { kind: "bvnk:payment:payin:status-change" }>
 ): Promise<void> {
-  if (event.status !== "COMPLETED" || !event.customerReference || !event.walletId) {
+  if (
+    event.status !== "COMPLETED" ||
+    !event.customerReference ||
+    !event.walletId ||
+    !event.amount
+  ) {
     return;
   }
   const repo = createSystemCounterpartiesRepository(c.env);
@@ -194,38 +203,45 @@ async function handleProviderOnrampSettlementWebhook(
       `BVNK webhook customer ${event.customerReference} was not found or is not active`
     );
   }
-  // Single guarded UPDATE: the status exclusion is on the write itself (not just the
-  // lookup), so a transfer canceled in the race window can't be reopened to completed.
-  await getDb(c.env)
-    .prepare(
-      `UPDATE payment_transfers
-       SET status = 'completed',
-           amount = CASE WHEN ?::boolean THEN ? ELSE amount END,
-           fiat_amount = CASE WHEN ?::boolean THEN ? ELSE fiat_amount END,
-           updated_at = ?
-       WHERE id = (
-         SELECT id
-         FROM payment_transfers
-         WHERE provider = 'bvnk'
-           AND type = 'onramp'
-           AND counterparty_id = ?
-           AND provider_data->'bvnk'->>'fundingWalletId' = ?
-           AND status NOT IN ('completed', 'failed', 'expired', 'canceled')
-         ORDER BY created_at DESC
-         LIMIT 1
-       )
-         AND status NOT IN ('completed', 'failed', 'expired', 'canceled')`
-    )
-    .bind(
-      event.amount !== undefined,
-      event.amount ?? null,
-      event.amount !== undefined,
-      event.amount ?? null,
-      new Date().toISOString(),
-      counterparty.id,
-      event.walletId
-    )
-    .run();
+  const paymentAmount = event.amount;
+  const payments = createSystemPaymentsRepository(c.env);
+  const { rows } = await payments.listTransfers({
+    organizationId: counterparty.organization_id,
+    projectId: counterparty.project_id,
+    counterpartyId: counterparty.id,
+    provider: "bvnk",
+    types: ["onramp"],
+    statuses: ["pending", "awaiting_payment", "settling"],
+    limit: 100,
+    offset: 0,
+  });
+  const matches = rows.filter((transfer) => {
+    const bvnk = readRecord(transfer.provider_data.bvnk);
+    return (
+      readString(bvnk?.fundingWalletId) === event.walletId &&
+      transfer.fiat_amount !== null &&
+      compareDecimalAmounts(transfer.fiat_amount, paymentAmount) === 0
+    );
+  });
+  // BVNK pay-in events do not carry the SDP quote id. Only a unique active
+  // wallet+amount match is safe; choosing the newest row can settle the wrong quote.
+  if (matches.length !== 1) {
+    getLogger().warn(
+      `[bvnk webhook] refusing ambiguous pay-in settlement customer=${event.customerReference} wallet=${event.walletId} matches=${matches.length}`
+    );
+    return;
+  }
+  const transfer = matches[0];
+  await payments.updateTransferStatusGuarded({
+    transferId: transfer.id,
+    organizationId: transfer.organization_id,
+    projectId: transfer.project_id,
+    fromStatuses: ["pending", "awaiting_payment", "settling"],
+    toStatus: "completed",
+    amount: paymentAmount,
+    fiatAmount: paymentAmount,
+    updatedAt: new Date().toISOString(),
+  });
 }
 
 async function applyBvnkCustomerRequirementWebhook(

--- a/apps/sdp-api/src/routes/webhooks/ramps/mural.test.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/mural.test.ts
@@ -1,8 +1,12 @@
 import { createSign, generateKeyPairSync } from "node:crypto";
 import type { RampWebhookValidationContext } from "@sdp/payments/ramps/types";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
 import { AppError } from "@/lib/errors";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
 import { MuralWebhookProcessor } from "./mural";
+import type { AppContext } from "./processor";
 
 function context(input: {
   headers?: Record<string, string>;
@@ -60,7 +64,10 @@ describe("MuralWebhookProcessor.verify", () => {
     };
 
     const result = await processor.verify(context({ env: signedEnv, rawBody, headers }));
-    expect(result).toEqual({ payload: { type: "tos_accepted", organizationId: "org_9" } });
+    expect(result).toMatchObject({
+      payload: { type: "tos_accepted", organizationId: "org_9" },
+      __sdpDeliveryId: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
 
     await expect(
       processor.verify(context({ env: signedEnv, rawBody: `${rawBody} `, headers }))
@@ -77,5 +84,188 @@ describe("MuralWebhookProcessor.parse", () => {
         payload: { type: "tos_accepted", organizationId: "org_9" },
       })
     ).toEqual({ kind: "tos_accepted", organizationId: "org_9" });
+  });
+});
+
+describe("MuralWebhookProcessor.process", () => {
+  const organizationId = "org_mural_webhook_test";
+  const projectId = "prj_mural_webhook_test";
+  const userId = "usr_mural_webhook_test";
+  const counterpartyId = "cp_mural_webhook_test";
+  const muralOrganizationId = "mural_org_webhook_test";
+  const accountId = "mural_account_webhook_test";
+  const processor = new MuralWebhookProcessor();
+  const appContext = { env } as unknown as AppContext;
+
+  async function seedTransfer(id: string): Promise<void> {
+    const now = new Date().toISOString();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers (
+           id, organization_id, project_id, wallet_id, counterparty_id,
+           source_address, destination_address, token, amount, memo, type,
+           direction, status, provider, provider_reference, delivery_mode,
+           fiat_currency, fiat_amount, provider_data, signature, serialized_tx,
+           initiated_by_key_id, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        id,
+        organizationId,
+        projectId,
+        "wallet_mural_webhook_test",
+        counterpartyId,
+        null,
+        "destination",
+        "USDC",
+        null,
+        null,
+        "onramp",
+        "inbound",
+        "awaiting_payment",
+        "mural",
+        `quote_${id}`,
+        "manual_instructions",
+        "USD",
+        "100",
+        { mural: { accountId } },
+        null,
+        null,
+        null,
+        now,
+        now
+      )
+      .run();
+  }
+
+  async function transferStatus(id: string): Promise<string | undefined> {
+    const row = await getDb(env)
+      .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+      .bind(id)
+      .first<{ status: string }>();
+    return row?.status;
+  }
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env).batch([
+      getDb(env)
+        .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+        .bind(organizationId, "Mural Webhook Test", "mural-webhook-test", "enterprise", "active"),
+      getDb(env)
+        .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+        .bind(userId, "mural-webhook@example.com", 1, "active"),
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          projectId,
+          organizationId,
+          "Mural Webhook Project",
+          "mural-webhook-project",
+          "sandbox",
+          "active",
+          userId
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO counterparties (
+             id, organization_id, project_id, entity_type, display_name, email,
+             identity, status, created_by, mural_organization_id, provider_data
+           ) VALUES (?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?::jsonb)`
+        )
+        .bind(
+          counterpartyId,
+          organizationId,
+          projectId,
+          "business",
+          "Mural Buyer",
+          "mural-buyer@example.com",
+          { businessName: "Mural Buyer" },
+          "active",
+          userId,
+          muralOrganizationId,
+          {}
+        ),
+    ]);
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+  });
+
+  it("consumes a signed account-credit delivery once", async () => {
+    await seedTransfer("xfr_mural_first");
+
+    await processor.process(appContext, "sandbox", {
+      kind: "account_credited",
+      organizationId: muralOrganizationId,
+      accountId,
+      tokenAmount: 99,
+      deliveryId: "delivery_mural_once",
+    });
+    await seedTransfer("xfr_mural_second");
+    await processor.process(appContext, "sandbox", {
+      kind: "account_credited",
+      organizationId: muralOrganizationId,
+      accountId,
+      tokenAmount: 99,
+      deliveryId: "delivery_mural_once",
+    });
+
+    expect(await transferStatus("xfr_mural_first")).toBe("completed");
+    expect(await transferStatus("xfr_mural_second")).toBe("awaiting_payment");
+  });
+
+  it("refuses to guess between ambiguous live quotes", async () => {
+    await seedTransfer("xfr_mural_ambiguous_a");
+    await seedTransfer("xfr_mural_ambiguous_b");
+
+    await processor.process(appContext, "sandbox", {
+      kind: "account_credited",
+      organizationId: muralOrganizationId,
+      accountId,
+      tokenAmount: 99,
+      deliveryId: "delivery_mural_ambiguous",
+    });
+
+    expect(await transferStatus("xfr_mural_ambiguous_a")).toBe("awaiting_payment");
+    expect(await transferStatus("xfr_mural_ambiguous_b")).toBe("awaiting_payment");
+  });
+
+  it("refuses an organization reference associated with multiple tenants", async () => {
+    await getDb(env)
+      .prepare(
+        `INSERT INTO counterparties (
+           id, organization_id, project_id, entity_type, display_name, email,
+           identity, status, created_by, provider_data
+         ) VALUES (?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?::jsonb)`
+      )
+      .bind(
+        "cp_mural_ambiguous_tenant",
+        organizationId,
+        projectId,
+        "business",
+        "Other Mural Buyer",
+        "other-mural-buyer@example.com",
+        { businessName: "Other Mural Buyer" },
+        "active",
+        userId,
+        { mural: { organization: { id: muralOrganizationId } } }
+      )
+      .run();
+    await seedTransfer("xfr_mural_ambiguous_tenant");
+
+    await processor.process(appContext, "sandbox", {
+      kind: "account_credited",
+      organizationId: muralOrganizationId,
+      accountId,
+      tokenAmount: 99,
+      deliveryId: "delivery_mural_ambiguous_tenant",
+    });
+
+    expect(await transferStatus("xfr_mural_ambiguous_tenant")).toBe("awaiting_payment");
   });
 });

--- a/apps/sdp-api/src/routes/webhooks/ramps/mural.test.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/mural.test.ts
@@ -235,6 +235,46 @@ describe("MuralWebhookProcessor.process", () => {
     expect(await transferStatus("xfr_mural_ambiguous_b")).toBe("awaiting_payment");
   });
 
+  it("finds an exact account match beyond one hundred newer candidates", async () => {
+    await seedTransfer("xfr_mural_complete_set_match");
+    await getDb(env)
+      .prepare(
+        `UPDATE payment_transfers
+         SET created_at = '2026-08-03T00:00:00.000Z'
+         WHERE id = 'xfr_mural_complete_set_match'`
+      )
+      .run();
+    await getDb(env)
+      .prepare(
+        `INSERT INTO payment_transfers (
+           id, organization_id, project_id, wallet_id, counterparty_id,
+           destination_address, token, type, direction, status, provider,
+           provider_reference, delivery_mode, fiat_currency, fiat_amount,
+           provider_data, created_at, updated_at
+         )
+         SELECT
+           'xfr_mural_decoy_' || candidate,
+           ?, ?, ?, ?, 'destination', 'USDC', 'onramp', 'inbound',
+           'awaiting_payment', 'mural', 'quote_mural_decoy_' || candidate,
+           'manual_instructions', 'USD', '100',
+           jsonb_build_object('mural', jsonb_build_object('accountId', 'decoy_' || candidate)),
+           '2026-08-04T00:00:00.000Z', '2026-08-04T00:00:00.000Z'
+         FROM generate_series(1, 100) AS candidate`
+      )
+      .bind(organizationId, projectId, "wallet_mural_webhook_test", counterpartyId)
+      .run();
+
+    await processor.process(appContext, "sandbox", {
+      kind: "account_credited",
+      organizationId: muralOrganizationId,
+      accountId,
+      tokenAmount: 99,
+      deliveryId: "delivery_mural_complete_set_match",
+    });
+
+    expect(await transferStatus("xfr_mural_complete_set_match")).toBe("completed");
+  });
+
   it("refuses an organization reference associated with multiple tenants", async () => {
     await getDb(env)
       .prepare(

--- a/apps/sdp-api/src/routes/webhooks/ramps/mural.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/mural.ts
@@ -2,6 +2,7 @@ import { RAMP_PROVIDER_CLIENTS } from "@sdp/payments/ramps";
 import type { MuralWebhookEvent } from "@sdp/payments/ramps/providers/mural/client";
 import type { RampWebhookValidationContext } from "@sdp/payments/ramps/types";
 import type { SdpEnvironment } from "@sdp/types";
+import { getDb } from "@/db";
 import {
   createSystemCounterpartiesRepository,
   createSystemPaymentsRepository,
@@ -14,6 +15,34 @@ import { badRequest, providerNotConfigured, unauthorized } from "@/lib/errors";
 import { verifyWebhookSignature } from "@/lib/webhook-signature";
 import { getLogger } from "@/runtime/logger";
 import type { AppContext, WebhookProcessor } from "./processor";
+import { applyRampSettlementEvent } from "./settlements";
+
+const MURAL_DELIVERY_ID_FIELD = "__sdpDeliveryId";
+
+type MuralProcessorEvent =
+  | Exclude<MuralWebhookEvent, { kind: "account_credited" }>
+  | (Extract<MuralWebhookEvent, { kind: "account_credited" }> & { deliveryId: string });
+
+async function muralDeliveryId(timestamp: string, rawBody: string): Promise<string> {
+  const bytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${timestamp}.${rawBody}`)
+  );
+  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function readMuralData(transfer: PaymentTransferRow): Record<string, unknown> {
+  const mural = transfer.provider_data.mural;
+  if (!mural || typeof mural !== "object" || Array.isArray(mural)) {
+    return {};
+  }
+  return mural as Record<string, unknown>;
+}
+
+function readMuralAccountId(transfer: PaymentTransferRow): string | undefined {
+  const accountId = readMuralData(transfer).accountId;
+  return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
+}
 
 function readMuralWebhookPublicKey(
   env: Record<string, string | undefined>,
@@ -36,6 +65,7 @@ function readMuralWebhookPublicKey(
 async function findMuralOnrampTransfer(
   payments: PaymentsRepository,
   counterparty: CounterpartyRow,
+  accountId: string,
   statuses: PaymentTransferStatus[]
 ): Promise<PaymentTransferRow | undefined> {
   const { rows } = await payments.listTransfers({
@@ -44,15 +74,25 @@ async function findMuralOnrampTransfer(
     counterpartyId: counterparty.id,
     types: ["onramp"],
     statuses,
-    limit: 20,
+    provider: "mural",
+    limit: 100,
     offset: 0,
   });
-  return rows.find((row) => row.provider === "mural");
+  const matches = rows.filter((row) => readMuralAccountId(row) === accountId);
+  // Mural's account_credited event has no quote/transfer reference. Refuse to
+  // guess when multiple live quotes share an account; a single signed event
+  // must never settle more than one transfer through replay or ordering.
+  return matches.length === 1 && rows.length < 100 ? matches[0] : undefined;
 }
 
 async function handleAccountCredited(
   c: AppContext,
-  event: { organizationId: string; accountId: string; tokenAmount: number }
+  event: {
+    organizationId: string;
+    accountId: string;
+    tokenAmount: number;
+    deliveryId: string;
+  }
 ): Promise<void> {
   getLogger().info(
     `[mural webhook] account_credited account=${event.accountId} amount=${event.tokenAmount} org=${event.organizationId}`
@@ -65,7 +105,22 @@ async function handleAccountCredited(
     return;
   }
   const payments = createSystemPaymentsRepository(c.env);
-  const transfer = await findMuralOnrampTransfer(payments, counterparty, ["awaiting_payment"]);
+  const replay = await getDb(c.env)
+    .prepare(
+      `SELECT id
+       FROM payment_transfers
+       WHERE provider = 'mural'
+         AND provider_data->'mural'->>'accountCreditedDeliveryId' = ?
+       LIMIT 1`
+    )
+    .bind(event.deliveryId)
+    .first<{ id: string }>();
+  if (replay) {
+    return;
+  }
+  const transfer = await findMuralOnrampTransfer(payments, counterparty, event.accountId, [
+    "awaiting_payment",
+  ]);
   if (!transfer) {
     getLogger().warn(
       `[mural webhook] no awaiting on-ramp transfer for counterparty ${counterparty.id}`
@@ -81,6 +136,12 @@ async function handleAccountCredited(
     toStatus: "completed",
     updatedAt: new Date().toISOString(),
     amount: String(event.tokenAmount),
+    providerData: {
+      mural: {
+        ...readMuralData(transfer),
+        accountCreditedDeliveryId: event.deliveryId,
+      },
+    },
   });
   if (!claimed) {
     return;
@@ -108,7 +169,7 @@ async function handleOrganizationLifecycleEvent(
   });
 }
 
-export class MuralWebhookProcessor implements WebhookProcessor<unknown, MuralWebhookEvent> {
+export class MuralWebhookProcessor implements WebhookProcessor<unknown, MuralProcessorEvent> {
   readonly provider = "mural";
 
   async verify({
@@ -136,20 +197,38 @@ export class MuralWebhookProcessor implements WebhookProcessor<unknown, MuralWeb
     });
 
     try {
-      return JSON.parse(rawBody);
+      const payload = JSON.parse(rawBody) as unknown;
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        return {
+          ...(payload as Record<string, unknown>),
+          [MURAL_DELIVERY_ID_FIELD]: await muralDeliveryId(timestamp, rawBody),
+        };
+      }
+      return payload;
     } catch {
       throw badRequest("Mural webhook body must be valid JSON", { provider: this.provider });
     }
   }
 
-  parse(payload: unknown): MuralWebhookEvent {
-    return RAMP_PROVIDER_CLIENTS.mural.parseMuralWebhookEvent(payload);
+  parse(payload: unknown): MuralProcessorEvent {
+    const event = RAMP_PROVIDER_CLIENTS.mural.parseMuralWebhookEvent(payload);
+    if (event.kind !== "account_credited") {
+      return event;
+    }
+    const deliveryId =
+      payload && typeof payload === "object" && !Array.isArray(payload)
+        ? (payload as Record<string, unknown>)[MURAL_DELIVERY_ID_FIELD]
+        : undefined;
+    if (typeof deliveryId !== "string" || deliveryId.length === 0) {
+      throw badRequest("Mural webhook is missing its verified delivery id", { provider: "mural" });
+    }
+    return { ...event, deliveryId };
   }
 
   async process(
     c: AppContext,
     _environment: SdpEnvironment,
-    event: MuralWebhookEvent
+    event: MuralProcessorEvent
   ): Promise<void> {
     switch (event.kind) {
       case "ignore":
@@ -161,9 +240,17 @@ export class MuralWebhookProcessor implements WebhookProcessor<unknown, MuralWeb
       case "account_credited":
         return handleAccountCredited(c, event);
       case "payout_settled":
+        return applyRampSettlementEvent(c, {
+          provider: "mural",
+          kind: "settled",
+          reference: event.payoutRequestId,
+        });
       case "payout_failed":
-        getLogger().info(`[mural webhook] ignored unimplemented payout event: ${event.kind}`);
-        return;
+        return applyRampSettlementEvent(c, {
+          provider: "mural",
+          kind: "failed",
+          reference: event.payoutRequestId,
+        });
     }
   }
 }

--- a/apps/sdp-api/src/routes/webhooks/ramps/mural.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/mural.ts
@@ -39,11 +39,6 @@ function readMuralData(transfer: PaymentTransferRow): Record<string, unknown> {
   return mural as Record<string, unknown>;
 }
 
-function readMuralAccountId(transfer: PaymentTransferRow): string | undefined {
-  const accountId = readMuralData(transfer).accountId;
-  return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
-}
-
 function readMuralWebhookPublicKey(
   env: Record<string, string | undefined>,
   environment: SdpEnvironment
@@ -63,26 +58,51 @@ function readMuralWebhookPublicKey(
 }
 
 async function findMuralOnrampTransfer(
+  c: AppContext,
   payments: PaymentsRepository,
   counterparty: CounterpartyRow,
   accountId: string,
   statuses: PaymentTransferStatus[]
 ): Promise<PaymentTransferRow | undefined> {
-  const { rows } = await payments.listTransfers({
-    organizationId: counterparty.organization_id,
-    projectId: counterparty.project_id,
-    counterpartyId: counterparty.id,
-    types: ["onramp"],
-    statuses,
-    provider: "mural",
-    limit: 100,
-    offset: 0,
-  });
-  const matches = rows.filter((row) => readMuralAccountId(row) === accountId);
+  const matches = await getDb(c.env)
+    .prepare(
+      `SELECT id
+       FROM payment_transfers
+       WHERE organization_id = ?
+         AND project_id IS NOT DISTINCT FROM ?
+         AND counterparty_id = ?
+         AND provider = 'mural'
+         AND type = 'onramp'
+         AND status = ANY(?)
+         AND provider_data->'mural'->>'accountId' = ?
+       ORDER BY id
+       LIMIT 2`
+    )
+    .bind(
+      counterparty.organization_id,
+      counterparty.project_id,
+      counterparty.id,
+      statuses,
+      accountId
+    )
+    .all<{ id: string }>();
   // Mural's account_credited event has no quote/transfer reference. Refuse to
   // guess when multiple live quotes share an account; a single signed event
   // must never settle more than one transfer through replay or ordering.
-  return matches.length === 1 && rows.length < 100 ? matches[0] : undefined;
+  if (matches.results.length !== 1) {
+    return undefined;
+  }
+  const match = matches.results[0];
+  if (!match) {
+    return undefined;
+  }
+  return (
+    (await payments.getTransferById({
+      transferId: match.id,
+      organizationId: counterparty.organization_id,
+      projectId: counterparty.project_id,
+    })) ?? undefined
+  );
 }
 
 async function handleAccountCredited(
@@ -118,7 +138,7 @@ async function handleAccountCredited(
   if (replay) {
     return;
   }
-  const transfer = await findMuralOnrampTransfer(payments, counterparty, event.accountId, [
+  const transfer = await findMuralOnrampTransfer(c, payments, counterparty, event.accountId, [
     "awaiting_payment",
   ]);
   if (!transfer) {

--- a/apps/sdp-api/src/routes/webhooks/ramps/settlements.test.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/settlements.test.ts
@@ -1,0 +1,172 @@
+import type { RampSettlementEvent } from "@sdp/payments/ramps";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { env } from "@/test/helpers/env";
+import { clearTestDatabase, seedTestDatabase } from "@/test/mocks/db";
+import type { AppContext } from "./processor";
+import { applyRampSettlementEvent } from "./settlements";
+
+const ORG_ID = "org_ramp_settlement_test";
+const PROJECT_ID = "prj_ramp_settlement_test";
+const USER_ID = "usr_ramp_settlement_test";
+
+function context(): AppContext {
+  return { env } as unknown as AppContext;
+}
+
+async function seedTransfer(input: {
+  id: string;
+  reference: string;
+  status: string;
+  type?: "onramp" | "offramp" | "transfer";
+}) {
+  const type = input.type ?? "onramp";
+  await getDb(env)
+    .prepare(
+      `INSERT INTO payment_transfers (
+         id, organization_id, project_id, wallet_id, source_address, destination_address,
+         token, amount, memo, type, direction, status, provider, provider_reference,
+         delivery_mode, fiat_currency, fiat_amount, provider_data, signature, serialized_tx,
+         initiated_by_key_id, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      input.id,
+      ORG_ID,
+      PROJECT_ID,
+      "wallet_ramp_settlement_test",
+      type === "offramp" ? "source" : null,
+      type === "onramp" ? "destination" : "destination",
+      "USDC",
+      "10",
+      null,
+      type,
+      type === "onramp" ? "inbound" : "outbound",
+      input.status,
+      "coinbase",
+      input.reference,
+      "hosted",
+      "USD",
+      "10",
+      {},
+      null,
+      null,
+      null,
+      "2026-08-04T00:00:00.000Z",
+      "2026-08-04T00:00:00.000Z"
+    )
+    .run();
+}
+
+async function readTransfer(id: string) {
+  return getDb(env)
+    .prepare(
+      "SELECT status, amount, fiat_amount, error, provider_data FROM payment_transfers WHERE id = ?"
+    )
+    .bind(id)
+    .first<{
+      status: string;
+      amount: string | null;
+      fiat_amount: string | null;
+      error: string | null;
+      provider_data: Record<string, unknown>;
+    }>();
+}
+
+describe("applyRampSettlementEvent", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    await getDb(env).batch([
+      getDb(env)
+        .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+        .bind(ORG_ID, "Ramp Settlement Test", "ramp-settlement-test", "enterprise", "active"),
+      getDb(env)
+        .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+        .bind(USER_ID, "ramp-settlement@example.com", 1, "active"),
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          PROJECT_ID,
+          ORG_ID,
+          "Ramp Settlement Project",
+          "ramp-settlement-project",
+          "sandbox",
+          "active",
+          USER_ID
+        ),
+    ]);
+  });
+
+  afterEach(async () => {
+    await clearTestDatabase(env);
+  });
+
+  it("never reopens a canceled transfer", async () => {
+    await seedTransfer({ id: "xfr_canceled", reference: "order_canceled", status: "canceled" });
+
+    await applyRampSettlementEvent(context(), {
+      provider: "coinbase",
+      kind: "settled",
+      reference: "order_canceled",
+      receivedAmount: "12",
+    });
+
+    expect(await readTransfer("xfr_canceled")).toMatchObject({
+      status: "canceled",
+      amount: "10",
+    });
+  });
+
+  it("does not regress a settling transfer on an out-of-order event", async () => {
+    await seedTransfer({ id: "xfr_settling", reference: "order_settling", status: "settling" });
+
+    await applyRampSettlementEvent(context(), {
+      provider: "coinbase",
+      kind: "awaiting_payment",
+      reference: "order_settling",
+    });
+
+    expect(await readTransfer("xfr_settling")).toMatchObject({ status: "settling" });
+  });
+
+  it("serializes concurrent terminal events", async () => {
+    await seedTransfer({ id: "xfr_race", reference: "order_race", status: "settling" });
+    const events: RampSettlementEvent[] = [
+      { provider: "coinbase", kind: "settled", reference: "order_race", receivedAmount: "9" },
+      { provider: "coinbase", kind: "failed", reference: "order_race", error: "declined" },
+    ];
+
+    await Promise.all(events.map((event) => applyRampSettlementEvent(context(), event)));
+
+    const transfer = await readTransfer("xfr_race");
+    expect(["completed", "failed"]).toContain(transfer?.status);
+    if (transfer?.status === "completed") {
+      expect(transfer.amount).toBe("9");
+      expect(transfer.error).toBeNull();
+    } else {
+      expect(transfer?.amount).toBe("10");
+      expect(transfer?.error).toBe("declined");
+    }
+  });
+
+  it("makes exact retries idempotent", async () => {
+    await seedTransfer({ id: "xfr_retry", reference: "order_retry", status: "settling" });
+    const event: RampSettlementEvent = {
+      provider: "coinbase",
+      kind: "settled",
+      reference: "order_retry",
+      receivedAmount: "9",
+    };
+
+    await applyRampSettlementEvent(context(), event);
+    await applyRampSettlementEvent(context(), { ...event, receivedAmount: "999" });
+
+    expect(await readTransfer("xfr_retry")).toMatchObject({
+      status: "completed",
+      amount: "9",
+    });
+  });
+});

--- a/apps/sdp-api/src/routes/webhooks/ramps/settlements.ts
+++ b/apps/sdp-api/src/routes/webhooks/ramps/settlements.ts
@@ -1,6 +1,6 @@
 import type { RampSettlementEvent } from "@sdp/payments/ramps";
 import type { Context } from "hono";
-import type { PaymentTransferStatus, UpdatePaymentTransferInput } from "@/db/repositories";
+import type { PaymentTransferStatus } from "@/db/repositories";
 import { createSystemPaymentsRepository, isRampTransferType } from "@/db/repositories";
 import type { Env } from "@/types/env";
 
@@ -18,7 +18,19 @@ const TERMINAL_RAMP_TRANSFER_STATUSES = [
   "completed",
   "failed",
   "expired",
+  "canceled",
 ] as const satisfies readonly PaymentTransferStatus[];
+
+const ALLOWED_RAMP_SETTLEMENT_SOURCE_STATUSES = {
+  awaiting_payment: ["pending"],
+  settling: ["pending", "awaiting_payment"],
+  settled: ["pending", "awaiting_payment", "settling"],
+  failed: ["pending", "awaiting_payment", "settling"],
+  expired: ["pending", "awaiting_payment", "settling"],
+} as const satisfies Record<
+  Exclude<RampSettlementEvent["kind"], "ignore">,
+  readonly PaymentTransferStatus[]
+>;
 
 function isTerminalRampTransferStatus(status: PaymentTransferStatus): boolean {
   return (TERMINAL_RAMP_TRANSFER_STATUSES as readonly PaymentTransferStatus[]).includes(status);
@@ -46,9 +58,12 @@ export async function applyRampSettlementEvent(c: AppContext, event: RampSettlem
     return;
   }
 
-  const update: UpdatePaymentTransferInput = {
+  const update: Parameters<typeof repo.updateTransferStatusGuarded>[0] = {
     transferId: transfer.id,
-    status: RAMP_SETTLEMENT_STATUS[event.kind],
+    organizationId: transfer.organization_id,
+    projectId: transfer.project_id,
+    fromStatuses: ALLOWED_RAMP_SETTLEMENT_SOURCE_STATUSES[event.kind],
+    toStatus: RAMP_SETTLEMENT_STATUS[event.kind],
     updatedAt: new Date().toISOString(),
   };
   // Record the actual settled amount the provider reports: the fiat payout for
@@ -72,5 +87,5 @@ export async function applyRampSettlementEvent(c: AppContext, event: RampSettlem
     update.providerData = { settlement: event.settlement };
   }
 
-  await repo.updateTransfer(update);
+  await repo.updateTransferStatusGuarded(update);
 }

--- a/packages/sdp-payments/src/ramps/providers/mural/client.ts
+++ b/packages/sdp-payments/src/ramps/providers/mural/client.ts
@@ -435,7 +435,7 @@ function parseMuralWebhookEvent(payload: unknown): MuralWebhookEvent {
       const tokenAmountRecord = readRecord(body.tokenAmount);
       const tokenAmount =
         tokenAmountRecord === undefined ? undefined : readNumber(tokenAmountRecord.tokenAmount);
-      if (!accountId || tokenAmount === undefined) {
+      if (!accountId || tokenAmount === undefined || tokenAmount <= 0) {
         throw badRequest('Mural "account_credited" webhook is missing accountId or tokenAmount', {
           provider: "mural",
         });

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -975,10 +975,8 @@ export type RampEventProvider = (typeof RAMP_EVENT_PROVIDERS)[number];
 /**
  * Coinbase headless on-ramp events, forwarded from the payment-link iframe's
  * postMessage stream (`onramp_api.*`). `orderId` is the create-order id used as
- * the transfer's provider reference. Client events are provisional and only
- * advance the transfer to non-terminal states; the server-side webhook is the
- * settlement authority — it alone completes the transfer, carrying the actual
- * delivered crypto amount, which a client-set terminal status would block.
+ * the transfer's provider reference. Client events are advisory telemetry only;
+ * the signature-verified server-side webhook is the sole settlement authority.
  */
 export type CoinbaseRampEvent =
   | { kind: "committed"; orderId: string }


### PR DESCRIPTION
## Summary

- make signature-verified provider webhooks the sole terminal settlement authority
- serialize ramp state changes with tenant-scoped guarded updates and immutable terminal states
- bind MoneyGram, BVNK, and Mural events to exact wallet, amount, account, provider, and provider references
- reject ambiguous provider/customer matches and consume Mural signed deliveries once
- process Mural payout outcomes through the shared guarded settlement contract

## Security invariants

- browser/widget callbacks are advisory and cannot complete, fail, expire, or reopen transfers
- canceled and terminal transfers never regress
- concurrent terminal events produce one coherent final state
- ambiguous, replayed, cross-tenant, out-of-order, and mismatched crypto-leg events fail closed

## Validation

- `pnpm lint` (passes; existing warnings only)
- `pnpm typecheck`
- `pnpm check:module-boundaries`
- `pnpm --filter @sdp/api typecheck`
- `pnpm --filter @sdp/api test` — 1,936 passed, 14 skipped
- focused ramp settlement, replay, ambiguity, and client-forgery regressions passed
- fresh Postgres test database migration through `0047_ramp_settlement_integrity.sql`

## QA

Change-specific local API coverage verifies forged client terminal claims remain advisory, MoneyGram crypto-leg amount binding, Mural signed-delivery replay and ambiguity handling, canceled/out-of-order transitions, concurrent terminal events, and BVNK ambiguity refusal.

Smoky QA is intentionally pending: this commit is not deployed to the smoky environment yet, so no deployed claim is made.

Closes HOO-1016
