### PR TITLE
feat(sdp-api): roll policyGate out to ramps, transfer batches, issuance, and signer-check (PRO-1657)

### DIFF
--- a/apps/sdp-api/src/middleware/policy-gate.ts
+++ b/apps/sdp-api/src/middleware/policy-gate.ts
@@ -9,7 +9,10 @@ import {
   approvedWalletOperationId,
   walletOperationExecutionRequest,
 } from "@/services/policy/approved-operation-replay";
-import { dryRunPolicyCandidate } from "@/services/policy/candidate-evaluation.service";
+import {
+  dryRunPolicyCandidate,
+  UNGOVERNED_POLICY_DRY_RUN_RESULT,
+} from "@/services/policy/candidate-evaluation.service";
 import { enforceWalletOperationPolicy } from "@/services/policy/enforcement.service";
 import type { Env } from "@/types/env";
 import { isDryRunRequest } from "./dry-run";
@@ -18,7 +21,7 @@ import { IDEMPOTENCY_KEY_HEADER } from "./idempotency-key";
 type GateContext = Context<{ Bindings: Env }>;
 
 export interface PolicyGateExtraction {
-  candidate: PolicyCandidate;
+  candidate: PolicyCandidate | null;
   body: Record<string, unknown>;
   resolved: unknown;
   rawPayload: Record<string, unknown>;
@@ -33,11 +36,15 @@ export interface PolicyGateConfig {
   ) => Promise<Response | null>;
 }
 
-export interface PolicyGateContext<TBody = unknown, TResolved = unknown> {
+export interface PolicyGateContext<
+  TBody = unknown,
+  TResolved = unknown,
+  TEnforcement extends WalletOperationPolicyEnforcement | null = WalletOperationPolicyEnforcement,
+> {
   body: TBody;
-  candidate: PolicyCandidate;
+  candidate: PolicyCandidate | null;
   resolved: TResolved;
-  enforcement: WalletOperationPolicyEnforcement;
+  enforcement: TEnforcement;
 }
 
 /**
@@ -69,6 +76,11 @@ export interface PolicyGateContext<TBody = unknown, TResolved = unknown> {
  * The gate stores the replay envelope on the operation uniformly, so routes
  * no longer hand-build enforcement inputs.
  *
+ * An extraction may return a null candidate when the operation resolves no
+ * custody wallet and is therefore ungoverned: dry-run answers allow with no
+ * criteria, enforcement is skipped, and the handler receives a null
+ * enforcement.
+ *
  * @param config - The route's extractor and optional idempotent-replay finder.
  * @returns Hono middleware enforcing policy ahead of the handler.
  */
@@ -79,7 +91,12 @@ export function policyGate(config: PolicyGateConfig): MiddlewareHandler<{ Bindin
     const scope = getRequestTenantScope(c);
 
     if (isDryRunRequest(c)) {
-      return success(c, await dryRunPolicyCandidate(c.env, scope, candidate));
+      return success(
+        c,
+        candidate === null
+          ? UNGOVERNED_POLICY_DRY_RUN_RESULT
+          : await dryRunPolicyCandidate(c.env, scope, candidate)
+      );
     }
 
     const idempotencyKey = c.req.header(IDEMPOTENCY_KEY_HEADER);
@@ -88,6 +105,11 @@ export function policyGate(config: PolicyGateConfig): MiddlewareHandler<{ Bindin
       if (replayed !== null) {
         return replayed;
       }
+    }
+
+    if (candidate === null) {
+      c.set("policyGate", { body, candidate: null, resolved, enforcement: null });
+      return next();
     }
 
     const enforcement = await enforceWalletOperationPolicy(
@@ -116,12 +138,14 @@ export function policyGate(config: PolicyGateConfig): MiddlewareHandler<{ Bindin
  * @param c - Request context.
  * @returns The validated body, resolved resources, candidate, and enforcement.
  */
-export function getPolicyGateContext<TBody, TResolved>(
-  c: GateContext
-): PolicyGateContext<TBody, TResolved> {
+export function getPolicyGateContext<
+  TBody,
+  TResolved,
+  TEnforcement extends WalletOperationPolicyEnforcement | null = WalletOperationPolicyEnforcement,
+>(c: GateContext): PolicyGateContext<TBody, TResolved, TEnforcement> {
   const context = c.get("policyGate");
   if (context === undefined) {
     throw internalError("Policy gate context is unavailable");
   }
-  return context as PolicyGateContext<TBody, TResolved>;
+  return context as unknown as PolicyGateContext<TBody, TResolved, TEnforcement>;
 }

--- a/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
+++ b/apps/sdp-api/src/routes/custody-wallet-scope.test.ts
@@ -238,6 +238,83 @@ describe("Custody wallet scope routes", () => {
     getSplTokenBalancesMock.mockReset();
   });
 
+  it("dry-runs a signer check with zero writes", async () => {
+    await seedCachedKey({
+      signingWalletId: "privy_wallet_a",
+      walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],
+    });
+
+    const response = await app.request(
+      "/v1/wallets/signer-check",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+          "Dry-Run": "true",
+        },
+        body: JSON.stringify({ walletId: "privy_wallet_a", memo: "policy dry run" }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { decision: "allow", criteria: [] },
+    });
+    expect(createSigningServiceMock).not.toHaveBeenCalled();
+
+    const operationCount = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+      .first<{ count: number }>();
+    expect(operationCount).toEqual({ count: 0 });
+  });
+
+  it("stops a denied signer check before signing side effects", async () => {
+    await seedCachedKey({
+      signingWalletId: "privy_wallet_a",
+      walletBindings: [{ walletId: "privy_wallet_a", permissions: ["wallets:write"] }],
+    });
+    await getDb(env)
+      .prepare("UPDATE custody_configs SET project_id = ? WHERE id = ?")
+      .bind(TEST_PROJECT.id, PRIVY_CONFIG_ID)
+      .run();
+    const policyResponse = await app.request(
+      "/v1/payments/wallets/privy_wallet_a/policies",
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationAllowlist: [],
+          defaultAction: "allow",
+          rules: [{ id: "deny-signer-check", kind: "always", action: "deny" }],
+        }),
+      },
+      env
+    );
+    expect(policyResponse.status).toBe(200);
+    createSigningServiceMock.mockClear();
+
+    const response = await app.request(
+      "/v1/wallets/signer-check",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({ walletId: "privy_wallet_a", memo: "denied signer check" }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(createSigningServiceMock).not.toHaveBeenCalled();
+  });
+
   it("filters listed wallets to the API key bindings", async () => {
     await seedCachedKey({
       walletBindings: [{ walletId: "para_wallet_a", permissions: ["wallets:read"] }],

--- a/apps/sdp-api/src/routes/custody/handlers.ts
+++ b/apps/sdp-api/src/routes/custody/handlers.ts
@@ -14,7 +14,7 @@ export {
   initializeSigning,
   switchSigning,
 } from "./handlers/provider";
-export { signerCheck } from "./handlers/signer-check";
+export { extractSignerCheckPolicyCandidate, signerCheck } from "./handlers/signer-check";
 export {
   createWallet,
   deleteWallet,

--- a/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
+++ b/apps/sdp-api/src/routes/custody/handlers/signer-check.ts
@@ -15,19 +15,13 @@ import {
 import { partiallySignTransactionMessageWithSigners } from "@solana/signers";
 import { z } from "zod";
 import { getDb } from "@/db";
-import { getAuth } from "@/lib/auth";
+import { type ApiKeyContext, getAuth } from "@/lib/auth";
 import { AppError, badRequest } from "@/lib/errors";
 import { success } from "@/lib/response";
-import { getRequestTenantScope } from "@/lib/tenant-scope";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
+import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
 import {
-  approvedWalletOperationAttemptId,
-  approvedWalletOperationId,
-  beginApprovedWalletOperationEffect,
-  walletOperationExecutionRequest,
-} from "@/services/policy/approved-operation-replay";
-import {
-  enforceWalletOperationPolicy,
   resolvePolicyCustodyWallet,
   walletOperationActorFromAuth,
 } from "@/services/policy/enforcement.service";
@@ -42,6 +36,14 @@ const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" as Ad
 const KORA_MEMO_ALLOWED_PROGRAM_HINT =
   "Add MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr to Kora validation.allowed_programs.";
 
+type SignerCheckBody = z.output<typeof signerCheckSchema>;
+
+interface SignerCheckPolicyResolved {
+  auth: ApiKeyContext;
+  resolvedWalletId: string;
+  memo: string;
+}
+
 function isKoraMemoProgramPolicyError(message: string): boolean {
   const normalized = message.toLowerCase();
   return (
@@ -50,7 +52,15 @@ function isKoraMemoProgramPolicyError(message: string): boolean {
   );
 }
 
-export const signerCheck = async (c: AppContext) => {
+/**
+ * Parse and resolve a signer check into its wallet-operation policy candidate.
+ *
+ * @param c - Request context.
+ * @returns The candidate, validated body, resolved auth and wallet, and raw payload.
+ */
+export async function extractSignerCheckPolicyCandidate(
+  c: AppContext
+): Promise<PolicyGateExtraction> {
   const auth = getAuth(c);
   if (auth.authType !== "api_key") {
     throw new AppError("UNAUTHORIZED", "API key authentication is required");
@@ -58,7 +68,6 @@ export const signerCheck = async (c: AppContext) => {
 
   const body = await c.req.json().catch(() => ({}));
   const parsed = signerCheckSchema.safeParse(body);
-
   if (!parsed.success) {
     throw badRequest("Invalid request body", {
       errors: z.flattenError(parsed.error).fieldErrors,
@@ -75,34 +84,38 @@ export const signerCheck = async (c: AppContext) => {
   }
 
   const policyWallet = await resolvePolicyCustodyWallet(c.env, auth, resolvedWalletId);
-  const policyScope = getRequestTenantScope(c);
-  const policyInput = {
-    organizationId: auth.organizationId,
-    projectId: auth.projectId,
-    custodyWalletId: policyWallet?.id ?? null,
-    walletId: resolvedWalletId,
-    apiKeyId: auth.apiKeyId,
-    actor: walletOperationActorFromAuth(auth),
-    operationFamily: "raw_sign" as const,
-    operationType: "custody_signer_check" as const,
-    context: {
-      memo,
+  return {
+    candidate: {
+      organizationId: auth.organizationId,
+      projectId: auth.projectId,
+      custodyWalletId: policyWallet === null ? null : policyWallet.id,
+      walletId: resolvedWalletId,
+      apiKeyId: auth.apiKeyId,
+      actor: walletOperationActorFromAuth(auth),
+      source: "api",
+      operationFamily: "raw_sign",
+      operationType: "custody_signer_check",
+      asset: null,
+      amount: null,
+      destination: null,
+      context: {
+        memo,
+      },
+      providerExtensions: {},
     },
+    body: parsed.data,
+    resolved: { auth, resolvedWalletId, memo },
     rawPayload: {
-      requestedWalletId: parsed.data.walletId ?? null,
+      requestedWalletId: parsed.data.walletId === undefined ? null : parsed.data.walletId,
       memo,
-      executionRequest: walletOperationExecutionRequest(c, parsed.data),
     },
   };
-  const approvedOperationId = approvedWalletOperationId(c);
-  const attemptId = approvedWalletOperationAttemptId(c);
-  await enforceWalletOperationPolicy(
-    c.env,
-    policyScope,
-    policyInput,
-    approvedOperationId,
-    attemptId
-  );
+}
+
+export const signerCheck = async (c: AppContext) => {
+  const {
+    resolved: { auth, resolvedWalletId, memo },
+  } = getPolicyGateContext<SignerCheckBody, SignerCheckPolicyResolved>(c);
 
   try {
     const signer = await createOrgSigner(

--- a/apps/sdp-api/src/routes/custody/index.ts
+++ b/apps/sdp-api/src/routes/custody/index.ts
@@ -6,6 +6,7 @@
 
 import { Hono } from "hono";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { policyGate } from "@/middleware/policy-gate";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
@@ -13,6 +14,7 @@ import {
   cancelApprovalRequest,
   createWallet,
   deleteWallet,
+  extractSignerCheckPolicyCandidate,
   getApprovalRequest,
   getConfig,
   getConfigs,
@@ -43,7 +45,12 @@ wallets.post("/", requirePermissions("custody:admin"), createWallet);
 wallets.delete("/", requirePermissions("custody:admin"), deleteWallet);
 wallets.post("/default-wallet", requirePermissions("custody:admin"), setDefaultWallet);
 wallets.patch("/:walletId", requirePermissions("custody:admin"), updateWallet);
-wallets.post("/signer-check", requirePermissions("wallets:write"), signerCheck);
+wallets.post(
+  "/signer-check",
+  requirePermissions("wallets:write"),
+  policyGate({ extract: extractSignerCheckPolicyCandidate }),
+  signerCheck
+);
 
 // Read configuration and wallets
 wallets.get("/config", requirePermissions("wallets:read"), getConfig);

--- a/apps/sdp-api/src/routes/issuance.test.ts
+++ b/apps/sdp-api/src/routes/issuance.test.ts
@@ -8,6 +8,7 @@ import * as FeePaymentAdapters from "@sdp/payments/fee-payment";
 import { hashString } from "@sdp/payments/hash";
 import * as SolanaRpc from "@sdp/rpc/solana";
 import type { Address } from "@sdp/solana/address";
+import { address, createNoopSigner } from "@solana/kit";
 import * as MosaicSdk from "@solana/mosaic-sdk";
 import { findAssociatedTokenPda, TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -238,6 +239,10 @@ describe("Issuance Routes", () => {
 
     // Clear token-related tables
     await db
+      .prepare("DELETE FROM wallet_operations")
+      .run()
+      .catch(() => {});
+    await db
       .prepare("DELETE FROM frozen_accounts")
       .run()
       .catch(() => {});
@@ -451,6 +456,228 @@ describe("Issuance Routes", () => {
         total_supply_cached: "900",
         execution_effect_started_at: null,
       });
+    });
+  });
+
+  describe("wallet-operation policy gate", () => {
+    const policyMintAuthority = "9wVmMF2GpxZMsJLxCv2xXWjDWVv8HtqTmKqnZxNKkYTz";
+
+    it("dry-runs a governed mint with zero writes", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_mint_dry_run",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_mint_dry_run",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const createOrgSignerSpy = vi.spyOn(SolanaServices, "createOrgSigner");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/mint`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              "Dry-Run": "true",
+            },
+            body: JSON.stringify({
+              mint: { destination: TEST_SOLANA_ADDRESSES.wallet2, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          data: { decision: "allow", criteria: [] },
+        });
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        expect(operationCount).toEqual({ count: 0 });
+      } finally {
+        createOrgSignerSpy.mockRestore();
+      }
+    });
+
+    it("dry-runs an authority update with zero writes", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_authority_dry_run",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_authority_dry_run",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const createOrgSignerSpy = vi.spyOn(SolanaServices, "createOrgSigner");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/authority`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              "Dry-Run": "true",
+            },
+            body: JSON.stringify({
+              authority: {
+                role: "mint",
+                newAuthority: TEST_SOLANA_ADDRESSES.wallet2,
+              },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+          data: { decision: "allow", criteria: [] },
+        });
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+        expect(operationCount).toEqual({ count: 0 });
+      } finally {
+        createOrgSignerSpy.mockRestore();
+      }
+    });
+
+    it("stops a denied mint before signer and issuance side effects", async () => {
+      const wallet = await seedIssuanceActivityWallet(
+        "wal_issuance_mint_denied",
+        policyMintAuthority
+      );
+      const token = await seedIssuedToken({
+        id: "tok_issuance_mint_denied",
+        signingWalletId: wallet.walletId,
+        mintAuthority: policyMintAuthority,
+      });
+      const policyResponse = await app.request(
+        `/v1/payments/wallets/${wallet.walletId}/policies`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+          },
+          body: JSON.stringify({
+            destinationAllowlist: [],
+            defaultAction: "allow",
+            rules: [{ id: "deny-issuance-mint", kind: "always", action: "deny" }],
+          }),
+        },
+        env
+      );
+      expect(policyResponse.status).toBe(200);
+      const createOrgSignerSpy = vi.spyOn(SolanaServices, "createOrgSigner");
+
+      try {
+        const response = await app.request(
+          `/v1/issuance/tokens/${token.id}/mint`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: JSON.stringify({
+              mint: { destination: TEST_SOLANA_ADDRESSES.wallet2, amount: "1" },
+            }),
+          },
+          env
+        );
+
+        expect(response.status).toBe(403);
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+        const transactionCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM issuance_transactions")
+          .first<{ count: number }>();
+        expect(transactionCount).toEqual({ count: 0 });
+      } finally {
+        createOrgSignerSpy.mockRestore();
+      }
+    });
+
+    it("allows an ungoverned mint dry-run and executes without policy enforcement", async () => {
+      const token = await seedIssuedToken({
+        id: "tok_issuance_ungoverned_mint",
+        signingWalletId: null,
+      });
+      const createOrgSignerSpy = vi
+        .spyOn(SolanaServices, "createOrgSigner")
+        .mockResolvedValue(createNoopSigner(address(policyMintAuthority)));
+      const mintToSpy = vi.spyOn(MosaicService.prototype, "mintTo").mockResolvedValue({
+        signature: "sig_ungoverned_mint",
+        slot: 321n,
+        tokenAccount: address(TEST_SOLANA_ADDRESSES.wallet2),
+      });
+      const requestBody = JSON.stringify({
+        mint: { destination: TEST_SOLANA_ADDRESSES.wallet2, amount: "1" },
+      });
+
+      try {
+        const dryRun = await app.request(
+          `/v1/issuance/tokens/${token.id}/mint`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+              "Dry-Run": "true",
+            },
+            body: requestBody,
+          },
+          env
+        );
+        expect(dryRun.status).toBe(200);
+        expect(await dryRun.json()).toMatchObject({
+          data: { decision: "allow", criteria: [] },
+        });
+        expect(createOrgSignerSpy).not.toHaveBeenCalled();
+
+        const executed = await app.request(
+          `/v1/issuance/tokens/${token.id}/mint`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${TEST_PROJECT_API_KEY.raw}`,
+            },
+            body: requestBody,
+          },
+          env
+        );
+        expect(executed.status).toBe(200);
+        expect(createOrgSignerSpy).toHaveBeenCalledTimes(1);
+        expect(mintToSpy).toHaveBeenCalledTimes(1);
+
+        const operationCount = await getDb(env)
+          .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+          .first<{ count: number }>();
+        expect(operationCount).toEqual({ count: 0 });
+      } finally {
+        createOrgSignerSpy.mockRestore();
+        mintToSpy.mockRestore();
+      }
     });
   });
 

--- a/apps/sdp-api/src/routes/issuance/handlers/authority.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/authority.ts
@@ -5,15 +5,18 @@ import { AuthorityType } from "@solana-program/token-2022";
 import type { Context } from "hono";
 import { z } from "zod";
 import { getDb } from "@/db";
+import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { AuditService } from "@/services/audit.service";
 import {
   approvedWalletOperationId,
   beginApprovedWalletOperationEffect,
   runApprovedWalletOperationEffectTransaction,
-  walletOperationExecutionRequest,
 } from "@/services/policy/approved-operation-replay";
+import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
+import type { TokenService } from "@/services/token.service";
 import type { Env } from "@/types/env";
 import {
   createIssuanceMosaicService,
@@ -29,7 +32,7 @@ import {
   resolveCurrentAuthorityForRole,
 } from "./authority-resolution";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { enforceIssuanceWalletOperationPolicy } from "./policy";
+import { buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransactionThenOutcome,
   recoverSettledTransactionReplay,
@@ -37,6 +40,18 @@ import {
 
 type AppContext = Context<{ Bindings: Env }>;
 type MosaicAuthorityRole = Parameters<MosaicService["prepareUpdateAuthority"]>[0]["role"];
+type UpdateAuthorityBody = z.output<typeof updateAuthoritySchema>;
+
+interface UpdateAuthorityPolicyResolved {
+  tokenId: string;
+  auth: ApiKeyContext;
+  tokenService: TokenService;
+  role: AuthorityRole;
+  currentAuthorityRaw: string;
+  walletId: string;
+  mintAddress: ReturnType<typeof assertValidAddress>;
+  newAuthority: ReturnType<typeof assertValidAddress> | null;
+}
 
 const mapAuthorityRole = (role: AuthorityRole): MosaicAuthorityRole => {
   switch (role) {
@@ -160,43 +175,46 @@ export const prepareUpdateAuthority = async (c: AppContext) => {
   });
 };
 
-export const executeUpdateAuthority = async (c: AppContext) => {
+/**
+ * Parse and resolve an authority update into its wallet-operation policy candidate.
+ *
+ * @param c - Request context.
+ * @returns The candidate, validated body, resolved resources, and raw payload.
+ */
+export async function extractUpdateAuthorityPolicyCandidate(
+  c: AppContext
+): Promise<PolicyGateExtraction> {
   const { tokenId } = c.req.param();
   const { auth, projectId, orgId } = requireProjectScope(c);
-
-  const body = await c.req.json();
-  const parsed = updateAuthoritySchema.safeParse(body);
-
+  const parsed = updateAuthoritySchema.safeParse(await c.req.json());
   if (!parsed.success) {
     throw badRequest("Invalid request body", {
       errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
+  const input = parsed.data;
   const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
     projectId,
   });
-
   if (!token) {
     throw notFound("Token");
   }
-
   if (!token.mintAddress || token.status === "pending") {
     throw new AppError("TOKEN_NOT_DEPLOYED", "Token has not been deployed to Solana");
   }
 
-  const role = parsed.data.authority.role;
+  const role = input.authority.role;
   const currentAuthorityRaw = await resolveCurrentAuthorityForRole(
     c.env,
     tokenService,
     token,
     role,
-    parsed.data.authority.currentAuthority
+    input.authority.currentAuthority
   );
-
   if (!currentAuthorityRaw) {
     throw badRequest("Current authority is not available for this token");
   }
@@ -205,35 +223,67 @@ export const executeUpdateAuthority = async (c: AppContext) => {
     env: c.env,
     auth,
     token,
-    requestedWalletId: parsed.data.signingWalletId,
+    requestedWalletId: input.signingWalletId,
     currentAuthority: currentAuthorityRaw,
   });
-
   const mintAddress = assertValidAddress(token.mintAddress, "mintAddress");
-  const newAuthority = parsed.data.authority.newAuthority
-    ? assertValidAddress(parsed.data.authority.newAuthority, "newAuthority")
+  const newAuthority = input.authority.newAuthority
+    ? assertValidAddress(input.authority.newAuthority, "newAuthority")
     : null;
+  const policyWallet = await resolvePolicyCustodyWallet(c.env, auth, walletId);
 
-  await enforceIssuanceWalletOperationPolicy(c, {
-    auth,
-    token,
-    walletId,
-    operationType: "issuance_update_authority_execute",
-    destination: newAuthority,
+  return {
+    candidate: buildIssuancePolicyCandidate({
+      auth,
+      token,
+      custodyWalletId: policyWallet === null ? null : policyWallet.id,
+      walletId,
+      operationType: "issuance_update_authority_execute",
+      amount: null,
+      destination: newAuthority,
+    }),
+    body: input,
+    resolved: {
+      tokenId,
+      auth,
+      tokenService,
+      role,
+      currentAuthorityRaw,
+      walletId,
+      mintAddress,
+      newAuthority,
+    },
     rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
       action: "update_authority",
       role,
       currentAuthority: currentAuthorityRaw,
       newAuthority,
-      executionRequest: walletOperationExecutionRequest(c, parsed.data),
     },
-  });
+  };
+}
+
+export const executeUpdateAuthority = async (c: AppContext) => {
+  const {
+    body: input,
+    resolved: {
+      tokenId,
+      auth,
+      tokenService,
+      role,
+      currentAuthorityRaw,
+      walletId,
+      mintAddress,
+      newAuthority,
+    },
+  } = getPolicyGateContext<UpdateAuthorityBody, UpdateAuthorityPolicyResolved>(c);
 
   const idempotencyMetadata = buildIdempotencyMetadata(c.req.header("Idempotency-Key"), {
     tokenId,
     operation: "update_authority",
     mode: "execute",
-    params: parsed.data,
+    params: input,
   });
 
   const { transaction: tx, replayed } = await runApprovedWalletOperationEffectTransaction(c, (db) =>

--- a/apps/sdp-api/src/routes/issuance/handlers/mint.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/mint.ts
@@ -1,11 +1,14 @@
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import { createRpc, simulateTransaction } from "@sdp/rpc/solana";
 import { assertValidAddress } from "@sdp/solana/address";
 import type { TokenTransaction } from "@sdp/types";
 import type { Context } from "hono";
 import { z } from "zod";
 import { getDb } from "@/db";
+import type { ApiKeyContext } from "@/lib/auth";
 import { AppError, badRequest, notFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { getLogger } from "@/runtime/logger";
 import { resolveApiKeySigningWalletId } from "@/services/api-key-scope.service";
 import { type AuditIntent, AuditService } from "@/services/audit.service";
@@ -13,8 +16,8 @@ import {
   approvedWalletOperationId,
   beginApprovedWalletOperationEffect,
   reserveMintSupplyAtApprovedEffectBoundary,
-  walletOperationExecutionRequest,
 } from "@/services/policy/approved-operation-replay";
+import { resolvePolicyCustodyWallet } from "@/services/policy/enforcement.service";
 import { createOrgSigner } from "@/services/solana";
 import type { TokenService } from "@/services/token.service";
 import { resolveMintOperationAmount } from "@/services/token-operation.service";
@@ -30,13 +33,29 @@ import {
   getOnChainAllowlistMutationForMint,
 } from "./access-control";
 import { buildIdempotencyMetadata } from "./idempotency";
-import { enforceIssuanceWalletOperationPolicy } from "./policy";
+import { buildIssuancePolicyCandidate } from "./policy";
 import {
   persistSettledTransaction,
   persistSettledTransactionThenOutcome,
 } from "./settled-transaction";
 
 type AppContext = Context<{ Bindings: Env }>;
+
+type MintBody = z.output<typeof mintSchema>;
+
+type MintOperationAmount = ReturnType<typeof resolveMintOperationAmount>;
+
+interface MintPolicyResolved {
+  tokenId: string;
+  auth: ApiKeyContext;
+  tokenService: TokenService;
+  mintAddress: ReturnType<typeof assertValidAddress>;
+  destination: ReturnType<typeof assertValidAddress>;
+  mosaicAmount: MintOperationAmount["mosaicAmount"];
+  amountBaseUnits: MintOperationAmount["amountBaseUnits"];
+  ablListAddress: string | null;
+  signingWalletId: string | null;
+}
 
 interface SettledMintEvidence {
   signature: string;
@@ -450,26 +469,29 @@ async function recordPreSubmissionMintFailure(options: {
   }
 }
 
-export const executeMint = async (c: AppContext) => {
+/**
+ * Parse and resolve an execute-mint request into its wallet-operation policy candidate.
+ *
+ * @param c - Request context.
+ * @returns The candidate or ungoverned marker, validated body, resources, and raw payload.
+ */
+export async function extractMintPolicyCandidate(c: AppContext): Promise<PolicyGateExtraction> {
   const { tokenId } = c.req.param();
   const { auth, projectId, orgId } = requireProjectScope(c);
-
-  const body = await c.req.json();
-  const parsed = mintSchema.safeParse(body);
-
+  const parsed = mintSchema.safeParse(await c.req.json());
   if (!parsed.success) {
     throw badRequest("Invalid request body", {
       errors: z.flattenError(parsed.error).fieldErrors,
     });
   }
 
+  const input = parsed.data;
   const tokenService = getTenantTokenService(c);
   const token = await tokenService.getToken({
     tokenId,
     organizationId: orgId,
     projectId,
   });
-
   if (!token) {
     throw notFound("Token");
   }
@@ -478,44 +500,84 @@ export const executeMint = async (c: AppContext) => {
     mintAddress: mintAddressRaw,
     mosaicAmount,
     amountBaseUnits,
-  } = resolveMintOperationAmount(token, parsed.data.mint.amount);
-
+  } = resolveMintOperationAmount(token, input.mint.amount);
   const ablListAddress = getOnChainAllowlistMutationForMint(token);
   if (!ablListAddress) {
-    const isOnControlList = await tokenService.isAddressAllowed(
-      tokenId,
-      parsed.data.mint.destination
-    );
+    const isOnControlList = await tokenService.isAddressAllowed(tokenId, input.mint.destination);
     assertDestinationAllowedByControlList({
       token,
-      destination: parsed.data.mint.destination,
+      destination: input.mint.destination,
       isOnControlList,
     });
   }
 
-  const signingWalletId = resolveApiKeySigningWalletId(
-    auth,
-    parsed.data.signingWalletId ?? token.signingWalletId,
-    ["tokens:write"]
-  );
+  const requestedSigningWalletId =
+    input.signingWalletId === undefined || input.signingWalletId === null
+      ? token.signingWalletId
+      : input.signingWalletId;
+  const signingWalletId = resolveApiKeySigningWalletId(auth, requestedSigningWalletId, [
+    "tokens:write",
+  ]);
   const mintAddress = assertValidAddress(mintAddressRaw, "mintAddress");
-  const destination = assertValidAddress(parsed.data.mint.destination, "destination");
+  const destination = assertValidAddress(input.mint.destination, "destination");
+  const policyWallet =
+    signingWalletId === null
+      ? null
+      : await resolvePolicyCustodyWallet(c.env, auth, signingWalletId);
 
-  await enforceIssuanceWalletOperationPolicy(c, {
-    auth,
-    token,
-    walletId: signingWalletId,
-    operationType: "issuance_mint_execute",
-    amount: parsed.data.mint.amount,
-    destination: parsed.data.mint.destination,
-    rawPayload: {
-      action: "mint",
-      destination: parsed.data.mint.destination,
-      amount: parsed.data.mint.amount,
-      memo: parsed.data.mint.memo ?? null,
-      executionRequest: walletOperationExecutionRequest(c, parsed.data),
+  return {
+    candidate:
+      signingWalletId === null
+        ? null
+        : buildIssuancePolicyCandidate({
+            auth,
+            token,
+            custodyWalletId: policyWallet === null ? null : policyWallet.id,
+            walletId: signingWalletId,
+            operationType: "issuance_mint_execute",
+            amount: input.mint.amount,
+            destination: input.mint.destination,
+          }),
+    body: input,
+    resolved: {
+      tokenId,
+      auth,
+      tokenService,
+      mintAddress,
+      destination,
+      mosaicAmount,
+      amountBaseUnits,
+      ablListAddress,
+      signingWalletId,
     },
-  });
+    rawPayload: {
+      tokenId: token.id,
+      mintAddress: token.mintAddress,
+      action: "mint",
+      destination: input.mint.destination,
+      amount: input.mint.amount,
+      memo: input.mint.memo === undefined ? null : input.mint.memo,
+    },
+  };
+}
+
+export const executeMint = async (c: AppContext) => {
+  const {
+    body: input,
+    resolved: {
+      tokenId,
+      auth,
+      tokenService,
+      mintAddress,
+      destination,
+      mosaicAmount,
+      amountBaseUnits,
+      ablListAddress,
+      signingWalletId,
+    },
+  } = getPolicyGateContext<MintBody, MintPolicyResolved, WalletOperationPolicyEnforcement | null>(
+    c
+  );
 
   // Resolve signer + sync the destination on-chain BEFORE createTransaction.
   // If sync (or its inner revoke check) throws inside the try block below,
@@ -535,7 +597,7 @@ export const executeMint = async (c: AppContext) => {
         mosaic,
         tokenId,
         ablListAddress,
-        destinationRaw: parsed.data.mint.destination,
+        destinationRaw: input.mint.destination,
         destination,
         addedBy: auth.id,
       })
@@ -545,7 +607,7 @@ export const executeMint = async (c: AppContext) => {
     tokenId,
     operation: "mint",
     mode: "execute",
-    params: parsed.data,
+    params: input,
   });
 
   // Create transaction record after sync so a sync-time error does not poison
@@ -555,9 +617,9 @@ export const executeMint = async (c: AppContext) => {
     organizationId: auth.organizationId,
     type: "mint",
     params: {
-      destination: parsed.data.mint.destination,
-      amount: parsed.data.mint.amount,
-      memo: parsed.data.mint.memo,
+      destination: input.mint.destination,
+      amount: input.mint.amount,
+      memo: input.mint.memo,
     },
     initiatedByKeyId: auth.id,
     idempotencyKey: idempotencyMetadata.idempotencyKey,
@@ -573,7 +635,7 @@ export const executeMint = async (c: AppContext) => {
         : undefined;
     return success(c, {
       transaction: replayedTransaction,
-      tokenAccount: txTokenAccount ?? parsed.data.mint.destination,
+      tokenAccount: txTokenAccount === undefined ? input.mint.destination : txTokenAccount,
     });
   }
 
@@ -583,8 +645,8 @@ export const executeMint = async (c: AppContext) => {
     resourceId: tx.id,
     metadata: {
       tokenId,
-      destination: parsed.data.mint.destination,
-      amount: parsed.data.mint.amount,
+      destination: input.mint.destination,
+      amount: input.mint.amount,
       mode: "execute",
     },
   });
@@ -620,7 +682,8 @@ export const executeMint = async (c: AppContext) => {
       }
     );
 
-    const settledTokenAccount = result.tokenAccount ?? parsed.data.mint.destination;
+    const settledTokenAccount =
+      result.tokenAccount === undefined ? input.mint.destination : result.tokenAccount;
     const settledEvidence: SettledMintEvidence = {
       signature: result.signature,
       slot: Number(result.slot),

--- a/apps/sdp-api/src/routes/issuance/handlers/policy.ts
+++ b/apps/sdp-api/src/routes/issuance/handlers/policy.ts
@@ -1,64 +1,43 @@
-import type { Token } from "@sdp/types";
+import type { PolicyCandidate, Token } from "@sdp/types";
 import type { ApiKeyContext } from "@/lib/auth";
-import { getRequestTenantScope } from "@/lib/tenant-scope";
-import {
-  approvedWalletOperationAttemptId,
-  approvedWalletOperationId,
-} from "@/services/policy/approved-operation-replay";
-import {
-  enforceWalletOperationPolicy,
-  resolvePolicyCustodyWallet,
-  walletOperationActorFromAuth,
-} from "@/services/policy/enforcement.service";
-import type { AppContext } from "../helpers";
+import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
 
 type IssuancePolicyOperationType = "issuance_mint_execute" | "issuance_update_authority_execute";
 
-export async function enforceIssuanceWalletOperationPolicy(
-  c: AppContext,
-  input: {
-    auth: ApiKeyContext;
-    token: Token;
-    walletId: string | null;
-    operationType: IssuancePolicyOperationType;
-    amount?: string | null;
-    destination?: string | null;
-    rawPayload?: Record<string, unknown>;
-  }
-): Promise<void> {
-  if (!input.walletId) {
-    return;
-  }
-
-  const policyWallet = await resolvePolicyCustodyWallet(c.env, input.auth, input.walletId);
-
-  await enforceWalletOperationPolicy(
-    c.env,
-    getRequestTenantScope(c),
-    {
-      organizationId: input.auth.organizationId,
-      projectId: input.token.projectId,
-      custodyWalletId: policyWallet?.id ?? null,
-      walletId: input.walletId,
-      apiKeyId: input.auth.apiKeyId,
-      actor: walletOperationActorFromAuth(input.auth),
-      operationFamily: "issuance",
-      operationType: input.operationType,
-      asset: input.token.symbol,
-      amount: input.amount ?? null,
-      destination: input.destination ?? null,
-      context: {
-        tokenId: input.token.id,
-        tokenSymbol: input.token.symbol,
-        mintAddress: input.token.mintAddress,
-      },
-      rawPayload: {
-        tokenId: input.token.id,
-        mintAddress: input.token.mintAddress,
-        ...(input.rawPayload ?? {}),
-      },
+/**
+ * Build the issuance wallet-operation policy candidate shared by the mint and
+ * update-authority policy gates.
+ *
+ * @param input - The auth context, token, resolved wallet ids, operation type, amount, and destination.
+ * @returns The policy candidate for the issuance operation.
+ */
+export function buildIssuancePolicyCandidate(input: {
+  auth: ApiKeyContext;
+  token: Token;
+  custodyWalletId: string | null;
+  walletId: string;
+  operationType: IssuancePolicyOperationType;
+  amount: string | null;
+  destination: string | null;
+}): PolicyCandidate {
+  return {
+    organizationId: input.auth.organizationId,
+    projectId: input.token.projectId,
+    custodyWalletId: input.custodyWalletId,
+    walletId: input.walletId,
+    apiKeyId: input.auth.apiKeyId,
+    actor: walletOperationActorFromAuth(input.auth),
+    source: "api",
+    operationFamily: "issuance",
+    operationType: input.operationType,
+    asset: input.token.symbol,
+    amount: input.amount,
+    destination: input.destination,
+    context: {
+      tokenId: input.token.id,
+      tokenSymbol: input.token.symbol,
+      mintAddress: input.token.mintAddress,
     },
-    approvedWalletOperationId(c),
-    approvedWalletOperationAttemptId(c)
-  );
+    providerExtensions: {},
+  };
 }

--- a/apps/sdp-api/src/routes/issuance/index.ts
+++ b/apps/sdp-api/src/routes/issuance/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { policyGate } from "@/middleware/policy-gate";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
@@ -9,7 +10,11 @@ import {
   removeAllowlistEntry,
 } from "./handlers/allowlist";
 import { getAssetAuditHistory } from "./handlers/audit";
-import { executeUpdateAuthority, prepareUpdateAuthority } from "./handlers/authority";
+import {
+  executeUpdateAuthority,
+  extractUpdateAuthorityPolicyCandidate,
+  prepareUpdateAuthority,
+} from "./handlers/authority";
 import { executeBurn, prepareBurn } from "./handlers/burn";
 import {
   confirmDeploy,
@@ -20,7 +25,7 @@ import {
 import { executeForceBurn, prepareForceBurn } from "./handlers/force-burn";
 import { freezeAccount, listFrozenAccounts, unfreezeAccount } from "./handlers/freeze";
 import { serveTokenMetadata } from "./handlers/metadata";
-import { executeMint, prepareMint } from "./handlers/mint";
+import { executeMint, extractMintPolicyCandidate, prepareMint } from "./handlers/mint";
 import { pauseToken, unpauseToken } from "./handlers/pause";
 import { executeSeize, prepareSeize } from "./handlers/seize";
 import { refreshTokenSupply } from "./handlers/supply";
@@ -82,7 +87,12 @@ issuance.post(
 
 // Mint
 issuance.post("/tokens/:tokenId/mint/prepare", requirePermissions("tokens:write"), prepareMint);
-issuance.post("/tokens/:tokenId/mint", requirePermissions("tokens:write"), executeMint);
+issuance.post(
+  "/tokens/:tokenId/mint",
+  requirePermissions("tokens:write"),
+  policyGate({ extract: extractMintPolicyCandidate }),
+  executeMint
+);
 
 // Burn
 issuance.post("/tokens/:tokenId/burn/prepare", requirePermissions("tokens:write"), prepareBurn);
@@ -109,6 +119,7 @@ issuance.post(
 issuance.post(
   "/tokens/:tokenId/authority",
   requirePermissions("tokens:admin"),
+  policyGate({ extract: extractUpdateAuthorityPolicyCandidate }),
   executeUpdateAuthority
 );
 

--- a/apps/sdp-api/src/routes/payments.ramps.test.ts
+++ b/apps/sdp-api/src/routes/payments.ramps.test.ts
@@ -14,6 +14,7 @@ import {
   TEST_API_KEY,
   TEST_BVNK_API_BASE_URL,
   TEST_BVNK_HAWK_AUTH_ID,
+  TEST_CONFIG_ID,
   TEST_MOONPAY_API_KEY,
   TEST_MOONPAY_ONRAMP_URL,
   TEST_MOONPAY_SECRET_KEY,
@@ -377,6 +378,139 @@ describe("Payments routes — ramps", () => {
       data: { transfer: { rampsMemo: Record<string, string> } };
     };
     expect(transferBody.data.transfer.rampsMemo).toEqual({ invoice: "INV-123", po: "PO-9" });
+  });
+
+  it("dry-runs an on-ramp quote with zero writes", async () => {
+    const counterpartyId = await seedCounterparty({ externalId: "moonpay_onramp_dry_run" });
+
+    const response = await app.request(
+      "/v1/payments/ramps/onramp/quote",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+          "Dry-Run": "true",
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          counterpartyId,
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "SOL",
+          fiatCurrency: "USD",
+          fiatAmount: "120.50",
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { decision: "allow", criteria: [] },
+    });
+
+    const [transferCount, operationCount] = await Promise.all([
+      getDb(env)
+        .prepare("SELECT COUNT(*)::int AS count FROM payment_transfers")
+        .first<{ count: number }>(),
+      getDb(env)
+        .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+        .first<{ count: number }>(),
+    ]);
+    expect(transferCount).toEqual({ count: 0 });
+    expect(operationCount).toEqual({ count: 0 });
+  });
+
+  it("dry-runs an off-ramp quote with zero writes", async () => {
+    const counterpartyId = await seedCounterparty({ externalId: "moonpay_offramp_dry_run" });
+
+    const response = await app.request(
+      "/v1/payments/ramps/offramp/quote",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+          "Dry-Run": "true",
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          counterpartyId,
+          sourceWallet: TEST_WALLET_ID,
+          cryptoToken: "SOL",
+          fiatCurrency: "USD",
+          cryptoAmount: "75.25",
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { decision: "allow", criteria: [] },
+    });
+
+    const [transferCount, operationCount] = await Promise.all([
+      getDb(env)
+        .prepare("SELECT COUNT(*)::int AS count FROM payment_transfers")
+        .first<{ count: number }>(),
+      getDb(env)
+        .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+        .first<{ count: number }>(),
+    ]);
+    expect(transferCount).toEqual({ count: 0 });
+    expect(operationCount).toEqual({ count: 0 });
+  });
+
+  it("stops a denied ramp quote before provider and transfer side effects", async () => {
+    await getDb(env)
+      .prepare("UPDATE custody_configs SET project_id = ? WHERE id = ?")
+      .bind(TEST_PROJECT.id, TEST_CONFIG_ID)
+      .run();
+    const policyResponse = await app.request(
+      `/v1/payments/wallets/${TEST_WALLET_ID}/policies`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationAllowlist: [],
+          defaultAction: "allow",
+          rules: [{ id: "deny-ramp-quotes", kind: "always", action: "deny" }],
+        }),
+      },
+      env
+    );
+    expect(policyResponse.status).toBe(200);
+    const counterpartyId = await seedCounterparty({ externalId: "moonpay_denied_quote" });
+
+    const response = await app.request(
+      "/v1/payments/ramps/onramp/quote",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          provider: "moonpay",
+          counterpartyId,
+          destinationWallet: TEST_WALLET_ID,
+          cryptoToken: "SOL",
+          fiatCurrency: "USD",
+          fiatAmount: "120.50",
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    const transferCount = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM payment_transfers")
+      .first<{ count: number }>();
+    expect(transferCount).toEqual({ count: 0 });
   });
 
   it("rejects a ramp quote memo with more than 20 fields", async () => {

--- a/apps/sdp-api/src/routes/payments/handlers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers.ts
@@ -11,6 +11,8 @@ export {
   createOnrampQuote,
   estimateOfframp,
   estimateOnramp,
+  extractOfframpQuotePolicyCandidate,
+  extractOnrampQuotePolicyCandidate,
   listOfframpCurrencies,
   listOnrampCurrencies,
   simulateSandboxTransfer,
@@ -44,6 +46,8 @@ export {
 export {
   createTransferBatch,
   estimateTransferBatch,
+  extractTransferBatchPolicyCandidate,
+  findTransferBatchIdempotentKeyReplay,
   getTransferBatch,
   listTransferBatches,
 } from "./handlers/transfer-batches";

--- a/apps/sdp-api/src/routes/payments/handlers/ramps.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/ramps.ts
@@ -55,19 +55,11 @@ import {
   unsupportedRampCorridor,
 } from "@/lib/errors";
 import { success } from "@/lib/response";
-import { getRequestTenantScope } from "@/lib/tenant-scope";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { getCounterpartiesRepository } from "@/routes/counterparties/context";
 import { rampTransferTokenMint } from "@/services/payment-operation.service";
-import {
-  approvedWalletOperationAttemptId,
-  approvedWalletOperationId,
-  beginApprovedWalletOperationEffect,
-  walletOperationExecutionRequest,
-} from "@/services/policy/approved-operation-replay";
-import {
-  enforceWalletOperationPolicy,
-  walletOperationActorFromAuth,
-} from "@/services/policy/enforcement.service";
+import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
+import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
 import { assertProviderAvailable } from "@/services/provider-availability.service";
 import {
   type AppContext,
@@ -204,7 +196,17 @@ function assertRampCorridorSupported(
 }
 type ScopedRampWallet = ResolvedScope["wallets"][number];
 
-type RampPolicyOperationType = "ramp_onramp_quote" | "ramp_offramp_quote";
+type CreateOnrampQuoteBody = z.output<typeof createOnrampQuoteSchema>;
+
+type CreateOfframpQuoteBody = z.output<typeof createOfframpQuoteSchema>;
+
+interface RampQuotePolicyResolved {
+  scope: ResolvedScope;
+  projectId: string;
+  counterparty: CounterpartyRow;
+  wallet: ScopedRampWallet;
+  walletAddress: string;
+}
 
 interface PersistRampQuoteTransferInput {
   scope: ResolvedScope;
@@ -237,45 +239,161 @@ function requireRampTransferWallet(
   return wallet;
 }
 
-async function enforceRampWalletOperationPolicy(
+/**
+ * Resolve the state shared by both ramp-quote extractions: corridor support,
+ * provider availability, the counterparty, and the SDP wallet on the crypto
+ * leg.
+ *
+ * @param c - Request context.
+ * @param direction - The quote direction.
+ * @param input - The validated quote request body.
+ * @param walletFieldName - The request field naming the wallet.
+ * @param walletIdOrAddress - The requested wallet id or address.
+ * @returns The resolved scope, project, counterparty, wallet, and address.
+ */
+async function resolveRampQuoteRequest(
   c: AppContext,
-  input: {
-    scope: ResolvedScope;
-    wallet: ScopedRampWallet;
-    operationType: RampPolicyOperationType;
-    provider: RampProviderId;
-    counterpartyId: string;
-    asset: string;
-    amount?: string | null;
-    destination?: string | null;
-    rawPayload?: Record<string, unknown>;
+  direction: RampQuoteDirection,
+  input: CreateOnrampQuoteBody | CreateOfframpQuoteBody,
+  walletFieldName: "destinationWallet" | "sourceWallet",
+  walletIdOrAddress: string
+): Promise<RampQuotePolicyResolved> {
+  assertRampCorridorSupported(direction, input);
+  const scope = await resolveScope(c);
+  await assertRampProviderAvailable(c, input.provider, scope.auth.organizationId);
+
+  const projectId = requireProjectId(c);
+  const counterparty = await getCounterpartiesRepository(c).getCounterpartyById({
+    counterpartyId: input.counterpartyId,
+    organizationId: scope.auth.organizationId,
+    projectId,
+  });
+  if (!counterparty) {
+    throw new AppError("NOT_FOUND", "Counterparty not found");
   }
-) {
-  return enforceWalletOperationPolicy(
-    c.env,
-    getRequestTenantScope(c),
-    {
-      organizationId: input.scope.auth.organizationId,
-      projectId: input.scope.auth.projectId,
-      custodyWalletId: input.wallet.id,
-      walletId: input.wallet.walletId,
-      apiKeyId: input.scope.auth.apiKeyId,
-      actor: walletOperationActorFromAuth(input.scope.auth),
-      operationFamily: "ramp",
-      operationType: input.operationType,
-      asset: input.asset,
-      amount: input.amount ?? null,
-      destination: input.destination ?? null,
-      providerExtensions: { provider: input.provider },
-      rawPayload: {
-        provider: input.provider,
-        counterpartyId: input.counterpartyId,
-        ...(input.rawPayload ?? {}),
-      },
-    },
-    approvedWalletOperationId(c),
-    approvedWalletOperationAttemptId(c)
+
+  const walletAddress = resolveWalletAddress(
+    scope.wallets,
+    walletIdOrAddress,
+    walletFieldName,
+    scope.auth,
+    ["payments:write"]
   );
+  const wallet = requireRampTransferWallet(
+    scope,
+    walletIdOrAddress,
+    walletAddress,
+    walletFieldName
+  );
+  return { scope, projectId, counterparty, wallet, walletAddress };
+}
+
+/**
+ * Parse and resolve an on-ramp quote into its wallet-operation policy candidate.
+ *
+ * @param c - Request context.
+ * @returns The candidate, validated body, resolved resources, and raw payload.
+ */
+export async function extractOnrampQuotePolicyCandidate(
+  c: AppContext
+): Promise<PolicyGateExtraction> {
+  const parsed = createOnrampQuoteSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const input = parsed.data;
+  const { scope, projectId, counterparty, wallet, walletAddress } = await resolveRampQuoteRequest(
+    c,
+    "onramp",
+    input,
+    "destinationWallet",
+    input.destinationWallet
+  );
+
+  return {
+    candidate: {
+      organizationId: scope.auth.organizationId,
+      projectId: scope.auth.projectId,
+      custodyWalletId: wallet.id,
+      walletId: wallet.walletId,
+      apiKeyId: scope.auth.apiKeyId,
+      actor: walletOperationActorFromAuth(scope.auth),
+      source: "api",
+      operationFamily: "ramp",
+      operationType: "ramp_onramp_quote",
+      asset: input.cryptoToken,
+      amount: input.fiatAmount,
+      destination: walletAddress,
+      context: {},
+      providerExtensions: { provider: input.provider },
+    },
+    body: input,
+    resolved: { scope, projectId, counterparty, wallet, walletAddress },
+    rawPayload: {
+      provider: input.provider,
+      counterpartyId: input.counterpartyId,
+      fiatCurrency: input.fiatCurrency,
+      fiatAmount: input.fiatAmount,
+      cryptoToken: input.cryptoToken,
+    },
+  };
+}
+
+/**
+ * Parse and resolve an off-ramp quote into its wallet-operation policy candidate.
+ *
+ * @param c - Request context.
+ * @returns The candidate, validated body, resolved resources, and raw payload.
+ */
+export async function extractOfframpQuotePolicyCandidate(
+  c: AppContext
+): Promise<PolicyGateExtraction> {
+  const parsed = createOfframpQuoteSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const input = parsed.data;
+  const { scope, projectId, counterparty, wallet, walletAddress } = await resolveRampQuoteRequest(
+    c,
+    "offramp",
+    input,
+    "sourceWallet",
+    input.sourceWallet
+  );
+
+  return {
+    candidate: {
+      organizationId: scope.auth.organizationId,
+      projectId: scope.auth.projectId,
+      custodyWalletId: wallet.id,
+      walletId: wallet.walletId,
+      apiKeyId: scope.auth.apiKeyId,
+      actor: walletOperationActorFromAuth(scope.auth),
+      source: "api",
+      operationFamily: "ramp",
+      operationType: "ramp_offramp_quote",
+      asset: input.cryptoToken,
+      amount: input.cryptoAmount,
+      destination: null,
+      context: {},
+      providerExtensions: { provider: input.provider },
+    },
+    body: input,
+    resolved: { scope, projectId, counterparty, wallet, walletAddress },
+    rawPayload: {
+      provider: input.provider,
+      counterpartyId: input.counterpartyId,
+      fiatCurrency: input.fiatCurrency,
+      cryptoAmount: input.cryptoAmount,
+      cryptoToken: input.cryptoToken,
+    },
+  };
 }
 
 function rampQuoteTransferStatus(quote: PaymentRampQuote): PaymentTransferStatus {
@@ -507,60 +625,16 @@ export async function estimateOfframp(c: AppContext) {
 }
 
 export async function createOnrampQuote(c: AppContext): Promise<Response> {
-  const body = await c.req.json();
-  const parsed = createOnrampQuoteSchema.safeParse(body);
-
-  if (!parsed.success) {
-    throw badRequest("Invalid request body", {
-      errors: z.flattenError(parsed.error).fieldErrors,
-    });
-  }
-
-  const input = parsed.data;
-  assertRampCorridorSupported("onramp", input);
-  const scope = await resolveScope(c);
-  await assertRampProviderAvailable(c, input.provider, scope.auth.organizationId);
-
-  const projectId = requireProjectId(c);
-  const repo = getCounterpartiesRepository(c);
-  const counterparty = await repo.getCounterpartyById({
-    counterpartyId: input.counterpartyId,
-    organizationId: scope.auth.organizationId,
-    projectId,
-  });
-  if (!counterparty) {
-    throw new AppError("NOT_FOUND", "Counterparty not found");
-  }
-
-  const destinationWalletAddress = resolveWalletAddress(
-    scope.wallets,
-    input.destinationWallet,
-    "destinationWallet",
-    scope.auth,
-    ["payments:write"]
-  );
-  const destinationWallet = requireRampTransferWallet(
-    scope,
-    input.destinationWallet,
-    destinationWalletAddress,
-    "destinationWallet"
-  );
-  await enforceRampWalletOperationPolicy(c, {
-    scope,
-    wallet: destinationWallet,
-    operationType: "ramp_onramp_quote",
-    provider: input.provider,
-    counterpartyId: input.counterpartyId,
-    asset: input.cryptoToken,
-    amount: input.fiatAmount,
-    destination: destinationWalletAddress,
-    rawPayload: {
-      fiatCurrency: input.fiatCurrency,
-      fiatAmount: input.fiatAmount,
-      cryptoToken: input.cryptoToken,
-      executionRequest: walletOperationExecutionRequest(c, input),
+  const {
+    body: input,
+    resolved: {
+      scope,
+      projectId,
+      counterparty,
+      wallet: destinationWallet,
+      walletAddress: destinationWalletAddress,
     },
-  });
+  } = getPolicyGateContext<CreateOnrampQuoteBody, RampQuotePolicyResolved>(c);
 
   await beginApprovedWalletOperationEffect(c);
 
@@ -684,59 +758,16 @@ export async function createOnrampQuote(c: AppContext): Promise<Response> {
 }
 
 export async function createOfframpQuote(c: AppContext): Promise<Response> {
-  const body = await c.req.json();
-  const parsed = createOfframpQuoteSchema.safeParse(body);
-
-  if (!parsed.success) {
-    throw badRequest("Invalid request body", {
-      errors: z.flattenError(parsed.error).fieldErrors,
-    });
-  }
-
-  const input = parsed.data;
-  assertRampCorridorSupported("offramp", input);
-  const scope = await resolveScope(c);
-  await assertRampProviderAvailable(c, input.provider, scope.auth.organizationId);
-
-  const projectId = requireProjectId(c);
-  const repo = getCounterpartiesRepository(c);
-  const counterparty = await repo.getCounterpartyById({
-    counterpartyId: input.counterpartyId,
-    organizationId: scope.auth.organizationId,
-    projectId,
-  });
-  if (!counterparty) {
-    throw new AppError("NOT_FOUND", "Counterparty not found");
-  }
-
-  const sourceWalletAddress = resolveWalletAddress(
-    scope.wallets,
-    input.sourceWallet,
-    "sourceWallet",
-    scope.auth,
-    ["payments:write"]
-  );
-  const sourceWallet = requireRampTransferWallet(
-    scope,
-    input.sourceWallet,
-    sourceWalletAddress,
-    "sourceWallet"
-  );
-  await enforceRampWalletOperationPolicy(c, {
-    scope,
-    wallet: sourceWallet,
-    operationType: "ramp_offramp_quote",
-    provider: input.provider,
-    counterpartyId: input.counterpartyId,
-    asset: input.cryptoToken,
-    amount: input.cryptoAmount,
-    rawPayload: {
-      fiatCurrency: input.fiatCurrency,
-      cryptoToken: input.cryptoToken,
-      cryptoAmount: input.cryptoAmount,
-      executionRequest: walletOperationExecutionRequest(c, input),
+  const {
+    body: input,
+    resolved: {
+      scope,
+      projectId,
+      counterparty,
+      wallet: sourceWallet,
+      walletAddress: sourceWalletAddress,
     },
-  });
+  } = getPolicyGateContext<CreateOfframpQuoteBody, RampQuotePolicyResolved>(c);
 
   await beginApprovedWalletOperationEffect(c);
 

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/create.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/create.ts
@@ -9,16 +9,21 @@ import { createPostgresPaymentTransferBatchesRepository } from "@/db/repositorie
 import { AppError, badRequest, internalError } from "@/lib/errors";
 import { buildTransferBatchFingerprint } from "@/lib/idempotency";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import {
   approvedWalletOperationId,
   beginApprovedWalletOperationEffect,
   runApprovedWalletOperationEffectTransaction,
 } from "@/services/policy/approved-operation-replay";
+import {
+  recordLegacyWalletPolicyDenial,
+  walletOperationActorFromAuth,
+} from "@/services/policy/enforcement.service";
 import * as solanaServices from "@/services/solana";
 import { type AppContext, getFeePayment, getPaymentTransferBatchesRepository } from "../../context";
 import { createTransferBatchSchema } from "../../schemas";
 import { applyRecipientRowUpdates, executeChunk, updateRecipientRows } from "./execute";
-import { enforceBatchPolicies } from "./policy";
+import { assertLegacyBatchPolicies } from "./policy";
 import { resolveBatchRequest } from "./resolve";
 import { buildTransferBatchResponse, resolveTransferBatchIdempotencyReplay } from "./respond";
 import {
@@ -26,8 +31,13 @@ import {
   chunkInstructionGroups,
   DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION,
 } from "./transaction";
+import type { CreateTransferBatchInput, ResolvedBatchRequest } from "./types";
 
 type TransferBatchResponse = Awaited<ReturnType<typeof buildTransferBatchResponse>>;
+
+interface TransferBatchGateResolved extends ResolvedBatchRequest {
+  idempotencyFingerprint: string;
+}
 
 async function assertApprovedBatchReplayCompleted(
   c: AppContext,
@@ -78,6 +88,123 @@ async function respondToTransferBatchReplay(
 }
 
 /**
+ * Parse and resolve a transfer-batch request into its wallet-operation policy candidate.
+ *
+ * @param c - Request context.
+ * @returns The candidate, validated body, resolved request, and raw payload.
+ */
+export async function extractTransferBatchPolicyCandidate(
+  c: AppContext
+): Promise<PolicyGateExtraction> {
+  const parsed = createTransferBatchSchema.safeParse(await c.req.json());
+  if (!parsed.success) {
+    throw badRequest("Invalid request body", {
+      errors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const input = parsed.data;
+  const resolved = await resolveBatchRequest(c, input, ["payments:write"]);
+
+  return {
+    candidate: {
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.scope.auth.projectId,
+      custodyWalletId: resolved.sourceWallet.id,
+      walletId: resolved.sourceWallet.walletId,
+      apiKeyId: resolved.scope.auth.apiKeyId,
+      actor: walletOperationActorFromAuth(resolved.scope.auth),
+      source: "api",
+      operationFamily: "payment",
+      operationType: "payment_transfer_batch_execute",
+      asset: resolved.tokenContext.token,
+      amount: resolved.totalAmount,
+      destination: null,
+      context: {
+        sourceAddress: resolved.sourceAddress,
+        recipientCount: resolved.recipients.length,
+        transactionCount: null,
+      },
+      providerExtensions: {},
+    },
+    body: input,
+    resolved: {
+      ...resolved,
+      idempotencyFingerprint: buildBatchIdempotencyFingerprint(resolved, input.options),
+    },
+    rawPayload: {
+      externalId: input.externalId === undefined ? null : input.externalId,
+      source: input.source,
+      token: input.token,
+      recipients: input.recipients.map((recipient) => ({
+        externalId: recipient.externalId === undefined ? null : recipient.externalId,
+        counterpartyId: recipient.counterpartyId,
+        counterpartyAccountId: recipient.counterpartyAccountId,
+        amount: recipient.amount,
+      })),
+      options: input.options === undefined ? null : input.options,
+    },
+  };
+}
+
+/**
+ * Build the batch idempotency fingerprint from the resolved request.
+ *
+ * @param resolved - The resolved batch request.
+ * @param options - The request's batch options.
+ * @returns The fingerprint string.
+ */
+function buildBatchIdempotencyFingerprint(
+  resolved: ResolvedBatchRequest,
+  options: CreateTransferBatchInput["options"]
+): string {
+  return buildTransferBatchFingerprint({
+    sourceAddress: resolved.sourceAddress,
+    token: resolved.tokenContext.token,
+    recipients: resolved.recipients.map((recipient) => ({
+      externalId: recipient.externalId,
+      counterpartyId: recipient.counterpartyId,
+      counterpartyAccountId: recipient.counterpartyAccountId,
+      destinationAddress: recipient.destinationAddress,
+      amount: recipient.amount,
+    })),
+    options,
+  });
+}
+
+/**
+ * Resolve an Idempotency-Key replay before transfer-batch policy enforcement.
+ *
+ * @param c - Request context.
+ * @param extraction - The transfer-batch gate extraction.
+ * @param idempotencyKey - The Idempotency-Key header value.
+ * @returns The recorded batch response, or null for a new request.
+ */
+export async function findTransferBatchIdempotentKeyReplay(
+  c: AppContext,
+  extraction: PolicyGateExtraction,
+  idempotencyKey: string
+): Promise<Response | null> {
+  const resolved = extraction.resolved as TransferBatchGateResolved;
+  const replay = await resolveTransferBatchIdempotencyReplay(
+    getPaymentTransferBatchesRepository(c),
+    resolved.scope.auth.organizationId,
+    resolved.projectId,
+    idempotencyKey,
+    resolved.idempotencyFingerprint
+  );
+  if (replay === null) {
+    return null;
+  }
+  return respondToTransferBatchReplay(
+    c,
+    replay,
+    resolved.scope.auth.organizationId,
+    resolved.projectId
+  );
+}
+
+/**
  * POST /transfer-batches — creates the batch aggregate, submits all chunks
  * concurrently, and responds without waiting for on-chain confirmation:
  * transfers come back processing and the pending-transfers job settles them.
@@ -97,49 +224,19 @@ async function respondToTransferBatchReplay(
  * @returns JSON batch response with recipients and chunk transfers.
  */
 export async function createTransferBatch(c: AppContext) {
-  const body = await c.req.json();
-  const parsed = createTransferBatchSchema.safeParse(body);
-  const idempotencyKey = c.req.header("Idempotency-Key") ?? null;
-
-  if (!parsed.success) {
-    throw badRequest("Invalid request body", {
-      errors: z.flattenError(parsed.error).fieldErrors,
-    });
+  const { body, resolved, enforcement } = getPolicyGateContext<
+    CreateTransferBatchInput,
+    TransferBatchGateResolved
+  >(c);
+  const idempotencyKeyHeader = c.req.header("Idempotency-Key");
+  const idempotencyKey = idempotencyKeyHeader === undefined ? null : idempotencyKeyHeader;
+  const idempotencyFingerprint = idempotencyKey ? resolved.idempotencyFingerprint : null;
+  try {
+    await assertLegacyBatchPolicies(c, resolved);
+  } catch (error) {
+    await recordLegacyWalletPolicyDenial(c.env, enforcement, error);
+    throw error;
   }
-
-  const resolved = await resolveBatchRequest(c, parsed.data, ["payments:write"]);
-  const idempotencyFingerprint = idempotencyKey
-    ? buildTransferBatchFingerprint({
-        sourceAddress: resolved.sourceAddress,
-        token: resolved.tokenContext.token,
-        recipients: resolved.recipients.map((recipient) => ({
-          externalId: recipient.externalId,
-          counterpartyId: recipient.counterpartyId,
-          counterpartyAccountId: recipient.counterpartyAccountId,
-          destinationAddress: recipient.destinationAddress,
-          amount: recipient.amount,
-        })),
-        options: parsed.data.options,
-      })
-    : null;
-  if (idempotencyKey && idempotencyFingerprint) {
-    const replay = await resolveTransferBatchIdempotencyReplay(
-      getPaymentTransferBatchesRepository(c),
-      resolved.scope.auth.organizationId,
-      resolved.projectId,
-      idempotencyKey,
-      idempotencyFingerprint
-    );
-    if (replay) {
-      return respondToTransferBatchReplay(
-        c,
-        replay,
-        resolved.scope.auth.organizationId,
-        resolved.projectId
-      );
-    }
-  }
-  await enforceBatchPolicies(c, resolved, parsed.data);
 
   const feePayment = getFeePayment(c);
   const [signer, feePayer, lifetime] = await Promise.all([
@@ -167,7 +264,9 @@ export async function createTransferBatch(c: AppContext) {
     feePayer,
     lifetime,
     maxRecipientsPerTransaction:
-      parsed.data.options?.maxRecipientsPerTransaction ?? DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION,
+      body.options?.maxRecipientsPerTransaction === undefined
+        ? DEFAULT_MAX_RECIPIENTS_PER_TRANSACTION
+        : body.options.maxRecipientsPerTransaction,
   });
 
   const batchRepository = getPaymentTransferBatchesRepository(c);
@@ -179,7 +278,7 @@ export async function createTransferBatch(c: AppContext) {
         batch: {
           organizationId: resolved.scope.auth.organizationId,
           projectId: resolved.projectId,
-          externalId: parsed.data.externalId ?? null,
+          externalId: body.externalId === undefined ? null : body.externalId,
           sourceWalletId: resolved.sourceWallet.walletId,
           sourceAddress: resolved.sourceAddress,
           token: resolved.tokenContext.token,
@@ -187,7 +286,7 @@ export async function createTransferBatch(c: AppContext) {
           totalAmount: resolved.totalAmount,
           recipientCount: resolved.recipients.length,
           transactionCount: chunks.length,
-          options: parsed.data.options ?? {},
+          options: body.options === undefined ? {} : body.options,
           initiatedByKeyId: resolved.scope.auth.id,
           idempotencyKey,
           idempotencyFingerprint,
@@ -239,7 +338,7 @@ export async function createTransferBatch(c: AppContext) {
         chunk,
         recipientsByIndex,
         feePayment,
-        preflight: parsed.data.options?.preflight !== false,
+        preflight: body.options?.preflight !== false,
       })
     )
   );

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/index.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/index.ts
@@ -1,3 +1,7 @@
-export { createTransferBatch } from "./create";
+export {
+  createTransferBatch,
+  extractTransferBatchPolicyCandidate,
+  findTransferBatchIdempotentKeyReplay,
+} from "./create";
 export { estimateTransferBatch } from "./estimate";
 export { getTransferBatch, listTransferBatches } from "./read";

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/policy.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/policy.ts
@@ -1,97 +1,41 @@
-import { getRequestTenantScope } from "@/lib/tenant-scope";
 import { assertWalletPolicyAllowsTransferWithRows } from "@/services/payments/wallet-policy";
-import {
-  approvedWalletOperationAttemptId,
-  approvedWalletOperationId,
-  walletOperationExecutionRequest,
-} from "@/services/policy/approved-operation-replay";
-import {
-  enforceWalletOperationPolicy,
-  recordLegacyWalletPolicyDenial,
-  walletOperationActorFromAuth,
-} from "@/services/policy/enforcement.service";
 import { type AppContext, getPaymentsRepository } from "../../context";
-import type { CreateTransferBatchInput, ResolvedBatchRequest } from "./types";
+import type { ResolvedBatchRequest } from "./types";
 
 /**
- * Enforces wallet-operation and wallet policies for a batch: destination
- * allowlist per recipient and transfer/daily limits against the batch total,
- * with the policy rows fetched once for the whole batch. Denials are recorded
- * before rethrowing.
+ * Enforces legacy wallet policies for a batch: destination allowlist per
+ * recipient and transfer/daily limits against the batch total, with policy
+ * rows fetched once for the whole batch.
  *
  * @param c - Request context.
  * @param resolved - Resolved batch request.
- * @param input - Original request body, recorded with the enforcement event.
+ * @returns A promise that resolves when every legacy wallet policy allows.
  */
-export async function enforceBatchPolicies(
+export async function assertLegacyBatchPolicies(
   c: AppContext,
-  resolved: ResolvedBatchRequest,
-  input: CreateTransferBatchInput
+  resolved: ResolvedBatchRequest
 ): Promise<void> {
-  const enforcement = await enforceWalletOperationPolicy(
-    c.env,
-    getRequestTenantScope(c),
-    {
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.scope.auth.projectId,
-      custodyWalletId: resolved.sourceWallet.id,
-      walletId: resolved.sourceWallet.walletId,
-      apiKeyId: resolved.scope.auth.apiKeyId,
-      actor: walletOperationActorFromAuth(resolved.scope.auth),
-      operationFamily: "payment",
-      operationType: "payment_transfer_batch_execute",
-      asset: resolved.tokenContext.token,
-      amount: resolved.totalAmount,
-      destination: null,
-      context: {
-        sourceAddress: resolved.sourceAddress,
-        recipientCount: resolved.recipients.length,
-        transactionCount: null,
-      },
-      rawPayload: {
-        externalId: input.externalId ?? null,
-        source: input.source,
-        token: input.token,
-        recipients: input.recipients.map((recipient) => ({
-          externalId: recipient.externalId ?? null,
-          counterpartyId: recipient.counterpartyId,
-          counterpartyAccountId: recipient.counterpartyAccountId,
-          amount: recipient.amount,
-        })),
-        options: input.options ?? null,
-        executionRequest: walletOperationExecutionRequest(c, input),
-      },
-    },
-    approvedWalletOperationId(c),
-    approvedWalletOperationAttemptId(c)
-  );
-
-  try {
-    const repository = getPaymentsRepository(c);
-    const rows = await repository.getWalletPoliciesByCustodyWalletId(resolved.sourceWallet.id);
-    for (const recipient of resolved.recipients) {
-      await assertWalletPolicyAllowsTransferWithRows(repository, rows, {
-        organizationId: resolved.scope.auth.organizationId,
-        projectId: resolved.projectId,
-        wallet: resolved.sourceWallet,
-        destinationAddress: recipient.destinationAddress,
-        enforceDailyLimit: false,
-        token: resolved.tokenContext.token,
-        amount: recipient.amount,
-      });
-    }
-
+  const repository = getPaymentsRepository(c);
+  const rows = await repository.getWalletPoliciesByCustodyWalletId(resolved.sourceWallet.id);
+  for (const recipient of resolved.recipients) {
     await assertWalletPolicyAllowsTransferWithRows(repository, rows, {
       organizationId: resolved.scope.auth.organizationId,
       projectId: resolved.projectId,
       wallet: resolved.sourceWallet,
-      destinationAddress: null,
-      enforceDestinationAllowlist: false,
+      destinationAddress: recipient.destinationAddress,
+      enforceDailyLimit: false,
       token: resolved.tokenContext.token,
-      amount: resolved.totalAmount,
+      amount: recipient.amount,
     });
-  } catch (error) {
-    await recordLegacyWalletPolicyDenial(c.env, enforcement, error);
-    throw error;
   }
+
+  await assertWalletPolicyAllowsTransferWithRows(repository, rows, {
+    organizationId: resolved.scope.auth.organizationId,
+    projectId: resolved.projectId,
+    wallet: resolved.sourceWallet,
+    destinationAddress: null,
+    enforceDestinationAllowlist: false,
+    token: resolved.tokenContext.token,
+    amount: resolved.totalAmount,
+  });
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -281,7 +281,7 @@ function buildTransferPolicyCandidate(
     projectId: scope.auth.projectId,
     custodyWalletId: operation.sourceWallet.id,
     walletId: operation.sourceWallet.walletId,
-    apiKeyId: scope.auth.apiKeyId === undefined ? null : scope.auth.apiKeyId,
+    apiKeyId: scope.auth.apiKeyId,
     actor: walletOperationActorFromAuth(scope.auth),
     source: "api",
     operationFamily: "payment",
@@ -394,12 +394,12 @@ export async function findTransferIdempotentKeyReplay(
   idempotencyKey: string
 ): Promise<Response | null> {
   const body = extraction.body as CreateTransferBody;
-  const { operation, privateTransfer } = extraction.resolved as TransferPolicyResolved;
+  const { scope, operation, privateTransfer } = extraction.resolved as TransferPolicyResolved;
 
   const replay = await resolveTransferIdempotencyReplay(
     getPaymentsRepository(c),
-    extraction.candidate.organizationId,
-    extraction.candidate.projectId,
+    scope.auth.organizationId,
+    scope.auth.projectId,
     idempotencyKey,
     buildPaymentTransferFingerprint({
       sourceAddress: operation.sourceWallet.publicKey,

--- a/apps/sdp-api/src/routes/payments/index.ts
+++ b/apps/sdp-api/src/routes/payments/index.ts
@@ -19,7 +19,11 @@ import {
   estimateOfframp,
   estimateOnramp,
   estimateTransferBatch,
+  extractOfframpQuotePolicyCandidate,
+  extractOnrampQuotePolicyCandidate,
+  extractTransferBatchPolicyCandidate,
   extractTransferPolicyCandidate,
+  findTransferBatchIdempotentKeyReplay,
   findTransferIdempotentKeyReplay,
   getRecurringPayment,
   getSubscription,
@@ -195,6 +199,10 @@ payments.post(
 payments.post(
   "/transfer-batches",
   requirePermissions("payments:write", "wallets:read", "counterparties:read"),
+  policyGate({
+    extract: extractTransferBatchPolicyCandidate,
+    findIdempotentKeyReplay: findTransferBatchIdempotentKeyReplay,
+  }),
   createTransferBatch
 );
 payments.get("/transfer-batches", requirePermissions("payments:read"), listTransferBatches);
@@ -213,11 +221,13 @@ payments.post("/ramps/offramp/estimate", requirePermissions("payments:read"), es
 payments.post(
   "/ramps/onramp/quote",
   requirePermissions("payments:write", "wallets:read"),
+  policyGate({ extract: extractOnrampQuotePolicyCandidate }),
   createOnrampQuote
 );
 payments.post(
   "/ramps/offramp/quote",
   requirePermissions("payments:write", "wallets:read"),
+  policyGate({ extract: extractOfframpQuotePolicyCandidate }),
   createOfframpQuote
 );
 payments.post(

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -662,6 +662,102 @@ describe("payment transfer batches", () => {
     expect(listBody.data.map((batch) => batch.id)).toContain(body.data.batch.id);
   });
 
+  it("dry-runs a transfer batch with zero writes", async () => {
+    const counterpartyId = await seedCounterparty("batch_dry_run_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const response = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+          "Dry-Run": "true",
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { decision: "allow", criteria: [] },
+    });
+    expect(createOrgSignerMock).not.toHaveBeenCalled();
+
+    const batchCount = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM payment_transfer_batches")
+      .first<{ count: number }>();
+    const operationCount = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations")
+      .first<{ count: number }>();
+    expect(batchCount).toEqual({ count: 0 });
+    expect(operationCount).toEqual({ count: 0 });
+  });
+
+  it("stops a denied transfer batch before signer and batch side effects", async () => {
+    await getDb(env)
+      .prepare("UPDATE custody_configs SET project_id = ? WHERE id = ?")
+      .bind(TEST_PROJECT.id, TEST_CONFIG_ID)
+      .run();
+    const policyResponse = await app.request(
+      `/v1/payments/wallets/${TEST_WALLET_ID}/policies`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          destinationAllowlist: [],
+          defaultAction: "allow",
+          rules: [{ id: "deny-transfer-batches", kind: "always", action: "deny" }],
+        }),
+      },
+      env
+    );
+    expect(policyResponse.status).toBe(200);
+    const counterpartyId = await seedCounterparty("batch_policy_denial_counterparty");
+    const counterpartyAccountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const response = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(createOrgSignerMock).not.toHaveBeenCalled();
+    const batchCount = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM payment_transfer_batches")
+      .first<{ count: number }>();
+    expect(batchCount).toEqual({ count: 0 });
+  });
+
   it("replays the original transfer batch for the same idempotency key and payload", async () => {
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);
@@ -697,17 +793,27 @@ describe("payment transfer batches", () => {
       { method: "POST", headers, body: requestBody },
       env
     );
+    const operationsAfterFirst = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations WHERE organization_id = ?")
+      .bind(TEST_ORG.id)
+      .first<{ count: number }>();
     const second = await app.request(
       "/v1/payments/transfer-batches",
       { method: "POST", headers, body: requestBody },
       env
     );
+    const operationsAfterSecond = await getDb(env)
+      .prepare("SELECT COUNT(*)::int AS count FROM wallet_operations WHERE organization_id = ?")
+      .bind(TEST_ORG.id)
+      .first<{ count: number }>();
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
     const firstBody = (await first.json()) as { data: unknown };
     const secondBody = (await second.json()) as { data: unknown };
     expect(secondBody.data).toEqual(firstBody.data);
+    expect(operationsAfterFirst).toEqual({ count: 1 });
+    expect(operationsAfterSecond).toEqual(operationsAfterFirst);
     expect(signAndSendMock).toHaveBeenCalledTimes(1);
     expect(createOrgSignerMock).toHaveBeenCalledTimes(1);
 

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -1,7 +1,10 @@
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { type ContextVariableMap, Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppError } from "@/lib/errors";
+import { policyGate } from "@/middleware/policy-gate";
+import type { Env } from "@/types/env";
 
 const boundaryMocks = vi.hoisted(() => ({
   createOrgSigner: vi.fn(),
@@ -26,7 +29,7 @@ vi.mock("@/services/policy/enforcement.service", async (importOriginal) => ({
   resolvePolicyCustodyWallet: boundaryMocks.resolvePolicyWallet,
 }));
 
-import { signerCheck } from "@/routes/custody/handlers/signer-check";
+import { extractSignerCheckPolicyCandidate } from "@/routes/custody/handlers/signer-check";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "../../../..");
 
@@ -71,10 +74,10 @@ const contracts: ValueMovingContract[] = [
       evidence: "resolved.scope.auth.organizationId",
     },
     authorization: {
-      file: "apps/sdp-api/src/routes/payments/handlers/transfer-batches/create.ts",
-      section: "export async function createTransferBatch",
-      before: "await enforceBatchPolicies(c, resolved, parsed.data)",
-      after: "solanaServices.createOrgSigner(",
+      file: "apps/sdp-api/src/routes/payments/index.ts",
+      section: '"/transfer-batches",',
+      before: "extract: extractTransferBatchPolicyCandidate",
+      after: "createTransferBatch",
     },
     replay: [
       {
@@ -118,14 +121,14 @@ const contracts: ValueMovingContract[] = [
   {
     family: "issuance",
     trustedContext: {
-      file: "apps/sdp-api/src/routes/issuance/handlers/policy.ts",
-      evidence: "getRequestTenantScope(c)",
+      file: "apps/sdp-api/src/routes/issuance/handlers/authority.ts",
+      evidence: "const { auth, projectId, orgId } = requireProjectScope(c)",
     },
     authorization: {
-      file: "apps/sdp-api/src/routes/issuance/handlers/authority.ts",
-      section: "export const executeUpdateAuthority",
-      before: "await enforceIssuanceWalletOperationPolicy(c",
-      after: "createResolvedAuthoritySigner({",
+      file: "apps/sdp-api/src/routes/issuance/index.ts",
+      section: '"/tokens/:tokenId/authority",',
+      before: "policyGate({ extract: extractUpdateAuthorityPolicyCandidate })",
+      after: "executeUpdateAuthority",
     },
     replay: [
       {
@@ -142,10 +145,10 @@ const contracts: ValueMovingContract[] = [
       evidence: "createRequestSponsorshipFeePayment(c)",
     },
     authorization: {
-      file: "apps/sdp-api/src/routes/payments/handlers/transfers.ts",
-      section: "export async function createTransfer",
-      before: "getPolicyGateContext<CreateTransferBody, TransferPolicyResolved>(c)",
-      after: "await executeSolTransfer(",
+      file: "apps/sdp-api/src/routes/payments/index.ts",
+      section: '"/transfers",',
+      before: "extract: extractTransferPolicyCandidate",
+      after: "createTransfer",
     },
     replay: [
       {
@@ -164,13 +167,13 @@ const contracts: ValueMovingContract[] = [
     family: "ramps",
     trustedContext: {
       file: "apps/sdp-api/src/routes/payments/handlers/ramps.ts",
-      evidence: "getRequestTenantScope(c)",
+      evidence: "scope.auth.organizationId",
     },
     authorization: {
-      file: "apps/sdp-api/src/routes/payments/handlers/ramps.ts",
-      section: "export async function createOnrampQuote",
-      before: "await enforceRampWalletOperationPolicy(c",
-      after: "RAMP_PROVIDER_CLIENTS.moonpay.createOnrampQuote",
+      file: "apps/sdp-api/src/routes/payments/index.ts",
+      section: '"/ramps/onramp/quote",',
+      before: "policyGate({ extract: extractOnrampQuotePolicyCandidate })",
+      after: "createOnrampQuote",
     },
     replay: [
       {
@@ -214,13 +217,13 @@ const contracts: ValueMovingContract[] = [
     family: "raw_signing",
     trustedContext: {
       file: "apps/sdp-api/src/routes/custody/handlers/signer-check.ts",
-      evidence: "getRequestTenantScope(c)",
+      evidence: "const auth = getAuth(c)",
     },
     authorization: {
-      file: "apps/sdp-api/src/routes/custody/handlers/signer-check.ts",
-      section: "export const signerCheck",
-      before: "await enforceWalletOperationPolicy(",
-      after: "const signer = await createOrgSigner(",
+      file: "apps/sdp-api/src/routes/custody/index.ts",
+      section: '"/signer-check",',
+      before: "policyGate({ extract: extractSignerCheckPolicyCandidate })",
+      after: "signerCheck",
     },
     replay: [
       {
@@ -347,6 +350,26 @@ describe("value-moving authorization and replay conformance", () => {
     }
   });
 
+  it("enforces policy inside the gate before the handler runs", () => {
+    const gateSource = readSource("apps/sdp-api/src/middleware/policy-gate.ts");
+    const start = gateSource.indexOf("export function policyGate");
+    expect(start, "policy gate middleware must exist").toBeGreaterThanOrEqual(0);
+    const source = gateSource.slice(start);
+    const orderedMarkers = [
+      "isDryRunRequest(c)",
+      "findIdempotentKeyReplay",
+      "candidate === null",
+      "await enforceWalletOperationPolicy(",
+      "return next()",
+    ];
+    let cursor = 0;
+    for (const marker of orderedMarkers) {
+      const index = source.indexOf(marker, cursor);
+      expect(index, `policy gate must retain ${marker} in order`).toBeGreaterThanOrEqual(cursor);
+      cursor = index + marker.length;
+    }
+  });
+
   it("catalogs every production signing sink", () => {
     expect(discoverSigningSinks()).toEqual(signingSinkInventory);
   });
@@ -361,7 +384,7 @@ describe("value-moving authorization and replay conformance", () => {
     );
   });
 
-  it("stops a raw-sign policy denial before signer, KMS, or Kora access", async () => {
+  it("stops a raw-sign policy denial in the gate before handler, KMS, or Kora access", async () => {
     boundaryMocks.enforcePolicy.mockRejectedValueOnce(
       new AppError("FORBIDDEN", "Denied by wallet policy")
     );
@@ -375,21 +398,32 @@ describe("value-moving authorization and replay conformance", () => {
       signingWalletId: "wal_conformance",
       signingWalletIds: ["wal_conformance"],
       walletBindings: [{ walletId: "wal_conformance", permissions: ["wallets:write"] }],
-    };
-    const context = {
-      env: {},
-      req: {
-        json: vi.fn().mockResolvedValue({ walletId: "wal_conformance", memo: "conformance" }),
-      },
-      get: vi.fn((key: string) => {
-        if (key === "apiKey") return apiKey;
-        if (key === "projectId") return "prj_conformance";
-        if (key === "projectEnvironment") return "sandbox";
-        return undefined;
-      }),
-    } as never;
+    } satisfies NonNullable<ContextVariableMap["apiKey"]>;
+    const handler = vi.fn(() => new Response(null, { status: 204 }));
+    const testApp = new Hono<{ Bindings: Env }>();
+    testApp.use("*", async (c, next) => {
+      c.set("apiKey", apiKey);
+      c.set("projectId", "prj_conformance");
+      c.set("projectEnvironment", "sandbox");
+      await next();
+    });
+    testApp.post(
+      "/signer-check",
+      policyGate({ extract: extractSignerCheckPolicyCandidate }),
+      handler
+    );
+    testApp.onError((error) => {
+      throw error;
+    });
 
-    await expect(signerCheck(context)).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(
+      testApp.request("/signer-check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletId: "wal_conformance", memo: "conformance" }),
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(handler).not.toHaveBeenCalled();
     expect(boundaryMocks.createOrgSigner).not.toHaveBeenCalled();
     expect(boundaryMocks.createSponsorship).not.toHaveBeenCalled();
   });

--- a/apps/sdp-api/src/services/policy/candidate-evaluation.service.ts
+++ b/apps/sdp-api/src/services/policy/candidate-evaluation.service.ts
@@ -6,6 +6,18 @@ import type { Env } from "@/types/env";
 import { PostgresPolicyEnforcementStore } from "./enforcement.store";
 
 /**
+ * The dry-run verdict for an operation that resolves no custody wallet: no
+ * wallet policy governs it, so it is allowed with nothing to evaluate.
+ */
+export const UNGOVERNED_POLICY_DRY_RUN_RESULT: PolicyDryRunResult = {
+  decision: "allow",
+  reason: "The operation resolves no custody wallet, so no wallet policy governs it.",
+  criteria: [],
+  walletPolicyRevisionId: null,
+  apiKeyPolicyRevisionId: null,
+};
+
+/**
  * Evaluate a candidate wallet operation against its effective policies
  * without persisting anything: no wallet-operation row, no approval request,
  * no evaluation audit row. Backs the Dry-Run exit of the policy gate, where

--- a/apps/sdp-api/src/services/policy/enforcement.service.ts
+++ b/apps/sdp-api/src/services/policy/enforcement.service.ts
@@ -10,10 +10,11 @@ import type {
   WalletOperationEnvelope,
   WalletOperationProviderExtensions,
 } from "@sdp/types";
-import { getDb } from "@/db";
+import { asTransactionalClient, getDb } from "@/db";
 import {
   type ApprovalRequestRow,
   createPolicyRepository,
+  createPostgresPolicyRepository,
   type PolicyRepository,
 } from "@/db/repositories";
 import type { ApiKeyContext } from "@/lib/auth";
@@ -268,6 +269,9 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
  * Record a legacy wallet-policy denial against an operation the new engine
  * already allowed, so the legacy decision stays visible in the audit trail.
  *
+ * The legacy wallet-policy checks and every call site of this recorder are
+ * deleted when the legacy system is cut over (PRO-1617) — don't build on it.
+ *
  * @param env - The runtime environment.
  * @param enforcement - The enforcement the legacy check overruled.
  * @param error - The legacy denial.
@@ -277,34 +281,34 @@ export async function recordLegacyWalletPolicyDenial(
   enforcement: WalletOperationPolicyEnforcement,
   error: unknown
 ): Promise<void> {
-  const repository = createPolicyRepository(
-    env,
-    createTenantScope({
-      organizationId: enforcement.operation.organizationId,
-      projectId: enforcement.operation.projectId,
-    })
-  );
+  const scope = createTenantScope({
+    organizationId: enforcement.operation.organizationId,
+    projectId: enforcement.operation.projectId,
+  });
   const reason =
     error instanceof Error && error.message
       ? error.message
       : "Legacy wallet policy denied wallet operation";
 
   try {
-    if (enforcement.evaluation.evaluationContext) {
-      await repository.createPolicyEvaluation({
-        walletOperationId: enforcement.operation.id,
-        walletPolicyRevisionId: null,
-        apiKeyPolicyRevisionId: null,
-        decision: "deny",
-        reasonCode: "legacy_wallet_policy_denied",
-        reason,
-        matchedRules: [],
-        evaluationContext: enforcement.evaluation.evaluationContext,
-        requiresApproval: false,
-      });
-    }
+    await getDb(env).transaction(async (tx) => {
+      const repository = createPostgresPolicyRepository(asTransactionalClient(tx), scope);
+      if (enforcement.evaluation.evaluationContext) {
+        await repository.createPolicyEvaluation({
+          walletOperationId: enforcement.operation.id,
+          walletPolicyRevisionId: null,
+          apiKeyPolicyRevisionId: null,
+          decision: "deny",
+          reasonCode: "legacy_wallet_policy_denied",
+          reason,
+          matchedRules: [],
+          evaluationContext: enforcement.evaluation.evaluationContext,
+          requiresApproval: false,
+        });
+      }
 
-    await repository.updateWalletOperationStatus(enforcement.operation.id, "failed");
+      await repository.updateWalletOperationStatus(enforcement.operation.id, "failed");
+    });
   } catch (auditError) {
     getLogger().error(
       {

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -1,5 +1,6 @@
 /** Environment variables consumed by the Node API runtime. */
 
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
 import type { ClerkJwtPayload } from "@/lib/clerk-token";
 import type { PolicyGateContext } from "@/middleware/policy-gate";
 import type { KVStoreSet } from "@/runtime/kv";
@@ -302,7 +303,7 @@ declare module "hono" {
     approvedWalletOperationId?: string;
     approvedWalletOperationAttemptId?: string;
     // Set by policyGate middleware for gated routes
-    policyGate?: PolicyGateContext;
+    policyGate?: PolicyGateContext<unknown, unknown, WalletOperationPolicyEnforcement | null>;
     apiKey?: {
       id: string;
       organizationId: string;


### PR DESCRIPTION
Rolls the `policyGate` middleware (#1186) out to every remaining policy-checked route. Handlers no longer hand-build enforcement calls; each route owns only its extractor, and `Dry-Run: true` is live on all of them.

## Routes migrated

| Route | Extractor | Replay finder |
|---|---|---|
| `POST /v1/payments/transfer-batches` | `extractTransferBatchPolicyCandidate` | `findTransferBatchIdempotentKeyReplay` |
| `POST /v1/payments/ramps/onramp/quote` | `extractOnrampQuotePolicyCandidate` | — |
| `POST /v1/payments/ramps/offramp/quote` | `extractOfframpQuotePolicyCandidate` | — |
| `POST /v1/issuance/tokens/:tokenId/mint` | `extractMintPolicyCandidate` | — |
| `POST /v1/issuance/tokens/:tokenId/authority` | `extractUpdateAuthorityPolicyCandidate` | — |
| `POST /v1/wallets/signer-check` | `extractSignerCheckPolicyCandidate` | — |

Left inline deliberately: private-transfer signer-leg enforcement (per-signer, mid-flow) and custody approval-requests (the approvals surface itself). Issuance burn/freeze/seize/pause carry no policy enforcement today, so gating them would be new behavior — out of scope.

## Gate + engine changes

- `extract` may now return `candidate: null` for ungoverned operations (issuance with no resolvable signing wallet — pre-existing semantics, preserved): dry-run answers `allow` with an honest reason and empty criteria (`UNGOVERNED_POLICY_DRY_RUN_RESULT`, exported from the candidate-evaluation service), enforcement is skipped, and the handler receives a typed-null enforcement.
- `recordLegacyWalletPolicyDenial` now writes its deny evaluation and the operation's `failed` status in one transaction (previously two independent writes — a crash in between left a deny evaluation on a never-failed operation). Documented as deleted with the PRO-1617 legacy cutover.
- Batch idempotency fingerprint is computed once in the extractor and shared by the gate replay finder and the handler insert (was computed twice per keyed request).
- `value-moving-conformance.node.test.ts` re-anchored: authorization evidence now checks the router wiring carries the exact extractor per route, plus a gate-internal ordering assertion (dry-run → replay → ungoverned exit → enforce → handler) and a runtime test that a denial through the real middleware never reaches the handler.

## Live examples — org `org_5f9565dd-1496-4b28-b496-0246b3196c5c`, wallet `privy_xu2wa57iix0fej8ispl3gfjy`

Policy authored via the API — cap any operation amount at 1, deny raw signing, require approval for ramps:

```http
PUT /v1/payments/wallets/privy_xu2wa57iix0fej8ispl3gfjy/policies HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json

{"destinationAllowlist":[],"defaultAction":"allow","commitMessage":"policy gate rollout demo","rules":[{"id":"cap-1","kind":"amount","name":"Cap operations at 1","max":"1","action":"allow"},{"id":"no-raw-signing","kind":"operation_family","name":"Block raw signing","family":"raw_sign","action":"deny"},{"id":"approve-ramps","kind":"approval","name":"Ramps need approval","families":["ramp"]}]}
```

### Transfer batches — dry-run evaluates the batch TOTAL

- total 0.6 (2 × 0.3) → `allow`, `cap-1` matched with action allow
- total 3 (2 × 1.5) → `deny` — same request body, only the amounts changed:

```http
POST /v1/payments/transfer-batches HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json
Dry-Run: true

{"source":"privy_xu2wa57iix0fej8ispl3gfjy","token":"SOL","recipients":[{"counterpartyId":"counterparty_dc70923d-6c09-4b3e-a688-7b30e98233e4","counterpartyAccountId":"counterparty_account_e5bcdb90-dcad-4768-a0c3-378730c896cd","amount":"1.5"},{"counterpartyId":"counterparty_dc70923d-6c09-4b3e-a688-7b30e98233e4","counterpartyAccountId":"counterparty_account_e5bcdb90-dcad-4768-a0c3-378730c896cd","amount":"1.5"}]}
```

HTTP 200, nothing written:

```json
{
  "data": {
    "decision": "deny",
    "reason": "Operation amount 3 exceeds policy maximum 1. Combined policy decision: wallet=deny, API key=allow.",
    "criteria": [
      {
        "scope": "wallet",
        "ruleId": "cap-1",
        "kind": "amount",
        "name": "Cap operations at 1",
        "matched": true,
        "action": "deny",
        "reason": "Operation amount 3 exceeds policy maximum 1."
      },
      {
        "scope": "wallet",
        "ruleId": "no-raw-signing",
        "kind": "operation_family",
        "name": "Block raw signing",
        "matched": false,
        "action": null,
        "reason": null
      },
      {
        "scope": "wallet",
        "ruleId": "approve-ramps",
        "kind": "approval",
        "name": "Ramps need approval",
        "matched": false,
        "action": null,
        "reason": null
      }
    ],
    "walletPolicyRevisionId": "wcpr_ebecf50d-4a95-43b4-ac55-c5bfbab038f6",
    "apiKeyPolicyRevisionId": null
  },
  "meta": {
    "requestId": "req_777d9393-c4dc-44d2-818e-0baf1b3399bd",
    "timestamp": "2026-08-10T15:47:44.550Z"
  }
}
```

### Transfer batches — same request without Dry-Run → 403, no batch row created

```http
POST /v1/payments/transfer-batches HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json

{"source":"privy_xu2wa57iix0fej8ispl3gfjy","token":"SOL","recipients":[{"counterpartyId":"counterparty_dc70923d-6c09-4b3e-a688-7b30e98233e4","counterpartyAccountId":"counterparty_account_e5bcdb90-dcad-4768-a0c3-378730c896cd","amount":"1.5"},{"counterpartyId":"counterparty_dc70923d-6c09-4b3e-a688-7b30e98233e4","counterpartyAccountId":"counterparty_account_e5bcdb90-dcad-4768-a0c3-378730c896cd","amount":"1.5"}]}
```

HTTP 403:

```json
{
  "error": {
    "code": "FORBIDDEN",
    "message": "Wallet operation denied by policy",
    "details": {
      "walletOperationId": "wop_f774e3e0-3c81-4838-9f83-bfc5a89f25a6",
      "policyEvaluationId": "peval_02c09d06-54ba-428d-91cb-b364cb07b33f",
      "decision": "deny",
      "reasonCode": "wallet_policy_match",
      "reason": "Operation amount 3 exceeds policy maximum 1. Combined policy decision: wallet=deny, API key=[REDACTED]",
      "requiresApproval": false,
      "approvalRequestId": null
    }
  },
  "meta": {
    "requestId": "req_cdf2a3db-662c-467a-bd82-de4f32e9e295"
  }
}
```

### Signer-check — dry-run, `raw_sign` family rule → deny

```http
POST /v1/wallets/signer-check HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json
Dry-Run: true

{"walletId":"privy_xu2wa57iix0fej8ispl3gfjy","memo":"policy gate rollout demo"}
```

HTTP 200, nothing written, no signer resolved:

```json
{
  "data": {
    "decision": "deny",
    "reason": "Operation family raw_sign matched policy. Combined policy decision: wallet=deny, API key=allow.",
    "criteria": [
      {
        "scope": "wallet",
        "ruleId": "cap-1",
        "kind": "amount",
        "name": "Cap operations at 1",
        "matched": false,
        "action": null,
        "reason": null
      },
      {
        "scope": "wallet",
        "ruleId": "no-raw-signing",
        "kind": "operation_family",
        "name": "Block raw signing",
        "matched": true,
        "action": "deny",
        "reason": "Operation family raw_sign matched policy."
      },
      {
        "scope": "wallet",
        "ruleId": "approve-ramps",
        "kind": "approval",
        "name": "Ramps need approval",
        "matched": false,
        "action": null,
        "reason": null
      }
    ],
    "walletPolicyRevisionId": "wcpr_ebecf50d-4a95-43b4-ac55-c5bfbab038f6",
    "apiKeyPolicyRevisionId": null
  },
  "meta": {
    "requestId": "req_16e6b437-da35-4bea-b595-e8d17f5dbcf1",
    "timestamp": "2026-08-10T15:47:44.617Z"
  }
}
```

### Signer-check — real request → 403 before any KMS/Kora access

```http
POST /v1/wallets/signer-check HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json

{"walletId":"privy_xu2wa57iix0fej8ispl3gfjy","memo":"policy gate rollout demo"}
```

HTTP 403:

```json
{
  "error": {
    "code": "FORBIDDEN",
    "message": "Wallet operation denied by policy",
    "details": {
      "walletOperationId": "wop_9e744e12-8d71-4d66-976f-9a4dcf3ff8b2",
      "policyEvaluationId": "peval_82d3fe44-7702-41b8-a840-ae6fedd73825",
      "decision": "deny",
      "reasonCode": "wallet_policy_match",
      "reason": "Operation family raw_sign matched policy. Combined policy decision: wallet=deny, API key=[REDACTED]",
      "requiresApproval": false,
      "approvalRequestId": null
    }
  },
  "meta": {
    "requestId": "req_de942e4b-e35b-4803-b31a-8870bd7ad341"
  }
}
```

### Onramp quote — dry-run with an approval rule → approval_required

```http
POST /v1/payments/ramps/onramp/quote HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json
Dry-Run: true

{"provider":"moonpay","counterpartyId":"counterparty_dc70923d-6c09-4b3e-a688-7b30e98233e4","destinationWallet":"privy_xu2wa57iix0fej8ispl3gfjy","cryptoToken":"SOL","fiatCurrency":"USD","fiatAmount":"0.5"}
```

HTTP 200, nothing written, provider never called:

```json
{
  "data": {
    "decision": "approval_required",
    "reason": "Approval policy matched operation. Combined policy decision: wallet=approval_required, API key=allow.",
    "criteria": [
      {
        "scope": "wallet",
        "ruleId": "cap-1",
        "kind": "amount",
        "name": "Cap operations at 1",
        "matched": true,
        "action": "allow",
        "reason": "Operation amount 0.5 matched policy."
      },
      {
        "scope": "wallet",
        "ruleId": "no-raw-signing",
        "kind": "operation_family",
        "name": "Block raw signing",
        "matched": false,
        "action": null,
        "reason": null
      },
      {
        "scope": "wallet",
        "ruleId": "approve-ramps",
        "kind": "approval",
        "name": "Ramps need approval",
        "matched": true,
        "action": "approval_required",
        "reason": "Approval policy matched operation."
      }
    ],
    "walletPolicyRevisionId": "wcpr_ebecf50d-4a95-43b4-ac55-c5bfbab038f6",
    "apiKeyPolicyRevisionId": null
  },
  "meta": {
    "requestId": "req_8d7e523b-47b6-47c0-ad1f-60a7ac881c2a",
    "timestamp": "2026-08-10T15:47:44.670Z"
  }
}
```

### Onramp quote — real request → 202 with a pollable approval request

```http
POST /v1/payments/ramps/onramp/quote HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json

{"provider":"moonpay","counterpartyId":"counterparty_dc70923d-6c09-4b3e-a688-7b30e98233e4","destinationWallet":"privy_xu2wa57iix0fej8ispl3gfjy","cryptoToken":"SOL","fiatCurrency":"USD","fiatAmount":"0.5"}
```

HTTP 202:

```json
{
  "error": {
    "code": "SIGNING_PENDING",
    "message": "Wallet operation requires policy approval",
    "details": {
      "walletOperationId": "wop_9df075db-b39b-4399-b666-78d0e0333065",
      "policyEvaluationId": "peval_45de82d0-1be9-4d8c-9374-f002ef73c3ff",
      "decision": "approval_required",
      "reasonCode": "wallet_policy_match",
      "reason": "Approval policy matched operation. Combined policy decision: wallet=approval_required, API key=[REDACTED]",
      "requiresApproval": true,
      "approvalRequestId": "appr_ff789597-d16f-49e9-8ec9-eb1ee9ddd89e"
    }
  },
  "meta": {
    "requestId": "req_260aeeac-8c68-4e8b-9002-1286f67b7423"
  }
}
```

### Mint — no resolvable signing wallet → ungoverned dry-run verdict

```http
POST /v1/issuance/tokens/tok_4ea78860-9ac0-45dd-ac4e-341047c17cd5/mint HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json
Dry-Run: true

{"mint":{"destination":"7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSFCQGXa","amount":"1"}}
```

HTTP 200, nothing written:

```json
{
  "data": {
    "decision": "allow",
    "reason": "The operation resolves no custody wallet, so no wallet policy governs it.",
    "criteria": [],
    "walletPolicyRevisionId": null,
    "apiKeyPolicyRevisionId": null
  },
  "meta": {
    "requestId": "req_296fc03d-82d8-4503-8fbd-a5de41047fde",
    "timestamp": "2026-08-10T15:47:44.716Z"
  }
}
```

### Mint — explicit signing wallet → governed verdict

```http
POST /v1/issuance/tokens/tok_4ea78860-9ac0-45dd-ac4e-341047c17cd5/mint HTTP/1.1
Authorization: Bearer sk_test_[redacted]
Content-Type: application/json
Dry-Run: true

{"signingWalletId":"privy_xu2wa57iix0fej8ispl3gfjy","mint":{"destination":"7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSFCQGXa","amount":"1"}}
```

HTTP 200:

```json
{
  "data": {
    "decision": "allow",
    "reason": "Operation amount 1 matched policy. Combined policy decision: wallet=allow, API key=allow.",
    "criteria": [
      {
        "scope": "wallet",
        "ruleId": "cap-1",
        "kind": "amount",
        "name": "Cap operations at 1",
        "matched": true,
        "action": "allow",
        "reason": "Operation amount 1 matched policy."
      },
      {
        "scope": "wallet",
        "ruleId": "no-raw-signing",
        "kind": "operation_family",
        "name": "Block raw signing",
        "matched": false,
        "action": null,
        "reason": null
      },
      {
        "scope": "wallet",
        "ruleId": "approve-ramps",
        "kind": "approval",
        "name": "Ramps need approval",
        "matched": false,
        "action": null,
        "reason": null
      }
    ],
    "walletPolicyRevisionId": "wcpr_ebecf50d-4a95-43b4-ac55-c5bfbab038f6",
    "apiKeyPolicyRevisionId": null
  },
  "meta": {
    "requestId": "req_d81c4db3-aca7-48a7-a0b3-ffb3f4651655",
    "timestamp": "2026-08-10T15:47:44.736Z"
  }
}
```

## Tests

- suites: payments.transfers, transfer-batches, payments.ramps, issuance, custody-wallet-scope, value-moving-conformance — 255 passed / 9 skipped, plus 614 service-level tests green
- new per-module dry-run zero-write tests, denial-ordering tests (denied op → 403 with no signer/provider/batch side effects), issuance ungoverned-path coverage
- `tsc --noEmit` and biome clean across the 23 changed files
