### PR TITLE
fix(ci): deploy releases from protected main flow

### DIFF
--- a/.github/scripts/verify-release-identity.sh
+++ b/.github/scripts/verify-release-identity.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: $0 <release-tag> <release-sha>" >&2
+  exit 2
+fi
+
+release_tag="$1"
+release_sha="$2"
+
+if [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "release-tag must use the vX.Y.Z format." >&2
+  exit 1
+fi
+
+if [[ ! "${release_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "release-sha must be a lowercase 40-character Git SHA." >&2
+  exit 1
+fi
+
+head_sha="$(git rev-parse HEAD)"
+if [[ "${head_sha}" != "${release_sha}" ]]; then
+  echo "Checked out ${head_sha}, expected release SHA ${release_sha}." >&2
+  exit 1
+fi
+
+tag_sha="$(git rev-parse "${release_tag}^{commit}")"
+if [[ "${tag_sha}" != "${release_sha}" ]]; then
+  echo "${release_tag} resolves to ${tag_sha}, expected ${release_sha}." >&2
+  exit 1
+fi
+
+if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+  echo "origin/main is unavailable; release provenance cannot be verified." >&2
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor "${release_sha}" refs/remotes/origin/main; then
+  echo "${release_sha} is not contained in origin/main." >&2
+  exit 1
+fi
+
+package_version="$(node -p "require('./package.json').version")"
+tag_version="${release_tag#v}"
+if [[ "${tag_version}" != "${package_version}" ]]; then
+  echo "${release_tag} does not match package.json version ${package_version}." >&2
+  exit 1
+fi
+
+echo "Verified ${release_tag} at ${release_sha} on origin/main."

--- a/.github/workflows/deploy-sdp-api-gcp-prod.yml
+++ b/.github/workflows/deploy-sdp-api-gcp-prod.yml
@@ -1,14 +1,22 @@
 name: Deploy sdp-api to Cloud Run (prod)
 
 on:
+  workflow_call:
+    inputs:
+      release_sha:
+        description: "Exact release commit to build and deploy"
+        type: string
+        required: true
+      release_tag:
+        description: "Version tag that must resolve to release_sha"
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       image_sha:
         description: "Existing 40-character Git SHA image tag to redeploy (run from main)"
         type: string
         required: true
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -24,8 +32,9 @@ jobs:
     if: >-
       always() &&
       github.repository == 'solana-foundation/solana-developer-platform' &&
-      (github.event_name == 'release' ||
-       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
+      github.ref == 'refs/heads/main' &&
+      ((inputs.release_sha != '' && inputs.release_tag != '') ||
+       (github.event_name == 'workflow_dispatch' && inputs.image_sha != ''))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: production
@@ -40,7 +49,7 @@ jobs:
     steps:
       - name: Validate deploy image SHA
         env:
-          DEPLOY_IMAGE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.image_sha || github.sha }}
+          DEPLOY_IMAGE_SHA: ${{ inputs.release_sha != '' && inputs.release_sha || inputs.image_sha }}
         run: |
           set -euo pipefail
           if [[ ! "${DEPLOY_IMAGE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -50,8 +59,15 @@ jobs:
           echo "DEPLOY_IMAGE_SHA=${DEPLOY_IMAGE_SHA}" >> "${GITHUB_ENV}"
 
       - name: Checkout
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ inputs.release_sha != '' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_sha }}
+
+      - name: Verify release identity
+        if: ${{ inputs.release_sha != '' }}
+        run: .github/scripts/verify-release-identity.sh "${{ inputs.release_tag }}" "${{ inputs.release_sha }}"
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
@@ -63,18 +79,18 @@ jobs:
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Configure Docker for Artifact Registry
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ inputs.release_sha != '' }}
         run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 
       - name: Build and push image
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ inputs.release_sha != '' }}
         timeout-minutes: 20
         run: |
           set -euo pipefail
           VERSION="$(node -p "require('./package.json').version")"
           VERSION_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/sdp-api-public:${VERSION}"
-          SHA_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/sdp-api-public:${GITHUB_SHA}"
-          docker build -f apps/sdp-api/Dockerfile --build-arg GIT_SHA="${GITHUB_SHA}" \
+          SHA_IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/sdp-api-public:${DEPLOY_IMAGE_SHA}"
+          docker build -f apps/sdp-api/Dockerfile --build-arg GIT_SHA="${DEPLOY_IMAGE_SHA}" \
             -t "${VERSION_IMAGE}" -t "${SHA_IMAGE}" .
           docker push "${VERSION_IMAGE}"
           docker push "${SHA_IMAGE}"
@@ -103,7 +119,7 @@ jobs:
           echo "Deploying ${tagged_image} as ${resolved_image}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Run database migrations
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ inputs.release_sha != '' }}
         timeout-minutes: 15
         run: |
           gcloud run jobs update "${MIGRATE_JOB}" \

--- a/.github/workflows/deploy-sdp-web-vercel-prod.yml
+++ b/.github/workflows/deploy-sdp-web-vercel-prod.yml
@@ -1,14 +1,22 @@
 name: Deploy sdp-web to Vercel (prod)
 
 on:
+  workflow_call:
+    inputs:
+      release_sha:
+        description: "Exact release commit to build and deploy"
+        type: string
+        required: true
+      release_tag:
+        description: "Version tag that must resolve to release_sha"
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       ref:
         description: "Git ref (tag or SHA) to deploy"
         type: string
         required: true
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -20,7 +28,11 @@ concurrency:
 jobs:
   deploy:
     name: Deploy production build
-    if: github.repository == 'solana-foundation/solana-developer-platform'
+    if: >-
+      github.repository == 'solana-foundation/solana-developer-platform' &&
+      github.ref == 'refs/heads/main' &&
+      ((inputs.release_sha != '' && inputs.release_tag != '') ||
+       (github.event_name == 'workflow_dispatch' && inputs.ref != ''))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
@@ -31,7 +43,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          fetch-depth: 0
+          ref: ${{ inputs.release_sha != '' && inputs.release_sha || inputs.ref }}
+
+      - name: Verify release identity
+        if: ${{ inputs.release_sha != '' }}
+        run: .github/scripts/verify-release-identity.sh "${{ inputs.release_tag }}" "${{ inputs.release_sha }}"
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.sha }}
           token: ${{ steps.release-app.outputs.token }}
 
       - name: Setup Node

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,6 +94,9 @@ jobs:
   publish-release:
     if: "${{ startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
+    outputs:
+      release_sha: ${{ steps.release.outputs.release_sha }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
     concurrency:
       group: release-flow-main
       cancel-in-progress: false
@@ -123,3 +126,38 @@ jobs:
           GITHUB_TOKEN: ${{ steps.release-app.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node .github/scripts/release-flow.mjs publish
+
+      - name: Resolve published release
+        id: release
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          release_tag="v${version}"
+          release_sha="$(git rev-parse "${release_tag}^{commit}")"
+
+          if [[ "${release_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "${release_tag} resolves to ${release_sha}, expected ${GITHUB_SHA}." >&2
+            exit 1
+          fi
+
+          echo "release_sha=${release_sha}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+
+  deploy-api-production:
+    needs: publish-release
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-sdp-api-gcp-prod.yml
+    with:
+      release_sha: ${{ needs.publish-release.outputs.release_sha }}
+      release_tag: ${{ needs.publish-release.outputs.release_tag }}
+
+  deploy-web-production:
+    needs: publish-release
+    permissions:
+      contents: read
+    uses: ./.github/workflows/deploy-sdp-web-vercel-prod.yml
+    with:
+      release_sha: ${{ needs.publish-release.outputs.release_sha }}
+      release_tag: ${{ needs.publish-release.outputs.release_tag }}

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -8,13 +8,13 @@
 | --- | --- | --- |
 | Relevant push to `main` | Dev | Builds a SHA-tagged image, runs migrations, updates the dev service, and updates the dev cron job |
 | `chore(main): release X.Y.Z` commit on `main` | Release publication | Creates the `vX.Y.Z` tag, publishes the GitHub release, and triggers release-image/checksum workflows |
-| `vX.Y.Z` release published | Production API | Builds version- and SHA-tagged images from the tagged commit, runs migrations, updates the production service, and updates the production cron job |
-| `vX.Y.Z` release published | Production web | Builds sdp-web from the tagged commit and deploys it to Vercel production |
+| Release publication job on `main` | Production API | Verifies the published tag and SHA, builds version- and SHA-tagged images from that commit, runs migrations, updates the production service, and updates the production cron job |
+| Release publication job on `main` | Production web | Verifies the published tag and SHA, builds sdp-web from that commit, and deploys it to Vercel production |
 | Manual dev workflow dispatch | Dev | Rebuilds and deploys the selected workflow revision |
 | Manual production workflow dispatch from `main` | Production API | Resolves an existing 40-character Git SHA image tag and redeploys its immutable digest without running migrations |
 | Manual sdp-web workflow dispatch | Production web | Builds and deploys the provided ref to Vercel production |
 
-Vercel's git integration builds previews for pull-request branches only; `apps/sdp-web/vercel.json` skips git-triggered builds on `main`, so sdp-web reaches production exclusively through the release-triggered workflow.
+Vercel's git integration builds previews for pull-request branches only; `apps/sdp-web/vercel.json` skips git-triggered builds on `main`, so sdp-web reaches production exclusively through the release flow's production deployment job.
 
 The hosted API runs as a Node.js container on Cloud Run. Dev and production use separate GCP projects, Artifact Registry repositories, services, migration jobs, and cron jobs.
 
@@ -109,15 +109,17 @@ Auto-merge is enabled, but branch protection still requires review approval and 
 
 ### 3. Deploy and publish production
 
-Merging the release pull request creates a `chore(main): release X.Y.Z` commit on `main`. That push runs [`release-please.yml`](../../.github/workflows/release-please.yml), which creates the `vX.Y.Z` tag and publishes the GitHub release. Publishing the release then starts two independent deployments from the tagged commit:
+Merging the release pull request creates a `chore(main): release X.Y.Z` commit on `main`. That push runs [`release-please.yml`](../../.github/workflows/release-please.yml), which creates the `vX.Y.Z` tag, publishes the GitHub release, resolves the tag to the exact `main` commit, and then calls two independent production deployments with that immutable tag and SHA:
 
 - [`deploy-sdp-api-gcp-prod.yml`](../../.github/workflows/deploy-sdp-api-gcp-prod.yml) deploys the production API.
 - [`deploy-sdp-web-vercel-prod.yml`](../../.github/workflows/deploy-sdp-web-vercel-prod.yml) deploys sdp-web to Vercel production.
 
+Both called workflows retain the `main` event context required by the `production` environment. Before using production credentials, they verify that the checked-out SHA matches the published tag, belongs to `origin/main`, and has the matching version in `package.json`.
+
 The production deploy workflow:
 
 1. Authenticates to the production GCP project.
-2. Builds the API image and pushes both `X.Y.Z` and `GITHUB_SHA` tags.
+2. Builds the API image and pushes both `X.Y.Z` and release-SHA tags.
 3. Resolves the SHA tag to an immutable image digest.
 4. Updates and executes `sdp-prod-api-public-migrate`.
 5. Captures the current service traffic and cron image for rollback.

--- a/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
+++ b/scripts/deploy-sdp-api-gcp-prod-workflow.test.mjs
@@ -19,22 +19,27 @@ test("manual production deploy requires an immutable SHA-tagged image", () => {
   assert.match(workflow, /\^sha256:\[0-9a-f\]\{64\}\$/);
 });
 
-test("production deploys are triggered by release publication, not push", () => {
-  assert.match(workflow, /release:\n\s+types: \[published\]/);
-  assert.doesNotMatch(workflow, /push:/);
-  assert.doesNotMatch(workflow, /head_commit\.message/);
+test("automatic production deploys are called from the protected main release flow", () => {
+  assert.match(workflow, /workflow_call:\n\s+inputs:/);
+  assert.match(workflow, /release_sha:\n\s+description:/);
+  assert.match(workflow, /release_tag:\n\s+description:/);
+  assert.doesNotMatch(workflow, /\n\s+release:\n/);
+  assert.match(workflow, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /\.github\/scripts\/verify-release-identity\.sh/);
 });
 
 test("manual production redeploy always skips builds and migrations", () => {
   assert.doesNotMatch(workflow, /run_migrations:/);
   assert.match(
     workflow,
-    /- name: Build and push image\n\s+if: \$\{\{ github\.event_name == 'release' \}\}/
+    /- name: Build and push image\n\s+if: \$\{\{ inputs\.release_sha != '' \}\}/
   );
   assert.match(
     workflow,
-    /- name: Run database migrations\n\s+if: \$\{\{ github\.event_name == 'release' \}\}/
+    /- name: Run database migrations\n\s+if: \$\{\{ inputs\.release_sha != '' \}\}/
   );
+  assert.match(workflow, /--build-arg GIT_SHA="\$\{DEPLOY_IMAGE_SHA\}"/);
+  assert.match(workflow, /sdp-api-public:\$\{DEPLOY_IMAGE_SHA\}/);
 });
 
 test("candidate is revision-specific and Cloud Run-ready before promotion", () => {

--- a/scripts/release-production-workflows.test.mjs
+++ b/scripts/release-production-workflows.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const releaseWorkflow = fs.readFileSync(
+  path.resolve(here, "../.github/workflows/release-please.yml"),
+  "utf8"
+);
+const webWorkflow = fs.readFileSync(
+  path.resolve(here, "../.github/workflows/deploy-sdp-web-vercel-prod.yml"),
+  "utf8"
+);
+
+test("release publication passes an immutable identity to both production deployments", () => {
+  assert.match(
+    releaseWorkflow,
+    /publish-release:[\s\S]*outputs:\n\s+release_sha: \$\{\{ steps\.release\.outputs\.release_sha \}\}\n\s+release_tag: \$\{\{ steps\.release\.outputs\.release_tag \}\}/
+  );
+  assert.match(releaseWorkflow, /- name: Resolve published release\n\s+id: release/);
+  assert.match(releaseWorkflow, /git rev-parse "\$\{release_tag\}\^\{commit\}"/);
+  assert.match(releaseWorkflow, /if \[\[ "\$\{release_sha\}" != "\$\{GITHUB_SHA\}" \]\]/);
+
+  for (const [job, workflow] of [
+    ["deploy-api-production", "deploy-sdp-api-gcp-prod.yml"],
+    ["deploy-web-production", "deploy-sdp-web-vercel-prod.yml"],
+  ]) {
+    assert.match(
+      releaseWorkflow,
+      new RegExp(
+        `${job}:[\\s\\S]*needs: publish-release[\\s\\S]*uses: \\.\\/.github/workflows/${workflow}[\\s\\S]*release_sha: \\$\\{\\{ needs\\.publish-release\\.outputs\\.release_sha \\}\\}[\\s\\S]*release_tag: \\$\\{\\{ needs\\.publish-release\\.outputs\\.release_tag \\}\\}`
+      )
+    );
+  }
+
+  assert.doesNotMatch(releaseWorkflow, /secrets:\s+inherit/);
+});
+
+test("web production deploys run from main and verify automatic release identity", () => {
+  assert.match(webWorkflow, /workflow_call:\n\s+inputs:/);
+  assert.match(webWorkflow, /release_sha:\n\s+description:/);
+  assert.match(webWorkflow, /release_tag:\n\s+description:/);
+  assert.doesNotMatch(webWorkflow, /\n\s+release:\n/);
+  assert.match(webWorkflow, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(
+    webWorkflow,
+    /ref: \$\{\{ inputs\.release_sha != '' && inputs\.release_sha \|\| inputs\.ref \}\}/
+  );
+  assert.match(webWorkflow, /\.github\/scripts\/verify-release-identity\.sh/);
+});

--- a/scripts/release-production-workflows.test.mjs
+++ b/scripts/release-production-workflows.test.mjs
@@ -15,13 +15,20 @@ const webWorkflow = fs.readFileSync(
 );
 
 test("release publication passes an immutable identity to both production deployments", () => {
+  const publishJob = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  publish-release:"),
+    releaseWorkflow.indexOf("  deploy-api-production:")
+  );
+
+  assert.match(publishJob, /ref: \$\{\{ github\.sha \}\}/);
+  assert.doesNotMatch(publishJob, /ref: main/);
   assert.match(
-    releaseWorkflow,
+    publishJob,
     /publish-release:[\s\S]*outputs:\n\s+release_sha: \$\{\{ steps\.release\.outputs\.release_sha \}\}\n\s+release_tag: \$\{\{ steps\.release\.outputs\.release_tag \}\}/
   );
-  assert.match(releaseWorkflow, /- name: Resolve published release\n\s+id: release/);
-  assert.match(releaseWorkflow, /git rev-parse "\$\{release_tag\}\^\{commit\}"/);
-  assert.match(releaseWorkflow, /if \[\[ "\$\{release_sha\}" != "\$\{GITHUB_SHA\}" \]\]/);
+  assert.match(publishJob, /- name: Resolve published release\n\s+id: release/);
+  assert.match(publishJob, /git rev-parse "\$\{release_tag\}\^\{commit\}"/);
+  assert.match(publishJob, /if \[\[ "\$\{release_sha\}" != "\$\{GITHUB_SHA\}" \]\]/);
 
   for (const [job, workflow] of [
     ["deploy-api-production", "deploy-sdp-api-gcp-prod.yml"],

--- a/scripts/verify-release-identity.test.mjs
+++ b/scripts/verify-release-identity.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const verifier = path.resolve(here, "../.github/scripts/verify-release-identity.sh");
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function releaseRepository(version = "1.2.3") {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "sdp-release-identity-"));
+  git(directory, "init", "--initial-branch=main");
+  git(directory, "config", "user.name", "Release Test");
+  git(directory, "config", "user.email", "release-test@example.com");
+  fs.writeFileSync(path.join(directory, "package.json"), `${JSON.stringify({ version })}\n`);
+  git(directory, "add", "package.json");
+  git(directory, "commit", "-m", `chore(main): release ${version}`);
+  const sha = git(directory, "rev-parse", "HEAD");
+  git(directory, "-c", "tag.gpgSign=false", "tag", `v${version}`);
+  git(directory, "update-ref", "refs/remotes/origin/main", sha);
+  return { directory, sha, tag: `v${version}` };
+}
+
+test("accepts an exact version tag and SHA contained in origin/main", (t) => {
+  const fixture = releaseRepository();
+  t.after(() => fs.rmSync(fixture.directory, { recursive: true, force: true }));
+
+  const output = execFileSync(verifier, [fixture.tag, fixture.sha], {
+    cwd: fixture.directory,
+    encoding: "utf8",
+  });
+
+  assert.match(output, /Verified v1\.2\.3 at [0-9a-f]{40} on origin\/main/);
+});
+
+test("rejects a tag whose version differs from package.json", (t) => {
+  const fixture = releaseRepository();
+  t.after(() => fs.rmSync(fixture.directory, { recursive: true, force: true }));
+  git(fixture.directory, "-c", "tag.gpgSign=false", "tag", "v1.2.4");
+
+  const result = spawnSync(verifier, ["v1.2.4", fixture.sha], {
+    cwd: fixture.directory,
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not match package\.json version 1\.2\.3/);
+});
+
+test("rejects a release commit outside origin/main", (t) => {
+  const fixture = releaseRepository();
+  t.after(() => fs.rmSync(fixture.directory, { recursive: true, force: true }));
+  git(fixture.directory, "checkout", "--orphan", "untrusted");
+  fs.writeFileSync(
+    path.join(fixture.directory, "package.json"),
+    `${JSON.stringify({ version: "2.0.0" })}\n`
+  );
+  git(fixture.directory, "add", "package.json");
+  git(fixture.directory, "commit", "-m", "chore(main): release 2.0.0");
+  const untrustedSha = git(fixture.directory, "rev-parse", "HEAD");
+  git(fixture.directory, "-c", "tag.gpgSign=false", "tag", "v2.0.0");
+
+  const result = spawnSync(verifier, ["v2.0.0", untrustedSha], {
+    cwd: fixture.directory,
+    encoding: "utf8",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /is not contained in origin\/main/);
+});


### PR DESCRIPTION
## Summary

- call the API and web production deploy workflows from the protected `main` release run after the GitHub release is published
- pass the immutable release tag and SHA into both reusable workflows
- verify the checked-out SHA, tag target, `origin/main` ancestry, and `package.json` version before production credentials are used
- preserve manual API redeploy behavior without rebuilding or rerunning migrations

## Why

Release-triggered runs execute on a tag, but the `production` environment and GCP Workload Identity trust policy only admit `main`. That caused both production jobs to be rejected before their first step even though the tag, GitHub release, images, and checksums were published.

The caller now stays on `refs/heads/main`, satisfying the existing trust boundary, while the deploy workflows build and deploy the exact published release commit.

## Validation

- `pnpm test:scripts` (74 passing)
- targeted `pnpm exec biome check`
- YAML parse for all changed workflows
- `bash -n .github/scripts/verify-release-identity.sh`
- `actionlint`
