### PR TITLE
feat(helius): HMAC-signed router and the timeout ladder

### DIFF
--- a/apps/sdp-helius-gateway/README.md
+++ b/apps/sdp-helius-gateway/README.md
@@ -38,27 +38,30 @@ Two consequences shape this crate:
 
 ## Status
 
-`GET /health` is the only route wired up so far. It answers unauthenticated, because a liveness probe
-carries no shared secret and requiring one would make an HMAC misconfiguration look like a dead
-container instead of failing requests with a clear cause.
+`/health` is implemented. All eight flow endpoints are routed and return
+`501 NOT_IMPLEMENTED` with the real error body, so a `404` in a test means a routing mistake rather than
+unfinished work. Each one parses and validates its request first, which means the contract is exercised
+before the flow behind it exists.
 
-The full contract is already here as types in [`src/wire/`](src/wire/), ahead of the handlers that will
-consume it. That ordering is deliberate: the contract is the thing SDP builds against and the thing
-worth reviewing first, and `wire/mod.rs` carries a module-wide `allow(dead_code)` for exactly as long
-as nothing reads it.
+`/health` answers unauthenticated, because a liveness probe carries no shared secret and requiring one
+would make an HMAC misconfiguration look like a dead container instead of failing requests with a clear
+cause.
 
-Eight endpoints are specified and land behind this one, five of which never see a secret:
+| Endpoint | Caller | Key material | Status |
+| --- | --- | --- | --- |
+| `POST /v1/wallets/register` | `sdp-api` | no | 501 |
+| `POST /v1/wallets/merging` | `sdp-api` | no | 501 |
+| `POST /v1/operations/shield` | `sdp-api` | no | 501 |
+| `POST /v1/transactions/assemble` | `sdp-api` | no | 501 |
+| `POST /v1/nullifiers/status` | `sdp-api` | no | 501 |
+| `POST /v1/wallets/sync` | `rings-key-auth` | yes | 501 |
+| `POST /v1/operations/plan` | `rings-key-auth` | yes | 501 |
+| `POST /v1/operations/prove` | `rings-key-auth` | yes | 501 |
+| `GET /health` | none | no | **200** |
 
-| Endpoint | Caller | Key material |
-| --- | --- | --- |
-| `POST /v1/wallets/register` | `sdp-api` | no |
-| `POST /v1/wallets/merging` | `sdp-api` | no |
-| `POST /v1/operations/shield` | `sdp-api` | no |
-| `POST /v1/transactions/assemble` | `sdp-api` | no |
-| `POST /v1/nullifiers/status` | `sdp-api` | no |
-| `POST /v1/wallets/sync` | `rings-key-auth` | yes |
-| `POST /v1/operations/plan` | `rings-key-auth` | yes |
-| `POST /v1/operations/prove` | `rings-key-auth` | yes |
+Five of the eight never see a secret. The caller column is enforced, not documentation: each route is
+verified against its own caller's HMAC secret, so a key-bearing route signed with the sdp-api secret is
+`401`.
 
 Registration is keyless because a `ShieldedAddress` is built entirely from public halves — the owner's
 Ed25519 pubkey, the 32-byte nullifier pubkey and the 33-byte compressed P256 viewing pubkey — so no
@@ -93,7 +96,7 @@ Each preflight read is bounded in-process. The agave client retries a `429` five
 ## Running it
 
 ```bash
-cargo test                 # 14 unit + 1 contract test
+cargo test                 # 22 unit + 16 contract tests
 cargo clippy --all-targets --locked -- -D warnings
 cargo fmt --check
 
@@ -114,6 +117,85 @@ CI runs the same three commands in
 path-filtered to this directory. It is the crate's only correctness gate: Biome ignores `.rs`, the
 `typecheck` job resolves this directory and then no-ops via `--if-present`, and CodeQL has no Rust
 analysis.
+
+## Timeout ladder
+
+Every budget below is a number this service chooses. That is the whole point of the section: **nothing
+upstream bounds a prove call**, so if the gateway does not impose a bound, there is none.
+
+### In-process route budgets
+
+Defined in `src/routes/mod.rs`, enforced as tower layers, and checked against each other at compile
+time by a `const` block in the same file.
+
+| Route | Constant | Budget | Why |
+| --- | --- | --- | --- |
+| `/v1/transactions/assemble` | `DEFAULT_TIMEOUT` | 15 s | pure local work, no RPC, no key material |
+| `/v1/wallets/register` | `RPC_TIMEOUT` | 35 s | one registry read, above the agave client's own 30 s |
+| `/v1/operations/shield` | `RPC_TIMEOUT` | 35 s | same |
+| `/v1/wallets/merging` | `RPC_TIMEOUT` | 35 s | one registry read, same shape as register |
+| `/v1/nullifiers/status` | `SYNC_TIMEOUT` | 60 s | indexer-bound; borrows sync's budget |
+| `/v1/wallets/sync` | `SYNC_TIMEOUT` | 60 s | several indexer rounds |
+| `/v1/operations/plan` | `PLAN_TIMEOUT` | 60 s | a sync plus input selection |
+| `/v1/operations/prove` | `PROVE_TIMEOUT` | 660 s | backstop; see below |
+| `/health` | none | — | serves a startup snapshot, no request-time I/O |
+
+`RPC_TIMEOUT` sits deliberately above 30 s. The agave RPC client applies its own 30 s per-request
+timeout, so a route that gives up sooner turns every slow-RPC case into a bodyless `504` and throws away
+the `RPC_UNAVAILABLE` the transport was about to report.
+
+### The prove ladder
+
+| # | Layer | Value | Status |
+| --- | --- | --- | --- |
+| 1 | SDK `AsyncPollConfig::max_wait_secs` | 600 s | lands with the prove handler |
+| 2 | handler `tokio::time::timeout` | 630 s | lands with the prove handler |
+| 3 | layer `PROVE_TIMEOUT` | 660 s | **exists today** |
+| 4 | Cloud Run `--timeout` | 700 s | sdp-infra, **not applied** |
+| 5 | SDP outbound client | 720 s | no SDP caller exists yet |
+| 6 | Cloud Run `--task-timeout` | 780 s | sdp-infra, currently 120 s |
+
+**Why it has to increase outward.** Only the innermost bound that fires can answer with a structured
+`ErrorBody`. Every layer above it produces a bodyless `504` (first the tower layer, then Cloud Run's own
+error page) and leaves SDP to guess what happened. A ladder that inverts anywhere converts a diagnosable
+failure into an opaque one.
+
+**What the SDK's 600 is not.** `PROVE_REQUEST_TIMEOUT_SECS = 600` is easy to read as a ceiling on a
+prove call. It is a timeout on one HTTP request. The submit is retried three times with a two-second
+backoff, and transfer and merge proofs are queued, so the SDK then polls a job under
+`AsyncPollConfig::max_wait_secs` (default 1200). That poll ceiling counts only the time spent *sleeping*
+between polls, never the time spent inside the status request: 1200/3 is 400 polls, each of which can
+take up to 600 s on its own. So the SDK has no wall-clock bound at all, and layer 2 is the only thing
+that provides one.
+
+**600 s is an unmeasured placeholder.** It is a guess with no measurement behind it. Replace it with p99
+of a cold transfer prove and a cold merge prove against the devnet prover, then re-derive rows 2 to 6.
+Upstream gives a prior worth calibrating against: a first P256 request loads a 63 MB proving key and
+runs a 205k-constraint Groth16 prove, and the prover server caps *synchronous* work per circuit well
+below that.
+
+**The handler must classify the SDK's own timeout as `PROVER_TIMEOUT`.** When layer 1 fires, the SDK
+returns a generic `ClientError::ProverServer`, whose natural mapping is `PROVER_FAILED` with
+`retryable: false`. That would tell SDP never to retry a prove that merely timed out. Layer 1 is
+deliberately the first to fire because its error carries the `job_id`, which is useful for
+reconciliation, but that only helps if the handler translates it.
+
+**Layer timeouts are a backstop, never the plan.** The async Photon client is built with no HTTP timeout
+at all, so `/sync` and `/plan` need their own `tokio::time::timeout` for the same reason `/prove` does.
+The same applies at startup: `src/zolana/preflight.rs` bounds each RPC read itself, because the agave
+client retries a `429` five times honouring `Retry-After` and a single read can otherwise take around 13
+minutes without ever being unreachable.
+
+**Launch gate.** Until sdp-infra sets `--timeout=700`, Cloud Run's 300 s default truncates every prove
+and layer 3 is unreachable in production. The prove handler is blocked on that flag, not just on its own
+implementation.
+
+**Why the sync budgets are provisional.** `WalletProjection` in `src/wire/common.rs` round-trips
+`tagCounters` and `utxos`, but not upstream's `request_count`, `known_senders` or `known_recipients`. So
+every stateless request rediscovers the counterparty graph from zero and re-sweeps every shared view-tag
+stream at roughly 100 µs per ECDH. Whatever `/sync` and `/plan` measure today will change structurally
+once the projection carries that state, so treat their budgets as provisional for that reason and not
+only for being unmeasured.
 
 ## Findings
 

--- a/apps/sdp-helius-gateway/src/auth.rs
+++ b/apps/sdp-helius-gateway/src/auth.rs
@@ -1,0 +1,289 @@
+//! Request authentication.
+//!
+//! # Why there is no JWT verification here
+//!
+//! In production this service runs on Cloud Run with `--no-allow-unauthenticated`
+//! and `roles/run.invoker` granted only to the SDP API's service account. Google's
+//! front end validates the caller's OIDC identity token and rejects unauthenticated
+//! requests *before* they reach this container. Verifying the token again in-process
+//! would mean fetching and caching JWKS to re-derive a decision the platform has
+//! already made and enforced.
+//!
+//! # What HMAC adds
+//!
+//! Peer identity is not the whole problem. HMAC over `timestamp + body` gives:
+//!
+//! - **body integrity** — IAM authenticates the caller, not the bytes;
+//! - **a bounded replay window** — see [`HMAC_TIMESTAMP_TOLERANCE_SECS`];
+//! - **an auth path that exists off Cloud Run** — docker-compose, self-hosted
+//!   deployments and integration tests have no IAM front end at all.
+//!
+//! The scheme matches SDP's existing signer byte for byte
+//! (`createHmacSignature` in `packages/sdp-payments/src/fee-payment/kora.adapter.ts`):
+//! HMAC-SHA256, key is the UTF-8 bytes of the shared secret, message is the
+//! decimal-seconds timestamp concatenated with the raw body, signature is
+//! lowercase hex. The key authority's Rust signer has to match the same scheme.
+//!
+//! # Two callers, one secret each
+//!
+//! The gateway serves `sdp-api` on the keyless routes and `rings-key-auth` on the
+//! key-bearing ones. Each route is verified against **its own caller's secret only,
+//! never "either"** — a key-bearing route signed with the sdp-api secret is
+//! `UNAUTHORIZED`. The key-authority design states that this service holds no route
+//! *to* the key authority; making the reverse true costs one config entry.
+//!
+//! In production Cloud Run IAM already separates the two service accounts, so this is
+//! defence in depth there. It is the **only** such control in docker-compose,
+//! self-hosted deployments and integration tests — which is the same gap that makes
+//! HMAC worth having at all.
+//!
+//! # Why not a nested or origin signature
+//!
+//! Because the key authority mutates the body. `sdp-api`'s signature over the body
+//! *it* composed cannot be re-derived here from the final bytes: JSON
+//! re-serialization is not byte-stable, and this service cannot know what was added.
+//!
+//! The property such a scheme would reach for is proof that `sdp-api` authored the
+//! action, and the key authority already provides it — `sdp-api` presents a
+//! single-use intent token naming the exact operation, and the key authority
+//! independently verifies that the operation exists, is approved, and is in a
+//! provable state *before* unwrapping. This gateway sits downstream of that decision
+//! and has no authority to refuse on it, so re-verifying the token here would add a
+//! dependency without adding a control.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::body::{Body, Bytes};
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
+// `KeyInit` carries `new_from_slice`. In hmac 0.13 it is re-exported from
+// `digest`; older snippets that only import `Mac` do not compile.
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+use crate::config::{HMAC_TIMESTAMP_TOLERANCE_SECS, MAX_BODY_BYTES};
+use crate::error::GatewayError;
+use crate::state::AppState;
+
+/// Header carrying unix seconds.
+pub const TIMESTAMP_HEADER: &str = "x-timestamp";
+/// Header carrying the lowercase-hex HMAC-SHA256 tag.
+pub const SIGNATURE_HEADER: &str = "x-hmac-signature";
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Middleware for the routes `sdp-api` calls: everything that carries no key
+/// material.
+pub async fn verify_sdp_api(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, GatewayError> {
+    let secret = state.config.hmac_secret_sdp_api.clone();
+    verify(secret.expose(), request, next).await
+}
+
+/// Middleware for the routes `rings-key-auth` calls: everything that carries key
+/// material.
+///
+/// Separate from [`verify_sdp_api`] rather than parameterized at the call site,
+/// because axum's `from_fn_with_state` takes a plain async fn — and because two named
+/// entry points make the route table in [`crate::routes`] state which caller each
+/// route expects.
+pub async fn verify_key_auth(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, GatewayError> {
+    let secret = state.config.hmac_secret_key_auth.clone();
+    verify(secret.expose(), request, next).await
+}
+
+/// Verifies the request signature against one caller's secret, then passes the
+/// request on.
+///
+/// The body must be buffered whole because it is covered by the signature, so
+/// this is also where the body-size bound is enforced.
+async fn verify(secret: &[u8], request: Request, next: Next) -> Result<Response, GatewayError> {
+    let (parts, body) = request.into_parts();
+
+    let timestamp = parts
+        .headers
+        .get(TIMESTAMP_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(GatewayError::Unauthorized)?
+        .to_owned();
+
+    let signature = parts
+        .headers
+        .get(SIGNATURE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(GatewayError::Unauthorized)?
+        .to_owned();
+
+    let bytes = axum::body::to_bytes(body, MAX_BODY_BYTES)
+        .await
+        .map_err(|_| GatewayError::InvalidRequest("body exceeded the size limit".to_owned()))?;
+
+    check_timestamp(&timestamp)?;
+    check_signature(secret, &timestamp, &bytes, &signature)?;
+
+    Ok(next
+        .run(Request::from_parts(parts, Body::from(bytes)))
+        .await)
+}
+
+/// Rejects a timestamp outside the tolerance window in either direction.
+///
+/// Both directions matter: a future timestamp is as suspicious as a stale one,
+/// and allowing it would widen the replay window for a caller with a skewed
+/// clock.
+fn check_timestamp(raw: &str) -> Result<(), GatewayError> {
+    let claimed: i64 = raw.trim().parse().map_err(|_| GatewayError::Unauthorized)?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| GatewayError::Internal("system clock is before the unix epoch".into()))?
+        .as_secs() as i64;
+
+    if (now - claimed).abs() > HMAC_TIMESTAMP_TOLERANCE_SECS {
+        return Err(GatewayError::Unauthorized);
+    }
+    Ok(())
+}
+
+/// Recomputes the tag over `timestamp + body` and compares in constant time.
+fn check_signature(
+    secret: &[u8],
+    timestamp: &str,
+    body: &Bytes,
+    presented_hex: &str,
+) -> Result<(), GatewayError> {
+    let presented = decode_hex(presented_hex).ok_or(GatewayError::Unauthorized)?;
+
+    let mut mac = HmacSha256::new_from_slice(secret)
+        .map_err(|_| GatewayError::Internal("hmac key rejected".into()))?;
+    mac.update(timestamp.as_bytes());
+    mac.update(body);
+    let expected = mac.finalize().into_bytes();
+
+    // Constant-time: a byte-wise early return would leak the tag one byte at a
+    // time to a caller who can measure response latency.
+    if expected.as_slice().ct_eq(&presented).into() {
+        Ok(())
+    } else {
+        Err(GatewayError::Unauthorized)
+    }
+}
+
+fn decode_hex(input: &str) -> Option<Vec<u8>> {
+    if !input.len().is_multiple_of(2) {
+        return None;
+    }
+    input
+        .as_bytes()
+        .chunks(2)
+        .map(|pair| {
+            let text = std::str::from_utf8(pair).ok()?;
+            u8::from_str_radix(text, 16).ok()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"a-shared-secret-of-at-least-32-bytes";
+    /// The other caller's secret. Verification must be against one secret, not
+    /// either, so a tag made with this one must fail against [`SECRET`].
+    const OTHER_SECRET: &[u8] = b"the-other-callers-secret-32-bytes-min";
+
+    /// Mirrors SDP's signer, so these tests double as a check that the two
+    /// implementations agree on the message construction.
+    fn sign(timestamp: &str, body: &[u8]) -> String {
+        sign_with(SECRET, timestamp, body)
+    }
+
+    fn sign_with(secret: &[u8], timestamp: &str, body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(timestamp.as_bytes());
+        mac.update(body);
+        mac.finalize()
+            .into_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn now() -> String {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .to_string()
+    }
+
+    #[test]
+    fn rejects_a_signature_from_the_other_caller() {
+        // The whole point of two secrets: a caller who can sign the keyless routes
+        // must not be able to sign a key-bearing one. Verification is against one
+        // secret, never "either".
+        let timestamp = now();
+        let body = br#"{"requestId":"op_1"}"#;
+        let forged = sign_with(OTHER_SECRET, &timestamp, body);
+
+        assert!(
+            check_signature(SECRET, &timestamp, &Bytes::from_static(body), &forged).is_err(),
+            "a tag made with the other caller's secret must not verify"
+        );
+        // …and it is a valid tag, just not for this secret.
+        assert!(
+            check_signature(OTHER_SECRET, &timestamp, &Bytes::from_static(body), &forged).is_ok(),
+            "sanity: the tag is well-formed for its own secret"
+        );
+    }
+
+    #[test]
+    fn accepts_a_correct_signature() {
+        let body = Bytes::from_static(b"{\"requestId\":\"op_1\"}");
+        let ts = now();
+        let sig = sign(&ts, &body);
+        assert!(check_signature(SECRET, &ts, &body, &sig).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_tampered_body() {
+        let ts = now();
+        let sig = sign(&ts, b"{\"amount\":\"1\"}");
+        let tampered = Bytes::from_static(b"{\"amount\":\"1000000\"}");
+        assert!(check_signature(SECRET, &ts, &tampered, &sig).is_err());
+    }
+
+    #[test]
+    fn rejects_a_signature_bound_to_a_different_timestamp() {
+        let body = Bytes::from_static(b"{}");
+        let sig = sign("1700000000", &body);
+        assert!(check_signature(SECRET, "1700000001", &body, &sig).is_err());
+    }
+
+    #[test]
+    fn rejects_a_stale_or_future_timestamp() {
+        let now: i64 = now().parse().unwrap();
+        let stale = (now - HMAC_TIMESTAMP_TOLERANCE_SECS - 1).to_string();
+        let ahead = (now + HMAC_TIMESTAMP_TOLERANCE_SECS + 1).to_string();
+
+        assert!(check_timestamp(&stale).is_err());
+        assert!(check_timestamp(&ahead).is_err());
+        assert!(check_timestamp(&now.to_string()).is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_hex() {
+        assert!(decode_hex("abc").is_none(), "odd length");
+        assert!(decode_hex("zz").is_none(), "not hex");
+        assert_eq!(decode_hex("00ff"), Some(vec![0x00, 0xff]));
+    }
+}

--- a/apps/sdp-helius-gateway/src/extract.rs
+++ b/apps/sdp-helius-gateway/src/extract.rs
@@ -1,0 +1,114 @@
+//! A JSON extractor that fails with the gateway's own error shape.
+//!
+//! axum's built-in `Json` rejection produces its own status and body. That would
+//! leave two error contracts on the wire, and SDP switches on `code` — so every
+//! failure, including a malformed body, has to come back as an [`ErrorBody`].
+//!
+//! It is also where [`Validate`] runs. Deserialization cannot express key widths or
+//! index ordering, and those now arrive from another service across a language
+//! boundary, so they are checked here rather than deep inside a handler. Both failure
+//! kinds share one error path on purpose — see [`crate::validate`].
+//!
+//! [`ErrorBody`]: crate::error::ErrorBody
+
+use axum::extract::{FromRequest, Request};
+use axum::http::HeaderMap;
+use axum::{Json, RequestExt};
+use serde::de::DeserializeOwned;
+
+use crate::error::GatewayError;
+use crate::validate::Validate;
+
+/// Header SDP already uses for correlation
+/// (`apps/sdp-api/src/middleware/request-id.ts`).
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// Deserializes a JSON body, reporting failures as [`GatewayError::InvalidRequest`].
+pub struct ValidatedJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for ValidatedJson<T>
+where
+    // `Validate` is part of the bound rather than something a handler remembers to
+    // call. Every request type implements it, so a new one cannot be routed without
+    // deciding what its validation is.
+    T: DeserializeOwned + Validate + 'static,
+    S: Send + Sync,
+{
+    type Rejection = GatewayError;
+
+    async fn from_request(request: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        // Captured before consuming the request, so an unparseable body is still
+        // correlatable. A malformed body is what makes the `requestId` inside it
+        // unreachable.
+        let correlation = correlation_id(request.headers());
+
+        match request.extract::<Json<T>, _>().await {
+            Ok(Json(value)) => {
+                // Structural checks that the type system and serde cannot express.
+                // Its errors are authored here, so unlike the serde detail below they
+                // are safe to return verbatim — they name a field and a length.
+                value.validate()?;
+                Ok(Self(value))
+            }
+            Err(rejection) => {
+                // Full detail goes to the log, never to the response. serde's
+                // messages can quote the offending value, and these bodies carry
+                // viewing and nullifier keys — a wrong-typed `nullifierKey` would
+                // otherwise be echoed straight back.
+                tracing::warn!(
+                    request_id = %correlation,
+                    detail = %rejection.body_text(),
+                    "request body failed validation"
+                );
+                Err(GatewayError::InvalidRequest(format!(
+                    "body failed validation; see gateway logs for x-request-id {correlation}"
+                )))
+            }
+        }
+    }
+}
+
+fn correlation_id(headers: &HeaderMap) -> String {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        // Same character class and cap as SDP's own request-id middleware, so a
+        // hostile header cannot inject newlines into our logs.
+        .map(|value| {
+            value
+                .chars()
+                .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '-'))
+                .take(128)
+                .collect::<String>()
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unset".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn strips_control_characters_and_caps_length() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            REQUEST_ID_HEADER,
+            HeaderValue::from_static("op_01J:attempt-3.a"),
+        );
+        assert_eq!(correlation_id(&headers), "op_01J:attempt-3.a");
+
+        let mut long = HeaderMap::new();
+        long.insert(
+            REQUEST_ID_HEADER,
+            HeaderValue::from_str(&"a".repeat(500)).unwrap(),
+        );
+        assert_eq!(correlation_id(&long).len(), 128);
+    }
+
+    #[test]
+    fn falls_back_when_absent() {
+        assert_eq!(correlation_id(&HeaderMap::new()), "unset");
+    }
+}

--- a/apps/sdp-helius-gateway/src/lib.rs
+++ b/apps/sdp-helius-gateway/src/lib.rs
@@ -21,8 +21,10 @@
 //! rather than by calling handlers directly is the difference between testing the
 //! contract and testing the functions behind it.
 
+pub mod auth;
 pub mod config;
 pub mod error;
+pub mod extract;
 pub mod redact;
 pub mod routes;
 pub mod state;

--- a/apps/sdp-helius-gateway/src/routes/assemble.rs
+++ b/apps/sdp-helius-gateway/src/routes/assemble.rs
@@ -1,0 +1,17 @@
+//! `POST /v1/transactions/assemble`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::assemble::{AssembleRequest, AssembleResponse};
+
+/// Turns a proved payload plus a fresh blockhash into an unsigned transaction.
+///
+/// Takes no key material, so it is pure and freely retryable.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<AssembleRequest>,
+) -> Result<Json<AssembleResponse>, GatewayError> {
+    tracing::info!(request_id = %request.request_id, "assemble requested");
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/merging.rs
+++ b/apps/sdp-helius-gateway/src/routes/merging.rs
@@ -1,0 +1,23 @@
+//! `POST /v1/wallets/merging`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::merging::{MergingRequest, MergingResponse};
+
+/// Builds an unsigned transaction that sets the wallet's merge opt-in.
+///
+/// Takes no key material — an address and a boolean are both public. The owner must
+/// sign the result, which is why this cannot be a key-authority-only operation.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<MergingRequest>,
+) -> Result<Json<MergingResponse>, GatewayError> {
+    tracing::info!(
+        request_id = %request.request_id,
+        owner = %request.owner,
+        enabled = request.enabled,
+        "merging opt-in requested"
+    );
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/mod.rs
+++ b/apps/sdp-helius-gateway/src/routes/mod.rs
@@ -1,34 +1,235 @@
 //! Router assembly.
 //!
-//! Only `/health` is routed so far. The signed flow endpoints, their per-route
-//! timeout budgets and the HMAC middleware land on top of this.
+//! Every endpoint is routed; only `/health` is implemented. The eight flow
+//! endpoints return `501 NOT_IMPLEMENTED` rather than being absent, so a `404` in
+//! a test unambiguously means a routing mistake instead of unfinished work.
+//!
+//! # The route table is also the caller table
+//!
+//! Routes are grouped by which caller may sign them, not only by path:
+//!
+//! | Caller | Routes |
+//! | --- | --- |
+//! | `sdp-api` | `register`, `merging`, `shield`, `assemble`, `nullifiers/status` |
+//! | `rings-key-auth` | `sync`, `plan`, `prove` |
+//! | unauthenticated | `health` |
+//!
+//! The split is load bearing: the key-bearing routes are the ones that receive
+//! decrypted key material, and they are accepted only from the service that holds it.
+//! See [`crate::auth`].
+
+use std::time::Duration;
 
 use axum::Router;
-use axum::routing::get;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
 use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
+use crate::auth;
 use crate::config::MAX_BODY_BYTES;
 use crate::state::AppState;
 
+pub mod assemble;
 pub mod health;
+pub mod merging;
+pub mod nullifiers;
+pub mod plan;
+pub mod prove;
+pub mod register;
+pub mod shield;
+pub mod sync;
+
+/// Backstop for `/v1/operations/prove`. Nothing upstream bounds a prove call, so
+/// the 600-second budget this sits above is one the gateway chooses, not one it
+/// inherits.
+///
+/// The SDK's `PROVE_REQUEST_TIMEOUT_SECS = 600` is easy to mistake for a ceiling.
+/// It is a timeout on one HTTP *request*: the submit is retried three times with a
+/// two-second backoff, and transfer and merge proofs are queued, so the SDK then
+/// polls a job under `AsyncPollConfig::max_wait_secs` (default 1200). That poll
+/// ceiling counts only the time it spends *sleeping* between polls, never the time
+/// spent in the status request itself — 1200/3 is 400 polls, each of which can take
+/// up to 600 seconds on its own.
+///
+/// So the prove handler must impose `tokio::time::timeout` around its own work.
+/// That is the only wall-clock bound in the system and the only one that can answer
+/// with a structured `PROVER_TIMEOUT`. This constant is the outer backstop for a
+/// handler that hangs outside its own timeout.
+///
+/// The Cloud Run service must be configured with `--timeout=700` so that this layer
+/// answers first; the platform default of 300s would truncate it. That flag lives
+/// in sdp-infra, not this repo. See the timeout ladder in the crate README
+/// (apps/sdp-helius-gateway/README.md) for the full chain and what each layer owns.
+const PROVE_TIMEOUT: Duration = Duration::from_secs(660);
+/// `/v1/wallets/sync`. Walks the indexer in several rounds, so it needs more than a
+/// single round trip.
+const SYNC_TIMEOUT: Duration = Duration::from_secs(60);
+/// `/v1/operations/plan`. Plan is a sync plus input selection, so it is strictly
+/// more work than `/v1/wallets/sync` and strictly less than a prove.
+///
+/// Equal to [`SYNC_TIMEOUT`] today and deliberately a separate constant: sharing one
+/// would mean the next person to raise either budget silently raises both.
+const PLAN_TIMEOUT: Duration = Duration::from_secs(60);
+/// `/v1/wallets/register` and `/v1/operations/shield`. One on-chain registry read
+/// each.
+///
+/// Above the agave RPC client's own 30-second per-request timeout, on purpose. Below
+/// it, this layer always wins the race and SDP gets a bodyless `504` instead of the
+/// structured `RPC_UNAVAILABLE` the transport error would have produced.
+const RPC_TIMEOUT: Duration = Duration::from_secs(35);
+/// `/v1/transactions/assemble`. Pure local work: no key material, no RPC, a function
+/// of its request body.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// A layer-level timeout that answers with `504`, matching how the handler-level
+/// `PROVER_TIMEOUT` is reported.
+///
+/// `TimeoutLayer::new` is deprecated in tower-http 0.7 and defaults to `408`,
+/// which would tell SDP the *client* was slow. A layer timeout cannot produce our
+/// structured [`ErrorBody`], so handlers should prefer timing out internally; this
+/// is the backstop for a handler that hangs.
+///
+/// [`ErrorBody`]: crate::error::ErrorBody
+fn timeout(duration: Duration) -> TimeoutLayer {
+    TimeoutLayer::with_status_code(StatusCode::GATEWAY_TIMEOUT, duration)
+}
 
 /// Builds the application router.
 ///
-/// `/health` is unauthenticated on purpose, and will stay outside the signed router
-/// when that arrives: a liveness probe carries no shared secret, and requiring one
-/// would make an HMAC misconfiguration look like a dead container instead of failing
-/// requests with a clear cause.
+/// `/health` sits outside the signed router. A liveness probe carries no shared
+/// secret, and requiring one would make an HMAC misconfiguration look like a dead
+/// container instead of failing requests with a clear cause.
 pub fn app(state: AppState) -> Router {
+    // Keyless routes, signed by `sdp-api`. None of these ever receives key material,
+    // which is why registration and the merge opt-in can be called directly rather
+    // than through the key authority.
+    let sdp_api = Router::new()
+        .route(
+            "/v1/wallets/register",
+            post(register::handle).layer(timeout(RPC_TIMEOUT)),
+        )
+        // Same shape as register: one registry read, then build a transaction the
+        // owner must sign.
+        .route(
+            "/v1/wallets/merging",
+            post(merging::handle).layer(timeout(RPC_TIMEOUT)),
+        )
+        // Grouped with the other operations rather than with `/transactions`,
+        // because SDP calls it when a user shields — it is the whole operation, not
+        // a step in one.
+        .route(
+            "/v1/operations/shield",
+            post(shield::handle).layer(timeout(RPC_TIMEOUT)),
+        )
+        .route(
+            "/v1/transactions/assemble",
+            post(assemble::handle).layer(timeout(DEFAULT_TIMEOUT)),
+        )
+        // Indexer-bound, so it borrows `SYNC_TIMEOUT` rather than introducing a
+        // constant the ladder would have to order. A single nullifier lookup is
+        // lighter than a full sync; a dedicated budget can come with the handler,
+        // once there is something to measure.
+        .route(
+            "/v1/nullifiers/status",
+            post(nullifiers::handle).layer(timeout(SYNC_TIMEOUT)),
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::verify_sdp_api,
+        ));
+
+    // Key-bearing routes, signed by `rings-key-auth`. These are the requests whose
+    // bodies the key authority has injected material into, so they are accepted only
+    // from it — a tag made with the sdp-api secret is `UNAUTHORIZED` here.
+    let key_auth = Router::new()
+        .route(
+            "/v1/wallets/sync",
+            post(sync::handle).layer(timeout(SYNC_TIMEOUT)),
+        )
+        .route(
+            "/v1/operations/plan",
+            post(plan::handle).layer(timeout(PLAN_TIMEOUT)),
+        )
+        .route(
+            "/v1/operations/prove",
+            post(prove::handle).layer(timeout(PROVE_TIMEOUT)),
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::verify_key_auth,
+        ));
+
     Router::new()
         .route("/health", get(health::handle))
-        // Signed bodies will have to be buffered whole to verify their HMAC, so this
-        // bound is load bearing rather than hygiene — it is what caps memory per
-        // in-flight request. Applied from the start so no route is ever unbounded.
+        .merge(sdp_api)
+        .merge(key_auth)
+        // Bodies are buffered whole for HMAC verification, so this bound is what
+        // caps memory per in-flight request.
         .layer(RequestBodyLimitLayer::new(MAX_BODY_BYTES))
-        // Records method, path, status and latency. It must never be configured to
-        // capture bodies or headers: request bodies will carry viewing and nullifier
-        // keys, and `x-hmac-signature` is a credential.
+        // Records method, path, status and latency. It must never be configured
+        // to capture bodies or headers: request bodies carry viewing and
+        // nullifier keys, and `x-hmac-signature` is a credential.
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
+
+/// The agave RPC client's own per-request timeout. A route that waits less than this
+/// converts every slow-RPC case into a bodyless `504`, discarding the
+/// `RPC_UNAVAILABLE` the transport would have reported.
+const AGAVE_HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// The outer half of the prove ladder, which lives outside this crate: the Cloud Run
+/// service timeout, the SDP client that calls us, and the reconciler job that drives
+/// it. Mirrored here so the ordering is checkable at all. See the timeout ladder in
+/// apps/sdp-helius-gateway/README.md for what each layer owns.
+const CLOUD_RUN_SERVICE_TIMEOUT_SECS: u64 = 700;
+const SDP_OUTBOUND_CLIENT_TIMEOUT_SECS: u64 = 720;
+const CLOUD_RUN_JOB_TASK_TIMEOUT_SECS: u64 = 780;
+
+// The ladder, enforced at compile time.
+//
+// Only the innermost bound that fires can answer with a structured `ErrorBody`;
+// every layer above it produces a bodyless `504` and leaves SDP to guess. So the
+// budgets have to increase outward.
+//
+// A compile-time block rather than a test, because nothing asserted any of these
+// numbers before and a false claim about the prover's ceiling survived in nine
+// places. What it cannot check is whether sdp-infra actually applied 700 and 780; it
+// pins this crate against the recorded intent.
+const _: () = {
+    assert!(
+        DEFAULT_TIMEOUT.as_secs() <= RPC_TIMEOUT.as_secs(),
+        "assemble is pure local work, so it must not outlast an RPC-bound route"
+    );
+    assert!(
+        RPC_TIMEOUT.as_secs() <= SYNC_TIMEOUT.as_secs(),
+        "a single registry read must not outlast a multi-round indexer walk"
+    );
+    assert!(
+        SYNC_TIMEOUT.as_secs() <= PLAN_TIMEOUT.as_secs(),
+        "plan is a sync plus selection, so it must have at least a sync's budget"
+    );
+    assert!(
+        PLAN_TIMEOUT.as_secs() < PROVE_TIMEOUT.as_secs(),
+        "a prove is the long call and must have the largest in-process budget"
+    );
+
+    assert!(
+        RPC_TIMEOUT.as_secs() > AGAVE_HTTP_TIMEOUT_SECS,
+        "an RPC-bound route must outwait the transport so its error can surface"
+    );
+    assert!(
+        PROVE_TIMEOUT.as_secs() < CLOUD_RUN_SERVICE_TIMEOUT_SECS,
+        "the layer timeout must answer before Cloud Run cuts the request"
+    );
+    assert!(
+        CLOUD_RUN_SERVICE_TIMEOUT_SECS < SDP_OUTBOUND_CLIENT_TIMEOUT_SECS,
+        "SDP must outwait the gateway, or it discards an answer already on the wire"
+    );
+    assert!(
+        SDP_OUTBOUND_CLIENT_TIMEOUT_SECS < CLOUD_RUN_JOB_TASK_TIMEOUT_SECS,
+        "the reconciler job must outlast the request it is driving"
+    );
+};

--- a/apps/sdp-helius-gateway/src/routes/nullifiers.rs
+++ b/apps/sdp-helius-gateway/src/routes/nullifiers.rs
@@ -1,0 +1,30 @@
+//! `POST /v1/nullifiers/status`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::nullifiers::{NullifierStatusRequest, NullifierStatusResponse};
+
+/// Reports whether each supplied nullifier has been observed spent.
+///
+/// Takes no key material and mutates nothing, so it is always safe to repeat — which
+/// is what makes it usable as the reconciliation probe after a lost response.
+///
+/// When implemented, the one rule that matters: an indexer failure must surface as
+/// `INDEXER_UNAVAILABLE` or `INDEXER_LAG`, **never** as `seen: false`. A false
+/// negative causes a retry and a second payment; a false positive only stalls one
+/// operation. See the wire module for the full reasoning.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<NullifierStatusRequest>,
+) -> Result<Json<NullifierStatusResponse>, GatewayError> {
+    tracing::info!(
+        request_id = %request.request_id,
+        // A count, not the nullifiers themselves: they are not secret, but they are
+        // the exactly-once key and there is no reason to scatter them through logs.
+        nullifiers = request.nullifiers.len(),
+        require_slot = ?request.require_slot,
+        "nullifier status requested"
+    );
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/plan.rs
+++ b/apps/sdp-helius-gateway/src/routes/plan.rs
@@ -1,0 +1,19 @@
+//! `POST /v1/operations/plan`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::plan::{PlanRequest, PlanResponse};
+
+/// Selects inputs and describes the operation, without proving.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<PlanRequest>,
+) -> Result<Json<PlanResponse>, GatewayError> {
+    tracing::info!(
+        request_id = %request.preamble.request_id,
+        fee_payer = %request.fee_payer,
+        "plan requested"
+    );
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/prove.rs
+++ b/apps/sdp-helius-gateway/src/routes/prove.rs
@@ -1,0 +1,21 @@
+//! `POST /v1/operations/prove`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::prove::{ProveRequest, ProveResponse};
+
+/// Assembles the witness and obtains a proof. The long call.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<ProveRequest>,
+) -> Result<Json<ProveResponse>, GatewayError> {
+    tracing::info!(
+        request_id = %request.preamble.request_id,
+        // Zero pinned inputs is the retry-unsafe case: without them a retry can
+        // re-select different notes and double-pay. Worth seeing in logs.
+        pinned_inputs = request.pinned_inputs.len(),
+        "prove requested"
+    );
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/register.rs
+++ b/apps/sdp-helius-gateway/src/routes/register.rs
@@ -1,0 +1,27 @@
+//! `POST /v1/wallets/register`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::register::{RegisterRequest, RegisterResponse};
+
+/// Builds an unsigned registration transaction.
+///
+/// Validates the body and stops. The body is parsed rather than ignored so the
+/// wire contract is exercised even before the flow behind it exists.
+///
+/// Takes no key material: a `ShieldedAddress` is built entirely from public halves,
+/// so this handler will construct one directly rather than through a
+/// `WalletAuthority`.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<RegisterRequest>,
+) -> Result<Json<RegisterResponse>, GatewayError> {
+    // Safe to log in full: every field on this request is public.
+    tracing::info!(
+        request_id = %request.request_id,
+        owner = %request.owner,
+        "register requested"
+    );
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/shield.rs
+++ b/apps/sdp-helius-gateway/src/routes/shield.rs
@@ -1,0 +1,18 @@
+//! `POST /v1/operations/shield`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::shield::{ShieldRequest, ShieldResponse};
+
+/// Builds an unsigned deposit transaction in a single call.
+///
+/// Takes no key material: the shielded address is resolved from the on-chain user
+/// registry, so like assemble this handler never sees a secret.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<ShieldRequest>,
+) -> Result<Json<ShieldResponse>, GatewayError> {
+    tracing::info!(request_id = %request.request_id, "shield requested");
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/src/routes/sync.rs
+++ b/apps/sdp-helius-gateway/src/routes/sync.rs
@@ -1,0 +1,22 @@
+//! `POST /v1/wallets/sync`.
+
+use axum::Json;
+
+use crate::error::GatewayError;
+use crate::extract::ValidatedJson;
+use crate::wire::sync::{SyncRequest, SyncResponse};
+
+/// Scans the indexer and reports private state.
+pub async fn handle(
+    ValidatedJson(request): ValidatedJson<SyncRequest>,
+) -> Result<Json<SyncResponse>, GatewayError> {
+    tracing::info!(
+        request_id = %request.preamble.request_id,
+        // Safe and useful: tells us whether a resume was attempted or the
+        // request will hit the tag-window horizon on a full rescan.
+        resuming = request.preamble.wallet_projection.is_some(),
+        require_slot = ?request.preamble.require_slot,
+        "sync requested"
+    );
+    Err(GatewayError::NotImplemented)
+}

--- a/apps/sdp-helius-gateway/tests/contract.rs
+++ b/apps/sdp-helius-gateway/tests/contract.rs
@@ -5,33 +5,76 @@
 
 //! Contract tests against the real router.
 //!
-//! These drive `routes::app` through `oneshot`, so routing, middleware ordering and
-//! the response body are all exercised as deployed rather than by calling handlers
-//! directly.
+//! These drive `routes::app` through `oneshot`, so routing, middleware ordering,
+//! per-caller HMAC verification, boundary validation and the error body are all
+//! exercised as deployed rather than by calling handlers directly.
 //!
 //! Preflight is not involved: `AppState` is built with `protocol_config: None`,
 //! which is also the shape a real cold start takes when RPC is briefly unreachable.
 
 use axum::Router;
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{Request, StatusCode, header};
+use hmac::{Hmac, KeyInit, Mac};
 use sdp_helius_gateway::config::Config;
 use sdp_helius_gateway::redact::SecretBytes;
 use sdp_helius_gateway::routes;
 use sdp_helius_gateway::state::AppState;
-use serde_json::Value;
+use serde_json::{Value, json};
+use sha2::Sha256;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tower::ServiceExt as _;
 
 /// The `sdp-api` caller's secret, for the keyless routes.
-const SECRET: &str = "contract-test-secret-of-at-least-32-bytes";
+const SDP_API_SECRET: &str = "contract-test-secret-of-at-least-32-bytes";
 /// The `rings-key-auth` caller's secret, for the key-bearing routes. Deliberately
-/// different from [`SECRET`], so a test signing with the wrong one fails.
+/// different, so signing with the wrong one is a detectable failure.
 const KEY_AUTH_SECRET: &str = "contract-test-key-auth-secret-at-least-32";
+
+/// Which caller a route expects. The gateway verifies against one secret, never
+/// either, so this is part of the contract rather than a test convenience.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Caller {
+    SdpApi,
+    KeyAuth,
+}
+
+impl Caller {
+    fn secret(self) -> &'static str {
+        match self {
+            Self::SdpApi => SDP_API_SECRET,
+            Self::KeyAuth => KEY_AUTH_SECRET,
+        }
+    }
+
+    /// The other caller's identity, for the wrong-secret tests.
+    fn other(self) -> Self {
+        match self {
+            Self::SdpApi => Self::KeyAuth,
+            Self::KeyAuth => Self::SdpApi,
+        }
+    }
+}
+
+/// Every signed endpoint and the caller it belongs to.
+///
+/// Exhaustive by design: a new route cannot be added without deciding which caller
+/// may sign it, which is the decision that matters most about a new route.
+const SIGNED_ENDPOINTS: &[(&str, Caller)] = &[
+    ("/v1/wallets/register", Caller::SdpApi),
+    ("/v1/wallets/merging", Caller::SdpApi),
+    ("/v1/operations/shield", Caller::SdpApi),
+    ("/v1/transactions/assemble", Caller::SdpApi),
+    ("/v1/nullifiers/status", Caller::SdpApi),
+    ("/v1/wallets/sync", Caller::KeyAuth),
+    ("/v1/operations/plan", Caller::KeyAuth),
+    ("/v1/operations/prove", Caller::KeyAuth),
+];
 
 fn app() -> Router {
     let config = Config {
         port: 0,
-        hmac_secret_sdp_api: SecretBytes::from_bytes(SECRET.as_bytes().to_vec()),
+        hmac_secret_sdp_api: SecretBytes::from_bytes(SDP_API_SECRET.as_bytes().to_vec()),
         hmac_secret_key_auth: SecretBytes::from_bytes(KEY_AUTH_SECRET.as_bytes().to_vec()),
         solana_rpc_url: "https://api.devnet.solana.com".to_owned(),
         photon_url: "https://photon.invalid".to_owned(),
@@ -42,6 +85,42 @@ fn app() -> Router {
     routes::app(AppState::new(config, None))
 }
 
+fn now() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs()
+        .to_string()
+}
+
+/// Mirrors `createHmacSignature` in
+/// `packages/sdp-payments/src/fee-payment/kora.adapter.ts`: HMAC-SHA256 over
+/// `timestamp + body`, keyed on the secret's UTF-8 bytes, lowercase hex.
+fn sign_as(caller: Caller, timestamp: &str, body: &str) -> String {
+    let mut mac =
+        <Hmac<Sha256> as KeyInit>::new_from_slice(caller.secret().as_bytes()).expect("any length");
+    mac.update(timestamp.as_bytes());
+    mac.update(body.as_bytes());
+    mac.finalize()
+        .into_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn signed_request(path: &str, caller: Caller, body: &str) -> Request<Body> {
+    let timestamp = now();
+    let signature = sign_as(caller, &timestamp, body);
+    Request::builder()
+        .method("POST")
+        .uri(path)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("x-timestamp", timestamp)
+        .header("x-hmac-signature", signature)
+        .body(Body::from(body.to_owned()))
+        .expect("valid request")
+}
+
 async fn send(request: Request<Body>) -> (StatusCode, Value) {
     let response = app().oneshot(request).await.expect("router responds");
     let status = response.status();
@@ -50,6 +129,42 @@ async fn send(request: Request<Body>) -> (StatusCode, Value) {
         .expect("body readable");
     let json = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
     (status, json)
+}
+
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+const ADDRESS: &str = "11111111111111111111111111111111";
+
+/// A minimal valid preamble, as the key authority would compose it.
+///
+/// Widths matter and are asymmetric: viewing keys are 32 bytes, the nullifier secret
+/// is 31. Indices are the key authority's generation numbers, not array positions.
+fn preamble() -> Value {
+    json!({
+        "requestId": "op_contract_test",
+        "owner": ADDRESS,
+        "keyMaterial": {
+            "viewingKeys": [{ "index": 0, "key": b64(&[3u8; 32]) }],
+            "nullifierKey": b64(&[5u8; 31]),
+        },
+        "walletProjection": null,
+        "requireSlot": null,
+    })
+}
+
+/// A valid keyless registration body. Nothing here is secret.
+fn register_body() -> Value {
+    json!({
+        "requestId": "op_contract_test",
+        "owner": ADDRESS,
+        "viewingPubkey": b64(&[2u8; 33]),
+        "nullifierPubkey": b64(&[4u8; 32]),
+        "recentBlockhash": ADDRESS,
+        "feePayer": ADDRESS,
+    })
 }
 
 #[tokio::test]
@@ -74,4 +189,323 @@ async fn health_is_unauthenticated_and_reports_skew_fields() {
         body["protocolConfig"].is_null(),
         "no preflight in this state"
     );
+}
+
+#[tokio::test]
+async fn every_flow_endpoint_is_routed_and_reports_not_implemented() {
+    // A body that satisfies no endpoint in particular. Either 501 or 400 proves the
+    // route exists and reached its handler or extractor; a 404 would mean it does not.
+    let body = json!({ "preamble": preamble() }).to_string();
+
+    for (path, caller) in SIGNED_ENDPOINTS {
+        let (status, json) = send(signed_request(path, *caller, &body)).await;
+        assert_ne!(status, StatusCode::NOT_FOUND, "{path} is not routed");
+        assert!(
+            status == StatusCode::NOT_IMPLEMENTED || status == StatusCode::BAD_REQUEST,
+            "{path} returned {status} with {json}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn register_is_keyless_and_returns_the_error_contract() {
+    let body = register_body().to_string();
+    let (status, json) = send(signed_request(
+        "/v1/wallets/register",
+        Caller::SdpApi,
+        &body,
+    ))
+    .await;
+
+    // Reaching the handler with a body that carries no key material is the point:
+    // registration is buildable from public halves alone.
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "got {json}");
+    // SDP switches on `code`, so the shape matters as much as the status.
+    assert_eq!(json["code"], "NOT_IMPLEMENTED");
+    assert_eq!(json["retryable"], false);
+    assert_eq!(json["reconcile"], false);
+}
+
+#[tokio::test]
+async fn shield_reaches_its_handler_with_no_key_material() {
+    let body = json!({
+        "requestId": "op_contract_test",
+        "owner": ADDRESS,
+        "asset": ADDRESS,
+        "amount": "1500000000",
+        "splTokenAccount": null,
+        "splTokenProgram": null,
+        "recentBlockhash": ADDRESS,
+        "feePayer": ADDRESS,
+        "cuPriceMicroLamports": null,
+    })
+    .to_string();
+
+    let (status, json) = send(signed_request(
+        "/v1/operations/shield",
+        Caller::SdpApi,
+        &body,
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "got {json}");
+    assert_eq!(json["code"], "NOT_IMPLEMENTED");
+}
+
+#[tokio::test]
+async fn the_merging_opt_in_is_routed_and_keyless() {
+    // The prerequisite that makes merge usable at all: `merging_enabled` defaults to
+    // false on a fresh registration, and the program rejects `merge_transact` while
+    // it is.
+    let body = json!({
+        "requestId": "op_contract_test",
+        "owner": ADDRESS,
+        "enabled": true,
+        "recentBlockhash": ADDRESS,
+        "feePayer": ADDRESS,
+    })
+    .to_string();
+
+    let (status, json) = send(signed_request("/v1/wallets/merging", Caller::SdpApi, &body)).await;
+
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "got {json}");
+    assert_eq!(json["code"], "NOT_IMPLEMENTED");
+}
+
+#[tokio::test]
+async fn nullifier_status_is_routed_and_keyless() {
+    let body = json!({
+        "requestId": "op_contract_test",
+        "nullifiers": [b64(&[8u8; 32])],
+        "requireSlot": 1_234_567_890u64,
+    })
+    .to_string();
+
+    let (status, json) = send(signed_request(
+        "/v1/nullifiers/status",
+        Caller::SdpApi,
+        &body,
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "got {json}");
+    assert_eq!(json["code"], "NOT_IMPLEMENTED");
+}
+
+#[tokio::test]
+async fn an_empty_nullifier_list_is_rejected() {
+    let body = json!({ "requestId": "op_x", "nullifiers": [], "requireSlot": null }).to_string();
+    let (status, json) = send(signed_request(
+        "/v1/nullifiers/status",
+        Caller::SdpApi,
+        &body,
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {json}");
+    assert_eq!(json["code"], "INVALID_REQUEST");
+}
+
+#[tokio::test]
+async fn unsigned_requests_are_rejected() {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/wallets/sync")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{}"))
+        .expect("valid request");
+
+    let (status, _) = send(request).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn each_route_rejects_the_other_callers_secret() {
+    // The control C6 exists for: a caller who can sign the keyless routes must not be
+    // able to sign a key-bearing one, and vice versa. Verification is against one
+    // secret, never "either".
+    let body = json!({ "preamble": preamble() }).to_string();
+
+    for (path, caller) in SIGNED_ENDPOINTS {
+        let (status, _) = send(signed_request(path, caller.other(), &body)).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "{path} accepted a signature from the wrong caller"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_tampered_body_is_rejected() {
+    let signed_body = json!({ "preamble": preamble() }).to_string();
+    let timestamp = now();
+    let signature = sign_as(Caller::KeyAuth, &timestamp, &signed_body);
+
+    // Same signature, different body: exactly what body integrity must catch,
+    // and what Cloud Run IAM alone would not.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/wallets/sync")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("x-timestamp", timestamp)
+        .header("x-hmac-signature", signature)
+        .body(Body::from(r#"{"preamble":{}}"#))
+        .expect("valid request");
+
+    let (status, _) = send(request).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn a_stale_timestamp_is_rejected() {
+    let body = json!({ "preamble": preamble() }).to_string();
+    let stale = (now().parse::<i64>().expect("numeric") - 3_600).to_string();
+    let signature = sign_as(Caller::KeyAuth, &stale, &body);
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/wallets/sync")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("x-timestamp", stale)
+        .header("x-hmac-signature", signature)
+        .body(Body::from(body))
+        .expect("valid request");
+
+    let (status, _) = send(request).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "replay window must bind");
+}
+
+#[tokio::test]
+async fn an_unknown_field_is_rejected_with_our_error_shape() {
+    // Otherwise valid, so the typoed field is the only defect under test.
+    let mut body = register_body();
+    body["typoedField"] = json!("surprise");
+    let body = body.to_string();
+
+    let (status, json) = send(signed_request(
+        "/v1/wallets/register",
+        Caller::SdpApi,
+        &body,
+    ))
+    .await;
+
+    // deny_unknown_fields: a typed contract should reject drift loudly rather
+    // than silently ignore a field SDP believed it sent.
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {json}");
+    assert_eq!(json["code"], "INVALID_REQUEST");
+}
+
+#[tokio::test]
+async fn a_validation_error_never_echoes_the_request_body() {
+    // On a key-bearing route, because that is where secrets are. Register no longer
+    // carries any, so asserting this there would prove nothing.
+    let nullifier = b64(&[9u8; 31]);
+
+    // Wrong type on a secret field, which is the case where serde would quote the
+    // offending value straight back into the response.
+    let body = json!({
+        "preamble": {
+            "requestId": "op_leak_check",
+            "owner": ADDRESS,
+            "keyMaterial": {
+                "viewingKeys": [{ "index": 0, "key": 12345 }],
+                "nullifierKey": nullifier,
+            },
+            "walletProjection": null,
+            "requireSlot": null,
+        }
+    })
+    .to_string();
+
+    let (status, json) = send(signed_request("/v1/wallets/sync", Caller::KeyAuth, &body)).await;
+    let rendered = json.to_string();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        !rendered.contains(&nullifier),
+        "key material leaked into the error body: {rendered}"
+    );
+    assert!(
+        !rendered.contains("12345"),
+        "serde echoed a body value: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn the_swapped_key_widths_are_rejected() {
+    // The realistic cross-service mistake: a 31-byte viewing key and a 32-byte
+    // nullifier secret. Both decode as valid base64, so only a width check catches it.
+    let body = json!({
+        "preamble": {
+            "requestId": "op_swapped",
+            "owner": ADDRESS,
+            "keyMaterial": {
+                "viewingKeys": [{ "index": 0, "key": b64(&[3u8; 31]) }],
+                "nullifierKey": b64(&[5u8; 32]),
+            },
+            "walletProjection": null,
+            "requireSlot": null,
+        }
+    })
+    .to_string();
+
+    let (status, json) = send(signed_request("/v1/wallets/sync", Caller::KeyAuth, &body)).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {json}");
+    assert_eq!(json["code"], "INVALID_REQUEST");
+    // The message names the field and the widths, and nothing else.
+    let message = json["message"].as_str().unwrap_or_default();
+    assert!(message.contains("viewingKeys"), "got {message}");
+    assert!(!message.contains("AwMD"), "base64 of the key leaked");
+}
+
+#[tokio::test]
+async fn out_of_order_viewing_key_indices_are_rejected() {
+    // Indices must be strictly ascending and unique, because that is what lets array
+    // position and generation number agree — and a stored counter pointing at the
+    // wrong key under-reports a balance silently rather than erroring.
+    let body = json!({
+        "preamble": {
+            "requestId": "op_indices",
+            "owner": ADDRESS,
+            "keyMaterial": {
+                "viewingKeys": [
+                    { "index": 5, "key": b64(&[3u8; 32]) },
+                    { "index": 2, "key": b64(&[4u8; 32]) },
+                ],
+                "nullifierKey": b64(&[5u8; 31]),
+            },
+            "walletProjection": null,
+            "requireSlot": null,
+        }
+    })
+    .to_string();
+
+    let (status, json) = send(signed_request("/v1/wallets/sync", Caller::KeyAuth, &body)).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {json}");
+    assert_eq!(json["code"], "INVALID_REQUEST");
+}
+
+#[tokio::test]
+async fn register_rejects_a_wrong_width_public_key() {
+    // A viewing pubkey is a 33-byte compressed P256 point. 32 is the plausible slip,
+    // and it would otherwise fail deep inside `P256Pubkey::from_bytes`.
+    let mut body = register_body();
+    body["viewingPubkey"] = json!(b64(&[2u8; 32]));
+    let body = body.to_string();
+
+    let (status, json) = send(signed_request(
+        "/v1/wallets/register",
+        Caller::SdpApi,
+        &body,
+    ))
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {json}");
+    assert_eq!(json["code"], "INVALID_REQUEST");
+    let message = json["message"].as_str().unwrap_or_default();
+    assert!(message.contains("viewingPubkey"), "got {message}");
+    assert!(message.contains("33"), "must name the expected width");
 }


### PR DESCRIPTION
## What

Puts all eight flow endpoints behind **per-caller** HMAC verification, runs the boundary validation from #1289 inside the extractor so no handler can skip it, and gives each route a bounded budget. Handlers parse and validate, then return `501 NOT_IMPLEMENTED` with the real error body — **routed but unimplemented, so a `404` in a test means a routing mistake rather than unfinished work.** Also adds the two endpoints that were specified but missing: the merge opt-in and the nullifier-status read.

## Security invariant: one secret per caller, never "either"

The gateway serves two callers with different privileges, so the route table is also the caller table:

| Caller | Routes |
| --- | --- |
| `sdp-api` | `register`, `merging`, `shield`, `assemble`, `nullifiers/status` |
| `rings-key-auth` | `sync`, `plan`, `prove` |
| unauthenticated | `health` |

Two middleware entry points, `verify_sdp_api` and `verify_key_auth`, over one shared `verify(secret, …)`. **A key-bearing route signed with the sdp-api secret is `401`**, and vice versa — `each_route_rejects_the_other_callers_secret` asserts that for all eight, in both directions. The key-authority design states that this service holds no route *to* the key authority; making the reverse true costs one config entry.

Scoped honestly: in production Cloud Run IAM already separates the two service accounts and rejects unauthenticated callers before our code runs, so this is defence in depth there. It is the **only** such control in docker-compose, self-hosted deployments and integration tests — the same gap that makes HMAC worth having at all.

Everything else about the scheme is byte-identical: HMAC-SHA256 over decimal-seconds timestamp concatenated with the raw body, lowercase hex, 300 s window, constant-time compare. It has to keep matching `createHmacSignature` in `packages/sdp-payments/src/fee-payment/kora.adapter.ts`, and now the key authority's Rust equivalent.

**Explicitly not doing a nested or origin signature.** The key authority mutates the body, so `sdp-api`'s signature over the body *it* composed cannot be re-derived here from the final bytes — JSON re-serialization is not byte-stable and this service cannot know what was added. The property such a scheme would reach for is proof that `sdp-api` authored the action, and the key authority already provides it: `sdp-api` presents a single-use intent token naming the exact operation, and the key authority independently verifies the operation exists, is approved, and is in a provable state *before* unwrapping. This gateway sits downstream of that decision with no authority to refuse on it, so re-verifying the token here would add a dependency without adding a control.

## Validation is in the extractor's bound, not in the handlers

`ValidatedJson<T>` now requires `T: DeserializeOwned + Validate`, and calls `validate()` on the success arm. Every request type implements `Validate`, so the bound is total — a new request type cannot be routed without deciding what its validation is, and the compiler enforces it rather than a review checklist.

Both failure kinds share one error path deliberately. It already logs the serde detail and returns only an `x-request-id` pointer, precisely because these bodies carry viewing and nullifier keys and serde would otherwise quote the offending value straight back.

`a_validation_error_never_echoes_the_request_body` **moved off register onto `/v1/wallets/sync`**. Register no longer carries secrets, so asserting the no-echo property there would prove nothing; it belongs on a key-bearing route.

## Two endpoints that were missing

**`POST /v1/wallets/merging`** — a live defect in the contract, independent of the key authority. `UserRecord.merging_enabled` defaults to **false** (`RegisterData` has no such field, so registration never sets it) and the shielded-pool program rejects `merge_transact` while it is. Merge is documented as the recovery path for `UNSUPPORTED_SHAPE` — the case where a wallet's notes are too fragmented for one transfer — so **on every freshly registered wallet that recovery path fails on chain.** Flipping the flag needs `set_merging_enabled`, which requires the owner to sign, so it is an `sdp-api` plus custody flow that needs a gateway endpoint only because SDP does not encode zolana instructions. The merge *transaction* still carries no custody signature; this is a one-time prerequisite, recorded as a prerequisite rather than as a weakening of that claim.

**`POST /v1/nullifiers/status`** — the reconciliation probe, keyless and pure. Its one rule, in the module docs: **an indexer error must never be reported as `seen: false`.** A false negative tells SDP the operation did not land, so it retries, re-syncs, selects different notes, produces disjoint nullifiers, and the recipient is paid twice. A false positive only stalls one operation into manual reconciliation. That asymmetry is also why `signature` is nullable while `seen` is not: a spend the indexer knows about but cannot attribute still correctly forbids the retry.

## The timeout ladder

Unchanged in substance, now covering both new routes. `merging` takes `RPC_TIMEOUT` (35 s, one registry read, same shape as register); `nullifiers/status` borrows `SYNC_TIMEOUT` (60 s, indexer-bound) rather than introducing a constant the ladder would have to order — a dedicated budget can come with the handler, once there is something to measure.

**Nothing upstream bounds a prove call.** The SDK's `PROVE_REQUEST_TIMEOUT_SECS = 600` reads like a ceiling but is a timeout on one HTTP request: the submit retries three times, transfer and merge proofs are queued, and the poll ceiling counts only time spent *sleeping* between polls — 1200/3 is 400 polls of up to 600 s each. So every budget here is one this service chooses, and they must increase outward because only the innermost bound that fires can answer with a structured `ErrorBody`. A `const` block asserts that ordering at build time, including against the agave client's own 30 s per-request timeout.

## Known limits (deliberately not addressed here)

- **Every handler still returns `501`.** The wire contract is exercised on the way in — each one parses and validates — but nothing behind them is built.
- **660 s derives from an unmeasured 600 s placeholder.** Replace with p99 of a cold transfer prove and a cold merge prove against the devnet prover, then re-derive the rows above it.
- **Layer 3 is unreachable in production until sdp-infra sets `--timeout=700`.** Cloud Run's 300 s default truncates every prove first. The `const` block pins this crate against the recorded intent; it cannot check whether the flag was applied.
- **The `/plan` merge check is not here.** `/plan` with `kind: Merge` should read `merging_enabled` from the record it already fetches and fail fast, because discovering it after a prove call is expensive and the proof cannot land. That needs the handler.
- **Layer timeouts are a backstop, never the plan.** The async Photon client is built with no HTTP timeout at all, so `/sync` and `/plan` will need their own `tokio::time::timeout`.
- **The handler will have to classify the SDK's own timeout as `PROVER_TIMEOUT`.** It returns a generic `ClientError::ProverServer`, whose natural mapping is `PROVER_FAILED` with `retryable: false` — which would tell SDP never to retry a prove that merely timed out.
- **14 of 19 `GatewayError` variants are unconstructed**, hence the module-level `allow(dead_code)` in #1289. They are the contract SDP codes against, so they land with it rather than trickling in per handler.

## Testing

```
cargo fmt --check
cargo clippy --all-targets --locked -- -D warnings
cargo test --locked          # 22 unit + 16 contract tests, all passing
```

Contract tests go through the real router via `oneshot`, so middleware ordering is part of what is asserted. New in this PR: all eight routes reachable and `501`/`400` (never `404`), every route rejecting the other caller's secret, the swapped 31/32 key widths rejected as `INVALID_REQUEST` with the field named and no base64 echoed, out-of-order viewing-key indices rejected, a wrong-width `viewingPubkey` rejected with the expected width named, an empty nullifier list rejected, and the merge opt-in and nullifier-status routes reachable and keyless. `SIGNED_ENDPOINTS` is now `(path, caller)` pairs and exhaustive, so a new route cannot be added without deciding who may sign it.
