### PR TITLE
feat(helius): redact rings key material in logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,12 @@ jobs:
       - name: Scripts tests
         run: pnpm test:scripts
 
+      # Runs here rather than in the Module Boundaries job because it parses
+      # TypeScript with the compiler's own parser, and that job installs no
+      # dependencies.
+      - name: Check SecretRef serialization
+        run: pnpm check:secretref-serialization
+
   build_api:
     name: Build API
     runs-on: ubuntu-latest

--- a/apps/sdp-api/src/runtime/log-redaction.test.ts
+++ b/apps/sdp-api/src/runtime/log-redaction.test.ts
@@ -1,0 +1,132 @@
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+import {
+  LOG_REDACTION_PATHS,
+  REDACTED_LEAF_FIELDS,
+  REDACTED_NESTED_PATHS,
+  REDACTION_CENSOR,
+} from "./log-redaction";
+import { baseLoggerOptions } from "./logger";
+
+/**
+ * Stands in for `SecretRef` from `@sdp/helius-rings`, which sdp-api does not yet
+ * depend on — A5 adds that dependency when the repositories need the domain
+ * types. What matters here is the contract pino relies on, `toJSON()` returning
+ * the censor; that `SecretRef` honours it is asserted in
+ * packages/sdp-helius-rings/src/secrets.test.ts.
+ */
+class WrappedSecret {
+  readonly #value: string;
+  constructor(value: string) {
+    this.#value = value;
+  }
+  reveal(): string {
+    return this.#value;
+  }
+  toJSON(): string {
+    return REDACTION_CENSOR;
+  }
+}
+
+/** Captures what the real logger options would actually emit to a sink. */
+function captureLogs(write: (logger: pino.Logger) => void): string {
+  const lines: string[] = [];
+  const logger = pino(
+    { ...baseLoggerOptions(), transport: undefined, timestamp: false },
+    { write: (line: string) => lines.push(line) }
+  );
+  write(logger);
+  return lines.join("\n");
+}
+
+describe("log redaction registry", () => {
+  it("expands every registered field to the root and one level deep", () => {
+    for (const field of [...REDACTED_LEAF_FIELDS, ...REDACTED_NESTED_PATHS]) {
+      expect(LOG_REDACTION_PATHS).toContain(field);
+      expect(LOG_REDACTION_PATHS).toContain(`*.${field}`);
+    }
+  });
+
+  it("is accepted by pino — an unsupported path shape throws at construction", () => {
+    expect(() => captureLogs((logger) => logger.info("ok"))).not.toThrow();
+  });
+
+  it("censors the Rings key domain at the root of a log object", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ viewingKey: "vk-plaintext", nullifierKey: "nk-plaintext" }, "provisioned");
+    });
+
+    expect(output).not.toContain("vk-plaintext");
+    expect(output).not.toContain("nk-plaintext");
+    expect(output).toContain(REDACTION_CENSOR);
+  });
+
+  it("censors the Rings key domain one level deep, where callers actually put it", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ wallet: { id: "hrw_1", viewingKey: "vk-plaintext" } }, "wallet ready");
+    });
+
+    expect(output).not.toContain("vk-plaintext");
+    expect(output).toContain("hrw_1");
+  });
+
+  it("censors proof internals and key ref material", () => {
+    const output = captureLogs((logger) => {
+      logger.info(
+        {
+          operation: {
+            id: "hro_1",
+            proof: { ref: "proof-handle", internal: "witness-bytes" },
+          },
+          keyRefs: [{ material: "blob-a" }, { material: "blob-b" }],
+        },
+        "proof received"
+      );
+    });
+
+    expect(output).not.toContain("proof-handle");
+    expect(output).not.toContain("witness-bytes");
+    expect(output).not.toContain("blob-a");
+    expect(output).not.toContain("blob-b");
+    expect(output).toContain("hro_1");
+  });
+
+  it("censors the gateway metadata envelope", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ ringsMetadata: { anything: "opaque-upstream-detail" } }, "gateway replied");
+    });
+
+    expect(output).not.toContain("opaque-upstream-detail");
+  });
+
+  it("leaves a wrapped secret redacted by the wrapper, at any depth", () => {
+    // This is why the one-level limit on the registry is tolerable: a wrapped
+    // secret redacts itself through toJSON(), so depth does not matter for
+    // wrapped material. The registry only has to cover plaintext that escaped
+    // wrapping.
+    const output = captureLogs((logger) => {
+      logger.info(
+        { a: { b: { c: { secret: new WrappedSecret("hunter2"), note: "deeply nested" } } } },
+        "deep"
+      );
+    });
+
+    expect(output).not.toContain("hunter2");
+    expect(output).toContain(REDACTION_CENSOR);
+    expect(output).toContain("deeply nested");
+  });
+
+  it("keeps ordinary operational fields readable", () => {
+    const output = captureLogs((logger) => {
+      logger.info(
+        { operation: { id: "hro_2", state: "proving", opType: "transfer_anonymous" } },
+        "advanced"
+      );
+    });
+
+    expect(output).toContain("hro_2");
+    expect(output).toContain("proving");
+    expect(output).toContain("transfer_anonymous");
+    expect(output).not.toContain(REDACTION_CENSOR);
+  });
+});

--- a/apps/sdp-api/src/runtime/log-redaction.ts
+++ b/apps/sdp-api/src/runtime/log-redaction.ts
@@ -1,0 +1,73 @@
+/**
+ * The log redaction registry: field paths pino censors before anything reaches
+ * a log sink.
+ *
+ * This is the belt, not the braces. The primary defence against secret material
+ * in logs is the type layer — `SecretRef<T>` in `@sdp/helius-rings` overrides
+ * `toJSON()`/`toString()` to `"[REDACTED]"`, so a wrapped secret is already safe
+ * wherever it is serialized. This registry catches the case the type layer
+ * cannot: a *plaintext* value that reached a log object without ever being
+ * wrapped, because someone called `reveal()` upstream, read a column straight
+ * out of the database, or destructured a gateway response.
+ *
+ * A known limit, verified against pino 10: the `*.` prefix matches exactly one
+ * intermediate key, not arbitrary depth. `{ wallet: { viewingKey } }` is
+ * censored; `{ a: { b: { viewingKey } } }` is not. fast-redact has no
+ * recursive-descent wildcard, so the alternative would be a hand-rolled deep
+ * walk on every log call — a cost paid on every log line in production to cover
+ * a shape that only appears if secret material is being passed around
+ * unwrapped, which is the thing `SecretRef` and
+ * `scripts/check-secretref-serialization.mjs` exist to prevent. Keep log objects
+ * shallow, and keep secrets wrapped.
+ *
+ * To register a field: add the key to `REDACTED_LEAF_FIELDS` if it can appear
+ * anywhere under its own name, or the full path to `REDACTED_NESTED_PATHS` if it
+ * is only meaningful inside a parent object. Both forms are expanded to cover
+ * the top level and one nesting level.
+ */
+
+/** What a censored value is replaced with. */
+export const REDACTION_CENSOR = "[REDACTED]";
+
+/**
+ * Keys that are sensitive wherever they appear, regardless of parent.
+ *
+ * `viewingKey` and `nullifierKey` are the Helius Rings key domain: a viewing key
+ * deanonymizes every transfer a shielded wallet has ever received, and a
+ * nullifier key can spend from it. `ringsMetadata` is the catch-all envelope the
+ * gateway attaches to operations, whose contents are not ours to audit.
+ */
+export const REDACTED_LEAF_FIELDS: readonly string[] = [
+  "viewingKey",
+  "nullifierKey",
+  "ringsMetadata",
+];
+
+/**
+ * Paths that are only sensitive in context.
+ *
+ * `proof.ref` is the gateway's opaque handle to a proof and `proof.internal` its
+ * witness data — neither is a secret about SDP, but both are a secret about the
+ * customer's transfer graph. `keyRefs[*].material` is the encrypted key blob as
+ * it travels in memory between the key authority and the signer.
+ */
+export const REDACTED_NESTED_PATHS: readonly string[] = [
+  "proof.ref",
+  "proof.internal",
+  "keyRefs[*].material",
+];
+
+/**
+ * Expands a registered field into the shapes pino can actually match: the path
+ * at the root of the log object, and the same path one key deeper (the common
+ * case, where the caller logs `{ operation: {...} }` or `{ wallet: {...} }`).
+ */
+function withOneLevelOfNesting(path: string): string[] {
+  return [path, `*.${path}`];
+}
+
+/** Paths handed to pino's `redact` option. */
+export const LOG_REDACTION_PATHS: readonly string[] = [
+  ...REDACTED_LEAF_FIELDS.flatMap(withOneLevelOfNesting),
+  ...REDACTED_NESTED_PATHS.flatMap(withOneLevelOfNesting),
+];

--- a/apps/sdp-api/src/runtime/logger.ts
+++ b/apps/sdp-api/src/runtime/logger.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import pino, { type Logger, type LoggerOptions } from "pino";
+import { LOG_REDACTION_PATHS, REDACTION_CENSOR } from "./log-redaction";
 
 export interface LogContext {
   request_id?: string;
@@ -43,6 +44,7 @@ export function baseLoggerOptions(): LoggerOptions {
       },
     },
     serializers: { error: serializeError, err: serializeError },
+    redact: { paths: [...LOG_REDACTION_PATHS], censor: REDACTION_CENSOR },
     mixin: () => ({ ...getLogContext() }),
     ...(process.env.LOG_FORMAT === "pretty" ? { transport: { target: "pino-pretty" } } : {}),
   };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "check:env-configurator-drift": "node scripts/check-env-configurator-drift.mjs",
     "check:module-boundaries": "node scripts/check-module-boundaries.mjs",
     "check:pinned-dependencies": "node scripts/check-pinned-dependency-versions.mjs",
+    "check:secretref-serialization": "node scripts/check-secretref-serialization.mjs",
     "check:well-known-mints": "pnpm --filter @sdp/api exec tsx ../../scripts/check-well-known-mints.mjs",
     "check:api-playground": "pnpm -C apps/sdp-api playground:check",
     "generate:api-playground": "pnpm -C apps/sdp-api playground:generate",

--- a/packages/sdp-helius-rings/src/secrets.ts
+++ b/packages/sdp-helius-rings/src/secrets.ts
@@ -1,10 +1,16 @@
 /**
  * Wraps a secret value so it never leaks through logs, JSON serialization, or
- * template literals. `reveal()` is the only path to the raw value; the scope
- * argument is a documentation-level contract for reviewers, not enforced at
- * runtime. A lint rule (A23) will forbid `JSON.stringify` on any value typed
- * `SecretRef<*>`; until then the `toJSON`/`toString` overrides are the safety
- * net.
+ * template literals. The `toJSON`/`toString` overrides mean a wrapped secret is
+ * safe wherever it is serialized or interpolated, at any depth.
+ *
+ * `reveal()` is the only path to the raw value, and the only real leak vector:
+ * the result is an ordinary string or Uint8Array with no redaction behaviour.
+ * The scope argument is a documentation-level contract for reviewers, not
+ * enforced at runtime. `scripts/check-secretref-serialization.mjs` fails the
+ * build if a `reveal()` result reaches `JSON.stringify`, a logger, `String()`,
+ * or a template literal — test files excepted, which is what the "test" scope is
+ * for. Plaintext key material that never got wrapped is caught separately by the
+ * log redaction registry in `apps/sdp-api/src/runtime/log-redaction.ts`.
  */
 export type RevealScope = "adapter" | "signer" | "test";
 

--- a/scripts/check-secretref-serialization.mjs
+++ b/scripts/check-secretref-serialization.mjs
@@ -1,0 +1,265 @@
+/**
+ * Forbids revealed `SecretRef` material from reaching a serializer, a logger, or
+ * a string.
+ *
+ * `SecretRef<T>` (packages/sdp-helius-rings/src/secrets.ts) wraps viewing keys,
+ * nullifier keys and proof internals. Its `toJSON()`/`toString()` overrides
+ * already return "[REDACTED]", so passing a *wrapped* secret to
+ * `JSON.stringify` or a log call is safe by construction — the plan's original
+ * wording ("forbid JSON.stringify on any value typed SecretRef<*>") targets a
+ * pattern that cannot actually leak.
+ *
+ * The pattern that leaks is `reveal()`. Once unwrapped, the value is an ordinary
+ * string or Uint8Array with no redaction behaviour at all, and the wrapper's
+ * whole purpose is gone. So this check follows the intent rather than the letter
+ * and flags reveal() results flowing into:
+ *
+ *   1. JSON.stringify / JSON.stringify-like serialization
+ *   2. a logger or console call
+ *   3. a template literal or String()
+ *
+ * It also flags `JSON.stringify` applied directly to a `SecretRef` construction,
+ * which is harmless at runtime but always means the author misunderstood the
+ * wrapper.
+ *
+ * `reveal("test")` inside test files is the sanctioned path — `RevealScope`
+ * includes "test" precisely so tests can assert on real values — so test files
+ * are exempt.
+ *
+ * This is a standalone script rather than a lint rule because the repo lints
+ * with Biome, which has no custom-rule authoring mechanism in use here, and the
+ * established convention for bespoke static checks is scripts/check-*.mjs with a
+ * sibling .test.mjs (see check-module-boundaries.mjs, check-env-contract.mjs).
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+/** Methods that write somewhere a human or a log sink can read. */
+const LOG_METHODS = new Set([
+  "log",
+  "info",
+  "warn",
+  "error",
+  "debug",
+  "trace",
+  "fatal",
+  "captureException",
+  "captureMessage",
+]);
+
+const SCAN_ROOTS = ["apps", "packages"];
+
+/** Files that legitimately handle raw secret material. */
+const EXEMPT_SUFFIXES = [
+  "packages/sdp-helius-rings/src/secrets.ts",
+  "scripts/check-secretref-serialization.mjs",
+];
+
+function isTestFile(relativePath) {
+  return (
+    /\.(test|spec)\.(ts|tsx|mts)$/.test(relativePath) || /(^|\/)(test|tests)\//.test(relativePath)
+  );
+}
+
+function isExempt(relativePath) {
+  return EXEMPT_SUFFIXES.some((suffix) => relativePath.endsWith(suffix));
+}
+
+/** True when `node` is a `<something>.reveal(...)` call. */
+function isRevealCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "reveal"
+  );
+}
+
+/** True when `node` is `JSON.stringify(...)`. */
+function isJsonStringifyCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "stringify" &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "JSON"
+  );
+}
+
+/** True when `node` is a `<obj>.info(...)`-style call onto a log-ish method. */
+function isLogCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    LOG_METHODS.has(node.expression.name.text)
+  );
+}
+
+/** True when `node` is `String(...)`. */
+function isStringCoercionCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "String"
+  );
+}
+
+/** True when `node` is `new SecretRef(...)`. */
+function isSecretRefConstruction(node) {
+  return (
+    ts.isNewExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "SecretRef"
+  );
+}
+
+/** Walks `root` (inclusive) looking for any node satisfying `predicate`. */
+function containsNode(root, predicate) {
+  let found = false;
+  const visit = (node) => {
+    if (found) return;
+    if (predicate(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return found;
+}
+
+function lineOf(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+/** True when any argument of a call contains a reveal(). */
+function hasRevealedArgument(node) {
+  return node.arguments.some((argument) => containsNode(argument, isRevealCall));
+}
+
+/**
+ * The rules. Each takes a node and returns the violation message for it, or
+ * null. Kept as separate small functions rather than one branching visitor so
+ * adding a rule does not push the walker past the repo's complexity ceiling.
+ */
+const RULES = [
+  function serialization(node) {
+    if (!isJsonStringifyCall(node)) return null;
+    const [argument] = node.arguments;
+    if (!argument) return null;
+    if (containsNode(argument, isRevealCall)) {
+      return "JSON.stringify() receives a revealed SecretRef. Serialize the wrapper, or a hash of the value, not reveal().";
+    }
+    if (containsNode(argument, isSecretRefConstruction)) {
+      return 'JSON.stringify() receives a SecretRef. It serializes to "[REDACTED]" and carries no information — drop the call.';
+    }
+    return null;
+  },
+
+  function logging(node) {
+    if (!isLogCall(node) || !hasRevealedArgument(node)) return null;
+    return `${node.expression.name.text}() receives a revealed SecretRef. Log an identifier or a hash, never the material.`;
+  },
+
+  function stringCoercion(node) {
+    if (!isStringCoercionCall(node) || !hasRevealedArgument(node)) return null;
+    return 'String() receives a revealed SecretRef. Coerce the wrapper instead — it yields "[REDACTED]".';
+  },
+
+  function interpolation(node) {
+    if (!ts.isTemplateExpression(node)) return null;
+    const interpolatesReveal = node.templateSpans.some((span) =>
+      containsNode(span.expression, isRevealCall)
+    );
+    if (!interpolatesReveal) return null;
+    return 'Template literal interpolates a revealed SecretRef. Interpolate the wrapper instead — it yields "[REDACTED]".';
+  },
+];
+
+/**
+ * Returns violation strings for one file's source text. Exported so the sibling
+ * test can drive it without touching the filesystem.
+ */
+export function findSecretRefViolations(sourceText, relativePath) {
+  const violations = [];
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  const visit = (node) => {
+    for (const rule of RULES) {
+      const message = rule(node);
+      if (message) {
+        violations.push(`${relativePath}:${lineOf(sourceFile, node)}: ${message}`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sourceFile, visit);
+  return violations;
+}
+
+function collectSourceFiles(repositoryRoot) {
+  const files = [];
+
+  for (const root of SCAN_ROOTS) {
+    const absoluteRoot = path.join(repositoryRoot, root);
+    let entries;
+    try {
+      if (!statSync(absoluteRoot).isDirectory()) continue;
+      entries = readdirSync(absoluteRoot, { recursive: true, encoding: "utf8" });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!/\.(ts|tsx|mts)$/.test(entry)) continue;
+      if (/(^|\/)(node_modules|dist|build|\.next|\.turbo)(\/|$)/.test(entry)) continue;
+      if (entry.endsWith(".d.ts")) continue;
+
+      const relativePath = path.posix.join(root, entry.split(path.sep).join("/"));
+      if (isTestFile(relativePath) || isExempt(relativePath)) continue;
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
+export function checkSecretRefSerialization(repositoryRoot) {
+  const violations = [];
+
+  for (const relativePath of collectSourceFiles(repositoryRoot)) {
+    const sourceText = readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+    // Cheap prefilter: parsing every file in the monorepo to find a handful of
+    // reveal() calls is wasted work.
+    if (!sourceText.includes("reveal(") && !sourceText.includes("SecretRef")) continue;
+    violations.push(...findSecretRefViolations(sourceText, relativePath));
+  }
+
+  return violations;
+}
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMainModule) {
+  const repositoryRoot = path.resolve(
+    process.argv[2] ?? path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+  );
+  const violations = checkSecretRefSerialization(repositoryRoot);
+
+  if (violations.length > 0) {
+    console.error("SecretRef serialization violations:\n");
+    console.error(violations.map((violation) => `- ${violation}`).join("\n"));
+    process.exitCode = 1;
+  } else {
+    console.log("SecretRef serialization check passed.");
+  }
+}

--- a/scripts/check-secretref-serialization.test.mjs
+++ b/scripts/check-secretref-serialization.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findSecretRefViolations } from "./check-secretref-serialization.mjs";
+
+test("flags a revealed secret passed to JSON.stringify", () => {
+  const violations = findSecretRefViolations(
+    `const payload = JSON.stringify({ key: keyRef.material.reveal("adapter") });\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /^apps\/sdp-api\/src\/services\/helius-rings\/example\.ts:1: /);
+  assert.match(violations[0], /JSON\.stringify\(\) receives a revealed SecretRef/);
+});
+
+test("flags a revealed secret passed to a logger", () => {
+  const violations = findSecretRefViolations(
+    `getLogger().info({ viewingKey: keys.viewing.reveal("adapter") }, "provisioned");\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /info\(\) receives a revealed SecretRef/);
+});
+
+test("flags a revealed secret interpolated into a template literal", () => {
+  const violations = findSecretRefViolations(
+    `const message = \`viewing key is \${secret.reveal("signer")}\`;\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /Template literal interpolates a revealed SecretRef/);
+});
+
+test("flags a revealed secret coerced with String()", () => {
+  const violations = findSecretRefViolations(
+    `const asText = String(secret.reveal("adapter"));\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /String\(\) receives a revealed SecretRef/);
+});
+
+test("flags stringifying a SecretRef as pointless rather than dangerous", () => {
+  const violations = findSecretRefViolations(
+    `const encoded = JSON.stringify(new SecretRef("hunter2"));\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /carries no information/);
+});
+
+test("finds a reveal nested deep inside a log argument", () => {
+  const violations = findSecretRefViolations(
+    `logger.error({ op: { detail: { material: ref.material.reveal("signer") } } }, "failed");\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /error\(\) receives a revealed SecretRef/);
+});
+
+test("reports each offending call once, with its own line", () => {
+  const violations = findSecretRefViolations(
+    [
+      `logger.info({ a: s.reveal("adapter") }, "one");`,
+      `const t = \`\${s.reveal("adapter")}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/example.ts"
+  );
+
+  assert.equal(violations.length, 2);
+  assert.match(violations[0], /:1: /);
+  assert.match(violations[1], /:2: /);
+});
+
+test("allows passing the wrapper itself to a logger or serializer", () => {
+  const violations = findSecretRefViolations(
+    [
+      `getLogger().info({ proof: operation.proof }, "prepared");`,
+      `const body = JSON.stringify({ ref: operation.proof.ref });`,
+      `const shown = \`proof \${operation.proof.ref}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("allows reveal() where it belongs — handed to an adapter or signer", () => {
+  const violations = findSecretRefViolations(
+    [
+      `await gateway.buildOperation({ material: keyRef.material.reveal("adapter") });`,
+      `const signature = await signer.sign(payload, key.reveal("signer"));`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("does not confuse an unrelated reveal() method", () => {
+  const violations = findSecretRefViolations(
+    `logger.info({ state: animation.reveal() }, "toggled");\n`,
+    "apps/sdp-web/src/example.ts"
+  );
+
+  // A false positive here is acceptable and deliberate: the check is
+  // name-based, and `reveal()` is rare enough outside SecretRef that catching
+  // the leak is worth the occasional rename. Documented so the behaviour is a
+  // decision rather than a surprise.
+  assert.equal(violations.length, 1);
+});


### PR DESCRIPTION
Adds the two halves of the redaction posture the plan calls a Week-1
non-negotiable: a log redaction registry, and a build-time check that secret
material does not reach a log or a serializer.

The registry lives in apps/sdp-api/src/runtime/log-redaction.ts and is wired
into baseLoggerOptions() as pino's redact option, covering viewingKey,
nullifierKey, ringsMetadata, proof.ref, proof.internal and
keyRefs[*].material. Each entry is expanded to the root and one nesting
level, which is pino's actual limit: fast-redact's wildcard matches exactly
one intermediate key, not arbitrary depth. That limit is tolerable because
wrapped secrets redact themselves through SecretRef.toJSON() at any depth, so
the registry only has to catch plaintext that escaped wrapping. Both halves
of that claim are asserted.

The check departs from the plan's letter. It specified an ESLint rule
forbidding JSON.stringify on values typed SecretRef<*>, but this repo lints
with Biome and has no custom-rule mechanism in use, and more importantly that
rule would guard a pattern that cannot leak: SecretRef.toJSON() already
returns "[REDACTED]", so stringifying the wrapper is safe by construction.
The pattern that leaks is reveal(), whose result is an ordinary string with no
redaction behaviour. So scripts/check-secretref-serialization.mjs parses with
the TypeScript compiler's own parser and fails the build when a reveal()
result flows into JSON.stringify, a logger, String(), or a template literal,
while leaving reveal() alone where it belongs — passed to an adapter or a
signer. Stringifying a SecretRef is still reported, as pointless rather than
dangerous.

Test files are exempt, which is what the "test" RevealScope is for. The check
is a standalone script with a sibling .test.mjs, following the convention
check-module-boundaries.mjs and check-env-contract.mjs established, and runs
in the Unit Tests CI job rather than Module Boundaries because that job is the
one that installs dependencies.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Verification

- `node --test scripts/*.test.mjs` — 84 passing, 10 of them new (each rule's positive case, plus the negative cases that must stay legal: passing the wrapper to a logger or serializer, and calling `reveal()` to hand material to an adapter or signer).
- `vitest run src/runtime/log-redaction.test.ts src/runtime/logger.test.ts` — 15 passing.
- `pnpm --filter @sdp/helius-rings test` — 15 passing; `typecheck` clean.
- `pnpm check:module-boundaries`, `biome check` — clean.
- Confirmed the check is not passing vacuously: planting `JSON.stringify({ k: secret.reveal("adapter") })` in a source file made it report `file:line` and exit 1; removing the file returned it to green.
- Repo-wide runtime is ~1.7s, so the CI cost is negligible.

## Notes for review

**This deliberately does not implement what the plan specified.** `HELIUS_TRACKS.md` A23 asks for an ESLint rule forbidding `JSON.stringify` on `SecretRef<*>`. Two problems: the repo lints with Biome and has no custom-rule mechanism in use, and that rule would guard a pattern that cannot leak — `SecretRef.toJSON()` already returns `"[REDACTED]"`. The leak vector is `reveal()`. If you'd rather have the literal rule as well, say so and I'll add it, but it would flag safe code.

One known and intentional false positive: the check matches `reveal()` by name, so an unrelated `.reveal()` method elsewhere would be flagged. There's a test pinning that behaviour so it reads as a decision rather than a surprise.

Also worth knowing, verified empirically against pino 10: `fast-redact`'s `*.` wildcard matches exactly one intermediate key, not arbitrary depth. Registry entries are expanded to the root and one level; deeper plaintext is not covered. That's tolerable only because wrapped secrets redact themselves at any depth — which is the argument for keeping `SecretRef` mandatory rather than treating the registry as the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
