### PR TITLE
fix(integration): assert the reservation-ceiling invariant, not zero outflow

### DIFF
--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -192,6 +192,7 @@ export interface Env {
   KORA_API_KEY?: string;
   KORA_CLOUD_RUN_AUDIENCE?: string;
   KORA_TIMEOUT_MS?: string;
+  KORA_PER_TRANSACTION_BUDGET_LAMPORTS?: string;
   KORA_SURFPOOL_SHIM?: string;
   KORA_SURFPOOL_ABL_REMOVE_TIMEOUT_MS?: string;
 

--- a/packages/sdp-api-integration/src/tests/kora.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora.test.ts
@@ -50,16 +50,25 @@ describe.skipIf(!KORA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Kora Fee Payment", 
       expect(config.validation_config.allowed_programs).toBeDefined();
     });
 
-    it("reports zero fee-payer outflow, so sponsorship reserves only the network fee", async () => {
+    it("keeps the reservation ceiling under the per-transaction budget", async () => {
       const configuration = await adapter.getSponsorshipConfiguration?.();
 
       expect(configuration).toBeDefined();
-      // A false here is what keeps the reservation ceiling at the network fee.
-      // When it flips, admission reserves fee + max_allowed_lamports instead,
-      // which exceeds the per-transaction limit and denies every request — the
-      // deployed Kora having grown an authority this code does not recognise is
-      // enough to cause it, without any change to this repository.
-      expect(configuration?.feePayerMayTransferLamports).toBe(false);
+      // Devnet deliberately lets the fee payer fund token-deploy rent
+      // (fee_payer_policy.system.allow_transfer/allow_create_account), so
+      // admission reserves fee + max_allowed_lamports per transaction. The
+      // invariant that keeps sponsorship alive is that this ceiling stays
+      // under the seeded 10M-lamport per-transaction budget: if the deployed
+      // Kora raises max_allowed_lamports past the headroom, or grows an
+      // authority this code reads as spend without a matching cap, every
+      // request is denied without any change to this repository.
+      const PER_TRANSACTION_BUDGET_LAMPORTS = 10_000_000n;
+      const NETWORK_FEE_HEADROOM_LAMPORTS = 50_000n;
+      expect(configuration?.feePayerMayTransferLamports).toBe(true);
+      expect(configuration?.maxAllowedLamports).toBeDefined();
+      expect(
+        (configuration?.maxAllowedLamports ?? 0n) + NETWORK_FEE_HEADROOM_LAMPORTS
+      ).toBeLessThanOrEqual(PER_TRANSACTION_BUDGET_LAMPORTS);
     });
 
     it("gets fee payer address", async () => {

--- a/packages/sdp-api-integration/src/tests/kora.test.ts
+++ b/packages/sdp-api-integration/src/tests/kora.test.ts
@@ -62,7 +62,13 @@ describe.skipIf(!KORA_CONFIGURED || !RUN_INTEGRATION_TESTS)("Kora Fee Payment", 
       // Kora raises max_allowed_lamports past the headroom, or grows an
       // authority this code reads as spend without a matching cap, every
       // request is denied without any change to this repository.
-      const PER_TRANSACTION_BUDGET_LAMPORTS = 10_000_000n;
+      // Mirrors the deployed environment's seeded per-transaction budget
+      // (migration 0055), not the 20M policies kora-flow.test.ts seeds for its
+      // own suite. Override alongside a coordinated budget raise so this pin
+      // follows the environment instead of paging on a healthy change.
+      const PER_TRANSACTION_BUDGET_LAMPORTS = env.KORA_PER_TRANSACTION_BUDGET_LAMPORTS
+        ? BigInt(env.KORA_PER_TRANSACTION_BUDGET_LAMPORTS)
+        : 10_000_000n;
       const NETWORK_FEE_HEADROOM_LAMPORTS = 50_000n;
       expect(configuration?.feePayerMayTransferLamports).toBe(true);
       expect(configuration?.maxAllowedLamports).toBeDefined();


### PR DESCRIPTION
The Kora live smoke ("reports zero fee-payer outflow…") fails on every PR since devnet Kora deliberately lets the fee payer fund token-deploy rent (sdp-infra#52 / sdp-infra#53): the adapter now truthfully reports `feePayerMayTransferLamports = true`, and the test pinned `false`.

The invariant that actually keeps sponsorship alive is not "the sponsor cannot spend" but "the admission ceiling (network fee + `max_allowed_lamports`) stays under the seeded 10M-lamport per-transaction budget". The test now asserts exactly that: outflow is enabled, and `max_allowed_lamports` (currently 9.9M) leaves network-fee headroom below the budget — so it still catches the failure mode it was written for (a deployed Kora raising the cap or growing an unrecognized spend authority denies every request without any change to this repository).

Verified live against dev Kora: 9 passed.