### PR TITLE
build(helius): gateway container image and compose profile

### DIFF
--- a/apps/sdp-helius-gateway/Dockerfile
+++ b/apps/sdp-helius-gateway/Dockerfile
@@ -1,0 +1,83 @@
+# sdp-helius-gateway — Rust runtime image. Unlike the Node images in this repo,
+# the build context is this directory, not the monorepo root: the crate is not a
+# pnpm workspace member and has nothing to copy from outside itself.
+#
+#     docker build -f apps/sdp-helius-gateway/Dockerfile -t sdp-helius-gateway \
+#       apps/sdp-helius-gateway
+#
+# amd64 only. Cloud Run is amd64, and cross-building the Groth16 and Poseidon
+# dependencies under QEMU is slow enough to be impractical in any build that has to
+# finish on a timer. Apple Silicon developers either emulate or run the gateway
+# remotely.
+#
+# Digest-pinned to match the convention in apps/sdp-api/Dockerfile.
+
+# --- chef: cargo-chef, so the dependency graph caches independently of our source
+FROM rust:1.97.0-slim-bookworm@sha256:6d220bf85c74e842a79da63997af8d2e74455c0b8847d8bb3a5888572334991d AS chef
+WORKDIR /build
+# git: the zolana crates are unpublished and resolved from a git revision.
+#
+# pkg-config/libssl-dev: `openssl-sys` is in the graph, and not for TLS — reqwest
+# here uses rustls. The path is
+# openssl-sys <- openssl <- solana-secp256r1-program <- zolana-user-registry-interface,
+# so it is the P256 curve support that needs it. That also means the runtime image
+# needs libssl3; see the runner stage.
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y git pkg-config libssl-dev ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+  cargo install cargo-chef --version 0.1.77 --locked
+
+# --- planner: reduce the manifest to a dependency-only recipe
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY src ./src
+COPY build.rs ./
+RUN cargo chef prepare --recipe-path recipe.json
+
+# --- builder: build dependencies first, then the crate
+FROM chef AS builder
+COPY --from=planner /build/recipe.json recipe.json
+# This layer is the expensive one (~450 crates including solana-rpc-client,
+# groth16 and poseidon) and it only invalidates when Cargo.lock changes.
+RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+  cargo chef cook --release --recipe-path recipe.json
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY src ./src
+COPY build.rs ./
+RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+  cargo build --release --locked --bin sdp-helius-gateway \
+  && strip target/release/sdp-helius-gateway
+
+# --- runner: no toolchain, no source, no cargo registry
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS runner
+# libssl3: the binary dynamically links libssl.so.3 and libcrypto.so.3, because
+# `solana-secp256r1-program` reaches OpenSSL for P256. Without it the loader fails
+# before the listener ever binds, so this is a start-up dependency and not an
+# optional hardening step. `libssl3` is bookworm's runtime package for OpenSSL 3.x;
+# `libssl-dev` from the builder stage is deliberately not carried over.
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y ca-certificates libssl3 \
+  && rm -rf /var/lib/apt/lists/*
+
+# UID/GID 1001 matches sdp-api and sdp-web so a shared k8s securityContext works.
+RUN groupadd --gid 1001 sdp && useradd --uid 1001 --gid 1001 --no-create-home sdp
+
+COPY --from=builder /build/target/release/sdp-helius-gateway /usr/local/bin/sdp-helius-gateway
+
+USER 1001:1001
+ENV HELIUS_GATEWAY_PORT=8788
+EXPOSE 8788
+
+# Liveness only, matching apps/sdp-api/Dockerfile: a status below 500 means the
+# HTTP layer is up. Dependency probing belongs on a readiness probe, and /health
+# does not reach the indexer, prover or RPC.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/usr/local/bin/sdp-helius-gateway", "--health-check"]
+
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.revision="${GIT_SHA}"
+LABEL org.opencontainers.image.title="sdp-helius-gateway"
+LABEL org.opencontainers.image.source="https://github.com/solana-foundation/solana-developer-platform"
+
+CMD ["/usr/local/bin/sdp-helius-gateway"]

--- a/apps/sdp-helius-gateway/Dockerfile.dockerignore
+++ b/apps/sdp-helius-gateway/Dockerfile.dockerignore
@@ -1,0 +1,7 @@
+# Build context is this directory (not the monorepo root), so these are relative
+# to apps/sdp-helius-gateway.
+target/
+tests/
+clippy.toml
+package.json
+*.md

--- a/apps/sdp-helius-gateway/README.md
+++ b/apps/sdp-helius-gateway/README.md
@@ -118,6 +118,23 @@ path-filtered to this directory. It is the crate's only correctness gate: Biome 
 `typecheck` job resolves this directory and then no-ops via `--if-present`, and CodeQL has no Rust
 analysis.
 
+Under compose it is behind an opt-in profile, because it is a Rust release build that would push the
+`docker_compose_smoke` CI job past its timeout, and because it is useless without a reachable indexer
+and prover:
+
+```bash
+docker compose --profile rings up sdp-helius-gateway
+```
+
+Compose supplies both HMAC secrets as local-only placeholders. Because the gateway verifies each route
+against its own caller's secret, a client configured with only one of them can reach only that caller's
+half of the API — which is the behaviour to expect when testing against it, not a misconfiguration.
+
+**On Apple Silicon, build natively.** The image is amd64-only, because Cloud Run is amd64 and
+cross-building the Groth16 and Poseidon dependencies under QEMU is impractically slow. Building
+`--platform linux/amd64` locally on an M-series Mac is emulated and just as slow; use `cargo run`
+or build for your native architecture.
+
 ## Timeout ladder
 
 Every budget below is a number this service chooses. That is the whole point of the section: **nothing
@@ -288,6 +305,13 @@ which would move a secret for no reason. Re-checked on every rev bump, on the sa
   this gateway, which does not exist yet; declaring keys nothing reads would be speculative. The
   gateway's own variables are read by this process and belong in compose and Cloud Run config, not in
   the API's `Env` interface.
+
+- **Not added to `.github/workflows/release-images.yml`.** That workflow hardcodes `context: .` and
+  builds amd64 + arm64 before a multi-arch push, and this crate needs a crate-directory context and
+  amd64 only. Wiring it in requires per-service `context` and `platforms` in the matrix, which is a
+  change to the release path for three production images. It should land with the deploy decision — and
+  it is worth asking first whether a Cloud Run service with SDP-internal IAM belongs in the self-hosted
+  GHCR bundle at all.
 
 ## Open questions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,5 +127,43 @@ services:
     ports:
       - "${SDP_DOCS_PORT:-3001}:3001"
 
+  # Opt-in: `docker compose --profile rings up sdp-helius-gateway`.
+  #
+  # Behind a profile for two reasons. It is a Rust release build of ~450 crates,
+  # which would push the docker_compose_smoke job past its 25-minute timeout; and
+  # it is useless without a reachable Photon indexer and prover, which the default
+  # local stack does not provide.
+  sdp-helius-gateway:
+    profiles:
+      - rings
+    build:
+      # Context is the crate directory, not the repo root: it is not a pnpm
+      # workspace member and has nothing to copy from outside itself.
+      context: apps/sdp-helius-gateway
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      # Loopback-only, unlike the other services here. This one ships working
+      # default HMAC secrets in this file, so an unrestricted mapping would let
+      # anything that can reach the developer's host sign valid requests once the
+      # handlers do real work. Local testing is unaffected.
+      - "127.0.0.1:${HELIUS_GATEWAY_PORT:-8788}:8788"
+    environment:
+      HELIUS_GATEWAY_PORT: 8788
+      # One secret per caller: the gateway verifies each route against its own
+      # caller's secret rather than against either, so the keyless routes and the
+      # key-bearing ones cannot be signed interchangeably.
+      #
+      # Local-only placeholders. Both must be at least 32 bytes, and each must match
+      # what that caller signs with. Never reuse these values anywhere real.
+      HELIUS_GATEWAY_HMAC_SECRET_SDP_API: ${HELIUS_GATEWAY_HMAC_SECRET_SDP_API:-local-development-only-sdp-api-secret-32b}
+      HELIUS_GATEWAY_HMAC_SECRET_KEY_AUTH: ${HELIUS_GATEWAY_HMAC_SECRET_KEY_AUTH:-local-development-only-key-auth-secret-32}
+      # Upstream endpoints are env-only. A caller-supplied prover URL alongside a
+      # decrypted nullifier key would let one request exfiltrate that key.
+      SOLANA_RPC_URL: ${SOLANA_RPC_URL:-https://api.devnet.solana.com}
+      PHOTON_URL: ${PHOTON_URL:-http://host.docker.internal:8784}
+      PROVER_URL: ${PROVER_URL:-http://host.docker.internal:3001}
+      RUST_LOG: ${RUST_LOG:-info}
+
 volumes:
   sdp-postgres-data:


### PR DESCRIPTION
## What

Runtime image plus an opt-in compose service, so the gateway can be built and run locally and is ready for a Cloud Run deploy decision. **No CI cost:** the compose service is behind a profile, and the image is not built in CI.

## The Dockerfile

Staged through `cargo-chef` so the expensive layer — ~450 crates including `groth16-solana`, `light-poseidon` and the `ark-*` graph — keys only on `Cargo.lock` and survives source edits.

The build context is the crate directory, not the repo root, because this is not a pnpm workspace member and has nothing to copy from outside itself. That is also why the ignore file is `Dockerfile.dockerignore` rather than a root `.dockerignore`.

The runner stage carries no toolchain, no source and no cargo registry, runs as UID/GID 1001 to match `sdp-api` and `sdp-web` so a shared k8s `securityContext` works, and both base images are digest-pinned to match the convention in `apps/sdp-api/Dockerfile`.

`HEALTHCHECK` calls the binary's own `--health-check` (implemented in `src/main.rs`, which probes `/health` over loopback and maps the status line to an exit code) rather than installing `curl` — one fewer package to keep patched and to answer for in the Trivy scan that gates every tagged release. Liveness only, matching `sdp-api`: any status below 500 means the HTTP layer is up. Dependency probing belongs on a readiness probe, and `/health` deliberately does not reach the indexer, prover or RPC.

amd64 only. Cloud Run is amd64, and cross-building the Groth16 and Poseidon dependencies under QEMU is slow enough to be impractical in any build that has to finish on a timer.

## Two secrets in compose

The gateway verifies each route against its own caller's HMAC secret, so compose now supplies both `HELIUS_GATEWAY_HMAC_SECRET_SDP_API` and `HELIUS_GATEWAY_HMAC_SECRET_KEY_AUTH` as local-only placeholders, both at least 32 bytes.

Worth knowing when testing against it: **a client configured with only one of them can reach only that caller's half of the API.** That is the control working, not a misconfiguration.

**Upstream endpoints stay env-only by design.** `PHOTON_URL` and `PROVER_URL` are never read from a request: accepting a caller-supplied prover URL alongside a decrypted nullifier key would be an exfiltration primitive.

## Why the profile, and why the smoke job is unaffected

`docker compose --profile rings up sdp-helius-gateway`. Behind a profile for two reasons: it is a release build that would push `docker_compose_smoke` past its 25-minute timeout, and it is useless without a reachable Photon indexer and prover, which the default local stack does not provide.

Verified rather than assumed:

```
$ docker compose config --services
postgres redis sdp-migrate sdp-api sdp-docs sdp-web

$ docker compose --profile rings config --services
postgres redis sdp-migrate sdp-api sdp-docs sdp-helius-gateway sdp-web
```

## Known limits (deliberately not addressed here)

- **No CI image build.** An earlier draft added a `docker_build_gateway` job to `ci.yml`. It was dropped: it had no path filter, so every PR in the repo would have paid a Rust release build (3–8 min warm, 30–45 cold), and nothing consumes the image yet. It should land with the deploy target that needs it, path-gated the way `rust-gateway.yml` is.
- **Not wired into `release-images.yml`.** That workflow hardcodes `context: .` and builds amd64+arm64 before a multi-arch push; this crate needs a crate-directory context and amd64 only. Wiring it in means per-service `context` and `platforms` in the matrix, which changes the release path for three production images. Worth asking first whether a Cloud Run service with SDP-internal IAM belongs in the self-hosted GHCR bundle at all.
- **The `--mount=type=cache` directives do nothing in a GHA build.** `cache-to: type=gha` exports layers, not cache mounts, so the registry download repeats on a cold cache. The `cargo chef cook` layer is still layer-cached, which is the expensive part.
- **The compose service is not usable end to end yet.** It needs a Photon indexer and prover alongside it; those are not in the stack. Until then it documents the env contract rather than enabling a workflow.
- **Cloud Run still needs `--timeout=700`** for the prove route's layer timeout to be reachable at all, and `--task-timeout=780` for the reconciler. Both are sdp-infra, neither is applied.

## Testing

```
docker compose config --services                    # gateway absent
docker compose --profile rings config --services    # gateway present
docker compose --profile rings config               # both secrets resolve
cargo fmt --check
cargo clippy --all-targets --locked -- -D warnings
cargo test --locked          # 32 unit + 16 contract tests, unchanged by this PR
```

CI still has to verify the image actually builds — there is no gateway image job, by the decision above, so the Docker build is unexercised in CI on purpose. A full `docker build` against this Dockerfile has not been run on Linux/amd64; it should be before anything depends on the image.
