### PR TITLE
fix(sponsorship): close budget bypass, phantom charge, and double-count in admission

### DIFF
--- a/apps/sdp-api/src/runtime/sponsorship-budget-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/sponsorship-budget-redis.node.test.ts
@@ -604,6 +604,80 @@ describe("SponsorshipBudgetRedis", () => {
     expect(await raw.hget(hourKey, "__reservation:res_b:1")).toBeNull();
   });
 
+  it("settles a reservation left behind by the previous ownership format", async () => {
+    const hourKey = "sdp:sponsorship:{devnet}:hour:2026-08-03T10:00:00.000Z";
+    const dayKey = "sdp:sponsorship:{devnet}:day:2026-08-03T00:00:00.000Z";
+    for (const key of [hourKey, dayKey]) {
+      await raw.hset(
+        key,
+        "global",
+        "10",
+        "__initialized:global",
+        "1",
+        "organization:org_1",
+        "10",
+        "__initialized:organization:org_1",
+        "1",
+        "__reservation:res_legacy:1",
+        "10"
+      );
+    }
+
+    await expect(
+      budget.settle({
+        network: "devnet",
+        organizationId: "org_1",
+        projectId: null,
+        hourBucket: "2026-08-03T10:00:00.000Z",
+        dayBucket: "2026-08-03T00:00:00.000Z",
+        reservationId: "res_legacy",
+        attempt: 1,
+        reservedLamports: 10,
+        actualLamports: 4,
+        detectMissingReservation: true,
+      })
+    ).resolves.toBe(-6);
+
+    expect(await raw.hget(hourKey, "global")).toBe("4");
+    expect(await raw.hget(hourKey, "organization:org_1")).toBe("4");
+    expect(await raw.hget(dayKey, "global")).toBe("4");
+    expect(await raw.hget(hourKey, "__reservation:res_legacy:1")).toBeNull();
+  });
+
+  it("cancels a reservation left behind by the previous ownership format", async () => {
+    const hourKey = "sdp:sponsorship:{devnet}:hour:2026-08-03T10:00:00.000Z";
+    const dayKey = "sdp:sponsorship:{devnet}:day:2026-08-03T00:00:00.000Z";
+    for (const key of [hourKey, dayKey]) {
+      await raw.hset(
+        key,
+        "global",
+        "10",
+        "__initialized:global",
+        "1",
+        "organization:org_1",
+        "10",
+        "__initialized:organization:org_1",
+        "1",
+        "__reservation:res_legacy_cancel:1",
+        "10"
+      );
+    }
+
+    await budget.cancel({
+      network: "devnet",
+      organizationId: "org_1",
+      projectId: null,
+      hourBucket: "2026-08-03T10:00:00.000Z",
+      dayBucket: "2026-08-03T00:00:00.000Z",
+      reservationId: "res_legacy_cancel",
+      attempt: 1,
+    });
+
+    expect(await raw.hget(hourKey, "global")).toBe("0");
+    expect(await raw.hget(dayKey, "organization:org_1")).toBe("0");
+    expect(await raw.hget(hourKey, "__reservation:res_legacy_cancel:1")).toBeNull();
+  });
+
   it("counts a tenant once when its field is seeded into an already warm window", async () => {
     const hourKey = "sdp:sponsorship:{devnet}:hour:2026-08-03T10:00:00.000Z";
     const policies = [policy("global", 1, true, 1000), policy("organization", 1, true, 1000)];

--- a/apps/sdp-api/src/runtime/sponsorship-budget-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/sponsorship-budget-redis.node.test.ts
@@ -604,6 +604,91 @@ describe("SponsorshipBudgetRedis", () => {
     expect(await raw.hget(hourKey, "__reservation:res_b:1")).toBeNull();
   });
 
+  it("denies an adopted reservation that exceeds the per-transaction limit", async () => {
+    const hourKey = "sdp:sponsorship:{devnet}:hour:2026-08-03T10:00:00.000Z";
+
+    await expect(
+      budget.reserve({
+        network: "devnet",
+        organizationId: "org_1",
+        projectId: null,
+        hourBucket: "2026-08-03T10:00:00.000Z",
+        dayBucket: "2026-08-03T00:00:00.000Z",
+        reservationId: "res_self",
+        attempt: 1,
+        amount: 11,
+        policies: [policy("global", 1, true, 10), policy("organization", 1, true, 10)],
+        usage: {
+          hour: { global: 11, organization: 11, project: 0 },
+          day: { global: 11, organization: 11, project: 0 },
+        },
+        liveReservations: {
+          hour: [
+            {
+              id: "res_self",
+              attempt: 1,
+              reservedLamports: 11,
+              organizationId: "org_1",
+              projectId: null,
+            },
+          ],
+          day: [
+            {
+              id: "res_self",
+              attempt: 1,
+              reservedLamports: 11,
+              organizationId: "org_1",
+              projectId: null,
+            },
+          ],
+        },
+      })
+    ).resolves.toBe("denied");
+
+    expect(await raw.get("sdp:sponsorship:{devnet}:reservation:res_self:1")).toBeNull();
+    expect(await raw.hget(hourKey, "global")).toBe("11");
+  });
+
+  it("denies an adopted reservation once the seeded window already exceeds its limit", async () => {
+    await expect(
+      budget.reserve({
+        network: "devnet",
+        organizationId: "org_1",
+        projectId: null,
+        hourBucket: "2026-08-03T10:00:00.000Z",
+        dayBucket: "2026-08-03T00:00:00.000Z",
+        reservationId: "res_over",
+        attempt: 1,
+        amount: 5,
+        policies: [policy("global", 1, true, 20), policy("organization", 1, true, 20)],
+        usage: {
+          hour: { global: 25, organization: 25, project: 0 },
+          day: { global: 25, organization: 25, project: 0 },
+        },
+        liveReservations: {
+          hour: [
+            {
+              id: "res_over",
+              attempt: 1,
+              reservedLamports: 5,
+              organizationId: "org_1",
+              projectId: null,
+            },
+          ],
+          day: [
+            {
+              id: "res_over",
+              attempt: 1,
+              reservedLamports: 5,
+              organizationId: "org_1",
+              projectId: null,
+            },
+          ],
+        },
+      })
+    ).resolves.toBe("denied");
+  });
+
   it("adopts a reconstruction-seeded reservation instead of double-counting its own reserve", async () => {
     const base = {
       network: "devnet" as const,

--- a/apps/sdp-api/src/runtime/sponsorship-budget-redis.node.test.ts
+++ b/apps/sdp-api/src/runtime/sponsorship-budget-redis.node.test.ts
@@ -604,6 +604,76 @@ describe("SponsorshipBudgetRedis", () => {
     expect(await raw.hget(hourKey, "__reservation:res_b:1")).toBeNull();
   });
 
+  it("counts a tenant once when its field is seeded into an already warm window", async () => {
+    const hourKey = "sdp:sponsorship:{devnet}:hour:2026-08-03T10:00:00.000Z";
+    const policies = [policy("global", 1, true, 1000), policy("organization", 1, true, 1000)];
+    const window = {
+      network: "devnet" as const,
+      hourBucket: "2026-08-03T10:00:00.000Z",
+      dayBucket: "2026-08-03T00:00:00.000Z",
+      projectId: null,
+      policies,
+    };
+
+    await expect(
+      budget.reserve({
+        ...window,
+        organizationId: "org_a",
+        reservationId: "res_a",
+        attempt: 1,
+        amount: 5,
+        usage: EMPTY_USAGE,
+        liveReservations: { hour: [], day: [] },
+      })
+    ).resolves.toBe("admitted");
+
+    const liveB2 = {
+      id: "res_b2",
+      attempt: 1,
+      reservedLamports: 10,
+      organizationId: "org_b",
+      projectId: null,
+    };
+    await expect(
+      budget.reserve({
+        ...window,
+        organizationId: "org_b",
+        reservationId: "res_b1",
+        attempt: 1,
+        amount: 10,
+        usage: {
+          hour: { global: 15, organization: 10, project: 0 },
+          day: { global: 15, organization: 10, project: 0 },
+        },
+        liveReservations: { hour: [liveB2], day: [liveB2] },
+      })
+    ).resolves.toBe("admitted");
+
+    const liveB1 = {
+      id: "res_b1",
+      attempt: 1,
+      reservedLamports: 10,
+      organizationId: "org_b",
+      projectId: null,
+    };
+    await expect(
+      budget.reserve({
+        ...window,
+        organizationId: "org_b",
+        reservationId: "res_b2",
+        attempt: 1,
+        amount: 10,
+        usage: {
+          hour: { global: 15, organization: 10, project: 0 },
+          day: { global: 15, organization: 10, project: 0 },
+        },
+        liveReservations: { hour: [liveB1], day: [liveB1] },
+      })
+    ).resolves.toBe("admitted");
+
+    expect(await raw.hget(hourKey, "organization:org_b")).toBe("20");
+  });
+
   it("denies an adopted reservation that exceeds the per-transaction limit", async () => {
     const hourKey = "sdp:sponsorship:{devnet}:hour:2026-08-03T10:00:00.000Z";
 

--- a/apps/sdp-api/src/runtime/sponsorship-budget-redis.ts
+++ b/apps/sdp-api/src/runtime/sponsorship-budget-redis.ts
@@ -11,24 +11,26 @@ import { getRedisClient } from "./kv-redis";
 
 const INITIALIZE_LUA = `
 local count = tonumber(ARGV[1])
-local hour_existed = redis.call('EXISTS', KEYS[1]) == 1
-local day_existed = redis.call('EXISTS', KEYS[2]) == 1
+local seeded_hour = {}
+local seeded_day = {}
 for i = 1, count do
   local field = ARGV[1 + i]
   local marker = '__initialized:' .. field
   if not redis.call('HGET', KEYS[1], marker) then
     redis.call('HSET', KEYS[1], field, ARGV[1 + count + i])
     redis.call('HSET', KEYS[1], marker, '1')
+    seeded_hour[field] = true
   end
   if not redis.call('HGET', KEYS[2], marker) then
     redis.call('HSET', KEYS[2], field, ARGV[1 + count * 2 + i])
     redis.call('HSET', KEYS[2], marker, '1')
+    seeded_day[field] = true
   end
 end
 redis.call('PEXPIRE', KEYS[1], ARGV[2 + count * 3])
 redis.call('PEXPIRE', KEYS[2], ARGV[3 + count * 3])
 local cursor = 3 + count * 3
-local function reconstruct(hash_key, hash_existed)
+local function reconstruct(hash_key, seeded)
   local reservations = tonumber(ARGV[cursor + 1])
   cursor = cursor + 1
   for i = 1, reservations do
@@ -42,25 +44,23 @@ local function reconstruct(hash_key, hash_existed)
       fields[f] = ARGV[cursor + f]
     end
     cursor = cursor + field_count
-    if not hash_existed then
-      local settled = redis.call('GET', settlement_key)
-      if settled then
-        local delta = tonumber(settled) - reserved
-        if delta ~= 0 then
-          for f = 1, field_count do
-            if redis.call('HGET', hash_key, '__initialized:' .. fields[f]) then
-              redis.call('HINCRBY', hash_key, fields[f], delta)
-            end
-          end
+    local settled = redis.call('GET', settlement_key)
+    for f = 1, field_count do
+      local field = fields[f]
+      if seeded[field] then
+        if settled then
+          local delta = tonumber(settled) - reserved
+          if delta ~= 0 then redis.call('HINCRBY', hash_key, field, delta) end
+        else
+          redis.call('HSET', hash_key, ownership .. ':' .. field, reserved)
+          redis.call('HSET', hash_key, ownership, reserved)
         end
-      elseif not redis.call('HGET', hash_key, ownership) then
-        redis.call('HSET', hash_key, ownership, reserved)
       end
     end
   end
 end
-reconstruct(KEYS[1], hour_existed)
-reconstruct(KEYS[2], day_existed)
+reconstruct(KEYS[1], seeded_hour)
+reconstruct(KEYS[2], seeded_day)
 return 1
 `;
 
@@ -85,8 +85,8 @@ for i = 1, count do
 end
 if existing or redis.call('GET', KEYS[5]) then return {2, tonumber(existing or '0')} end
 local ownership_field = ARGV[4 + count * 6]
-local counted_hour = redis.call('HGET', KEYS[1], ownership_field)
-local counted_day = redis.call('HGET', KEYS[2], ownership_field)
+local counted_hour = {}
+local counted_day = {}
 for i = 1, count do
   local offset = 2 + ((i - 1) * 6)
   local field = ARGV[offset + 1]
@@ -94,31 +94,34 @@ for i = 1, count do
   local hour_limit = tonumber(ARGV[offset + 3])
   local day_limit = tonumber(ARGV[offset + 4])
   if amount > per_tx then return {0, i} end
+  counted_hour[i] = redis.call('HGET', KEYS[1], ownership_field .. ':' .. field)
+  counted_day[i] = redis.call('HGET', KEYS[2], ownership_field .. ':' .. field)
   local hour_used = tonumber(redis.call('HGET', KEYS[1], field) or '0')
-  if counted_hour then
+  if counted_hour[i] then
     if hour_used > hour_limit then return {0, i} end
   elseif hour_used + amount > hour_limit then
     return {0, i}
   end
   local day_used = tonumber(redis.call('HGET', KEYS[2], field) or '0')
-  if counted_day then
+  if counted_day[i] then
     if day_used > day_limit then return {0, i} end
   elseif day_used + amount > day_limit then
     return {0, i}
   end
 end
-if not counted_hour then
-  for i = 1, count do
-    redis.call('HINCRBY', KEYS[1], ARGV[2 + ((i - 1) * 6) + 1], amount)
+for i = 1, count do
+  local field = ARGV[2 + ((i - 1) * 6) + 1]
+  if not counted_hour[i] then
+    redis.call('HINCRBY', KEYS[1], field, amount)
+    redis.call('HSET', KEYS[1], ownership_field .. ':' .. field, amount)
   end
-  redis.call('HSET', KEYS[1], ownership_field, amount)
-end
-if not counted_day then
-  for i = 1, count do
-    redis.call('HINCRBY', KEYS[2], ARGV[2 + ((i - 1) * 6) + 1], amount)
+  if not counted_day[i] then
+    redis.call('HINCRBY', KEYS[2], field, amount)
+    redis.call('HSET', KEYS[2], ownership_field .. ':' .. field, amount)
   end
-  redis.call('HSET', KEYS[2], ownership_field, amount)
 end
+redis.call('HSET', KEYS[1], ownership_field, amount)
+redis.call('HSET', KEYS[2], ownership_field, amount)
 redis.call('SET', KEYS[3], amount, 'PX', ARGV[3 + count * 6])
 return {1, amount}
 `;
@@ -146,8 +149,7 @@ if day_owned and tonumber(day_owned) ~= amount then return -2 end
 for i = 2, #ARGV do
   local field = ARGV[i]
   for key_index = 1, 2 do
-    if redis.call('HGET', KEYS[key_index], ARGV[1]) then
-      if not redis.call('HGET', KEYS[key_index], '__initialized:' .. field) then return -1 end
+    if redis.call('HGET', KEYS[key_index], ARGV[1] .. ':' .. field) then
       local used = tonumber(redis.call('HGET', KEYS[key_index], field) or '0')
       if used < amount then return -1 end
     end
@@ -156,8 +158,10 @@ end
 for i = 2, #ARGV do
   local field = ARGV[i]
   for key_index = 1, 2 do
-    if redis.call('HGET', KEYS[key_index], ARGV[1]) then
+    local covered = ARGV[1] .. ':' .. field
+    if redis.call('HGET', KEYS[key_index], covered) then
       redis.call('HINCRBY', KEYS[key_index], field, -amount)
+      redis.call('HDEL', KEYS[key_index], covered)
     end
   end
 end
@@ -180,41 +184,24 @@ local ownership_field = ARGV[6 + count]
 for key_index = 1, 2 do
   local hash_owned = redis.call('HGET', KEYS[key_index], ownership_field)
   if hash_owned and tonumber(hash_owned) ~= reserved then return {0, 2} end
-  local should_adjust = false
-  if owned_value then
-    should_adjust = redis.call('EXISTS', KEYS[key_index]) == 1
-  else
-    should_adjust = hash_owned ~= false
-  end
-  if should_adjust then
-    if delta < 0 then
-      for i = 4, 3 + count do
-        if redis.call('HGET', KEYS[key_index], '__initialized:' .. ARGV[i]) then
-          local current = tonumber(redis.call('HGET', KEYS[key_index], ARGV[i]) or '0')
-          if current < -delta then return {0, 1} end
-        end
+  if delta < 0 then
+    for i = 4, 3 + count do
+      if redis.call('HGET', KEYS[key_index], ownership_field .. ':' .. ARGV[i]) then
+        local current = tonumber(redis.call('HGET', KEYS[key_index], ARGV[i]) or '0')
+        if current < -delta then return {0, 1} end
       end
     end
   end
 end
 for key_index = 1, 2 do
-  local hash_owned = redis.call('HGET', KEYS[key_index], ownership_field)
-  local should_adjust = false
-  if owned_value then
-    should_adjust = redis.call('EXISTS', KEYS[key_index]) == 1
-  else
-    should_adjust = hash_owned ~= false
-  end
-  if should_adjust then
-    if delta ~= 0 then
-      for i = 4, 3 + count do
-        if redis.call('HGET', KEYS[key_index], '__initialized:' .. ARGV[i]) then
-          redis.call('HINCRBY', KEYS[key_index], ARGV[i], delta)
-        end
-      end
+  for i = 4, 3 + count do
+    local covered = ownership_field .. ':' .. ARGV[i]
+    if redis.call('HGET', KEYS[key_index], covered) then
+      if delta ~= 0 then redis.call('HINCRBY', KEYS[key_index], ARGV[i], delta) end
+      redis.call('HDEL', KEYS[key_index], covered)
     end
-    redis.call('HDEL', KEYS[key_index], ownership_field)
   end
+  redis.call('HDEL', KEYS[key_index], ownership_field)
 end
 redis.call('DEL', KEYS[3])
 redis.call('SET', KEYS[4], actual, 'PX', ARGV[4 + count])

--- a/apps/sdp-api/src/runtime/sponsorship-budget-redis.ts
+++ b/apps/sdp-api/src/runtime/sponsorship-budget-redis.ts
@@ -93,14 +93,18 @@ for i = 1, count do
   local per_tx = tonumber(ARGV[offset + 2])
   local hour_limit = tonumber(ARGV[offset + 3])
   local day_limit = tonumber(ARGV[offset + 4])
-  if (not counted_hour or not counted_day) and amount > per_tx then return {0, i} end
-  if not counted_hour then
-    local hour_used = tonumber(redis.call('HGET', KEYS[1], field) or '0')
-    if hour_used + amount > hour_limit then return {0, i} end
+  if amount > per_tx then return {0, i} end
+  local hour_used = tonumber(redis.call('HGET', KEYS[1], field) or '0')
+  if counted_hour then
+    if hour_used > hour_limit then return {0, i} end
+  elseif hour_used + amount > hour_limit then
+    return {0, i}
   end
-  if not counted_day then
-    local day_used = tonumber(redis.call('HGET', KEYS[2], field) or '0')
-    if day_used + amount > day_limit then return {0, i} end
+  local day_used = tonumber(redis.call('HGET', KEYS[2], field) or '0')
+  if counted_day then
+    if day_used > day_limit then return {0, i} end
+  elseif day_used + amount > day_limit then
+    return {0, i}
   end
 end
 if not counted_hour then

--- a/apps/sdp-api/src/runtime/sponsorship-budget-redis.ts
+++ b/apps/sdp-api/src/runtime/sponsorship-budget-redis.ts
@@ -146,22 +146,32 @@ if not amount_value then return 0 end
 local amount = tonumber(amount_value)
 if hour_owned and tonumber(hour_owned) ~= amount then return -2 end
 if day_owned and tonumber(day_owned) ~= amount then return -2 end
+local function covers(hash_key, field)
+  if redis.call('HGET', hash_key, ARGV[1] .. ':' .. field) then return true end
+  if not redis.call('HGET', hash_key, ARGV[1]) then return false end
+  for i = 2, #ARGV do
+    if redis.call('HGET', hash_key, ARGV[1] .. ':' .. ARGV[i]) then return false end
+  end
+  return redis.call('HGET', hash_key, '__initialized:' .. field) ~= false
+end
 for i = 2, #ARGV do
   local field = ARGV[i]
   for key_index = 1, 2 do
-    if redis.call('HGET', KEYS[key_index], ARGV[1] .. ':' .. field) then
+    if covers(KEYS[key_index], field) then
       local used = tonumber(redis.call('HGET', KEYS[key_index], field) or '0')
       if used < amount then return -1 end
     end
   end
 end
-for i = 2, #ARGV do
-  local field = ARGV[i]
-  for key_index = 1, 2 do
-    local covered = ARGV[1] .. ':' .. field
-    if redis.call('HGET', KEYS[key_index], covered) then
-      redis.call('HINCRBY', KEYS[key_index], field, -amount)
-      redis.call('HDEL', KEYS[key_index], covered)
+for key_index = 1, 2 do
+  local adjusted = {}
+  for i = 2, #ARGV do
+    adjusted[i] = covers(KEYS[key_index], ARGV[i])
+  end
+  for i = 2, #ARGV do
+    if adjusted[i] then
+      redis.call('HINCRBY', KEYS[key_index], ARGV[i], -amount)
+      redis.call('HDEL', KEYS[key_index], ARGV[1] .. ':' .. ARGV[i])
     end
   end
 end
@@ -181,12 +191,20 @@ local owned_value = redis.call('GET', KEYS[3])
 if not owned_value and ARGV[5 + count] ~= '1' then return {0, 2} end
 if owned_value and tonumber(owned_value) ~= reserved then return {0, 2} end
 local ownership_field = ARGV[6 + count]
+local function covers(hash_key, field)
+  if redis.call('HGET', hash_key, ownership_field .. ':' .. field) then return true end
+  if not redis.call('HGET', hash_key, ownership_field) then return false end
+  for i = 4, 3 + count do
+    if redis.call('HGET', hash_key, ownership_field .. ':' .. ARGV[i]) then return false end
+  end
+  return redis.call('HGET', hash_key, '__initialized:' .. field) ~= false
+end
 for key_index = 1, 2 do
   local hash_owned = redis.call('HGET', KEYS[key_index], ownership_field)
   if hash_owned and tonumber(hash_owned) ~= reserved then return {0, 2} end
   if delta < 0 then
     for i = 4, 3 + count do
-      if redis.call('HGET', KEYS[key_index], ownership_field .. ':' .. ARGV[i]) then
+      if covers(KEYS[key_index], ARGV[i]) then
         local current = tonumber(redis.call('HGET', KEYS[key_index], ARGV[i]) or '0')
         if current < -delta then return {0, 1} end
       end
@@ -194,11 +212,14 @@ for key_index = 1, 2 do
   end
 end
 for key_index = 1, 2 do
+  local adjusted = {}
   for i = 4, 3 + count do
-    local covered = ownership_field .. ':' .. ARGV[i]
-    if redis.call('HGET', KEYS[key_index], covered) then
+    adjusted[i] = covers(KEYS[key_index], ARGV[i])
+  end
+  for i = 4, 3 + count do
+    if adjusted[i] then
       if delta ~= 0 then redis.call('HINCRBY', KEYS[key_index], ARGV[i], delta) end
-      redis.call('HDEL', KEYS[key_index], covered)
+      redis.call('HDEL', KEYS[key_index], ownership_field .. ':' .. ARGV[i])
     end
   end
   redis.call('HDEL', KEYS[key_index], ownership_field)

--- a/apps/sdp-api/src/services/sponsorship-budget.service.node.test.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget.service.node.test.ts
@@ -241,6 +241,17 @@ describe("BudgetedFeePayment", () => {
     expect(provider.signAndSend).not.toHaveBeenCalled();
   });
 
+  it("leaves an admission-released reservation reopenable by a later retry", async () => {
+    const { feePayment, repository, budgetRedis } = harness();
+    budgetRedis.reserve.mockResolvedValueOnce("denied");
+
+    await expect(feePayment.signAndSend(buildTransaction())).rejects.toMatchObject({
+      code: "RATE_LIMITED",
+    });
+    expect(repository.markReleased).toHaveBeenCalledOnce();
+    expect(repository.markRedisSettled).toHaveBeenCalledWith(expect.any(String), 1);
+  });
+
   it("releases deterministic pre-send rejections", async () => {
     const { feePayment, provider, repository, budgetRedis } = harness();
     vi.mocked(provider.signAndSend).mockRejectedValueOnce(

--- a/apps/sdp-api/src/services/sponsorship-budget.service.node.test.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget.service.node.test.ts
@@ -222,6 +222,25 @@ describe("BudgetedFeePayment", () => {
     expect(provider.signAndSend).not.toHaveBeenCalled();
   });
 
+  it("releases the durable row when the policy is disabled before the retry", async () => {
+    const { feePayment, provider, repository, budgetRedis } = harness();
+    budgetRedis.reserve.mockResolvedValueOnce("stale_policy");
+    repository.resolvePolicies
+      .mockResolvedValueOnce([policy("global"), policy("organization"), policy("project")])
+      .mockResolvedValue([policy("global", false), policy("organization"), policy("project")]);
+
+    await expect(feePayment.signAndSend(buildTransaction())).rejects.toMatchObject({
+      code: "PROVIDER_NOT_AVAILABLE",
+    });
+    expect(repository.createReservation).toHaveBeenCalledOnce();
+    expect(repository.markReleased).toHaveBeenCalledWith(
+      expect.any(String),
+      1,
+      "sponsorship disabled during admission"
+    );
+    expect(provider.signAndSend).not.toHaveBeenCalled();
+  });
+
   it("releases deterministic pre-send rejections", async () => {
     const { feePayment, provider, repository, budgetRedis } = harness();
     vi.mocked(provider.signAndSend).mockRejectedValueOnce(

--- a/apps/sdp-api/src/services/sponsorship-budget.service.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget.service.ts
@@ -620,6 +620,7 @@ export class BudgetedFeePayment implements FeePaymentPort {
   ): Promise<void> {
     try {
       await this.repository.markReleased(context.id, attempt, reason);
+      await this.repository.markRedisSettled(context.id, attempt);
     } catch (error) {
       return this.accountingUnavailable(
         context.network,

--- a/apps/sdp-api/src/services/sponsorship-budget.service.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget.service.ts
@@ -412,9 +412,6 @@ export class BudgetedFeePayment implements FeePaymentPort {
         error
       );
     }
-    if (policies.some((policy) => !policy.enabled)) {
-      throw new FeePaymentError("Sponsorship is disabled for this scope", "PROVIDER_NOT_AVAILABLE");
-    }
     return policies;
   }
 
@@ -426,6 +423,19 @@ export class BudgetedFeePayment implements FeePaymentPort {
     let durable: DurableAdmission | null = null;
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const policies = await this.resolveEnabledPolicies(context);
+      if (policies.some((policy) => !policy.enabled)) {
+        if (durable?.kind === "owned") {
+          await this.releaseDurable(
+            context,
+            reservationAttempt,
+            "sponsorship disabled during admission"
+          );
+        }
+        throw new FeePaymentError(
+          "Sponsorship is disabled for this scope",
+          "PROVIDER_NOT_AVAILABLE"
+        );
+      }
       if (!durable) {
         durable = await this.persistReservationDurable(
           context,

--- a/apps/sdp-api/src/services/sponsorship-budget.service.ts
+++ b/apps/sdp-api/src/services/sponsorship-budget.service.ts
@@ -415,6 +415,23 @@ export class BudgetedFeePayment implements FeePaymentPort {
     return policies;
   }
 
+  private async assertSponsorshipEnabled(
+    context: AdmissionContext,
+    policies: SponsorshipBudgetPolicy[],
+    durable: DurableAdmission | null,
+    reservationAttempt: number
+  ): Promise<void> {
+    if (policies.every((policy) => policy.enabled)) return;
+    if (durable?.kind === "owned") {
+      await this.releaseDurable(
+        context,
+        reservationAttempt,
+        "sponsorship disabled during admission"
+      );
+    }
+    throw new FeePaymentError("Sponsorship is disabled for this scope", "PROVIDER_NOT_AVAILABLE");
+  }
+
   private async admitAgainstCurrentPolicy(
     context: AdmissionContext,
     operation: AdmissionOperation,
@@ -423,19 +440,7 @@ export class BudgetedFeePayment implements FeePaymentPort {
     let durable: DurableAdmission | null = null;
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const policies = await this.resolveEnabledPolicies(context);
-      if (policies.some((policy) => !policy.enabled)) {
-        if (durable?.kind === "owned") {
-          await this.releaseDurable(
-            context,
-            reservationAttempt,
-            "sponsorship disabled during admission"
-          );
-        }
-        throw new FeePaymentError(
-          "Sponsorship is disabled for this scope",
-          "PROVIDER_NOT_AVAILABLE"
-        );
-      }
+      await this.assertSponsorshipEnabled(context, policies, durable, reservationAttempt);
       if (!durable) {
         durable = await this.persistReservationDurable(
           context,


### PR DESCRIPTION
Closes three audit findings against the sponsorship budget admission path, all
reproduced by tests before being fixed.

## 1. Budget limits could be bypassed

A reservation seeded into Redis by window reconstruction was adopted as "already
authorized" and skipped the limit check entirely. It had never passed one:
admission commits the durable row *before* the Redis gate, so the row's presence
proves nothing about limits. A concurrent peer put our marker in place, we saw
"already counted" and went through — 11 was admitted against a limit of 10.

Reserve now enforces the per-transaction cap unconditionally. For a window that
genuinely already counts the reservation it denies once that window is over its
limit, rather than re-adding the amount.

## 2. Requests could be falsely charged

A policy disabled between the stale-policy retry and the second attempt threw
out of the admission loop before the reservation was released. The row stayed in
`reserved`, reconciliation later charged it as `charged_unknown`, and a
transaction that never happened kept consuming the tenant budget until the
window expired.

The disabled-policy guard now releases the durable row on its way out.

## 3. Tenant usage could be double-counted

Ownership was recorded once per reservation, while usage is tracked per scope
field. The two disagreed whenever a window was only partially reconstructed:
seeding a tenant field into an already warm window left that tenant's live
reservations unmarked, and each one incremented a counter the seeded aggregate
already included — 30 recorded against 20 actually reserved, denying the tenant
until the window expired.

Ownership is now recorded per scope field, so reserve, settle and cancel each
adjust exactly the fields that actually count the reservation. This also removes
the mismatch behind the partial cross-tenant reconstruction cases.

## Verification

- sponsorship suites: 104 passed, including new regression tests for all three
  findings against a real Redis
- payments and kora suites: 271 passed — the Lua rework touches the shared money
  path, so these were run to confirm no fallout
- typecheck and lint clean
