### PR TITLE
fix(security): close product alert backlog

### DIFF
--- a/apps/sdp-docs/scripts/generate-api-docs.mjs
+++ b/apps/sdp-docs/scripts/generate-api-docs.mjs
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { escapeMarkdownTableCell } from "./lib/markdown-escaping.mjs";
 import {
   getPrimaryTagName,
   isPublicTag,
@@ -18,10 +19,8 @@ const rootMetaPath = path.resolve(__dirname, "../content/docs/meta.json");
 
 const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "options"]);
 const SOURCE_PATH = "apps/sdp-api/generated/openapi.json";
-const escapeTableText = (value) => value.replace(/\|/g, "\\|");
-
 const renderOperationRow = (operation) =>
-  `| \`${operation.method}\` | \`${operation.path}\` | ${escapeTableText(operation.summary || "-")} |`;
+  `| \`${operation.method}\` | \`${operation.path}\` | ${escapeMarkdownTableCell(operation.summary || "-")} |`;
 
 const parseJsonSpec = (spec) => {
   const tagDescriptions = new Map();

--- a/apps/sdp-docs/scripts/lib/markdown-escaping.mjs
+++ b/apps/sdp-docs/scripts/lib/markdown-escaping.mjs
@@ -1,0 +1,6 @@
+export function escapeMarkdownTableCell(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/\r\n?|\n/g, " ")
+    .replace(/\|/g, "\\|");
+}

--- a/apps/sdp-web/src/lib/playground-api-keys.ts
+++ b/apps/sdp-web/src/lib/playground-api-keys.ts
@@ -1,44 +1,7 @@
 "use client";
 
-const STORAGE_KEY = "sdp.playground.api-keys.v1";
-
-interface StoredApiKeys {
-  byId: Record<string, string>;
-  byPrefix: Record<string, string>;
-}
-
-function getEmptyStore(): StoredApiKeys {
-  return { byId: {}, byPrefix: {} };
-}
-
-function readStore(): StoredApiKeys {
-  if (typeof window === "undefined") {
-    return getEmptyStore();
-  }
-
-  const raw = window.sessionStorage.getItem(STORAGE_KEY);
-  if (!raw) {
-    return getEmptyStore();
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as StoredApiKeys;
-    return {
-      byId: parsed.byId ?? {},
-      byPrefix: parsed.byPrefix ?? {},
-    };
-  } catch {
-    return getEmptyStore();
-  }
-}
-
-function writeStore(store: StoredApiKeys) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-}
+const apiKeysById = new Map<string, string>();
+const apiKeysByPrefix = new Map<string, string>();
 
 export function normalizeApiKeyInput(rawValue: string): string {
   const trimmed = rawValue.trim();
@@ -58,36 +21,36 @@ export function storeApiKeySecret(params: {
     return;
   }
 
-  const store = readStore();
   if (params.apiKeyId) {
-    store.byId[params.apiKeyId] = normalized;
+    apiKeysById.set(params.apiKeyId, normalized);
   }
   if (params.keyPrefix) {
-    store.byPrefix[params.keyPrefix] = normalized;
+    apiKeysByPrefix.set(params.keyPrefix, normalized);
   }
-
-  writeStore(store);
 }
 
 export function getStoredApiKeySecret(params: {
   apiKeyId?: string | null;
   keyPrefix?: string | null;
 }): string | null {
-  const store = readStore();
-
   if (params.apiKeyId) {
-    const byId = store.byId[params.apiKeyId];
+    const byId = apiKeysById.get(params.apiKeyId);
     if (byId) {
       return byId;
     }
   }
 
   if (params.keyPrefix) {
-    const byPrefix = store.byPrefix[params.keyPrefix];
+    const byPrefix = apiKeysByPrefix.get(params.keyPrefix);
     if (byPrefix) {
       return byPrefix;
     }
   }
 
   return null;
+}
+
+export function clearStoredApiKeySecrets(): void {
+  apiKeysById.clear();
+  apiKeysByPrefix.clear();
 }

--- a/apps/sdp-web/src/lib/playground-api-keys.unit.test.ts
+++ b/apps/sdp-web/src/lib/playground-api-keys.unit.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStoredApiKeySecrets,
+  getStoredApiKeySecret,
+  normalizeApiKeyInput,
+  storeApiKeySecret,
+} from "./playground-api-keys";
+
+describe("playground API key secrets", () => {
+  beforeEach(() => {
+    clearStoredApiKeySecrets();
+  });
+
+  it("keeps generated secrets only in memory", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+    storeApiKeySecret({
+      value: "Bearer sk_sdp_generated",
+      apiKeyId: "key-1",
+      keyPrefix: "sk_sdp_",
+    });
+
+    expect(getStoredApiKeySecret({ apiKeyId: "key-1" })).toBe("sk_sdp_generated");
+    expect(getStoredApiKeySecret({ keyPrefix: "sk_sdp_" })).toBe("sk_sdp_generated");
+    expect(getItem).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("does not retain empty values and can clear all secrets", () => {
+    storeApiKeySecret({ value: "   ", apiKeyId: "empty" });
+    expect(getStoredApiKeySecret({ apiKeyId: "empty" })).toBeNull();
+
+    storeApiKeySecret({ value: "secret", apiKeyId: "key-2" });
+    clearStoredApiKeySecrets();
+    expect(getStoredApiKeySecret({ apiKeyId: "key-2" })).toBeNull();
+  });
+
+  it("normalizes pasted bearer credentials", () => {
+    expect(normalizeApiKeyInput("  Bearer sk_sdp_example  ")).toBe("sk_sdp_example");
+  });
+});

--- a/docs/security/codeql-secret-alert-triage-2026-08-04.md
+++ b/docs/security/codeql-secret-alert-triage-2026-08-04.md
@@ -1,0 +1,30 @@
+# CodeQL and secret-scanning triage — 2026-08-04
+
+Owner: `@solana-foundation/sdp-maintainers`
+
+Scope: GitHub security alerts open on `main` at `21b0253b`. This record deliberately excludes secret values.
+
+## CodeQL
+
+| Alert | Severity | Surface | Disposition and evidence |
+| --- | --- | --- | --- |
+| [#35](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/35) | High | Generated API docs | Fix in HOO-989. Markdown table content now escapes existing backslashes before delimiters and collapses line breaks; regression tests cover both bypasses. |
+| [#39](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/39) | High | Dashboard API playground | Fix in HOO-989. Generated API-key secrets are memory-only and are never written to Web Storage; regression tests spy on both Web Storage methods. |
+| [#44](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/44), [#45](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/45) | Medium | Clerk organization service | Dismiss as false positive. The reported source is an operator-owned local environment file and the outbound request intentionally sends the configured Clerk credential to the operator-configured Clerk API. No request-controlled value selects the credential or destination. |
+| [#46](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/46) | Medium | Playwright Clerk setup | Dismiss as test-only false positive. The helper sends the E2E Clerk credential only to the constant `https://api.clerk.com/v1` origin. |
+| [#47](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/47) | Medium | Local dashboard bootstrap | Dismiss as test-only false positive. The test runner intentionally reads its RPC target from operator-controlled local or CI configuration; no product request can select it. |
+| [#48](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/48) | Medium | Solana RPC health probe | Dismiss as false positive. The test harness intentionally probes provider URLs from operator-controlled test configuration; the values do not originate from an HTTP request. |
+| [#73](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/73) | Medium | Issuance E2E fixtures | Dismiss as test-only false positive. API response data is intentionally serialized to a constant repository fixture path; response data cannot influence the path. |
+| [#106](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/106), [#107](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/107) | Medium | Release workflow | Dismiss as false positive. The protected release job intentionally reads the repository manifest and calls the fixed GitHub API with its workflow token; no product request reaches this path. |
+| [#119](https://github.com/solana-foundation/solana-developer-platform/security/code-scanning/119) | Medium | Local API Playwright client | Dismiss as test-only false positive. The E2E API target is supplied by trusted local or CI configuration and is not reachable from product input. |
+
+## Secret scanning
+
+| Alerts | Provider validity | Disposition and evidence |
+| --- | --- | --- |
+| [#1](https://github.com/solana-foundation/solana-developer-platform/security/secret-scanning/1), [#2](https://github.com/solana-foundation/solana-developer-platform/security/secret-scanning/2), [#3](https://github.com/solana-foundation/solana-developer-platform/security/secret-scanning/3), [#4](https://github.com/solana-foundation/solana-developer-platform/security/secret-scanning/4) | Inactive | Resolve as revoked. GitHub provider checks report every historical credential inactive; none exists on the current tree. |
+| [#5](https://github.com/solana-foundation/solana-developer-platform/security/secret-scanning/5) | Not provider-verifiable | Resolve as a non-production example. The only location is an OpenAPI webhook example in a retired source file; it is not a deployed credential and is absent from the current tree. |
+
+## Follow-up rule
+
+New High alerts block release. Medium alerts require an owner and evidence-backed fix or dismissal; test and automation findings must be re-opened if their inputs become reachable from product requests or an untrusted repository context.

--- a/scripts/markdown-escaping.test.mjs
+++ b/scripts/markdown-escaping.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { escapeMarkdownTableCell } from "../apps/sdp-docs/scripts/lib/markdown-escaping.mjs";
+
+test("escapes backslashes before markdown table delimiters", () => {
+  assert.equal(escapeMarkdownTableCell("allow \\| deny | audit"), "allow \\\\\\| deny \\| audit");
+});
+
+test("keeps generated table content on one row", () => {
+  assert.equal(escapeMarkdownTableCell("first\r\nsecond\nthird"), "first second third");
+});


### PR DESCRIPTION
## Summary

- keep generated playground API keys in memory instead of browser storage
- harden generated API-doc table escaping against backslash and newline bypasses
- record owners, evidence, and dispositions for the complete CodeQL and historical secret-scanning backlog

## Security behavior

- raw API keys disappear on reload and never enter Web Storage
- generated OpenAPI summaries cannot escape their Markdown table row
- high alerts are remediated; medium findings and historical secrets have evidence-backed closure dispositions

## Validation

- `pnpm --filter sdp-web test:unit` (97 files, 666 tests)
- `pnpm test:scripts` (54 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:module-boundaries`
- `pnpm --filter sdp-docs check:links`
- `pnpm --filter sdp-docs build`

Note: the package-local web ESLint command currently crashes in the existing ESLint 10 / react-plugin compatibility path; repository Biome lint is green with pre-existing warnings.

Linear: https://linear.app/solana-fndn/issue/HOO-989/close-the-sdp-codeql-and-secret-scanning-backlog