### PR TITLE
fix(sdp-api): normalize API-key wallet-policy bindings onto custody_wallet_id

### DIFF
--- a/apps/sdp-api/src/db/migrations/api-key-policy-binding-custody-identity.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/api-key-policy-binding-custody-identity.migration.test.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { expect, it } from "vitest";
+import { env } from "@/test/helpers/env";
+
+it("backfills only unambiguous in-scope custody wallet identities", async () => {
+  const migrationPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "postgres/0053_api_key_policy_binding_custody_identity.sql"
+  );
+  const sql = readFileSync(migrationPath, "utf8");
+  const client = new Client({ connectionString: env.DATABASE_URL });
+  await client.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(`CREATE TEMP TABLE api_keys (
+      id TEXT PRIMARY KEY,
+      organization_id TEXT NOT NULL,
+      project_id TEXT
+    )`);
+    await client.query(`CREATE TEMP TABLE custody_configs (
+      id TEXT PRIMARY KEY,
+      organization_id TEXT NOT NULL,
+      project_id TEXT,
+      status TEXT NOT NULL
+    )`);
+    await client.query(`CREATE TEMP TABLE custody_wallets (
+      id TEXT PRIMARY KEY,
+      custody_config_id TEXT NOT NULL,
+      wallet_id TEXT NOT NULL,
+      status TEXT NOT NULL
+    )`);
+    await client.query(`CREATE TEMP TABLE api_key_wallet_policy_bindings (
+      id TEXT PRIMARY KEY,
+      api_key_id TEXT NOT NULL,
+      binding_scope TEXT NOT NULL,
+      wallet_id TEXT,
+      custody_wallet_id TEXT,
+      CONSTRAINT api_key_wallet_policy_bindings_wallet_check CHECK (
+        (binding_scope = 'all' AND wallet_id IS NULL AND custody_wallet_id IS NULL)
+        OR (binding_scope = 'selected' AND wallet_id IS NOT NULL)
+      )
+    )`);
+    await client.query(`CREATE UNIQUE INDEX idx_api_key_wallet_policy_bindings_selected
+      ON api_key_wallet_policy_bindings(api_key_id, wallet_id)
+      WHERE binding_scope = 'selected'`);
+    await client.query(
+      `INSERT INTO api_keys (id, organization_id, project_id)
+       VALUES ($1, $2, $3)`,
+      ["key_project", "org_one", "project_one"]
+    );
+    await client.query(
+      `INSERT INTO custody_configs
+         (id, organization_id, project_id, status)
+       VALUES
+         ($1, $2, $3, $4),
+         ($5, $6, $7, $8),
+         ($9, $10, $11, $12),
+         ($13, $14, $15, $16)`,
+      [
+        "config_unique",
+        "org_one",
+        "project_one",
+        "active",
+        "config_ambiguous_one",
+        "org_one",
+        "project_one",
+        "active",
+        "config_ambiguous_two",
+        "org_one",
+        "project_one",
+        "active",
+        "config_foreign_project",
+        "org_one",
+        "project_two",
+        "active",
+      ]
+    );
+    await client.query(
+      `INSERT INTO custody_wallets
+         (id, custody_config_id, wallet_id, status)
+       VALUES
+         ($1, $2, $3, $4),
+         ($5, $6, $7, $8),
+         ($9, $10, $11, $12),
+         ($13, $14, $15, $16)`,
+      [
+        "custody_unique",
+        "config_unique",
+        "provider_unique",
+        "active",
+        "custody_unique_foreign",
+        "config_foreign_project",
+        "provider_unique",
+        "active",
+        "custody_ambiguous_one",
+        "config_ambiguous_one",
+        "provider_ambiguous",
+        "active",
+        "custody_ambiguous_two",
+        "config_ambiguous_two",
+        "provider_ambiguous",
+        "active",
+      ]
+    );
+    await client.query(
+      `INSERT INTO api_key_wallet_policy_bindings
+         (id, api_key_id, binding_scope, wallet_id, custody_wallet_id)
+       VALUES
+         ($1, $2, $3, $4, $5),
+         ($6, $7, $8, $9, $10),
+         ($11, $12, $13, $14, $15),
+         ($16, $17, $18, $19, $20)`,
+      [
+        "binding_all",
+        "key_project",
+        "all",
+        null,
+        null,
+        "binding_unique",
+        "key_project",
+        "selected",
+        "provider_unique",
+        null,
+        "binding_ambiguous",
+        "key_project",
+        "selected",
+        "provider_ambiguous",
+        null,
+        "binding_orphan",
+        "key_project",
+        "selected",
+        "provider_missing",
+        null,
+      ]
+    );
+
+    await client.query(sql);
+
+    const result = await client.query<{
+      id: string;
+      custody_wallet_id: string | null;
+    }>(`SELECT id, custody_wallet_id
+        FROM api_key_wallet_policy_bindings
+        ORDER BY id`);
+    expect(result.rows).toEqual([
+      { id: "binding_all", custody_wallet_id: null },
+      { id: "binding_unique", custody_wallet_id: "custody_unique" },
+    ]);
+    expect(sql).toMatch(
+      /OR\s+\(\s*binding_scope = 'selected'\s+AND wallet_id IS NOT NULL\s+AND custody_wallet_id IS NOT NULL\s*\)/
+    );
+    expect(sql).toMatch(
+      /ON api_key_wallet_policy_bindings\(api_key_id, custody_wallet_id\)\s+WHERE binding_scope = 'selected'/
+    );
+  } finally {
+    await client.query("ROLLBACK");
+    await client.end();
+  }
+});

--- a/apps/sdp-api/src/db/migrations/postgres/0053_api_key_policy_binding_custody_identity.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0053_api_key_policy_binding_custody_identity.sql
@@ -1,0 +1,61 @@
+WITH unique_wallet_matches AS (
+    SELECT
+        binding.id AS binding_id,
+        MIN(wallet.id) AS custody_wallet_id
+    FROM api_key_wallet_policy_bindings binding
+    JOIN api_keys api_key
+      ON api_key.id = binding.api_key_id
+    JOIN custody_configs config
+      ON config.organization_id = api_key.organization_id
+     AND (
+          config.project_id IS NULL
+          OR api_key.project_id IS NULL
+          OR config.project_id = api_key.project_id
+     )
+     AND config.status = 'active'
+    JOIN custody_wallets wallet
+      ON wallet.custody_config_id = config.id
+     AND wallet.wallet_id = binding.wallet_id
+     AND wallet.status = 'active'
+    WHERE binding.binding_scope = 'selected'
+      AND binding.custody_wallet_id IS NULL
+    GROUP BY binding.id
+    HAVING COUNT(*) = 1
+)
+UPDATE api_key_wallet_policy_bindings binding
+SET custody_wallet_id = unique_wallet_matches.custody_wallet_id
+FROM unique_wallet_matches
+WHERE binding.id = unique_wallet_matches.binding_id;
+
+DO $$
+DECLARE
+    deleted_binding_count BIGINT;
+BEGIN
+    DELETE FROM api_key_wallet_policy_bindings
+    WHERE binding_scope = 'selected'
+      AND custody_wallet_id IS NULL;
+
+    GET DIAGNOSTICS deleted_binding_count = ROW_COUNT;
+    RAISE NOTICE 'Deleted % unresolved selected API key wallet policy bindings', deleted_binding_count;
+END;
+$$;
+
+ALTER TABLE api_key_wallet_policy_bindings
+    DROP CONSTRAINT api_key_wallet_policy_bindings_wallet_check;
+
+ALTER TABLE api_key_wallet_policy_bindings
+    ADD CONSTRAINT api_key_wallet_policy_bindings_wallet_check
+    CHECK (
+        (binding_scope = 'all' AND wallet_id IS NULL AND custody_wallet_id IS NULL)
+        OR (
+            binding_scope = 'selected'
+            AND wallet_id IS NOT NULL
+            AND custody_wallet_id IS NOT NULL
+        )
+    );
+
+DROP INDEX idx_api_key_wallet_policy_bindings_selected;
+
+CREATE UNIQUE INDEX idx_api_key_wallet_policy_bindings_selected
+    ON api_key_wallet_policy_bindings(api_key_id, custody_wallet_id)
+    WHERE binding_scope = 'selected';

--- a/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.postgres.ts
@@ -166,7 +166,7 @@ api_key_binding_aggregates AS (
   SELECT
     b.api_key_id,
     BOOL_OR(b.binding_scope = 'all') AS has_all_scope,
-    COUNT(DISTINCT b.wallet_id) FILTER (WHERE b.binding_scope = 'selected') AS selected_wallet_count,
+    COUNT(DISTINCT b.custody_wallet_id) FILTER (WHERE b.binding_scope = 'selected') AS selected_wallet_count,
     COUNT(*) AS binding_count
   FROM api_key_wallet_policy_bindings b
   INNER JOIN api_key_targets target ON target.target_id = b.api_key_id
@@ -644,6 +644,10 @@ function validateApiKeyWalletPolicyBindingInput(input: UpsertApiKeyWalletPolicyB
     throw badRequest("walletId is required for selected API key wallet policy bindings");
   }
 
+  if (input.bindingScope === "selected" && !input.custodyWalletId) {
+    throw badRequest("custodyWalletId is required for selected API key wallet policy bindings");
+  }
+
   if (input.bindingScope === "all" && (input.walletId || input.custodyWalletId)) {
     throw badRequest("walletId and custodyWalletId must be omitted for all-wallet policy bindings");
   }
@@ -816,10 +820,12 @@ async function upsertApiKeyWalletPolicyBindingInternal(
   input: UpsertApiKeyWalletPolicyBindingInput
 ): Promise<ApiKeyWalletPolicyBindingRow | null> {
   const id = generateApiKeyWalletPolicyBindingId();
+  const walletId = input.bindingScope === "selected" ? input.walletId : null;
+  const custodyWalletId = input.bindingScope === "selected" ? input.custodyWalletId : null;
   const conflictTarget =
     input.bindingScope === "all"
       ? "(api_key_id) WHERE binding_scope = 'all'"
-      : "(api_key_id, wallet_id) WHERE binding_scope = 'selected'";
+      : "(api_key_id, custody_wallet_id) WHERE binding_scope = 'selected'";
 
   const row = await db
     .prepare(
@@ -844,8 +850,8 @@ async function upsertApiKeyWalletPolicyBindingInternal(
       id,
       input.apiKeyId,
       input.bindingScope,
-      input.walletId ?? null,
-      input.custodyWalletId ?? null,
+      walletId,
+      custodyWalletId,
       input.walletControlProfileId ?? null,
       input.apiKeyControlProfileId ?? null
     )
@@ -1786,10 +1792,10 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
       return rows.results;
     },
 
-    async getApiKeyWalletPolicyBindingResolution(apiKeyId: string, walletId: string) {
+    async getApiKeyWalletPolicyBindingResolution(apiKeyId: string, custodyWalletId: string) {
       if (
         !(await tenantOwnsRow(db, scope, "api_keys", apiKeyId)) ||
-        !(await tenantOwnsWallet(db, scope, walletId))
+        !(await tenantOwnsWallet(db, scope, custodyWalletId))
       ) {
         return {
           total_binding_count: 0,
@@ -1809,7 +1815,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
              WHERE api_key_id = ?
                AND (
                  binding_scope = 'all'
-                 OR (binding_scope = 'selected' AND wallet_id = ?)
+                 OR (binding_scope = 'selected' AND custody_wallet_id = ?)
                )
              ORDER BY
                CASE WHEN binding_scope = 'selected' THEN 0 ELSE 1 END,
@@ -1823,16 +1829,16 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
            FROM binding_count
            LEFT JOIN applicable ON TRUE`
         )
-        .bind(apiKeyId, apiKeyId, walletId)
+        .bind(apiKeyId, apiKeyId, custodyWalletId)
         .first<Record<string, unknown>>();
 
       return mapApiKeyWalletPolicyBindingResolutionRow(row);
     },
 
-    async getApiKeyWalletPolicyTarget(apiKeyId: string, walletId: string) {
+    async getApiKeyWalletPolicyTarget(apiKeyId: string, custodyWalletId: string) {
       if (
         !(await tenantOwnsRow(db, scope, "api_keys", apiKeyId)) ||
-        !(await tenantOwnsWallet(db, scope, walletId))
+        !(await tenantOwnsWallet(db, scope, custodyWalletId))
       ) {
         return null;
       }
@@ -1866,7 +1872,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
            JOIN custody_wallets w
              ON w.custody_config_id = c.id
             AND w.status = 'active'
-            AND w.wallet_id = ?
+            AND w.id = ?
            LEFT JOIN endpoint_scope es ON es.api_key_id = ak.id
            LEFT JOIN api_key_wallet_permissions perm
              ON perm.api_key_id = ak.id
@@ -1880,7 +1886,7 @@ export function createPostgresPolicyRepository(db: AppDb, scope: TenantScope): P
              w.created_at DESC
            LIMIT 1`
         )
-        .bind(apiKeyId, apiKeyId, walletId)
+        .bind(apiKeyId, apiKeyId, custodyWalletId)
         .first<Record<string, unknown>>();
 
       return row ? mapApiKeyWalletPolicyTargetRow(row) : null;

--- a/apps/sdp-api/src/db/repositories/policy.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.test.ts
@@ -53,6 +53,15 @@ const SECOND_CUSTODY_WALLET = {
   purpose: "payments",
 };
 
+const DUPLICATE_PROVIDER_CUSTODY_CONFIG_ID = "ccfg_policy_duplicate_provider_wallet";
+const DUPLICATE_PROVIDER_CUSTODY_WALLET = {
+  id: "cw_policy_duplicate_provider_wallet",
+  walletId: TEST_CUSTODY_WALLET.walletId,
+  publicKey: "DuplicateProviderPolicyWallet11111111111111111",
+  label: "Duplicate provider policy wallet",
+  purpose: "payments",
+};
+
 const OTHER_PROJECT = {
   id: "prj_policy_other",
   name: "Other policy project",
@@ -853,6 +862,43 @@ describe("PolicyRepository (postgres)", () => {
     });
   });
 
+  it("keeps selected policy bindings distinct when provider wallet IDs collide", async () => {
+    await seedDuplicateProviderCustodyWallet();
+
+    await repo.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "selected",
+      walletId: TEST_CUSTODY_WALLET.walletId,
+      custodyWalletId: TEST_CUSTODY_WALLET.id,
+    });
+    await repo.upsertApiKeyWalletPolicyBinding({
+      apiKeyId: TEST_API_KEY.id,
+      bindingScope: "selected",
+      walletId: DUPLICATE_PROVIDER_CUSTODY_WALLET.walletId,
+      custodyWalletId: DUPLICATE_PROVIDER_CUSTODY_WALLET.id,
+    });
+
+    const bindings = await repo.listApiKeyWalletPolicyBindings(TEST_API_KEY.id);
+    expect(bindings).toHaveLength(2);
+    expect(bindings.map((binding) => binding.custody_wallet_id).sort()).toEqual(
+      [TEST_CUSTODY_WALLET.id, DUPLICATE_PROVIDER_CUSTODY_WALLET.id].sort()
+    );
+
+    await expect(
+      repo.getApiKeyWalletPolicyBindingResolution(TEST_API_KEY.id, TEST_CUSTODY_WALLET.id)
+    ).resolves.toMatchObject({
+      binding: { custody_wallet_id: TEST_CUSTODY_WALLET.id },
+    });
+    await expect(
+      repo.getApiKeyWalletPolicyBindingResolution(
+        TEST_API_KEY.id,
+        DUPLICATE_PROVIDER_CUSTODY_WALLET.id
+      )
+    ).resolves.toMatchObject({
+      binding: { custody_wallet_id: DUPLICATE_PROVIDER_CUSTODY_WALLET.id },
+    });
+  });
+
   it("resolves an all-wallet API key policy binding for every in-scope wallet", async () => {
     const service = policyStores(repo);
     await seedAdditionalCustodyWallet();
@@ -872,7 +918,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: TEST_CUSTODY_WALLET.walletId,
+        custodyWalletId: TEST_CUSTODY_WALLET.id,
       })
     ).resolves.toMatchObject({
       binding: { bindingScope: "all", apiKeyControlProfileId: profile.id },
@@ -882,7 +928,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: SECOND_CUSTODY_WALLET.walletId,
+        custodyWalletId: SECOND_CUSTODY_WALLET.id,
       })
     ).resolves.toMatchObject({
       binding: { bindingScope: "all", apiKeyControlProfileId: profile.id },
@@ -907,22 +953,24 @@ describe("PolicyRepository (postgres)", () => {
       apiKeyId: TEST_API_KEY.id,
       bindingScope: "selected",
       walletId: TEST_CUSTODY_WALLET.walletId,
+      custodyWalletId: TEST_CUSTODY_WALLET.id,
       apiKeyControlProfileId: profile.id,
     });
     await service.upsertApiKeyWalletPolicyBinding({
       apiKeyId: TEST_API_KEY.id,
       bindingScope: "selected",
       walletId: SECOND_CUSTODY_WALLET.walletId,
+      custodyWalletId: SECOND_CUSTODY_WALLET.id,
       apiKeyControlProfileId: profile.id,
     });
 
     const primary = await service.resolveApiKeyWalletPolicyScope({
       apiKeyId: TEST_API_KEY.id,
-      walletId: TEST_CUSTODY_WALLET.walletId,
+      custodyWalletId: TEST_CUSTODY_WALLET.id,
     });
     const second = await service.resolveApiKeyWalletPolicyScope({
       apiKeyId: TEST_API_KEY.id,
-      walletId: SECOND_CUSTODY_WALLET.walletId,
+      custodyWalletId: SECOND_CUSTODY_WALLET.id,
     });
 
     expect(primary).toMatchObject({
@@ -956,13 +1004,14 @@ describe("PolicyRepository (postgres)", () => {
       apiKeyId: TEST_API_KEY.id,
       bindingScope: "selected",
       walletId: SECOND_CUSTODY_WALLET.walletId,
+      custodyWalletId: SECOND_CUSTODY_WALLET.id,
       apiKeyControlProfileId: override.profile.id,
     });
 
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: TEST_CUSTODY_WALLET.walletId,
+        custodyWalletId: TEST_CUSTODY_WALLET.id,
       })
     ).resolves.toMatchObject({
       binding: { bindingScope: "all" },
@@ -972,7 +1021,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: SECOND_CUSTODY_WALLET.walletId,
+        custodyWalletId: SECOND_CUSTODY_WALLET.id,
       })
     ).resolves.toMatchObject({
       binding: { bindingScope: "selected", walletId: SECOND_CUSTODY_WALLET.walletId },
@@ -992,13 +1041,14 @@ describe("PolicyRepository (postgres)", () => {
       apiKeyId: TEST_API_KEY.id,
       bindingScope: "selected",
       walletId: TEST_CUSTODY_WALLET.walletId,
+      custodyWalletId: TEST_CUSTODY_WALLET.id,
       apiKeyControlProfileId: profile.id,
     });
 
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: SECOND_CUSTODY_WALLET.walletId,
+        custodyWalletId: SECOND_CUSTODY_WALLET.id,
       })
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
@@ -1024,7 +1074,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: SECOND_CUSTODY_WALLET.walletId,
+        custodyWalletId: SECOND_CUSTODY_WALLET.id,
       })
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
@@ -1049,7 +1099,7 @@ describe("PolicyRepository (postgres)", () => {
     await expect(
       service.resolveApiKeyWalletPolicyScope({
         apiKeyId: TEST_API_KEY.id,
-        walletId: OTHER_PROJECT_CUSTODY_WALLET.walletId,
+        custodyWalletId: OTHER_PROJECT_CUSTODY_WALLET.id,
       })
     ).rejects.toMatchObject({
       code: "FORBIDDEN",
@@ -1205,6 +1255,7 @@ describe("PolicyRepository (postgres)", () => {
       custody_wallet_id: null,
     });
     expect(clonedSelectedBinding?.wallet_id).toBe(TEST_CUSTODY_WALLET.walletId);
+    expect(clonedSelectedBinding?.custody_wallet_id).toBe(TEST_CUSTODY_WALLET.id);
     expect(clonedAllBinding?.api_key_control_profile_id).not.toBe(apiKeyProfile?.id);
     expect(clonedSelectedBinding?.api_key_control_profile_id).not.toBe(apiKeyProfile?.id);
 
@@ -1335,6 +1386,56 @@ async function seedAdditionalCustodyWallet(): Promise<void> {
       SECOND_CUSTODY_WALLET.publicKey,
       SECOND_CUSTODY_WALLET.label,
       SECOND_CUSTODY_WALLET.purpose
+    )
+    .run();
+}
+
+/**
+ * Seed a second custody row that shares the primary wallet's provider identifier.
+ *
+ * @returns A promise that resolves when the duplicate provider wallet is stored.
+ */
+async function seedDuplicateProviderCustodyWallet(): Promise<void> {
+  const db = getDb(env);
+  await db
+    .prepare(
+      `INSERT INTO custody_configs (
+         id,
+         organization_id,
+         project_id,
+         provider,
+         config_encrypted,
+         default_wallet_id,
+         status
+       ) VALUES (?, ?, ?, 'privy', 'encrypted', ?, 'active')`
+    )
+    .bind(
+      DUPLICATE_PROVIDER_CUSTODY_CONFIG_ID,
+      TEST_ORG.id,
+      TEST_PROJECT.id,
+      DUPLICATE_PROVIDER_CUSTODY_WALLET.walletId
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO custody_wallets (
+         id,
+         custody_config_id,
+         wallet_id,
+         public_key,
+         label,
+         purpose,
+         status
+       ) VALUES (?, ?, ?, ?, ?, ?, 'active')`
+    )
+    .bind(
+      DUPLICATE_PROVIDER_CUSTODY_WALLET.id,
+      DUPLICATE_PROVIDER_CUSTODY_CONFIG_ID,
+      DUPLICATE_PROVIDER_CUSTODY_WALLET.walletId,
+      DUPLICATE_PROVIDER_CUSTODY_WALLET.publicKey,
+      DUPLICATE_PROVIDER_CUSTODY_WALLET.label,
+      DUPLICATE_PROVIDER_CUSTODY_WALLET.purpose
     )
     .run();
 }

--- a/apps/sdp-api/src/db/repositories/policy.repository.ts
+++ b/apps/sdp-api/src/db/repositories/policy.repository.ts
@@ -387,7 +387,7 @@ export type UpsertApiKeyWalletPolicyBindingInput = UpsertApiKeyWalletPolicyBindi
     | {
         bindingScope: "selected";
         walletId: string;
-        custodyWalletId?: string | null;
+        custodyWalletId: string;
       }
   );
 
@@ -573,11 +573,11 @@ export interface PolicyRepository {
   ): Promise<ActivePolicyProfileRevisionRefRow[]>;
   getApiKeyWalletPolicyBindingResolution(
     apiKeyId: string,
-    walletId: string
+    custodyWalletId: string
   ): Promise<ApiKeyWalletPolicyBindingResolutionRow>;
   getApiKeyWalletPolicyTarget(
     apiKeyId: string,
-    walletId: string
+    custodyWalletId: string
   ): Promise<ApiKeyWalletPolicyTargetRow | null>;
 
   createWalletOperation(input: CreateWalletOperationInput): Promise<WalletOperationRow | null>;

--- a/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/api-keys-wallet-scope.test.ts
@@ -821,6 +821,11 @@ describe("API key wallet scope routes", () => {
       env
     );
     expect(firstReplace.status).toBe(200);
+    await expect(firstReplace.json()).resolves.toMatchObject({
+      data: {
+        policyBindings: [{ custodyWalletId: "cwlt_scope_a" }],
+      },
+    });
 
     const outOfScopeReplace = await app.request(
       `/v1/api-keys/${apiKeyId}/policy-bindings`,
@@ -890,5 +895,67 @@ describe("API key wallet scope routes", () => {
     expect(secondBody.data.policyBindings.map((binding) => binding.walletId)).toEqual([
       "wal_scope_b",
     ]);
+  });
+
+  it("rejects an ambiguous provider wallet ID when authoring a selected policy binding", async () => {
+    const apiKeyId = await createManagedApiKey({
+      name: "Ambiguous selected-wallet policy key",
+      walletScope: "selected",
+      walletIds: ["wal_scope_a"],
+    });
+    const { profileId } = await createAndActivateApiKeyPolicy(apiKeyId);
+
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs
+             (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          "cust_cfg_api_key_wallet_scope_duplicate",
+          TEST_ORG.id,
+          TEST_PROJECT.id,
+          "privy",
+          "test-config",
+          "active"
+        ),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, label, purpose, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          "cwlt_scope_a_duplicate",
+          "cust_cfg_api_key_wallet_scope_duplicate",
+          "wal_scope_a",
+          "pub_scope_a_duplicate",
+          "Duplicate Wallet Scope A",
+          "transfer",
+          "active"
+        ),
+    ]);
+
+    const response = await app.request(
+      `/v1/api-keys/${apiKeyId}/policy-bindings`,
+      {
+        method: "PUT",
+        headers: authenticatedJsonHeaders(),
+        body: JSON.stringify({
+          mode: "replace",
+          bindings: [
+            {
+              bindingScope: "selected",
+              walletId: "wal_scope_a",
+              apiKeyControlProfileId: profileId,
+            },
+          ],
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
   });
 });

--- a/apps/sdp-api/src/routes/api-keys/handlers.ts
+++ b/apps/sdp-api/src/routes/api-keys/handlers.ts
@@ -15,7 +15,7 @@ import {
   type UpsertApiKeyWalletPolicyBindingInput,
 } from "@/db/repositories";
 import { requireProjectId } from "@/lib/auth";
-import { AppError, badRequest, notFound } from "@/lib/errors";
+import { AppError, badRequest, forbidden, notFound } from "@/lib/errors";
 import { created, success } from "@/lib/response";
 import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { ApiKeyService } from "@/services/api-key.service";
@@ -28,7 +28,7 @@ import { replaceApiKeyWalletBindings } from "@/services/api-key-wallets.service"
 import { AuditService } from "@/services/audit.service";
 import { createSigningService } from "@/services/domain/signing.service";
 import { ApiKeyPolicyStore } from "@/services/policy/api-key-policy.store";
-import type { WalletPurpose } from "@/services/stores/custody-config.store";
+import { CustodyConfigStore, type WalletPurpose } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import { buildApiKeyAccessSummaries } from "./access-response";
 import {
@@ -519,13 +519,32 @@ export const writeApiKeyPolicyBindings = async (c: AppContext) => {
     });
   }
 
+  const custodyStore = new CustodyConfigStore(getDb(c.env), c.env);
   const bindings: UpsertApiKeyWalletPolicyBindingInput[] =
-    parsed.data.mode === "clear"
-      ? []
-      : parsed.data.bindings.map((binding) => ({
-          apiKeyId: keyId,
-          ...binding,
-        }));
+    parsed.data.mode === "replace"
+      ? await Promise.all(
+          parsed.data.bindings.map(async (binding) => {
+            if (binding.bindingScope === "all") {
+              return { apiKeyId: keyId, ...binding };
+            }
+
+            const wallet = await custodyStore.findUniqueActiveWalletByIdentifier(
+              actor.organizationId,
+              projectId,
+              binding.walletId
+            );
+            if (!wallet) {
+              throw forbidden("API key is not authorized for the requested wallet");
+            }
+            return {
+              apiKeyId: keyId,
+              ...binding,
+              walletId: wallet.walletId,
+              custodyWalletId: wallet.id,
+            };
+          })
+        )
+      : [];
 
   await new ApiKeyPolicyStore(
     createPolicyRepository(c.env, getRequestTenantScope(c))

--- a/apps/sdp-api/src/services/api-key.service.ts
+++ b/apps/sdp-api/src/services/api-key.service.ts
@@ -15,7 +15,8 @@ import type {
 } from "@sdp/types";
 import type { DatabaseExecutor } from "@/db";
 import { parseOptionalPostgresJson, parsePostgresJson } from "@/db/postgres-utils";
-import { AppError, badRequest } from "@/lib/errors";
+import type { ApiKeyWalletPolicyBindingRow } from "@/db/repositories";
+import { AppError, badRequest, internalError } from "@/lib/errors";
 import { assertTenantClaim, type TenantScope, TenantScopeViolationError } from "@/lib/tenant-scope";
 import { createApiKeyMaterial } from "./api-key.utils";
 import { assertGrantableApiKeyPermissions } from "./api-key-scope.service";
@@ -673,12 +674,17 @@ export class ApiKeyService {
          ORDER BY created_at ASC`
       )
       .bind(sourceApiKeyId)
-      .all<Record<string, unknown>>();
+      .all<ApiKeyWalletPolicyBindingRow>();
 
     for (const binding of bindingRows.results) {
-      const apiKeyControlProfileId = binding.api_key_control_profile_id
-        ? (profileIdMap.get(binding.api_key_control_profile_id as string) ?? null)
-        : null;
+      let apiKeyControlProfileId: string | null = null;
+      if (binding.api_key_control_profile_id !== null) {
+        const mappedProfileId = profileIdMap.get(binding.api_key_control_profile_id);
+        if (mappedProfileId === undefined) {
+          throw internalError("Failed to clone API key policy binding profile");
+        }
+        apiKeyControlProfileId = mappedProfileId;
+      }
 
       await db
         .prepare(
@@ -696,9 +702,9 @@ export class ApiKeyService {
           `akwpol_${crypto.randomUUID()}`,
           targetApiKeyId,
           binding.binding_scope,
-          binding.wallet_id ?? null,
-          binding.custody_wallet_id ?? null,
-          binding.wallet_control_profile_id ?? null,
+          binding.wallet_id,
+          binding.custody_wallet_id,
+          binding.wallet_control_profile_id,
           apiKeyControlProfileId
         )
         .run();

--- a/apps/sdp-api/src/services/policy/api-key-policy.store.ts
+++ b/apps/sdp-api/src/services/policy/api-key-policy.store.ts
@@ -23,8 +23,7 @@ import { WalletPolicyStore } from "./wallet-policy.store";
 
 export interface ResolveApiKeyWalletPolicyScopeInput {
   apiKeyId: string;
-  walletId: string;
-  custodyWalletId?: string | null;
+  custodyWalletId: string;
 }
 
 export interface ResolvedApiKeyWalletPolicyScope {
@@ -181,6 +180,22 @@ export class ApiKeyPolicyStore {
     };
   }
 
+  /**
+   * Resolve an API-key policy when an operation has no custody-wallet identity.
+   *
+   * @param apiKeyId - The API key initiating the operation.
+   * @returns The effective API-key policy when no wallet bindings require a custody target.
+   */
+  async resolveOperationPolicyWithoutCustodyWallet(
+    apiKeyId: string
+  ): Promise<EffectiveApiKeyPolicy> {
+    const bindings = await this.repository.listApiKeyWalletPolicyBindings(apiKeyId);
+    if (bindings.length > 0) {
+      throw forbidden("API key policy binding is not configured for the requested wallet");
+    }
+    return this.resolveEffectiveApiKeyPolicy(apiKeyId);
+  }
+
   async upsertApiKeyWalletPolicyBinding(
     input: UpsertApiKeyWalletPolicyBindingInput
   ): Promise<ApiKeyWalletPolicyBinding> {
@@ -197,7 +212,7 @@ export class ApiKeyPolicyStore {
   ): Promise<ResolvedApiKeyWalletPolicyScope> {
     const resolution = await this.repository.getApiKeyWalletPolicyBindingResolution(
       input.apiKeyId,
-      input.walletId
+      input.custodyWalletId
     );
 
     this.assertApplicablePolicyBindingExists(resolution);
@@ -212,7 +227,7 @@ export class ApiKeyPolicyStore {
    * closed instead of falling back to the plain per-key profile lookup; a
    * binding may also supply the wallet policy and custody wallet.
    *
-   * @param input - The API key, requested wallet, and custody-wallet claim.
+   * @param input - The API key and requested custody wallet.
    * @returns The effective API-key policy plus any binding-supplied wallet scope.
    */
   async resolveOperationScope(
@@ -220,7 +235,7 @@ export class ApiKeyPolicyStore {
   ): Promise<ApiKeyOperationScope> {
     const resolution = await this.repository.getApiKeyWalletPolicyBindingResolution(
       input.apiKeyId,
-      input.walletId
+      input.custodyWalletId
     );
 
     if (resolution.total_binding_count === 0) {
@@ -299,15 +314,11 @@ export class ApiKeyPolicyStore {
   ): Promise<ApiKeyWalletPolicyTargetRow> {
     const target = await this.repository.getApiKeyWalletPolicyTarget(
       input.apiKeyId,
-      input.walletId
+      input.custodyWalletId
     );
 
     if (!target) {
       throw forbidden("API key is not authorized for the requested wallet");
-    }
-
-    if (input.custodyWalletId && input.custodyWalletId !== target.custody_wallet_id) {
-      throw forbidden("API key wallet policy target does not match the requested custody wallet");
     }
 
     if (
@@ -335,7 +346,6 @@ export class ApiKeyPolicyStore {
     if (input.bindingScope === "selected") {
       const target = await this.assertApiKeyWalletPolicyTarget({
         apiKeyId: input.apiKeyId,
-        walletId: input.walletId,
         custodyWalletId: input.custodyWalletId,
       });
 
@@ -419,7 +429,7 @@ export class ApiKeyPolicyStore {
   private assertUniquePolicyBindingTargets(bindings: UpsertApiKeyWalletPolicyBindingInput[]): void {
     const targets = new Set<string>();
     for (const binding of bindings) {
-      const target = binding.bindingScope === "all" ? "all" : `selected:${binding.walletId}`;
+      const target = binding.bindingScope === "all" ? "all" : `selected:${binding.custodyWalletId}`;
       if (targets.has(target)) {
         throw badRequest("Policy binding targets must be unique");
       }
@@ -431,11 +441,10 @@ export class ApiKeyPolicyStore {
     binding: ApiKeyWalletPolicyBindingRow,
     target: ApiKeyWalletPolicyTargetRow
   ): void {
-    if (binding.binding_scope === "selected" && binding.wallet_id !== target.wallet_id) {
-      throw forbidden("API key policy binding does not match the requested wallet");
-    }
-
-    if (binding.custody_wallet_id && binding.custody_wallet_id !== target.custody_wallet_id) {
+    if (
+      binding.binding_scope === "selected" &&
+      binding.custody_wallet_id !== target.custody_wallet_id
+    ) {
       throw forbidden("API key policy binding does not match the requested custody wallet");
     }
   }

--- a/apps/sdp-api/src/services/policy/enforcement.service.test.ts
+++ b/apps/sdp-api/src/services/policy/enforcement.service.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   ActiveApiKeyControlProfileResult,
   ActiveWalletControlProfileResult,
+  ApiKeyWalletPolicyBindingRow,
   ApprovalRequestRow,
   CreatePolicyEvaluationInput,
   CreateWalletOperationInput,
@@ -99,6 +100,7 @@ function apiKeyProfile(
 function createRepository(options: {
   walletPolicy?: ActiveWalletControlProfileResult | null;
   apiKeyPolicy?: ActiveApiKeyControlProfileResult | null;
+  hasApiKeyWalletPolicyBindings?: boolean;
   evaluationError?: Error;
   policyEvaluationError?: Error;
   approvalStatusUpdateError?: Error;
@@ -262,6 +264,24 @@ function createRepository(options: {
     listPolicyEvaluationsForOperation: vi.fn(async () => []),
     getActiveWalletControlProfileByCustodyWalletId: vi.fn(async () => options.walletPolicy ?? null),
     getActiveApiKeyControlProfileByApiKeyId: vi.fn(async () => options.apiKeyPolicy ?? null),
+    listApiKeyWalletPolicyBindings: vi.fn(async (): Promise<ApiKeyWalletPolicyBindingRow[]> => {
+      if (!options.hasApiKeyWalletPolicyBindings) {
+        return [];
+      }
+      return [
+        {
+          id: "akwpol_1",
+          api_key_id: "key_1",
+          binding_scope: "selected",
+          wallet_id: "wal_bound",
+          custody_wallet_id: "cw_bound",
+          wallet_control_profile_id: null,
+          api_key_control_profile_id: "akcp_1",
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        },
+      ];
+    }),
     getApiKeyWalletPolicyBindingResolution: vi.fn(async () => {
       if (options.evaluationError) {
         throw options.evaluationError;
@@ -645,6 +665,45 @@ describe("WalletPolicyEnforcementService", () => {
       },
     });
     expect(repository.updateWalletOperationStatus).toHaveBeenCalledWith("wop_1", "failed");
+  });
+
+  it("applies the API key policy without wallet binding resolution when custody identity is absent", async () => {
+    const repository = createRepository({
+      apiKeyPolicy: apiKeyProfile([
+        { id: "api-key-destination", kind: "destination", blocklist: ["recipient_1"] },
+      ]),
+    });
+    const service = new WalletPolicyEnforcementService(repository);
+
+    await expect(
+      service.enforce({
+        ...baseOperation,
+        custodyWalletId: null,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      details: {
+        decision: "deny",
+        reasonCode: "api_key_policy_match",
+      },
+    });
+    expect(repository.getApiKeyWalletPolicyBindingResolution).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when wallet bindings exist without a custody identity to match", async () => {
+    const repository = createRepository({ hasApiKeyWalletPolicyBindings: true });
+    const service = new WalletPolicyEnforcementService(repository);
+
+    await expect(
+      service.enforce({
+        ...baseOperation,
+        custodyWalletId: null,
+      })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "API key policy binding is not configured for the requested wallet",
+    });
+    expect(repository.getApiKeyWalletPolicyBindingResolution).not.toHaveBeenCalled();
   });
 
   it("marks the operation failed when policy evaluation throws", async () => {

--- a/apps/sdp-api/src/services/policy/enforcement.store.ts
+++ b/apps/sdp-api/src/services/policy/enforcement.store.ts
@@ -7,6 +7,7 @@ import type {
 } from "@sdp/policy";
 import { IMPLICIT_DEFAULT_ALLOW_POLICY } from "@sdp/policy";
 import type {
+  EffectiveApiKeyPolicy,
   PolicyEvaluation,
   WalletOperationActor,
   WalletOperationContext,
@@ -51,16 +52,24 @@ export class PostgresPolicyEnforcementStore implements PolicyEnforcementStore {
     operation: WalletOperationEnvelope
   ): Promise<EffectiveOperationPolicies> {
     const apiKeyScope =
-      operation.apiKeyId !== null
+      operation.apiKeyId !== null && operation.custodyWalletId !== null
         ? await this.apiKeyPolicies.resolveOperationScope({
             apiKeyId: operation.apiKeyId,
-            walletId: operation.walletId,
             custodyWalletId: operation.custodyWalletId,
           })
         : null;
 
+    let apiKeyPolicy: EffectiveApiKeyPolicy | null = null;
+    if (apiKeyScope !== null) {
+      apiKeyPolicy = apiKeyScope.apiKeyPolicy;
+    } else if (operation.apiKeyId !== null) {
+      apiKeyPolicy = await this.apiKeyPolicies.resolveOperationPolicyWithoutCustodyWallet(
+        operation.apiKeyId
+      );
+    }
+
     if (apiKeyScope !== null && apiKeyScope.walletPolicy !== null) {
-      return { walletPolicy: apiKeyScope.walletPolicy, apiKeyPolicy: apiKeyScope.apiKeyPolicy };
+      return { walletPolicy: apiKeyScope.walletPolicy, apiKeyPolicy };
     }
 
     const custodyWalletId =
@@ -74,7 +83,7 @@ export class PostgresPolicyEnforcementStore implements PolicyEnforcementStore {
 
     return {
       walletPolicy,
-      apiKeyPolicy: apiKeyScope === null ? null : apiKeyScope.apiKeyPolicy,
+      apiKeyPolicy,
     };
   }
 

--- a/apps/sdp-api/src/services/stores/custody-config.store.ts
+++ b/apps/sdp-api/src/services/stores/custody-config.store.ts
@@ -450,61 +450,72 @@ export class CustodyConfigStore implements SigningConfigStore {
     projectId: string | undefined,
     walletIdentifier: string
   ): Promise<CustodyWalletLookup | null> {
-    const row = projectId
-      ? await this.db
-          .prepare(
-            `SELECT
-               w.id,
-               w.custody_config_id,
-               w.wallet_id,
-               w.public_key,
-               w.label,
-               w.purpose,
-               w.status,
-               w.created_at,
-               w.updated_at,
-               c.provider,
-               c.project_id
-             FROM custody_wallets w
-             JOIN custody_configs c ON c.id = w.custody_config_id
-             WHERE c.organization_id = ?
-               AND c.status = 'active'
-               AND w.status = 'active'
-               AND (w.wallet_id = ? OR w.id = ?)
-               AND (c.project_id = ? OR c.project_id IS NULL)
-             ORDER BY CASE WHEN c.project_id = ? THEN 0 ELSE 1 END, c.updated_at DESC, c.id DESC
-             LIMIT 1`
-          )
-          .bind(orgId, walletIdentifier, walletIdentifier, projectId, projectId)
-          .first<CustodyWalletLookupRow>()
-      : await this.db
-          .prepare(
-            `SELECT
-               w.id,
-               w.custody_config_id,
-               w.wallet_id,
-               w.public_key,
-               w.label,
-               w.purpose,
-               w.status,
-               w.created_at,
-               w.updated_at,
-               c.provider,
-               c.project_id
-             FROM custody_wallets w
-             JOIN custody_configs c ON c.id = w.custody_config_id
-             WHERE c.organization_id = ?
-               AND c.project_id IS NULL
-               AND c.status = 'active'
-               AND w.status = 'active'
-               AND (w.wallet_id = ? OR w.id = ?)
-             ORDER BY c.updated_at DESC, c.id DESC
-             LIMIT 1`
-          )
-          .bind(orgId, walletIdentifier, walletIdentifier)
-          .first<CustodyWalletLookupRow>();
+    const rows = await this.queryActiveWalletsByIdentifier(orgId, projectId, walletIdentifier, 1);
+    return rows.length === 1 ? this.mapWalletLookupRow(rows[0]) : null;
+  }
 
-    return row ? this.mapWalletLookupRow(row) : null;
+  /**
+   * Find an active wallet only when its identifier resolves to one custody row in scope.
+   *
+   * @param orgId - The organization that owns the wallet.
+   * @param projectId - The project whose wallets and organization fallbacks are eligible.
+   * @param walletIdentifier - A provider wallet ID or custody-wallet row ID.
+   * @returns The unique active wallet, or null when zero or multiple rows match.
+   */
+  async findUniqueActiveWalletByIdentifier(
+    orgId: string,
+    projectId: string | undefined,
+    walletIdentifier: string
+  ): Promise<CustodyWalletLookup | null> {
+    const rows = await this.queryActiveWalletsByIdentifier(orgId, projectId, walletIdentifier, 2);
+    return rows.length === 1 ? this.mapWalletLookupRow(rows[0]) : null;
+  }
+
+  /**
+   * Query active wallets matching an identifier within the resolved scope,
+   * project-scoped configs first, then organization-level fallbacks. Without a
+   * project, only organization-level configs match.
+   *
+   * @param orgId - The organization that owns the wallet.
+   * @param projectId - The project whose wallets and organization fallbacks are eligible.
+   * @param walletIdentifier - A provider wallet ID or custody-wallet row ID.
+   * @param limit - The maximum number of rows to return.
+   * @returns The matching wallet lookup rows in scope-priority order.
+   */
+  private async queryActiveWalletsByIdentifier(
+    orgId: string,
+    projectId: string | undefined,
+    walletIdentifier: string,
+    limit: number
+  ): Promise<CustodyWalletLookupRow[]> {
+    const projectScope = projectId === undefined ? null : projectId;
+    const rows = await this.db
+      .prepare(
+        `SELECT
+           w.id,
+           w.custody_config_id,
+           w.wallet_id,
+           w.public_key,
+           w.label,
+           w.purpose,
+           w.status,
+           w.created_at,
+           w.updated_at,
+           c.provider,
+           c.project_id
+         FROM custody_wallets w
+         JOIN custody_configs c ON c.id = w.custody_config_id
+         WHERE c.organization_id = ?
+           AND c.status = 'active'
+           AND w.status = 'active'
+           AND (w.wallet_id = ? OR w.id = ?)
+           AND (c.project_id = ? OR c.project_id IS NULL)
+         ORDER BY CASE WHEN c.project_id = ? THEN 0 ELSE 1 END, c.updated_at DESC, c.id DESC
+         LIMIT ?`
+      )
+      .bind(orgId, walletIdentifier, walletIdentifier, projectScope, projectScope, limit)
+      .all<CustodyWalletLookupRow>();
+    return rows.results;
   }
 
   /**


### PR DESCRIPTION
Closes PRO-1658.

**Binding row + resolution, before → after migration 0053:**

| | api_key_id | binding_scope | wallet_id | custody_wallet_id | resolution matches on |
|---|---|---|---|---|---|
| before | key_ci | selected | privy-w-7f2 | NULL | `wallet_id = 'privy-w-7f2'` |
| after | key_ci | selected | privy-w-7f2 | cw_9d41f2ab | `custody_wallet_id = 'cw_9d41f2ab'` |

`privy-w-7f2` is the custody provider's identifier — unique only per `(custody_config_id, wallet_id)`, so two custody configs in one org can both own it. `cw_9d41f2ab` is the `custody_wallets.id` primary key, unambiguous org-wide. `wallet_id` stays on the row as display metadata only.

- The policy layer keyed the same wallet two ways: wallet control profiles bind to `custody_wallet_id`, but API-key policy bindings matched on the provider `wallet_id` — the 2026-08-09 dual-identity mismatch
- Migration 0053: backfills `custody_wallet_id` where the provider id resolves unambiguously in the key's scope, deletes unresolved selected bindings (devnet-only data, deletion count logged), tightens the CHECK so selected bindings require `custody_wallet_id`, and moves the partial unique index to `(api_key_id, custody_wallet_id)`
- Binding resolution, target lookup, and the upsert conflict target now match on `custody_wallet_id`; `walletId` leaves the policy-resolution input types entirely
- `PUT /api-keys/:keyId/policy-bindings` resolves the client-supplied provider `walletId` to a unique active custody wallet in tenant scope; missing or ambiguous resolution → 403
- Behavior tightening: operations carrying an API key but no custody-wallet identity now fail closed when that key has wallet bindings (previously resolvable via the provider id)
- Tests: new migration suite (backfill, orphan deletion, constraint, index) + updated repo, wallet-scope, and enforcement suites — 53 tests across the 4 affected suites