### PR TITLE
fix(web): align wallet card skeleton button margin and update policy e2e flow

### DIFF
--- a/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/wallets.e2e.spec.ts
@@ -389,9 +389,6 @@ test.describe
       const drawer = page.getByRole("dialog", { name: "Revision history" });
 
       await page.goto(policyHref, { waitUntil: "domcontentloaded" });
-      await expect(page.locator(`a[href="${auditHref}"]`)).toBeVisible({
-        timeout: E2E_POLL_TIMEOUT_MS,
-      });
       await expect(revisionTrigger).toBeVisible({ timeout: E2E_POLL_TIMEOUT_MS });
 
       await revisionTrigger.click();
@@ -408,6 +405,10 @@ test.describe
       await page.keyboard.press("Escape");
       await expect(drawer).toBeHidden({ timeout: E2E_POLL_TIMEOUT_MS });
 
+      await page.goto(walletHref, { waitUntil: "domcontentloaded" });
+      await expect(page.locator(`a[href="${auditHref}"]`)).toBeVisible({
+        timeout: E2E_POLL_TIMEOUT_MS,
+      });
       await page.locator(`a[href="${auditHref}"]`).click();
       await expect(page).toHaveURL(new RegExp(`${auditHref.replaceAll("/", "\\/")}$`));
       await expect(page.getByRole("button", { name: "Revision history" })).toBeVisible({

--- a/apps/sdp-web/src/app/dashboard/wallets/wallet-route-skeletons.tsx
+++ b/apps/sdp-web/src/app/dashboard/wallets/wallet-route-skeletons.tsx
@@ -60,7 +60,9 @@ function WalletCardSkeleton() {
           </div>
         ))}
       </div>
-      <Pulse className="mt-auto h-11 w-full rounded-[10px]" />
+      <div className="mt-auto pt-3">
+        <Pulse className="h-11 w-full rounded-[10px]" />
+      </div>
     </article>
   );
 }


### PR DESCRIPTION
- Wallet card skeleton: Manage-button pulse wrapped in the real card's `mt-auto pt-3` so it keeps its gap above
- wallets e2e: policy page now only asserts the Revision history trigger; the Policy audit link is asserted and followed from the wallet detail panel (follow-up to #1115, pushed after it merged)