### PR TITLE
fix(cron): log every underlying cause of a failed reconciliation tick

### DIFF
--- a/apps/sdp-api/src/job.node.test.ts
+++ b/apps/sdp-api/src/job.node.test.ts
@@ -12,7 +12,7 @@ import { runDueWorkflowExecutions } from "@/services/jobs/run-workflow-execution
 import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
 import { recoverApprovedWalletOperations } from "@/services/policy/approved-operation-replay";
 import type { Env } from "@/types/env";
-import { runCronJob } from "./job";
+import { describeCronFailure, runCronJob } from "./job";
 
 vi.mock("@sentry/node", () => ({
   close: vi.fn(async () => true),
@@ -281,5 +281,32 @@ describe("runCronJob", () => {
     await expect(runCronJob()).rejects.toThrow("transfers down");
 
     expect(reconcileSponsorshipBudgets).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports every underlying cause when a tick fails on more than one task", () => {
+    const failure = new AggregateError(
+      [new Error("transfers down"), new Error("sponsorship down")],
+      "pending-transfers tick had multiple failures"
+    );
+
+    expect(describeCronFailure(failure)).toEqual({
+      error: failure,
+      causes: [
+        { message: "transfers down", stack: expect.any(String) },
+        { message: "sponsorship down", stack: expect.any(String) },
+      ],
+    });
+  });
+
+  it("keeps a single failure unchanged", () => {
+    const failure = new Error("transfers down");
+    expect(describeCronFailure(failure)).toEqual({ error: failure });
+  });
+
+  it("describes a rejected non-error value", () => {
+    expect(describeCronFailure(new AggregateError(["boom"], "tick"))).toEqual({
+      error: expect.any(AggregateError),
+      causes: [{ message: "boom" }],
+    });
   });
 });

--- a/apps/sdp-api/src/job.ts
+++ b/apps/sdp-api/src/job.ts
@@ -100,12 +100,24 @@ export async function runCronJob(): Promise<void> {
   }
 }
 
+export function describeCronFailure(error: unknown): Record<string, unknown> {
+  if (!(error instanceof AggregateError)) return { error };
+  return {
+    error,
+    causes: error.errors.map((cause: unknown) =>
+      cause instanceof Error
+        ? { message: cause.message, stack: cause.stack }
+        : { message: String(cause) }
+    ),
+  };
+}
+
 const invokedPath = process.argv[1];
 if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
   runCronJob()
     .then(() => process.exit(0))
     .catch((err: unknown) => {
-      getLogger().error({ error: err }, "Reconciliation job failed");
+      getLogger().error(describeCronFailure(err), "Reconciliation job failed");
       process.exit(1);
     });
 }


### PR DESCRIPTION
The reconciliation tick runs its tasks concurrently and collects their failures,
so when more than one fails the job rejects with an `AggregateError`. The handler
logs only the top-level error, and the standard serializer does not walk the
aggregate's list of causes.

The result is a log line saying `pending-transfers tick had multiple failures`
with no indication of which task failed or why — the individual causes are
dropped. Dev hit this three times in the last day, each time leaving nothing
actionable behind.

`describeCronFailure` now unwraps the aggregate and records each cause alongside
the original error. A single failure keeps its existing shape, and a rejected
non-error value is still described rather than dropped.

## Verification

- `job` suite: 14 passed, including three cases covering aggregate, single and
  non-error rejections
- typecheck and lint clean
