### PR TITLE
fix(sdp-api): bootstrap audit-ledger checkpoint when the external key is absent

### DIFF
--- a/apps/sdp-api/src/services/audit.service.test.ts
+++ b/apps/sdp-api/src/services/audit.service.test.ts
@@ -266,8 +266,26 @@ describe("AuditService", () => {
     );
   });
 
-  it("fails closed instead of repairing a checkpoint more than one row behind", async () => {
+  it("bootstraps the checkpoint from a verified head when the external key is absent", async () => {
     const { db, queryOne, checkpoint } = createAuditWriter({ initialCommittedSequence: 2 });
+    const audit = new AuditService(db as never, checkpoint);
+
+    await expect(
+      audit.logSystem({ action: "maintenance", resourceType: "audit_ledger" })
+    ).resolves.toBeUndefined();
+
+    expect(insertedCalls(queryOne)).toHaveLength(1);
+    await expect(checkpoint.get(AUDIT_LEDGER_CHECKPOINT_KEY)).resolves.toBe(
+      JSON.stringify({ sequence: 3, headHash: hashForSequence(3) })
+    );
+  });
+
+  it("fails closed instead of repairing a checkpoint present but more than one row behind", async () => {
+    const { db, queryOne, checkpoint } = createAuditWriter({ initialCommittedSequence: 2 });
+    await checkpoint.put(
+      AUDIT_LEDGER_CHECKPOINT_KEY,
+      JSON.stringify({ sequence: 1, headHash: hashForSequence(1) })
+    );
 
     await expect(
       new AuditService(db as never, checkpoint).logSystem({
@@ -277,7 +295,6 @@ describe("AuditService", () => {
     ).rejects.toBeInstanceOf(AuditPersistenceError);
 
     expect(insertedCalls(queryOne)).toHaveLength(0);
-    expect(checkpoint.compareAndSet).not.toHaveBeenCalled();
   });
 
   it("fails closed when the recoverable head does not match its seal and anchor", async () => {

--- a/apps/sdp-api/src/services/audit.service.ts
+++ b/apps/sdp-api/src/services/audit.service.ts
@@ -274,6 +274,25 @@ async function reconcileExternalCheckpoint(
       return expectedCheckpoint;
     }
   }
+
+  if (externalCheckpoint === null && expectedCheckpoint !== null) {
+    const seeded = await checkpointStore.compareAndSet(
+      AUDIT_LEDGER_CHECKPOINT_KEY,
+      null,
+      expectedCheckpoint
+    );
+    if (seeded) {
+      getLogger().warn(
+        { event: "audit_checkpoint_bootstrapped", sequence: head?.ledger_sequence },
+        "External audit-ledger checkpoint was absent; bootstrapped from the verified database head"
+      );
+      return expectedCheckpoint;
+    }
+    if ((await checkpointStore.get(AUDIT_LEDGER_CHECKPOINT_KEY)) === expectedCheckpoint) {
+      return expectedCheckpoint;
+    }
+  }
+
   throw new Error("External audit-ledger checkpoint diverged; writes are locked");
 }
 


### PR DESCRIPTION
## Problem

`AuditService.reconcileExternalCheckpoint` compares the external checkpoint against the Postgres ledger head on every mutating request. If the external checkpoint key is **absent** (`external === null`) while the ledger head is non-empty, reconcile treats the missing key as divergence and throws `External audit-ledger checkpoint diverged; writes are locked`, surfaced as `AuditPersistenceError`.

This is **permanent**: the checkpoint is only ever written by `persist()`, which aborts at reconcile before it can seed the key. Once the ledger head is non-empty and the key is missing, every audit-writing (i.e. every mutating) request fails closed with no path to self-recover.

An absent key is a bootstrap/cold-start condition (e.g. the checkpoint was never seeded for a pre-populated ledger, or an ephemeral store lost it), not evidence of tampering.

## Fix

In `reconcileExternalCheckpoint`, when the external key is absent **and** the current head passes seal/anchor validation (`assertValidCurrentHead`), seed the checkpoint from the verified head via `compareAndSet(null -> expected)` and continue, emitting an `audit_checkpoint_bootstrapped` warning for visibility.

A checkpoint that is **present but mismatched** (and not a finalizable pending witness) still fails closed, so tamper-evidence is preserved.

## Scope / follow-up

This removes the self-lock caused by a missing external checkpoint. It does not change where the checkpoint is stored; making the external anchor durable and independent of the primary database is tracked separately.

## Tests

- New: bootstraps the checkpoint from a verified head when the external key is absent (writes proceed, checkpoint is seeded).
- New: still fails closed when a checkpoint is present but more than one row behind.
- Full `audit.service.test.ts` suite passes (23/23); biome + tsc clean.