### PR TITLE
refactor(web): share one search input across issuance and integrations

### DIFF
--- a/apps/sdp-web/messages/en/shared.json
+++ b/apps/sdp-web/messages/en/shared.json
@@ -332,6 +332,8 @@
     "searchPlaceholder": "Search integrations",
     "filterAllFamilies": "All",
     "filterAllStatuses": "All statuses",
+    "filterAll": "All",
+    "filterByStatus": "Filter by status",
     "clearFilters": "Clear filters",
     "emptyTitle": "No integrations match",
     "emptyBody": "Try a different search or clear the filters.",

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.tsx
@@ -248,28 +248,36 @@ export function IntegrationsCatalog({
   };
 
   return (
-    <div className="w-full space-y-8 px-4 py-6 md:px-6">
-      <p className="mx-auto max-w-2xl text-center text-sm leading-6 text-tertiary">
+    <div className="w-full space-y-6 px-4 py-6 md:px-6">
+      {/* Left-aligned lead-in: with the family tabs in the header above, a
+          centered slogan floats in dead space instead of leading the page. */}
+      <p className="max-w-2xl text-sm leading-6 text-tertiary">
         {t("Shared.integrations.pageDescription")}
       </p>
 
-      {/* One toolbar row: status pills lead, search trails at toolbar width.
-          The family axis already moved to the header tabs, so stacking a
-          second full-width row here would reopen the clash it removed. */}
-      <div className="flex flex-wrap items-center gap-2" data-integrations-filters="true">
-        <div className="flex flex-wrap items-center gap-2" data-integrations-status-pills="true">
-          {STATUS_FILTERS.map((option) => (
-            <FilterPill key={option} active={status === option} onClick={() => setStatus(option)}>
-              {statusLabel(option, t)}
-            </FilterPill>
-          ))}
+      {/* One toolbar: status pills lead and wrap within their own cluster,
+          search holds a fixed slot on the right from lg up. Below lg the two
+          stack, with the search full-width first — never a lonely field
+          floating right on its own wrap line. */}
+      <div
+        className="flex flex-col-reverse gap-3 lg:flex-row lg:items-center"
+        data-integrations-filters="true"
+      >
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          <div className="contents" data-integrations-status-pills="true">
+            {STATUS_FILTERS.map((option) => (
+              <FilterPill key={option} active={status === option} onClick={() => setStatus(option)}>
+                {statusLabel(option, t)}
+              </FilterPill>
+            ))}
+          </div>
+          {filtered ? (
+            <Button variant="ghost" size="sm" onClick={clearFilters}>
+              {t("Shared.integrations.clearFilters")}
+            </Button>
+          ) : null}
         </div>
-        {filtered ? (
-          <Button variant="ghost" size="sm" onClick={clearFilters}>
-            {t("Shared.integrations.clearFilters")}
-          </Button>
-        ) : null}
-        <div className="w-full sm:ms-auto sm:w-64">
+        <div className="w-full lg:w-64 lg:shrink-0">
           <SearchInput
             value={query}
             onChange={(event) => setQuery(event.currentTarget.value)}

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ComplianceProviderId, OrganizationRpcProvider, RampProviderId } from "@sdp/types";
+import { SegmentedControl } from "@solana/design-system/segmented-control";
 import { ChevronRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -39,7 +40,7 @@ const STATUS_FILTERS: StatusFilter[] = [
 function statusLabel(status: IntegrationStatus | "all", t: Translate): string {
   switch (status) {
     case "all":
-      return t("Shared.integrations.filterAllStatuses");
+      return t("Shared.integrations.filterAll");
     case "active":
       return t("Shared.integrations.statusActive");
     case "available":
@@ -67,30 +68,6 @@ function StatusBadge({ status, t }: { status: IntegrationStatus; t: Translate })
     >
       {statusLabel(status, t)}
     </span>
-  );
-}
-
-function FilterPill({
-  active,
-  children,
-  onClick,
-}: {
-  active: boolean;
-  children: ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={cn(
-        "rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors motion-reduce:transition-none",
-        active ? "bg-primary text-on-primary" : "bg-fill-subtle text-secondary hover:bg-fill-strong"
-      )}
-    >
-      {children}
-    </button>
   );
 }
 
@@ -239,45 +216,39 @@ export function IntegrationsCatalog({
   }, [custody, rpc, ramps, compliance, t]);
 
   const visible = rows.filter((row) => matchesFilters(row, { family, status, query }));
-  // The header tab is navigation, not a filter: "Clear filters" only resets
-  // what this page owns, so it never shows for a tab choice alone.
-  const filtered = status !== "all" || query.trim().length > 0;
   const clearFilters = () => {
     setStatus("all");
     setQuery("");
   };
 
   return (
-    <div className="w-full space-y-6 px-4 py-6 md:px-6">
-      {/* Left-aligned lead-in: with the family tabs in the header above, a
-          centered slogan floats in dead space instead of leading the page. */}
-      <p className="max-w-2xl text-sm leading-6 text-tertiary">
-        {t("Shared.integrations.pageDescription")}
-      </p>
-
-      {/* One toolbar: status pills lead and wrap within their own cluster,
-          search holds a fixed slot on the right from lg up. Below lg the two
-          stack, with the search full-width first — never a lonely field
-          floating right on its own wrap line. */}
+    <div className="w-full space-y-6 px-4 py-5 md:px-6">
+      {/* No lead-in paragraph: each section explains itself, and the header
+          tabs already frame the page — content starts at the toolbar. The
+          status group is one contained segmented control (the secondary pill
+          tabs), so it can never shed an orphaned pill onto its own wrap line;
+          on narrow viewports it scrolls within its strip instead. */}
       <div
-        className="flex flex-col-reverse gap-3 lg:flex-row lg:items-center"
+        className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between"
         data-integrations-filters="true"
       >
-        <div className="flex flex-1 flex-wrap items-center gap-2">
-          <div className="contents" data-integrations-status-pills="true">
-            {STATUS_FILTERS.map((option) => (
-              <FilterPill key={option} active={status === option} onClick={() => setStatus(option)}>
-                {statusLabel(option, t)}
-              </FilterPill>
-            ))}
-          </div>
-          {filtered ? (
-            <Button variant="ghost" size="sm" onClick={clearFilters}>
-              {t("Shared.integrations.clearFilters")}
-            </Button>
-          ) : null}
+        <div
+          className="-mx-4 overflow-x-auto px-4 [scrollbar-width:none] md:-mx-6 md:px-6 xl:mx-0 xl:px-0"
+          data-integrations-status-pills="true"
+        >
+          <SegmentedControl
+            aria-label={t("Shared.integrations.filterByStatus")}
+            items={STATUS_FILTERS.map((option) => ({
+              value: option,
+              label: statusLabel(option, t),
+            }))}
+            value={status}
+            // Re-clicking the active segment can emit an empty value from the
+            // underlying toggle group; a status filter always has a selection.
+            onValueChange={(value) => value && setStatus(value as StatusFilter)}
+          />
         </div>
-        <div className="w-full lg:w-64 lg:shrink-0">
+        <div className="w-full max-w-xs xl:w-64 xl:shrink-0">
           <SearchInput
             value={query}
             onChange={(event) => setQuery(event.currentTarget.value)}

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComplianceProviderId, OrganizationRpcProvider, RampProviderId } from "@sdp/types";
-import { ChevronRight, Search } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { type ReactNode, useMemo, useState } from "react";
@@ -9,7 +9,7 @@ import type { CustodyProviderAvailability } from "@/app/dashboard/custody/provid
 import { WalletProviderMark } from "@/app/dashboard/custody/wallet-provider-mark";
 import { RpcProviderMark } from "@/app/dashboard/onboarding/rpc-provider-mark";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import { useTranslations } from "@/i18n/provider";
 import { COMPLIANCE_PROVIDER_LOGOS } from "@/lib/compliance";
 import { useDashboardTab } from "@/lib/dashboard-url-state";
@@ -253,33 +253,28 @@ export function IntegrationsCatalog({
         {t("Shared.integrations.pageDescription")}
       </p>
 
-      <div className="space-y-3" data-integrations-filters="true">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="w-full max-w-md">
-            <Input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.currentTarget.value)}
-              placeholder={t("Shared.integrations.searchPlaceholder")}
-              aria-label={t("Shared.integrations.searchPlaceholder")}
-              iconLeft={<Search />}
-              // The DS input paints its border on an inner span via
-              // --input-border-*, so border-* classes are inert here.
-              className="h-10 rounded-[10px] bg-surface-raised [--input-border-hover:var(--color-border-strong)] [--input-border-idle:var(--color-border-default)] [--input-border-width:1px]"
-            />
-          </div>
-          {filtered ? (
-            <Button variant="ghost" size="sm" onClick={clearFilters}>
-              {t("Shared.integrations.clearFilters")}
-            </Button>
-          ) : null}
-        </div>
+      {/* One toolbar row: status pills lead, search trails at toolbar width.
+          The family axis already moved to the header tabs, so stacking a
+          second full-width row here would reopen the clash it removed. */}
+      <div className="flex flex-wrap items-center gap-2" data-integrations-filters="true">
         <div className="flex flex-wrap items-center gap-2" data-integrations-status-pills="true">
           {STATUS_FILTERS.map((option) => (
             <FilterPill key={option} active={status === option} onClick={() => setStatus(option)}>
               {statusLabel(option, t)}
             </FilterPill>
           ))}
+        </div>
+        {filtered ? (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            {t("Shared.integrations.clearFilters")}
+          </Button>
+        ) : null}
+        <div className="w-full sm:ms-auto sm:w-64">
+          <SearchInput
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder={t("Shared.integrations.searchPlaceholder")}
+          />
         </div>
       </div>
 

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-catalog.unit.test.tsx
@@ -97,9 +97,9 @@ describe("IntegrationsCatalog filtering", () => {
     await user.click(screen.getByRole("button", { name: "Connected" }));
     expect(visibleRowLabels()).toEqual(["Helius"]);
 
-    // Clear filters owns only what this page controls; the header tab is
-    // navigation and stays put.
-    await user.click(screen.getByRole("button", { name: "Clear filters" }));
+    // The status control owns only what this page controls; the header tab
+    // is navigation and stays put.
+    await user.click(screen.getByRole("button", { name: "All" }));
     expect(visibleRowLabels()).toEqual(["Helius", "Alchemy"]);
   });
 
@@ -173,7 +173,7 @@ describe("IntegrationsCatalog filtering", () => {
     await user.type(screen.getByRole("searchbox"), "moon");
     expect(visibleRowLabels()).toEqual(["MoonPay"]);
 
-    await user.click(screen.getByRole("button", { name: "Clear filters" }));
+    await user.clear(screen.getByRole("searchbox"));
     expect(visibleRowLabels().length).toBeGreaterThan(5);
   });
 

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-skeleton.tsx
@@ -5,15 +5,13 @@ export function IntegrationsSkeleton() {
         <div className="mx-auto h-4 w-full rounded bg-fill-subtle" />
         <div className="mx-auto h-4 w-1/2 rounded bg-fill-subtle" />
       </div>
-      <div className="space-y-3">
-        <div className="h-11 w-full max-w-md rounded-2xl bg-fill-subtle" />
-        {/* One row, matching the six status pills the loaded catalog renders;
-            the family axis lives in the header tabs. */}
-        <div className="flex flex-wrap gap-2">
-          {[104, 96, 132, 84, 148, 120].map((width) => (
-            <div key={width} className="h-8 rounded-full bg-fill-subtle" style={{ width }} />
-          ))}
-        </div>
+      {/* One toolbar row, matching the loaded catalog: six status pills
+          leading, the search field trailing at toolbar width. */}
+      <div className="flex flex-wrap items-center gap-2">
+        {[104, 96, 132, 84, 148, 120].map((width) => (
+          <div key={width} className="h-8 rounded-full bg-fill-subtle" style={{ width }} />
+        ))}
+        <div className="h-10 w-full rounded-[10px] bg-fill-subtle sm:ms-auto sm:w-64" />
       </div>
       {[0, 1].map((section) => (
         <div key={section} className="space-y-4">

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-skeleton.tsx
@@ -1,17 +1,19 @@
 export function IntegrationsSkeleton() {
   return (
-    <div className="w-full animate-pulse space-y-8 px-4 py-6 md:px-6">
-      <div className="mx-auto max-w-2xl space-y-2">
-        <div className="mx-auto h-4 w-full rounded bg-fill-subtle" />
-        <div className="mx-auto h-4 w-1/2 rounded bg-fill-subtle" />
+    <div className="w-full animate-pulse space-y-6 px-4 py-6 md:px-6">
+      <div className="max-w-2xl space-y-2">
+        <div className="h-4 w-full rounded bg-fill-subtle" />
+        <div className="h-4 w-1/2 rounded bg-fill-subtle" />
       </div>
-      {/* One toolbar row, matching the loaded catalog: six status pills
-          leading, the search field trailing at toolbar width. */}
-      <div className="flex flex-wrap items-center gap-2">
-        {[104, 96, 132, 84, 148, 120].map((width) => (
-          <div key={width} className="h-8 rounded-full bg-fill-subtle" style={{ width }} />
-        ))}
-        <div className="h-10 w-full rounded-[10px] bg-fill-subtle sm:ms-auto sm:w-64" />
+      {/* Matches the loaded toolbar: pills cluster leading with the search
+          slot on the right from lg up, stacked search-first below. */}
+      <div className="flex flex-col-reverse gap-3 lg:flex-row lg:items-center">
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          {[104, 96, 132, 84, 148, 120].map((width) => (
+            <div key={width} className="h-8 rounded-full bg-fill-subtle" style={{ width }} />
+          ))}
+        </div>
+        <div className="h-10 w-full rounded-[10px] bg-fill-subtle lg:w-64 lg:shrink-0" />
       </div>
       {[0, 1].map((section) => (
         <div key={section} className="space-y-4">

--- a/apps/sdp-web/src/app/dashboard/integrations/integrations-skeleton.tsx
+++ b/apps/sdp-web/src/app/dashboard/integrations/integrations-skeleton.tsx
@@ -1,19 +1,11 @@
 export function IntegrationsSkeleton() {
   return (
-    <div className="w-full animate-pulse space-y-6 px-4 py-6 md:px-6">
-      <div className="max-w-2xl space-y-2">
-        <div className="h-4 w-full rounded bg-fill-subtle" />
-        <div className="h-4 w-1/2 rounded bg-fill-subtle" />
-      </div>
-      {/* Matches the loaded toolbar: pills cluster leading with the search
-          slot on the right from lg up, stacked search-first below. */}
-      <div className="flex flex-col-reverse gap-3 lg:flex-row lg:items-center">
-        <div className="flex flex-1 flex-wrap items-center gap-2">
-          {[104, 96, 132, 84, 148, 120].map((width) => (
-            <div key={width} className="h-8 rounded-full bg-fill-subtle" style={{ width }} />
-          ))}
-        </div>
-        <div className="h-10 w-full rounded-[10px] bg-fill-subtle lg:w-64 lg:shrink-0" />
+    <div className="w-full animate-pulse space-y-6 px-4 py-5 md:px-6">
+      {/* Matches the loaded toolbar: one segmented status control leading,
+          the search slot on the right from xl up, stacked below. */}
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+        <div className="h-9 w-full max-w-[560px] rounded-full bg-fill-subtle" />
+        <div className="h-10 w-full max-w-xs rounded-[10px] bg-fill-subtle xl:w-64 xl:shrink-0" />
       </div>
       {[0, 1].map((section) => (
         <div key={section} className="space-y-4">

--- a/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/issuance/issuance-workspace.tsx
@@ -8,9 +8,7 @@ import {
   Coins,
   LayoutGrid,
   List,
-  Loader2,
   Plus,
-  Search,
   ShieldCheck,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -21,7 +19,7 @@ import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react
 import { DashboardWorkspaceTabShell } from "@/components/dashboard-workspace-tab-shell";
 import { ArrowPagination } from "@/components/ui/arrow-pagination";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import { SkeletonBlock } from "@/components/ui/skeleton-block";
 import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import { useLocale, useTranslations } from "@/i18n/provider";
@@ -712,26 +710,17 @@ export function IssuanceWorkspace({
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
               <div className="flex items-center gap-3 sm:flex-1">
                 <div className="flex-1">
-                  <Input
+                  <SearchInput
                     value={search}
                     onChange={(event) => {
                       const value = event.currentTarget.value;
                       setSearch(value);
                     }}
-                    // The DS input paints its border on an inner span via
-                    // --input-border-*, so border-* classes are inert — override the
-                    // vars to 1px + shared tokens to match the filter/toggle buttons.
-                    className="h-10 rounded-[10px] bg-surface-raised [--input-border-hover:var(--color-border-strong)] [--input-border-idle:var(--color-border-default)] [--input-border-width:1px]"
                     placeholder={t("DashboardIssuance.workspace.search")}
-                    iconLeft={<Search />}
                     // Keystrokes are debounced and answered by the server, so the
                     // input says so — otherwise typing has no acknowledgement at
                     // all until the rows change.
-                    iconRight={
-                      isSearchPending ? (
-                        <Loader2 className="animate-spin" aria-hidden="true" />
-                      ) : null
-                    }
+                    pending={isSearchPending}
                   />
                 </div>
                 {/* Filter & sort — icon-only trigger opening a popover. */}

--- a/apps/sdp-web/src/components/ui/search-input.tsx
+++ b/apps/sdp-web/src/components/ui/search-input.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Loader2, Search } from "lucide-react";
+import type { ComponentProps } from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+type SearchInputProps = Omit<ComponentProps<typeof Input>, "type" | "iconLeft" | "iconRight"> & {
+  /** Shows a spinner while a debounced or server-answered search is in flight. */
+  pending?: boolean;
+};
+
+/**
+ * The one search field every workspace toolbar shares: outlined 40px field,
+ * leading search icon, searchbox role, and an optional pending spinner for
+ * server-driven lists. The aria-label falls back to the placeholder so a
+ * bare usage stays labelled.
+ */
+export function SearchInput({
+  pending = false,
+  className,
+  placeholder,
+  "aria-label": ariaLabel,
+  ...props
+}: SearchInputProps) {
+  return (
+    <Input
+      type="search"
+      placeholder={placeholder}
+      aria-label={ariaLabel ?? placeholder}
+      iconLeft={<Search />}
+      iconRight={pending ? <Loader2 className="animate-spin" aria-hidden="true" /> : null}
+      // The DS input paints its border on an inner span via --input-border-*,
+      // so border-* classes are inert — override the vars to 1px + shared
+      // tokens to match the filter and toggle buttons beside it.
+      className={cn(
+        "h-10 rounded-[10px] bg-surface-raised [--input-border-hover:var(--color-border-strong)] [--input-border-idle:var(--color-border-default)] [--input-border-width:1px]",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/sdp-web/src/components/ui/search-input.unit.test.tsx
+++ b/apps/sdp-web/src/components/ui/search-input.unit.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { SearchInput } from "./search-input";
+
+describe("SearchInput", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("is a labelled searchbox, falling back to the placeholder", () => {
+    render(<SearchInput placeholder="Search integrations" />);
+
+    const input = screen.getByRole("searchbox", { name: "Search integrations" });
+    expect(input.getAttribute("type")).toBe("search");
+  });
+
+  it("prefers an explicit aria-label over the placeholder", () => {
+    render(<SearchInput placeholder="Search" aria-label="Search tokens" />);
+
+    expect(screen.getByRole("searchbox", { name: "Search tokens" })).toBeTruthy();
+  });
+
+  it("only shows the pending spinner while a search is in flight", () => {
+    const { container, rerender } = render(<SearchInput placeholder="Search" />);
+    expect(container.querySelector(".animate-spin")).toBeNull();
+
+    rerender(<SearchInput placeholder="Search" pending />);
+    expect(container.querySelector(".animate-spin")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Issuance and integrations each hand-rolled the same search field with a copy-pasted border-variable override, and they had drifted (different roles, labels, busy states). Both now render a shared `SearchInput`: searchbox role, aria-label falling back to the placeholder, and an optional pending spinner for server-answered lists.

The integrations toolbar is also redesigned around it. The status filters move from six loose pills into the design system's `SegmentedControl` (first use in sdp-web) — one contained secondary tab group with a sliding indicator that scrolls in its strip on narrow viewports instead of shedding an orphaned pill onto its own wrap line. The search sits to its right from xl up and tucks underneath at narrower widths. The lead-in paragraph is gone since every section already explains itself, and the toolbar Clear button went with it (the All segment and clearing the input are each one click; the no-results empty state keeps its reset). Skeleton matches.

Other surfaces with hand-rolled searches (policies, custody, recurring, transactions) can adopt the shared input in follow-ups; transactions is left alone deliberately since it has a lot in flight.

Stacked on #1251 (it reshapes the same toolbar); it retargets to main when that merges. Screenshots in a comment.

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/e2accc3b-3e54-4d21-88a9-32334fe17c77" />
<img width="1512" height="949" alt="Screenshot 2026-08-12 at 12 26 07" src="https://github.com/user-attachments/assets/1ba4989f-32b1-4eb3-9b52-eb182c3c1c28" />

