### PR TITLE
feat(earn): sort the strategy catalogue by pool size and APY

### DIFF
--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -234,12 +234,28 @@ Ground publishes **no** risk tier, rating, grade, or score on a yield source —
 its own docs say so, and `riskMetadata.riskTier` is written only by the local dev
 seed. There is deliberately no profile or bucket step: every active, fundable
 strategy appears once in a comparison table. Liquidity is the explicit
-redemption-speed filter; yield is the APY sort. Neither assigns a synthetic
+redemption-speed filter; yield is the APY ranking. Neither assigns a synthetic
 category, and copy must never imply that the provider rated anything.
 
 Changing a filter clears a selected strategy if that row becomes hidden, so the
-review step can never confirm a choice the reader can no longer see. Missing
-pool size remains visible as `—` and sorts after reported values.
+review step can never confirm a choice the reader can no longer see.
+
+**Ranking is the reader's; the ordering rules are the model's.** Pool size and
+APY are clickable column headers (`SortableColumnHeader` → `nextStrategySort`):
+the active column flips direction, a newly clicked one opens descending, and
+`aria-sort` on the `th` carries the state (the ARIA sortable-table pattern — no
+separate live region). `sortStrategies` is the ONE comparator, and
+`rankedFundableStrategies` is that function at `DEFAULT_STRATEGY_SORT` (APY
+desc), so the step re-ranking the list it was handed is a no-op until a header
+is clicked — do not add a second comparator. Two rules hold in BOTH directions:
+an unreported figure stays visible as `—` and sorts LAST (an ascending pass must
+not promote the rows we know least about above every row the reader can
+compare), and ties break on name (the catalogue is re-read on revalidation, so
+two 5.1% rows must not swap under the cursor). The sort is the step's own state,
+not the wizard's: re-entering restores the default order, the way the step also
+lands pre-scrolled at the top, while the selection belongs to the wizard and
+survives wherever its row moves to. Backing and Access are labels, not rankings
+— leave them unsortable.
 
 ### Confirm is idempotent — keep it that way
 
@@ -309,6 +325,24 @@ funding instructions and nothing else — never imply a transfer happens.
   mono by design. Selection state is `border-primary bg-fill-subtle` across the
   whole module — do not mix in the issuance/ramps outline+ring variant. `Badge`
   is status-only; a plain label is an inline chip.
+- **Nothing may overlap — provider names run long.** Two traps, both sprung by
+  "Janus Henderson JTRSY tokenized by Centrifuge":
+  - `@solana/design-system`'s `cn` is a plain string join — **no
+    tailwind-merge**. A class handed to `Table*` that conflicts with one of its
+    own base classes does not win; it loses to CSS source order
+    (`.whitespace-nowrap` is emitted after `.whitespace-normal`), and under
+    `table-fixed` the still-unwrapped text overflows into the next column. The
+    strategy table therefore declares wrapping and clamping on the child spans,
+    where nothing competes. Never assume an override of a DS base class took —
+    and watch for the same trap with `display` (`block` vs `line-clamp-*`).
+  - `SummaryRow` gives the LABEL `shrink-0` and the VALUE `ml-auto min-w-0
+    break-words`. The inverse — a `shrink-0 whitespace-nowrap` value — is what
+    drove a fund name back over its own label: `justify-between` distributes
+    NEGATIVE free space, so a value that cannot shrink overlaps rather than
+    merely overflowing. Mirrors `payments/wizard-summary-list`.
+
+  Long text wraps inside a bounded clamp, or truncates with a `title` carrying
+  the full string. Numbers never truncate — wrap them instead.
 - Steps must land pre-scrolled at top (useLayoutEffect, `behavior: "instant"`,
   then focus the first `h2` — keep it). `WizardFrame` owns the only scroll
   container AND already renders the step `h2` + description, so step children

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-chrome.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-chrome.tsx
@@ -109,12 +109,23 @@ export function StepNote({
   );
 }
 
-/** One label/value line. The label wraps first so short values stay intact. */
+/**
+ * One label/value line: the label keeps its width, the value takes the slack and
+ * wraps inside it.
+ *
+ * The inverse — a `shrink-0 whitespace-nowrap` value — is what put "Janus
+ * Henderson JTRSY tokenized by Centrifuge" straight through the "Strategy"
+ * label. A value that refuses to shrink does not merely overflow the row:
+ * `justify-between` distributes NEGATIVE free space too, so it slid back OVER
+ * the label. Hence `ml-auto` for the right edge rather than `justify-between`,
+ * and `break-words` so an unbroken value (an API base URL) breaks instead of
+ * escaping. Mirrors `payments/wizard-summary-list`.
+ */
 export function SummaryRow({ label, value }: { label: ReactNode; value: ReactNode }) {
   return (
-    <div className="flex items-baseline justify-between gap-4 border-b border-border-subtle py-2.5 text-sm last:border-b-0">
-      <span className="min-w-0 text-secondary">{label}</span>
-      <span className="shrink-0 text-right whitespace-nowrap text-primary">{value}</span>
+    <div className="flex items-baseline gap-4 border-b border-border-subtle py-2.5 text-sm last:border-b-0">
+      <span className="shrink-0 text-secondary">{label}</span>
+      <span className="ml-auto min-w-0 break-words text-right text-primary">{value}</span>
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
@@ -1,9 +1,10 @@
 import type { EarnPortfolioAllocationInput, EarnPortfolioToken, EarnStrategy } from "@sdp/types";
-import { strategyApy, strategyToken } from "../earn-program-presentation";
+import { strategyApy, strategyPoolUsd, strategyToken } from "../earn-program-presentation";
 
 /**
- * Pure model for the Earn deposit flow: full catalogue → APY-ranked fundable
- * rows → ONE strategy → a 100% allocation.
+ * Pure model for the Earn deposit flow: full catalogue → ranked fundable rows
+ * (APY by default, or whichever column the reader ranked by) → ONE strategy →
+ * a 100% allocation.
  *
  * Every value is derived from a field the provider actually reports. For Ground
  * (the only live provider) the catalogue row is mapped from
@@ -28,20 +29,74 @@ export function fundableStrategies(strategies: readonly EarnStrategy[]): readonl
   return strategies.filter((strategy) => strategyToken(strategy) !== undefined);
 }
 
-function descendingUnknownLast(left: number | undefined, right: number | undefined): number {
-  if (left === undefined && right === undefined) return 0;
-  if (left === undefined) return 1;
-  if (right === undefined) return -1;
-  return right - left;
+/** The reported columns a reader may rank the comparison table by. */
+export type EarnStrategySortColumn = "apy" | "pool";
+
+export interface EarnStrategySort {
+  column: EarnStrategySortColumn;
+  direction: "asc" | "desc";
 }
 
-/** The browse step's short list, highest indicative APY first. */
+/** Highest indicative APY first — the order the comparison table opens in. */
+export const DEFAULT_STRATEGY_SORT: EarnStrategySort = { column: "apy", direction: "desc" };
+
+/** The reported figure behind each sortable column; `undefined` = unreported. */
+const SORT_VALUES: Record<EarnStrategySortColumn, (strategy: EarnStrategy) => number | undefined> =
+  {
+    apy: strategyApy,
+    pool: strategyPoolUsd,
+  };
+
+/**
+ * Rank the catalogue by one reported column. The ONE comparator in this module —
+ * the default order below is this function, so re-ranking an already-ranked list
+ * with {@link DEFAULT_STRATEGY_SORT} is a no-op rather than a second opinion.
+ *
+ * Two rules hold in BOTH directions:
+ * - **Unreported sorts last.** A strategy with no pool size or no rate renders
+ *   "—", and floating those to the top of an ascending pass would rank the rows
+ *   we know least about above every row the reader can actually compare.
+ * - **Ties break on name.** The catalogue arrives in provider order and is
+ *   re-read on revalidation, so two strategies reporting the same figure (5.1%
+ *   and 5.1%) would otherwise be free to swap places under the reader's cursor.
+ */
+export function sortStrategies(
+  strategies: readonly EarnStrategy[],
+  sort: EarnStrategySort
+): readonly EarnStrategy[] {
+  const reportedValue = SORT_VALUES[sort.column];
+  return [...strategies].sort((left, right) => {
+    const leftValue = reportedValue(left);
+    const rightValue = reportedValue(right);
+    if (leftValue === undefined || rightValue === undefined) {
+      if (leftValue === rightValue) return left.name.localeCompare(right.name);
+      return leftValue === undefined ? 1 : -1;
+    }
+    if (leftValue !== rightValue) {
+      return sort.direction === "asc" ? leftValue - rightValue : rightValue - leftValue;
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
+
+/**
+ * What clicking a column header does: the active column flips direction, and a
+ * newly clicked column opens descending — for both pool size and APY the end
+ * worth landing on first is the large one.
+ */
+export function nextStrategySort(
+  current: EarnStrategySort,
+  column: EarnStrategySortColumn
+): EarnStrategySort {
+  if (current.column !== column) return { column, direction: "desc" };
+  return { column, direction: current.direction === "desc" ? "asc" : "desc" };
+}
+
+/** The browse step's short list in its default order, highest APY first. */
 export function rankedFundableStrategies(
   strategies: readonly EarnStrategy[]
 ): readonly EarnStrategy[] {
-  return [...fundableStrategies(strategies)].sort((left, right) =>
-    descendingUnknownLast(strategyApy(left), strategyApy(right))
-  );
+  return sortStrategies(fundableStrategies(strategies), DEFAULT_STRATEGY_SORT);
 }
 
 /** Stablecoins the catalogue can fund; used to avoid a redundant table column. */

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
@@ -2,8 +2,11 @@ import type { EarnStrategy } from "@sdp/types";
 import { describe, expect, it } from "vitest";
 import {
   availableTokens,
+  DEFAULT_STRATEGY_SORT,
+  nextStrategySort,
   rankedFundableStrategies,
   singleStrategyAllocation,
+  sortStrategies,
 } from "./earn-deposit-model";
 
 const TIMESTAMP = "2026-07-18T09:00:00.000Z";
@@ -61,6 +64,90 @@ describe("rankedFundableStrategies", () => {
     const input = [instantLow, instantHigh];
     rankedFundableStrategies(input);
     expect(input.map((entry) => entry.id)).toEqual(["instant-low", "instant-high"]);
+  });
+});
+
+describe("sortStrategies", () => {
+  const bigPool = strategy({
+    id: "big-pool",
+    currentApy: "0.041",
+    riskMetadata: { tvlUsd: 22_000_000 },
+  });
+  const smallPool = strategy({
+    id: "small-pool",
+    currentApy: "0.058",
+    riskMetadata: { tvlUsd: 374_900 },
+  });
+  const unreportedPool = strategy({ id: "unreported-pool", currentApy: "0.051" });
+  const catalogue = [smallPool, unreportedPool, bigPool];
+
+  const ids = (entries: readonly EarnStrategy[]) => entries.map((entry) => entry.id);
+
+  it("ranks by pool size, largest first", () => {
+    expect(ids(sortStrategies(catalogue, { column: "pool", direction: "desc" }))).toEqual([
+      "big-pool",
+      "small-pool",
+      "unreported-pool",
+    ]);
+  });
+
+  it("reverses to smallest first on the ascending pass", () => {
+    expect(ids(sortStrategies(catalogue, { column: "pool", direction: "asc" }))).toEqual([
+      "small-pool",
+      "big-pool",
+      "unreported-pool",
+    ]);
+  });
+
+  it("keeps an unreported figure last in both directions", () => {
+    // A row rendering "—" is the row we know least about; ascending must not
+    // promote it above every strategy the reader can actually compare.
+    const rateless = [strategy({ id: "no-rate", currentApy: undefined }), bigPool, smallPool];
+    for (const direction of ["asc", "desc"] as const) {
+      expect(ids(sortStrategies(catalogue, { column: "pool", direction })).at(-1)).toBe(
+        "unreported-pool"
+      );
+      expect(ids(sortStrategies(rateless, { column: "apy", direction })).at(-1)).toBe("no-rate");
+    }
+  });
+
+  it("breaks ties on name, so a re-read cannot shuffle equal rows", () => {
+    const tied = [
+      strategy({ id: "gauntlet", name: "Kamino Gauntlet USDC", currentApy: "0.051" }),
+      strategy({ id: "allez", name: "Kamino Allez USDC", currentApy: "0.051" }),
+    ];
+    const order = ids(sortStrategies(tied, { column: "apy", direction: "desc" }));
+    expect(order).toEqual(["allez", "gauntlet"]);
+    // Same answer whichever order the provider happened to report them in.
+    expect(ids(sortStrategies([...tied].reverse(), { column: "apy", direction: "desc" }))).toEqual(
+      order
+    );
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [smallPool, bigPool];
+    sortStrategies(input, { column: "pool", direction: "desc" });
+    expect(ids(input)).toEqual(["small-pool", "big-pool"]);
+  });
+
+  it("is a no-op on a list already in the default order", () => {
+    const ranked = rankedFundableStrategies(catalogue);
+    expect(ids(sortStrategies(ranked, DEFAULT_STRATEGY_SORT))).toEqual(ids(ranked));
+  });
+});
+
+describe("nextStrategySort", () => {
+  it("opens a newly clicked column at descending", () => {
+    expect(nextStrategySort({ column: "apy", direction: "asc" }, "pool")).toEqual({
+      column: "pool",
+      direction: "desc",
+    });
+  });
+
+  it("flips the direction of the active column", () => {
+    const flipped = nextStrategySort(DEFAULT_STRATEGY_SORT, "apy");
+    expect(flipped).toEqual({ column: "apy", direction: "asc" });
+    expect(nextStrategySort(flipped, "apy")).toEqual(DEFAULT_STRATEGY_SORT);
   });
 });
 

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-steps.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-steps.unit.test.tsx
@@ -227,6 +227,38 @@ describe("StrategyStep", () => {
     expect(html).not.toContain("DashboardEarn.deposit.clearFilters");
   });
 
+  /**
+   * Overlap regressions. Neither renderer here does layout, so the rendered
+   * classes are the only observable — and that is exactly where both bugs lived:
+   * a class that silently never applied, and one that applied when it should not
+   * have.
+   */
+  it("keeps a long provider name inside its own column", () => {
+    const html = renderToStaticMarkup(
+      <StrategyStep
+        hasError={false}
+        isLoading={false}
+        onSelect={() => {}}
+        selectedStrategyId={null}
+        strategies={[
+          strategy({ id: "long", name: "Janus Henderson JTRSY tokenized by Centrifuge" }),
+        ]}
+        tokens={["usdc"]}
+      />
+    );
+
+    // `TableCell` merges its own classes with a plain join (no tailwind-merge)
+    // and `.whitespace-nowrap` is emitted last, so wrapping only takes effect
+    // when it is declared on the span — where an own value beats an inherited
+    // one. The clamp then bounds the row height instead of the column width.
+    const nameClasses = /<span class="([^"]*)" id="earn-strategy-long-name"/.exec(html)?.[1] ?? "";
+    expect(nameClasses).toContain("whitespace-normal");
+    expect(nameClasses).toContain("line-clamp-2");
+    expect(nameClasses).toContain("break-words");
+    // The full name stays reachable on hover even when the clamp bites.
+    expect(html).toContain('title="Janus Henderson JTRSY tokenized by Centrifuge"');
+  });
+
   it("renders an unreported pool without inventing a number", () => {
     const html = renderToStaticMarkup(
       <StrategyStep
@@ -309,6 +341,28 @@ describe("ReviewStep", () => {
     );
     expect(html).toContain("DashboardEarn.overview.providerNotConfigured");
     expect(html).not.toContain("DashboardEarn.deposit.createTitle");
+  });
+
+  it("lets a long summary value wrap instead of running back over its label", () => {
+    const html = renderToStaticMarkup(
+      <ReviewStep
+        onEditStrategy={() => {}}
+        onEditWallet={() => {}}
+        programExists={false}
+        providerUnconfigured={false}
+        strategy={strategy({ id: "long", name: "Janus Henderson JTRSY tokenized by Centrifuge" })}
+        submitError={null}
+        wallet={wallet()}
+      />
+    );
+
+    expect(html).toContain("Janus Henderson JTRSY tokenized by Centrifuge");
+    // A `shrink-0 whitespace-nowrap` value did not merely overflow the row:
+    // `justify-between` distributes negative free space, so it slid back over
+    // the label. The value now takes the slack (`ml-auto`) and wraps in it.
+    expect(html).not.toContain("whitespace-nowrap");
+    expect(html).toContain("ml-auto");
+    expect(html).toContain("break-words");
   });
 
   it("surfaces a submit failure inline", () => {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/strategy-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/strategy-step.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { EarnPortfolioToken, EarnStrategy } from "@sdp/types";
+import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon } from "lucide-react";
+import { useMemo, useState } from "react";
 import {
   Table,
   TableBody,
@@ -10,6 +12,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useTranslations } from "@/i18n/provider";
+import { cn } from "@/lib/utils";
 import { formatApy, formatUsdCompact } from "../earn-format";
 import {
   strategyCuratorLabel,
@@ -24,6 +27,60 @@ import {
   StepListSkeleton,
   StepNotice,
 } from "./earn-deposit-chrome";
+import {
+  DEFAULT_STRATEGY_SORT,
+  type EarnStrategySort,
+  type EarnStrategySortColumn,
+  nextStrategySort,
+  sortStrategies,
+} from "./earn-deposit-model";
+
+/**
+ * A numeric column the reader can rank the table by.
+ *
+ * `aria-sort` sits on the `th` and the click target is a real button inside it —
+ * the ARIA sortable-table pattern — so the current ranking is announced with the
+ * column itself rather than through a separate live region. At rest the neutral
+ * chevrons say "this column is clickable"; the active column shows the direction
+ * it is ranked in.
+ */
+function SortableColumnHeader({
+  className,
+  column,
+  label,
+  onSort,
+  sort,
+}: {
+  className: string;
+  column: EarnStrategySortColumn;
+  label: string;
+  onSort: (column: EarnStrategySortColumn) => void;
+  sort: EarnStrategySort;
+}) {
+  const active = sort.column === column;
+  const ascending = active && sort.direction === "asc";
+  const Indicator = active ? (ascending ? ArrowUpIcon : ArrowDownIcon) : ChevronsUpDownIcon;
+
+  return (
+    <TableHead
+      align="right"
+      aria-sort={active ? (ascending ? "ascending" : "descending") : "none"}
+      className={className}
+    >
+      <button
+        className="inline-flex cursor-pointer items-center gap-1.5 rounded-sm transition-colors hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/40"
+        onClick={() => onSort(column)}
+        type="button"
+      >
+        {label}
+        <Indicator
+          aria-hidden="true"
+          className={cn("size-3.5 shrink-0", active ? "text-secondary" : "text-muted")}
+        />
+      </button>
+    </TableHead>
+  );
+}
 
 function StrategyTableRow({
   onSelect,
@@ -91,11 +148,33 @@ function StrategyTableRow({
           <span className="sr-only">{t("DashboardEarn.deposit.selectStrategy")}</span>
         </label>
       </TableCell>
-      <TableCell className="whitespace-normal text-sm font-normal">
-        <span className="block text-primary" id={nameId}>
+      {/*
+        Both lines declare their OWN wrapping and their own clip, and the cell
+        declares neither.
+
+        `TableCell` joins its base classes with the design system's `cn`, which is
+        a plain string join with no tailwind-merge — and `.whitespace-nowrap` is
+        emitted after `.whitespace-normal`, so the `whitespace-normal` this cell
+        used to pass in never applied. Provider names run long ("Janus Henderson
+        JTRSY tokenized by Centrifuge"), and under `table-fixed` a nowrap name
+        overflowed its column and collided with Backing. Declaring it on the
+        spans works because an element's own value beats an inherited one.
+      */}
+      <TableCell className="text-sm font-normal">
+        {/* No `block`: line-clamp-2 sets `display:-webkit-box`, and with no
+            tailwind-merge here the two display utilities would fight. */}
+        <span
+          className="line-clamp-2 break-words whitespace-normal text-primary"
+          id={nameId}
+          title={strategy.name}
+        >
           {strategy.name}
         </span>
-        <span className="mt-1 block text-secondary">{sourceMeta || "—"}</span>
+        {/* Secondary metadata: one line, ellipsis past it — the name is what
+            must stay legible. */}
+        <span className="mt-1 block truncate text-secondary" title={sourceMeta || undefined}>
+          {sourceMeta || "—"}
+        </span>
       </TableCell>
       {showTokenColumn ? (
         <TableCell className="text-sm font-normal text-secondary">
@@ -141,6 +220,20 @@ export function StrategyStep({
   // A lone stablecoin needs no repeated table column; review still names it.
   const showTokenColumn = tokens.length > 1;
 
+  /**
+   * How the reader ranked the table. View state, held here rather than in the
+   * wizard: re-entering this step restores the default order, the same way it
+   * lands pre-scrolled at the top. The selected strategy survives either way —
+   * it is the wizard's, and it stays checked wherever the row moves to.
+   *
+   * Rows arrive already in {@link DEFAULT_STRATEGY_SORT} order, so this is a
+   * no-op until the reader clicks a column (one comparator, see the model).
+   */
+  const [sort, setSort] = useState<EarnStrategySort>(DEFAULT_STRATEGY_SORT);
+  const rows = useMemo(() => sortStrategies(strategies, sort), [sort, strategies]);
+  const sortBy = (column: EarnStrategySortColumn) =>
+    setSort((current) => nextStrategySort(current, column));
+
   return (
     <div className="space-y-4">
       {isLoading ? <StepListSkeleton rowClassName="h-32 w-full rounded-2xl" /> : null}
@@ -165,7 +258,13 @@ export function StrategyStep({
               <TableHead className="w-12">
                 <span className="sr-only">{t("DashboardEarn.deposit.strategySelectColumn")}</span>
               </TableHead>
-              <TableHead className={showTokenColumn ? "w-[25%]" : "w-[31%]"}>
+              {/* Widths follow the content. The name column carries fund names
+                  several words long ("Bitwise Crypto Carry Fund tokenized by
+                  Superstate") plus a curator line, while Backing and Access only
+                  ever hold "DeFi"/"RWA" and "Instant"/"T+n". Measured at the
+                  wizard's 830px: 41% is what lets the longest row in today's
+                  catalogue render both of its lines in full. */}
+              <TableHead className={showTokenColumn ? "w-[33%]" : "w-[41%]"}>
                 {t("DashboardEarn.deposit.strategyColumn")}
               </TableHead>
               {showTokenColumn ? (
@@ -173,22 +272,30 @@ export function StrategyStep({
                   {t("DashboardEarn.deposit.strategyStablecoinColumn")}
                 </TableHead>
               ) : null}
-              <TableHead className={showTokenColumn ? "w-[14%]" : "w-[15%]"}>
+              <TableHead className="w-[12%]">
                 {t("DashboardEarn.deposit.strategyBackingColumn")}
               </TableHead>
-              <TableHead className={showTokenColumn ? "w-[17%]" : "w-[19%]"}>
+              <TableHead className="w-[12%]">
                 {t("DashboardEarn.deposit.strategyAccessColumn")}
               </TableHead>
-              <TableHead align="right" className={showTokenColumn ? "w-[14%]" : "w-[15%]"}>
-                {t("DashboardEarn.deposit.strategyPoolColumn")}
-              </TableHead>
-              <TableHead align="right" className={showTokenColumn ? "w-[14%]" : "w-[15%]"}>
-                {t("DashboardEarn.deposit.strategyApyColumn")}
-              </TableHead>
+              <SortableColumnHeader
+                className={showTokenColumn ? "w-[14%]" : "w-[15%]"}
+                column="pool"
+                label={t("DashboardEarn.deposit.strategyPoolColumn")}
+                onSort={sortBy}
+                sort={sort}
+              />
+              <SortableColumnHeader
+                className={showTokenColumn ? "w-[14%]" : "w-[15%]"}
+                column="apy"
+                label={t("DashboardEarn.deposit.strategyApyColumn")}
+                onSort={sortBy}
+                sort={sort}
+              />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {strategies.map((strategy) => (
+            {rows.map((strategy) => (
               <StrategyTableRow
                 key={strategy.id}
                 onSelect={() => onSelect(strategy.id)}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/strategy-step.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/strategy-step.unit.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import type { EarnStrategy } from "@sdp/types";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { getMessages } from "@/i18n/messages";
+import { I18nProvider } from "@/i18n/provider";
+import { rankedFundableStrategies } from "./earn-deposit-model";
+import { StrategyStep } from "./strategy-step";
+
+/**
+ * The comparison table's ranking behaviour, driven through real clicks. The
+ * ordering rules themselves are the model's (see earn-deposit-model.unit.test);
+ * this covers the wiring the model cannot see — which header is clickable, what
+ * `aria-sort` reports, and that the rendered row order actually follows.
+ */
+
+const TIMESTAMP = "2026-07-18T09:00:00.000Z";
+const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function strategy(partial: Partial<EarnStrategy> & { id: string }): EarnStrategy {
+  return {
+    provider: "ground",
+    providerReference: `${partial.id}-ref`,
+    name: partial.id,
+    sourceKind: "defi",
+    depositMints: [USDC],
+    apyType: "variable",
+    currentApy: "0.05",
+    liquidityTerm: "instant",
+    status: "active",
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+    ...partial,
+  };
+}
+
+/** Deliberately not in either sorted order, and one row reports no pool. */
+const CATALOGUE = [
+  strategy({ id: "mid-pool", currentApy: "0.058", riskMetadata: { tvlUsd: 12_100_000 } }),
+  strategy({ id: "no-pool", currentApy: "0.041" }),
+  strategy({ id: "big-pool", currentApy: "0.051", riskMetadata: { tvlUsd: 22_000_000 } }),
+];
+
+function renderStep() {
+  return render(
+    <I18nProvider locale="en" messages={getMessages("en")}>
+      <StrategyStep
+        hasError={false}
+        isLoading={false}
+        onSelect={() => {}}
+        selectedStrategyId={null}
+        strategies={rankedFundableStrategies(CATALOGUE)}
+        tokens={["usdc"]}
+      />
+    </I18nProvider>
+  );
+}
+
+/** Rendered row order, read off the radios so it cannot drift from selection. */
+function renderedOrder(): string[] {
+  return screen.getAllByRole("radio").map((radio) => (radio as HTMLInputElement).value);
+}
+
+afterEach(cleanup);
+
+describe("StrategyStep ranking", () => {
+  it("opens on highest APY first, with that column marked descending", () => {
+    renderStep();
+    expect(renderedOrder()).toEqual(["mid-pool", "big-pool", "no-pool"]);
+    expect(screen.getByRole("columnheader", { name: "APY" }).getAttribute("aria-sort")).toBe(
+      "descending"
+    );
+    expect(screen.getByRole("columnheader", { name: "Pool size" }).getAttribute("aria-sort")).toBe(
+      "none"
+    );
+  });
+
+  it("ranks by pool size when that header is clicked, largest first", async () => {
+    renderStep();
+    await userEvent.click(screen.getByRole("button", { name: "Pool size" }));
+
+    expect(renderedOrder()).toEqual(["big-pool", "mid-pool", "no-pool"]);
+    expect(screen.getByRole("columnheader", { name: "Pool size" }).getAttribute("aria-sort")).toBe(
+      "descending"
+    );
+    // Ranking moves to the clicked column; the previous one goes neutral.
+    expect(screen.getByRole("columnheader", { name: "APY" }).getAttribute("aria-sort")).toBe(
+      "none"
+    );
+  });
+
+  it("flips direction on a second click, keeping the unreported pool last", async () => {
+    renderStep();
+    const poolHeader = screen.getByRole("button", { name: "Pool size" });
+    await userEvent.click(poolHeader);
+    await userEvent.click(poolHeader);
+
+    expect(renderedOrder()).toEqual(["mid-pool", "big-pool", "no-pool"]);
+    expect(screen.getByRole("columnheader", { name: "Pool size" }).getAttribute("aria-sort")).toBe(
+      "ascending"
+    );
+  });
+
+  it("ranks by lowest APY after clicking back onto the APY column", async () => {
+    renderStep();
+    await userEvent.click(screen.getByRole("button", { name: "Pool size" }));
+    await userEvent.click(screen.getByRole("button", { name: "APY" }));
+    expect(renderedOrder()).toEqual(["mid-pool", "big-pool", "no-pool"]);
+
+    await userEvent.click(screen.getByRole("button", { name: "APY" }));
+    expect(renderedOrder()).toEqual(["no-pool", "big-pool", "mid-pool"]);
+    expect(screen.getByRole("columnheader", { name: "APY" }).getAttribute("aria-sort")).toBe(
+      "ascending"
+    );
+  });
+
+  it("does not offer the descriptive columns as sort controls", () => {
+    renderStep();
+    // Backing and Access are labels, not rankings — nothing to compare them by.
+    expect(screen.queryByRole("button", { name: "Backing" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Access" })).toBeNull();
+  });
+});

--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -227,7 +227,10 @@ that is correct, not a bug. Grant the override in the **local** DB to proceed.
   made every Ground 4xx fall back to `"<provider> request failed with status
   <n>"`, which names the status and explains nothing, so a refused write reached
   the dashboard with its reason stripped. Do not narrow these shapes again; the
-  provider's own sentence is the most useful thing on this path.
+  provider's own sentence is the most useful thing on this path. It picks the
+  first NON-BLANK of `error` / `message` / `reason` — the first *present* one
+  would let `error: ""` beside a real `message` select the blank and fall back,
+  discarding an explanation the body did carry.
 - **Chain keys are HARD-SET in `GROUND_SOLANA_CHAINS`**
   (providers/ground/client.ts): sandbox = `solana_devnet`, production =
   `solana`. Ground confirmed (2026-08-05) sandbox supports both Ethereum

--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -220,6 +220,14 @@ that is correct, not a bug. Grant the override in the **local** DB to proceed.
   missing for an id in `EARN_PROVIDERS`.
 - All HTTP goes through `providerFetch`/`providerFetchJson` (src/fetch.ts) —
   never raw `fetch` in a client.
+- **`error` on a failure body is read as BOTH an object and a bare string**
+  (`extractProviderErrorMessage`). Measured 2026-08-14: Ground rejects a request
+  with `{"error":"Invalid query params: unknown parameter(s)","code":
+  "unknown_parameters",…}` — `error` is a STRING. Reading only `error.message`
+  made every Ground 4xx fall back to `"<provider> request failed with status
+  <n>"`, which names the status and explains nothing, so a refused write reached
+  the dashboard with its reason stripped. Do not narrow these shapes again; the
+  provider's own sentence is the most useful thing on this path.
 - **Chain keys are HARD-SET in `GROUND_SOLANA_CHAINS`**
   (providers/ground/client.ts): sandbox = `solana_devnet`, production =
   `solana`. Ground confirmed (2026-08-05) sandbox supports both Ethereum

--- a/packages/sdp-earn/src/fetch.test.ts
+++ b/packages/sdp-earn/src/fetch.test.ts
@@ -231,6 +231,30 @@ describe("providerFetchJson", () => {
     );
   });
 
+  it("skips a blank error in favour of an explanation the body does carry", async () => {
+    // The first NON-BLANK candidate wins. Taking the first PRESENT one would
+    // pick `error` here and then fall back, throwing away the real reason.
+    mock.method(globalThis, "fetch", async () =>
+      jsonResponse(400, { error: "", message: "Yield source is not fundable on this chain" })
+    );
+
+    await assert.rejects(
+      providerFetchJson("ground", "https://ground.test/v2/wallets", { method: "POST" }),
+      earnError("BAD_REQUEST", /^Yield source is not fundable on this chain$/)
+    );
+  });
+
+  it("falls through a blank error AND a blank message to reason", async () => {
+    mock.method(globalThis, "fetch", async () =>
+      jsonResponse(409, { error: { message: "  " }, message: "", reason: "Wallet is rebalancing" })
+    );
+
+    await assert.rejects(
+      providerFetchJson("ground", "https://ground.test/v2/wallets", { method: "POST" }),
+      earnError("CONFLICT", /^Wallet is rebalancing$/)
+    );
+  });
+
   it("falls back to a status message when the failure body is not JSON", async () => {
     mock.method(globalThis, "fetch", async () => new Response("Bad Gateway", { status: 502 }));
 

--- a/packages/sdp-earn/src/fetch.test.ts
+++ b/packages/sdp-earn/src/fetch.test.ts
@@ -204,6 +204,33 @@ describe("providerFetchJson", () => {
     );
   });
 
+  it("surfaces a bare string error, the shape Ground rejects writes with", async () => {
+    // Verbatim from Ground sandbox 2026-08-14. Reading only `error.message`
+    // dropped this sentence and left the caller staring at the bare status.
+    mock.method(globalThis, "fetch", async () =>
+      jsonResponse(400, {
+        error: "Invalid query params: unknown parameter(s)",
+        code: "unknown_parameters",
+        unknownKeys: ["limit"],
+        allowedKeys: [],
+      })
+    );
+
+    await assert.rejects(
+      providerFetchJson("ground", "https://ground.test/v2/wallets", { method: "POST" }),
+      earnError("BAD_REQUEST", /^Invalid query params: unknown parameter\(s\)$/)
+    );
+  });
+
+  it("falls back when a string error is blank rather than reporting an empty reason", async () => {
+    mock.method(globalThis, "fetch", async () => jsonResponse(400, { error: "   " }));
+
+    await assert.rejects(
+      providerFetchJson("ground", "https://ground.test/v2/wallets", { method: "POST" }),
+      earnError("BAD_REQUEST", /^ground request failed with status 400$/)
+    );
+  });
+
   it("falls back to a status message when the failure body is not JSON", async () => {
     mock.method(globalThis, "fetch", async () => new Response("Bad Gateway", { status: 502 }));
 

--- a/packages/sdp-earn/src/fetch.ts
+++ b/packages/sdp-earn/src/fetch.ts
@@ -48,14 +48,26 @@ export function classifyProviderStatus(status: number): SdpEarnErrorCode {
   return "BAD_REQUEST";
 }
 
+/**
+ * The provider's own explanation, from whichever field it puts it in.
+ *
+ * `error` is read BOTH as an object carrying `message` and as a bare string,
+ * because providers disagree: Ground answers a rejected write with
+ * `{"error":"Invalid query params: unknown parameter(s)","code":"…"}`, and
+ * reading only `error.message` there yields `undefined` — every Ground 4xx
+ * degraded to the caller's fallback ("ground request failed with status 400"),
+ * which names the status and explains nothing. The reason a write was refused is
+ * the most useful sentence on this path; do not narrow these shapes again.
+ */
 export function extractProviderErrorMessage(payload: unknown, fallback: string): string {
   if (!payload || typeof payload !== "object") return fallback;
   const record = payload as {
-    error?: { message?: unknown };
+    error?: { message?: unknown } | string;
     message?: unknown;
     reason?: unknown;
   };
-  const message = record.error?.message ?? record.message ?? record.reason;
+  const error = typeof record.error === "string" ? record.error : record.error?.message;
+  const message = error ?? record.message ?? record.reason;
   return typeof message === "string" && message.trim() ? message : fallback;
 }
 

--- a/packages/sdp-earn/src/fetch.ts
+++ b/packages/sdp-earn/src/fetch.ts
@@ -67,8 +67,14 @@ export function extractProviderErrorMessage(payload: unknown, fallback: string):
     reason?: unknown;
   };
   const error = typeof record.error === "string" ? record.error : record.error?.message;
-  const message = error ?? record.message ?? record.reason;
-  return typeof message === "string" && message.trim() ? message : fallback;
+  // The first NON-BLANK candidate, not merely the first PRESENT one: a body
+  // carrying `error: ""` beside a real `message` would otherwise select the
+  // blank and degrade to the fallback, discarding the explanation it did send.
+  return (
+    [error, record.message, record.reason].find(
+      (candidate): candidate is string => typeof candidate === "string" && candidate.trim() !== ""
+    ) ?? fallback
+  );
 }
 
 export async function providerFetch<TBody = never>(


### PR DESCRIPTION
Pool size and APY become clickable column headers in the deposit flow's strategy comparison table, and two overlaps that the longer provider names exposed are fixed.

## Sorting

Click a header to rank by it; the active column flips direction, and a newly clicked one opens **descending** since the large end is the interesting one for both figures. APY-descending remains the order the table opens in, so **the default view is unchanged**.

`sortStrategies` is the module's ONE comparator, and `rankedFundableStrategies` is now that function at `DEFAULT_STRATEGY_SORT` — so the step re-ranking the list it was handed is a no-op until a header is clicked. Two rules hold in **both** directions:

- **Unreported sorts last.** A row rendering `—` is the row we know least about; an ascending pass must not promote it above every row the reader can actually compare.
- **Ties break on name.** The catalogue is re-read on revalidation, so two 5.1% rows must not swap places under the reader's cursor.

`aria-sort` sits on the `th` with a real button inside it (the ARIA sortable-table pattern), so the ranking is announced with the column rather than through a separate live region. Backing and Access stay unsortable — they are labels, not rankings. Sort is the step's own state: re-entering restores the default order, the way the step already lands pre-scrolled at the top, while the selection belongs to the wizard and survives wherever its row moves.

## Two overlap fixes, different causes

Both were triggered by names like "Janus Henderson JTRSY tokenized by Centrifuge".

**The table.** The strategy cell passed `whitespace-normal`, which *never applied*: `@solana/design-system`'s `cn` is a plain string join with **no tailwind-merge**, and `.whitespace-nowrap` is emitted after `.whitespace-normal` at equal specificity — so the design system's own base class won and the name has always been `nowrap`. Under `table-fixed` it overflowed into Backing. Wrapping and clamping now sit on the spans, where an element's own value beats an inherited one. Worth knowing beyond this file: **any** class passed to a DS `Table*` that collides with one of its base classes silently loses.

**The program box.** `SummaryRow` gave the label and value the exact inverse of the working `payments/wizard-summary-list` pattern. A `shrink-0 whitespace-nowrap` value does not merely overflow — `justify-between` distributes *negative* free space, so the name slid back **over** its own label. Now `shrink-0` label, `ml-auto min-w-0 break-words` value. This also fixes the integration screen's base URL, which carried the same latent bug.

Column widths were rebalanced 31/15/19/15/15 → 41/12/12/15/15: Access only ever holds `Instant`/`T+2`, while the name column carries four-word fund names plus a curator line.

## Provider errors kept their reason

Ground answers a refused write with `{"error":"<sentence>","code":…}` — `error` is a **string**. `extractProviderErrorMessage` read only `error.message`, so every Ground 4xx degraded to `"ground request failed with status 400"`, which names the status and explains nothing. Found while diagnosing a real create failure; the shape is measured, not guessed (Ground sandbox, 2026-08-14).

## Verification

- `@sdp/earn` 98 pass, sdp-web earn 133 pass (13 new), biome clean, no new typecheck errors. Note CI does not run the sdp-web tests — they were run locally.
- The interaction has a jsdom test driving real clicks, asserting rendered row order and `aria-sort` after each one.
- Neither renderer does layout, so the overlap regressions assert the classes **and where they live** — which is precisely what broke.
- Layout was measured, not eyeballed: a standalone harness of just the CSS under test, rendered at the wizard's real 830px via Playwright. No name overflows its cell, none hit the clamp, every curator line fits in full (the longest needed 271px and now has 280px), no header overflows, and no rail value overlaps its label or escapes its row.

## Reviewer notes

- The `whitespace-normal` on the old cell was dead code, so the table has never wrapped in production — this is a first-time fix, not a regression repair.
- `descendingUnknownLast` is gone, absorbed into `sortStrategies`; behaviour for the default order is identical apart from the added name tiebreak.
- Both CLAUDE.md files are updated in-branch: the earn module's ranking/overlap rules, and `packages/sdp-earn`'s measured-Ground-behaviour conventions.
- No i18n changes — the headers reuse the existing `strategyPoolColumn` / `strategyApyColumn` labels, so the Translation Catalog Policy is not in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)