### PR TITLE
fix(e2e): match the api-keys CTA in both zero-state and populated state

### DIFF
--- a/apps/sdp-web/playwright/tests/api-keys.e2e.spec.ts
+++ b/apps/sdp-web/playwright/tests/api-keys.e2e.spec.ts
@@ -20,7 +20,7 @@ test.describe
       const keyName = `Playwright Selected Wallet Key ${Date.now()}`;
 
       await page.goto("/dashboard/api-keys");
-      await page.getByRole("link", { name: "New API key", exact: true }).click();
+      await page.getByRole("link", { name: /^(Create new API key|New API key)$/ }).click();
 
       await page.getByLabel("Name").fill(keyName);
       await page.getByRole("button", { name: "Continue" }).click();
@@ -80,7 +80,7 @@ test.describe
       const keyName = `Playwright Restricted Key ${Date.now()}`;
 
       await page.goto("/dashboard/api-keys");
-      await page.getByRole("link", { name: "New API key", exact: true }).click();
+      await page.getByRole("link", { name: /^(Create new API key|New API key)$/ }).click();
       await page.getByLabel("Name").fill(keyName);
       await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("button", { name: "Continue" }).click();


### PR DESCRIPTION
- #1221 renamed the zero-state CTA on /dashboard/api-keys to "Create new API key" and pinned the e2e locator to `New API key` with `exact: true`
- the header "New API key" link only renders when the org already has keys (#1013), so on a fresh CI org the locator matches nothing and `api-keys.e2e.spec.ts` times out — Dashboard E2E (Surfpool Local) has failed on every run since #1221 merged (first failure: run 31473934285 on main)
- locator now matches whichever CTA the state shows; the two labels never coexist, so it stays strict-mode-safe