### PR TITLE
feat(policy): revision message placeholder, history revalidation, secondary wallet actions

### DIFF
--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -98,6 +98,9 @@ const walletControlProfileSummarySchema = z
     revisionNumber: z.number().int().nullable().openapi({
       description: "Returned immutable revision number.",
     }),
+    commitMessage: z.string().nullable().openapi({
+      description: "Message describing the returned revision's changes, when provided.",
+    }),
     defaultAction: z.enum(["allow", "deny", "approval_required", "review"]).openapi({
       description: "Decision used when no rule matches.",
     }),

--- a/apps/sdp-api/src/routes/payments.test.ts
+++ b/apps/sdp-api/src/routes/payments.test.ts
@@ -6149,6 +6149,7 @@ describe("Payments routes", () => {
     expect(updateBody.data.policy.controlProfile).toMatchObject({
       status: "active",
       revisionNumber: 1,
+      commitMessage: "Restrict raw signing and large transfers.",
       providerMappingStatus: "not_applicable",
     });
 

--- a/apps/sdp-api/src/routes/payments/handlers/balances.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/balances.ts
@@ -47,6 +47,7 @@ function mapWalletControlProfileSummary(
     activeRevisionId: active.profile.active_revision_id,
     revisionId: active.revision?.id ?? null,
     revisionNumber: active.revision?.revision_number ?? null,
+    commitMessage: active.revision === null ? null : active.revision.commit_message,
     defaultAction: active.revision?.default_action ?? "allow",
     rules: (active.revision?.rules ?? []) as unknown as PolicyRule[],
     providerMappingStatus: "not_applicable",

--- a/apps/sdp-web/messages/en/dashboard-custody.json
+++ b/apps/sdp-web/messages/en/dashboard-custody.json
@@ -632,6 +632,7 @@
     "policyAuditViewApprovalRequest": "Approval request",
     "policyAuditUnavailableTitle": "Policy history unavailable",
     "policyAuditUnavailableDescription": "Wallet policy history could not be loaded right now.",
+    "policyRevisionsNoMessage": "No revision message",
     "policyRevisionsEmpty": "No policy revisions yet",
     "policyRevisionsEmptyDescription": "A revision will appear after wallet controls are saved.",
     "policyRevisionsChanges": "Changes",

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/page.tsx
@@ -642,21 +642,13 @@ async function WalletControlsPanel({
           )}
         </div>
         <div className="flex w-full shrink-0 flex-col gap-2 sm:w-auto sm:flex-row">
-          <Button
-            asChild
-            variant={hasRestrictions ? "secondary" : "default"}
-            className="w-full sm:w-auto"
-          >
+          <Button asChild variant="secondary" className="w-full sm:w-auto">
             <Link href={`${policyHref}/audit`}>
               <ListChecks className="size-4" />
               {t("DashboardCustody.policyAuditTitle")}
             </Link>
           </Button>
-          <Button
-            asChild
-            variant={hasRestrictions ? "secondary" : "default"}
-            className="w-full sm:w-auto"
-          >
+          <Button asChild variant="secondary" className="w-full sm:w-auto">
             <Link href={policyHref}>
               <SlidersHorizontal className="size-4" />
               {hasRestrictions

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/policy-revision-explorer.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/policy-revision-explorer.tsx
@@ -145,7 +145,11 @@ export function PolicyRevisionExplorer({
                       <p className="min-w-0 break-words text-sm text-secondary">
                         {revision.commitMessage}
                       </p>
-                    ) : null}
+                    ) : (
+                      <p className="text-sm italic text-tertiary">
+                        {t("DashboardCustody.policyRevisionsNoMessage")}
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/policy-revision-explorer.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/policy-revision-explorer.unit.test.tsx
@@ -113,11 +113,11 @@ describe("policy revision explorer", () => {
     expect(html).toContain("Draft");
   });
 
-  it("shows commit messages without rendering a placeholder for revisions without one", () => {
+  it("shows commit messages and an italic placeholder for revisions without one", () => {
     const html = renderExplorer();
 
     expect(html).toContain("Restrict assets and blocked destinations.");
-    expect(html).not.toContain("No revision message");
+    expect(html).toContain("No revision message");
   });
 
   it("links destinations to the active project cluster on Solana Explorer", () => {

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/revision-history-drawer.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/revision-history-drawer.tsx
@@ -19,6 +19,17 @@ import { PolicyRevisionExplorer } from "./policy-revision-explorer";
 import { fetchWalletRevisionHistoryAction } from "./revision-history.actions";
 
 /**
+ * SWR cache key for a wallet's policy revision history; mutate it after a
+ * revision is created so the drawer refetches on next open.
+ *
+ * @param walletId - The wallet whose history is cached.
+ * @returns The cache key.
+ */
+export function walletPolicyRevisionsKey(walletId: string): string {
+  return `wallet-policy-revisions-${walletId}`;
+}
+
+/**
  * "Revision history" trigger that opens the revision explorer in a right-side
  * drawer instead of navigating to the full revisions page. History loads
  * lazily on first open so the trigger costs nothing on pages that never use
@@ -96,7 +107,7 @@ export function RevisionHistoryDrawer({
     initialRevisionId && initialRevisionId !== "latest" ? initialRevisionId : defaultRevisionId
   );
   const { data } = useSWR(
-    open && !preloaded ? `wallet-policy-revisions-${walletId}` : null,
+    open && !preloaded ? walletPolicyRevisionsKey(walletId) : null,
     () => fetchWalletRevisionHistoryAction(walletId),
     { revalidateOnFocus: false, revalidateIfStale: false, revalidateOnReconnect: false }
   );

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { mutate } from "swr";
 import { updateWalletPolicy } from "@/app/dashboard/payments/payments-workspace.data";
 import { Button } from "@/components/ui/button";
 import {
@@ -26,7 +27,7 @@ import type { IssuedPolicyToken } from "./policy-assets.data";
 import { PolicyCommitDrawer } from "./policy-commit-drawer";
 import { PolicySummaryRail } from "./policy-summary-rail";
 import { ReviewStep } from "./review-step";
-import { RevisionHistoryDrawer } from "./revision-history-drawer";
+import { RevisionHistoryDrawer, walletPolicyRevisionsKey } from "./revision-history-drawer";
 import {
   buildDisabledPolicyPayload,
   buildPolicyAssetOptions,
@@ -235,6 +236,7 @@ export function WalletPolicyStartingProfileFlow({
       setState(returnedState);
       setCommitMessage("");
       setReviewDrawerOpen(false);
+      void mutate(walletPolicyRevisionsKey(wallet.walletId), undefined);
       setActiveFingerprint(policyStateFingerprint(wallet.walletId, returnedState));
       clearPolicyDraft(window.localStorage, projectId, wallet.walletId);
       toast.success(t("DashboardCustody.policyActive"), {

--- a/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
+++ b/apps/sdp-web/src/app/dashboard/custody/[walletId]/policy/wallet-policy-starting-profile-flow.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { mutate } from "swr";
+import { useSWRConfig } from "swr";
 import { updateWalletPolicy } from "@/app/dashboard/payments/payments-workspace.data";
 import { Button } from "@/components/ui/button";
 import {
@@ -75,6 +75,7 @@ export function WalletPolicyStartingProfileFlow({
   initialRevisionId,
 }: WalletPolicyStartingProfileFlowProps) {
   const t = useTranslations();
+  const { mutate } = useSWRConfig();
   const router = useDashboardRouter();
   const pathname = usePathname();
   const { sdpEnvironment } = useDashboardWorkspace();
@@ -236,7 +237,7 @@ export function WalletPolicyStartingProfileFlow({
       setState(returnedState);
       setCommitMessage("");
       setReviewDrawerOpen(false);
-      void mutate(walletPolicyRevisionsKey(wallet.walletId), undefined);
+      void mutate(walletPolicyRevisionsKey(wallet.walletId), undefined, { revalidate: false });
       setActiveFingerprint(policyStateFingerprint(wallet.walletId, returnedState));
       clearPolicyDraft(window.localStorage, projectId, wallet.walletId);
       toast.success(t("DashboardCustody.policyActive"), {
@@ -363,7 +364,7 @@ export function WalletPolicyStartingProfileFlow({
                     type="button"
                     variant="secondary"
                     onClick={() => persistDraft(true)}
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || !isDirty}
                   >
                     {t("DashboardCustody.policySaveDraft")}
                   </Button>

--- a/packages/sdp-types/src/payments.ts
+++ b/packages/sdp-types/src/payments.ts
@@ -58,6 +58,7 @@ export interface PaymentWalletControlProfileSummary {
   activeRevisionId: string | null;
   revisionId: string | null;
   revisionNumber: number | null;
+  commitMessage: string | null;
   defaultAction: PolicyDefaultAction;
   rules: PolicyRule[];
   providerMappingStatus: PolicyProviderSyncStatus;


### PR DESCRIPTION
- revision rows show an italic "No revision message" placeholder when a revision has no commit message
- revision-history SWR cache clears after activating controls so the drawer refetches instead of serving a stale list
- extracted `walletPolicyRevisionsKey` so the flow and drawer share the cache key
- "Policy audit" and "Review controls" wallet actions are always `secondary` (previously primary when the wallet had no restrictions)

Follow-ups from PRO-1625 (#1156)

Update should revalidate revision history
<img width="3832" height="1946" alt="CleanShot 2026-08-08 at 00 29 47@2x" src="https://github.com/user-attachments/assets/57925db7-5c4f-4060-be63-62bc76f1abb9" />
