### PR TITLE
[Superseded] feat(earn): deposit into Kamino K-Vaults from an SDP custody wallet

### DIFF
--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -30,6 +30,7 @@ COPY packages/sdp-private-channels/package.json ./packages/sdp-private-channels/
 COPY packages/sdp-spc-escrow/package.json ./packages/sdp-spc-escrow/
 COPY packages/sdp-spc-withdraw/package.json ./packages/sdp-spc-withdraw/
 COPY packages/kit-augment/package.json ./packages/kit-augment/
+COPY packages/sdp-kamino/package.json ./packages/sdp-kamino/
 COPY patches ./patches
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
@@ -53,6 +54,7 @@ COPY packages/sdp-private-channels ./packages/sdp-private-channels
 COPY packages/sdp-spc-escrow ./packages/sdp-spc-escrow
 COPY packages/sdp-spc-withdraw ./packages/sdp-spc-withdraw
 COPY packages/kit-augment ./packages/kit-augment
+COPY packages/sdp-kamino ./packages/sdp-kamino
 
 WORKDIR /repo/apps/sdp-api
 RUN node scripts/build-node.mjs

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -29,6 +29,7 @@ packages/*
 !packages/sdp-spc-escrow
 !packages/sdp-spc-withdraw
 !packages/kit-augment
+!packages/sdp-kamino
 docs
 infra
 scripts

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@clerk/backend": "3.15.0",
+    "@coinbase/cdp-sdk": "1.54.0",
     "@hono/node-server": "2.0.12",
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.1.0",
@@ -51,13 +52,14 @@
     "@sdp/earn": "workspace:*",
     "@sdp/env-config": "workspace:*",
     "@sdp/issuance": "workspace:*",
+    "@sdp/kamino": "workspace:*",
     "@sdp/payments": "workspace:*",
     "@sdp/policy": "workspace:*",
     "@sdp/private-channels": "workspace:*",
     "@sdp/rpc": "workspace:*",
+    "@sdp/solana": "workspace:*",
     "@sdp/spc-escrow": "workspace:*",
     "@sdp/spc-withdraw": "workspace:*",
-    "@sdp/solana": "workspace:*",
     "@sdp/types": "workspace:*",
     "@sentry/node": "10.70.0",
     "@solana-program/system": "catalog:",
@@ -89,8 +91,7 @@
     "pino": "10.3.1",
     "react": "19.2.8",
     "resend": "6.18.1",
-    "zod": "4.4.3",
-    "@coinbase/cdp-sdk": "1.54.0"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@asteasolutions/zod-to-openapi": "9.1.0",

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -1,5 +1,36 @@
 /* biome-ignore-all lint/security/noSecrets: file contains the esbuild banner template, which trips the high-entropy heuristic */
+import { copyFileSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
 import esbuild from "esbuild";
+
+/**
+ * WASM binaries that must sit BESIDE the bundle.
+ *
+ * esbuild inlines JavaScript, but a wasm-bindgen module loads its binary at
+ * MODULE SCOPE with `readFileSync(path.join(__dirname, "<name>.wasm"))`. After
+ * bundling, `__dirname` is the output directory — `/app` in the runner image,
+ * which ships `dist/` alone with no `node_modules` — so without this the API
+ * dies ON STARTUP, not on first use, with
+ * `ENOENT: ... orca_whirlpools_core_js_bindings_bg.wasm`.
+ *
+ * The dependency is transitive and non-obvious: `@sdp/kamino` →
+ * `@kamino-finance/klend-sdk` → `@orca-so/whirlpools-core`. Nothing in the API
+ * imports Orca directly.
+ *
+ * Resolved by walking that chain rather than hard-coding a path, because pnpm's
+ * strict layout does not expose a transitive package to `apps/sdp-api` and the
+ * `.pnpm` directory name carries a version hash. A version bump therefore moves
+ * the file and this still finds it — or fails the BUILD, loudly, instead of the
+ * container at boot.
+ */
+function resolveOrcaWasm() {
+  // Anchor on the workspace package that actually depends on klend-sdk.
+  const kaminoAnchor = path.resolve("../../packages/sdp-kamino/package.json");
+  const klend = createRequire(kaminoAnchor).resolve("@kamino-finance/klend-sdk");
+  const orca = createRequire(klend).resolve("@orca-so/whirlpools-core");
+  return path.join(path.dirname(orca), "orca_whirlpools_core_js_bindings_bg.wasm");
+}
 
 // CJS interop banner for ESM output: pg and other native-backed deps still
 // reach for require/__filename/__dirname even when bundled as ESM.
@@ -32,3 +63,13 @@ await esbuild.build({
   external: ["pg-native", "@sentry/profiling-node"],
   banner: { js: banner },
 });
+
+const wasmSource = resolveOrcaWasm();
+if (!existsSync(wasmSource)) {
+  throw new Error(
+    `Expected the Orca wasm binary at ${wasmSource}. klend-sdk loads it at module scope, so a ` +
+      "missing file here means the built image dies on startup. Check whether " +
+      "@orca-so/whirlpools-core moved or renamed it."
+  );
+}
+copyFileSync(wasmSource, path.join("dist", path.basename(wasmSource)));

--- a/apps/sdp-api/src/db/migrations/postgres/0058_earn_vault_direct.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0058_earn_vault_direct.sql
@@ -1,0 +1,175 @@
+-- Solana Earn: non-custodial ("vault_direct") positions and the movements SDP
+-- initiates into them — the execution era arriving for the second provider
+-- shape (PRO-1634, ADR 0002).
+--
+-- ── Why this is not earn_provider_wallets ──────────────────────────────────
+-- That table models a CUSTODIAL program: SDP asks a provider to provision an
+-- omnibus wallet, the customer funds its address, and one provider wallet is
+-- claimable by exactly one org platform-wide (0056's global unique on
+-- (provider, provider_wallet_ref)).
+--
+-- A K-Vault is the opposite. It is a public, permissionless on-chain vault: it
+-- has no address SDP can hand out (stablecoins sent to the vault's program
+-- account are DESTROYED), SDP custodies nothing, and money moves only when a
+-- wallet SDP can sign for submits an instruction. Crucially, MANY orgs and many
+-- wallets legitimately hold the same vault at the same time — so reusing 0056's
+-- global unique would lock a public vault to whichever org deposited first.
+-- That single constraint difference is why these are separate tables rather
+-- than a nullable column on the existing one.
+--
+-- Conventions inherited from 0055 (earn_program_withdrawals):
+-- * provider is open TEXT (ADR 0001/0002 drift rule) — a row can outlive its
+--   provider's registry entry; allowed values live in code registries.
+-- * Money is decimal strings. No numeric columns anywhere.
+-- * project_id / created_by / initiated_by_key_id are forensic attribution on a
+--   money table even where no wire surface reads them.
+-- * created_at/updated_at are TEXT ISO via sdp_iso_now().
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1. The claim set: which custody wallet holds which vault.
+--
+-- NOT a balance. Balances and share counts are read LIVE from chain on every
+-- request (ADR 0002: positions are provider truth, and for a non-custodial
+-- vault the chain IS the provider). This table only records that an org opened
+-- a position, so the reads know which (wallet, vault) pairs to hydrate and the
+-- dashboard can list them without scanning every vault on the shelf.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS earn_vault_positions (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    environment TEXT NOT NULL,
+
+    provider TEXT NOT NULL,
+    -- The vault's own on-chain address (the catalogue's provider_reference).
+    provider_reference TEXT NOT NULL,
+    -- The SDP custody wallet that signs for this position and holds the shares.
+    custody_wallet_id TEXT NOT NULL,
+
+    -- Denormalised from the vault at open time so a position still renders when
+    -- the catalogue row is delisted. Never used to build an instruction — the
+    -- builder always re-reads vault state from chain.
+    share_mint TEXT,
+    token_mint TEXT,
+    label TEXT,
+
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    -- Set when the position is fully exited. Kept rather than deleted: the
+    -- movement history below references it, and a re-entry reuses the row.
+    closed_at TEXT,
+
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    -- Deliberately NO cascade: a wallet holding vault shares must not be
+    -- deletable out from under them (same fail-loud rule as 0055's wallet FK).
+    FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id),
+    FOREIGN KEY (created_by) REFERENCES users(id),
+
+    CONSTRAINT earn_vault_positions_environment_check
+        CHECK (environment IN ('sandbox', 'production'))
+);
+
+-- One row per (org, environment, provider, vault, wallet).
+--
+-- Scoped to the ORG and the WALLET — emphatically NOT global on
+-- (provider, provider_reference) the way 0056 scopes a custodial wallet. The
+-- registry is permissionless and public: two orgs holding "Steakhouse USDC" is
+-- normal, and so is one org holding it from two different wallets. A global
+-- unique here would refuse the second org's deposit outright.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_vault_positions_claim
+    ON earn_vault_positions(organization_id, environment, provider, provider_reference, custody_wallet_id);
+
+-- List path: id joins created_at as the deterministic pagination tiebreaker
+-- (same lesson as 0055 and the payment_transfers migrations).
+CREATE INDEX IF NOT EXISTS idx_earn_vault_positions_org_created
+    ON earn_vault_positions(organization_id, environment, created_at DESC, id DESC);
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2. The movement ledger: money SDP itself moved.
+--
+-- ADR 0002's rule is "SDP ledgers what SDP INITIATES; SDP reads live what the
+-- provider observes". Ground deposits are unledgered because the customer sends
+-- funds and SDP has no intent moment. Here SDP builds, signs and submits BOTH
+-- directions — so both get a row, written at intent and advanced by guarded CAS
+-- on every observation. Without it, a crash between signing and confirmation is
+-- unrecoverable: the transaction is on chain and SDP has no record it exists.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS earn_vault_movements (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    environment TEXT NOT NULL,
+    position_id TEXT NOT NULL,
+
+    provider TEXT NOT NULL,
+    provider_reference TEXT NOT NULL,
+    custody_wallet_id TEXT NOT NULL,
+
+    direction TEXT NOT NULL,
+    -- 'pending' is SDP-only intent (row exists, nothing signed yet); 'submitted'
+    -- means a signature exists and the transaction is on the wire. Both terminal
+    -- states are chain-observed.
+    status TEXT NOT NULL DEFAULT 'pending',
+
+    -- Decimal strings in the vault token's own units. amount is what was asked
+    -- for; shares is what the chain actually minted or burned, so the two are
+    -- deliberately separate and shares stays NULL until confirmation.
+    amount TEXT,
+    shares TEXT,
+
+    -- Base58 transaction signature, set at submit. A row without one never
+    -- reached the chain and is a terminal failure — no funds moved.
+    signature TEXT,
+    failure_reason TEXT,
+
+    -- Caller idempotency key, REQUIRED. A retried deposit without a stable key
+    -- double-spends, and unlike the custodial create there is no provider-side
+    -- dedupe to fall back on: the chain will happily accept the same transfer
+    -- twice.
+    request_id TEXT NOT NULL,
+
+    created_by TEXT,
+    initiated_by_key_id TEXT,
+
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    confirmed_at TEXT,
+
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    -- No cascade: money history outlives the position row.
+    FOREIGN KEY (position_id) REFERENCES earn_vault_positions(id),
+    FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id),
+    FOREIGN KEY (created_by) REFERENCES users(id),
+
+    CONSTRAINT earn_vault_movements_environment_check
+        CHECK (environment IN ('sandbox', 'production')),
+    CONSTRAINT earn_vault_movements_direction_check
+        CHECK (direction IN ('deposit', 'withdraw')),
+    CONSTRAINT earn_vault_movements_status_check
+        CHECK (status IN ('pending', 'submitted', 'confirmed', 'failed'))
+);
+
+-- SDP-side idempotency lock: one movement per caller key per organization.
+-- Org-scoped rather than position-scoped on purpose — a retry that resolves to
+-- a DIFFERENT position (e.g. the caller corrected the vault) is a different
+-- request and must not silently reuse the key.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_vault_movements_request
+    ON earn_vault_movements(organization_id, request_id);
+
+-- Chain correlation for the confirmation sweep. Partial, because a pending row
+-- legitimately has no signature yet.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_vault_movements_signature
+    ON earn_vault_movements(signature)
+    WHERE signature IS NOT NULL;
+
+-- History for one position, newest first, with the id tiebreaker.
+CREATE INDEX IF NOT EXISTS idx_earn_vault_movements_position_created
+    ON earn_vault_movements(position_id, created_at DESC, id DESC);
+
+-- The sweep's work queue: rows that reached the chain but have no outcome yet.
+CREATE INDEX IF NOT EXISTS idx_earn_vault_movements_unsettled
+    ON earn_vault_movements(status, created_at)
+    WHERE status = 'submitted';

--- a/apps/sdp-api/src/db/migrations/postgres/0058_earn_vault_direct.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0058_earn_vault_direct.sql
@@ -20,7 +20,8 @@
 -- Conventions inherited from 0055 (earn_program_withdrawals):
 -- * provider is open TEXT (ADR 0001/0002 drift rule) — a row can outlive its
 --   provider's registry entry; allowed values live in code registries.
--- * Money is decimal strings. No numeric columns anywhere.
+-- * Money is decimal strings. The only NUMERIC column is the unsigned protocol
+--   block height, so exact fund amounts round-trip without DB coercion.
 -- * project_id / created_by / initiated_by_key_id are forensic attribution on a
 --   money table even where no wire surface reads them.
 -- * created_at/updated_at are TEXT ISO via sdp_iso_now().
@@ -37,7 +38,9 @@
 CREATE TABLE IF NOT EXISTS earn_vault_positions (
     id TEXT PRIMARY KEY,
     organization_id TEXT NOT NULL,
-    project_id TEXT NOT NULL,
+    -- Forensic attribution, not ownership. Organization fallback wallets may
+    -- hold one claim for movements initiated by multiple projects.
+    project_id TEXT,
     environment TEXT NOT NULL,
 
     provider TEXT NOT NULL,
@@ -49,26 +52,39 @@ CREATE TABLE IF NOT EXISTS earn_vault_positions (
     -- Denormalised from the vault at open time so a position still renders when
     -- the catalogue row is delisted. Never used to build an instruction — the
     -- builder always re-reads vault state from chain.
-    share_mint TEXT,
-    token_mint TEXT,
-    label TEXT,
+    share_mint TEXT NOT NULL,
+    token_mint TEXT NOT NULL,
+    label TEXT NOT NULL,
 
     created_by TEXT,
     created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
     updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    -- A claim is activated only in the transaction that durably records the
+    -- signed transaction that can create the holding. Failed preflight and
+    -- idempotency losers create no position; rolled-back claims never render.
+    activated_at TEXT,
     -- Set when the position is fully exited. Kept rather than deleted: the
     -- movement history below references it, and a re-entry reuses the row.
     closed_at TEXT,
 
     FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
-    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL,
     -- Deliberately NO cascade: a wallet holding vault shares must not be
     -- deletable out from under them (same fail-loud rule as 0055's wallet FK).
     FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id),
     FOREIGN KEY (created_by) REFERENCES users(id),
 
     CONSTRAINT earn_vault_positions_environment_check
-        CHECK (environment IN ('sandbox', 'production'))
+        CHECK (environment IN ('sandbox', 'production')),
+    CONSTRAINT earn_vault_positions_movement_identity_key
+        UNIQUE (
+            id,
+            organization_id,
+            environment,
+            provider,
+            provider_reference,
+            custody_wallet_id
+        )
 );
 
 -- One row per (org, environment, provider, vault, wallet).
@@ -81,10 +97,30 @@ CREATE TABLE IF NOT EXISTS earn_vault_positions (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_vault_positions_claim
     ON earn_vault_positions(organization_id, environment, provider, provider_reference, custody_wallet_id);
 
--- List path: id joins created_at as the deterministic pagination tiebreaker
--- (same lesson as 0055 and the payment_transfers migrations).
-CREATE INDEX IF NOT EXISTS idx_earn_vault_positions_org_created
-    ON earn_vault_positions(organization_id, environment, created_at DESC, id DESC);
+-- Project-scoped list path. Every read supplies the current project's custody
+-- wallet row ids (plus organization fallbacks), pages by (created_at, id), and
+-- excludes provisional claims that never reached the signed boundary.
+CREATE INDEX IF NOT EXISTS idx_earn_vault_positions_wallet_created
+    ON earn_vault_positions(
+        organization_id,
+        environment,
+        custody_wallet_id,
+        created_at DESC,
+        id DESC
+    )
+    WHERE activated_at IS NOT NULL AND closed_at IS NULL;
+
+-- Complement the narrow-wallet index above for pages spanning many custody
+-- rows: ORDER BY can stream globally before applying the wallet-array filter.
+CREATE INDEX IF NOT EXISTS idx_earn_vault_positions_created_wallet
+    ON earn_vault_positions(
+        organization_id,
+        environment,
+        created_at DESC,
+        id DESC,
+        custody_wallet_id
+    )
+    WHERE activated_at IS NOT NULL AND closed_at IS NULL;
 
 -- ───────────────────────────────────────────────────────────────────────────
 -- 2. The movement ledger: money SDP itself moved.
@@ -92,14 +128,16 @@ CREATE INDEX IF NOT EXISTS idx_earn_vault_positions_org_created
 -- ADR 0002's rule is "SDP ledgers what SDP INITIATES; SDP reads live what the
 -- provider observes". Ground deposits are unledgered because the customer sends
 -- funds and SDP has no intent moment. Here SDP builds, signs and submits BOTH
--- directions — so both get a row, written at intent and advanced by guarded CAS
--- on every observation. Without it, a crash between signing and confirmation is
--- unrecoverable: the transaction is on chain and SDP has no record it exists.
+-- directions — so both get a row, written with the signed bytes before broadcast
+-- and advanced by guarded CAS on every observation. Without it, a crash between
+-- signing and confirmation is unrecoverable: the transaction may be on chain
+-- while SDP has no record it exists.
 -- ───────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS earn_vault_movements (
     id TEXT PRIMARY KEY,
     organization_id TEXT NOT NULL,
-    project_id TEXT NOT NULL,
+    -- Initiating project attribution; history survives project deletion.
+    project_id TEXT,
     environment TEXT NOT NULL,
     position_id TEXT NOT NULL,
 
@@ -108,20 +146,30 @@ CREATE TABLE IF NOT EXISTS earn_vault_movements (
     custody_wallet_id TEXT NOT NULL,
 
     direction TEXT NOT NULL,
-    -- 'pending' is SDP-only intent (row exists, nothing signed yet); 'submitted'
-    -- means a signature exists and the transaction is on the wire. Both terminal
-    -- states are chain-observed.
+    -- 'pending' means a signed transaction is durably recorded but is not yet
+    -- known to be on the wire; 'submitted' means broadcast returned. Both remain
+    -- nonterminal until a chain observer establishes the outcome.
     status TEXT NOT NULL DEFAULT 'pending',
 
-    -- Decimal strings in the vault token's own units. amount is what was asked
-    -- for; shares is what the chain actually minted or burned, so the two are
-    -- deliberately separate and shares stays NULL until confirmation.
-    amount TEXT,
+    -- Decimal strings in each mint's own units. Keep the caller's text for the
+    -- audit trail, but ledger `amount` / `min_shares_out` from the provider plan:
+    -- those are canonical to mint precision and are what the signed instruction
+    -- actually encodes.
+    requested_amount TEXT NOT NULL,
+    amount TEXT NOT NULL,
+    requested_min_shares_out TEXT,
+    min_shares_out TEXT,
+    -- Shares is what the chain actually minted or burned and stays NULL until
+    -- confirmation.
     shares TEXT,
 
-    -- Base58 transaction signature, set at submit. A row without one never
-    -- reached the chain and is a terminal failure — no funds moved.
-    signature TEXT,
+    -- Signed outbox payload, recorded atomically with the movement and position
+    -- activation before the bytes can reach the network. This is enough for a
+    -- reconciler to query the exact signature and, while its blockhash remains
+    -- valid, rebroadcast the exact same transaction without re-signing.
+    signature TEXT NOT NULL,
+    signed_transaction TEXT NOT NULL,
+    last_valid_block_height NUMERIC NOT NULL,
     failure_reason TEXT,
 
     -- Caller idempotency key, REQUIRED. A retried deposit without a stable key
@@ -157,9 +205,24 @@ CREATE TABLE IF NOT EXISTS earn_vault_movements (
     confirmed_at TEXT,
 
     FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
-    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
-    -- No cascade: money history outlives the position row.
-    FOREIGN KEY (position_id) REFERENCES earn_vault_positions(id),
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL,
+    -- No cascade, and the duplicated movement identity must describe the exact
+    -- parent claim rather than merely point at any position id.
+    FOREIGN KEY (
+        position_id,
+        organization_id,
+        environment,
+        provider,
+        provider_reference,
+        custody_wallet_id
+    ) REFERENCES earn_vault_positions(
+        id,
+        organization_id,
+        environment,
+        provider,
+        provider_reference,
+        custody_wallet_id
+    ),
     FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id),
     FOREIGN KEY (created_by) REFERENCES users(id),
 
@@ -168,7 +231,61 @@ CREATE TABLE IF NOT EXISTS earn_vault_movements (
     CONSTRAINT earn_vault_movements_direction_check
         CHECK (direction IN ('deposit', 'withdraw')),
     CONSTRAINT earn_vault_movements_status_check
-        CHECK (status IN ('pending', 'submitted', 'confirmed', 'failed'))
+        CHECK (status IN ('pending', 'submitted', 'confirmed', 'failed')),
+    CONSTRAINT earn_vault_movements_confirmation_metadata_check
+        CHECK (
+            (status = 'confirmed') =
+            (NULLIF(BTRIM(confirmed_at), '') IS NOT NULL)
+        ),
+    CONSTRAINT earn_vault_movements_failure_metadata_check
+        CHECK (
+            (status = 'failed') =
+            (NULLIF(BTRIM(failure_reason), '') IS NOT NULL)
+        ),
+    CONSTRAINT earn_vault_movements_amount_format_check
+        CHECK (
+            LENGTH(requested_amount) BETWEEN 1 AND 128
+            AND LENGTH(amount) BETWEEN 1 AND 128
+            AND requested_amount ~ '^\d+(\.\d+)?$'
+            AND amount ~ '^\d+(\.\d+)?$'
+            AND requested_amount ~ '[1-9]'
+            AND amount ~ '[1-9]'
+        ),
+    CONSTRAINT earn_vault_movements_amount_identity_check
+        CHECK (
+            CASE
+                WHEN LENGTH(requested_amount) BETWEEN 1 AND 128
+                 AND LENGTH(amount) BETWEEN 1 AND 128
+                 AND requested_amount ~ '^\d+(\.\d+)?$'
+                 AND amount ~ '^\d+(\.\d+)?$'
+                THEN requested_amount::NUMERIC = amount::NUMERIC
+                ELSE FALSE
+            END
+        ),
+    CONSTRAINT earn_vault_movements_floor_pair_check
+        CHECK ((requested_min_shares_out IS NULL) = (min_shares_out IS NULL)),
+    CONSTRAINT earn_vault_movements_floor_identity_check
+        CHECK (
+            CASE
+                WHEN requested_min_shares_out IS NULL AND min_shares_out IS NULL
+                THEN TRUE
+                WHEN requested_min_shares_out IS NOT NULL
+                 AND min_shares_out IS NOT NULL
+                 AND LENGTH(requested_min_shares_out) BETWEEN 1 AND 128
+                 AND LENGTH(min_shares_out) BETWEEN 1 AND 128
+                 AND requested_min_shares_out ~ '^\d+(\.\d+)?$'
+                 AND min_shares_out ~ '^\d+(\.\d+)?$'
+                 AND requested_min_shares_out ~ '[1-9]'
+                 AND min_shares_out ~ '[1-9]'
+                THEN requested_min_shares_out::NUMERIC = min_shares_out::NUMERIC
+                ELSE FALSE
+            END
+        ),
+    CONSTRAINT earn_vault_movements_last_valid_block_height_check
+        CHECK (
+            last_valid_block_height = TRUNC(last_valid_block_height)
+            AND last_valid_block_height BETWEEN 0 AND 18446744073709551615
+        )
 );
 
 -- SDP-side idempotency lock: one movement per caller key per organization.
@@ -178,17 +295,22 @@ CREATE TABLE IF NOT EXISTS earn_vault_movements (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_vault_movements_request
     ON earn_vault_movements(organization_id, request_id);
 
--- Chain correlation for the confirmation sweep. Partial, because a pending row
--- legitimately has no signature yet.
+-- Chain correlation for the confirmation sweep.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_vault_movements_signature
-    ON earn_vault_movements(signature)
-    WHERE signature IS NOT NULL;
+    ON earn_vault_movements(signature);
 
 -- History for one position, newest first, with the id tiebreaker.
 CREATE INDEX IF NOT EXISTS idx_earn_vault_movements_position_created
     ON earn_vault_movements(position_id, created_at DESC, id DESC);
 
--- The sweep's work queue: rows that reached the chain but have no outcome yet.
+-- Hot existence probe for active-list defense and failed-attempt cleanup.
+CREATE INDEX IF NOT EXISTS idx_earn_vault_movements_position_live_evidence
+    ON earn_vault_movements(position_id)
+    WHERE status IN ('pending', 'submitted', 'confirmed');
+
+-- The sweep's work queue: every signed row without a chain outcome. A broadcast
+-- timeout or crash leaves `pending` WITH a signature, so indexing only
+-- `submitted` would omit precisely the ambiguous rows reconciliation is for.
 CREATE INDEX IF NOT EXISTS idx_earn_vault_movements_unsettled
-    ON earn_vault_movements(status, created_at)
-    WHERE status = 'submitted';
+    ON earn_vault_movements(created_at ASC, id ASC)
+    WHERE status IN ('pending', 'submitted');

--- a/apps/sdp-api/src/db/migrations/postgres/0058_earn_vault_direct.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0058_earn_vault_direct.sql
@@ -129,6 +129,25 @@ CREATE TABLE IF NOT EXISTS earn_vault_movements (
     -- dedupe to fall back on: the chain will happily accept the same transfer
     -- twice.
     request_id TEXT NOT NULL,
+    -- Canonical fingerprint of the request that wrote this row.
+    --
+    -- The key alone is not enough, and the gap is not hypothetical. Matching on
+    -- `request_id` only cannot distinguish a genuine RETRY from a DIFFERENT
+    -- request wearing the same key: reusing a key with another vault, wallet or
+    -- amount would return 200 carrying the ORIGINAL movement's signature. And
+    -- because the position is claimed as part of the same call, such a request
+    -- would also open a real position row for the new vault and then answer
+    -- with the old vault's transaction — a response that is not merely stale
+    -- but self-contradictory.
+    --
+    -- Storing the fingerprint lets the replay path compare INTENT, not just the
+    -- key, and answer 409 on mismatch. NOT NULL follows 0055's earn convention
+    -- rather than the nullable payments one, because the caller key is required
+    -- on this route: a NULL fingerprint would read as "unclaimed" to
+    -- `resolveIdempotencyReplay` and turn the replay backstop into an
+    -- unrecoverable unique-violation instead of a clean 409.
+    -- Built by `buildEarnVaultDepositFingerprint` (src/lib/idempotency.ts).
+    idempotency_fingerprint TEXT NOT NULL,
 
     created_by TEXT,
     initiated_by_key_id TEXT,

--- a/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
@@ -1,18 +1,8 @@
 import type { SdpEnvironment } from "@sdp/types";
-import type { AppDb } from "@/db";
+import { type AppDb, asTransactionalClient } from "@/db";
 import { conflict } from "@/lib/errors";
 
-/**
- * Persistence for NON-CUSTODIAL ("vault_direct") Earn positions and the money
- * SDP itself moves into and out of them (migration 0058).
- *
- * Kept out of `earn.repository.ts` deliberately: that file models the custodial
- * program — a provider-provisioned wallet with a fundable address, uniquely
- * claimed platform-wide. These tables model the opposite shape, and the
- * constraint that differs (many orgs may hold the same public vault) is the
- * whole reason they are separate. Mixing them invites someone to "unify" the
- * two uniques, which would lock a permissionless vault to its first depositor.
- */
+/** Persistence for signed, non-custodial Earn vault movements and holdings. */
 
 export function generateEarnVaultPositionId(): string {
   return `earn_vault_position_${crypto.randomUUID()}`;
@@ -28,24 +18,25 @@ export type EarnVaultMovementStatus = "pending" | "submitted" | "confirmed" | "f
 export interface EarnVaultPositionRow {
   id: string;
   organization_id: string;
-  project_id: string;
+  project_id: string | null;
   environment: SdpEnvironment;
   provider: string;
   provider_reference: string;
   custody_wallet_id: string;
-  share_mint: string | null;
-  token_mint: string | null;
-  label: string | null;
+  share_mint: string;
+  token_mint: string;
+  label: string;
   created_by: string | null;
   created_at: string;
   updated_at: string;
+  activated_at: string | null;
   closed_at: string | null;
 }
 
 export interface EarnVaultMovementRow {
   id: string;
   organization_id: string;
-  project_id: string;
+  project_id: string | null;
   environment: SdpEnvironment;
   position_id: string;
   provider: string;
@@ -53,19 +44,18 @@ export interface EarnVaultMovementRow {
   custody_wallet_id: string;
   direction: EarnVaultMovementDirection;
   status: EarnVaultMovementStatus;
-  amount: string | null;
+  requested_amount: string;
+  amount: string;
+  requested_min_shares_out: string | null;
+  min_shares_out: string | null;
   shares: string | null;
-  signature: string | null;
+  signature: string;
+  signed_transaction: string;
+  last_valid_block_height: string;
   failure_reason: string | null;
   request_id: string;
-  /**
-   * Canonical fingerprint of the request that created this row, so a reused
-   * `request_id` carrying a different intent is a 409 rather than a silent
-   * replay of someone else's deposit. Built by
-   * `buildEarnVaultDepositFingerprint`; nullable in the TYPE only to satisfy
-   * `resolveIdempotencyReplay`'s generic, NOT NULL in the schema (0059).
-   */
-  idempotency_fingerprint: string | null;
+  /** Canonical request fingerprint; NOT NULL in migration 0058. */
+  idempotency_fingerprint: string;
   created_by: string | null;
   initiated_by_key_id: string | null;
   created_at: string;
@@ -73,32 +63,25 @@ export interface EarnVaultMovementRow {
   confirmed_at: string | null;
 }
 
-export interface ClaimEarnVaultPositionInput {
+export interface CreateSignedEarnVaultDepositIntentInput {
   organizationId: string;
   projectId: string;
   environment: SdpEnvironment;
   provider: string;
   providerReference: string;
   custodyWalletId: string;
-  shareMint?: string | null;
-  tokenMint?: string | null;
-  label?: string | null;
-  createdBy?: string | null;
-}
-
-export interface CreateEarnVaultMovementInput {
-  organizationId: string;
-  projectId: string;
-  environment: SdpEnvironment;
-  positionId: string;
-  provider: string;
-  providerReference: string;
-  custodyWalletId: string;
-  direction: EarnVaultMovementDirection;
+  shareMint: string;
+  tokenMint: string;
+  label: string;
+  requestedAmount: string;
+  acceptedAmount: string;
+  requestedMinSharesOut?: string | null;
+  acceptedMinSharesOut?: string | null;
+  signature: string;
+  signedTransaction: string;
+  lastValidBlockHeight: string;
   requestId: string;
-  /** Canonical fingerprint of this request; compared on replay (0059). */
   idempotencyFingerprint: string;
-  amount?: string | null;
   createdBy?: string | null;
   initiatedByKeyId?: string | null;
 }
@@ -106,28 +89,28 @@ export interface CreateEarnVaultMovementInput {
 export interface AdvanceEarnVaultMovementInput {
   movementId: string;
   organizationId: string;
-  /**
-   * The states this transition is legal FROM. The guard is the point: two
-   * observers (the submit path and the confirmation sweep) race on the same row,
-   * and a blind UPDATE would let a late failure overwrite a settled success.
-   */
+  /** Legal source states for this guarded transition. */
   fromStatuses: readonly EarnVaultMovementStatus[];
   toStatus: EarnVaultMovementStatus;
-  signature?: string | null;
   shares?: string | null;
   failureReason?: string | null;
   confirmedAt?: string | null;
 }
 
+export interface EarnVaultPositionCursor {
+  createdAt: string;
+  id: string;
+}
+
 export interface EarnVaultRepository {
   /**
-   * Record that an org holds a vault from a wallet, or return the existing row.
-   *
-   * Idempotent by design (`ON CONFLICT … DO UPDATE`): opening a position is not
-   * the money movement — the deposit is — so a second deposit into the same
-   * vault from the same wallet must find the same position rather than fail.
+   * Atomically claim/refresh the position, insert the signed movement, and
+   * activate the holding. A divergent idempotency loser throws so the entire
+   * claim rolls back; an identical loser returns the winning signed row.
    */
-  claimPosition(input: ClaimEarnVaultPositionInput): Promise<EarnVaultPositionRow>;
+  createSignedDepositIntent(
+    input: CreateSignedEarnVaultDepositIntentInput
+  ): Promise<{ position: EarnVaultPositionRow; movement: EarnVaultMovementRow; replayed: boolean }>;
   getPositionById(params: {
     organizationId: string;
     environment: SdpEnvironment;
@@ -136,35 +119,11 @@ export interface EarnVaultRepository {
   listPositions(params: {
     organizationId: string;
     environment: SdpEnvironment;
-    /**
-     * Restrict to these `custody_wallets.id` values — the API key's wallet
-     * bindings, already translated out of the provider id space by the caller.
-     *
-     * `undefined` means UNBOUND and applies no filter. An empty array is
-     * refused rather than treated as "no filter": that mistake is how a scope
-     * check silently widens to everything, so the caller must short-circuit
-     * before reaching here.
-     */
-    custodyWalletIds?: readonly string[];
-  }): Promise<EarnVaultPositionRow[]>;
-
-  /**
-   * Write the intent row BEFORE anything is signed.
-   *
-   * Returns the existing row on an idempotency-key collision instead of
-   * throwing: that is what makes a retried deposit safe. The chain has no
-   * request-id dedupe, so this row is the only thing standing between a retry
-   * and a second real transfer.
-   *
-   * Callers must resolve the replay through `findMovementByRequestId` +
-   * `resolveIdempotencyReplay` FIRST, so a key reused with a different intent
-   * 409s before anything else is written. The collision handling here is the
-   * backstop for the concurrent case, where two identical requests race.
-   */
-  createMovement(
-    input: CreateEarnVaultMovementInput
-  ): Promise<{ row: EarnVaultMovementRow; replayed: boolean }>;
-  /** The movement holding this caller key, for the replay/fingerprint check. */
+    /** Always the current project's wallet rows plus organization fallbacks. */
+    custodyWalletIds: readonly string[];
+    limit: number;
+    before?: EarnVaultPositionCursor;
+  }): Promise<{ rows: EarnVaultPositionRow[]; hasMore: boolean }>;
   findMovementByRequestId(params: {
     organizationId: string;
     requestId: string;
@@ -182,158 +141,276 @@ export interface EarnVaultRepository {
   }): Promise<EarnVaultMovementRow[]>;
 }
 
+function assertMovementFingerprint(movement: EarnVaultMovementRow, fingerprint: string): void {
+  if (movement.idempotency_fingerprint !== fingerprint) {
+    throw conflict("Idempotency key already used with different request payload");
+  }
+}
+
+function assertValidMovementTransition(input: AdvanceEarnVaultMovementInput): void {
+  if (input.fromStatuses.length === 0) {
+    throw new Error("advanceMovement requires at least one source status");
+  }
+  if (new Set(input.fromStatuses).size !== input.fromStatuses.length) {
+    throw new Error("advanceMovement source statuses must be unique");
+  }
+
+  const validSources =
+    input.toStatus === "submitted"
+      ? input.fromStatuses.length === 1 && input.fromStatuses[0] === "pending"
+      : (input.toStatus === "confirmed" || input.toStatus === "failed") &&
+        input.fromStatuses.every((status) => status === "pending" || status === "submitted");
+  if (!validSources) {
+    throw new Error(
+      `Illegal earn vault movement transition: ${input.fromStatuses.join("|")} -> ${input.toStatus}`
+    );
+  }
+  if (input.failureReason !== undefined && input.toStatus !== "failed") {
+    throw new Error("failureReason is only valid when failing an earn vault movement");
+  }
+  if (input.confirmedAt !== undefined && input.toStatus !== "confirmed") {
+    throw new Error("confirmedAt is only valid when confirming an earn vault movement");
+  }
+  if (input.shares !== undefined && input.toStatus !== "confirmed") {
+    throw new Error("shares are only valid when confirming an earn vault movement");
+  }
+  if (input.toStatus === "confirmed" && !input.confirmedAt?.trim()) {
+    throw new Error("confirmedAt is required when confirming an earn vault movement");
+  }
+  if (input.toStatus === "failed" && !input.failureReason?.trim()) {
+    throw new Error("failureReason is required when failing an earn vault movement");
+  }
+}
+
+async function findMovementByRequestId(
+  db: AppDb,
+  organizationId: string,
+  requestId: string
+): Promise<EarnVaultMovementRow | null> {
+  return db
+    .prepare(`SELECT * FROM earn_vault_movements WHERE organization_id = ? AND request_id = ?`)
+    .bind(organizationId, requestId)
+    .first<EarnVaultMovementRow>();
+}
+
+async function getPositionById(
+  db: AppDb,
+  params: { organizationId: string; environment: SdpEnvironment; positionId: string }
+): Promise<EarnVaultPositionRow | null> {
+  return db
+    .prepare(
+      `SELECT * FROM earn_vault_positions
+       WHERE id = ? AND organization_id = ? AND environment = ?`
+    )
+    .bind(params.positionId, params.organizationId, params.environment)
+    .first<EarnVaultPositionRow>();
+}
+
+async function requireMovementPosition(
+  db: AppDb,
+  movement: EarnVaultMovementRow
+): Promise<EarnVaultPositionRow> {
+  const position = await getPositionById(db, {
+    organizationId: movement.organization_id,
+    environment: movement.environment,
+    positionId: movement.position_id,
+  });
+  if (!position) {
+    throw new Error(
+      `Earn vault movement ${movement.id} references missing position ${movement.position_id}`
+    );
+  }
+  return position;
+}
+
+async function claimPosition(
+  db: AppDb,
+  input: CreateSignedEarnVaultDepositIntentInput
+): Promise<EarnVaultPositionRow> {
+  const row = await db
+    .prepare(
+      `INSERT INTO earn_vault_positions (
+         id, organization_id, project_id, environment,
+         provider, provider_reference, custody_wallet_id,
+         share_mint, token_mint, label, created_by, activated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, sdp_iso_now())
+       ON CONFLICT (organization_id, environment, provider, provider_reference, custody_wallet_id)
+       DO UPDATE SET
+         updated_at = sdp_iso_now(),
+         label = EXCLUDED.label,
+         activated_at = COALESCE(earn_vault_positions.activated_at, sdp_iso_now()),
+         closed_at = NULL
+       WHERE earn_vault_positions.token_mint = EXCLUDED.token_mint
+         AND earn_vault_positions.share_mint = EXCLUDED.share_mint
+       RETURNING *`
+    )
+    .bind(
+      generateEarnVaultPositionId(),
+      input.organizationId,
+      input.projectId,
+      input.environment,
+      input.provider,
+      input.providerReference,
+      input.custodyWalletId,
+      input.shareMint,
+      input.tokenMint,
+      input.label,
+      input.createdBy ?? null
+    )
+    .first<EarnVaultPositionRow>();
+  if (!row) {
+    throw conflict("Vault asset identity changed for an existing position");
+  }
+  return row;
+}
+
+async function insertMovement(
+  db: AppDb,
+  input: CreateSignedEarnVaultDepositIntentInput,
+  positionId: string
+): Promise<EarnVaultMovementRow | null> {
+  return db
+    .prepare(
+      `INSERT INTO earn_vault_movements (
+         id, organization_id, project_id, environment, position_id,
+         provider, provider_reference, custody_wallet_id,
+         direction, request_id, idempotency_fingerprint,
+         requested_amount, amount, requested_min_shares_out, min_shares_out,
+         signature, signed_transaction, last_valid_block_height,
+         created_by, initiated_by_key_id
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'deposit', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (organization_id, request_id) DO NOTHING
+       RETURNING *`
+    )
+    .bind(
+      generateEarnVaultMovementId(),
+      input.organizationId,
+      input.projectId,
+      input.environment,
+      positionId,
+      input.provider,
+      input.providerReference,
+      input.custodyWalletId,
+      input.requestId,
+      input.idempotencyFingerprint,
+      input.requestedAmount,
+      input.acceptedAmount,
+      input.requestedMinSharesOut ?? null,
+      input.acceptedMinSharesOut ?? null,
+      input.signature,
+      input.signedTransaction,
+      input.lastValidBlockHeight,
+      input.createdBy ?? null,
+      input.initiatedByKeyId ?? null
+    )
+    .first<EarnVaultMovementRow>();
+}
+
 export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepository {
   return {
-    async claimPosition(input) {
-      const id = generateEarnVaultPositionId();
-      const row = await db
-        .prepare(
-          `INSERT INTO earn_vault_positions (
-             id, organization_id, project_id, environment,
-             provider, provider_reference, custody_wallet_id,
-             share_mint, token_mint, label, created_by
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT (organization_id, environment, provider, provider_reference, custody_wallet_id)
-           DO UPDATE SET
-             updated_at = sdp_iso_now(),
-             -- Re-entering a fully-exited position reopens the same row rather
-             -- than stranding history under a closed one.
-             closed_at = NULL,
-             -- COALESCE keeps a previously-learned mint when a later claim omits
-             -- it; never overwrite known chain identity with NULL.
-             share_mint = COALESCE(EXCLUDED.share_mint, earn_vault_positions.share_mint),
-             token_mint = COALESCE(EXCLUDED.token_mint, earn_vault_positions.token_mint),
-             label = COALESCE(EXCLUDED.label, earn_vault_positions.label)
-           RETURNING *`
-        )
-        .bind(
-          id,
+    async createSignedDepositIntent(input) {
+      // This remains a real transaction for ordinary requests. When the caller
+      // supplied an approved-operation transaction, asTransactionalClient makes
+      // this nested call execute inline on that same connection.
+      return db.transaction(async (executor) => {
+        const transaction = asTransactionalClient(executor);
+
+        const prior = await findMovementByRequestId(
+          transaction,
           input.organizationId,
-          input.projectId,
-          input.environment,
-          input.provider,
-          input.providerReference,
-          input.custodyWalletId,
-          input.shareMint ?? null,
-          input.tokenMint ?? null,
-          input.label ?? null,
-          input.createdBy ?? null
-        )
-        .first<EarnVaultPositionRow>();
-      if (!row) throw new Error("Failed to claim earn vault position");
-      return row;
+          input.requestId
+        );
+        if (prior) {
+          assertMovementFingerprint(prior, input.idempotencyFingerprint);
+          return {
+            position: await requireMovementPosition(transaction, prior),
+            movement: prior,
+            replayed: true,
+          };
+        }
+
+        const claimed = await claimPosition(transaction, input);
+        const inserted = await insertMovement(transaction, input, claimed.id);
+        if (!inserted) {
+          // A concurrent request committed after the preflight. A divergent
+          // fingerprint throws and rolls the claim back with this transaction.
+          const winner = await findMovementByRequestId(
+            transaction,
+            input.organizationId,
+            input.requestId
+          );
+          if (!winner) throw new Error("Failed to resolve concurrent earn vault movement");
+          assertMovementFingerprint(winner, input.idempotencyFingerprint);
+          return {
+            position: await requireMovementPosition(transaction, winner),
+            movement: winner,
+            replayed: true,
+          };
+        }
+
+        return {
+          position: claimed,
+          movement: inserted,
+          replayed: false,
+        };
+      });
     },
 
     async getPositionById(params) {
-      return await db
-        .prepare(
-          `SELECT * FROM earn_vault_positions
-           WHERE id = ? AND organization_id = ? AND environment = ?`
-        )
-        .bind(params.positionId, params.organizationId, params.environment)
-        .first<EarnVaultPositionRow>();
+      return getPositionById(db, params);
     },
 
     async listPositions(params) {
-      const scoped = params.custodyWalletIds;
-      if (scoped !== undefined && scoped.length === 0) {
-        // Fail LOUD rather than returning the whole org. An empty allow-list
-        // means "bound to nothing that qualifies", and the one thing it must
-        // never do is degrade into no filter at all.
-        throw new Error(
-          "listPositions received an empty custodyWalletIds allow-list; the caller must " +
-            "short-circuit to an empty page instead of querying."
-        );
+      if (params.custodyWalletIds.length === 0) {
+        throw new Error("listPositions requires at least one project-scoped custody wallet id");
       }
-
-      const placeholders = scoped?.map(() => "?").join(", ");
+      const beforeClause = params.before ? "AND (created_at, id) < (?, ?)" : "";
+      const beforeValues = params.before ? [params.before.createdAt, params.before.id] : [];
       const result = await db
         .prepare(
           `SELECT * FROM earn_vault_positions
-           WHERE organization_id = ? AND environment = ?
-           ${placeholders ? `AND custody_wallet_id IN (${placeholders})` : ""}
-           ORDER BY created_at DESC, id DESC`
-        )
-        .bind(params.organizationId, params.environment, ...(scoped ?? []))
-        .all<EarnVaultPositionRow>();
-      return result.results ?? [];
-    },
-
-    async createMovement(input) {
-      const id = generateEarnVaultMovementId();
-      const inserted = await db
-        .prepare(
-          `INSERT INTO earn_vault_movements (
-             id, organization_id, project_id, environment, position_id,
-             provider, provider_reference, custody_wallet_id,
-             direction, request_id, idempotency_fingerprint,
-             amount, created_by, initiated_by_key_id
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT (organization_id, request_id) DO NOTHING
-           RETURNING *`
+           WHERE organization_id = ?
+             AND environment = ?
+             AND activated_at IS NOT NULL
+             AND closed_at IS NULL
+             AND custody_wallet_id = ANY (?::text[])
+             AND EXISTS (
+               SELECT 1
+               FROM earn_vault_movements movement
+               WHERE movement.position_id = earn_vault_positions.id
+                 AND movement.status IN ('pending', 'submitted', 'confirmed')
+             )
+             ${beforeClause}
+           ORDER BY created_at DESC, id DESC
+           LIMIT ?`
         )
         .bind(
-          id,
-          input.organizationId,
-          input.projectId,
-          input.environment,
-          input.positionId,
-          input.provider,
-          input.providerReference,
-          input.custodyWalletId,
-          input.direction,
-          input.requestId,
-          input.idempotencyFingerprint,
-          input.amount ?? null,
-          input.createdBy ?? null,
-          input.initiatedByKeyId ?? null
+          params.organizationId,
+          params.environment,
+          params.custodyWalletIds,
+          ...beforeValues,
+          params.limit + 1
         )
-        .first<EarnVaultMovementRow>();
-
-      if (inserted) return { row: inserted, replayed: false };
-
-      // DO NOTHING means the key was already used — a concurrent identical
-      // request won the race (the differing-intent case 409s before we get
-      // here). Return that row rather than moving money a second time.
-      const existing = await db
-        .prepare(`SELECT * FROM earn_vault_movements WHERE organization_id = ? AND request_id = ?`)
-        .bind(input.organizationId, input.requestId)
-        .first<EarnVaultMovementRow>();
-      if (!existing) throw new Error("Failed to create earn vault movement");
-      // Re-check the fingerprint here too. The preflight resolved against a
-      // read taken before the insert, so a request that lost the race to a
-      // DIFFERENT intent would otherwise be handed that other deposit's row.
-      if (
-        existing.idempotency_fingerprint !== null &&
-        existing.idempotency_fingerprint !== input.idempotencyFingerprint
-      ) {
-        throw conflict("Idempotency key already used with different request payload");
-      }
-      return { row: existing, replayed: true };
+        .all<EarnVaultPositionRow>();
+      const rows = result.results ?? [];
+      return { rows: rows.slice(0, params.limit), hasMore: rows.length > params.limit };
     },
 
     async findMovementByRequestId(params) {
-      return await db
-        .prepare(`SELECT * FROM earn_vault_movements WHERE organization_id = ? AND request_id = ?`)
-        .bind(params.organizationId, params.requestId)
-        .first<EarnVaultMovementRow>();
+      return findMovementByRequestId(db, params.organizationId, params.requestId);
     },
 
     async getMovementById(params) {
-      return await db
+      return db
         .prepare(`SELECT * FROM earn_vault_movements WHERE id = ? AND organization_id = ?`)
         .bind(params.movementId, params.organizationId)
         .first<EarnVaultMovementRow>();
     },
 
     async advanceMovement(input) {
+      assertValidMovementTransition(input);
       const assignments = ["status = ?", "updated_at = sdp_iso_now()"];
       const values: unknown[] = [input.toStatus];
-      // `undefined` means "leave alone"; an explicit null is a real write.
-      if (input.signature !== undefined) {
-        assignments.push("signature = ?");
-        values.push(input.signature);
-      }
       if (input.shares !== undefined) {
         assignments.push("shares = ?");
         values.push(input.shares);
@@ -348,15 +425,53 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
       }
 
       const guards = input.fromStatuses.map(() => "?").join(", ");
-      return await db
-        .prepare(
-          `UPDATE earn_vault_movements
-             SET ${assignments.join(", ")}
-           WHERE id = ? AND organization_id = ? AND status IN (${guards})
-           RETURNING *`
-        )
-        .bind(...values, input.movementId, input.organizationId, ...input.fromStatuses)
-        .first<EarnVaultMovementRow>();
+      const advance = (target: AppDb) =>
+        target
+          .prepare(
+            `UPDATE earn_vault_movements
+               SET ${assignments.join(", ")}
+             WHERE id = ? AND organization_id = ? AND status IN (${guards})
+             RETURNING *`
+          )
+          .bind(...values, input.movementId, input.organizationId, ...input.fromStatuses)
+          .first<EarnVaultMovementRow>();
+
+      if (input.toStatus !== "failed") return advance(db);
+
+      return db.transaction(async (executor) => {
+        const transaction = asTransactionalClient(executor);
+        const candidate = await transaction
+          .prepare(
+            `SELECT position_id
+             FROM earn_vault_movements
+             WHERE id = ? AND organization_id = ?`
+          )
+          .bind(input.movementId, input.organizationId)
+          .first<{ position_id: string }>();
+        if (!candidate) return null;
+        await transaction
+          .prepare("SELECT id FROM earn_vault_positions WHERE id = ? FOR UPDATE")
+          .bind(candidate.position_id)
+          .first<{ id: string }>();
+        const movement = await advance(transaction);
+        if (!movement) return null;
+        await transaction
+          .prepare(
+            `UPDATE earn_vault_positions position
+             SET activated_at = NULL, updated_at = sdp_iso_now()
+             WHERE position.id = ?
+               AND position.activated_at IS NOT NULL
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM earn_vault_movements movement
+                 WHERE movement.position_id = position.id
+                   AND movement.status IN ('pending', 'submitted', 'confirmed')
+               )`
+          )
+          .bind(movement.position_id)
+          .run();
+        return movement;
+      });
     },
 
     async listMovements(params) {

--- a/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
@@ -1,0 +1,301 @@
+import type { SdpEnvironment } from "@sdp/types";
+import type { AppDb } from "@/db";
+
+/**
+ * Persistence for NON-CUSTODIAL ("vault_direct") Earn positions and the money
+ * SDP itself moves into and out of them (migration 0058).
+ *
+ * Kept out of `earn.repository.ts` deliberately: that file models the custodial
+ * program — a provider-provisioned wallet with a fundable address, uniquely
+ * claimed platform-wide. These tables model the opposite shape, and the
+ * constraint that differs (many orgs may hold the same public vault) is the
+ * whole reason they are separate. Mixing them invites someone to "unify" the
+ * two uniques, which would lock a permissionless vault to its first depositor.
+ */
+
+export function generateEarnVaultPositionId(): string {
+  return `earn_vault_position_${crypto.randomUUID()}`;
+}
+
+export function generateEarnVaultMovementId(): string {
+  return `earn_vault_movement_${crypto.randomUUID()}`;
+}
+
+export type EarnVaultMovementDirection = "deposit" | "withdraw";
+export type EarnVaultMovementStatus = "pending" | "submitted" | "confirmed" | "failed";
+
+export interface EarnVaultPositionRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  environment: SdpEnvironment;
+  provider: string;
+  provider_reference: string;
+  custody_wallet_id: string;
+  share_mint: string | null;
+  token_mint: string | null;
+  label: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+}
+
+export interface EarnVaultMovementRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  environment: SdpEnvironment;
+  position_id: string;
+  provider: string;
+  provider_reference: string;
+  custody_wallet_id: string;
+  direction: EarnVaultMovementDirection;
+  status: EarnVaultMovementStatus;
+  amount: string | null;
+  shares: string | null;
+  signature: string | null;
+  failure_reason: string | null;
+  request_id: string;
+  created_by: string | null;
+  initiated_by_key_id: string | null;
+  created_at: string;
+  updated_at: string;
+  confirmed_at: string | null;
+}
+
+export interface ClaimEarnVaultPositionInput {
+  organizationId: string;
+  projectId: string;
+  environment: SdpEnvironment;
+  provider: string;
+  providerReference: string;
+  custodyWalletId: string;
+  shareMint?: string | null;
+  tokenMint?: string | null;
+  label?: string | null;
+  createdBy?: string | null;
+}
+
+export interface CreateEarnVaultMovementInput {
+  organizationId: string;
+  projectId: string;
+  environment: SdpEnvironment;
+  positionId: string;
+  provider: string;
+  providerReference: string;
+  custodyWalletId: string;
+  direction: EarnVaultMovementDirection;
+  requestId: string;
+  amount?: string | null;
+  createdBy?: string | null;
+  initiatedByKeyId?: string | null;
+}
+
+export interface AdvanceEarnVaultMovementInput {
+  movementId: string;
+  organizationId: string;
+  /**
+   * The states this transition is legal FROM. The guard is the point: two
+   * observers (the submit path and the confirmation sweep) race on the same row,
+   * and a blind UPDATE would let a late failure overwrite a settled success.
+   */
+  fromStatuses: readonly EarnVaultMovementStatus[];
+  toStatus: EarnVaultMovementStatus;
+  signature?: string | null;
+  shares?: string | null;
+  failureReason?: string | null;
+  confirmedAt?: string | null;
+}
+
+export interface EarnVaultRepository {
+  /**
+   * Record that an org holds a vault from a wallet, or return the existing row.
+   *
+   * Idempotent by design (`ON CONFLICT … DO UPDATE`): opening a position is not
+   * the money movement — the deposit is — so a second deposit into the same
+   * vault from the same wallet must find the same position rather than fail.
+   */
+  claimPosition(input: ClaimEarnVaultPositionInput): Promise<EarnVaultPositionRow>;
+  getPositionById(params: {
+    organizationId: string;
+    environment: SdpEnvironment;
+    positionId: string;
+  }): Promise<EarnVaultPositionRow | null>;
+  listPositions(params: {
+    organizationId: string;
+    environment: SdpEnvironment;
+  }): Promise<EarnVaultPositionRow[]>;
+
+  /**
+   * Write the intent row BEFORE anything is signed.
+   *
+   * Returns the existing row on an idempotency-key collision instead of
+   * throwing: that is what makes a retried deposit safe. The chain has no
+   * request-id dedupe, so this row is the only thing standing between a retry
+   * and a second real transfer.
+   */
+  createMovement(
+    input: CreateEarnVaultMovementInput
+  ): Promise<{ row: EarnVaultMovementRow; replayed: boolean }>;
+  /** Guarded CAS. Returns null when the row was not in `fromStatuses`. */
+  advanceMovement(input: AdvanceEarnVaultMovementInput): Promise<EarnVaultMovementRow | null>;
+  listMovements(params: {
+    organizationId: string;
+    positionId: string;
+    limit?: number;
+  }): Promise<EarnVaultMovementRow[]>;
+}
+
+export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepository {
+  return {
+    async claimPosition(input) {
+      const id = generateEarnVaultPositionId();
+      const row = await db
+        .prepare(
+          `INSERT INTO earn_vault_positions (
+             id, organization_id, project_id, environment,
+             provider, provider_reference, custody_wallet_id,
+             share_mint, token_mint, label, created_by
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT (organization_id, environment, provider, provider_reference, custody_wallet_id)
+           DO UPDATE SET
+             updated_at = sdp_iso_now(),
+             -- Re-entering a fully-exited position reopens the same row rather
+             -- than stranding history under a closed one.
+             closed_at = NULL,
+             -- COALESCE keeps a previously-learned mint when a later claim omits
+             -- it; never overwrite known chain identity with NULL.
+             share_mint = COALESCE(EXCLUDED.share_mint, earn_vault_positions.share_mint),
+             token_mint = COALESCE(EXCLUDED.token_mint, earn_vault_positions.token_mint),
+             label = COALESCE(EXCLUDED.label, earn_vault_positions.label)
+           RETURNING *`
+        )
+        .bind(
+          id,
+          input.organizationId,
+          input.projectId,
+          input.environment,
+          input.provider,
+          input.providerReference,
+          input.custodyWalletId,
+          input.shareMint ?? null,
+          input.tokenMint ?? null,
+          input.label ?? null,
+          input.createdBy ?? null
+        )
+        .first<EarnVaultPositionRow>();
+      if (!row) throw new Error("Failed to claim earn vault position");
+      return row;
+    },
+
+    async getPositionById(params) {
+      return await db
+        .prepare(
+          `SELECT * FROM earn_vault_positions
+           WHERE id = ? AND organization_id = ? AND environment = ?`
+        )
+        .bind(params.positionId, params.organizationId, params.environment)
+        .first<EarnVaultPositionRow>();
+    },
+
+    async listPositions(params) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM earn_vault_positions
+           WHERE organization_id = ? AND environment = ?
+           ORDER BY created_at DESC, id DESC`
+        )
+        .bind(params.organizationId, params.environment)
+        .all<EarnVaultPositionRow>();
+      return result.results ?? [];
+    },
+
+    async createMovement(input) {
+      const id = generateEarnVaultMovementId();
+      const inserted = await db
+        .prepare(
+          `INSERT INTO earn_vault_movements (
+             id, organization_id, project_id, environment, position_id,
+             provider, provider_reference, custody_wallet_id,
+             direction, request_id, amount, created_by, initiated_by_key_id
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT (organization_id, request_id) DO NOTHING
+           RETURNING *`
+        )
+        .bind(
+          id,
+          input.organizationId,
+          input.projectId,
+          input.environment,
+          input.positionId,
+          input.provider,
+          input.providerReference,
+          input.custodyWalletId,
+          input.direction,
+          input.requestId,
+          input.amount ?? null,
+          input.createdBy ?? null,
+          input.initiatedByKeyId ?? null
+        )
+        .first<EarnVaultMovementRow>();
+
+      if (inserted) return { row: inserted, replayed: false };
+
+      // DO NOTHING means the key was already used. Return that row — the caller
+      // reports the original movement rather than moving money a second time.
+      const existing = await db
+        .prepare(`SELECT * FROM earn_vault_movements WHERE organization_id = ? AND request_id = ?`)
+        .bind(input.organizationId, input.requestId)
+        .first<EarnVaultMovementRow>();
+      if (!existing) throw new Error("Failed to create earn vault movement");
+      return { row: existing, replayed: true };
+    },
+
+    async advanceMovement(input) {
+      const assignments = ["status = ?", "updated_at = sdp_iso_now()"];
+      const values: unknown[] = [input.toStatus];
+      // `undefined` means "leave alone"; an explicit null is a real write.
+      if (input.signature !== undefined) {
+        assignments.push("signature = ?");
+        values.push(input.signature);
+      }
+      if (input.shares !== undefined) {
+        assignments.push("shares = ?");
+        values.push(input.shares);
+      }
+      if (input.failureReason !== undefined) {
+        assignments.push("failure_reason = ?");
+        values.push(input.failureReason);
+      }
+      if (input.confirmedAt !== undefined) {
+        assignments.push("confirmed_at = ?");
+        values.push(input.confirmedAt);
+      }
+
+      const guards = input.fromStatuses.map(() => "?").join(", ");
+      return await db
+        .prepare(
+          `UPDATE earn_vault_movements
+             SET ${assignments.join(", ")}
+           WHERE id = ? AND organization_id = ? AND status IN (${guards})
+           RETURNING *`
+        )
+        .bind(...values, input.movementId, input.organizationId, ...input.fromStatuses)
+        .first<EarnVaultMovementRow>();
+    },
+
+    async listMovements(params) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM earn_vault_movements
+           WHERE organization_id = ? AND position_id = ?
+           ORDER BY created_at DESC, id DESC
+           LIMIT ?`
+        )
+        .bind(params.organizationId, params.positionId, params.limit ?? 50)
+        .all<EarnVaultMovementRow>();
+      return result.results ?? [];
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
@@ -1,5 +1,6 @@
 import type { SdpEnvironment } from "@sdp/types";
 import type { AppDb } from "@/db";
+import { conflict } from "@/lib/errors";
 
 /**
  * Persistence for NON-CUSTODIAL ("vault_direct") Earn positions and the money
@@ -57,6 +58,14 @@ export interface EarnVaultMovementRow {
   signature: string | null;
   failure_reason: string | null;
   request_id: string;
+  /**
+   * Canonical fingerprint of the request that created this row, so a reused
+   * `request_id` carrying a different intent is a 409 rather than a silent
+   * replay of someone else's deposit. Built by
+   * `buildEarnVaultDepositFingerprint`; nullable in the TYPE only to satisfy
+   * `resolveIdempotencyReplay`'s generic, NOT NULL in the schema (0059).
+   */
+  idempotency_fingerprint: string | null;
   created_by: string | null;
   initiated_by_key_id: string | null;
   created_at: string;
@@ -87,6 +96,8 @@ export interface CreateEarnVaultMovementInput {
   custodyWalletId: string;
   direction: EarnVaultMovementDirection;
   requestId: string;
+  /** Canonical fingerprint of this request; compared on replay (0059). */
+  idempotencyFingerprint: string;
   amount?: string | null;
   createdBy?: string | null;
   initiatedByKeyId?: string | null;
@@ -125,6 +136,16 @@ export interface EarnVaultRepository {
   listPositions(params: {
     organizationId: string;
     environment: SdpEnvironment;
+    /**
+     * Restrict to these `custody_wallets.id` values — the API key's wallet
+     * bindings, already translated out of the provider id space by the caller.
+     *
+     * `undefined` means UNBOUND and applies no filter. An empty array is
+     * refused rather than treated as "no filter": that mistake is how a scope
+     * check silently widens to everything, so the caller must short-circuit
+     * before reaching here.
+     */
+    custodyWalletIds?: readonly string[];
   }): Promise<EarnVaultPositionRow[]>;
 
   /**
@@ -134,10 +155,24 @@ export interface EarnVaultRepository {
    * throwing: that is what makes a retried deposit safe. The chain has no
    * request-id dedupe, so this row is the only thing standing between a retry
    * and a second real transfer.
+   *
+   * Callers must resolve the replay through `findMovementByRequestId` +
+   * `resolveIdempotencyReplay` FIRST, so a key reused with a different intent
+   * 409s before anything else is written. The collision handling here is the
+   * backstop for the concurrent case, where two identical requests race.
    */
   createMovement(
     input: CreateEarnVaultMovementInput
   ): Promise<{ row: EarnVaultMovementRow; replayed: boolean }>;
+  /** The movement holding this caller key, for the replay/fingerprint check. */
+  findMovementByRequestId(params: {
+    organizationId: string;
+    requestId: string;
+  }): Promise<EarnVaultMovementRow | null>;
+  getMovementById(params: {
+    movementId: string;
+    organizationId: string;
+  }): Promise<EarnVaultMovementRow | null>;
   /** Guarded CAS. Returns null when the row was not in `fromStatuses`. */
   advanceMovement(input: AdvanceEarnVaultMovementInput): Promise<EarnVaultMovementRow | null>;
   listMovements(params: {
@@ -200,13 +235,26 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
     },
 
     async listPositions(params) {
+      const scoped = params.custodyWalletIds;
+      if (scoped !== undefined && scoped.length === 0) {
+        // Fail LOUD rather than returning the whole org. An empty allow-list
+        // means "bound to nothing that qualifies", and the one thing it must
+        // never do is degrade into no filter at all.
+        throw new Error(
+          "listPositions received an empty custodyWalletIds allow-list; the caller must " +
+            "short-circuit to an empty page instead of querying."
+        );
+      }
+
+      const placeholders = scoped?.map(() => "?").join(", ");
       const result = await db
         .prepare(
           `SELECT * FROM earn_vault_positions
            WHERE organization_id = ? AND environment = ?
+           ${placeholders ? `AND custody_wallet_id IN (${placeholders})` : ""}
            ORDER BY created_at DESC, id DESC`
         )
-        .bind(params.organizationId, params.environment)
+        .bind(params.organizationId, params.environment, ...(scoped ?? []))
         .all<EarnVaultPositionRow>();
       return result.results ?? [];
     },
@@ -218,8 +266,9 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
           `INSERT INTO earn_vault_movements (
              id, organization_id, project_id, environment, position_id,
              provider, provider_reference, custody_wallet_id,
-             direction, request_id, amount, created_by, initiated_by_key_id
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             direction, request_id, idempotency_fingerprint,
+             amount, created_by, initiated_by_key_id
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT (organization_id, request_id) DO NOTHING
            RETURNING *`
         )
@@ -234,6 +283,7 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
           input.custodyWalletId,
           input.direction,
           input.requestId,
+          input.idempotencyFingerprint,
           input.amount ?? null,
           input.createdBy ?? null,
           input.initiatedByKeyId ?? null
@@ -242,14 +292,38 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
 
       if (inserted) return { row: inserted, replayed: false };
 
-      // DO NOTHING means the key was already used. Return that row — the caller
-      // reports the original movement rather than moving money a second time.
+      // DO NOTHING means the key was already used — a concurrent identical
+      // request won the race (the differing-intent case 409s before we get
+      // here). Return that row rather than moving money a second time.
       const existing = await db
         .prepare(`SELECT * FROM earn_vault_movements WHERE organization_id = ? AND request_id = ?`)
         .bind(input.organizationId, input.requestId)
         .first<EarnVaultMovementRow>();
       if (!existing) throw new Error("Failed to create earn vault movement");
+      // Re-check the fingerprint here too. The preflight resolved against a
+      // read taken before the insert, so a request that lost the race to a
+      // DIFFERENT intent would otherwise be handed that other deposit's row.
+      if (
+        existing.idempotency_fingerprint !== null &&
+        existing.idempotency_fingerprint !== input.idempotencyFingerprint
+      ) {
+        throw conflict("Idempotency key already used with different request payload");
+      }
       return { row: existing, replayed: true };
+    },
+
+    async findMovementByRequestId(params) {
+      return await db
+        .prepare(`SELECT * FROM earn_vault_movements WHERE organization_id = ? AND request_id = ?`)
+        .bind(params.organizationId, params.requestId)
+        .first<EarnVaultMovementRow>();
+    },
+
+    async getMovementById(params) {
+      return await db
+        .prepare(`SELECT * FROM earn_vault_movements WHERE id = ? AND organization_id = ?`)
+        .bind(params.movementId, params.organizationId)
+        .first<EarnVaultMovementRow>();
     },
 
     async advanceMovement(input) {

--- a/apps/sdp-api/src/lib/idempotency.test.ts
+++ b/apps/sdp-api/src/lib/idempotency.test.ts
@@ -1,11 +1,39 @@
 import { describe, expect, it } from "vitest";
 import { AppError } from "@/lib/errors";
 import {
+  buildEarnVaultDepositFingerprint,
   buildPaymentTransferFingerprint,
   buildTransferBatchFingerprint,
   normalizeForFingerprint,
   resolveIdempotencyReplay,
 } from "./idempotency";
+
+describe("buildEarnVaultDepositFingerprint", () => {
+  const base = {
+    environment: "sandbox",
+    provider: "kamino",
+    providerReference: "vault_1",
+    custodyWalletId: "cwlt_1",
+    amount: "1",
+    minSharesOut: "0.5",
+  };
+
+  it("normalizes insignificant decimal zeroes without rounding", () => {
+    expect(buildEarnVaultDepositFingerprint(base)).toBe(
+      buildEarnVaultDepositFingerprint({
+        ...base,
+        amount: "0001.000000",
+        minSharesOut: "00.5000",
+      })
+    );
+  });
+
+  it("keeps different exact decimal magnitudes distinct", () => {
+    expect(buildEarnVaultDepositFingerprint(base)).not.toBe(
+      buildEarnVaultDepositFingerprint({ ...base, amount: "1.000001" })
+    );
+  });
+});
 
 describe("resolveIdempotencyReplay", () => {
   it("returns null when no row has claimed the key", async () => {

--- a/apps/sdp-api/src/lib/idempotency.ts
+++ b/apps/sdp-api/src/lib/idempotency.ts
@@ -138,6 +138,48 @@ export const buildTransferBatchFingerprint = (input: TransferBatchFingerprintInp
     })
   );
 
+export interface EarnVaultDepositFingerprintInput {
+  environment: string;
+  provider: string;
+  /** The vault address. */
+  providerReference: string;
+  /** The `custody_wallets` row id that signs and holds the shares. */
+  custodyWalletId: string;
+  amount: string;
+  /** The slippage floor, or null when none applies. */
+  minSharesOut: string | null;
+}
+
+/**
+ * Fingerprint for a non-custodial vault deposit.
+ *
+ * Every field here changes WHAT MOVES, which is the whole test for inclusion.
+ * `minSharesOut` earns its place for a reason that is easy to miss: the floor is
+ * baked into the built instruction, so omitting it would let a caller reuse a
+ * key with a weaker floor — or none — and get a silent `replayed: true` for the
+ * original, stricter deposit. `environment` is included because the same key
+ * arriving in sandbox and in production is two requests against two chains.
+ *
+ * Amounts are NOT numerically normalised, unlike the earn WITHDRAWAL
+ * fingerprint. That one matches a provider wire where `100` and `100.00` are
+ * literally one request; there is no such wire here, and the vault builder now
+ * refuses any amount finer than the mint, so distinct strings are distinct
+ * intents and should conflict rather than silently replay.
+ */
+export const buildEarnVaultDepositFingerprint = (input: EarnVaultDepositFingerprintInput): string =>
+  JSON.stringify(
+    normalizeForFingerprint({
+      scope: "earn_vault_deposit",
+      environment: input.environment,
+      provider: input.provider,
+      providerReference: input.providerReference,
+      custodyWalletId: input.custodyWalletId,
+      direction: "deposit",
+      amount: input.amount,
+      minSharesOut: input.minSharesOut,
+    })
+  );
+
 export interface EarnWithdrawalFingerprintInput {
   providerWalletRef: string;
   amountUsd: string;

--- a/apps/sdp-api/src/lib/idempotency.ts
+++ b/apps/sdp-api/src/lib/idempotency.ts
@@ -150,6 +150,16 @@ export interface EarnVaultDepositFingerprintInput {
   minSharesOut: string | null;
 }
 
+/** Canonicalize decimal spelling without rounding or passing through a float. */
+function normalizeDecimalString(value: string): string {
+  const [integer = "0", fraction = ""] = value.split(".");
+  const normalizedInteger = integer.replace(/^0+(?=\d)/, "") || "0";
+  const normalizedFraction = fraction.replace(/0+$/, "");
+  return normalizedFraction === ""
+    ? normalizedInteger
+    : `${normalizedInteger}.${normalizedFraction}`;
+}
+
 /**
  * Fingerprint for a non-custodial vault deposit.
  *
@@ -160,11 +170,10 @@ export interface EarnVaultDepositFingerprintInput {
  * original, stricter deposit. `environment` is included because the same key
  * arriving in sandbox and in production is two requests against two chains.
  *
- * Amounts are NOT numerically normalised, unlike the earn WITHDRAWAL
- * fingerprint. That one matches a provider wire where `100` and `100.00` are
- * literally one request; there is no such wire here, and the vault builder now
- * refuses any amount finer than the mint, so distinct strings are distinct
- * intents and should conflict rather than silently replay.
+ * Decimal spelling is normalized without rounding. The builder accepts
+ * insignificant zeroes and canonicalizes them to the same mint atoms, so `1`
+ * and `1.000000` are one intent. Non-zero sub-atom precision remains distinct
+ * here and is rejected by the provider builder before anything is signed.
  */
 export const buildEarnVaultDepositFingerprint = (input: EarnVaultDepositFingerprintInput): string =>
   JSON.stringify(
@@ -175,8 +184,8 @@ export const buildEarnVaultDepositFingerprint = (input: EarnVaultDepositFingerpr
       providerReference: input.providerReference,
       custodyWalletId: input.custodyWalletId,
       direction: "deposit",
-      amount: input.amount,
-      minSharesOut: input.minSharesOut,
+      amount: normalizeDecimalString(input.amount),
+      minSharesOut: input.minSharesOut === null ? null : normalizeDecimalString(input.minSharesOut),
     })
   );
 

--- a/apps/sdp-api/src/routes/earn.vault-positions.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault-positions.test.ts
@@ -1,0 +1,355 @@
+import { hashString } from "@sdp/payments/hash";
+import type { CachedApiKey } from "@sdp/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
+
+const readVaultPositions = vi.hoisted(() => vi.fn());
+const assertClusterEndpoint = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/earn/execution-registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/earn/execution-registry")>()),
+  resolveVaultDirectClient: () => ({ readVaultPositions }),
+  resolveClusterRpcUrl: () => "https://rpc.example.invalid",
+  assertClusterEndpoint,
+}));
+
+const ORG = "org_vault_positions";
+const USER = "usr_vault_positions";
+const PROJECT_A = "prj_vault_positions_a";
+const PROJECT_B = "prj_vault_positions_b";
+const CONFIG_A = "cfg_vault_positions_a";
+const CONFIG_B = "cfg_vault_positions_b";
+const WALLET_A = "cwlt_vault_positions_a";
+const WALLET_B = "cwlt_vault_positions_b";
+const PROVIDER_WALLET_A = "privy_vault_positions_a";
+const PROVIDER_WALLET_B = "privy_vault_positions_b";
+const PUBLIC_KEY_A = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const PUBLIC_KEY_B = "3nMFwZXwY1s1M5s8vYAHqd4wGs4iSxXE4LRoUMMYqEgF";
+const TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
+const API_KEY = { id: "key_vault_positions", raw: "sk_test_vault_positions" };
+
+function cachedKey(): CachedApiKey {
+  return {
+    id: API_KEY.id,
+    organizationId: ORG,
+    projectId: PROJECT_A,
+    role: "api_admin",
+    permissions: ["*"],
+    environment: "sandbox",
+    rateLimitTier: "standard",
+    allowedIps: null,
+    signingWalletId: null,
+    status: "active",
+    expiresAt: null,
+  };
+}
+
+async function seedScope(): Promise<void> {
+  const keyHash = await hashString(API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, cachedKey());
+  await getDb(env).batch([
+    getDb(env)
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(ORG, "Vault Positions Org", "vault-positions", "enterprise", "active"),
+    getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')")
+      .bind(USER, "vault-positions@example.com"),
+    ...[PROJECT_A, PROJECT_B].map((projectId, index) =>
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects
+             (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, ?, ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, ORG, `Project ${index}`, `vault-positions-${index}`, USER)
+    ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'api_admin', '["*"]'::jsonb, 'active')`
+      )
+      .bind(API_KEY.id, ORG, PROJECT_A, USER, "Vault key", "sk_test_vau", keyHash),
+    ...[
+      [CONFIG_A, PROJECT_A, WALLET_A, PROVIDER_WALLET_A, PUBLIC_KEY_A],
+      [CONFIG_B, PROJECT_B, WALLET_B, PROVIDER_WALLET_B, PUBLIC_KEY_B],
+    ].flatMap(([configId, projectId, walletId, providerWalletId, publicKey]) => [
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs
+             (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES (?, ?, ?, 'privy', 'encrypted', 'active')`
+        )
+        .bind(configId, ORG, projectId),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, status)
+           VALUES (?, ?, ?, ?, 'active')`
+        )
+        .bind(walletId, configId, providerWalletId, publicKey),
+    ]),
+  ]);
+}
+
+async function createPosition(params: {
+  projectId?: string;
+  walletId?: string;
+  providerReference?: string;
+  signature?: string;
+  requestId?: string;
+}) {
+  const providerReference = params.providerReference ?? `vault_${crypto.randomUUID()}`;
+  const walletId = params.walletId ?? WALLET_A;
+  return createPostgresEarnVaultRepository(getDb(env)).createSignedDepositIntent({
+    organizationId: ORG,
+    projectId: params.projectId ?? PROJECT_A,
+    environment: "sandbox",
+    provider: "kamino",
+    providerReference,
+    custodyWalletId: walletId,
+    tokenMint: TOKEN_MINT,
+    shareMint: SHARE_MINT,
+    label: `Vault ${providerReference}`,
+    requestedAmount: "1",
+    acceptedAmount: "1",
+    signature: params.signature ?? `sig_${crypto.randomUUID()}`,
+    signedTransaction: "AQ==",
+    lastValidBlockHeight: "12345",
+    requestId: params.requestId ?? crypto.randomUUID(),
+    idempotencyFingerprint: `fingerprint_${providerReference}`,
+    createdBy: USER,
+  });
+}
+
+function getPositions(query = "") {
+  return app.request(
+    `/v1/earn/vault-positions${query}`,
+    { headers: { Authorization: `Bearer ${API_KEY.raw}` } },
+    env
+  );
+}
+
+beforeEach(async () => {
+  env.MARKETS_ENABLED = "true";
+  env.EARN_ENABLED = "true";
+  await seedTestDatabase(env);
+  await clearKVStores(env);
+  await seedScope();
+  vi.clearAllMocks();
+  assertClusterEndpoint.mockResolvedValue(undefined);
+  readVaultPositions.mockImplementation(
+    async (_ctx: unknown, input: { owner: string; providerReferences: string[] }) =>
+      input.providerReferences.map((providerReference) => ({
+        providerReference,
+        owner: input.owner,
+        cluster: "devnet",
+        shares: "1",
+        tokenValue: "1",
+        tokenMint: TOKEN_MINT,
+        shareMint: SHARE_MINT,
+      }))
+  );
+});
+
+describe("GET /v1/earn/vault-positions", () => {
+  it("never exposes a sibling project's wallet position to an unbound project key", async () => {
+    const own = await createPosition({});
+    await createPosition({
+      projectId: PROJECT_B,
+      walletId: WALLET_B,
+      providerReference: "vault_sibling",
+    });
+
+    const response = await getPositions();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { positions: Array<{ id: string; custodyWalletId: string; label: string }> };
+    };
+
+    expect(body.data.positions).toEqual([
+      expect.objectContaining({
+        id: own.position.id,
+        custodyWalletId: WALLET_A,
+        label: own.position.label,
+      }),
+    ]);
+    expect(readVaultPositions).toHaveBeenCalledTimes(1);
+    expect(assertClusterEndpoint).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes no rows for an ambiguous selected-wallet provider id", async () => {
+    const orgConfigId = "cfg_vault_positions_org_fallback";
+    const orgWalletId = "cwlt_vault_positions_org_fallback";
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs
+             (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES (?, ?, NULL, 'privy', 'encrypted', 'active')`
+        )
+        .bind(orgConfigId, ORG),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, status)
+           VALUES (?, ?, ?, ?, 'active')`
+        )
+        .bind(orgWalletId, orgConfigId, PROVIDER_WALLET_A, PUBLIC_KEY_B),
+    ]);
+    await createPosition({ providerReference: "vault_project_binding" });
+    await createPosition({
+      walletId: orgWalletId,
+      providerReference: "vault_org_binding",
+      signature: "sig_org_binding",
+    });
+    const keyHash = await hashString(API_KEY.raw, env.API_KEY_PEPPER);
+    await seedCachedApiKey(env, keyHash, {
+      ...cachedKey(),
+      signingWalletId: PROVIDER_WALLET_A,
+      walletBindings: [{ walletId: PROVIDER_WALLET_A, permissions: ["earn:read"] }],
+    });
+
+    const response = await getPositions();
+    const body = (await response.json()) as { data: { positions: unknown[] } };
+
+    expect(response.status).toBe(200);
+    expect(body.data.positions).toEqual([]);
+    expect(assertClusterEndpoint).not.toHaveBeenCalled();
+    expect(readVaultPositions).not.toHaveBeenCalled();
+  });
+
+  it("returns stable bounded keyset pages without overlap", async () => {
+    await createPosition({ providerReference: "vault_page_1" });
+    await createPosition({ providerReference: "vault_page_2" });
+    await createPosition({ providerReference: "vault_page_3" });
+
+    const firstResponse = await getPositions("?limit=2");
+    const first = (await firstResponse.json()) as {
+      data: { positions: Array<{ id: string }>; hasMore: boolean; nextCursor: string | null };
+    };
+    expect(first.data.positions).toHaveLength(2);
+    expect(first.data.hasMore).toBe(true);
+    expect(first.data.nextCursor).toEqual(expect.any(String));
+
+    const secondResponse = await getPositions(
+      `?limit=2&before=${encodeURIComponent(first.data.nextCursor ?? "")}`
+    );
+    const second = (await secondResponse.json()) as {
+      data: { positions: Array<{ id: string }>; hasMore: boolean; nextCursor: string | null };
+    };
+    expect(second.data.positions).toHaveLength(1);
+    expect(second.data.hasMore).toBe(false);
+    expect(second.data.nextCursor).toBeNull();
+    expect(
+      first.data.positions.some((row) => second.data.positions.some((next) => next.id === row.id))
+    ).toBe(false);
+  });
+
+  it("does not attach live balances under a mismatched asset identity", async () => {
+    await createPosition({ providerReference: "vault_identity_mismatch" });
+    readVaultPositions.mockResolvedValue([
+      {
+        providerReference: "vault_identity_mismatch",
+        owner: PUBLIC_KEY_A,
+        cluster: "devnet",
+        shares: "99",
+        tokenValue: "99",
+        tokenMint: PUBLIC_KEY_B,
+        shareMint: SHARE_MINT,
+      },
+    ]);
+
+    const response = await getPositions();
+    const body = (await response.json()) as {
+      data: { positions: Array<Record<string, unknown>> };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.positions).toHaveLength(1);
+    expect(body.data.positions[0]).toMatchObject({
+      tokenMint: TOKEN_MINT,
+      shareMint: SHARE_MINT,
+    });
+    expect(body.data.positions[0]).not.toHaveProperty("shares");
+    expect(body.data.positions[0]).not.toHaveProperty("tokenValue");
+  });
+
+  it.each([
+    ["owner", { owner: PUBLIC_KEY_B }],
+    ["amount", { shares: "NaN" }],
+  ] as const)("does not attach live balances under a mismatched %s", async (kind, override) => {
+    const providerReference = `vault_${kind}_mismatch`;
+    await createPosition({ providerReference });
+    readVaultPositions.mockResolvedValue([
+      {
+        providerReference,
+        owner: PUBLIC_KEY_A,
+        cluster: "devnet",
+        shares: "99",
+        tokenValue: "99",
+        tokenMint: TOKEN_MINT,
+        shareMint: SHARE_MINT,
+        ...override,
+      },
+    ]);
+
+    const response = await getPositions();
+    const body = (await response.json()) as {
+      data: { positions: Array<Record<string, unknown>> };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.positions).toHaveLength(1);
+    expect(body.data.positions[0]).not.toHaveProperty("shares");
+    expect(body.data.positions[0]).not.toHaveProperty("tokenValue");
+  });
+
+  it("rejects an invalid cursor and caps page size", async () => {
+    expect((await getPositions("?before=not-a-cursor")).status).toBe(400);
+    expect((await getPositions("?limit=101")).status).toBe(400);
+  });
+
+  it("caps live wallet hydration at eight concurrent calls", async () => {
+    for (let index = 0; index < 10; index += 1) {
+      const walletId = `cwlt_vault_positions_many_${index}`;
+      await getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, status)
+           VALUES (?, ?, ?, ?, 'active')`
+        )
+        .bind(walletId, CONFIG_A, `privy_many_${index}`, `public_key_many_${index}`)
+        .run();
+      await createPosition({
+        walletId,
+        providerReference: `vault_many_${index}`,
+        signature: `sig_many_${index}`,
+        requestId: `11111111-1111-4111-8111-${String(index).padStart(12, "0")}`,
+      });
+    }
+
+    let active = 0;
+    let maximum = 0;
+    readVaultPositions.mockImplementation(async () => {
+      active += 1;
+      maximum = Math.max(maximum, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return [];
+    });
+
+    const response = await getPositions("?limit=20");
+
+    expect(response.status).toBe(200);
+    expect(readVaultPositions).toHaveBeenCalledTimes(10);
+    expect(maximum).toBe(8);
+    expect(assertClusterEndpoint).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -1,0 +1,278 @@
+import { hashString } from "@sdp/payments/hash";
+import type { CachedApiKey } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import {
+  createPostgresEarnRepository,
+  type EarnStrategyRow,
+  type UpsertEarnStrategyInput,
+} from "@/db/repositories";
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
+
+/**
+ * `POST /v1/earn/vault-deposits` — the gates and the idempotency contract.
+ *
+ * Two of these titles are load-bearing beyond this file:
+ * `value-moving-conformance.node.test.ts` names them verbatim as the `earn`
+ * family's replay evidence, so renaming one fails that test rather than
+ * silently dropping the guarantee.
+ *
+ * Everything here stops at or before the chain: the deposit path is gated,
+ * resolved and ledgered long before an RPC is reached, and the cases that
+ * matter for authorization and replay are all decided in that stretch.
+ */
+
+const TEST_ORG = { id: "org_earn_vault", name: "Earn Vault Org", slug: "earn-vault" };
+const TEST_PROJECT = { id: "prj_test_earn_vault", slug: "test-earn-vault-project" };
+const TEST_PRODUCTION_PROJECT = {
+  id: "prj_test_earn_vault_prod",
+  slug: "test-earn-vault-project-prod",
+};
+const TEST_USER = { id: "usr_earn_vault", email: "earn-vault@example.com" };
+const TEST_API_KEY = {
+  id: "key_earn_vault",
+  raw: "sk_test_earn_vault",
+  prefix: "sk_test_ear",
+};
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT.id,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const WALLET_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+
+let originalMarketsEnabled: string | undefined;
+let originalEarnEnabled: string | undefined;
+
+async function seedAuth(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+
+  await getDb(env).batch([
+    getDb(env)
+      .prepare(
+        "INSERT INTO organizations (id, name, slug, tier, status, settings) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(
+        TEST_ORG.id,
+        TEST_ORG.name,
+        TEST_ORG.slug,
+        "enterprise",
+        "active",
+        JSON.stringify({ providerOverrides: { earn: { kamino: true } } })
+      ),
+    getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+      .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    getDb(env)
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_PROJECT.id,
+        TEST_ORG.id,
+        "Test Project",
+        TEST_PROJECT.slug,
+        "sandbox",
+        "active",
+        TEST_USER.id
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_PRODUCTION_PROJECT.id,
+        TEST_ORG.id,
+        "Production Project",
+        TEST_PRODUCTION_PROJECT.slug,
+        "production",
+        "active",
+        TEST_USER.id
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_API_KEY.id,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_USER.id,
+        "Earn Vault Test Key",
+        TEST_API_KEY.prefix,
+        keyHash,
+        "api_admin",
+        JSON.stringify(["*"]),
+        "active"
+      ),
+  ]);
+}
+
+async function seedStrategy(
+  overrides: Partial<UpsertEarnStrategyInput> = {}
+): Promise<EarnStrategyRow> {
+  const strategy = await createPostgresEarnRepository(getDb(env)).upsertStrategy({
+    provider: "kamino",
+    providerReference: `vault-${crypto.randomUUID()}`,
+    name: "Test USDC Vault",
+    sourceKind: "defi",
+    underlyingSource: "kamino",
+    depositMints: [USDC_MINT],
+    shareMint: null,
+    apyType: "variable",
+    currentApy: "0.062",
+    liquidityTerm: "instant",
+    redemptionDelayDays: null,
+    riskMetadata: {},
+    status: "active",
+    hostCluster: "devnet",
+    environment: "sandbox",
+    ...overrides,
+  });
+  if (!strategy) throw new Error("Failed to seed earn strategy");
+  return strategy;
+}
+
+function postVaultDeposit(body: Record<string, unknown>) {
+  return app.request(
+    "/v1/earn/vault-deposits",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    env
+  );
+}
+
+beforeEach(async () => {
+  originalMarketsEnabled = env.MARKETS_ENABLED;
+  originalEarnEnabled = env.EARN_ENABLED;
+  env.MARKETS_ENABLED = "true";
+  env.EARN_ENABLED = "true";
+  await seedTestDatabase(env);
+  await clearKVStores(env);
+});
+
+afterEach(() => {
+  env.MARKETS_ENABLED = originalMarketsEnabled;
+  env.EARN_ENABLED = originalEarnEnabled;
+  vi.restoreAllMocks();
+});
+
+describe("POST /v1/earn/vault-deposits — catalogue admission", () => {
+  /**
+   * The operator stop switch. `paused` rows are deliberately retained by the
+   * catalogue sync so a human can halt deposits during an exploit or a depeg;
+   * this path used to resolve the row by id with no status predicate at all, so
+   * the switch had no effect on it.
+   */
+  it("refuses a paused strategy", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy({ status: "paused" });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      walletId: WALLET_ADDRESS,
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("paused");
+  });
+
+  it("refuses a deprecated strategy", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy({ status: "deprecated" });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      walletId: WALLET_ADDRESS,
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("refuses a strategy whose host cluster is not fundable here", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy({ hostCluster: "mainnet-beta" });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      walletId: WALLET_ADDRESS,
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("mainnet-beta");
+  });
+});
+
+describe("POST /v1/earn/vault-deposits — request validation", () => {
+  it("requires a requestId, because the chain has no dedupe of its own", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      walletId: WALLET_ADDRESS,
+      amount: "10",
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-positive amount", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      walletId: WALLET_ADDRESS,
+      amount: "0",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("404s an unknown strategy rather than leaking whether the id exists elsewhere", async () => {
+    await seedAuth();
+
+    const res = await postVaultDeposit({
+      strategyId: "earn_strategy_does_not_exist",
+      walletId: WALLET_ADDRESS,
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -12,6 +12,13 @@ import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
 import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
 
+const depositIntoVault = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/earn/vault-deposit.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/earn/vault-deposit.service")>()),
+  depositIntoVault,
+}));
+
 /**
  * `POST /v1/earn/vault-deposits` — the gates and the idempotency contract.
  *
@@ -52,10 +59,45 @@ const TEST_CACHED_API_KEY: CachedApiKey = {
 };
 
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
 const WALLET_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
 
 let originalMarketsEnabled: string | undefined;
 let originalEarnEnabled: string | undefined;
+
+async function seedWallet(params: {
+  configId: string;
+  custodyWalletId: string;
+  providerWalletId: string;
+  publicKey?: string;
+  projectId?: string | null;
+}): Promise<void> {
+  await getDb(env).batch([
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_configs
+           (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES (?, ?, ?, 'privy', 'encrypted', 'active')`
+      )
+      .bind(
+        params.configId,
+        TEST_ORG.id,
+        params.projectId === undefined ? TEST_PROJECT.id : params.projectId
+      ),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_wallets
+           (id, custody_config_id, wallet_id, public_key, status)
+         VALUES (?, ?, ?, ?, 'active')`
+      )
+      .bind(
+        params.custodyWalletId,
+        params.configId,
+        params.providerWalletId,
+        params.publicKey ?? WALLET_ADDRESS
+      ),
+  ]);
+}
 
 async function seedAuth(): Promise<void> {
   const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
@@ -136,7 +178,7 @@ async function seedStrategy(
     sourceKind: "defi",
     underlyingSource: "kamino",
     depositMints: [USDC_MINT],
-    shareMint: null,
+    shareMint: SHARE_MINT,
     apyType: "variable",
     currentApy: "0.062",
     liquidityTerm: "instant",
@@ -173,6 +215,17 @@ beforeEach(async () => {
   env.EARN_ENABLED = "true";
   await seedTestDatabase(env);
   await clearKVStores(env);
+  vi.clearAllMocks();
+  depositIntoVault.mockResolvedValue({
+    position: { id: "earn_vault_position_test" },
+    movement: {
+      id: "earn_vault_movement_test",
+      status: "submitted",
+      signature: "sig_test",
+      failure_reason: null,
+    },
+    replayed: false,
+  });
 });
 
 afterEach(() => {
@@ -194,7 +247,7 @@ describe("POST /v1/earn/vault-deposits — catalogue admission", () => {
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,
-      walletId: WALLET_ADDRESS,
+      custodyWalletId: WALLET_ADDRESS,
       amount: "10",
       requestId: crypto.randomUUID(),
     });
@@ -210,7 +263,7 @@ describe("POST /v1/earn/vault-deposits — catalogue admission", () => {
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,
-      walletId: WALLET_ADDRESS,
+      custodyWalletId: WALLET_ADDRESS,
       amount: "10",
       requestId: crypto.randomUUID(),
     });
@@ -224,7 +277,7 @@ describe("POST /v1/earn/vault-deposits — catalogue admission", () => {
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,
-      walletId: WALLET_ADDRESS,
+      custodyWalletId: WALLET_ADDRESS,
       amount: "10",
       requestId: crypto.randomUUID(),
     });
@@ -242,7 +295,7 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,
-      walletId: WALLET_ADDRESS,
+      custodyWalletId: WALLET_ADDRESS,
       amount: "10",
     });
 
@@ -255,7 +308,7 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
 
     const res = await postVaultDeposit({
       strategyId: strategy.id,
-      walletId: WALLET_ADDRESS,
+      custodyWalletId: WALLET_ADDRESS,
       amount: "0",
       requestId: crypto.randomUUID(),
     });
@@ -263,16 +316,151 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
     expect(res.status).toBe(400);
   });
 
+  it("rejects a zero minSharesOut without lossy numeric coercion", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_unused",
+      amount: "10",
+      minSharesOut: "000.0000",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(depositIntoVault).not.toHaveBeenCalled();
+  });
+
   it("404s an unknown strategy rather than leaking whether the id exists elsewhere", async () => {
     await seedAuth();
 
     const res = await postVaultDeposit({
       strategyId: "earn_strategy_does_not_exist",
-      walletId: WALLET_ADDRESS,
+      custodyWalletId: WALLET_ADDRESS,
       amount: "10",
       requestId: crypto.randomUUID(),
     });
 
     expect(res.status).toBe(404);
+  });
+
+  it("requires a custody row id and rejects a raw wallet address", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_raw_address",
+      custodyWalletId: "cwlt_earn_vault_raw_address",
+      providerWalletId: "privy_earn_vault_raw_address",
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: WALLET_ADDRESS,
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(404);
+    expect(depositIntoVault).not.toHaveBeenCalled();
+  });
+
+  it("selects the exact custody row when scoped configurations share an address", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_first",
+      custodyWalletId: "cwlt_earn_vault_first",
+      providerWalletId: "privy_earn_vault_first",
+    });
+    await seedWallet({
+      configId: "cfg_earn_vault_second",
+      custodyWalletId: "cwlt_earn_vault_second",
+      providerWalletId: "privy_earn_vault_second",
+      projectId: null,
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_second",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(depositIntoVault).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        wallet: expect.objectContaining({
+          id: "cwlt_earn_vault_second",
+          walletId: "privy_earn_vault_second",
+        }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it("rejects a provider wallet id even when scoped configurations reuse it", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_duplicate_a",
+      custodyWalletId: "cwlt_earn_vault_duplicate_a",
+      providerWalletId: "privy_earn_vault_duplicate",
+    });
+    await seedWallet({
+      configId: "cfg_earn_vault_duplicate_b",
+      custodyWalletId: "cwlt_earn_vault_duplicate_b",
+      providerWalletId: "privy_earn_vault_duplicate",
+      publicKey: "3nMFwZXwY1s1M5s8vYAHqd4wGs4iSxXE4LRoUMMYqEgF",
+      projectId: null,
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "privy_earn_vault_duplicate",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(404);
+    expect(depositIntoVault).not.toHaveBeenCalled();
+  });
+
+  it("does not let a selected-wallet key cross an ambiguous provider wallet id", async () => {
+    await seedAuth();
+    const strategy = await seedStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_bound_project",
+      custodyWalletId: "cwlt_earn_vault_bound_project",
+      providerWalletId: "privy_earn_vault_bound_duplicate",
+    });
+    await seedWallet({
+      configId: "cfg_earn_vault_bound_org",
+      custodyWalletId: "cwlt_earn_vault_bound_org",
+      providerWalletId: "privy_earn_vault_bound_duplicate",
+      projectId: null,
+    });
+    const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+    await seedCachedApiKey(env, keyHash, {
+      ...TEST_CACHED_API_KEY,
+      signingWalletId: "privy_earn_vault_bound_duplicate",
+      walletBindings: [
+        {
+          walletId: "privy_earn_vault_bound_duplicate",
+          permissions: ["earn:write"],
+        },
+      ],
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_bound_org",
+      amount: "10",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(403);
+    expect(depositIntoVault).not.toHaveBeenCalled();
   });
 });

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -289,6 +289,49 @@ other's balance.
   `GET /strategies/:id/nav` (no writer, no reachable reader). A regression
   test in `../earn.test.ts` pins all of them at 404.
 
+## Vault-direct routes (non-custodial positions)
+
+A second money model, added for Kamino. A `vault_direct` provider custodies
+nothing: there is no wallet to provision and no address to fund — the vault's
+account is a PROGRAM account and stablecoins sent to it are destroyed. Money
+moves only when SDP builds an instruction and signs it with one of the
+organization's own custody wallets.
+
+- `POST /vault-deposits` — **build + sign + submit + ledger**, in that order.
+  Body `{strategyId, walletId, amount, requestId}`. The caller names a CATALOGUE
+  row, never a raw vault address, so the sync's admission gates still bound this
+  path; the wallet resolves through `resolveWalletAddress`, the same
+  permission-checked helper payments and private channels use (it takes a
+  provider `walletId` or a public key — never the `cwlt_…` row id).
+  - `requestId` is **REQUIRED**, unlike the custodial create. There is no
+    provider-side dedupe to fall back on: the chain will happily accept the same
+    transfer twice, so the intent row written before signing is the only defence.
+  - Gate order mirrors `POST /programs`: schema → strategy resolution →
+    deposit-style check → `host_cluster` vs environment → surfacing → entitlement
+    → wallet. Surfacing before entitlement, for the same reason as create.
+  - Simulates before signing. The instructions come from a third-party SDK built
+    against live vault state, so a stale reserve set surfaces as a readable
+    program error instead of a landed, failed transaction the customer paid for.
+  - Fee payer is the CUSTODY WALLET today. Kora only sponsors allow-listed
+    programs and the kvault/klend ids are not on that list (the Private Channels
+    escrow hit the same wall); the sponsored path exists in
+    `services/earn/vault-execution.service.ts` and is one line away.
+- `GET /vault-positions` — DB claim rows **hydrated live from chain**. Shares and
+  value are never persisted: for a non-custodial vault the chain IS the provider.
+  Takes **no provider gate at all** — it is a read of money the org already
+  holds, and hiding it when a provider is un-offered would close the door out.
+  A failed chain read leaves a position UNHYDRATED rather than zero; reporting
+  zero is a claim about someone's money that a failed RPC call cannot support.
+
+Capability dispatch is `supportsVaultDirect` (`@sdp/earn/capabilities`), resolved
+through `services/earn/execution-registry.ts` — the one place a provider id maps
+to an executing client. `EARN_PROVIDER_CLIENTS` stays the CATALOGUE registry so
+the hourly sync keeps its small dependency surface.
+
+**Not built yet:** the withdraw counterpart, and the Active-tab snapshot. Until
+both land, a vault position can be entered and not exited through SDP, so Kamino
+must not become creatable on mainnet (ADR 0002).
+
 ## Gate asymmetry — DO NOT BREAK (ADR 0002 exit-safety)
 
 - **Money-in** (`POST /programs`, `PUT /programs/:programId`):
@@ -334,10 +377,10 @@ other's balance.
 - Zod schemas in schemas.ts; parse/paginate/envelope helpers in
   handlers/shared.ts — don't hand-roll either.
 - Capability gating: `supportsPortfolioWallets(client)` → NOT_IMPLEMENTED for
-  providers lacking the surface. This is how a **catalogue-only** provider is
-  handled: Kamino lists real strategies but moves no money through SDP (its
-  vaults are non-custodial — the customer's own wallet deposits), so every
-  program route answers 501 for it by capability, never by a provider-id check.
+  providers lacking the surface. Kamino implements NONE of it, so every
+  **program** route still answers 501 for it by capability, never by a
+  provider-id check — its money moves through the vault-direct routes above
+  instead. The two capabilities are asserted mutually exclusive.
 - Withdrawal approval is a SECOND optional capability
   (`supportsWithdrawalApprovals`) with **no public route on purpose**: casting
   a vote needs the account-level Turnkey signer (platform ops — one shared

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -297,8 +297,9 @@ account is a PROGRAM account and stablecoins sent to it are destroyed. Money
 moves only when SDP builds an instruction and signs it with one of the
 organization's own custody wallets.
 
-- `POST /vault-deposits` — **build + sign + record + broadcast + ledger**, in
-  that order. Body `{strategyId, walletId, amount, requestId, minSharesOut?}`.
+- `POST /vault-deposits` — **build + simulate + sign + record + broadcast**, in
+  that order. Body
+  `{strategyId, custodyWalletId, amount, requestId, minSharesOut?}`.
   Registered as
   `requirePermissions("earn:write", "wallets:read")` → `policyGate` → handler.
   The caller names a CATALOGUE row, never a raw vault address, so the sync's
@@ -314,8 +315,9 @@ organization's own custody wallets.
   - **Environment capability first.** `isVaultDirectDepositEnabled(environment)`
     (`@sdp/types/provider-access`) fail-closes PRODUCTION while SDP has no
     vault-withdraw route and no Active-tab surface. Entitlement cannot express
-    this — it is org-scoped, not environment-scoped. The dashboard hides the
-    affordance from the same constant.
+    this — it is org-scoped, not environment-scoped. The dashboard visibly
+    disables the affordance from the same constant so the opportunity remains
+    discoverable without advertising an action the API will refuse.
   - `minSharesOut` is **required in production** and optional in sandbox: the
     pinned Kamino SDK picks the LEGACY deposit instruction when it is absent, so
     there is no implicit floor at all.
@@ -335,14 +337,19 @@ organization's own custody wallets.
     binding must not be able to spend. Note this is the first `earn:*` scope
     asserted on a BINDING: a selected-scope key provisioned only with
     payments-family binding permissions will now 403 here.
+    `custodyWalletId` is the exact `custody_wallets.id` (`cwlt_…`) returned by
+    the wallet surface, never the provider-local `walletId` or public key. The
+    latter can repeat across configurations; a selected binding whose provider
+    id maps to multiple scoped rows fails closed.
   - Simulates before signing. The instructions come from a third-party SDK built
     against live vault state, so a stale reserve set surfaces as a readable
     program error instead of a landed, failed transaction the customer paid for.
-  - **Signature is recorded BEFORE broadcast.** `signVaultPlan` signs without
-    sending, the movement stores the signature while still `pending`, and only
-    then are the bytes broadcast. A send error leaves the row `pending` WITH its
-    signature — reconcilable — and never `failed`, because a lost response does
-    not prove the transaction did not land.
+  - **The signed outbox is recorded BEFORE broadcast.** `signVaultPlan` signs
+    without sending; one transaction stores the signature, base64 wire bytes,
+    last-valid block height, movement and activated claim while still `pending`.
+    Only the insert winner broadcasts. A send error leaves that row `pending`
+    and never `failed`, because a lost response does not prove the transaction
+    did not land.
   - Fee payer is the CUSTODY WALLET. Kora only sponsors allow-listed programs and
     the kvault/klend ids are not on that list. The sponsored path in
     `services/earn/vault-execution.service.ts` is no longer one line away: it

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -297,29 +297,67 @@ account is a PROGRAM account and stablecoins sent to it are destroyed. Money
 moves only when SDP builds an instruction and signs it with one of the
 organization's own custody wallets.
 
-- `POST /vault-deposits` — **build + sign + submit + ledger**, in that order.
-  Body `{strategyId, walletId, amount, requestId}`. The caller names a CATALOGUE
-  row, never a raw vault address, so the sync's admission gates still bound this
-  path; the wallet resolves through `resolveWalletAddress`, the same
-  permission-checked helper payments and private channels use (it takes a
-  provider `walletId` or a public key — never the `cwlt_…` row id).
+- `POST /vault-deposits` — **build + sign + record + broadcast + ledger**, in
+  that order. Body `{strategyId, walletId, amount, requestId, minSharesOut?}`.
+  Registered as
+  `requirePermissions("earn:write", "wallets:read")` → `policyGate` → handler.
+  The caller names a CATALOGUE row, never a raw vault address, so the sync's
+  admission gates still bound this path.
+  - **POLICY-GATED.** `policyGate({ extract:
+    extractEarnVaultDepositPolicyCandidate })` resolves everything (strategy,
+    wallet, amount) and enforces wallet policy BEFORE `createOrgSigner` is
+    reached. The extractor owns all the gates below; the handler only ledgers.
+    Registered as the `earn` family in
+    `src/security/value-moving-conformance.node.test.ts`, whose
+    `valueMovingSourceRoots` now includes `src/services/earn` — it did not, which
+    is how a whole money-moving surface stayed invisible to the sink inventory.
+  - **Environment capability first.** `isVaultDirectDepositEnabled(environment)`
+    (`@sdp/types/provider-access`) fail-closes PRODUCTION while SDP has no
+    vault-withdraw route and no Active-tab surface. Entitlement cannot express
+    this — it is org-scoped, not environment-scoped. The dashboard hides the
+    affordance from the same constant.
+  - `minSharesOut` is **required in production** and optional in sandbox: the
+    pinned Kamino SDK picks the LEGACY deposit instruction when it is absent, so
+    there is no implicit floor at all.
   - `requestId` is **REQUIRED**, unlike the custodial create. There is no
     provider-side dedupe to fall back on: the chain will happily accept the same
-    transfer twice, so the intent row written before signing is the only defence.
-  - Gate order mirrors `POST /programs`: schema → strategy resolution →
-    deposit-style check → `host_cluster` vs environment → surfacing → entitlement
-    → wallet. Surfacing before entitlement, for the same reason as create.
+    transfer twice. It is stored with a canonical
+    `buildEarnVaultDepositFingerprint`, and the replay is resolved BEFORE the
+    position is claimed — reusing a key with a different intent is a **409**, not
+    a silent replay, and writes nothing.
+  - Gate order: schema → environment capability → production floor → strategy
+    resolution → deposit-style check → surfacing → entitlement →
+    **catalogue admission** → wallet. `assertStrategyDepositable`
+    (`handlers/admission.ts`) is shared with the custodial path and asserts
+    `status = 'active'` plus `isClusterFundableInEnvironment`; without it a
+    `paused` row — an operator's deliberate stop — stayed fundable by id.
+  - Wallet binding takes **`earn:write`**, not `wallets:read`. A read-only
+    binding must not be able to spend. Note this is the first `earn:*` scope
+    asserted on a BINDING: a selected-scope key provisioned only with
+    payments-family binding permissions will now 403 here.
   - Simulates before signing. The instructions come from a third-party SDK built
     against live vault state, so a stale reserve set surfaces as a readable
     program error instead of a landed, failed transaction the customer paid for.
-  - Fee payer is the CUSTODY WALLET today. Kora only sponsors allow-listed
-    programs and the kvault/klend ids are not on that list (the Private Channels
-    escrow hit the same wall); the sponsored path exists in
-    `services/earn/vault-execution.service.ts` and is one line away.
+  - **Signature is recorded BEFORE broadcast.** `signVaultPlan` signs without
+    sending, the movement stores the signature while still `pending`, and only
+    then are the bytes broadcast. A send error leaves the row `pending` WITH its
+    signature — reconcilable — and never `failed`, because a lost response does
+    not prove the transaction did not land.
+  - Fee payer is the CUSTODY WALLET. Kora only sponsors allow-listed programs and
+    the kvault/klend ids are not on that list. The sponsored path in
+    `services/earn/vault-execution.service.ts` is no longer one line away: it
+    cannot satisfy record-before-broadcast, because the relay signs as fee payer
+    after SDP and the final signature is unknown until the bytes leave.
 - `GET /vault-positions` — DB claim rows **hydrated live from chain**. Shares and
   value are never persisted: for a non-custodial vault the chain IS the provider.
   Takes **no provider gate at all** — it is a read of money the org already
   holds, and hiding it when a provider is un-offered would close the door out.
+  It DOES take wallet-binding scope: `getAllowedApiKeyWalletIdsForPermissions(auth,
+  ["earn:read"])`, applied in the repository query before any chain read. Mind
+  the id spaces — that helper returns provider `walletId`s (`privy_…`) while
+  `earn_vault_positions.custody_wallet_id` is the `cwlt_…` row id, so the handler
+  translates through `scope.wallets`. Passing the allow-list straight through
+  matches nothing and silently returns an empty page.
   A failed chain read leaves a position UNHYDRATED rather than zero; reporting
   zero is a claim about someone's money that a failed RPC call cannot support.
 
@@ -328,9 +366,20 @@ through `services/earn/execution-registry.ts` — the one place a provider id ma
 to an executing client. `EARN_PROVIDER_CLIENTS` stays the CATALOGUE registry so
 the hourly sync keeps its small dependency surface.
 
-**Not built yet:** the withdraw counterpart, and the Active-tab snapshot. Until
-both land, a vault position can be entered and not exited through SDP, so Kamino
-must not become creatable on mainnet (ADR 0002).
+**Not built yet:** the withdraw counterpart, the Active-tab snapshot, and a
+confirmation sweep (`idx_earn_vault_movements_unsettled` is the work queue
+waiting for one, so `submitted` never advances to `confirmed`). Until the first
+two land, a vault position can be entered and not exited through SDP — which is
+why `VAULT_DIRECT_DEPOSIT_ENVIRONMENTS` fail-closes production rather than
+relying on anyone remembering ADR 0002.
+
+**Per-cluster RPC.** `resolveClusterRpcUrl` reads `SOLANA_DEVNET_RPC_URL` /
+`SOLANA_MAINNET_RPC_URL`, falling back to `SOLANA_RPC_URL`, and
+`assertClusterEndpoint` proves the endpoint by GENESIS HASH before anything is
+built against it (cached per endpoint). One process serves both environments, so
+the old cluster-agnostic read silently built against whichever chain the single
+URL happened to serve — and a mismatch does not error, because Kamino's mainnet
+kvault program id also resolves on devnet with no accounts under it.
 
 ## Gate asymmetry — DO NOT BREAK (ADR 0002 exit-safety)
 

--- a/apps/sdp-api/src/routes/earn/handlers/admission.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/admission.ts
@@ -1,0 +1,69 @@
+import { isClusterFundableInEnvironment } from "@sdp/earn/support";
+import type { SdpEnvironment } from "@sdp/types";
+import type { EarnStrategyRow } from "@/db/repositories/earn.repository";
+import { badRequest } from "@/lib/errors";
+
+/**
+ * The ONE money-in admission predicate for an Earn catalogue row.
+ *
+ * Both money-in paths reach this: `POST /programs` (custodial allocations) and
+ * `POST /vault-deposits` (non-custodial). Before it existed the two disagreed,
+ * and the disagreement was not theoretical — the vault path resolved its row
+ * with a bare `getStrategyById` and so would happily fund a `paused` or
+ * `deprecated` strategy that `POST /programs` refused. `paused` is the operator
+ * stop switch: the hourly sync goes out of its way NOT to clobber it and the
+ * delist pass deliberately leaves such rows behind, precisely so a human can
+ * halt deposits during an exploit or a depeg. A second money-in path that
+ * ignored it made that switch a suggestion.
+ *
+ * ── What this deliberately does NOT check ───────────────────────────────────
+ * Browse policy — hidden terms, curation, provider surfacing. Those live in
+ * `handlers/strategies.ts` and gate what a reader SEES, not what an existing
+ * customer may fund; see routes/earn/CLAUDE.md. Surfacing and entitlement are
+ * separate, earlier gates with their own error codes, because "SDP does not
+ * offer this" and "this instrument is halted" are different answers.
+ */
+export function assertStrategyDepositable(
+  strategy: EarnStrategyRow,
+  environment: SdpEnvironment
+): void {
+  if (strategy.environment !== environment) {
+    // Phrased as "not found" upstream; reaching here means a caller crossed
+    // project environments with a valid id from the other one.
+    throw badRequest(`Strategy ${strategy.id} does not belong to this ${environment} project.`);
+  }
+
+  if (strategy.status !== "active") {
+    throw badRequest(
+      `Strategy ${strategy.id} is ${strategy.status} and cannot accept new deposits. ` +
+        "An operator pauses a strategy to stop money going in — existing positions are unaffected.",
+      { strategyId: strategy.id, status: strategy.status }
+    );
+  }
+
+  // The single fundability rule. Do NOT re-derive the cluster comparison here
+  // or anywhere else (@sdp/earn support.ts): a second copy is a second thing
+  // that can drift toward permissive.
+  if (!isClusterFundableInEnvironment(strategy.host_cluster, environment)) {
+    throw badRequest(
+      `This strategy lives on ${strategy.host_cluster}, which is not fundable from a ${environment} project.`,
+      { strategyId: strategy.id, hostCluster: strategy.host_cluster, environment }
+    );
+  }
+}
+
+/**
+ * Non-throwing form, for callers filtering a page of rows rather than admitting
+ * one named row. Keeps the two uses on the same definition.
+ */
+export function isStrategyDepositable(
+  strategy: EarnStrategyRow,
+  environment: SdpEnvironment
+): boolean {
+  try {
+    assertStrategyDepositable(strategy, environment);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -1,17 +1,27 @@
-import { earnDepositStyle, isEarnProviderSurfaced } from "@sdp/types/provider-access";
+import type { SdpEnvironment } from "@sdp/types";
+import { earnDepositStyle, isVaultDirectDepositEnabled } from "@sdp/types/provider-access";
 import { z } from "zod";
 import { getDb } from "@/db";
+import type { EarnStrategyRow } from "@/db/repositories/earn.repository";
 import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
 import { requireProjectId } from "@/lib/auth";
-import { badRequest, notFound, walletNotFound } from "@/lib/errors";
+import { AppError, badRequest, notFound, walletNotFound } from "@/lib/errors";
 import { success } from "@/lib/response";
+import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
 import { resolveScope, resolveWalletAddress } from "@/routes/payments/wallets";
+import { getAllowedApiKeyWalletIdsForPermissions } from "@/services/api-key-scope.service";
 import { resolveVaultDirectClient } from "@/services/earn/execution-registry";
 import { depositIntoVault } from "@/services/earn/vault-deposit.service";
-import { assertProviderAvailable } from "@/services/provider-availability.service";
+import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
+import {
+  assertEarnProviderSurfaced,
+  assertProviderAvailable,
+} from "@/services/provider-availability.service";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { AppContext } from "../context";
 import { earnRuntime, getEarnRepository, resolveSdpEnvironment } from "../context";
 import { earnVaultDepositSchema } from "../schemas";
+import { assertStrategyDepositable } from "./admission";
 
 /**
  * POST /v1/earn/vault-deposits — open or add to a non-custodial vault position,
@@ -25,78 +35,11 @@ import { earnVaultDepositSchema } from "../schemas";
  * chain rejected the transfer.
  */
 export async function createEarnVaultDeposit(c: AppContext) {
-  const body = await c.req.json().catch(() => null);
-  const parsed = earnVaultDepositSchema.safeParse(body);
-  if (!parsed.success) {
-    throw badRequest("Invalid vault deposit request", {
-      fieldErrors: z.flattenError(parsed.error).fieldErrors,
-    });
-  }
-
-  const environment = resolveSdpEnvironment(c);
-  const { auth, wallets } = await resolveScope(c);
-  const projectId = requireProjectId(c);
-
-  // Resolve the strategy first: the caller names a catalogue row, never a raw
-  // vault address. That keeps the deposit target inside what SDP catalogues and
-  // means the admission gates the sync applied still bound this path.
-  const strategy = await getEarnRepository(c).getStrategyById(parsed.data.strategyId);
-  if (!strategy || strategy.environment !== environment) {
-    throw notFound("Earn strategy");
-  }
-
-  // Shape check before anything else: a custodial provider reaching this route
-  // would silently skip its wallet-provisioning model.
-  if (earnDepositStyle(strategy.provider) !== "vault_direct") {
-    throw badRequest(
-      `${strategy.provider} is a custodial provider; use POST /v1/earn/programs instead.`
-    );
-  }
-
-  // A mainnet instrument must never be funded from a sandbox project (and vice
-  // versa). `host_cluster` states where the vault actually lives; the sync
-  // already refuses to store a mismatch, so this is the second, per-request
-  // guard rather than the only one.
-  const expectedCluster = environment === "production" ? "mainnet-beta" : "devnet";
-  if (strategy.host_cluster !== expectedCluster) {
-    throw badRequest(
-      `This vault lives on ${strategy.host_cluster}, which is not fundable from a ${environment} project.`
-    );
-  }
-
-  // MONEY-IN GATES, in the same order and with the same meaning as
-  // `POST /programs` (see routes/earn/CLAUDE.md → "Gate asymmetry"). Opening a
-  // vault position is a new commitment, so it takes both:
-  //
-  //   surfacing  — "SDP does not offer this provider", which no per-org
-  //                override can lift, and which reads differently from
-  //                entitlement. Checked first so a caller is never pointed at
-  //                an activation door that does not exist.
-  //   entitlement — the org's own override plus the environment's credentials.
-  //
-  // Money-OUT must never inherit either of these (ADR 0002): un-offering a
-  // provider closes the door in, never the door out.
-  if (!isEarnProviderSurfaced(strategy.provider)) {
-    throw badRequest(`${strategy.provider} is not currently offered.`);
-  }
-  await assertProviderAvailable(
-    c.env,
-    getDb(c.env),
-    auth.organizationId,
-    "earn",
-    strategy.provider as never,
-    environment === "sandbox"
-  );
-
-  // The wallet must be one SDP can sign for, resolved through the same
-  // permission-checked helper the payments and private-channel deposits use.
-  const walletAddress = resolveWalletAddress(wallets, parsed.data.walletId, "walletId", auth, [
-    "wallets:read",
-  ]);
-  const wallet = wallets.find((candidate) => candidate.publicKey === walletAddress);
-  if (!wallet) {
-    throw walletNotFound();
-  }
+  const { body: parsedData, resolved } = getPolicyGateContext<
+    EarnVaultDepositBody,
+    EarnVaultDepositResolved
+  >(c);
+  const { strategy, wallet, auth, projectId, environment } = resolved;
 
   const result = await depositIntoVault(c.env, {
     organizationId: auth.organizationId,
@@ -105,11 +48,11 @@ export async function createEarnVaultDeposit(c: AppContext) {
     provider: strategy.provider,
     providerReference: strategy.provider_reference,
     wallet,
-    amount: parsed.data.amount,
-    requestId: parsed.data.requestId,
+    amount: parsedData.amount,
+    requestId: parsedData.requestId,
+    minSharesOut: parsedData.minSharesOut,
     userId: auth.userId ?? null,
     apiKeyId: auth.apiKeyId ?? null,
-    ...(parsed.data.minSharesOut === undefined ? {} : { minSharesOut: parsed.data.minSharesOut }),
   });
 
   return success(c, {
@@ -131,6 +74,195 @@ export async function createEarnVaultDeposit(c: AppContext) {
   });
 }
 
+type EarnVaultDepositBody = z.output<typeof earnVaultDepositSchema>;
+
+interface EarnVaultDepositResolved {
+  strategy: EarnStrategyRow;
+  wallet: CustodyWallet;
+  auth: Awaited<ReturnType<typeof resolveScope>>["auth"];
+  projectId: string;
+  environment: SdpEnvironment;
+}
+
+/**
+ * Parse and resolve a vault deposit into its wallet-operation policy candidate.
+ *
+ * Everything the handler needs is resolved HERE, before the gate enforces, for
+ * one reason: policy has to be decided from trusted, fully-resolved context —
+ * the real custody wallet, the real amount, the real target — and it has to be
+ * decided BEFORE `createOrgSigner` is reached. A gate that ran on the raw body
+ * could be argued out of a denial by a caller who names a wallet it does not
+ * hold; a gate that ran after resolution but inside the handler would already
+ * have touched custody.
+ */
+export async function extractEarnVaultDepositPolicyCandidate(
+  c: AppContext
+): Promise<PolicyGateExtraction> {
+  const body = await c.req.json().catch(() => null);
+  const parsed = earnVaultDepositSchema.safeParse(body);
+  if (!parsed.success) {
+    throw badRequest("Invalid vault deposit request", {
+      fieldErrors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const environment = resolveSdpEnvironment(c);
+  const { auth, wallets } = await resolveScope(c);
+  const projectId = requireProjectId(c);
+
+  // ENVIRONMENT CAPABILITY, before anything else and before any lookup.
+  //
+  // SDP can move money INTO a vault and not back out: there is no vault
+  // withdraw route, and the Active tab does not surface vault positions. Until
+  // both land, opening a position with real funds is a one-way door, so
+  // production is refused server-side. Entitlement cannot express this — it is
+  // org-scoped, not environment-scoped — which is exactly why an entitled org
+  // would otherwise reach mainnet. The dashboard hides the affordance from the
+  // same constant, so the button and the route agree by construction.
+  if (!isVaultDirectDepositEnabled(environment)) {
+    throw new AppError(
+      "FORBIDDEN",
+      "Vault deposits are not available in production yet: SDP has no vault-withdraw path, " +
+        "so a position opened here could not be exited through SDP."
+    );
+  }
+
+  // SLIPPAGE FLOOR, required wherever real money moves.
+  //
+  // Kamino's pinned SDK selects the LEGACY deposit instruction when no
+  // `minSharesOut` is given — there is no implicit floor, so a vault-state
+  // change between signing and inclusion can mint materially fewer shares than
+  // the caller reviewed. The dashboard does not yet quote one (that needs a
+  // live rate with a displayed tolerance and an expiry), so requiring it
+  // unconditionally today would break the only working flow.
+  //
+  // This is scoped to production deliberately, and it is NOT dead code: the
+  // environment gate above closes production for a different reason (no exit
+  // path), and whoever lifts that gate must not silently also ship
+  // unprotected deposits. This check is what makes the floor a prerequisite of
+  // that change rather than something to remember.
+  if (environment === "production" && parsed.data.minSharesOut === undefined) {
+    throw badRequest(
+      "minSharesOut is required for a production vault deposit: without a floor the pinned " +
+        "Kamino SDK builds the legacy deposit instruction, which accepts any number of shares."
+    );
+  }
+
+  // Resolve the strategy first: the caller names a catalogue row, never a raw
+  // vault address. That keeps the deposit target inside what SDP catalogues and
+  // means the admission gates the sync applied still bound this path.
+  const strategy = await getEarnRepository(c).getStrategyById(parsed.data.strategyId);
+  if (!strategy || strategy.environment !== environment) {
+    throw notFound("Earn strategy");
+  }
+
+  // Shape check before anything else: a custodial provider reaching this route
+  // would silently skip its wallet-provisioning model.
+  if (earnDepositStyle(strategy.provider) !== "vault_direct") {
+    throw badRequest(
+      `${strategy.provider} is a custodial provider; use POST /v1/earn/programs instead.`
+    );
+  }
+
+  // MONEY-IN GATES, in the same order and with the same meaning as
+  // `POST /programs` (see routes/earn/CLAUDE.md → "Gate asymmetry"). Opening a
+  // vault position is a new commitment, so it takes all of:
+  //
+  //   surfacing   — "SDP does not offer this provider", which no per-org
+  //                 override can lift, and which reads differently from
+  //                 entitlement. Checked first so a caller is never pointed at
+  //                 an activation door that does not exist.
+  //   entitlement — the org's own override plus the environment's credentials.
+  //   admission   — the catalogue row is `active` and its cluster is fundable
+  //                 here. Shared with `POST /programs` rather than re-derived:
+  //                 this path used to check neither, so a `paused` strategy —
+  //                 an operator's deliberate stop during an exploit or depeg —
+  //                 stayed fundable by id.
+  //
+  // Money-OUT must never inherit any of these (ADR 0002): un-offering a
+  // provider closes the door in, never the door out.
+  assertEarnProviderSurfaced(strategy.provider as never);
+  await assertProviderAvailable(
+    c.env,
+    getDb(c.env),
+    auth.organizationId,
+    "earn",
+    strategy.provider as never,
+    environment === "sandbox"
+  );
+  assertStrategyDepositable(strategy, environment);
+
+  // The wallet must be one SDP can sign for, and the binding must carry a WRITE
+  // scope. `wallets:read` on a binding only proves the key may LOOK at the
+  // wallet — a read-only-bound key was previously able to spend from it. Global
+  // `wallets:read` is required at the router for the same reason payments does
+  // it: for a key with NO bindings the per-wallet assertion is a no-op, so the
+  // router permission is the only gate that key ever meets.
+  const walletAddress = resolveWalletAddress(wallets, parsed.data.walletId, "walletId", auth, [
+    "earn:write",
+  ]);
+  const wallet = wallets.find((candidate) => candidate.publicKey === walletAddress);
+  if (!wallet) {
+    // Also closes the raw-address bypass: `resolveWalletAddress` returns an
+    // unknown base58 address unchecked, treating it as an external destination.
+    // For money-IN the wallet must be one SDP holds keys for.
+    throw walletNotFound();
+  }
+
+  const resolved: EarnVaultDepositResolved = {
+    strategy,
+    wallet,
+    auth,
+    projectId,
+    environment,
+  };
+
+  return {
+    candidate: {
+      organizationId: auth.organizationId,
+      projectId,
+      custodyWalletId: wallet.id,
+      walletId: wallet.walletId,
+      apiKeyId: auth.apiKeyId ?? null,
+      actor: walletOperationActorFromAuth(auth),
+      source: "earn_vault_deposit",
+      // `program`, not `payment`: this is an interaction with an on-chain
+      // program, and no funds leave the org — the shares come back to the same
+      // custody wallet. Family rules are opt-in (a rule listing no families
+      // matches everything), so wallet deny rules, amount limits and approval
+      // requirements still apply; only a rule that explicitly enumerates
+      // families would need `program` added to it.
+      operationFamily: "program",
+      operationType: "earn_vault_deposit",
+      // The DEPOSIT token, from the catalogue row. Named so an asset-scoped
+      // rule ("never move USDT") can see what is actually moving.
+      asset: strategy.deposit_mints[0] ?? null,
+      amount: parsed.data.amount,
+      // The vault account, which is emphatically NOT a payable address —
+      // funds sent to it directly are destroyed. It is carried because a
+      // destination-scoped rule still needs to name the thing being deposited
+      // into, and it is the only stable identifier for that.
+      destination: strategy.provider_reference,
+      context: {
+        provider: strategy.provider,
+        strategyId: strategy.id,
+        strategyName: strategy.name,
+        hostCluster: strategy.host_cluster,
+        environment,
+        depositStyle: "vault_direct",
+        ...(parsed.data.minSharesOut === undefined
+          ? {}
+          : { minSharesOut: parsed.data.minSharesOut }),
+      },
+      providerExtensions: {},
+    },
+    legs: [],
+    body: parsed.data,
+    resolved,
+    rawPayload: { ...(body as Record<string, unknown>) },
+  };
+}
+
 /**
  * GET /v1/earn/vault-positions — the org's vault positions, HYDRATED LIVE.
  *
@@ -146,11 +278,38 @@ export async function createEarnVaultDeposit(c: AppContext) {
  */
 export async function listEarnVaultPositions(c: AppContext) {
   const environment = resolveSdpEnvironment(c);
-  const { auth } = await resolveScope(c);
+  const { auth, wallets } = await resolveScope(c);
+
+  // WALLET-BINDING SCOPE, applied before the query and therefore before any
+  // chain read. A selected-wallet key must not hydrate — or even learn of —
+  // positions held by wallets it is not bound to.
+  //
+  // The id spaces differ and that is the trap here: this helper returns PROVIDER
+  // wallet ids (`privy_…`), while `earn_vault_positions.custody_wallet_id` is
+  // the `custody_wallets` row id (`cwlt_…`). `scope.wallets` carries both, so it
+  // is the translation table. Passing the allow-list straight through would
+  // match nothing and silently return an empty page — a filter that looks like
+  // it works and hides everything.
+  const allowedProviderWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["earn:read"]);
+  let custodyWalletIds: string[] | undefined;
+  if (allowedProviderWalletIds !== null) {
+    const allowed = new Set(allowedProviderWalletIds);
+    custodyWalletIds = wallets
+      .filter((wallet) => allowed.has(wallet.walletId))
+      .map((wallet) => wallet.id);
+    // Bound, but nothing qualifies: answer empty WITHOUT querying. `null` means
+    // unbound and takes no filter at all; `[]` here would otherwise widen back
+    // to "no filter" in the repository.
+    if (custodyWalletIds.length === 0) {
+      return success(c, { positions: [] });
+    }
+  }
+
   const repo = createPostgresEarnVaultRepository(getDb(c.env));
   const rows = await repo.listPositions({
     organizationId: auth.organizationId,
     environment,
+    ...(custodyWalletIds === undefined ? {} : { custodyWalletIds }),
   });
 
   // Group by provider so each client reads its whole shelf in one pass, sharing

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -1,3 +1,4 @@
+import { isDecimalString } from "@sdp/solana/amount";
 import type { SdpEnvironment } from "@sdp/types";
 import { earnDepositStyle, isVaultDirectDepositEnabled } from "@sdp/types/provider-access";
 import { z } from "zod";
@@ -5,13 +6,36 @@ import { getDb } from "@/db";
 import type { EarnStrategyRow } from "@/db/repositories/earn.repository";
 import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
 import { requireProjectId } from "@/lib/auth";
-import { AppError, badRequest, notFound, walletNotFound } from "@/lib/errors";
+import { mapSettledWithConcurrency } from "@/lib/concurrency";
+import {
+  AppError,
+  badRequest,
+  conflict,
+  internalError,
+  notFound,
+  walletNotFound,
+} from "@/lib/errors";
 import { success } from "@/lib/response";
 import { getPolicyGateContext, type PolicyGateExtraction } from "@/middleware/policy-gate";
-import { resolveScope, resolveWalletAddress } from "@/routes/payments/wallets";
-import { getAllowedApiKeyWalletIdsForPermissions } from "@/services/api-key-scope.service";
-import { resolveVaultDirectClient } from "@/services/earn/execution-registry";
+import { resolveScope } from "@/routes/payments/wallets";
+import { getLogger } from "@/runtime/logger";
+import {
+  assertApiKeyWalletAccess,
+  getAllowedApiKeyWalletIdsForPermissions,
+} from "@/services/api-key-scope.service";
+import {
+  assertClusterEndpoint,
+  earnClusterFor,
+  resolveClusterRpcUrl,
+  resolveVaultDirectClient,
+} from "@/services/earn/execution-registry";
+import { withVaultDeadline } from "@/services/earn/vault-deadline";
 import { depositIntoVault } from "@/services/earn/vault-deposit.service";
+import {
+  approvedWalletOperationId,
+  beginApprovedWalletOperationEffect,
+  runApprovedWalletOperationEffectTransaction,
+} from "@/services/policy/approved-operation-replay";
 import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
 import {
   assertEarnProviderSurfaced,
@@ -20,8 +44,9 @@ import {
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { AppContext } from "../context";
 import { earnRuntime, getEarnRepository, resolveSdpEnvironment } from "../context";
-import { earnVaultDepositSchema } from "../schemas";
+import { earnVaultDepositSchema, earnVaultPositionsQuerySchema } from "../schemas";
 import { assertStrategyDepositable } from "./admission";
+import { parseQuery } from "./shared";
 
 /**
  * POST /v1/earn/vault-deposits — open or add to a non-custodial vault position,
@@ -40,20 +65,49 @@ export async function createEarnVaultDeposit(c: AppContext) {
     EarnVaultDepositResolved
   >(c);
   const { strategy, wallet, auth, projectId, environment } = resolved;
+  const tokenMint = strategy.deposit_mints[0];
+  if (!tokenMint) {
+    throw internalError(`Earn strategy ${strategy.id} has no deposit mint`);
+  }
+  const shareMint = strategy.share_mint;
+  if (!shareMint) {
+    throw internalError(`Earn strategy ${strategy.id} has no share mint`);
+  }
 
-  const result = await depositIntoVault(c.env, {
-    organizationId: auth.organizationId,
-    projectId,
-    environment,
-    provider: strategy.provider,
-    providerReference: strategy.provider_reference,
-    wallet,
-    amount: parsedData.amount,
-    requestId: parsedData.requestId,
-    minSharesOut: parsedData.minSharesOut,
-    userId: auth.userId ?? null,
-    apiKeyId: auth.apiKeyId ?? null,
-  });
+  const result = await depositIntoVault(
+    c.env,
+    {
+      organizationId: auth.organizationId,
+      projectId,
+      environment,
+      provider: strategy.provider,
+      providerReference: strategy.provider_reference,
+      wallet,
+      tokenMint,
+      shareMint,
+      label: strategy.name,
+      amount: parsedData.amount,
+      requestId: parsedData.requestId,
+      minSharesOut: parsedData.minSharesOut,
+      userId: auth.userId ?? null,
+      apiKeyId: auth.apiKeyId ?? null,
+    },
+    {
+      runIntentTransaction: (mutation) => runApprovedWalletOperationEffectTransaction(c, mutation),
+    }
+  );
+
+  if (result.replayed && approvedWalletOperationId(c)) {
+    // Sequential replays do not pass through the insert transaction, so fence
+    // the approved operation before returning their durable outcome. A legacy
+    // unsigned row must fail closed instead of becoming a completed approval.
+    await beginApprovedWalletOperationEffect(c);
+    if (!result.movement.signature) {
+      throw conflict(
+        "Approved vault deposit execution is incomplete and requires manual reconciliation"
+      );
+    }
+  }
 
   return success(c, {
     positionId: result.position.id,
@@ -198,16 +252,12 @@ export async function extractEarnVaultDepositPolicyCandidate(
   // `wallets:read` is required at the router for the same reason payments does
   // it: for a key with NO bindings the per-wallet assertion is a no-op, so the
   // router permission is the only gate that key ever meets.
-  const walletAddress = resolveWalletAddress(wallets, parsed.data.walletId, "walletId", auth, [
-    "earn:write",
-  ]);
-  const wallet = wallets.find((candidate) => candidate.publicKey === walletAddress);
-  if (!wallet) {
-    // Also closes the raw-address bypass: `resolveWalletAddress` returns an
-    // unknown base58 address unchecked, treating it as an external destination.
-    // For money-IN the wallet must be one SDP holds keys for.
-    throw walletNotFound();
-  }
+  // Resolve only the exposed custody row id. Provider wallet ids are unique
+  // only within one custody configuration, and public keys may also repeat, so
+  // neither is a safe identifier for this money-in route.
+  const wallet = resolveEarnVaultCustodyWallet(wallets, parsed.data.custodyWalletId);
+  assertBoundWalletIdentifierIsUnique(auth, wallets, wallet);
+  assertApiKeyWalletAccess(auth, wallet.walletId, ["earn:write"]);
 
   const resolved: EarnVaultDepositResolved = {
     strategy,
@@ -263,6 +313,35 @@ export async function extractEarnVaultDepositPolicyCandidate(
   };
 }
 
+function resolveEarnVaultCustodyWallet(
+  wallets: readonly CustodyWallet[],
+  custodyWalletId: string
+): CustodyWallet {
+  const exact = wallets.find((wallet) => wallet.id === custodyWalletId);
+  if (exact) return exact;
+  throw walletNotFound();
+}
+
+function assertBoundWalletIdentifierIsUnique(
+  auth: EarnVaultDepositResolved["auth"],
+  wallets: readonly CustodyWallet[],
+  wallet: CustodyWallet
+): void {
+  const selectedScope =
+    auth.authType === "api_key" &&
+    (auth.walletBindings.length > 0 ||
+      auth.signingWalletId !== null ||
+      auth.signingWalletIds.length > 0);
+  if (!selectedScope) return;
+
+  if (wallets.filter((candidate) => candidate.walletId === wallet.walletId).length !== 1) {
+    throw new AppError(
+      "FORBIDDEN",
+      "The selected API-key wallet binding is ambiguous across custody configurations"
+    );
+  }
+}
+
 /**
  * GET /v1/earn/vault-positions — the org's vault positions, HYDRATED LIVE.
  *
@@ -277,6 +356,11 @@ export async function extractEarnVaultDepositPolicyCandidate(
  * money-in route above takes both gates; this one deliberately takes neither.
  */
 export async function listEarnVaultPositions(c: AppContext) {
+  const query = parseQuery(c, earnVaultPositionsQuerySchema);
+  const before = query.before ? decodeVaultPositionCursor(query.before) : null;
+  if (query.before && !before) {
+    throw badRequest("Invalid vault position pagination cursor");
+  }
   const environment = resolveSdpEnvironment(c);
   const { auth, wallets } = await resolveScope(c);
 
@@ -291,25 +375,31 @@ export async function listEarnVaultPositions(c: AppContext) {
   // match nothing and silently return an empty page — a filter that looks like
   // it works and hides everything.
   const allowedProviderWalletIds = getAllowedApiKeyWalletIdsForPermissions(auth, ["earn:read"]);
-  let custodyWalletIds: string[] | undefined;
-  if (allowedProviderWalletIds !== null) {
-    const allowed = new Set(allowedProviderWalletIds);
-    custodyWalletIds = wallets
-      .filter((wallet) => allowed.has(wallet.walletId))
-      .map((wallet) => wallet.id);
-    // Bound, but nothing qualifies: answer empty WITHOUT querying. `null` means
-    // unbound and takes no filter at all; `[]` here would otherwise widen back
-    // to "no filter" in the repository.
-    if (custodyWalletIds.length === 0) {
-      return success(c, { positions: [] });
-    }
+  const allowed = allowedProviderWalletIds === null ? null : new Set(allowedProviderWalletIds);
+  const scopedProviderWalletCounts = new Map<string, number>();
+  for (const wallet of wallets) {
+    scopedProviderWalletCounts.set(
+      wallet.walletId,
+      (scopedProviderWalletCounts.get(wallet.walletId) ?? 0) + 1
+    );
+  }
+  const scopedWallets = wallets.filter(
+    (wallet) =>
+      allowed === null ||
+      (allowed.has(wallet.walletId) && scopedProviderWalletCounts.get(wallet.walletId) === 1)
+  );
+  const custodyWalletIds = [...new Set(scopedWallets.map((wallet) => wallet.id))];
+  if (custodyWalletIds.length === 0) {
+    return success(c, { positions: [], hasMore: false, nextCursor: null });
   }
 
   const repo = createPostgresEarnVaultRepository(getDb(c.env));
-  const rows = await repo.listPositions({
+  const { rows, hasMore } = await repo.listPositions({
     organizationId: auth.organizationId,
     environment,
-    ...(custodyWalletIds === undefined ? {} : { custodyWalletIds }),
+    custodyWalletIds,
+    limit: query.limit,
+    ...(before === null ? {} : { before }),
   });
 
   // Group by provider so each client reads its whole shelf in one pass, sharing
@@ -317,56 +407,109 @@ export async function listEarnVaultPositions(c: AppContext) {
   // page against drifting slots.
   const byProvider = new Map<string, typeof rows>();
   for (const row of rows) {
-    byProvider.set(row.provider, [...(byProvider.get(row.provider) ?? []), row]);
+    const providerRows = byProvider.get(row.provider);
+    if (providerRows) providerRows.push(row);
+    else byProvider.set(row.provider, [row]);
   }
 
-  const live = new Map<string, { shares: string; tokenValue?: string }>();
-  await Promise.all(
-    [...byProvider.entries()].map(async ([provider, providerRows]) => {
-      const client = resolveVaultDirectClient(c.env, provider);
-      if (!client) return;
-      // Positions are grouped per WALLET too: one owner per read.
-      const byWallet = new Map<string, string[]>();
-      for (const row of providerRows) {
-        byWallet.set(row.custody_wallet_id, [
-          ...(byWallet.get(row.custody_wallet_id) ?? []),
-          row.provider_reference,
-        ]);
-      }
-      const walletAddresses = await resolveWalletAddresses(c, [...byWallet.keys()]);
-      await Promise.all(
-        [...byWallet.entries()].map(async ([walletId, references]) => {
-          const owner = walletAddresses.get(walletId);
-          if (!owner) return;
-          try {
-            const snapshots = await client.readVaultPositions(earnRuntime(c), {
-              owner,
-              providerReferences: references,
-            });
-            for (const snapshot of snapshots) {
-              live.set(`${walletId}:${snapshot.providerReference}`, {
-                shares: snapshot.shares,
-                ...(snapshot.tokenValue === undefined ? {} : { tokenValue: snapshot.tokenValue }),
-              });
-            }
-          } catch {
-            // A failed chain read leaves this position unhydrated rather than
-            // failing the whole list — the reader still sees that they hold it.
-            // Reporting zero would be a claim about their money that a failed
-            // RPC call does not support.
-          }
-        })
-      );
-    })
+  const walletAddresses = new Map(
+    scopedWallets.map((wallet) => [wallet.id, wallet.publicKey] as const)
   );
+  const live = new Map<
+    string,
+    {
+      shares: string;
+      tokenValue?: string;
+    }
+  >();
+  const hydrationJobs: Array<() => Promise<void>> = [];
+
+  for (const [provider, providerRows] of byProvider) {
+    const client = resolveVaultDirectClient(c.env, provider);
+    if (!client) continue;
+    const byWallet = new Map<string, typeof rows>();
+    for (const row of providerRows) {
+      const walletRows = byWallet.get(row.custody_wallet_id);
+      if (walletRows) walletRows.push(row);
+      else byWallet.set(row.custody_wallet_id, [row]);
+    }
+    for (const [walletId, walletRows] of byWallet) {
+      const owner = walletAddresses.get(walletId);
+      if (!owner) continue;
+      const trustedIdentity = new Map(
+        walletRows.map((row) => [
+          row.provider_reference,
+          { tokenMint: row.token_mint, shareMint: row.share_mint },
+        ])
+      );
+      const references = walletRows.map((row) => row.provider_reference);
+      hydrationJobs.push(async () => {
+        const snapshots = await withVaultDeadline(
+          client.readVaultPositions(earnRuntime(c), {
+            owner,
+            providerReferences: references,
+          }),
+          `Reading ${provider} vault positions`
+        );
+        for (const snapshot of snapshots) {
+          const trusted = trustedIdentity.get(snapshot.providerReference);
+          if (
+            !trusted ||
+            snapshot.owner !== owner ||
+            snapshot.cluster !== earnClusterFor(environment) ||
+            snapshot.tokenMint !== trusted.tokenMint ||
+            snapshot.shareMint !== trusted.shareMint ||
+            !isBoundedSnapshotAmount(snapshot.shares) ||
+            (snapshot.tokenValue !== undefined && !isBoundedSnapshotAmount(snapshot.tokenValue))
+          ) {
+            getLogger().warn(
+              {
+                provider,
+                walletId,
+                providerReference: snapshot.providerReference,
+                snapshotOwner: snapshot.owner,
+                snapshotCluster: snapshot.cluster,
+                snapshotTokenMint: snapshot.tokenMint,
+                snapshotShareMint: snapshot.shareMint,
+              },
+              "vault position: ignored live snapshot with mismatched identity"
+            );
+            continue;
+          }
+          live.set(vaultPositionLiveKey(provider, walletId, snapshot.providerReference), {
+            shares: snapshot.shares,
+            ...(snapshot.tokenValue === undefined ? {} : { tokenValue: snapshot.tokenValue }),
+          });
+        }
+      });
+    }
+  }
+
+  if (hydrationJobs.length > 0) {
+    const cluster = earnClusterFor(environment);
+    const rpcUrl = resolveClusterRpcUrl(c.env, cluster);
+    await withVaultDeadline(
+      assertClusterEndpoint(c.env, cluster, rpcUrl),
+      `Verifying the ${cluster} RPC endpoint`
+    );
+    // Failed reads intentionally leave only their rows unhydrated; never report
+    // zero when the chain could not be read. In-flight RPC work stays bounded.
+    await mapSettledWithConcurrency(hydrationJobs, 8, (hydrate) => hydrate());
+  }
+
+  const last = rows.at(-1);
+  const nextCursor = hasMore && last ? encodeVaultPositionCursor(last.created_at, last.id) : null;
 
   return success(c, {
     positions: rows.map((row) => {
-      const hydrated = live.get(`${row.custody_wallet_id}:${row.provider_reference}`);
+      const hydrated = live.get(
+        vaultPositionLiveKey(row.provider, row.custody_wallet_id, row.provider_reference)
+      );
       return {
         id: row.id,
         provider: row.provider,
         providerReference: row.provider_reference,
+        label: row.label,
         custodyWalletId: row.custody_wallet_id,
         tokenMint: row.token_mint,
         shareMint: row.share_mint,
@@ -377,20 +520,30 @@ export async function listEarnVaultPositions(c: AppContext) {
         tokenValue: hydrated?.tokenValue,
       };
     }),
+    hasMore,
+    nextCursor,
   });
 }
 
-/** Map custody wallet row ids to their public keys, for the chain reads above. */
-async function resolveWalletAddresses(
-  c: AppContext,
-  walletRowIds: readonly string[]
-): Promise<Map<string, string>> {
-  const { wallets } = await resolveScope(c);
-  const byId = new Map(wallets.map((wallet) => [wallet.id, wallet.publicKey]));
-  return new Map(
-    walletRowIds.flatMap((id) => {
-      const publicKey = byId.get(id);
-      return publicKey ? [[id, publicKey] as [string, string]] : [];
-    })
-  );
+function vaultPositionLiveKey(provider: string, walletId: string, reference: string): string {
+  return JSON.stringify([provider, walletId, reference]);
+}
+
+function isBoundedSnapshotAmount(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 128 && isDecimalString(value);
+}
+
+function encodeVaultPositionCursor(createdAt: string, id: string): string {
+  return btoa(`${createdAt}|${id}`).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function decodeVaultPositionCursor(cursor: string): { createdAt: string; id: string } | null {
+  try {
+    const decoded = atob(cursor.replace(/-/g, "+").replace(/_/g, "/"));
+    const separator = decoded.indexOf("|");
+    if (separator <= 0 || separator === decoded.length - 1) return null;
+    return { createdAt: decoded.slice(0, separator), id: decoded.slice(separator + 1) };
+  } catch {
+    return null;
+  }
 }

--- a/apps/sdp-api/src/routes/earn/handlers/vault.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/vault.ts
@@ -1,0 +1,237 @@
+import { earnDepositStyle, isEarnProviderSurfaced } from "@sdp/types/provider-access";
+import { z } from "zod";
+import { getDb } from "@/db";
+import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
+import { requireProjectId } from "@/lib/auth";
+import { badRequest, notFound, walletNotFound } from "@/lib/errors";
+import { success } from "@/lib/response";
+import { resolveScope, resolveWalletAddress } from "@/routes/payments/wallets";
+import { resolveVaultDirectClient } from "@/services/earn/execution-registry";
+import { depositIntoVault } from "@/services/earn/vault-deposit.service";
+import { assertProviderAvailable } from "@/services/provider-availability.service";
+import type { AppContext } from "../context";
+import { earnRuntime, getEarnRepository, resolveSdpEnvironment } from "../context";
+import { earnVaultDepositSchema } from "../schemas";
+
+/**
+ * POST /v1/earn/vault-deposits — open or add to a non-custodial vault position,
+ * funded from an SDP custody wallet and signed by SDP.
+ *
+ * A separate collection from `/programs` on purpose. A "program" is the
+ * CUSTODIAL model: SDP provisions a provider wallet and the customer funds its
+ * address later, so create and fund are two steps with an address in between.
+ * A vault position has no address and no gap — the deposit IS the creation. One
+ * endpoint that meant both would have to explain which half happened when the
+ * chain rejected the transfer.
+ */
+export async function createEarnVaultDeposit(c: AppContext) {
+  const body = await c.req.json().catch(() => null);
+  const parsed = earnVaultDepositSchema.safeParse(body);
+  if (!parsed.success) {
+    throw badRequest("Invalid vault deposit request", {
+      fieldErrors: z.flattenError(parsed.error).fieldErrors,
+    });
+  }
+
+  const environment = resolveSdpEnvironment(c);
+  const { auth, wallets } = await resolveScope(c);
+  const projectId = requireProjectId(c);
+
+  // Resolve the strategy first: the caller names a catalogue row, never a raw
+  // vault address. That keeps the deposit target inside what SDP catalogues and
+  // means the admission gates the sync applied still bound this path.
+  const strategy = await getEarnRepository(c).getStrategyById(parsed.data.strategyId);
+  if (!strategy || strategy.environment !== environment) {
+    throw notFound("Earn strategy");
+  }
+
+  // Shape check before anything else: a custodial provider reaching this route
+  // would silently skip its wallet-provisioning model.
+  if (earnDepositStyle(strategy.provider) !== "vault_direct") {
+    throw badRequest(
+      `${strategy.provider} is a custodial provider; use POST /v1/earn/programs instead.`
+    );
+  }
+
+  // A mainnet instrument must never be funded from a sandbox project (and vice
+  // versa). `host_cluster` states where the vault actually lives; the sync
+  // already refuses to store a mismatch, so this is the second, per-request
+  // guard rather than the only one.
+  const expectedCluster = environment === "production" ? "mainnet-beta" : "devnet";
+  if (strategy.host_cluster !== expectedCluster) {
+    throw badRequest(
+      `This vault lives on ${strategy.host_cluster}, which is not fundable from a ${environment} project.`
+    );
+  }
+
+  // MONEY-IN GATES, in the same order and with the same meaning as
+  // `POST /programs` (see routes/earn/CLAUDE.md → "Gate asymmetry"). Opening a
+  // vault position is a new commitment, so it takes both:
+  //
+  //   surfacing  — "SDP does not offer this provider", which no per-org
+  //                override can lift, and which reads differently from
+  //                entitlement. Checked first so a caller is never pointed at
+  //                an activation door that does not exist.
+  //   entitlement — the org's own override plus the environment's credentials.
+  //
+  // Money-OUT must never inherit either of these (ADR 0002): un-offering a
+  // provider closes the door in, never the door out.
+  if (!isEarnProviderSurfaced(strategy.provider)) {
+    throw badRequest(`${strategy.provider} is not currently offered.`);
+  }
+  await assertProviderAvailable(
+    c.env,
+    getDb(c.env),
+    auth.organizationId,
+    "earn",
+    strategy.provider as never,
+    environment === "sandbox"
+  );
+
+  // The wallet must be one SDP can sign for, resolved through the same
+  // permission-checked helper the payments and private-channel deposits use.
+  const walletAddress = resolveWalletAddress(wallets, parsed.data.walletId, "walletId", auth, [
+    "wallets:read",
+  ]);
+  const wallet = wallets.find((candidate) => candidate.publicKey === walletAddress);
+  if (!wallet) {
+    throw walletNotFound();
+  }
+
+  const result = await depositIntoVault(c.env, {
+    organizationId: auth.organizationId,
+    projectId,
+    environment,
+    provider: strategy.provider,
+    providerReference: strategy.provider_reference,
+    wallet,
+    amount: parsed.data.amount,
+    requestId: parsed.data.requestId,
+    userId: auth.userId ?? null,
+    apiKeyId: auth.apiKeyId ?? null,
+    ...(parsed.data.minSharesOut === undefined ? {} : { minSharesOut: parsed.data.minSharesOut }),
+  });
+
+  return success(c, {
+    positionId: result.position.id,
+    movementId: result.movement.id,
+    status: result.movement.status,
+    signature: result.movement.signature,
+    failureReason: result.movement.failure_reason,
+    // Tells a retrying caller that its key was already used and NOTHING was
+    // re-sent — distinct from a fresh success with the same shape.
+    replayed: result.replayed,
+    strategy: {
+      id: strategy.id,
+      name: strategy.name,
+      provider: strategy.provider,
+      providerReference: strategy.provider_reference,
+      hostCluster: strategy.host_cluster,
+    },
+  });
+}
+
+/**
+ * GET /v1/earn/vault-positions — the org's vault positions, HYDRATED LIVE.
+ *
+ * The DB rows are only the claim set (which wallet holds which vault). Shares
+ * and value are read from chain on every request, never persisted: for a
+ * non-custodial vault the chain IS the provider, and ADR 0002's rule is that
+ * positions are provider truth read live.
+ *
+ * NO provider gate here. This is a READ of money the org already holds, and
+ * ADR 0002's exit-safety asymmetry says un-offering or un-entitling a provider
+ * must never hide a position — it closes the door in, never the door out. The
+ * money-in route above takes both gates; this one deliberately takes neither.
+ */
+export async function listEarnVaultPositions(c: AppContext) {
+  const environment = resolveSdpEnvironment(c);
+  const { auth } = await resolveScope(c);
+  const repo = createPostgresEarnVaultRepository(getDb(c.env));
+  const rows = await repo.listPositions({
+    organizationId: auth.organizationId,
+    environment,
+  });
+
+  // Group by provider so each client reads its whole shelf in one pass, sharing
+  // one slot across the vaults — a per-position read would price a multi-vault
+  // page against drifting slots.
+  const byProvider = new Map<string, typeof rows>();
+  for (const row of rows) {
+    byProvider.set(row.provider, [...(byProvider.get(row.provider) ?? []), row]);
+  }
+
+  const live = new Map<string, { shares: string; tokenValue?: string }>();
+  await Promise.all(
+    [...byProvider.entries()].map(async ([provider, providerRows]) => {
+      const client = resolveVaultDirectClient(c.env, provider);
+      if (!client) return;
+      // Positions are grouped per WALLET too: one owner per read.
+      const byWallet = new Map<string, string[]>();
+      for (const row of providerRows) {
+        byWallet.set(row.custody_wallet_id, [
+          ...(byWallet.get(row.custody_wallet_id) ?? []),
+          row.provider_reference,
+        ]);
+      }
+      const walletAddresses = await resolveWalletAddresses(c, [...byWallet.keys()]);
+      await Promise.all(
+        [...byWallet.entries()].map(async ([walletId, references]) => {
+          const owner = walletAddresses.get(walletId);
+          if (!owner) return;
+          try {
+            const snapshots = await client.readVaultPositions(earnRuntime(c), {
+              owner,
+              providerReferences: references,
+            });
+            for (const snapshot of snapshots) {
+              live.set(`${walletId}:${snapshot.providerReference}`, {
+                shares: snapshot.shares,
+                ...(snapshot.tokenValue === undefined ? {} : { tokenValue: snapshot.tokenValue }),
+              });
+            }
+          } catch {
+            // A failed chain read leaves this position unhydrated rather than
+            // failing the whole list — the reader still sees that they hold it.
+            // Reporting zero would be a claim about their money that a failed
+            // RPC call does not support.
+          }
+        })
+      );
+    })
+  );
+
+  return success(c, {
+    positions: rows.map((row) => {
+      const hydrated = live.get(`${row.custody_wallet_id}:${row.provider_reference}`);
+      return {
+        id: row.id,
+        provider: row.provider,
+        providerReference: row.provider_reference,
+        custodyWalletId: row.custody_wallet_id,
+        tokenMint: row.token_mint,
+        shareMint: row.share_mint,
+        createdAt: row.created_at,
+        closedAt: row.closed_at,
+        // Absent (not zero) when the chain read failed or returned nothing.
+        shares: hydrated?.shares,
+        tokenValue: hydrated?.tokenValue,
+      };
+    }),
+  });
+}
+
+/** Map custody wallet row ids to their public keys, for the chain reads above. */
+async function resolveWalletAddresses(
+  c: AppContext,
+  walletRowIds: readonly string[]
+): Promise<Map<string, string>> {
+  const { wallets } = await resolveScope(c);
+  const byId = new Map(wallets.map((wallet) => [wallet.id, wallet.publicKey]));
+  return new Map(
+    walletRowIds.flatMap((id) => {
+      const publicKey = byId.get(id);
+      return publicKey ? [[id, publicKey] as [string, string]] : [];
+    })
+  );
+}

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -2,6 +2,7 @@ import { type Context, Hono, type Next } from "hono";
 import { AppError } from "@/lib/errors";
 import { isEarnEnabled } from "@/lib/feature-flags";
 import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { policyGate } from "@/middleware/policy-gate";
 import { projectContextMiddleware } from "@/middleware/project-context";
 import type { Env } from "@/types/env";
 import {
@@ -16,7 +17,11 @@ import {
   retargetEarnProgram,
 } from "./handlers/program";
 import { getEarnStrategy, listEarnStrategies } from "./handlers/strategies";
-import { createEarnVaultDeposit, listEarnVaultPositions } from "./handlers/vault";
+import {
+  createEarnVaultDeposit,
+  extractEarnVaultDepositPolicyCandidate,
+  listEarnVaultPositions,
+} from "./handlers/vault";
 
 const earn = new Hono<{ Bindings: Env }>();
 
@@ -41,10 +46,31 @@ earn.get("/strategies/:strategyId", requirePermissions("earn:read"), getEarnStra
 
 // Non-custodial ("vault_direct") positions: SDP builds and signs the deposit
 // from a custody wallet, so unlike /programs there is no provider wallet to
-// provision and no address to fund afterwards. Money-in takes earn:write;
-// the position listing is a plain read.
-earn.post("/vault-deposits", requirePermissions("earn:write"), createEarnVaultDeposit);
-earn.get("/vault-positions", requirePermissions("earn:read"), listEarnVaultPositions);
+// provision and no address to fund afterwards.
+//
+// Both routes take the GLOBAL `wallets:read` alongside their earn scope, the
+// same pairing every money-moving payments route uses. That is not belt and
+// braces: for an API key with NO wallet bindings the per-wallet assertion in
+// the handler is a documented NO-OP, so the router permission is the only gate
+// such a key ever meets when it names a wallet.
+//
+// `policyGate` is what makes this route governed at all. It reaches
+// `createOrgSigner` and broadcasts a value-moving transaction, so without the
+// gate an org's wallet deny rules, approval requirements, amount/asset limits
+// and destination controls were all bypassed — the handler simply never asked.
+// The gate must sit AFTER `requirePermissions` and immediately before the
+// handler, so a denial is decided before any KMS or relay access.
+earn.post(
+  "/vault-deposits",
+  requirePermissions("earn:write", "wallets:read"),
+  policyGate({ extract: extractEarnVaultDepositPolicyCandidate }),
+  createEarnVaultDeposit
+);
+earn.get(
+  "/vault-positions",
+  requirePermissions("earn:read", "wallets:read"),
+  listEarnVaultPositions
+);
 
 // Portfolio programs: N provider wallets per org+environment+provider
 // (PRO-1670), each addressed by its own id. Money-in (create, re-target) takes

--- a/apps/sdp-api/src/routes/earn/index.ts
+++ b/apps/sdp-api/src/routes/earn/index.ts
@@ -16,6 +16,7 @@ import {
   retargetEarnProgram,
 } from "./handlers/program";
 import { getEarnStrategy, listEarnStrategies } from "./handlers/strategies";
+import { createEarnVaultDeposit, listEarnVaultPositions } from "./handlers/vault";
 
 const earn = new Hono<{ Bindings: Env }>();
 
@@ -37,6 +38,13 @@ earn.use("*", projectContextMiddleware());
 // Strategy catalogue (source: DB, written only by the sync cron + dev seed).
 earn.get("/strategies", requirePermissions("earn:read"), listEarnStrategies);
 earn.get("/strategies/:strategyId", requirePermissions("earn:read"), getEarnStrategy);
+
+// Non-custodial ("vault_direct") positions: SDP builds and signs the deposit
+// from a custody wallet, so unlike /programs there is no provider wallet to
+// provision and no address to fund afterwards. Money-in takes earn:write;
+// the position listing is a plain read.
+earn.post("/vault-deposits", requirePermissions("earn:write"), createEarnVaultDeposit);
+earn.get("/vault-positions", requirePermissions("earn:read"), listEarnVaultPositions);
 
 // Portfolio programs: N provider wallets per org+environment+provider
 // (PRO-1670), each addressed by its own id. Money-in (create, re-target) takes

--- a/apps/sdp-api/src/routes/earn/schemas.ts
+++ b/apps/sdp-api/src/routes/earn/schemas.ts
@@ -213,3 +213,35 @@ export const earnProgramWithdrawalParamsSchema = earnProgramParamsSchema.extend(
  * trail outlives credential removal).
  */
 export const earnProgramWithdrawalsListQuerySchema = z.object(earnPageQueryShape);
+
+/**
+ * Open a position in a NON-CUSTODIAL vault, or add to one, from an SDP custody
+ * wallet.
+ *
+ * Unlike the custodial create this carries an AMOUNT and a WALLET, because for
+ * a `vault_direct` provider opening the position and funding it are the same
+ * on-chain action — there is no wallet to provision first and no address to
+ * fund afterwards.
+ */
+export const earnVaultDepositSchema = z.object({
+  /** Catalogue strategy id, resolved to a vault address server-side. */
+  strategyId: z.string().min(1),
+  /** SDP custody wallet that signs and holds the shares. */
+  walletId: z.string().min(1),
+  /** Deposit amount in the vault token's units, as a decimal string. */
+  amount: z
+    .string()
+    .regex(/^\d+(\.\d+)?$/, "amount must be a positive decimal string")
+    .refine((value) => Number(value) > 0, "amount must be greater than zero"),
+  /**
+   * Idempotency key, REQUIRED here unlike the custodial create. The chain has
+   * no request-id dedupe of its own, so this row is the only thing preventing a
+   * retry from moving money twice.
+   */
+  requestId: z.uuidv4(),
+  /** Optional slippage floor, in shares, as a decimal string. */
+  minSharesOut: z
+    .string()
+    .regex(/^\d+(\.\d+)?$/, "minSharesOut must be a decimal string")
+    .optional(),
+});

--- a/apps/sdp-api/src/routes/earn/schemas.ts
+++ b/apps/sdp-api/src/routes/earn/schemas.ts
@@ -226,13 +226,14 @@ export const earnProgramWithdrawalsListQuerySchema = z.object(earnPageQueryShape
 export const earnVaultDepositSchema = z.object({
   /** Catalogue strategy id, resolved to a vault address server-side. */
   strategyId: z.string().min(1),
-  /** SDP custody wallet that signs and holds the shares. */
-  walletId: z.string().min(1),
+  /** SDP custody-wallet row that signs and holds the shares (`id`, not provider `walletId`). */
+  custodyWalletId: z.string().min(1),
   /** Deposit amount in the vault token's units, as a decimal string. */
   amount: z
     .string()
+    .max(128)
     .regex(/^\d+(\.\d+)?$/, "amount must be a positive decimal string")
-    .refine((value) => Number(value) > 0, "amount must be greater than zero"),
+    .refine((value) => /[1-9]/.test(value), "amount must be greater than zero"),
   /**
    * Idempotency key, REQUIRED here unlike the custodial create. The chain has
    * no request-id dedupe of its own, so this row is the only thing preventing a
@@ -242,6 +243,14 @@ export const earnVaultDepositSchema = z.object({
   /** Optional slippage floor, in shares, as a decimal string. */
   minSharesOut: z
     .string()
+    .max(128)
     .regex(/^\d+(\.\d+)?$/, "minSharesOut must be a decimal string")
+    .refine((value) => /[1-9]/.test(value), "minSharesOut must be greater than zero")
     .optional(),
+});
+
+/** Bounded keyset page over active vault holdings, newest first. */
+export const earnVaultPositionsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  before: z.string().min(1).optional(),
 });

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -40,7 +40,8 @@ type ValueMovingFamily =
   | "payments"
   | "ramps"
   | "custody"
-  | "raw_signing";
+  | "raw_signing"
+  | "earn";
 
 interface OrderedBoundary {
   file: string;
@@ -214,6 +215,37 @@ const contracts: ValueMovingContract[] = [
     ],
   },
   {
+    /**
+     * Non-custodial Earn vault deposits. Registered late — the route shipped
+     * ungoverned, and the inventory below could not see it because
+     * `apps/sdp-api/src/services/earn` was not a scanned root, so this test
+     * passed while a value-moving path had no policy gate at all.
+     */
+    family: "earn",
+    trustedContext: {
+      file: "apps/sdp-api/src/routes/earn/handlers/vault.ts",
+      evidence: "const { auth, wallets } = await resolveScope(c)",
+    },
+    authorization: {
+      file: "apps/sdp-api/src/routes/earn/index.ts",
+      section: '"/vault-deposits",',
+      before: "policyGate({ extract: extractEarnVaultDepositPolicyCandidate })",
+      after: "createEarnVaultDeposit",
+    },
+    replay: [
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/services/earn/vault-deposit.service.test.ts",
+        evidence: "replays the original vault deposit for the same requestId and payload",
+      },
+      {
+        mode: "idempotency_fingerprint",
+        file: "apps/sdp-api/src/services/earn/vault-deposit.service.test.ts",
+        evidence: "rejects the same requestId with a different payload",
+      },
+    ],
+  },
+  {
     family: "raw_signing",
     trustedContext: {
       file: "apps/sdp-api/src/routes/custody/handlers/signer-check.ts",
@@ -237,6 +269,19 @@ const contracts: ValueMovingContract[] = [
 
 const signingSinkInventory: Record<string, string[]> = {
   "apps/sdp-api/src/routes/custody/handlers/signer-check.ts": ["signAndSend"],
+  "apps/sdp-api/src/services/earn/vault-execution.service.ts": [
+    // signVaultPlan — signs WITHOUT sending, so the deposit service can record
+    // the signature before the bytes can possibly land. This is the only sink
+    // the vault deposit path actually reaches.
+    "signTransactionMessageWithSigners",
+    // submitVaultPlan, sponsored leg — the relay signs as fee payer and sends
+    // in one call, so the final signature is not knowable beforehand.
+    "signAndSend",
+    // submitVaultPlan, wallet-pays leg. Both submitVaultPlan legs are retained
+    // for the sponsored path and are unreachable from the deposit service until
+    // the relay can name the signature before broadcast.
+    "signTransactionMessageWithSigners",
+  ],
   "apps/sdp-api/src/routes/pay.ts": ["signAsFeePayer"],
   "apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts": ["signAndSend"],
   "apps/sdp-api/src/routes/payments/handlers/transfers.ts": [
@@ -259,6 +304,10 @@ const valueMovingSourceRoots = [
   "apps/sdp-api/src/routes",
   "apps/sdp-api/src/services/payments",
   "apps/sdp-api/src/services/private-channels",
+  // Earn's vault-direct path signs and broadcasts from a custody wallet. It was
+  // missing here, which is why the inventory below did not notice a whole
+  // money-moving surface — the omission the `earn` contract above now pins.
+  "apps/sdp-api/src/services/earn",
   "packages/sdp-issuance/src",
   "packages/sdp-solana/src",
 ];
@@ -322,6 +371,7 @@ describe("value-moving authorization and replay conformance", () => {
     expect(contracts.map((contract) => contract.family).sort()).toEqual([
       "batch",
       "custody",
+      "earn",
       "issuance",
       "payments",
       "ramps",

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -1,0 +1,92 @@
+import * as solanaRpc from "@sdp/rpc/solana";
+import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "@/types/env";
+import {
+  assertClusterEndpoint,
+  CLUSTER_ENDPOINT_PROOF_TTL_MS,
+  resetClusterEndpointProofs,
+} from "./execution-registry";
+
+const env = {} as Env;
+const rpcUrl = "https://rpc.example.invalid";
+
+function mockGenesisSend() {
+  const send = vi.fn();
+  vi.spyOn(solanaRpc, "createRpc").mockReturnValue({
+    getGenesisHash: () => ({ send }),
+  } as never);
+  return send;
+}
+
+beforeEach(() => {
+  resetClusterEndpointProofs();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("assertClusterEndpoint", () => {
+  it("evicts a transient probe rejection so the endpoint can recover", async () => {
+    const send = mockGenesisSend()
+      .mockRejectedValueOnce(new Error("RPC request timed out after 30000ms"))
+      .mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
+
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/Could not verify/);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    // The successful observation is cached only for the short trust window.
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches an observed mismatch only within the short trust window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-16T00:00:00.000Z"));
+    const send = mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
+    expect(send).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(CLUSTER_ENDPOINT_PROOF_TTL_MS);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent probes and caches the successful observation", async () => {
+    let resolveGenesis!: (hash: string) => void;
+    const send = mockGenesisSend().mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveGenesis = resolve;
+      })
+    );
+
+    const first = assertClusterEndpoint(env, "devnet", rpcUrl);
+    const second = assertClusterEndpoint(env, "devnet", rpcUrl);
+    expect(send).toHaveBeenCalledOnce();
+
+    resolveGenesis(GENESIS_HASH_BY_CLUSTER.devnet);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("re-proves a successful URL after its trust window expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-16T00:00:00.000Z"));
+    const send = mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
+
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    vi.advanceTimersByTime(CLUSTER_ENDPOINT_PROOF_TTL_MS - 1);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(1);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -1,0 +1,66 @@
+import { supportsVaultDirect } from "@sdp/earn/capabilities";
+import type { EarnVaultDirectProvider, EarnVaultProvider } from "@sdp/earn/types";
+import { KaminoVaultDirectClient } from "@sdp/kamino";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
+import type { Env } from "@/types/env";
+
+/**
+ * Which providers this deployment can EXECUTE for, as opposed to merely
+ * catalogue.
+ *
+ * `EARN_PROVIDER_CLIENTS` in `@sdp/earn` stays the catalogue registry — it is
+ * what the hourly sync resolves through, and it must remain free of chain SDKs
+ * so that cron keeps its small dependency surface. This overlay is consulted
+ * only by routes that move money, and it is the ONE place a provider id is
+ * mapped to an executing client. Everything downstream narrows with
+ * `supportsVaultDirect`, never an id check.
+ */
+
+/**
+ * The RPC endpoint used to build instructions for `cluster`.
+ *
+ * Deliberately reads the EXISTING `SOLANA_RPC_URL` and introduces no new env
+ * key — a new one would have to be registered in `env.d.ts`, `turbo.json` and
+ * `secret-keys.mjs` together, and the env-configurator drift test enforces that
+ * they agree.
+ *
+ * The known limitation, stated rather than hidden: `SOLANA_RPC_URL` is a
+ * PROCESS-level value while the cluster is PER-REQUEST, so one process can only
+ * serve the cluster its endpoint points at. A production deployment (mainnet
+ * endpoint) therefore cannot build devnet instructions for a sandbox project.
+ * That fails LOUDLY rather than silently: `listKaminoDevnetVaults` proves the
+ * chain by genesis hash before returning anything, so a mismatch is a refusal,
+ * never a confidently wrong result. Serving both clusters from one process is a
+ * follow-up that owes the full env registration.
+ */
+export function resolveClusterRpcUrl(env: Env, _cluster: SolanaCluster): string {
+  const url = env.SOLANA_RPC_URL;
+  return typeof url === "string" ? url.trim() : "";
+}
+
+export function earnClusterFor(environment: SdpEnvironment): SolanaCluster {
+  return CLUSTER_BY_SDP_ENVIRONMENT[environment];
+}
+
+/**
+ * Build the executing client for a provider, or `null` when this deployment has
+ * none. Fail-closed: an unrecognized provider id answers null rather than
+ * throwing, so a row written by a newer deploy degrades to "cannot execute"
+ * instead of 500ing a read that happens to touch it.
+ */
+export function resolveEarnExecutionClient(env: Env, provider: string): EarnVaultProvider | null {
+  if (provider === "kamino") {
+    return new KaminoVaultDirectClient((cluster) => resolveClusterRpcUrl(env, cluster));
+  }
+  return null;
+}
+
+/** The executing client narrowed to the vault-direct capability, or null. */
+export function resolveVaultDirectClient(
+  env: Env,
+  provider: string
+): EarnVaultDirectProvider | null {
+  const client = resolveEarnExecutionClient(env, provider);
+  if (!client) return null;
+  return supportsVaultDirect(client) ? client : null;
+}

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -1,7 +1,14 @@
 import { supportsVaultDirect } from "@sdp/earn/capabilities";
+import { providerNotConfigured } from "@sdp/earn/errors";
 import type { EarnVaultDirectProvider, EarnVaultProvider } from "@sdp/earn/types";
 import { KaminoVaultDirectClient } from "@sdp/kamino";
-import { CLUSTER_BY_SDP_ENVIRONMENT, type SdpEnvironment, type SolanaCluster } from "@sdp/types";
+import * as solanaRpc from "@sdp/rpc/solana";
+import {
+  CLUSTER_BY_SDP_ENVIRONMENT,
+  GENESIS_HASH_BY_CLUSTER,
+  type SdpEnvironment,
+  type SolanaCluster,
+} from "@sdp/types";
 import type { Env } from "@/types/env";
 
 /**
@@ -19,23 +26,100 @@ import type { Env } from "@/types/env";
 /**
  * The RPC endpoint used to build instructions for `cluster`.
  *
- * Deliberately reads the EXISTING `SOLANA_RPC_URL` and introduces no new env
- * key — a new one would have to be registered in `env.d.ts`, `turbo.json` and
- * `secret-keys.mjs` together, and the env-configurator drift test enforces that
- * they agree.
+ * Per-cluster by construction, because one API process serves BOTH — a sandbox
+ * project is devnet and a production project is mainnet-beta, and the same
+ * deployment answers requests for each. Reading one process-level
+ * `SOLANA_RPC_URL` for both meant whichever chain that endpoint served, the
+ * other environment silently built and read against the wrong one.
  *
- * The known limitation, stated rather than hidden: `SOLANA_RPC_URL` is a
- * PROCESS-level value while the cluster is PER-REQUEST, so one process can only
- * serve the cluster its endpoint points at. A production deployment (mainnet
- * endpoint) therefore cannot build devnet instructions for a sandbox project.
- * That fails LOUDLY rather than silently: `listKaminoDevnetVaults` proves the
- * chain by genesis hash before returning anything, so a mismatch is a refusal,
- * never a confidently wrong result. Serving both clusters from one process is a
- * follow-up that owes the full env registration.
+ * `SOLANA_DEVNET_RPC_URL` / `SOLANA_MAINNET_RPC_URL` are optional overrides;
+ * `SOLANA_RPC_URL` stays the fallback so an existing single-cluster deployment
+ * keeps working unchanged. What makes the fallback SAFE rather than the same
+ * bug with more steps is `assertClusterEndpoint` below: the endpoint has to
+ * prove which chain it serves before anything is built against it.
  */
-export function resolveClusterRpcUrl(env: Env, _cluster: SolanaCluster): string {
-  const url = env.SOLANA_RPC_URL;
+export function resolveClusterRpcUrl(env: Env, cluster: SolanaCluster): string {
+  const perCluster = cluster === "devnet" ? env.SOLANA_DEVNET_RPC_URL : env.SOLANA_MAINNET_RPC_URL;
+  const url = perCluster ?? env.SOLANA_RPC_URL;
   return typeof url === "string" ? url.trim() : "";
+}
+
+/**
+ * Memoised verdicts, keyed by `cluster\nurl`.
+ *
+ * The genesis hash of an endpoint is immutable for the life of that endpoint,
+ * so this is a cache of a constant rather than of a reading — but it is also
+ * what keeps the assertion affordable: without it every deposit and every
+ * position page would pay an extra round trip.
+ *
+ * Failures are cached too, deliberately. A misconfigured endpoint is a
+ * deployment fact, not a transient one, and re-probing it on every request
+ * turns one configuration error into sustained load against someone else's RPC.
+ */
+const clusterProofs = new Map<string, Promise<void>>();
+
+/**
+ * Refuse to build against an endpoint that has not proved it serves `cluster`.
+ *
+ * This is the check the execution path was missing. The catalogue path already
+ * had it — `listKaminoDevnetVaults` verifies genesis before returning anything —
+ * but the money path trusted its URL, and a cluster mismatch does NOT surface as
+ * an error: Kamino's mainnet kvault program id also resolves on devnet with no
+ * accounts under it, so the failure mode is "this vault does not exist", or a
+ * transaction built for the wrong deployment.
+ *
+ * Called before every build and every position read. Cheap after the first hit,
+ * and the first hit is the one that matters.
+ */
+export async function assertClusterEndpoint(
+  env: Env,
+  cluster: SolanaCluster,
+  rpcUrl: string
+): Promise<void> {
+  if (rpcUrl === "") {
+    throw providerNotConfigured(
+      `No Solana RPC endpoint is configured for ${cluster}. Set SOLANA_${
+        cluster === "devnet" ? "DEVNET" : "MAINNET"
+      }_RPC_URL, or point SOLANA_RPC_URL at a ${cluster} endpoint.`
+    );
+  }
+
+  const key = `${cluster}\n${rpcUrl}`;
+  const existing = clusterProofs.get(key);
+  if (existing) return await existing;
+
+  const proof = (async () => {
+    const expected = GENESIS_HASH_BY_CLUSTER[cluster];
+    let observed: string;
+    try {
+      observed = await getGenesisHash(env, rpcUrl);
+    } catch (cause) {
+      throw providerNotConfigured(
+        `Could not verify that the configured ${cluster} RPC endpoint serves ${cluster}: ` +
+          `${cause instanceof Error ? cause.message : String(cause)}`
+      );
+    }
+    if (observed !== expected) {
+      throw providerNotConfigured(
+        `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. ` +
+          "Building against it would address the wrong chain — refusing. Set " +
+          `SOLANA_${cluster === "devnet" ? "DEVNET" : "MAINNET"}_RPC_URL to a ${cluster} endpoint.`
+      );
+    }
+  })();
+
+  clusterProofs.set(key, proof);
+  return await proof;
+}
+
+async function getGenesisHash(env: Env, rpcUrl: string): Promise<string> {
+  const rpc = solanaRpc.createRpc(env, { rpcUrl });
+  return String(await rpc.getGenesisHash().send());
+}
+
+/** Test seam: forget cached genesis verdicts. */
+export function resetClusterEndpointProofs(): void {
+  clusterProofs.clear();
 }
 
 export function earnClusterFor(environment: SdpEnvironment): SolanaCluster {

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -45,18 +45,27 @@ export function resolveClusterRpcUrl(env: Env, cluster: SolanaCluster): string {
 }
 
 /**
- * Memoised verdicts, keyed by `cluster\nurl`.
+ * Briefly memoised genesis observations, keyed by `cluster\nurl`.
  *
- * The genesis hash of an endpoint is immutable for the life of that endpoint,
- * so this is a cache of a constant rather than of a reading — but it is also
- * what keeps the assertion affordable: without it every deposit and every
- * position page would pay an extra round trip.
+ * The genesis hash returned by one backend is immutable, but a URL is not: DNS,
+ * a load balancer, or deployment configuration can repoint the same string at a
+ * different cluster. Cache only a short burst so concurrent/page fan-out stays
+ * affordable without turning one old observation into a process-lifetime funds
+ * authorization.
  *
- * Failures are cached too, deliberately. A misconfigured endpoint is a
- * deployment fact, not a transient one, and re-probing it on every request
- * turns one configuration error into sustained load against someone else's RPC.
+ * A rejected RPC call is NOT an observation. Timeouts, 429s and network failures
+ * are evicted immediately; successful matches and mismatches share the same
+ * short TTL.
  */
-const clusterProofs = new Map<string, Promise<void>>();
+export const CLUSTER_ENDPOINT_PROOF_TTL_MS = 30_000;
+
+interface ClusterEndpointProof {
+  promise: Promise<string>;
+  /** Null while the shared probe is still in flight. */
+  expiresAt: number | null;
+}
+
+const clusterProofs = new Map<string, ClusterEndpointProof>();
 
 /**
  * Refuse to build against an endpoint that has not proved it serves `cluster`.
@@ -68,8 +77,8 @@ const clusterProofs = new Map<string, Promise<void>>();
  * accounts under it, so the failure mode is "this vault does not exist", or a
  * transaction built for the wrong deployment.
  *
- * Called before every build and every position read. Cheap after the first hit,
- * and the first hit is the one that matters.
+ * Called before every build and every position read. Concurrent calls coalesce,
+ * and a later call re-proves the URL after the short trust window expires.
  */
 export async function assertClusterEndpoint(
   env: Env,
@@ -85,31 +94,41 @@ export async function assertClusterEndpoint(
   }
 
   const key = `${cluster}\n${rpcUrl}`;
-  const existing = clusterProofs.get(key);
-  if (existing) return await existing;
+  let proof = clusterProofs.get(key);
+  if (proof && proof.expiresAt !== null && proof.expiresAt <= Date.now()) {
+    clusterProofs.delete(key);
+    proof = undefined;
+  }
+  if (!proof) {
+    proof = { promise: getGenesisHash(env, rpcUrl), expiresAt: null };
+    clusterProofs.set(key, proof);
+  }
 
-  const proof = (async () => {
-    const expected = GENESIS_HASH_BY_CLUSTER[cluster];
-    let observed: string;
-    try {
-      observed = await getGenesisHash(env, rpcUrl);
-    } catch (cause) {
-      throw providerNotConfigured(
-        `Could not verify that the configured ${cluster} RPC endpoint serves ${cluster}: ` +
-          `${cause instanceof Error ? cause.message : String(cause)}`
-      );
+  let observed: string;
+  try {
+    observed = await proof.promise;
+    if (clusterProofs.get(key) === proof && proof.expiresAt === null) {
+      proof.expiresAt = Date.now() + CLUSTER_ENDPOINT_PROOF_TTL_MS;
     }
-    if (observed !== expected) {
-      throw providerNotConfigured(
-        `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. ` +
-          "Building against it would address the wrong chain — refusing. Set " +
-          `SOLANA_${cluster === "devnet" ? "DEVNET" : "MAINNET"}_RPC_URL to a ${cluster} endpoint.`
-      );
-    }
-  })();
+  } catch (cause) {
+    // Delete only if this is still the promise stored for the key. Concurrent
+    // callers may all observe the same rejection; none may delete a newer probe
+    // started after this one failed.
+    if (clusterProofs.get(key) === proof) clusterProofs.delete(key);
+    throw providerNotConfigured(
+      `Could not verify that the configured ${cluster} RPC endpoint serves ${cluster}: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`
+    );
+  }
 
-  clusterProofs.set(key, proof);
-  return await proof;
+  const expected = GENESIS_HASH_BY_CLUSTER[cluster];
+  if (observed !== expected) {
+    throw providerNotConfigured(
+      `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. ` +
+        "Building against it would address the wrong chain — refusing. Set " +
+        `SOLANA_${cluster === "devnet" ? "DEVNET" : "MAINNET"}_RPC_URL to a ${cluster} endpoint.`
+    );
+  }
 }
 
 async function getGenesisHash(env: Env, rpcUrl: string): Promise<string> {

--- a/apps/sdp-api/src/services/earn/vault-deadline.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withVaultDeadline } from "./vault-deadline";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withVaultDeadline", () => {
+  it("returns an external result before the deadline", async () => {
+    await expect(withVaultDeadline(Promise.resolve("ok"), "test call", 25)).resolves.toBe("ok");
+  });
+
+  it("rejects a call that never settles within its bound", async () => {
+    vi.useFakeTimers();
+    const result = withVaultDeadline(new Promise<never>(() => undefined), "test call", 25);
+    const rejection = expect(result).rejects.toThrow("test call timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+  });
+});

--- a/apps/sdp-api/src/services/earn/vault-deadline.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.ts
@@ -1,0 +1,29 @@
+/** Default ceiling for API-owned vault RPC, provider, and custody calls. */
+export const VAULT_EXTERNAL_CALL_TIMEOUT_MS = 20_000;
+
+/**
+ * Bound an external call even when its SDK does not expose an AbortSignal.
+ * Consume a late rejection so a timed-out operation cannot become unhandled.
+ */
+export async function withVaultDeadline<T>(
+  operation: Promise<T>,
+  label: string,
+  timeoutMs = VAULT_EXTERNAL_CALL_TIMEOUT_MS
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  void operation.catch(() => undefined);
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.test.ts
@@ -1,35 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
+import { createPostgresPolicyRepository } from "@/db/repositories/policy.repository.postgres";
+import { createTenantScope } from "@/lib/tenant-scope";
+import {
+  recoverApprovedWalletOperations,
+  runApprovedWalletOperationEffectTransaction,
+} from "@/services/policy/approved-operation-replay";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import { env } from "@/test/helpers/env";
 import { seedTestDatabase } from "@/test/mocks/db";
-
-/**
- * The idempotency contract for a non-custodial vault deposit.
- *
- * Two titles here are named verbatim by
- * `apps/sdp-api/src/security/value-moving-conformance.node.test.ts` as the
- * `earn` family's replay evidence — renaming one fails that test rather than
- * quietly dropping the guarantee it stands for.
- *
- * The chain is stubbed at the module boundary. What is under test is the ORDER
- * and the DECISIONS around the transfer, not the transfer: which row is written
- * before anything is signed, whether a reused key is a replay or a conflict,
- * and whether a mismatch can mutate state before it is refused.
- */
 
 const buildVaultDeposit = vi.hoisted(() => vi.fn());
 const signVaultPlan = vi.hoisted(() => vi.fn());
 const broadcastVaultTransaction = vi.hoisted(() => vi.fn());
 const simulateVaultPlan = vi.hoisted(() => vi.fn());
 const createOrgSigner = vi.hoisted(() => vi.fn());
+const assertClusterEndpoint = vi.hoisted(() => vi.fn());
 
 vi.mock("./execution-registry", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./execution-registry")>()),
   resolveVaultDirectClient: () => ({ buildVaultDeposit }),
   resolveClusterRpcUrl: () => "https://rpc.example.invalid",
-  assertClusterEndpoint: async () => undefined,
+  assertClusterEndpoint,
 }));
 
 vi.mock("./vault-execution.service", async (importOriginal) => ({
@@ -52,6 +45,8 @@ const USER = "usr_vault_deposit";
 const WALLET_ROW_ID = "cwlt_vault_deposit";
 const CUSTODY_CONFIG_ID = "cfg_vault_deposit";
 const WALLET_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
 const VAULT_A = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
 const VAULT_B = "3nMFwZXwY1s1M5s8vYAHqd4wGs4iSxXE4LRoUMMYqEgF";
 
@@ -69,10 +64,29 @@ function depositInput(overrides: Record<string, unknown> = {}) {
     provider: "kamino",
     providerReference: VAULT_A,
     wallet,
+    tokenMint: TOKEN_MINT,
+    shareMint: SHARE_MINT,
+    label: "Test USDC Vault",
     amount: "10",
     requestId: "11111111-1111-4111-8111-111111111111",
     userId: USER,
     apiKeyId: null,
+    ...overrides,
+  };
+}
+
+function plan(overrides: Record<string, unknown> = {}) {
+  return {
+    cluster: "devnet",
+    transactions: [
+      [{ programAddress: "11111111111111111111111111111111", accounts: [], data: "" }],
+    ],
+    lookupTables: [],
+    assetIdentity: {
+      depositTokenMint: TOKEN_MINT,
+      shareMint: SHARE_MINT,
+    },
+    accepted: { amount: "10" },
     ...overrides,
   };
 }
@@ -91,7 +105,6 @@ async function seedWallet(): Promise<void> {
          VALUES (?, ?, ?, ?, 'sandbox', 'active', ?)`
       )
       .bind(PROJECT, ORG, "Vault Deposit Project", "vault-deposit-project", USER),
-    // custody_wallets hangs off a custody_config, not off the org directly.
     getDb(env)
       .prepare(
         `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
@@ -103,26 +116,30 @@ async function seedWallet(): Promise<void> {
         `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
          VALUES (?, ?, ?, ?, 'active')`
       )
-      .bind(WALLET_ROW_ID, CUSTODY_CONFIG_ID, "privy_vault_deposit", WALLET_ADDRESS),
+      .bind(WALLET_ROW_ID, CUSTODY_CONFIG_ID, wallet.walletId, WALLET_ADDRESS),
   ]);
+}
+
+async function tableCount(table: "earn_vault_positions" | "earn_vault_movements") {
+  const row = await getDb(env)
+    .prepare(`SELECT COUNT(*) AS count FROM ${table}`)
+    .first<{ count: number | string }>();
+  return Number(row?.count ?? 0);
 }
 
 beforeEach(async () => {
   await seedTestDatabase(env);
   await seedWallet();
   vi.clearAllMocks();
-
-  buildVaultDeposit.mockResolvedValue({
-    cluster: "devnet",
-    transactions: [
-      [{ programAddress: "11111111111111111111111111111111", accounts: [], data: "" }],
-    ],
-    lookupTables: [],
-    accepted: { amount: "10" },
-  });
+  assertClusterEndpoint.mockResolvedValue(undefined);
+  buildVaultDeposit.mockResolvedValue(plan());
   simulateVaultPlan.mockResolvedValue({ ok: true });
   createOrgSigner.mockResolvedValue({ address: WALLET_ADDRESS });
-  signVaultPlan.mockResolvedValue({ bytes: new Uint8Array([1]), signature: "sig_original" });
+  signVaultPlan.mockResolvedValue({
+    bytes: new Uint8Array([1]),
+    signature: "sig_original",
+    lastValidBlockHeight: "12345",
+  });
   broadcastVaultTransaction.mockResolvedValue(undefined);
 });
 
@@ -133,115 +150,711 @@ afterEach(() => {
 describe("depositIntoVault — idempotency", () => {
   it("replays the original vault deposit for the same requestId and payload", async () => {
     const first = await depositIntoVault(env, depositInput());
-    expect(first.replayed).toBe(false);
-
     const second = await depositIntoVault(env, depositInput());
 
-    expect(second.replayed).toBe(true);
+    expect(second).toMatchObject({ replayed: true });
     expect(second.movement.id).toBe(first.movement.id);
     expect(second.position.id).toBe(first.position.id);
-    // The whole point: a replay must not put a second transfer on the wire.
     expect(signVaultPlan).toHaveBeenCalledTimes(1);
     expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
   });
 
-  /**
-   * The bug this closes was not just a missing 409. Because the position was
-   * claimed BEFORE the movement, a key reused against a different vault opened
-   * a real position row for vault B and then answered with vault A's signature.
-   */
+  it("serves a durable replay without proving or touching the RPC endpoint", async () => {
+    await depositIntoVault(env, depositInput());
+    vi.clearAllMocks();
+    assertClusterEndpoint.mockRejectedValue(new Error("RPC unavailable"));
+
+    const replay = await depositIntoVault(env, depositInput());
+
+    expect(replay.replayed).toBe(true);
+    expect(assertClusterEndpoint).not.toHaveBeenCalled();
+    expect(buildVaultDeposit).not.toHaveBeenCalled();
+    expect(signVaultPlan).not.toHaveBeenCalled();
+  });
+
+  it("treats insignificant decimal zeroes as the same on-chain intent", async () => {
+    await depositIntoVault(env, depositInput({ amount: "10.000000" }));
+    const replay = await depositIntoVault(env, depositInput({ amount: "10" }));
+
+    expect(replay.replayed).toBe(true);
+    expect(signVaultPlan).toHaveBeenCalledTimes(1);
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects the same requestId with a different payload", async () => {
     const first = await depositIntoVault(env, depositInput());
-
     await expect(
       depositIntoVault(env, depositInput({ providerReference: VAULT_B }))
     ).rejects.toMatchObject({ code: "CONFLICT" });
 
-    // Nothing was signed or sent for the mismatched request...
-    expect(signVaultPlan).toHaveBeenCalledTimes(1);
-    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
-
-    // ...and, critically, no position row was created for the other vault. The
-    // refusal has to land BEFORE the claim, or the ledger records a position
-    // the caller was never allowed to open.
-    const repo = createPostgresEarnVaultRepository(getDb(env));
-    const positions = await repo.listPositions({ organizationId: ORG, environment: "sandbox" });
-    expect(positions).toHaveLength(1);
-    expect(positions[0]?.id).toBe(first.position.id);
-    expect(positions[0]?.provider_reference).toBe(VAULT_A);
+    expect(await tableCount("earn_vault_positions")).toBe(1);
+    expect(await tableCount("earn_vault_movements")).toBe(1);
+    expect(first.position.provider_reference).toBe(VAULT_A);
   });
 
-  it("treats a changed minSharesOut as a different request, not a replay", async () => {
-    await depositIntoVault(env, depositInput());
+  it("rolls back a concurrent divergent requestId loser before it can claim a position", async () => {
+    let releaseBuilds: (() => void) | undefined;
+    const bothBuilding = new Promise<void>((resolve) => {
+      releaseBuilds = resolve;
+    });
+    let buildCount = 0;
+    buildVaultDeposit.mockImplementation(async () => {
+      buildCount += 1;
+      if (buildCount === 2) releaseBuilds?.();
+      await bothBuilding;
+      return plan();
+    });
+    let signCount = 0;
+    signVaultPlan.mockImplementation(async () => {
+      signCount += 1;
+      return {
+        bytes: new Uint8Array([signCount]),
+        signature: `sig_concurrent_${signCount}`,
+        lastValidBlockHeight: "12345",
+      };
+    });
 
-    // The floor is baked into the built instruction, so reusing a key with a
-    // weaker one must not silently return the stricter original.
-    await expect(depositIntoVault(env, depositInput({ minSharesOut: "1" }))).rejects.toMatchObject({
+    const outcomes = await Promise.allSettled([
+      depositIntoVault(env, depositInput({ providerReference: VAULT_A })),
+      depositIntoVault(env, depositInput({ providerReference: VAULT_B })),
+    ]);
+
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    const rejected = outcomes.find((outcome) => outcome.status === "rejected");
+    expect(rejected).toMatchObject({ reason: { code: "CONFLICT" } });
+    expect(await tableCount("earn_vault_positions")).toBe(1);
+    expect(await tableCount("earn_vault_movements")).toBe(1);
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("broadcasts exactly once when identical requests race with different signatures", async () => {
+    let releaseBuilds: (() => void) | undefined;
+    const bothBuilding = new Promise<void>((resolve) => {
+      releaseBuilds = resolve;
+    });
+    let buildCount = 0;
+    buildVaultDeposit.mockImplementation(async () => {
+      buildCount += 1;
+      if (buildCount === 2) releaseBuilds?.();
+      await bothBuilding;
+      return plan();
+    });
+    let signCount = 0;
+    signVaultPlan.mockImplementation(async () => {
+      signCount += 1;
+      return {
+        bytes: new Uint8Array([signCount]),
+        signature: `sig_identical_${signCount}`,
+        lastValidBlockHeight: "12345",
+      };
+    });
+
+    const results = await Promise.all([
+      depositIntoVault(env, depositInput()),
+      depositIntoVault(env, depositInput()),
+    ]);
+
+    expect(results.map((result) => result.replayed).sort()).toEqual([false, true]);
+    expect(new Set(results.map((result) => result.movement.id))).toHaveProperty("size", 1);
+    expect(new Set(results.map((result) => result.position.id))).toHaveProperty("size", 1);
+    expect(await tableCount("earn_vault_positions")).toBe(1);
+    expect(await tableCount("earn_vault_movements")).toBe(1);
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds independent request keys into distinct on-chain memo instructions", async () => {
+    const memoPayloads: string[] = [];
+    signVaultPlan.mockImplementation(async (_env, input) => {
+      const encoded = input.plan.transactions[0]?.at(-1)?.data;
+      if (!encoded) throw new Error("missing request memo");
+      memoPayloads.push(Buffer.from(encoded, "base64").toString("utf8"));
+      return {
+        bytes: new Uint8Array([memoPayloads.length]),
+        signature: `sig_distinct_${memoPayloads.length}`,
+        lastValidBlockHeight: "12345",
+      };
+    });
+
+    const firstRequestId = "11111111-1111-4111-8111-111111111111";
+    const secondRequestId = "22222222-2222-4222-8222-222222222222";
+    await Promise.all([
+      depositIntoVault(env, depositInput({ requestId: firstRequestId })),
+      depositIntoVault(env, depositInput({ requestId: secondRequestId })),
+    ]);
+
+    expect(memoPayloads.sort()).toEqual(
+      [firstRequestId, secondRequestId]
+        .map((requestId) => `sdp:earn:vault-deposit:${requestId}`)
+        .sort()
+    );
+    expect(await tableCount("earn_vault_positions")).toBe(1);
+    expect(await tableCount("earn_vault_movements")).toBe(2);
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a changed minSharesOut as a different request", async () => {
+    buildVaultDeposit.mockResolvedValue(plan({ accepted: { amount: "10", minSharesOut: "1" } }));
+    await depositIntoVault(env, depositInput({ minSharesOut: "1" }));
+
+    await expect(depositIntoVault(env, depositInput({ minSharesOut: "2" }))).rejects.toMatchObject({
       code: "CONFLICT",
     });
   });
 });
 
-describe("depositIntoVault — recoverability", () => {
-  /**
-   * Signing determines the signature; broadcasting only publishes it. Recording
-   * it first is what makes an ambiguous send reconcilable rather than an
-   * untraceable orphan.
-   */
-  it("records the signature before the transaction is broadcast", async () => {
-    const order: string[] = [];
-    signVaultPlan.mockImplementation(async () => {
-      order.push("sign");
-      return { bytes: new Uint8Array([1]), signature: "sig_ordered" };
-    });
-    broadcastVaultTransaction.mockImplementation(async () => {
-      // By the time the bytes are on the wire the row must already name them.
-      const repo = createPostgresEarnVaultRepository(getDb(env));
-      const rows = await repo.listMovements({ organizationId: ORG, positionId: positionId ?? "" });
-      order.push(rows[0]?.signature === "sig_ordered" ? "recorded-before-send" : "not-recorded");
+describe("depositIntoVault — signed persistence boundary", () => {
+  it("fails closed when the builder returns a plan for another cluster", async () => {
+    buildVaultDeposit.mockResolvedValue(plan({ cluster: "mainnet-beta" }));
+
+    await expect(depositIntoVault(env, depositInput())).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
     });
 
-    let positionId: string | undefined;
-    buildVaultDeposit.mockImplementation(async () => {
-      const repo = createPostgresEarnVaultRepository(getDb(env));
-      const positions = await repo.listPositions({ organizationId: ORG, environment: "sandbox" });
-      positionId = positions[0]?.id;
-      return {
-        cluster: "devnet",
-        transactions: [
-          [{ programAddress: "11111111111111111111111111111111", accounts: [], data: "" }],
-        ],
-        lookupTables: [],
-        accepted: { amount: "10" },
-      };
-    });
-
-    await depositIntoVault(env, depositInput());
-
-    expect(order).toEqual(["sign", "recorded-before-send"]);
+    expect(simulateVaultPlan).not.toHaveBeenCalled();
+    expect(signVaultPlan).not.toHaveBeenCalled();
+    expect(await tableCount("earn_vault_movements")).toBe(0);
   });
 
-  /**
-   * A send error does NOT prove the transaction failed — it may have landed and
-   * the response been lost. Marking it `failed` would assert that no money
-   * moved, which is precisely the claim that cannot be made.
-   */
-  it("leaves an ambiguous broadcast reconcilable instead of marking it failed", async () => {
+  it.each([
+    ["deposit token", { depositTokenMint: VAULT_B, shareMint: SHARE_MINT }],
+    ["share", { depositTokenMint: TOKEN_MINT, shareMint: VAULT_B }],
+  ])(
+    "fails closed when the builder's %s mint disagrees with the catalogue",
+    async (_name, assetIdentity) => {
+      buildVaultDeposit.mockResolvedValue(plan({ assetIdentity }));
+
+      await expect(depositIntoVault(env, depositInput())).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+      });
+
+      expect(simulateVaultPlan).not.toHaveBeenCalled();
+      expect(signVaultPlan).not.toHaveBeenCalled();
+      expect(await tableCount("earn_vault_positions")).toBe(0);
+      expect(await tableCount("earn_vault_movements")).toBe(0);
+    }
+  );
+
+  it.each([
+    ["amount", { accepted: { amount: "10.000001" } }, {}],
+    ["minSharesOut", { accepted: { amount: "10", minSharesOut: "0.9" } }, { minSharesOut: "1" }],
+    ["unexpected minSharesOut", { accepted: { amount: "10", minSharesOut: "1" } }, {}],
+  ])(
+    "fails closed when the builder changes the policy-approved %s",
+    async (_name, planOverrides, inputOverrides) => {
+      buildVaultDeposit.mockResolvedValue(plan(planOverrides));
+
+      await expect(depositIntoVault(env, depositInput(inputOverrides))).rejects.toMatchObject({
+        code: "INTERNAL_ERROR",
+      });
+
+      expect(simulateVaultPlan).not.toHaveBeenCalled();
+      expect(signVaultPlan).not.toHaveBeenCalled();
+      expect(await tableCount("earn_vault_movements")).toBe(0);
+    }
+  );
+
+  it("atomically records canonical amounts, metadata, activation, and signature before broadcast", async () => {
+    buildVaultDeposit.mockResolvedValue(plan({ accepted: { amount: "10", minSharesOut: "1" } }));
+    let movementAtBroadcast: Record<string, unknown> | null = null;
+    let positionAtBroadcast: Record<string, unknown> | null = null;
+    broadcastVaultTransaction.mockImplementation(async () => {
+      movementAtBroadcast = await getDb(env)
+        .prepare("SELECT * FROM earn_vault_movements")
+        .first<Record<string, unknown>>();
+      positionAtBroadcast = await getDb(env)
+        .prepare("SELECT * FROM earn_vault_positions")
+        .first<Record<string, unknown>>();
+    });
+
+    await depositIntoVault(env, depositInput({ amount: "10.000000", minSharesOut: "1.000" }));
+
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+    expect(movementAtBroadcast).toMatchObject({
+      requested_amount: "10.000000",
+      amount: "10",
+      requested_min_shares_out: "1.000",
+      min_shares_out: "1",
+      signature: "sig_original",
+      signed_transaction: "AQ==",
+      last_valid_block_height: "12345",
+      status: "pending",
+    });
+    expect(positionAtBroadcast).toMatchObject({
+      token_mint: TOKEN_MINT,
+      share_mint: SHARE_MINT,
+      label: "Test USDC Vault",
+    });
+    expect((positionAtBroadcast as Record<string, unknown> | null)?.activated_at).toEqual(
+      expect.any(String)
+    );
+  });
+
+  it("rejects direct SQL writes that break fund or parent-position identity", async () => {
+    const result = await depositIntoVault(env, depositInput());
+
+    await expect(
+      getDb(env)
+        .prepare("UPDATE earn_vault_movements SET amount = '11' WHERE id = ?")
+        .bind(result.movement.id)
+        .run()
+    ).rejects.toThrow();
+    await expect(
+      getDb(env)
+        .prepare("UPDATE earn_vault_movements SET requested_amount = ?, amount = ? WHERE id = ?")
+        .bind("9".repeat(129), "9".repeat(129), result.movement.id)
+        .run()
+    ).rejects.toThrow();
+    await expect(
+      getDb(env)
+        .prepare(
+          "UPDATE earn_vault_movements SET requested_min_shares_out = '0', min_shares_out = '0' WHERE id = ?"
+        )
+        .bind(result.movement.id)
+        .run()
+    ).rejects.toThrow();
+    await expect(
+      getDb(env)
+        .prepare("UPDATE earn_vault_movements SET last_valid_block_height = 1.5 WHERE id = ?")
+        .bind(result.movement.id)
+        .run()
+    ).rejects.toThrow();
+    await expect(
+      getDb(env)
+        .prepare("UPDATE earn_vault_movements SET provider_reference = ? WHERE id = ?")
+        .bind(VAULT_B, result.movement.id)
+        .run()
+    ).rejects.toThrow();
+    expect(
+      await createPostgresEarnVaultRepository(getDb(env)).getMovementById({
+        movementId: result.movement.id,
+        organizationId: ORG,
+      })
+    ).toMatchObject({ amount: "10", provider_reference: VAULT_A });
+  });
+
+  it.each([
+    ["deposit token", { tokenMint: VAULT_B }, { depositTokenMint: VAULT_B, shareMint: SHARE_MINT }],
+    ["share", { shareMint: VAULT_B }, { depositTokenMint: TOKEN_MINT, shareMint: VAULT_B }],
+  ])(
+    "never relabels an existing position's %s mint",
+    async (_name, inputOverrides, assetIdentity) => {
+      await depositIntoVault(env, depositInput());
+      buildVaultDeposit.mockResolvedValue(plan({ assetIdentity }));
+      signVaultPlan.mockResolvedValue({
+        bytes: new Uint8Array([2]),
+        signature: `sig_identity_change_${String(_name).replace(" ", "_")}`,
+        lastValidBlockHeight: "12346",
+      });
+
+      await expect(
+        depositIntoVault(
+          env,
+          depositInput({
+            ...inputOverrides,
+            requestId: "22222222-2222-4222-8222-222222222222",
+          })
+        )
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      expect(await tableCount("earn_vault_movements")).toBe(1);
+      const position = await getDb(env)
+        .prepare("SELECT token_mint, share_mint FROM earn_vault_positions")
+        .first<{ token_mint: string; share_mint: string }>();
+      expect(position).toEqual({ token_mint: TOKEN_MINT, share_mint: SHARE_MINT });
+    }
+  );
+
+  it("leaves an ambiguous broadcast as signed pending for reconciliation", async () => {
     broadcastVaultTransaction.mockRejectedValue(new Error("socket hang up"));
 
     const result = await depositIntoVault(env, depositInput());
 
-    expect(result.movement.status).not.toBe("failed");
-    expect(result.movement.signature).toBe("sig_original");
+    expect(result.movement).toMatchObject({ status: "pending", signature: "sig_original" });
   });
 
-  it("marks a pre-signature failure as failed, because nothing reached the chain", async () => {
-    simulateVaultPlan.mockResolvedValue({ ok: false, error: "custom program error", logs: [] });
+  it("returns a matching terminal CAS winner after broadcast", async () => {
+    broadcastVaultTransaction.mockImplementation(async () => {
+      const movement = await getDb(env)
+        .prepare("SELECT id FROM earn_vault_movements")
+        .first<{ id: string }>();
+      if (!movement) throw new Error("missing movement fixture");
+      await createPostgresEarnVaultRepository(getDb(env)).advanceMovement({
+        movementId: movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "failed",
+        failureReason: "chain rejected",
+      });
+    });
 
     const result = await depositIntoVault(env, depositInput());
 
-    expect(result.movement.status).toBe("failed");
-    expect(result.movement.signature).toBeNull();
-    expect(signVaultPlan).not.toHaveBeenCalled();
+    expect(result.movement).toMatchObject({
+      status: "failed",
+      signature: "sig_original",
+      failure_reason: "chain rejected",
+    });
+    const listed = await createPostgresEarnVaultRepository(getDb(env)).listPositions({
+      organizationId: ORG,
+      environment: "sandbox",
+      custodyWalletIds: [WALLET_ROW_ID],
+      limit: 20,
+    });
+    expect(listed.rows).toEqual([]);
+  });
+
+  it("keeps a position active when a later failed attempt follows a confirmed deposit", async () => {
+    const repository = createPostgresEarnVaultRepository(getDb(env));
+    const first = await depositIntoVault(
+      env,
+      depositInput({ requestId: "11111111-1111-4111-8111-111111111111" })
+    );
+    await repository.advanceMovement({
+      movementId: first.movement.id,
+      organizationId: ORG,
+      fromStatuses: ["submitted"],
+      toStatus: "confirmed",
+      confirmedAt: new Date().toISOString(),
+    });
+
+    signVaultPlan.mockResolvedValue({
+      bytes: new Uint8Array([2]),
+      signature: "sig_later_failed",
+      lastValidBlockHeight: "12346",
+    });
+    broadcastVaultTransaction.mockImplementation(async () => {
+      const movement = await getDb(env)
+        .prepare(
+          "SELECT id FROM earn_vault_movements WHERE status = 'pending' ORDER BY created_at DESC LIMIT 1"
+        )
+        .first<{ id: string }>();
+      if (!movement) throw new Error("missing later movement fixture");
+      await repository.advanceMovement({
+        movementId: movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "failed",
+        failureReason: "chain rejected",
+      });
+    });
+
+    await depositIntoVault(
+      env,
+      depositInput({ requestId: "22222222-2222-4222-8222-222222222222" })
+    );
+
+    const listed = await repository.listPositions({
+      organizationId: ORG,
+      environment: "sandbox",
+      custodyWalletIds: [WALLET_ROW_ID],
+      limit: 20,
+    });
+    expect(listed.rows).toHaveLength(1);
+    expect(listed.rows[0]?.id).toBe(first.position.id);
+    expect(listed.rows[0]?.activated_at).not.toBeNull();
+  });
+
+  it("deactivates after two concurrent failures settle the last nonterminal attempts", async () => {
+    let signedCount = 0;
+    signVaultPlan.mockImplementation(async () => {
+      signedCount += 1;
+      return {
+        bytes: new Uint8Array([signedCount]),
+        signature: `sig_concurrent_failure_${signedCount}`,
+        lastValidBlockHeight: "12345",
+      };
+    });
+    broadcastVaultTransaction.mockRejectedValue(new Error("ambiguous broadcast"));
+    const first = await depositIntoVault(
+      env,
+      depositInput({ requestId: "11111111-1111-4111-8111-111111111111" })
+    );
+    const second = await depositIntoVault(
+      env,
+      depositInput({ requestId: "22222222-2222-4222-8222-222222222222" })
+    );
+    const repository = createPostgresEarnVaultRepository(getDb(env));
+
+    const settled = await Promise.all([
+      repository.advanceMovement({
+        movementId: first.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "failed",
+        failureReason: "expired",
+      }),
+      repository.advanceMovement({
+        movementId: second.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "failed",
+        failureReason: "expired",
+      }),
+    ]);
+
+    expect(settled.every(Boolean)).toBe(true);
+    const position = await repository.getPositionById({
+      organizationId: ORG,
+      environment: "sandbox",
+      positionId: first.position.id,
+    });
+    expect(position?.activated_at).toBeNull();
+  });
+
+  it("keeps confirmed and failed movements terminal and rejects irrelevant metadata", async () => {
+    const repository = createPostgresEarnVaultRepository(getDb(env));
+    await expect(
+      repository.advanceMovement({
+        movementId: "earn_vault_movement_missing",
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "confirmed",
+      })
+    ).rejects.toThrow("confirmedAt is required");
+    await expect(
+      repository.advanceMovement({
+        movementId: "earn_vault_movement_missing",
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "failed",
+      })
+    ).rejects.toThrow("failureReason is required");
+    const confirmed = await depositIntoVault(env, depositInput());
+    await repository.advanceMovement({
+      movementId: confirmed.movement.id,
+      organizationId: ORG,
+      fromStatuses: ["submitted"],
+      toStatus: "confirmed",
+      confirmedAt: new Date().toISOString(),
+      shares: "9.5",
+    });
+    await expect(
+      repository.advanceMovement({
+        movementId: confirmed.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["confirmed"],
+        toStatus: "failed",
+        failureReason: "must not regress",
+      })
+    ).rejects.toThrow("Illegal earn vault movement transition");
+
+    signVaultPlan.mockResolvedValue({
+      bytes: new Uint8Array([2]),
+      signature: "sig_terminal_failed",
+      lastValidBlockHeight: "12346",
+    });
+    broadcastVaultTransaction.mockRejectedValue(new Error("ambiguous broadcast"));
+    const failed = await depositIntoVault(
+      env,
+      depositInput({ requestId: "22222222-2222-4222-8222-222222222222" })
+    );
+    await repository.advanceMovement({
+      movementId: failed.movement.id,
+      organizationId: ORG,
+      fromStatuses: ["pending"],
+      toStatus: "failed",
+      failureReason: "expired",
+    });
+    await expect(
+      repository.advanceMovement({
+        movementId: failed.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["failed"],
+        toStatus: "confirmed",
+      })
+    ).rejects.toThrow("Illegal earn vault movement transition");
+    await expect(
+      repository.advanceMovement({
+        movementId: failed.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "failed",
+        shares: "1",
+      })
+    ).rejects.toThrow("shares are only valid");
+  });
+
+  it.each([
+    ["build throws", () => buildVaultDeposit.mockRejectedValue(new Error("build failed"))],
+    ["simulation throws", () => simulateVaultPlan.mockRejectedValue(new Error("RPC failed"))],
+    [
+      "simulation rejects",
+      () => simulateVaultPlan.mockResolvedValue({ ok: false, error: "program error", logs: [] }),
+    ],
+    ["signer lookup throws", () => createOrgSigner.mockRejectedValue(new Error("custody failed"))],
+    ["signer address mismatches", () => createOrgSigner.mockResolvedValue({ address: VAULT_A })],
+    ["signing throws", () => signVaultPlan.mockRejectedValue(new Error("sign failed"))],
+  ])("does not invent a movement or holding when %s", async (_name, arrange) => {
+    arrange();
+
+    await expect(depositIntoVault(env, depositInput())).rejects.toBeTruthy();
+
+    expect(await tableCount("earn_vault_positions")).toBe(0);
+    expect(await tableCount("earn_vault_movements")).toBe(0);
+    expect(broadcastVaultTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("depositIntoVault — approved-operation effect fencing", () => {
+  it("makes an interrupted signed intent recover as ambiguous, never completed", async () => {
+    const repository = createPostgresPolicyRepository(
+      getDb(env),
+      createTenantScope({ organizationId: ORG, projectId: PROJECT })
+    );
+    const operation = await repository.createWalletOperation({
+      organizationId: ORG,
+      projectId: PROJECT,
+      custodyWalletId: WALLET_ROW_ID,
+      walletId: wallet.walletId,
+      source: "earn_vault_deposit",
+      operationFamily: "program",
+      operationType: "earn_vault_deposit",
+      asset: TOKEN_MINT,
+      amount: "10",
+      destination: VAULT_A,
+      rawPayload: { requestId: "11111111-1111-4111-8111-111111111111" },
+      status: "pending_approval",
+    });
+    if (!operation) throw new Error("failed to seed approved wallet operation");
+    const approval = await repository.createApprovalRequest({
+      organizationId: ORG,
+      projectId: PROJECT,
+      walletOperationId: operation.id,
+    });
+    if (!approval) throw new Error("failed to seed approval request");
+    await repository.updateApprovalRequestStatus({
+      organizationId: ORG,
+      projectId: PROJECT,
+      approvalRequestId: approval.id,
+      status: "approved",
+      operationStatus: "executing",
+      resolvedBy: USER,
+    });
+    const attemptId = "earn-approved-interrupted-attempt";
+    expect(await repository.claimWalletOperationExecution(operation.id, attemptId)).not.toBeNull();
+    const contextValues: Record<string, unknown> = {
+      apiKey: {
+        id: "key_earn_approved_test",
+        organizationId: ORG,
+        projectId: PROJECT,
+        role: "api_admin",
+        permissions: ["*"],
+        environment: "sandbox",
+        signingWalletId: null,
+        signingWalletIds: [],
+        walletBindings: [],
+      },
+      projectId: PROJECT,
+      approvedWalletOperationId: operation.id,
+      approvedWalletOperationAttemptId: attemptId,
+    };
+    const context = {
+      env,
+      get: (key: string) => contextValues[key],
+    } as never;
+    broadcastVaultTransaction.mockRejectedValue(new Error("worker interrupted after insert"));
+
+    const result = await depositIntoVault(env, depositInput(), {
+      runIntentTransaction: (mutation) =>
+        runApprovedWalletOperationEffectTransaction(context, mutation),
+    });
+    expect(result.movement.status).toBe("pending");
+    const fenced = await repository.getWalletOperationById(operation.id);
+    expect(fenced?.execution_effect_started_at).not.toBeNull();
+    await getDb(env)
+      .prepare(
+        `UPDATE wallet_operations
+         SET execution_lease_expires_at = '2000-01-01T00:00:00.000Z'
+         WHERE id = ?`
+      )
+      .bind(operation.id)
+      .run();
+
+    expect(await recoverApprovedWalletOperations(env)).toBe(0);
+    expect(await repository.getWalletOperationById(operation.id)).toMatchObject({
+      status: "failed",
+      execution_attempt_id: attemptId,
+    });
+    expect((await repository.getWalletOperationById(operation.id))?.execution_error).toContain(
+      "manual reconciliation"
+    );
+    expect(await tableCount("earn_vault_movements")).toBe(1);
+  });
+});
+
+describe("earn vault project attribution", () => {
+  it("preserves an organization-wallet claim and cross-project history when a project is deleted", async () => {
+    const otherProject = "prj_vault_deposit_other";
+    const orgConfig = "cfg_vault_deposit_org";
+    const orgWallet = "cwlt_vault_deposit_org";
+    await getDb(env).batch([
+      getDb(env)
+        .prepare(
+          `INSERT INTO projects
+             (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Other Vault Project', 'other-vault-project', 'sandbox', 'active', ?)`
+        )
+        .bind(otherProject, ORG, USER),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_configs
+             (id, organization_id, project_id, provider, config_encrypted, status)
+           VALUES (?, ?, NULL, 'privy', 'test-encrypted', 'active')`
+        )
+        .bind(orgConfig, ORG),
+      getDb(env)
+        .prepare(
+          `INSERT INTO custody_wallets
+             (id, custody_config_id, wallet_id, public_key, status)
+           VALUES (?, ?, 'privy_vault_deposit_org', ?, 'active')`
+        )
+        .bind(orgWallet, orgConfig, VAULT_B),
+    ]);
+    const repository = createPostgresEarnVaultRepository(getDb(env));
+    const base = {
+      organizationId: ORG,
+      environment: "sandbox" as const,
+      provider: "kamino",
+      providerReference: VAULT_A,
+      custodyWalletId: orgWallet,
+      tokenMint: TOKEN_MINT,
+      shareMint: SHARE_MINT,
+      label: "Shared Vault",
+      requestedAmount: "1",
+      acceptedAmount: "1",
+      signedTransaction: "AQ==",
+      lastValidBlockHeight: "12345",
+      createdBy: USER,
+    };
+    const first = await repository.createSignedDepositIntent({
+      ...base,
+      projectId: PROJECT,
+      signature: "sig_project_attribution_first",
+      requestId: "11111111-1111-4111-8111-111111111111",
+      idempotencyFingerprint: "fingerprint_project_attribution_first",
+    });
+    const second = await repository.createSignedDepositIntent({
+      ...base,
+      projectId: otherProject,
+      signature: "sig_project_attribution_second",
+      requestId: "22222222-2222-4222-8222-222222222222",
+      idempotencyFingerprint: "fingerprint_project_attribution_second",
+    });
+    expect(second.position.id).toBe(first.position.id);
+
+    await getDb(env).prepare("DELETE FROM projects WHERE id = ?").bind(PROJECT).run();
+
+    const position = await getDb(env)
+      .prepare("SELECT project_id FROM earn_vault_positions WHERE id = ?")
+      .bind(first.position.id)
+      .first<{ project_id: string | null }>();
+    const movements = await getDb(env)
+      .prepare(
+        "SELECT project_id FROM earn_vault_movements WHERE position_id = ? ORDER BY request_id"
+      )
+      .bind(first.position.id)
+      .all<{ project_id: string | null }>();
+    expect(position?.project_id).toBeNull();
+    expect(movements.results.map((row) => row.project_id)).toEqual([null, otherProject]);
   });
 });

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/db";
+import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+
+/**
+ * The idempotency contract for a non-custodial vault deposit.
+ *
+ * Two titles here are named verbatim by
+ * `apps/sdp-api/src/security/value-moving-conformance.node.test.ts` as the
+ * `earn` family's replay evidence — renaming one fails that test rather than
+ * quietly dropping the guarantee it stands for.
+ *
+ * The chain is stubbed at the module boundary. What is under test is the ORDER
+ * and the DECISIONS around the transfer, not the transfer: which row is written
+ * before anything is signed, whether a reused key is a replay or a conflict,
+ * and whether a mismatch can mutate state before it is refused.
+ */
+
+const buildVaultDeposit = vi.hoisted(() => vi.fn());
+const signVaultPlan = vi.hoisted(() => vi.fn());
+const broadcastVaultTransaction = vi.hoisted(() => vi.fn());
+const simulateVaultPlan = vi.hoisted(() => vi.fn());
+const createOrgSigner = vi.hoisted(() => vi.fn());
+
+vi.mock("./execution-registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./execution-registry")>()),
+  resolveVaultDirectClient: () => ({ buildVaultDeposit }),
+  resolveClusterRpcUrl: () => "https://rpc.example.invalid",
+  assertClusterEndpoint: async () => undefined,
+}));
+
+vi.mock("./vault-execution.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./vault-execution.service")>()),
+  signVaultPlan,
+  broadcastVaultTransaction,
+  simulateVaultPlan,
+}));
+
+vi.mock("@/services/solana", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/solana")>()),
+  createOrgSigner,
+}));
+
+const { depositIntoVault } = await import("./vault-deposit.service");
+
+const ORG = "org_vault_deposit";
+const PROJECT = "prj_vault_deposit";
+const USER = "usr_vault_deposit";
+const WALLET_ROW_ID = "cwlt_vault_deposit";
+const CUSTODY_CONFIG_ID = "cfg_vault_deposit";
+const WALLET_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const VAULT_A = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
+const VAULT_B = "3nMFwZXwY1s1M5s8vYAHqd4wGs4iSxXE4LRoUMMYqEgF";
+
+const wallet = {
+  id: WALLET_ROW_ID,
+  walletId: "privy_vault_deposit",
+  publicKey: WALLET_ADDRESS,
+} as unknown as CustodyWallet;
+
+function depositInput(overrides: Record<string, unknown> = {}) {
+  return {
+    organizationId: ORG,
+    projectId: PROJECT,
+    environment: "sandbox" as const,
+    provider: "kamino",
+    providerReference: VAULT_A,
+    wallet,
+    amount: "10",
+    requestId: "11111111-1111-4111-8111-111111111111",
+    userId: USER,
+    apiKeyId: null,
+    ...overrides,
+  };
+}
+
+async function seedWallet(): Promise<void> {
+  await getDb(env).batch([
+    getDb(env)
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(ORG, "Vault Deposit Org", "vault-deposit", "enterprise", "active"),
+    getDb(env)
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+      .bind(USER, "vault-deposit@example.com", 1, "active"),
+    getDb(env)
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, 'sandbox', 'active', ?)`
+      )
+      .bind(PROJECT, ORG, "Vault Deposit Project", "vault-deposit-project", USER),
+    // custody_wallets hangs off a custody_config, not off the org directly.
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES (?, ?, ?, 'privy', 'test-encrypted', 'active')`
+      )
+      .bind(CUSTODY_CONFIG_ID, ORG, PROJECT),
+    getDb(env)
+      .prepare(
+        `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+         VALUES (?, ?, ?, ?, 'active')`
+      )
+      .bind(WALLET_ROW_ID, CUSTODY_CONFIG_ID, "privy_vault_deposit", WALLET_ADDRESS),
+  ]);
+}
+
+beforeEach(async () => {
+  await seedTestDatabase(env);
+  await seedWallet();
+  vi.clearAllMocks();
+
+  buildVaultDeposit.mockResolvedValue({
+    cluster: "devnet",
+    transactions: [
+      [{ programAddress: "11111111111111111111111111111111", accounts: [], data: "" }],
+    ],
+    lookupTables: [],
+    accepted: { amount: "10" },
+  });
+  simulateVaultPlan.mockResolvedValue({ ok: true });
+  createOrgSigner.mockResolvedValue({ address: WALLET_ADDRESS });
+  signVaultPlan.mockResolvedValue({ bytes: new Uint8Array([1]), signature: "sig_original" });
+  broadcastVaultTransaction.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("depositIntoVault — idempotency", () => {
+  it("replays the original vault deposit for the same requestId and payload", async () => {
+    const first = await depositIntoVault(env, depositInput());
+    expect(first.replayed).toBe(false);
+
+    const second = await depositIntoVault(env, depositInput());
+
+    expect(second.replayed).toBe(true);
+    expect(second.movement.id).toBe(first.movement.id);
+    expect(second.position.id).toBe(first.position.id);
+    // The whole point: a replay must not put a second transfer on the wire.
+    expect(signVaultPlan).toHaveBeenCalledTimes(1);
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The bug this closes was not just a missing 409. Because the position was
+   * claimed BEFORE the movement, a key reused against a different vault opened
+   * a real position row for vault B and then answered with vault A's signature.
+   */
+  it("rejects the same requestId with a different payload", async () => {
+    const first = await depositIntoVault(env, depositInput());
+
+    await expect(
+      depositIntoVault(env, depositInput({ providerReference: VAULT_B }))
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    // Nothing was signed or sent for the mismatched request...
+    expect(signVaultPlan).toHaveBeenCalledTimes(1);
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+
+    // ...and, critically, no position row was created for the other vault. The
+    // refusal has to land BEFORE the claim, or the ledger records a position
+    // the caller was never allowed to open.
+    const repo = createPostgresEarnVaultRepository(getDb(env));
+    const positions = await repo.listPositions({ organizationId: ORG, environment: "sandbox" });
+    expect(positions).toHaveLength(1);
+    expect(positions[0]?.id).toBe(first.position.id);
+    expect(positions[0]?.provider_reference).toBe(VAULT_A);
+  });
+
+  it("treats a changed minSharesOut as a different request, not a replay", async () => {
+    await depositIntoVault(env, depositInput());
+
+    // The floor is baked into the built instruction, so reusing a key with a
+    // weaker one must not silently return the stricter original.
+    await expect(depositIntoVault(env, depositInput({ minSharesOut: "1" }))).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+  });
+});
+
+describe("depositIntoVault — recoverability", () => {
+  /**
+   * Signing determines the signature; broadcasting only publishes it. Recording
+   * it first is what makes an ambiguous send reconcilable rather than an
+   * untraceable orphan.
+   */
+  it("records the signature before the transaction is broadcast", async () => {
+    const order: string[] = [];
+    signVaultPlan.mockImplementation(async () => {
+      order.push("sign");
+      return { bytes: new Uint8Array([1]), signature: "sig_ordered" };
+    });
+    broadcastVaultTransaction.mockImplementation(async () => {
+      // By the time the bytes are on the wire the row must already name them.
+      const repo = createPostgresEarnVaultRepository(getDb(env));
+      const rows = await repo.listMovements({ organizationId: ORG, positionId: positionId ?? "" });
+      order.push(rows[0]?.signature === "sig_ordered" ? "recorded-before-send" : "not-recorded");
+    });
+
+    let positionId: string | undefined;
+    buildVaultDeposit.mockImplementation(async () => {
+      const repo = createPostgresEarnVaultRepository(getDb(env));
+      const positions = await repo.listPositions({ organizationId: ORG, environment: "sandbox" });
+      positionId = positions[0]?.id;
+      return {
+        cluster: "devnet",
+        transactions: [
+          [{ programAddress: "11111111111111111111111111111111", accounts: [], data: "" }],
+        ],
+        lookupTables: [],
+        accepted: { amount: "10" },
+      };
+    });
+
+    await depositIntoVault(env, depositInput());
+
+    expect(order).toEqual(["sign", "recorded-before-send"]);
+  });
+
+  /**
+   * A send error does NOT prove the transaction failed — it may have landed and
+   * the response been lost. Marking it `failed` would assert that no money
+   * moved, which is precisely the claim that cannot be made.
+   */
+  it("leaves an ambiguous broadcast reconcilable instead of marking it failed", async () => {
+    broadcastVaultTransaction.mockRejectedValue(new Error("socket hang up"));
+
+    const result = await depositIntoVault(env, depositInput());
+
+    expect(result.movement.status).not.toBe("failed");
+    expect(result.movement.signature).toBe("sig_original");
+  });
+
+  it("marks a pre-signature failure as failed, because nothing reached the chain", async () => {
+    simulateVaultPlan.mockResolvedValue({ ok: false, error: "custom program error", logs: [] });
+
+    const result = await depositIntoVault(env, depositInput());
+
+    expect(result.movement.status).toBe("failed");
+    expect(result.movement.signature).toBeNull();
+    expect(signVaultPlan).not.toHaveBeenCalled();
+  });
+});

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.ts
@@ -1,4 +1,4 @@
-import { notImplemented, providerNotConfigured } from "@sdp/earn/errors";
+import { notImplemented } from "@sdp/earn/errors";
 import type { EarnRuntimeContext } from "@sdp/earn/types";
 import type { SdpEnvironment } from "@sdp/types";
 import { address } from "@solana/kit";
@@ -9,16 +9,23 @@ import {
   type EarnVaultPositionRow,
 } from "@/db/repositories/earn-vault.repository";
 import { badRequest } from "@/lib/errors";
+import { buildEarnVaultDepositFingerprint, resolveIdempotencyReplay } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
 import * as solanaServices from "@/services/solana";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 import {
+  assertClusterEndpoint,
   earnClusterFor,
   resolveClusterRpcUrl,
   resolveVaultDirectClient,
 } from "./execution-registry";
-import { simulateVaultPlan, submitVaultPlan, type VaultFeeMode } from "./vault-execution.service";
+import {
+  broadcastVaultTransaction,
+  type SignedVaultTransaction,
+  signVaultPlan,
+  simulateVaultPlan,
+} from "./vault-execution.service";
 
 /**
  * Deposit into a non-custodial vault from an SDP custody wallet.
@@ -75,11 +82,13 @@ export async function depositIntoVault(
 
   const cluster = earnClusterFor(input.environment);
   const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  if (!rpcUrl) {
-    throw providerNotConfigured(
-      `No Solana RPC endpoint is configured, so a ${cluster} vault deposit cannot be built.`
-    );
-  }
+  // Proves the endpoint serves THIS cluster before anything is built against
+  // it. One process serves both environments, so an endpoint configured for the
+  // other one would otherwise build a transaction addressed to the wrong chain
+  // — and that failure is silent, because Kamino's mainnet program id also
+  // resolves on devnet with no accounts under it. Cached per endpoint, so this
+  // is one round trip per process, not per deposit.
+  await assertClusterEndpoint(env, cluster, rpcUrl);
 
   const repo = createPostgresEarnVaultRepository(getDb(env));
   const runtime: EarnRuntimeContext = {
@@ -87,7 +96,53 @@ export async function depositIntoVault(
     environment: input.environment,
   };
 
-  // 1. Claim the position and write the intent row.
+  // 1. RESOLVE THE REPLAY FIRST — before the position is claimed.
+  //
+  // The order here is the fix, not decoration. Claiming the position first
+  // meant a request reusing a key with a DIFFERENT vault wrote (or reopened) a
+  // real position row for the new vault and only then discovered the key was
+  // taken — answering with the new `positionId` beside the ORIGINAL movement's
+  // status and signature. That response is not merely stale, it describes a
+  // transaction that never touched the position it names.
+  //
+  // Comparing the fingerprint is what separates a genuine retry from a
+  // different request wearing the same key: the first replays, the second 409s
+  // and writes nothing at all.
+  const fingerprint = buildEarnVaultDepositFingerprint({
+    environment: input.environment,
+    provider: input.provider,
+    providerReference: input.providerReference,
+    custodyWalletId: input.wallet.id,
+    amount: input.amount,
+    minSharesOut: input.minSharesOut ?? null,
+  });
+
+  const priorMovement = await resolveIdempotencyReplay(
+    () =>
+      repo.findMovementByRequestId({
+        organizationId: input.organizationId,
+        requestId: input.requestId,
+      }),
+    fingerprint
+  );
+  if (priorMovement) {
+    const priorPosition = await repo.getPositionById({
+      organizationId: input.organizationId,
+      environment: input.environment,
+      positionId: priorMovement.position_id,
+    });
+    if (!priorPosition) {
+      // The FK makes this unreachable; if it ever fires, the ledger is
+      // inconsistent and guessing would be worse than failing.
+      throw new Error(
+        `Replayed movement ${priorMovement.id} references missing position ${priorMovement.position_id}`
+      );
+    }
+    // A replay must NOT move money again. Return what the original attempt did.
+    return { position: priorPosition, movement: priorMovement, replayed: true };
+  }
+
+  // 2. Claim the position and write the intent row.
   //
   // NOTE the two different wallet identifiers, which are easy to confuse and
   // fail in different ways: `wallet.id` is the SDP row (`cwlt_…`) and is what
@@ -115,12 +170,14 @@ export async function depositIntoVault(
     custodyWalletId: input.wallet.id,
     direction: "deposit",
     requestId: input.requestId,
+    idempotencyFingerprint: fingerprint,
     amount: input.amount,
     createdBy: input.userId ?? null,
     initiatedByKeyId: input.apiKeyId ?? null,
   });
 
-  // A replay must NOT move money again. Return what the original attempt did.
+  // Lost a race with a concurrent IDENTICAL request (the differing-intent case
+  // threw above and inside createMovement). The winner owns the money movement.
   if (replayed) {
     return { position, movement, replayed: true };
   }
@@ -177,45 +234,82 @@ export async function depositIntoVault(
     throw badRequest("Resolved signing wallet does not match the deposit wallet");
   }
 
-  let signature: string;
+  // 5. SIGN, RECORD, THEN BROADCAST — in that order, and the order is the point.
+  //
+  // Signing determines the signature; broadcasting only publishes it. Writing
+  // the signature down BEFORE the bytes can reach the network is what makes an
+  // ambiguous send recoverable: if the process dies, or the RPC accepts the
+  // transaction and the response is lost, there is a row naming the exact
+  // transaction to go and look for. Recording it afterwards — as this did —
+  // leaves a window where money has moved and SDP holds no evidence it exists.
+  let signed: SignedVaultTransaction;
   try {
-    const submitted = await submitVaultPlan(env, {
-      plan,
-      owner: signer,
-      rpcUrl,
-      fee: resolveVaultFeeMode(),
-    });
-    signature = submitted.signature;
+    signed = await signVaultPlan(env, { plan, owner: signer, rpcUrl });
   } catch (error) {
-    getLogger().error({ movementId: movement.id, error }, "vault deposit: submit failed");
-    return await fail(error instanceof Error ? error.message : "Failed to submit the deposit.");
+    // Nothing was broadcast, so this is a definitive failure.
+    getLogger().error({ movementId: movement.id, error }, "vault deposit: signing failed");
+    return await fail(error instanceof Error ? error.message : "Failed to sign the deposit.");
   }
 
-  // 5. Advance. Guarded so a concurrent observer cannot regress the row.
+  await repo.advanceMovement({
+    movementId: movement.id,
+    organizationId: input.organizationId,
+    fromStatuses: ["pending"],
+    // Deliberately still `pending`: nothing has been sent yet. What changes is
+    // that the row now carries the signature, so a crash between here and the
+    // send leaves a "pending WITH a signature" row — the state a reconciler can
+    // resolve by asking the chain, rather than an untraceable orphan.
+    toStatus: "pending",
+    signature: signed.signature,
+  });
+
+  try {
+    await broadcastVaultTransaction(env, { bytes: signed.bytes, rpcUrl });
+  } catch (error) {
+    // A send error does NOT mean the transaction failed — it may have landed
+    // and the response been lost. Marking this `failed` would assert that no
+    // money moved, which is exactly the claim we cannot make. Leave it pending
+    // with its signature so the outcome can be established from the chain.
+    getLogger().error(
+      { movementId: movement.id, signature: signed.signature, error },
+      "vault deposit: broadcast outcome unknown; left reconcilable"
+    );
+    const pending = await repo.getMovementById({
+      movementId: movement.id,
+      organizationId: input.organizationId,
+    });
+    return { position, movement: pending ?? movement, replayed: false };
+  }
+
+  // 6. Advance. Guarded so a concurrent observer cannot regress the row.
   const advanced = await repo.advanceMovement({
     movementId: movement.id,
     organizationId: input.organizationId,
     fromStatuses: ["pending"],
     toStatus: "submitted",
-    signature,
+    signature: signed.signature,
   });
 
   return { position, movement: advanced ?? movement, replayed: false };
 }
 
-/**
- * Who pays the transaction fee.
+/*
+ * WHO PAYS THE TRANSACTION FEE — the custody wallet, unconditionally.
  *
- * WALLET-PAYS for now, unconditionally. Kora only sponsors transactions whose
- * programs are on its allowlist, and the Kamino kvault/klend programs are not on
- * it — the Private Channels escrow hit exactly this and still pays its own fee
- * today. Attempting sponsorship would fail at the relay with an opaque
- * rejection AFTER the customer's wallet had already signed.
+ * Kora only sponsors transactions whose programs are on its allowlist, and the
+ * Kamino kvault/klend programs are not on it (the Private Channels escrow hit
+ * exactly this and still pays its own fee today). Attempting sponsorship would
+ * fail at the relay with an opaque rejection AFTER the customer's wallet had
+ * already signed.
  *
- * Flipping to sponsored is a one-line change here once `validation_config.allowed_programs`
- * carries the kvault, klend and farms ids on the relevant relay (an sdp-infra
- * change). The plumbing already exists: `submitVaultPlan` takes the mode.
+ * The sponsored path is deliberately NOT reachable from here any more. It
+ * cannot satisfy the record-before-broadcast rule above: the relay signs as fee
+ * payer after SDP does, so the final signature is not knowable before the bytes
+ * leave — which is precisely the window that made an ambiguous send
+ * untraceable. Turning sponsorship on therefore owes two things, not one: the
+ * kvault/klend/farms ids added to `validation_config.allowed_programs` in
+ * sdp-infra, AND a relay handshake that returns the signature before broadcast
+ * (or a ledger state that records the intent-to-sponsor first).
+ * `submitVaultPlan` in vault-execution.service.ts still carries the sponsored
+ * plumbing for when that lands.
  */
-function resolveVaultFeeMode(): VaultFeeMode {
-  return { kind: "wallet-pays" };
-}

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.ts
@@ -1,14 +1,15 @@
 import { notImplemented } from "@sdp/earn/errors";
-import type { EarnRuntimeContext } from "@sdp/earn/types";
+import type { EarnRuntimeContext, EarnVaultTransactionPlan } from "@sdp/earn/types";
+import { compareDecimalAmounts } from "@sdp/solana/amount";
 import type { SdpEnvironment } from "@sdp/types";
 import { address } from "@solana/kit";
-import { getDb } from "@/db";
+import { type AppDb, getDb } from "@/db";
 import {
   createPostgresEarnVaultRepository,
   type EarnVaultMovementRow,
   type EarnVaultPositionRow,
 } from "@/db/repositories/earn-vault.repository";
-import { badRequest } from "@/lib/errors";
+import { badRequest, internalError } from "@/lib/errors";
 import { buildEarnVaultDepositFingerprint, resolveIdempotencyReplay } from "@/lib/idempotency";
 import { getLogger } from "@/runtime/logger";
 import * as solanaServices from "@/services/solana";
@@ -20,6 +21,7 @@ import {
   resolveClusterRpcUrl,
   resolveVaultDirectClient,
 } from "./execution-registry";
+import { withVaultDeadline } from "./vault-deadline";
 import {
   broadcastVaultTransaction,
   type SignedVaultTransaction,
@@ -27,21 +29,14 @@ import {
   simulateVaultPlan,
 } from "./vault-execution.service";
 
+// biome-ignore lint/security/noSecrets: public Solana Memo program address.
+const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+
 /**
- * Deposit into a non-custodial vault from an SDP custody wallet.
- *
- * Order of operations is the point, and it mirrors
- * `services/private-channels/deposit.ts`:
- *
- *   1. write the intent row (idempotency anchor) BEFORE anything is signed
- *   2. build the plan from the provider
- *   3. simulate — a third-party SDK assembled these accounts against live state
- *   4. sign with custody and submit
- *   5. advance the ledger by guarded CAS
- *
- * Step 1 first is not bookkeeping pedantry: the chain has no request-id dedupe,
- * so if the process dies between signing and recording, the row written here is
- * the only evidence the transfer happened.
+ * Deposit ordering is deliberately `build → simulate → sign → record → send`.
+ * Signing alone cannot move funds. Recording the signed transaction and its
+ * position atomically before broadcast removes unsigned intents, makes a crash
+ * recoverable by signature, and lets an idempotency loser stop before sending.
  */
 
 export interface VaultDepositInput {
@@ -52,9 +47,13 @@ export interface VaultDepositInput {
   /** Vault address — the strategy's providerReference. */
   providerReference: string;
   wallet: CustodyWallet;
+  /** Trusted catalogue metadata persisted so delisted positions still render. */
+  tokenMint: string;
+  shareMint: string;
+  label: string;
   /** Decimal string in the vault token's units. */
   amount: string;
-  /** Caller idempotency key. REQUIRED — see the migration header. */
+  /** Caller idempotency key. */
   requestId: string;
   userId?: string | null;
   apiKeyId?: string | null;
@@ -65,49 +64,102 @@ export interface VaultDepositInput {
 export interface VaultDepositResult {
   position: EarnVaultPositionRow;
   movement: EarnVaultMovementRow;
-  /** True when the idempotency key had already been used — nothing was re-sent. */
+  /** True when an existing signed movement won; its bytes were not re-sent. */
   replayed: boolean;
+}
+
+export interface VaultDepositExecutionOptions {
+  /**
+   * Handler-owned boundary that couples an approved-operation effect fence to
+   * the repository's first durable mutation. The repository still opens a real
+   * transaction for ordinary calls.
+   */
+  runIntentTransaction?: <T>(mutation: (db: AppDb) => Promise<T>) => Promise<T>;
+}
+
+async function replayResult(
+  repo: ReturnType<typeof createPostgresEarnVaultRepository>,
+  input: VaultDepositInput,
+  movement: EarnVaultMovementRow
+): Promise<VaultDepositResult> {
+  const position = await repo.getPositionById({
+    organizationId: input.organizationId,
+    environment: input.environment,
+    positionId: movement.position_id,
+  });
+  if (!position) {
+    throw internalError(
+      `Replayed movement ${movement.id} references missing position ${movement.position_id}`
+    );
+  }
+  return { position, movement, replayed: true };
+}
+
+function requireAcceptedPlan(
+  plan: EarnVaultTransactionPlan,
+  input: Pick<VaultDepositInput, "tokenMint" | "shareMint" | "amount" | "minSharesOut">
+): {
+  amount: string;
+  minSharesOut: string | null;
+} {
+  if (plan.assetIdentity.depositTokenMint !== input.tokenMint) {
+    throw internalError(
+      "Vault builder deposit token mint does not match the admitted catalogue strategy"
+    );
+  }
+  if (plan.assetIdentity.shareMint !== input.shareMint) {
+    throw internalError("Vault builder share mint does not match the admitted catalogue strategy");
+  }
+  const amount = plan.accepted?.amount;
+  if (!amount) {
+    throw internalError("Vault builder did not report the canonical amount encoded on chain");
+  }
+  if (compareDecimalAmounts(amount, input.amount) !== 0) {
+    throw internalError("Vault builder amount does not match the policy-approved request amount");
+  }
+  const minSharesOut = plan.accepted?.minSharesOut ?? null;
+  if (input.minSharesOut !== undefined && minSharesOut === null) {
+    throw internalError("Vault builder omitted the canonical minSharesOut encoded on chain");
+  }
+  if (
+    (input.minSharesOut === undefined && minSharesOut !== null) ||
+    (input.minSharesOut !== undefined &&
+      minSharesOut !== null &&
+      compareDecimalAmounts(minSharesOut, input.minSharesOut) !== 0)
+  ) {
+    throw internalError(
+      "Vault builder minSharesOut does not match the policy-approved slippage floor"
+    );
+  }
+  return { amount, minSharesOut };
+}
+
+function appendRequestMemo(
+  plan: EarnVaultTransactionPlan,
+  requestId: string
+): EarnVaultTransactionPlan {
+  const memo = {
+    programAddress: MEMO_PROGRAM_ADDRESS,
+    accounts: [],
+    data: Buffer.from(`sdp:earn:vault-deposit:${requestId}`, "utf8").toString("base64"),
+  };
+  return {
+    ...plan,
+    transactions: plan.transactions.map((batch) => [...batch, memo]),
+  };
 }
 
 export async function depositIntoVault(
   env: Env,
-  input: VaultDepositInput
+  input: VaultDepositInput,
+  options: VaultDepositExecutionOptions = {}
 ): Promise<VaultDepositResult> {
   const client = resolveVaultDirectClient(env, input.provider);
   if (!client) {
-    // Same taxonomy the earn routes already raise, so the existing error
-    // handler maps it to a clean 501 rather than a generic 500.
     throw notImplemented(input.provider as never, "direct vault deposits");
   }
 
-  const cluster = earnClusterFor(input.environment);
-  const rpcUrl = resolveClusterRpcUrl(env, cluster);
-  // Proves the endpoint serves THIS cluster before anything is built against
-  // it. One process serves both environments, so an endpoint configured for the
-  // other one would otherwise build a transaction addressed to the wrong chain
-  // — and that failure is silent, because Kamino's mainnet program id also
-  // resolves on devnet with no accounts under it. Cached per endpoint, so this
-  // is one round trip per process, not per deposit.
-  await assertClusterEndpoint(env, cluster, rpcUrl);
-
-  const repo = createPostgresEarnVaultRepository(getDb(env));
-  const runtime: EarnRuntimeContext = {
-    env: env as unknown as Record<string, string | undefined>,
-    environment: input.environment,
-  };
-
-  // 1. RESOLVE THE REPLAY FIRST — before the position is claimed.
-  //
-  // The order here is the fix, not decoration. Claiming the position first
-  // meant a request reusing a key with a DIFFERENT vault wrote (or reopened) a
-  // real position row for the new vault and only then discovered the key was
-  // taken — answering with the new `positionId` beside the ORIGINAL movement's
-  // status and signature. That response is not merely stale, it describes a
-  // transaction that never touched the position it names.
-  //
-  // Comparing the fingerprint is what separates a genuine retry from a
-  // different request wearing the same key: the first replays, the second 409s
-  // and writes nothing at all.
+  const primaryRepo = createPostgresEarnVaultRepository(getDb(env));
   const fingerprint = buildEarnVaultDepositFingerprint({
     environment: input.environment,
     provider: input.provider,
@@ -117,199 +169,172 @@ export async function depositIntoVault(
     minSharesOut: input.minSharesOut ?? null,
   });
 
-  const priorMovement = await resolveIdempotencyReplay(
+  // Fast sequential replay path. The atomic insert below repeats this check to
+  // close the concurrent race; this read only avoids rebuilding and re-signing
+  // a transaction whose signed row already exists.
+  const prior = await resolveIdempotencyReplay(
     () =>
-      repo.findMovementByRequestId({
+      primaryRepo.findMovementByRequestId({
         organizationId: input.organizationId,
         requestId: input.requestId,
       }),
     fingerprint
   );
-  if (priorMovement) {
-    const priorPosition = await repo.getPositionById({
-      organizationId: input.organizationId,
-      environment: input.environment,
-      positionId: priorMovement.position_id,
-    });
-    if (!priorPosition) {
-      // The FK makes this unreachable; if it ever fires, the ledger is
-      // inconsistent and guessing would be worse than failing.
-      throw new Error(
-        `Replayed movement ${priorMovement.id} references missing position ${priorMovement.position_id}`
-      );
-    }
-    // A replay must NOT move money again. Return what the original attempt did.
-    return { position: priorPosition, movement: priorMovement, replayed: true };
-  }
+  if (prior) return replayResult(primaryRepo, input, prior);
 
-  // 2. Claim the position and write the intent row.
-  //
-  // NOTE the two different wallet identifiers, which are easy to confuse and
-  // fail in different ways: `wallet.id` is the SDP row (`cwlt_…`) and is what
-  // the FK on both tables points at, while `wallet.walletId` is the PROVIDER's
-  // own id (`privy_…`) and is what the signing service resolves an adapter by.
-  // Swapping them yields a foreign-key violation here and a "wallet not found"
-  // at signing time.
-  const position = await repo.claimPosition({
-    organizationId: input.organizationId,
-    projectId: input.projectId,
+  // Replays above are pure durable reads: they must keep working during an RPC
+  // outage and must never touch a chain client. Only a fresh attempt proves and
+  // uses the configured endpoint.
+  const cluster = earnClusterFor(input.environment);
+  const rpcUrl = resolveClusterRpcUrl(env, cluster);
+  await withVaultDeadline(
+    assertClusterEndpoint(env, cluster, rpcUrl),
+    `Verifying the ${cluster} RPC endpoint`
+  );
+  const runtime: EarnRuntimeContext = {
+    env: env as unknown as Record<string, string | undefined>,
     environment: input.environment,
-    provider: input.provider,
-    providerReference: input.providerReference,
-    custodyWalletId: input.wallet.id,
-    createdBy: input.userId ?? null,
-  });
-
-  const { row: movement, replayed } = await repo.createMovement({
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    environment: input.environment,
-    positionId: position.id,
-    provider: input.provider,
-    providerReference: input.providerReference,
-    custodyWalletId: input.wallet.id,
-    direction: "deposit",
-    requestId: input.requestId,
-    idempotencyFingerprint: fingerprint,
-    amount: input.amount,
-    createdBy: input.userId ?? null,
-    initiatedByKeyId: input.apiKeyId ?? null,
-  });
-
-  // Lost a race with a concurrent IDENTICAL request (the differing-intent case
-  // threw above and inside createMovement). The winner owns the money movement.
-  if (replayed) {
-    return { position, movement, replayed: true };
-  }
-
-  const fail = async (reason: string) => {
-    const failed = await repo.advanceMovement({
-      movementId: movement.id,
-      organizationId: input.organizationId,
-      fromStatuses: ["pending"],
-      toStatus: "failed",
-      failureReason: reason,
-    });
-    return { position, movement: failed ?? movement, replayed: false };
   };
 
-  // 2. Build.
   let plan: Awaited<ReturnType<typeof client.buildVaultDeposit>>;
   try {
-    plan = await client.buildVaultDeposit(runtime, {
-      providerReference: input.providerReference,
-      owner: input.wallet.publicKey,
-      amount: input.amount,
-      ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
-    });
-  } catch (error) {
-    getLogger().error({ movementId: movement.id, error }, "vault deposit: build failed");
-    return await fail(error instanceof Error ? error.message : "Failed to build the deposit.");
-  }
-
-  // 3. Simulate before signing — cheaper than a landed failure the customer paid for.
-  const simulation = await simulateVaultPlan(env, {
-    plan,
-    owner: address(input.wallet.publicKey),
-    rpcUrl,
-  });
-  if (!simulation.ok) {
-    getLogger().error(
-      { movementId: movement.id, error: simulation.error, logs: simulation.logs.slice(-5) },
-      "vault deposit: simulation failed"
+    const built = await withVaultDeadline(
+      client.buildVaultDeposit(runtime, {
+        providerReference: input.providerReference,
+        owner: input.wallet.publicKey,
+        amount: input.amount,
+        ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
+      }),
+      "Building the vault deposit"
     );
-    return await fail(`Simulation failed: ${simulation.error}`);
+    // Deterministic Solana signing plus a shared recent blockhash would make
+    // otherwise independent requests produce the same signature. Bind the
+    // caller key into the message so each ledger intent has a unique on-chain
+    // identity while retries of the same key remain byte-for-byte equivalent.
+    plan = appendRequestMemo(built, input.requestId);
+  } catch (error) {
+    getLogger().error({ error }, "vault deposit: build failed before signing");
+    throw error;
   }
 
-  // 4. Sign with custody and submit.
-  const signer = await solanaServices.createOrgSigner(
-    env,
-    input.organizationId,
-    input.projectId,
-    input.wallet.walletId
-  );
-  if (signer.address !== input.wallet.publicKey) {
-    // The same assertion private-channels makes: a resolved signer that is not
-    // the wallet we priced the deposit for would move someone else's money.
-    throw badRequest("Resolved signing wallet does not match the deposit wallet");
+  if (plan.cluster !== cluster) {
+    throw internalError(
+      `Vault builder returned a ${plan.cluster} plan for the configured ${cluster} cluster`
+    );
+  }
+  const accepted = requireAcceptedPlan(plan, input);
+
+  try {
+    const simulation = await withVaultDeadline(
+      simulateVaultPlan(env, {
+        plan,
+        owner: address(input.wallet.publicKey),
+        rpcUrl,
+      }),
+      "Simulating the vault deposit"
+    );
+    if (!simulation.ok) {
+      getLogger().error(
+        { error: simulation.error, logs: simulation.logs.slice(-5) },
+        "vault deposit: simulation failed before signing"
+      );
+      throw badRequest(`Vault deposit simulation failed: ${simulation.error}`);
+    }
+  } catch (error) {
+    if (!(error instanceof Error && error.message.startsWith("Vault deposit simulation failed:"))) {
+      getLogger().error({ error }, "vault deposit: simulation call failed before signing");
+    }
+    throw error;
   }
 
-  // 5. SIGN, RECORD, THEN BROADCAST — in that order, and the order is the point.
-  //
-  // Signing determines the signature; broadcasting only publishes it. Writing
-  // the signature down BEFORE the bytes can reach the network is what makes an
-  // ambiguous send recoverable: if the process dies, or the RPC accepts the
-  // transaction and the response is lost, there is a row naming the exact
-  // transaction to go and look for. Recording it afterwards — as this did —
-  // leaves a window where money has moved and SDP holds no evidence it exists.
   let signed: SignedVaultTransaction;
   try {
-    signed = await signVaultPlan(env, { plan, owner: signer, rpcUrl });
+    const signer = await withVaultDeadline(
+      solanaServices.createOrgSigner(
+        env,
+        input.organizationId,
+        input.projectId,
+        input.wallet.walletId
+      ),
+      "Resolving the vault deposit signer"
+    );
+    if (signer.address !== input.wallet.publicKey) {
+      throw badRequest("Resolved signing wallet does not match the deposit wallet");
+    }
+    signed = await withVaultDeadline(
+      signVaultPlan(env, { plan, owner: signer, rpcUrl }),
+      "Signing the vault deposit"
+    );
   } catch (error) {
-    // Nothing was broadcast, so this is a definitive failure.
-    getLogger().error({ movementId: movement.id, error }, "vault deposit: signing failed");
-    return await fail(error instanceof Error ? error.message : "Failed to sign the deposit.");
+    getLogger().error({ error }, "vault deposit: signer resolution or signing failed");
+    throw error;
   }
 
-  await repo.advanceMovement({
-    movementId: movement.id,
-    organizationId: input.organizationId,
-    fromStatuses: ["pending"],
-    // Deliberately still `pending`: nothing has been sent yet. What changes is
-    // that the row now carries the signature, so a crash between here and the
-    // send leaves a "pending WITH a signature" row — the state a reconciler can
-    // resolve by asking the chain, rather than an untraceable orphan.
-    toStatus: "pending",
-    signature: signed.signature,
-  });
+  const runIntentTransaction =
+    options.runIntentTransaction ??
+    (<T>(mutation: (db: AppDb) => Promise<T>) => mutation(getDb(env)));
+  const result = await runIntentTransaction((db) =>
+    createPostgresEarnVaultRepository(db).createSignedDepositIntent({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      environment: input.environment,
+      provider: input.provider,
+      providerReference: input.providerReference,
+      custodyWalletId: input.wallet.id,
+      tokenMint: plan.assetIdentity.depositTokenMint,
+      shareMint: plan.assetIdentity.shareMint,
+      label: input.label,
+      requestedAmount: input.amount,
+      acceptedAmount: accepted.amount,
+      requestedMinSharesOut: input.minSharesOut ?? null,
+      acceptedMinSharesOut: accepted.minSharesOut,
+      signature: signed.signature,
+      signedTransaction: Buffer.from(signed.bytes).toString("base64"),
+      lastValidBlockHeight: signed.lastValidBlockHeight,
+      requestId: input.requestId,
+      idempotencyFingerprint: fingerprint,
+      createdBy: input.userId ?? null,
+      initiatedByKeyId: input.apiKeyId ?? null,
+    })
+  );
+
+  // A concurrent identical request already owns the durable signature. Its
+  // signed bytes—not ours—are the only ones that may be broadcast.
+  if (result.replayed) return result;
 
   try {
-    await broadcastVaultTransaction(env, { bytes: signed.bytes, rpcUrl });
+    await withVaultDeadline(
+      broadcastVaultTransaction(env, { bytes: signed.bytes, rpcUrl }),
+      "Broadcasting the vault deposit"
+    );
   } catch (error) {
-    // A send error does NOT mean the transaction failed — it may have landed
-    // and the response been lost. Marking this `failed` would assert that no
-    // money moved, which is exactly the claim we cannot make. Leave it pending
-    // with its signature so the outcome can be established from the chain.
+    // Timeout/transport failure is ambiguous: the transaction may have landed.
+    // Leave the signed row pending for the confirmation sweep.
     getLogger().error(
-      { movementId: movement.id, signature: signed.signature, error },
+      { movementId: result.movement.id, signature: signed.signature, error },
       "vault deposit: broadcast outcome unknown; left reconcilable"
     );
-    const pending = await repo.getMovementById({
-      movementId: movement.id,
-      organizationId: input.organizationId,
-    });
-    return { position, movement: pending ?? movement, replayed: false };
+    return result;
   }
 
-  // 6. Advance. Guarded so a concurrent observer cannot regress the row.
-  const advanced = await repo.advanceMovement({
-    movementId: movement.id,
+  const advanced = await primaryRepo.advanceMovement({
+    movementId: result.movement.id,
     organizationId: input.organizationId,
     fromStatuses: ["pending"],
     toStatus: "submitted",
-    signature: signed.signature,
   });
+  if (advanced) return { ...result, movement: advanced };
 
-  return { position, movement: advanced ?? movement, replayed: false };
+  // A confirmer may have won the CAS after broadcast. Return its newer state;
+  // never fabricate the stale pending row or overwrite a terminal observation.
+  const observed = await primaryRepo.getMovementById({
+    movementId: result.movement.id,
+    organizationId: input.organizationId,
+  });
+  if (observed?.signature === signed.signature) {
+    return { ...result, movement: observed };
+  }
+  throw internalError(
+    "Vault deposit was broadcast but its ledger transition could not be verified"
+  );
 }
-
-/*
- * WHO PAYS THE TRANSACTION FEE — the custody wallet, unconditionally.
- *
- * Kora only sponsors transactions whose programs are on its allowlist, and the
- * Kamino kvault/klend programs are not on it (the Private Channels escrow hit
- * exactly this and still pays its own fee today). Attempting sponsorship would
- * fail at the relay with an opaque rejection AFTER the customer's wallet had
- * already signed.
- *
- * The sponsored path is deliberately NOT reachable from here any more. It
- * cannot satisfy the record-before-broadcast rule above: the relay signs as fee
- * payer after SDP does, so the final signature is not knowable before the bytes
- * leave — which is precisely the window that made an ambiguous send
- * untraceable. Turning sponsorship on therefore owes two things, not one: the
- * kvault/klend/farms ids added to `validation_config.allowed_programs` in
- * sdp-infra, AND a relay handshake that returns the signature before broadcast
- * (or a ledger state that records the intent-to-sponsor first).
- * `submitVaultPlan` in vault-execution.service.ts still carries the sponsored
- * plumbing for when that lands.
- */

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.ts
@@ -1,0 +1,221 @@
+import { notImplemented, providerNotConfigured } from "@sdp/earn/errors";
+import type { EarnRuntimeContext } from "@sdp/earn/types";
+import type { SdpEnvironment } from "@sdp/types";
+import { address } from "@solana/kit";
+import { getDb } from "@/db";
+import {
+  createPostgresEarnVaultRepository,
+  type EarnVaultMovementRow,
+  type EarnVaultPositionRow,
+} from "@/db/repositories/earn-vault.repository";
+import { badRequest } from "@/lib/errors";
+import { getLogger } from "@/runtime/logger";
+import * as solanaServices from "@/services/solana";
+import type { CustodyWallet } from "@/services/stores/custody-config.store";
+import type { Env } from "@/types/env";
+import {
+  earnClusterFor,
+  resolveClusterRpcUrl,
+  resolveVaultDirectClient,
+} from "./execution-registry";
+import { simulateVaultPlan, submitVaultPlan, type VaultFeeMode } from "./vault-execution.service";
+
+/**
+ * Deposit into a non-custodial vault from an SDP custody wallet.
+ *
+ * Order of operations is the point, and it mirrors
+ * `services/private-channels/deposit.ts`:
+ *
+ *   1. write the intent row (idempotency anchor) BEFORE anything is signed
+ *   2. build the plan from the provider
+ *   3. simulate — a third-party SDK assembled these accounts against live state
+ *   4. sign with custody and submit
+ *   5. advance the ledger by guarded CAS
+ *
+ * Step 1 first is not bookkeeping pedantry: the chain has no request-id dedupe,
+ * so if the process dies between signing and recording, the row written here is
+ * the only evidence the transfer happened.
+ */
+
+export interface VaultDepositInput {
+  organizationId: string;
+  projectId: string;
+  environment: SdpEnvironment;
+  provider: string;
+  /** Vault address — the strategy's providerReference. */
+  providerReference: string;
+  wallet: CustodyWallet;
+  /** Decimal string in the vault token's units. */
+  amount: string;
+  /** Caller idempotency key. REQUIRED — see the migration header. */
+  requestId: string;
+  userId?: string | null;
+  apiKeyId?: string | null;
+  /** Slippage floor, decimal string. */
+  minSharesOut?: string;
+}
+
+export interface VaultDepositResult {
+  position: EarnVaultPositionRow;
+  movement: EarnVaultMovementRow;
+  /** True when the idempotency key had already been used — nothing was re-sent. */
+  replayed: boolean;
+}
+
+export async function depositIntoVault(
+  env: Env,
+  input: VaultDepositInput
+): Promise<VaultDepositResult> {
+  const client = resolveVaultDirectClient(env, input.provider);
+  if (!client) {
+    // Same taxonomy the earn routes already raise, so the existing error
+    // handler maps it to a clean 501 rather than a generic 500.
+    throw notImplemented(input.provider as never, "direct vault deposits");
+  }
+
+  const cluster = earnClusterFor(input.environment);
+  const rpcUrl = resolveClusterRpcUrl(env, cluster);
+  if (!rpcUrl) {
+    throw providerNotConfigured(
+      `No Solana RPC endpoint is configured, so a ${cluster} vault deposit cannot be built.`
+    );
+  }
+
+  const repo = createPostgresEarnVaultRepository(getDb(env));
+  const runtime: EarnRuntimeContext = {
+    env: env as unknown as Record<string, string | undefined>,
+    environment: input.environment,
+  };
+
+  // 1. Claim the position and write the intent row.
+  //
+  // NOTE the two different wallet identifiers, which are easy to confuse and
+  // fail in different ways: `wallet.id` is the SDP row (`cwlt_…`) and is what
+  // the FK on both tables points at, while `wallet.walletId` is the PROVIDER's
+  // own id (`privy_…`) and is what the signing service resolves an adapter by.
+  // Swapping them yields a foreign-key violation here and a "wallet not found"
+  // at signing time.
+  const position = await repo.claimPosition({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    environment: input.environment,
+    provider: input.provider,
+    providerReference: input.providerReference,
+    custodyWalletId: input.wallet.id,
+    createdBy: input.userId ?? null,
+  });
+
+  const { row: movement, replayed } = await repo.createMovement({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    environment: input.environment,
+    positionId: position.id,
+    provider: input.provider,
+    providerReference: input.providerReference,
+    custodyWalletId: input.wallet.id,
+    direction: "deposit",
+    requestId: input.requestId,
+    amount: input.amount,
+    createdBy: input.userId ?? null,
+    initiatedByKeyId: input.apiKeyId ?? null,
+  });
+
+  // A replay must NOT move money again. Return what the original attempt did.
+  if (replayed) {
+    return { position, movement, replayed: true };
+  }
+
+  const fail = async (reason: string) => {
+    const failed = await repo.advanceMovement({
+      movementId: movement.id,
+      organizationId: input.organizationId,
+      fromStatuses: ["pending"],
+      toStatus: "failed",
+      failureReason: reason,
+    });
+    return { position, movement: failed ?? movement, replayed: false };
+  };
+
+  // 2. Build.
+  let plan: Awaited<ReturnType<typeof client.buildVaultDeposit>>;
+  try {
+    plan = await client.buildVaultDeposit(runtime, {
+      providerReference: input.providerReference,
+      owner: input.wallet.publicKey,
+      amount: input.amount,
+      ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
+    });
+  } catch (error) {
+    getLogger().error({ movementId: movement.id, error }, "vault deposit: build failed");
+    return await fail(error instanceof Error ? error.message : "Failed to build the deposit.");
+  }
+
+  // 3. Simulate before signing — cheaper than a landed failure the customer paid for.
+  const simulation = await simulateVaultPlan(env, {
+    plan,
+    owner: address(input.wallet.publicKey),
+    rpcUrl,
+  });
+  if (!simulation.ok) {
+    getLogger().error(
+      { movementId: movement.id, error: simulation.error, logs: simulation.logs.slice(-5) },
+      "vault deposit: simulation failed"
+    );
+    return await fail(`Simulation failed: ${simulation.error}`);
+  }
+
+  // 4. Sign with custody and submit.
+  const signer = await solanaServices.createOrgSigner(
+    env,
+    input.organizationId,
+    input.projectId,
+    input.wallet.walletId
+  );
+  if (signer.address !== input.wallet.publicKey) {
+    // The same assertion private-channels makes: a resolved signer that is not
+    // the wallet we priced the deposit for would move someone else's money.
+    throw badRequest("Resolved signing wallet does not match the deposit wallet");
+  }
+
+  let signature: string;
+  try {
+    const submitted = await submitVaultPlan(env, {
+      plan,
+      owner: signer,
+      rpcUrl,
+      fee: resolveVaultFeeMode(),
+    });
+    signature = submitted.signature;
+  } catch (error) {
+    getLogger().error({ movementId: movement.id, error }, "vault deposit: submit failed");
+    return await fail(error instanceof Error ? error.message : "Failed to submit the deposit.");
+  }
+
+  // 5. Advance. Guarded so a concurrent observer cannot regress the row.
+  const advanced = await repo.advanceMovement({
+    movementId: movement.id,
+    organizationId: input.organizationId,
+    fromStatuses: ["pending"],
+    toStatus: "submitted",
+    signature,
+  });
+
+  return { position, movement: advanced ?? movement, replayed: false };
+}
+
+/**
+ * Who pays the transaction fee.
+ *
+ * WALLET-PAYS for now, unconditionally. Kora only sponsors transactions whose
+ * programs are on its allowlist, and the Kamino kvault/klend programs are not on
+ * it — the Private Channels escrow hit exactly this and still pays its own fee
+ * today. Attempting sponsorship would fail at the relay with an opaque
+ * rejection AFTER the customer's wallet had already signed.
+ *
+ * Flipping to sponsored is a one-line change here once `validation_config.allowed_programs`
+ * carries the kvault, klend and farms ids on the relevant relay (an sdp-infra
+ * change). The plumbing already exists: `submitVaultPlan` takes the mode.
+ */
+function resolveVaultFeeMode(): VaultFeeMode {
+  return { kind: "wallet-pays" };
+}

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -7,6 +7,7 @@ import {
   createNoopSigner,
   createTransactionMessage,
   getBase64EncodedWireTransaction,
+  getSignatureFromTransaction,
   getTransactionEncoder,
   type Instruction,
   pipe,
@@ -59,6 +60,85 @@ export interface SubmitVaultPlanInput {
 
 export interface SubmitVaultPlanResult {
   signature: Signature;
+}
+
+export interface SignedVaultTransaction {
+  /** The wire bytes, ready to broadcast. */
+  bytes: Uint8Array;
+  /**
+   * The signature this transaction WILL have on chain, known before it is
+   * sent — a Solana signature is the fee payer's signature over the message,
+   * so signing determines it and broadcasting only publishes it.
+   */
+  signature: Signature;
+}
+
+/**
+ * Sign, WITHOUT sending.
+ *
+ * Split from the broadcast so the caller can durably record the signature
+ * before the transaction can possibly land. That ordering is the only thing
+ * that makes an ambiguous send recoverable: once bytes are on the wire, a
+ * timeout, a crash or a lost DB write leaves a transaction that may be on chain
+ * with money moved, and without the signature there is nothing to reconcile it
+ * against — SDP would not know the transfer exists.
+ *
+ * Wallet-pays only. In the sponsored path the relay signs as fee payer AFTER
+ * us, so the final signature is not knowable here; that path keeps the combined
+ * `submitVaultPlan` and owes the same treatment before it is switched on.
+ */
+export async function signVaultPlan(
+  env: Env,
+  input: { plan: EarnVaultTransactionPlan; owner: TransactionSigner; rpcUrl: string }
+): Promise<SignedVaultTransaction> {
+  const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayerSigner(input.owner, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(instructions, m)
+  );
+  const signed = await signTransactionMessageWithSigners(message);
+  return {
+    bytes: new Uint8Array(getTransactionEncoder().encode(signed)),
+    signature: getSignatureFromTransaction(signed),
+  };
+}
+
+/**
+ * Broadcast bytes whose signature the caller has already recorded.
+ *
+ * Throwing here does NOT mean the transaction failed — it may have landed and
+ * the response been lost. The caller must treat a throw as UNKNOWN and leave
+ * the ledger row reconcilable against its recorded signature, never mark it
+ * failed.
+ */
+export async function broadcastVaultTransaction(
+  env: Env,
+  input: { bytes: Uint8Array; rpcUrl: string }
+): Promise<void> {
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  await solanaRpc.sendTransaction(rpc, input.bytes);
+}
+
+/** The single batch a deposit plan carries, with the multi-transaction refusal. */
+function singleBatchInstructions(plan: EarnVaultTransactionPlan) {
+  const batch = plan.transactions[0];
+  if (!batch || batch.length === 0) {
+    throw new Error("Vault plan carried no instructions");
+  }
+  if (plan.transactions.length > 1) {
+    // Multi-transaction plans need per-leg ledger rows and a resume story; the
+    // deposit path never produces one today, so refuse rather than silently
+    // land only the first leg.
+    throw new Error(
+      `Vault plan needs ${plan.transactions.length} transactions; multi-transaction submission is not implemented`
+    );
+  }
+  return batch;
 }
 
 /**

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -71,6 +71,8 @@ export interface SignedVaultTransaction {
    * so signing determines it and broadcasting only publishes it.
    */
   signature: Signature;
+  /** Inclusive block height after which these exact bytes cannot land. */
+  lastValidBlockHeight: string;
 }
 
 /**
@@ -105,6 +107,7 @@ export async function signVaultPlan(
   return {
     bytes: new Uint8Array(getTransactionEncoder().encode(signed)),
     signature: getSignatureFromTransaction(signed),
+    lastValidBlockHeight: String(lastValidBlockHeight),
   };
 }
 
@@ -126,6 +129,12 @@ export async function broadcastVaultTransaction(
 
 /** The single batch a deposit plan carries, with the multi-transaction refusal. */
 function singleBatchInstructions(plan: EarnVaultTransactionPlan) {
+  if (plan.lookupTables.length > 0) {
+    // Address lookup tables require a different compilation path. Refuse them
+    // at the shared boundary so simulation, signing and submission cannot each
+    // make a different assumption about the same provider plan.
+    throw new Error("Vault plans with address lookup tables are not implemented");
+  }
   const batch = plan.transactions[0];
   if (!batch || batch.length === 0) {
     throw new Error("Vault plan carried no instructions");
@@ -160,20 +169,7 @@ export async function submitVaultPlan(
   env: Env,
   input: SubmitVaultPlanInput
 ): Promise<SubmitVaultPlanResult> {
-  const batch = input.plan.transactions[0];
-  if (!batch || batch.length === 0) {
-    throw new Error("Vault plan carried no instructions");
-  }
-  if (input.plan.transactions.length > 1) {
-    // Multi-transaction plans need per-leg ledger rows and a resume story; the
-    // deposit path never produces one today, so refuse rather than silently
-    // land only the first leg.
-    throw new Error(
-      `Vault plan needs ${input.plan.transactions.length} transactions; multi-transaction submission is not implemented`
-    );
-  }
-
-  const instructions = batch.map(toKitInstruction);
+  const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
   const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
 
@@ -220,8 +216,16 @@ export async function simulateVaultPlan(
   env: Env,
   input: { plan: EarnVaultTransactionPlan; owner: Address; rpcUrl: string }
 ): Promise<{ ok: true } | { ok: false; error: string; logs: readonly string[] }> {
-  const batch = input.plan.transactions[0];
-  if (!batch) return { ok: false, error: "empty plan", logs: [] };
+  let batch: ReturnType<typeof singleBatchInstructions>;
+  try {
+    batch = singleBatchInstructions(input.plan);
+  } catch (cause) {
+    return {
+      ok: false,
+      error: cause instanceof Error ? cause.message : "invalid vault plan",
+      logs: [],
+    };
+  }
 
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
   const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -1,0 +1,177 @@
+import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
+import * as solanaRpc from "@sdp/rpc/solana";
+import {
+  type Address,
+  address,
+  appendTransactionMessageInstructions,
+  createNoopSigner,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  getTransactionEncoder,
+  type Instruction,
+  pipe,
+  type Signature,
+  setTransactionMessageFeePayer,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type TransactionSigner,
+} from "@solana/kit";
+import {
+  partiallySignTransactionMessageWithSigners,
+  signTransactionMessageWithSigners,
+} from "@solana/signers";
+import type { FeePaymentPort } from "@/services/ports";
+import type { Env } from "@/types/env";
+
+/**
+ * Turn a provider's unsigned plan into a landed transaction, signed by an SDP
+ * custody wallet.
+ *
+ * This is the seam the whole vault-direct model rests on: a `vault_direct`
+ * provider custodies nothing and hands back instructions, so the ONLY thing
+ * that moves money is SDP signing with a wallet it controls. Nothing here is
+ * Kamino-specific — it consumes the neutral `EarnVaultTransactionPlan`.
+ */
+
+/** A plain-data instruction from the provider contract, back in kit form. */
+function toKitInstruction(instruction: EarnVaultTransactionPlan["transactions"][number][number]) {
+  return {
+    programAddress: address(instruction.programAddress),
+    accounts: instruction.accounts.map((account) => ({
+      address: address(account.address),
+      role: account.role,
+    })),
+    data: Uint8Array.from(Buffer.from(instruction.data, "base64")),
+  } as unknown as Instruction;
+}
+
+export type VaultFeeMode =
+  | { kind: "sponsored"; feePayment: FeePaymentPort }
+  | { kind: "wallet-pays" };
+
+export interface SubmitVaultPlanInput {
+  plan: EarnVaultTransactionPlan;
+  /** The custody wallet signer — the vault `user`, and the only real signer. */
+  owner: TransactionSigner;
+  rpcUrl: string;
+  fee: VaultFeeMode;
+}
+
+export interface SubmitVaultPlanResult {
+  signature: Signature;
+}
+
+/**
+ * Decide who pays the transaction fee.
+ *
+ * Kora only sponsors transactions whose programs are on its allowlist, and the
+ * Kamino kvault/klend programs are not on it (the Private Channels escrow hit
+ * the same wall and still pays its own fee). Rather than fail at submit with an
+ * opaque relay rejection, callers pass `wallet-pays` when sponsorship is not
+ * available for the programs in the plan.
+ *
+ * NOTE the distinction that is easy to lose: klend-sdk also has a `payer`
+ * concept, but that is the RENT payer for created ATAs, embedded in the
+ * instruction accounts. This function is about the TRANSACTION FEE payer, which
+ * is a property of the message. They are different spends and must not be
+ * conflated — a sponsor that agreed to fees has not agreed to fund rent.
+ */
+export async function submitVaultPlan(
+  env: Env,
+  input: SubmitVaultPlanInput
+): Promise<SubmitVaultPlanResult> {
+  const batch = input.plan.transactions[0];
+  if (!batch || batch.length === 0) {
+    throw new Error("Vault plan carried no instructions");
+  }
+  if (input.plan.transactions.length > 1) {
+    // Multi-transaction plans need per-leg ledger rows and a resume story; the
+    // deposit path never produces one today, so refuse rather than silently
+    // land only the first leg.
+    throw new Error(
+      `Vault plan needs ${input.plan.transactions.length} transactions; multi-transaction submission is not implemented`
+    );
+  }
+
+  const instructions = batch.map(toKitInstruction);
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+
+  if (input.fee.kind === "sponsored") {
+    // Sponsored: the relay's address is the fee payer and signs AFTER us, so the
+    // message carries a noop signer for it and the custody wallet signs its own
+    // slots only.
+    const feePayer = await input.fee.feePayment.getFeePayer();
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(createNoopSigner(feePayer), m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions(instructions, m)
+    );
+    const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+    const bytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
+    const signature = await input.fee.feePayment.signAndSend(bytes);
+    return { signature };
+  }
+
+  // Wallet pays: the custody wallet is both the vault `user` and the fee payer,
+  // so it signs once for both and we broadcast directly.
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayerSigner(input.owner, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(instructions, m)
+  );
+  const signed = await signTransactionMessageWithSigners(message);
+  const bytes = new Uint8Array(getTransactionEncoder().encode(signed));
+  const signature = await solanaRpc.sendTransaction(rpc, bytes);
+  return { signature };
+}
+
+/**
+ * Simulate before signing.
+ *
+ * Worth the extra round trip on this path specifically: the instructions were
+ * assembled by a third-party SDK against live vault state, so a stale reserve
+ * set or a changed vault config surfaces here as a readable program error
+ * instead of a landed, failed transaction the customer still paid for.
+ */
+export async function simulateVaultPlan(
+  env: Env,
+  input: { plan: EarnVaultTransactionPlan; owner: Address; rpcUrl: string }
+): Promise<{ ok: true } | { ok: false; error: string; logs: readonly string[] }> {
+  const batch = input.plan.transactions[0];
+  if (!batch) return { ok: false, error: "empty plan", logs: [] };
+
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(input.owner, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(batch.map(toKitInstruction), m)
+  );
+
+  // `sigVerify: false` + `replaceRecentBlockhash` so an unsigned message can be
+  // simulated: we want the PROGRAM's verdict, not a signature check.
+  const compiled = await partiallySignTransactionMessageWithSigners(message);
+  const wire = getBase64EncodedWireTransaction(compiled);
+  const result = await rpc
+    .simulateTransaction(wire, {
+      encoding: "base64",
+      sigVerify: false,
+      replaceRecentBlockhash: true,
+    })
+    .send();
+
+  if (result.value.err) {
+    return {
+      ok: false,
+      error: JSON.stringify(result.value.err, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      ),
+      logs: result.value.logs ?? [],
+    };
+  }
+  return { ok: true };
+}

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -84,6 +84,18 @@ export interface Env {
 
   // Solana configuration
   SOLANA_RPC_URL?: string;
+  /**
+   * Optional PER-CLUSTER overrides for the Earn execution path.
+   *
+   * One API process serves both clusters — sandbox projects are devnet,
+   * production projects are mainnet-beta — so a single `SOLANA_RPC_URL` cannot
+   * be correct for both. Unset falls back to `SOLANA_RPC_URL`, which must then
+   * prove its chain by genesis hash before anything is built against it
+   * (`assertClusterEndpoint`), so a single-cluster deployment keeps working and
+   * a mismatch is a refusal rather than a confidently wrong transaction.
+   */
+  SOLANA_DEVNET_RPC_URL?: string;
+  SOLANA_MAINNET_RPC_URL?: string;
   SOLANA_RPC_DEFAULT_PROVIDER?: OrganizationRpcProvider;
   SOLANA_RPC_TRITON_URL?: string;
   SOLANA_RPC_TRITON_API_KEY?: string;

--- a/apps/sdp-web/messages/en/dashboard-earn.json
+++ b/apps/sdp-web/messages/en/dashboard-earn.json
@@ -252,10 +252,15 @@
       "vaultSubmitting": "Submitting…",
       "vaultSubmitError": "The deposit could not be submitted.",
       "vaultDoneTitle": "Deposit submitted",
-      "vaultDoneBody": "Your deposit is on-chain. Vault shares are held by the wallet you chose.",
-      "vaultSettlingNote": "It can take a few moments to finalise. You will see the position under Active once it settles.",
+      "vaultDoneBody": "Your deposit was signed and broadcast. It is not confirmed yet — check the transaction to follow it on-chain.",
+      "vaultSettlingNote": "Vault positions are not listed under Active yet, so use the transaction link above to confirm the outcome.",
       "vaultDone": "Done",
-      "vaultTransaction": "Transaction"
+      "vaultTransaction": "Transaction",
+      "walletVaultDirectTitle": "This wallet signs and holds the shares",
+      "walletVaultDirectBody": "SDP builds the deposit and signs it with this wallet, which then holds the vault shares. There is no deposit address — confirming submits the transaction.",
+      "vaultPendingTitle": "Deposit in flight",
+      "vaultPendingBody": "This deposit was signed but SDP has not confirmed it reached the network. Do not retry with a new amount — check the transaction first, if one is shown.",
+      "vaultPendingNoSignature": "No transaction signature was recorded, so nothing was broadcast."
     }
   }
 }

--- a/apps/sdp-web/messages/en/dashboard-earn.json
+++ b/apps/sdp-web/messages/en/dashboard-earn.json
@@ -109,7 +109,7 @@
     },
     "opportunities": {
       "title": "Opportunities",
-      "description": "Ways to put idle stablecoins to work. Compare what each one pays, how it's backed, and how fast you can withdraw \u2014 rank by pool size or APY.",
+      "description": "Ways to put idle stablecoins to work. Compare what each one pays, how it's backed, and how fast you can withdraw — rank by pool size or APY.",
       "deposit": "Deposit",
       "depositDirectOnly": "Coming soon",
       "depositProviderClosed": "Not available",
@@ -235,7 +235,27 @@
       "timingDisclosure": "Confirming saves the target immediately, but money moves on the provider's later rebalances — not instantly. Slower strategies can take hours to converge, and small balances may stay as cash where deploying them isn't economical.",
       "programMissing": "That strategy could not be found — it may have been changed or removed since this link was made. Head back to Earn to see your current strategies.",
       "programMissingAction": "Back to Earn",
-      "creationUnavailable": "Earn strategies are open for comparison only right now — no provider is accepting deposits, so there is no strategy to set up. Head back to Earn to browse what is listed."
+      "creationUnavailable": "Earn strategies are open for comparison only right now — no provider is accepting deposits, so there is no strategy to set up. Head back to Earn to browse what is listed.",
+      "vaultWalletTitle": "Choose the wallet to deposit from",
+      "vaultWalletBody": "SDP signs the deposit with this wallet and the vault shares are held by it. Nothing is sent to an address — the deposit is an on-chain instruction.",
+      "vaultAmountTitle": "How much do you want to deposit?",
+      "vaultAmountBody": "Confirming signs and submits the transaction. There is no separate funding step afterwards.",
+      "vaultAmount": "Amount",
+      "vaultStrategy": "Vault",
+      "vaultBacking": "Backing",
+      "vaultFrom": "From wallet",
+      "vaultBalanceUnknown": "Balance unavailable right now — you can still deposit.",
+      "vaultBalanceAvailable": "{amount} available in this wallet.",
+      "vaultOverBalance": "That is more than this wallet's last known balance. You can still submit — the network decides.",
+      "vaultConfirmNote": "Confirming moves funds immediately. The wallet pays the network fee.",
+      "vaultSubmit": "Confirm deposit",
+      "vaultSubmitting": "Submitting…",
+      "vaultSubmitError": "The deposit could not be submitted.",
+      "vaultDoneTitle": "Deposit submitted",
+      "vaultDoneBody": "Your deposit is on-chain. Vault shares are held by the wallet you chose.",
+      "vaultSettlingNote": "It can take a few moments to finalise. You will see the position under Active once it settles.",
+      "vaultDone": "Done",
+      "vaultTransaction": "Transaction"
     }
   }
 }

--- a/apps/sdp-web/messages/en/dashboard-earn.json
+++ b/apps/sdp-web/messages/en/dashboard-earn.json
@@ -113,6 +113,8 @@
       "deposit": "Deposit",
       "depositDirectOnly": "Coming soon",
       "depositProviderClosed": "Not available",
+      "depositProductionClosed": "Production unavailable",
+      "depositProductionClosedReason": "Production vault deposits are unavailable until SDP supports vault withdrawals.",
       "columnAction": "Action"
     },
     "deposit": {
@@ -133,7 +135,7 @@
       "walletsEmptyTitle": "No wallets in SDP yet",
       "walletsEmptyBody": "Create one in the Wallets module first — the deposit flow needs a wallet to send from.",
       "walletUnnamed": "Unnamed wallet",
-      "walletAvailableToInvest": "Available to invest",
+      "walletAvailableToInvest": "Available {token}",
       "walletLegend": "Funding wallet",
       "connectFireblocksTitle": "Connect Fireblocks",
       "connectFireblocksBody": "Provision an institutional wallet on Fireblocks, then start this deposit again.",
@@ -240,7 +242,7 @@
       "vaultWalletBody": "SDP signs the deposit with this wallet and the vault shares are held by it. Nothing is sent to an address — the deposit is an on-chain instruction.",
       "vaultAmountTitle": "How much do you want to deposit?",
       "vaultAmountBody": "Confirming signs and submits the transaction. There is no separate funding step afterwards.",
-      "vaultAmount": "Amount",
+      "vaultAmount": "{token} amount",
       "vaultStrategy": "Vault",
       "vaultBacking": "Backing",
       "vaultFrom": "From wallet",
@@ -259,8 +261,7 @@
       "walletVaultDirectTitle": "This wallet signs and holds the shares",
       "walletVaultDirectBody": "SDP builds the deposit and signs it with this wallet, which then holds the vault shares. There is no deposit address — confirming submits the transaction.",
       "vaultPendingTitle": "Deposit in flight",
-      "vaultPendingBody": "This deposit was signed but SDP has not confirmed it reached the network. Do not retry with a new amount — check the transaction first, if one is shown.",
-      "vaultPendingNoSignature": "No transaction signature was recorded, so nothing was broadcast."
+      "vaultPendingBody": "This deposit was signed but SDP has not confirmed it reached the network. Do not submit it again with a new request — check the transaction first."
     }
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/markets/earn/vault-deposits/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/markets/earn/vault-deposits/route.ts
@@ -1,0 +1,22 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+/**
+ * Deposit into a NON-CUSTODIAL vault from an SDP custody wallet.
+ *
+ * Separate from `programs/route.ts` because the two model different money:
+ * creating a program provisions a provider wallet the customer funds later,
+ * while this call moves money now — SDP builds the instruction, signs it with
+ * the chosen custody wallet, and submits it.
+ *
+ * The API requires a body `requestId` (UUIDv4) and refuses a request without
+ * one. `proxyToSdpApi` forwards `{ method, body }` and builds its own headers,
+ * so an inbound `Idempotency-Key` never reaches the API — the body form is the
+ * only one that can, exactly as on the programs create route.
+ */
+export async function POST(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.earn.vaultDeposits.create",
+    path: "/v1/earn/vault-deposits",
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -247,10 +247,15 @@ full-page wizard keeps its shape because the CUSTODIAL run is a three-step
 provisioning flow ending in a program create; this is two short steps against a
 strategy the reader already chose by clicking its row.
 
-`EARN_VAULT_DEPOSITS_ENABLED` (`earn-surfacing.ts`) gates it, and it stayed
-`false` through every intermediate commit — flipping only once the modal existed.
-Keep that discipline: an enabled Deposit link with no flow behind it is the
-dead-end review caught on #1340.
+`EARN_VAULT_DEPOSITS_ENABLED` (`earn-surfacing.ts`) says the flow exists, and it
+stayed `false` through every intermediate commit — flipping only once the modal
+existed. A separate shared capability, `isVaultDirectDepositEnabled`, says the
+flow is OPEN in the selected project environment. The API and Opportunities row
+both read it: sandbox is open for integration testing; production stays visibly
+disabled until vault withdrawals and Active-tab positions exist. Keep both
+questions. An enabled Deposit button with no flow behind it is the dead-end
+review caught on #1340; a button the API refuses is the same failure at a later
+boundary.
 
 Two things still constrain the design, both discovered rather than assumed:
 
@@ -377,10 +382,10 @@ at the call site.
 
 ## Browse-only mode — when no provider can hold a program
 
-**This is the shipped state as of 2026-08-14.** Ground is un-surfaced
-(`EARN_PROVIDER_SURFACING` in `@sdp/types`) and Kamino, the only offered
-provider, is catalogue-only — so nothing can create a program and Earn is a
-comparison catalogue plus whatever programs already exist.
+Ground is un-surfaced (`EARN_PROVIDER_SURFACING` in `@sdp/types`) and Kamino is
+the only offered provider. Nothing can create a custodial program; Kamino vaults
+remain comparable in both environments and can be deposited into directly only
+from sandbox. Existing custodial programs remain visible and withdrawable.
 
 Everything branches on ONE derived boolean, `EARN_PROGRAM_CREATION_ENABLED`.
 Never re-derive it from a provider id, and never add a second flag beside it:
@@ -392,9 +397,10 @@ Never re-derive it from a provider id, and never add a second flag beside it:
 | Program card | Withdraw + "Change strategy" | Withdraw only |
 | `/deposit` route | the wizard | `EarnDepositUnavailable` notice, returned by the server shell before it fetches anything |
 
-Note the Opportunities row: `opportunityDepositability` asks THREE questions in order —
-cluster, then token (both facts about the INSTRUMENT), then whether SDP has a
-deposit path for the provider's shape at all (`no-sdp-route`).
+Note the Opportunities row: `opportunityDepositability` asks FOUR questions in
+order — cluster, token (both facts about the INSTRUMENT), whether the path is
+open in the selected project environment (`environment-closed`), then whether
+SDP has a deposit path for the provider's shape at all (`no-sdp-route`).
 
 Its `depositable` verdict CARRIES the `style`, and the row dispatches on that —
 never on whether an `onVaultDeposit` callback was passed. Callback presence is a
@@ -408,19 +414,28 @@ promised a "provider-managed deposit address", which is true for the custodial
 wizard and false for `vault_direct`, where confirming signs and submits on the
 spot and there is no address ever. It also takes REAL `fireblocksEnabled`,
 threaded from `page.tsx` — hard-coding `false` told entitled organizations that
-Fireblocks was locked.
+Fireblocks was locked. A direct vault also passes its `strategyToken` as
+`balanceToken`, so both the wallet row and amount screen show that exact
+stablecoin balance — a USDT vault must never quote the wallet's USDC balance.
+The picker keeps `custody_wallets.id` as local selection state and submits that
+same row id as `custodyWalletId`. The API authorizes the exact row before
+resolving its provider wallet; a provider `walletId` is unique only within its
+custody configuration, and a public key can match more than one provider
+record. A successful response always carries a transaction signature because
+signing precedes intent persistence; the submitted and ambiguous-pending panels
+therefore always expose the cluster-correct explorer link.
 
-**That third check is not optional, and omitting it shipped a dead end.** With
-only cluster + token, a PRODUCTION Kamino row is fundable, holds USDC, renders an
-enabled Deposit link — and lands on `EarnDepositUnavailable`, because the route
-creates custodial programs only. Sandbox hides it, since every Kamino row is
-`wrong-cluster` there, so this must be asserted in the model rather than checked
-by hand (`earn-deposit-model.unit.test.ts`). Caught in review on #1340.
+**That fourth check is not optional.** Before the vault-direct run existed,
+omitting it let a production Kamino row link into the custodial route, which
+could not create its provider shape. Style dispatch now selects the right run,
+but the route-shape verdict remains asserted in `earn-deposit-model.unit.test.ts`
+for the next provider rather than trusted to manual wiring. Caught in review on
+#1340.
 
-`no-sdp-route` carries the provider's `style` so the badge can name the real
-reason: a `vault_direct` vault takes deposits from the customer's own wallet and
-SDP does not route them yet, while a `custodial` one is simply not being offered.
-Both answer "no" today.
+`environment-closed` keeps a production vault row visible with a compact status
+and a full withdrawal-prerequisite explanation on its disabled action.
+`no-sdp-route` carries the provider's `style` so any genuinely unbuilt provider
+shape can still name the real reason rather than falling through to a wrong flow.
 
 **Vault positions have no UI exit yet.** `POST /v1/earn/vault-deposits` has no
 withdraw counterpart, and the Active tab still reads only `earn_provider_wallets`
@@ -492,22 +507,22 @@ what hid the bug above, so a surfacing change wants one browser pass on
   appearing in the UI as a provider-client bug, not something to patch here.
   A `cash` position can be a token the org never deposited on Solana, so do not
   assume positions imply a Solana deposit — only the addresses do.
-- **The catalogue shows strategies this module deliberately cannot select.**
-  Kamino is a catalogue-only provider: its K-Vaults are non-custodial — the
-  customer's own wallet deposits. Each environment catalogues its OWN cluster's
-  vaults (production → mainnet, everything else → devnet, read on-chain), so a
-  sandbox row is a real, reachable devnet vault. They reach
-  `GET /v1/earn/strategies` and the wizard's comparison table, but they must not
-  advance to review because there is no program to create for them. TWO
-  independent eligibility checks disable them, and both are intentional:
+- **The catalogue shows strategies the custodial wizard deliberately cannot
+  select.** Kamino's K-Vaults are non-custodial — the customer's own wallet
+  deposits. Each environment catalogues its OWN cluster's vaults (production →
+  mainnet, everything else → devnet, read on-chain), so a sandbox row is a real,
+  reachable devnet vault. It can open the direct-deposit modal from
+  Opportunities, but it must not advance through the separate custodial wizard
+  because there is no program to create for it. TWO independent eligibility
+  checks disable that wizard path, and both are intentional:
   - `EARN_PORTFOLIO_PROVIDER` — the existing Ground pin, which refuses selection
     for every non-portfolio provider while leaving its catalogue row visible.
   - `strategy.fundable` — the API's per-request answer to "does this instrument
     exist on the caller's cluster". Since Kamino catalogues per cluster this is
     now `true` in both environments, so it no longer disables anything for
     Kamino — the gate remains for Ground and any genuinely single-cluster
-    provider. What disables the row is `no-sdp-route`: SDP has no deposit path
-    for a `vault_direct` provider.
+    provider. The Opportunities action separately applies
+    `opportunityDepositability`, including the environment capability.
 
   Do not collapse visibility and eligibility. The pin is about which provider
   the flow can create a program with; `fundable` is about whether an instrument

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -396,6 +396,20 @@ Note the Opportunities row: `opportunityDepositability` asks THREE questions in 
 cluster, then token (both facts about the INSTRUMENT), then whether SDP has a
 deposit path for the provider's shape at all (`no-sdp-route`).
 
+Its `depositable` verdict CARRIES the `style`, and the row dispatches on that —
+never on whether an `onVaultDeposit` callback was passed. Callback presence is a
+fact about the parent's wiring; the style is a fact about the strategy, and only
+the second can say which endpoint the row may reach. If a custodial provider is
+surfaced again, branching on the callback would have opened the vault modal for
+its rows and posted them to the vault endpoint, which provisions no wallet.
+
+`WalletStep` takes a `depositMode` prop for the same class of reason: its note
+promised a "provider-managed deposit address", which is true for the custodial
+wizard and false for `vault_direct`, where confirming signs and submits on the
+spot and there is no address ever. It also takes REAL `fireblocksEnabled`,
+threaded from `page.tsx` — hard-coding `false` told entitled organizations that
+Fireblocks was locked.
+
 **That third check is not optional, and omitting it shipped a dead end.** With
 only cluster + token, a PRODUCTION Kamino row is fundable, holds USDC, renders an
 enabled Deposit link — and lands on `EarnDepositUnavailable`, because the route
@@ -415,9 +429,16 @@ until they land Kamino must not be creatable on mainnet — ADR 0002 forbids a
 position you can enter and not exit.
 
 **Withdraw is never gated on surfacing** (ADR 0002 — money out beats money off),
-and the withdraw modal's focus-return fallback
-(`data-earn-withdraw-focus-fallback`) therefore lives on the **Withdraw button**,
-not on "Change strategy" which disappears with it.
+and the modal focus-return fallback (`data-modal-focus-fallback`) therefore
+lives on the **Withdraw button**, not on "Change strategy" which disappears with
+it.
+
+That focus lifecycle now lives in `src/lib/use-modal-focus.ts` and is shared by
+the withdraw modal and `EarnVaultDepositModal`. The shared `Modal` gives a
+portal, `aria-modal` and Escape — and NOTHING about focus: no initial focus, no
+trap, no restoration. The deposit modal had none at all, which meant keyboard
+focus could sit on page content the dialog covered. Two halves of one position
+behaving differently for a keyboard user is a difference nobody can explain.
 
 The onboarding hero (`StartSection`) that used to own the "Set up Earn" CTA is
 GONE — the Opportunities tab is the landing surface now, so there is no empty state to

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -235,18 +235,29 @@ sentence about timing must trace to one of those.
   resolved from the `programId` the confirm returned.
 - `earn-deposit-chrome.tsx` / `earn-deposit-outcome.tsx` — shared primitives.
 
-### NOT BUILT: the simplified deposit run
+### The vault deposit run (BUILT)
 
-The intended shape is **Deposit → wallet → amount → summary → hand-off**, and it
-is not written. The Opportunities tab's Deposit link still enters the wizard above
-(wallet → strategy → review). Two things constrain the design, both discovered
-rather than assumed:
+Shipped as **`earn-vault-deposit-modal.tsx`** — wallet → amount → confirm, opened
+IN PLACE from an Opportunities row rather than navigating to `/deposit`.
 
-- **SDP has no code path that moves money into a vault, for either provider
-  shape.** A custodial program is funded by the customer sending stablecoins to
-  the program's address; a `vault_direct` vault is funded by the customer's own
-  wallet signing an on-chain instruction. So the "amount" step is context for a
-  hand-off, never an execution.
+A modal, not a page, for symmetry: `earn-withdraw-modal.tsx` is the money-OUT
+verb for the same position and is already a modal, and two halves of one
+position behaving differently is a difference no reader can explain. The
+full-page wizard keeps its shape because the CUSTODIAL run is a three-step
+provisioning flow ending in a program create; this is two short steps against a
+strategy the reader already chose by clicking its row.
+
+`EARN_VAULT_DEPOSITS_ENABLED` (`earn-surfacing.ts`) gates it, and it stayed
+`false` through every intermediate commit — flipping only once the modal existed.
+Keep that discipline: an enabled Deposit link with no flow behind it is the
+dead-end review caught on #1340.
+
+Two things still constrain the design, both discovered rather than assumed:
+
+- **Confirm MOVES MONEY here, unlike the custodial run.** The custodial wizard
+  provisions a wallet and hands back an address to fund later; this signs and
+  submits on the spot, so the copy says so and the modal cannot be dismissed
+  while submitting.
 - **A `vault_direct` completion must never present the vault as a send target.**
   Kamino's `providerReference` is the vault's PROGRAM ACCOUNT — stablecoins sent
   there are lost. `earnDepositStyle` (@sdp/types) is what the completion step
@@ -396,6 +407,12 @@ by hand (`earn-deposit-model.unit.test.ts`). Caught in review on #1340.
 reason: a `vault_direct` vault takes deposits from the customer's own wallet and
 SDP does not route them yet, while a `custodial` one is simply not being offered.
 Both answer "no" today.
+
+**Vault positions have no UI exit yet.** `POST /v1/earn/vault-deposits` has no
+withdraw counterpart, and the Active tab still reads only `earn_provider_wallets`
+(custodial), so a vault position does not render there. Both are outstanding, and
+until they land Kamino must not be creatable on mainnet — ADR 0002 forbids a
+position you can enter and not exit.
 
 **Withdraw is never gated on surfacing** (ADR 0002 — money out beats money off),
 and the withdraw modal's focus-return fallback

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-chrome.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-chrome.tsx
@@ -134,16 +134,25 @@ export function SummaryRow({ label, value }: { label: ReactNode; value: ReactNod
 export function StepSection({
   action,
   children,
+  focusHeading = false,
   title,
 }: {
   action?: ReactNode;
   children: ReactNode;
+  /** Marks the section title as the modal panel's semantic focus fallback. */
+  focusHeading?: boolean;
   title: ReactNode;
 }) {
   return (
     <section className="overflow-hidden rounded-2xl border border-border-default bg-surface-raised">
       <div className="flex items-center justify-between gap-3 border-b border-border-subtle bg-fill-subtle px-4 py-3">
-        <h3 className="text-sm font-medium text-primary">{title}</h3>
+        <h3
+          className="text-sm font-medium text-primary"
+          data-modal-focus-heading={focusHeading ? "" : undefined}
+          tabIndex={focusHeading ? -1 : undefined}
+        >
+          {title}
+        </h3>
         {action}
       </div>
       <div className="px-4 py-2">{children}</div>

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
@@ -5,6 +5,8 @@ import {
   type EarnProviderId,
   type EarnStrategy,
   earnDepositStyle,
+  isVaultDirectDepositEnabled,
+  type SdpEnvironment,
 } from "@sdp/types";
 import { strategyApy, strategyPoolUsd, strategyToken } from "../earn-program-presentation";
 import { EARN_PROGRAM_CREATION_ENABLED, EARN_VAULT_DEPOSITS_ENABLED } from "../earn-surfacing";
@@ -70,35 +72,38 @@ export function fundableStrategies(strategies: readonly EarnStrategy[]): readonl
  * Whether a catalogue row can start a deposit run that can actually FINISH, and
  * if not, why.
  *
- * Three questions, in the order that gives the reader the most actionable
+ * Four questions, in the order that gives the reader the most actionable
  * answer:
  *
  * 1. Does the instrument exist on this cluster (`wrong-cluster`)? Definitive and
  *    environment-specific, so it wins — a sandbox reader looking at a
  *    mainnet-only Kamino row needs that before they wonder about its token.
  * 2. Does its mint map to a supported stablecoin lane (`asset-unsupported`)?
- * 3. **Does SDP have a deposit path for this provider's shape at all
+ * 3. Is that path open in this project environment (`environment-closed`)? A
+ *    sandbox vault can be exercised while production stays closed until SDP
+ *    also supports the exit.
+ * 4. **Does SDP have a deposit path for this provider's shape at all
  *    (`no-sdp-route`)?**
  *
- * The third check is the one that is easy to omit and was: without it, a
- * production Kamino row is fundable, has a supported token, renders an enabled
- * Deposit link — and lands on `EarnDepositUnavailable`, because the route it
- * points at only creates custodial programs. Sandbox hides that (every Kamino
- * row is `wrong-cluster` there), which is exactly why the check belongs in the
- * model rather than in a manual pass.
+ * The fourth check is easy to omit and was caught before the vault-direct run
+ * existed: a production Kamino row rendered an enabled link into the custodial
+ * route, which could not create its provider shape. The style now dispatches to
+ * the right run, but the route-shape check remains the compiler-enforced guard
+ * for the next provider rather than a manual assumption.
  *
- * It answers differently per provider shape, and today both answer "no":
+ * It answers differently per provider shape:
  *
  * - `custodial` — needs a surfaced provider with a program model. With Ground
  *   un-surfaced there is none, so `EARN_PROGRAM_CREATION_ENABLED` is false.
- * - `vault_direct` — the API half is BUILT (`POST /v1/earn/vault-deposits`
- *   builds the instruction, signs it with an org custody wallet and submits it),
- *   but the wizard run is not, so `EARN_VAULT_DEPOSITS_ENABLED` still pins this
- *   to no. SDP never hands out an address for these: a K-Vault's account is a
- *   program account and funds sent to it are lost.
+ * - `vault_direct` — both the API and the in-place modal are built, so
+ *   `EARN_VAULT_DEPOSITS_ENABLED` follows provider surfacing. The independent
+ *   environment capability keeps production closed until withdrawal and Active
+ *   support exist. SDP never hands out an address for these: a K-Vault's account
+ *   is a program account and funds sent to it are lost.
  *
- * Re-enabling is therefore a real change in both cases, not a flag flip, and
- * this predicate is where the compiler will bring you.
+ * Opening either unavailable branch is therefore a real capability change, not
+ * a presentation-only flag flip, and this predicate is where the compiler will
+ * bring you.
  */
 /**
  * `depositable` carries the STYLE, so a caller dispatches on what the route
@@ -115,9 +120,13 @@ export type OpportunityDepositability =
   | { kind: "depositable"; style: EarnDepositStyle }
   | { kind: "wrong-cluster" }
   | { kind: "asset-unsupported" }
+  | { kind: "environment-closed" }
   | { kind: "no-sdp-route"; style: EarnDepositStyle };
 
-export function opportunityDepositability(strategy: EarnStrategy): OpportunityDepositability {
+export function opportunityDepositability(
+  strategy: EarnStrategy,
+  environment: SdpEnvironment
+): OpportunityDepositability {
   // `=== false`, not falsy: an API old enough to omit `fundable` predates any
   // mainnet-only provider, so absent must read as "no cluster objection" rather
   // than blanking every row. Same rule as `fundableStrategies` above.
@@ -125,6 +134,14 @@ export function opportunityDepositability(strategy: EarnStrategy): OpportunityDe
   if (strategyToken(strategy) === undefined) return { kind: "asset-unsupported" };
 
   const style = earnDepositStyle(strategy.provider);
+  // The route exists in both deploys, but the shared capability deliberately
+  // closes production until SDP can also show and withdraw a vault position.
+  // Mirror the API's gate here so a real-money project never gets an action the
+  // server must refuse. The row stays visible for comparison; only money-IN is
+  // unavailable.
+  if (style === "vault_direct" && !isVaultDirectDepositEnabled(environment)) {
+    return { kind: "environment-closed" };
+  }
   // `vault_direct` becomes depositable when the vault run is enabled: SDP builds
   // the instruction, signs it with one of the org's own custody wallets, and
   // submits it (POST /v1/earn/vault-deposits). Nothing is ever sent to an

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
@@ -7,7 +7,7 @@ import {
   earnDepositStyle,
 } from "@sdp/types";
 import { strategyApy, strategyPoolUsd, strategyToken } from "../earn-program-presentation";
-import { EARN_PROGRAM_CREATION_ENABLED } from "../earn-surfacing";
+import { EARN_PROGRAM_CREATION_ENABLED, EARN_VAULT_DEPOSITS_ENABLED } from "../earn-surfacing";
 
 /**
  * Pure model for the Earn deposit flow: full catalogue → ranked comparison
@@ -91,8 +91,11 @@ export function fundableStrategies(strategies: readonly EarnStrategy[]): readonl
  *
  * - `custodial` — needs a surfaced provider with a program model. With Ground
  *   un-surfaced there is none, so `EARN_PROGRAM_CREATION_ENABLED` is false.
- * - `vault_direct` — needs the wallet -> amount -> hand-off run, which is not
- *   built. SDP moves no money into a K-Vault and holds no address to point at.
+ * - `vault_direct` — the API half is BUILT (`POST /v1/earn/vault-deposits`
+ *   builds the instruction, signs it with an org custody wallet and submits it),
+ *   but the wizard run is not, so `EARN_VAULT_DEPOSITS_ENABLED` still pins this
+ *   to no. SDP never hands out an address for these: a K-Vault's account is a
+ *   program account and funds sent to it are lost.
  *
  * Re-enabling is therefore a real change in both cases, not a flag flip, and
  * this predicate is where the compiler will bring you.
@@ -111,6 +114,16 @@ export function opportunityDepositability(strategy: EarnStrategy): OpportunityDe
   if (strategyToken(strategy) === undefined) return { kind: "asset-unsupported" };
 
   const style = earnDepositStyle(strategy.provider);
+  // `vault_direct` becomes depositable when the vault run is enabled: SDP builds
+  // the instruction, signs it with one of the org's own custody wallets, and
+  // submits it (POST /v1/earn/vault-deposits). Nothing is ever sent to an
+  // address — the vault's account is a program account and funds sent there are
+  // lost — so this is true only because a path was BUILT, never by relaxing a
+  // check. `EARN_VAULT_DEPOSITS_ENABLED` is what keeps the affordance and the
+  // flow shipping together.
+  if (style === "vault_direct" && EARN_VAULT_DEPOSITS_ENABLED) {
+    return { kind: "depositable" };
+  }
   if (style === "custodial" && EARN_PROGRAM_CREATION_ENABLED) {
     return { kind: "depositable" };
   }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.ts
@@ -100,8 +100,19 @@ export function fundableStrategies(strategies: readonly EarnStrategy[]): readonl
  * Re-enabling is therefore a real change in both cases, not a flag flip, and
  * this predicate is where the compiler will bring you.
  */
+/**
+ * `depositable` carries the STYLE, so a caller dispatches on what the route
+ * actually IS rather than on which callback it happens to have been handed.
+ *
+ * The Opportunities row used to choose modal-vs-link by asking whether an
+ * `onVaultDeposit` prop was present — a property of the parent's wiring, not of
+ * the strategy. A custodial provider becoming surfaced again would then have
+ * opened the vault modal for its rows and posted them to the vault endpoint,
+ * which provisions no wallet and hands back no address. Putting the style in
+ * the verdict makes the compiler ask the question at every branch.
+ */
 export type OpportunityDepositability =
-  | { kind: "depositable" }
+  | { kind: "depositable"; style: EarnDepositStyle }
   | { kind: "wrong-cluster" }
   | { kind: "asset-unsupported" }
   | { kind: "no-sdp-route"; style: EarnDepositStyle };
@@ -122,10 +133,10 @@ export function opportunityDepositability(strategy: EarnStrategy): OpportunityDe
   // check. `EARN_VAULT_DEPOSITS_ENABLED` is what keeps the affordance and the
   // flow shipping together.
   if (style === "vault_direct" && EARN_VAULT_DEPOSITS_ENABLED) {
-    return { kind: "depositable" };
+    return { kind: "depositable", style };
   }
   if (style === "custodial" && EARN_PROGRAM_CREATION_ENABLED) {
-    return { kind: "depositable" };
+    return { kind: "depositable", style };
   }
   return { kind: "no-sdp-route", style };
 }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
@@ -109,19 +109,42 @@ describe("fundableStrategies", () => {
  * `wrong-cluster` there — so the third check has to be asserted, not eyeballed.
  */
 describe("opportunityDepositability", () => {
-  it("refuses a fundable vault-direct vault: SDP has no route for its deposit", () => {
+  it("allows a fundable vault-direct vault now that the deposit modal exists", () => {
     const kamino = strategy({
       id: "kamino-production",
       provider: "kamino",
       hostCluster: "mainnet-beta",
-      // The exact shape that used to slip through: on-cluster and USDC.
       fundable: true,
     });
 
-    expect(opportunityDepositability(kamino)).toEqual({
-      kind: "no-sdp-route",
-      style: "vault_direct",
-    });
+    // Flipped only once BOTH halves existed: POST /v1/earn/vault-deposits and
+    // `EarnVaultDepositModal` behind the row's button. An enabled link with no
+    // flow behind it is the dead-end review caught on #1340 — the two ship
+    // together, which is what `EARN_VAULT_DEPOSITS_ENABLED` encodes.
+    expect(opportunityDepositability(kamino)).toEqual({ kind: "depositable" });
+  });
+
+  it("still refuses a vault-direct vault on the wrong cluster", () => {
+    // Cluster is checked BEFORE the deposit style, so shipping the vault run
+    // must not make a mainnet vault look fundable from a sandbox project.
+    expect(
+      opportunityDepositability(
+        strategy({
+          id: "kamino-wrong-cluster",
+          provider: "kamino",
+          hostCluster: "mainnet-beta",
+          fundable: false,
+        })
+      )
+    ).toEqual({ kind: "wrong-cluster" });
+  });
+
+  it("still refuses a vault-direct vault in an unsupported asset", () => {
+    expect(
+      opportunityDepositability(
+        strategy({ id: "kamino-odd-mint", provider: "kamino", depositMints: [UNROUTABLE_MINT] })
+      )
+    ).toEqual({ kind: "asset-unsupported" });
   });
 
   it("refuses a custodial vault while no custodial provider is offered", () => {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
@@ -109,11 +109,11 @@ describe("fundableStrategies", () => {
  * `wrong-cluster` there — so the third check has to be asserted, not eyeballed.
  */
 describe("opportunityDepositability", () => {
-  it("allows a fundable vault-direct vault now that the deposit modal exists", () => {
+  it("allows a fundable vault-direct vault in sandbox", () => {
     const kamino = strategy({
-      id: "kamino-production",
+      id: "kamino-sandbox",
       provider: "kamino",
-      hostCluster: "mainnet-beta",
+      hostCluster: "devnet",
       fundable: true,
     });
 
@@ -123,9 +123,22 @@ describe("opportunityDepositability", () => {
     // together, which is what `EARN_VAULT_DEPOSITS_ENABLED` encodes.
     // The STYLE rides along with the verdict so the row dispatches on what the
     // route is, not on which callback the parent happened to pass.
-    expect(opportunityDepositability(kamino)).toEqual({
+    expect(opportunityDepositability(kamino, "sandbox")).toEqual({
       kind: "depositable",
       style: "vault_direct",
+    });
+  });
+
+  it("keeps a production vault visible but closes its deposit action", () => {
+    const kamino = strategy({
+      id: "kamino-production",
+      provider: "kamino",
+      hostCluster: "mainnet-beta",
+      fundable: true,
+    });
+
+    expect(opportunityDepositability(kamino, "production")).toEqual({
+      kind: "environment-closed",
     });
   });
 
@@ -139,7 +152,8 @@ describe("opportunityDepositability", () => {
           provider: "kamino",
           hostCluster: "mainnet-beta",
           fundable: false,
-        })
+        }),
+        "sandbox"
       )
     ).toEqual({ kind: "wrong-cluster" });
   });
@@ -147,7 +161,8 @@ describe("opportunityDepositability", () => {
   it("still refuses a vault-direct vault in an unsupported asset", () => {
     expect(
       opportunityDepositability(
-        strategy({ id: "kamino-odd-mint", provider: "kamino", depositMints: [UNROUTABLE_MINT] })
+        strategy({ id: "kamino-odd-mint", provider: "kamino", depositMints: [UNROUTABLE_MINT] }),
+        "sandbox"
       )
     ).toEqual({ kind: "asset-unsupported" });
   });
@@ -155,7 +170,7 @@ describe("opportunityDepositability", () => {
   it("refuses a custodial vault while no custodial provider is offered", () => {
     // Ground is un-surfaced, so EARN_PROGRAM_CREATION_ENABLED is false and the
     // deposit route answers with its unavailable notice.
-    expect(opportunityDepositability(strategy({ id: "ground-devnet" }))).toEqual({
+    expect(opportunityDepositability(strategy({ id: "ground-devnet" }), "sandbox")).toEqual({
       kind: "no-sdp-route",
       style: "custodial",
     });
@@ -169,12 +184,12 @@ describe("opportunityDepositability", () => {
       fundable: false,
     });
 
-    expect(opportunityDepositability(kamino)).toEqual({ kind: "wrong-cluster" });
+    expect(opportunityDepositability(kamino, "sandbox")).toEqual({ kind: "wrong-cluster" });
   });
 
   it("reports an unroutable mint once the cluster is fine", () => {
     expect(
-      opportunityDepositability(strategy({ id: "odd", depositMints: [UNROUTABLE_MINT] }))
+      opportunityDepositability(strategy({ id: "odd", depositMints: [UNROUTABLE_MINT] }), "sandbox")
     ).toEqual({
       kind: "asset-unsupported",
     });

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-model.unit.test.ts
@@ -121,7 +121,12 @@ describe("opportunityDepositability", () => {
     // `EarnVaultDepositModal` behind the row's button. An enabled link with no
     // flow behind it is the dead-end review caught on #1340 — the two ship
     // together, which is what `EARN_VAULT_DEPOSITS_ENABLED` encodes.
-    expect(opportunityDepositability(kamino)).toEqual({ kind: "depositable" });
+    // The STYLE rides along with the verdict so the row dispatches on what the
+    // route is, not on which callback the parent happened to pass.
+    expect(opportunityDepositability(kamino)).toEqual({
+      kind: "depositable",
+      style: "vault_direct",
+    });
   });
 
   it("still refuses a vault-direct vault on the wrong cluster", () => {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-steps.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-deposit-steps.unit.test.tsx
@@ -21,6 +21,7 @@ import { WalletStep } from "./wallet-step";
 
 const TIMESTAMP = "2026-07-18T09:00:00.000Z";
 const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const USDT = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
 
 function strategy(partial: Partial<EarnStrategy> & { id: string }): EarnStrategy {
   return {
@@ -115,8 +116,33 @@ describe("WalletStep", () => {
         ]}
       />
     );
-    expect(html).toContain("DashboardEarn.deposit.walletAvailableToInvest");
+    expect(html).toContain("DashboardEarn.deposit.walletAvailableToInvest(USDC)");
     expect(html).toContain("1,250 USDC");
+  });
+
+  it("shows only the requested stablecoin lane in each wallet row", () => {
+    const html = renderToStaticMarkup(
+      <WalletStep
+        balanceToken="usdt"
+        fireblocksEnabled
+        hasError={false}
+        isLoading={false}
+        onSelect={() => {}}
+        selectedWalletId="wallet_1"
+        wallets={[
+          wallet({
+            balances: [
+              { token: "USDC", mint: USDC, amount: "9000000000", uiAmount: "9000", decimals: 6 },
+              { token: "USDT", mint: USDT, amount: "12500000", uiAmount: "12.5", decimals: 6 },
+            ],
+          }),
+        ]}
+      />
+    );
+
+    expect(html).toContain("DashboardEarn.deposit.walletAvailableToInvest(USDT)");
+    expect(html).toContain("12.5 USDT");
+    expect(html).not.toContain("9,000 USDC");
   });
 
   it("distinguishes an unavailable balance read from a confirmed zero", () => {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-funding-wallets.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/earn-funding-wallets.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CustodyWalletSummary } from "@sdp/types";
+import type { CustodyWalletSummary, EarnPortfolioToken } from "@sdp/types";
 import useSWR from "swr";
 import { portfolioTokenForMint } from "../earn-program-presentation";
 
@@ -70,20 +70,28 @@ export function walletDisplayName(
 }
 
 /**
- * Spendable USDC observed in a custody wallet. `undefined` means the RPC read
- * was unavailable; zero is reserved for a successful observation with no USDC.
- * Earn currently funds over Ground's Solana USDC rail, so this is the number
- * that belongs on the first screen rather than a generic roll-up of stablecoins
- * the program cannot accept. `uiAmount` is authoritative here; `usdValue` is
- * optional and must not turn a funded wallet into "$0.00".
+ * Spendable balance for one exact Earn stablecoin lane. `undefined` means the
+ * RPC read was unavailable; zero is reserved for a successful observation with
+ * none of that token. Never aggregate stablecoins here: a USDT vault cannot
+ * spend USDC even though both are close to one dollar. `uiAmount` is
+ * authoritative; `usdValue` is optional and must not turn a funded wallet into
+ * "$0.00".
  */
-export function walletUsdcAmount(wallet: CustodyWalletSummary): number | undefined {
+export function walletTokenAmount(
+  wallet: CustodyWalletSummary,
+  token: EarnPortfolioToken
+): number | undefined {
   if (wallet.balances === undefined) return undefined;
   return wallet.balances.reduce((total, balance) => {
-    if (portfolioTokenForMint(balance.mint) !== "usdc") return total;
+    if (portfolioTokenForMint(balance.mint) !== token) return total;
     const amount = Number(balance.uiAmount);
     return Number.isFinite(amount) && amount > 0 ? total + amount : total;
   }, 0);
+}
+
+/** Ground's custodial flow chooses its strategy after the wallet, so it starts on USDC. */
+export function walletUsdcAmount(wallet: CustodyWalletSummary): number | undefined {
+  return walletTokenAmount(wallet, "usdc");
 }
 
 /** Aggregate only complete observations; one unknown wallet makes the total unknown. */

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import type { OnboardingStatusResponse } from "@/app/dashboard/onboarding-status";
 import {
   fetchActiveApiKeys,
   resolvePlaygroundApiBaseUrl,
@@ -8,6 +7,7 @@ import {
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { fetchProviderAvailability } from "@/lib/provider-availability";
 import { createRequestScopedSdpApiClients } from "@/lib/sdp-api";
+import { fetchEarnSdpOrganizationId } from "../earn-server-context";
 // From `earn-surfacing`, NOT `earn-program-data`: the latter is a client module,
 // and a Server Component importing a value from one receives a client-reference
 // proxy (truthy) instead of the boolean, which makes the guard below dead code.
@@ -77,14 +77,11 @@ export default async function EarnDepositPage({ searchParams }: EarnDepositPageP
     if (projectClient) {
       // Provider access is keyed by the SDP organization id, which is not the
       // Clerk org id — it comes from the onboarding link, same as custody setup.
-      const onboarding =
-        await organizationClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status");
+      const organizationId = await fetchEarnSdpOrganizationId(organizationClient);
       const [keysResult, availability] = await Promise.all([
         fetchActiveApiKeys(projectClient.request),
-        onboarding.organization
-          ? fetchProviderAvailability(projectClient.request, onboarding.organization.id).catch(
-              () => undefined
-            )
+        organizationId
+          ? fetchProviderAvailability(projectClient.request, organizationId).catch(() => undefined)
           : Promise.resolve(undefined),
       ]);
       if (keysResult.ok && keysResult.data) {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/wallet-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/wallet-step.tsx
@@ -136,6 +136,7 @@ function ConnectWalletCard({ fireblocksEnabled }: { fireblocksEnabled: boolean }
 }
 
 export function WalletStep({
+  depositMode = "custodial",
   fireblocksEnabled,
   hasError,
   isLoading,
@@ -143,6 +144,21 @@ export function WalletStep({
   selectedWalletId,
   wallets,
 }: {
+  /**
+   * Which money model this wallet is being chosen FOR.
+   *
+   * The note above the list is a promise about what happens next, and the two
+   * models make OPPOSITE promises: `custodial` provisions a provider-managed
+   * address and nothing moves until the customer sends funds to it later;
+   * `vault_direct` has no address at any point and confirming signs and submits
+   * immediately from the wallet chosen here.
+   *
+   * Defaulted so the existing custodial wizard is untouched. Hard-coding the
+   * custodial copy is what made the vault modal contradict itself — its own
+   * body says the deposit is immediate and addressless, and this note directly
+   * beneath it announced a deposit address was coming.
+   */
+  depositMode?: "custodial" | "vault_direct";
   fireblocksEnabled: boolean;
   hasError: boolean;
   isLoading: boolean;
@@ -165,9 +181,17 @@ export function WalletStep({
   return (
     <div className="space-y-5">
       <StepNote
-        body={t("DashboardEarn.deposit.walletCustodyBody")}
+        body={t(
+          depositMode === "vault_direct"
+            ? "DashboardEarn.deposit.walletVaultDirectBody"
+            : "DashboardEarn.deposit.walletCustodyBody"
+        )}
         icon={<ShieldCheckIcon className="size-5" />}
-        title={t("DashboardEarn.deposit.walletCustodyTitle")}
+        title={t(
+          depositMode === "vault_direct"
+            ? "DashboardEarn.deposit.walletVaultDirectTitle"
+            : "DashboardEarn.deposit.walletCustodyTitle"
+        )}
       />
 
       {isLoading ? <StepListSkeleton rowClassName="h-28 w-full rounded-2xl" /> : null}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/deposit/wallet-step.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/deposit/wallet-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CustodyWalletSummary } from "@sdp/types";
+import type { CustodyWalletSummary, EarnPortfolioToken } from "@sdp/types";
 import { ExternalLinkIcon, LockIcon, PlusIcon, ShieldCheckIcon } from "lucide-react";
 import Link from "next/link";
 import { useId, useMemo, useState } from "react";
@@ -22,7 +22,7 @@ import {
   matchesWalletQuery,
   shortenAddress,
   walletDisplayName,
-  walletUsdcAmount,
+  walletTokenAmount,
 } from "./earn-funding-wallets";
 
 /** Above this many wallets a search field is worth the extra chrome. */
@@ -33,10 +33,12 @@ const SEARCH_THRESHOLD = 6;
  * first line and the address the second — and neither is monospaced.
  */
 function WalletRow({
+  balanceToken,
   onSelect,
   selected,
   wallet,
 }: {
+  balanceToken: EarnPortfolioToken;
   onSelect: () => void;
   selected: boolean;
   wallet: CustodyWalletSummary;
@@ -45,7 +47,8 @@ function WalletRow({
   const inputId = `earn-funding-wallet-${wallet.id}`;
   const nameId = `${inputId}-name`;
   const detailId = `${inputId}-detail`;
-  const availableUsdc = walletUsdcAmount(wallet);
+  const availableAmount = walletTokenAmount(wallet, balanceToken);
+  const balanceTokenLabel = balanceToken.toUpperCase();
 
   return (
     <SelectableCard
@@ -79,10 +82,14 @@ function WalletRow({
           </span>
           <span className="mt-3 flex items-baseline justify-between gap-3 border-t border-border-subtle pt-3">
             <span className="text-xs text-tertiary">
-              {t("DashboardEarn.deposit.walletAvailableToInvest")}
+              {t("DashboardEarn.deposit.walletAvailableToInvest", {
+                token: balanceTokenLabel,
+              })}
             </span>
             <span className="text-sm font-medium text-primary tabular-nums">
-              {availableUsdc === undefined ? "—" : formatTokenQuantity(availableUsdc, "USDC")}
+              {availableAmount === undefined
+                ? "—"
+                : formatTokenQuantity(availableAmount, balanceTokenLabel)}
             </span>
           </span>
         </span>
@@ -136,6 +143,7 @@ function ConnectWalletCard({ fireblocksEnabled }: { fireblocksEnabled: boolean }
 }
 
 export function WalletStep({
+  balanceToken = "usdc",
   depositMode = "custodial",
   fireblocksEnabled,
   hasError,
@@ -144,6 +152,8 @@ export function WalletStep({
   selectedWalletId,
   wallets,
 }: {
+  /** Stablecoin balance shown in each wallet row; direct vaults pass their strategy token. */
+  balanceToken?: EarnPortfolioToken;
   /**
    * Which money model this wallet is being chosen FOR.
    *
@@ -230,6 +240,7 @@ export function WalletStep({
             <legend className="sr-only">{t("DashboardEarn.deposit.walletLegend")}</legend>
             {visible.map((wallet) => (
               <WalletRow
+                balanceToken={balanceToken}
                 key={wallet.id}
                 onSelect={() => onSelect(wallet.id)}
                 selected={wallet.id === selectedWalletId}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { EarnStrategy } from "@sdp/types";
+import type { EarnStrategy, SdpEnvironment } from "@sdp/types";
 import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
@@ -20,6 +20,7 @@ import {
   type EarnStrategySort,
   type EarnStrategySortColumn,
   nextStrategySort,
+  type OpportunityDepositability,
   opportunityDepositability,
   sortStrategies,
 } from "./deposit/earn-deposit-model";
@@ -27,6 +28,41 @@ import { formatApy, formatUsdCompact } from "./earn-format";
 import { strategyPoolUsd, strategyToken, useLiquidityLabel } from "./earn-program-presentation";
 
 const DEPOSIT_PATH = "/dashboard/markets/earn/deposit";
+
+function opportunityBlockedCopy(
+  depositable: OpportunityDepositability,
+  strategy: EarnStrategy,
+  t: ReturnType<typeof useTranslations>
+): { label: string | null; description: string | null } {
+  if (depositable.kind === "depositable") return { label: null, description: null };
+  if (depositable.kind === "wrong-cluster") {
+    const label = t("DashboardEarn.deposit.strategyEnvironmentOnly", {
+      environment: strategy.hostCluster === "mainnet-beta" ? "Mainnet" : "Devnet",
+    });
+    return { label, description: label };
+  }
+  if (depositable.kind === "asset-unsupported") {
+    const label = t("DashboardEarn.deposit.strategyAssetUnavailableLabel");
+    return { label, description: label };
+  }
+  if (depositable.kind === "environment-closed") {
+    return {
+      label: t("DashboardEarn.opportunities.depositProductionClosed"),
+      description: t("DashboardEarn.opportunities.depositProductionClosedReason"),
+    };
+  }
+
+  // Both say "not yet", never "go do it elsewhere". Depositing into a
+  // vault-direct vault THROUGH SDP is intended, so disabled copy must not send
+  // a reader off-platform. A custodial provider we are not offering is a
+  // different "not yet" from a capability we have not shipped.
+  const label = t(
+    depositable.style === "vault_direct"
+      ? "DashboardEarn.opportunities.depositDirectOnly"
+      : "DashboardEarn.opportunities.depositProviderClosed"
+  );
+  return { label, description: label };
+}
 
 /**
  * A numeric column the reader can rank the table by.
@@ -81,9 +117,11 @@ function SortableColumnHeader({
  * be entered directly without this table having to hand state across a route.
  */
 function OpportunityRow({
+  environment,
   strategy,
   onVaultDeposit,
 }: {
+  environment: SdpEnvironment;
   strategy: EarnStrategy;
   /**
    * Present only for non-custodial vaults, where the deposit opens in place.
@@ -97,29 +135,13 @@ function OpportunityRow({
   const nameId = `earn-opportunity-${strategy.id}-name`;
   const token = strategyToken(strategy);
   const poolUsd = strategyPoolUsd(strategy);
-  const depositable = opportunityDepositability(strategy);
+  const depositable = opportunityDepositability(strategy, environment);
 
-  const blockedLabel =
-    depositable.kind === "wrong-cluster"
-      ? t("DashboardEarn.deposit.strategyEnvironmentOnly", {
-          environment: strategy.hostCluster === "mainnet-beta" ? "Mainnet" : "Devnet",
-        })
-      : depositable.kind === "asset-unsupported"
-        ? t("DashboardEarn.deposit.strategyAssetUnavailableLabel")
-        : depositable.kind === "no-sdp-route"
-          ? // Both say "not yet", never "go do it elsewhere". Depositing into a
-            // vault-direct vault THROUGH SDP is intended and simply unbuilt, so
-            // this copy must not send a reader off-platform — that would be
-            // product direction a disabled-button label has no business
-            // implying. The two strings differ only because a custodial
-            // provider we are not offering is a different "not yet" from a
-            // capability we have not shipped.
-            t(
-              depositable.style === "vault_direct"
-                ? "DashboardEarn.opportunities.depositDirectOnly"
-                : "DashboardEarn.opportunities.depositProviderClosed"
-            )
-          : null;
+  const { label: blockedLabel, description: blockedDescription } = opportunityBlockedCopy(
+    depositable,
+    strategy,
+    t
+  );
 
   return (
     <TableRow>
@@ -192,6 +214,7 @@ function OpportunityRow({
           // rather than falling through to the custodial page — landing there
           // would be a wrong answer wearing a working affordance.
           <Button
+            data-modal-focus-fallback={strategy.id}
             disabled={!onVaultDeposit}
             onClick={() => onVaultDeposit?.(strategy)}
             size="sm"
@@ -210,7 +233,17 @@ function OpportunityRow({
           // the badge beside its name, and a missing verb reads as an oversight.
           // `title` carries the reason to a pointer, since the badge sits in a
           // different column.
-          <Button disabled size="sm" title={blockedLabel ?? undefined} variant="secondary">
+          <Button
+            aria-label={
+              blockedDescription
+                ? `${t("DashboardEarn.opportunities.deposit")} — ${blockedDescription}`
+                : undefined
+            }
+            disabled
+            size="sm"
+            title={blockedDescription ?? undefined}
+            variant="secondary"
+          >
             {t("DashboardEarn.opportunities.deposit")}
           </Button>
         )}
@@ -229,9 +262,11 @@ function OpportunityRow({
  * depositability, which is a different question (`opportunityDepositability`).
  */
 export function EarnOpportunitiesTable({
+  environment,
   strategies,
   onVaultDeposit,
 }: {
+  environment: SdpEnvironment;
   strategies: readonly EarnStrategy[];
   onVaultDeposit?: (strategy: EarnStrategy) => void;
 }) {
@@ -285,7 +320,12 @@ export function EarnOpportunitiesTable({
         </TableHeader>
         <TableBody>
           {rows.map((strategy) => (
-            <OpportunityRow key={strategy.id} onVaultDeposit={onVaultDeposit} strategy={strategy} />
+            <OpportunityRow
+              environment={environment}
+              key={strategy.id}
+              onVaultDeposit={onVaultDeposit}
+              strategy={strategy}
+            />
           ))}
         </TableBody>
       </Table>

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.tsx
@@ -176,11 +176,27 @@ function OpportunityRow({
         </span>
       </TableCell>
       <TableCell align="right">
-        {depositable.kind === "depositable" && onVaultDeposit ? (
+        {depositable.kind === "depositable" && depositable.style === "vault_direct" ? (
           // Non-custodial: two short steps against a strategy already chosen by
           // clicking this row, and its money-OUT counterpart is a modal too —
           // so it opens in place rather than navigating away from the table.
-          <Button onClick={() => onVaultDeposit(strategy)} size="sm" variant="secondary">
+          //
+          // Branches on the STYLE, never on whether a callback was passed. A
+          // callback's presence is a fact about the parent's wiring; the style
+          // is a fact about the strategy, and only the second can say which
+          // endpoint this row is allowed to reach. If a custodial provider is
+          // surfaced again, its rows keep the link below instead of silently
+          // posting to the vault endpoint, which provisions no wallet.
+          //
+          // A missing `onVaultDeposit` is a wiring bug, so the button disables
+          // rather than falling through to the custodial page — landing there
+          // would be a wrong answer wearing a working affordance.
+          <Button
+            disabled={!onVaultDeposit}
+            onClick={() => onVaultDeposit?.(strategy)}
+            size="sm"
+            variant="secondary"
+          >
             {t("DashboardEarn.opportunities.deposit")}
           </Button>
         ) : depositable.kind === "depositable" ? (

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.tsx
@@ -80,7 +80,18 @@ function SortableColumnHeader({
  * `?strategy=<id>`, so a row is shareable, middle-clickable, and the wizard can
  * be entered directly without this table having to hand state across a route.
  */
-function OpportunityRow({ strategy }: { strategy: EarnStrategy }) {
+function OpportunityRow({
+  strategy,
+  onVaultDeposit,
+}: {
+  strategy: EarnStrategy;
+  /**
+   * Present only for non-custodial vaults, where the deposit opens in place.
+   * Absent falls through to the custodial link, so the row keeps working for a
+   * provider whose deposit really is a separate page.
+   */
+  onVaultDeposit?: (strategy: EarnStrategy) => void;
+}) {
   const t = useTranslations();
   const liquidityLabel = useLiquidityLabel();
   const nameId = `earn-opportunity-${strategy.id}-name`;
@@ -165,7 +176,14 @@ function OpportunityRow({ strategy }: { strategy: EarnStrategy }) {
         </span>
       </TableCell>
       <TableCell align="right">
-        {depositable.kind === "depositable" ? (
+        {depositable.kind === "depositable" && onVaultDeposit ? (
+          // Non-custodial: two short steps against a strategy already chosen by
+          // clicking this row, and its money-OUT counterpart is a modal too —
+          // so it opens in place rather than navigating away from the table.
+          <Button onClick={() => onVaultDeposit(strategy)} size="sm" variant="secondary">
+            {t("DashboardEarn.opportunities.deposit")}
+          </Button>
+        ) : depositable.kind === "depositable" ? (
           <Button asChild size="sm" variant="secondary">
             <Link href={`${DEPOSIT_PATH}?strategy=${encodeURIComponent(strategy.id)}`}>
               {t("DashboardEarn.opportunities.deposit")}
@@ -194,7 +212,13 @@ function OpportunityRow({ strategy }: { strategy: EarnStrategy }) {
  * never re-applies a visibility rule. What it DOES decide is per-row
  * depositability, which is a different question (`opportunityDepositability`).
  */
-export function EarnOpportunitiesTable({ strategies }: { strategies: readonly EarnStrategy[] }) {
+export function EarnOpportunitiesTable({
+  strategies,
+  onVaultDeposit,
+}: {
+  strategies: readonly EarnStrategy[];
+  onVaultDeposit?: (strategy: EarnStrategy) => void;
+}) {
   const t = useTranslations();
   const [sort, setSort] = useState<EarnStrategySort>(DEFAULT_STRATEGY_SORT);
   const rows = useMemo(() => sortStrategies(strategies, sort), [strategies, sort]);
@@ -245,7 +269,7 @@ export function EarnOpportunitiesTable({ strategies }: { strategies: readonly Ea
         </TableHeader>
         <TableBody>
           {rows.map((strategy) => (
-            <OpportunityRow key={strategy.id} strategy={strategy} />
+            <OpportunityRow key={strategy.id} onVaultDeposit={onVaultDeposit} strategy={strategy} />
           ))}
         </TableBody>
       </Table>

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-opportunities-table.unit.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import type { EarnStrategy } from "@sdp/types";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EarnOpportunitiesTable } from "./earn-opportunities-table";
+
+vi.mock("@/i18n/provider", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+const KAMINO: EarnStrategy = {
+  id: "kamino-vault-one",
+  provider: "kamino",
+  providerReference: "vault-one",
+  name: "Kamino USDC Vault",
+  sourceKind: "defi",
+  depositMints: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"],
+  apyType: "variable",
+  currentApy: "0.05",
+  liquidityTerm: "instant",
+  status: "active",
+  hostCluster: "mainnet-beta",
+  fundable: true,
+  createdAt: "2026-08-15T00:00:00.000Z",
+  updatedAt: "2026-08-15T00:00:00.000Z",
+};
+
+afterEach(cleanup);
+
+describe("EarnOpportunitiesTable vault capability", () => {
+  it("keeps a production vault visible with a truthful disabled action", () => {
+    render(<EarnOpportunitiesTable environment="production" strategies={[KAMINO]} />);
+
+    expect(screen.getByText("Kamino USDC Vault")).not.toBeNull();
+    expect(screen.getByText("DashboardEarn.opportunities.depositProductionClosed")).not.toBeNull();
+    const deposit = screen.getByRole("button", {
+      name: /DashboardEarn\.opportunities\.depositProductionClosedReason/,
+    });
+    expect(deposit.hasAttribute("disabled")).toBe(true);
+    expect(deposit.getAttribute("title")).toBe(
+      "DashboardEarn.opportunities.depositProductionClosedReason"
+    );
+  });
+
+  it("opens a sandbox vault and marks the exact focus-return target", async () => {
+    const onVaultDeposit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <EarnOpportunitiesTable
+        environment="sandbox"
+        onVaultDeposit={onVaultDeposit}
+        strategies={[KAMINO]}
+      />
+    );
+
+    const deposit = screen.getByRole("button", { name: "DashboardEarn.opportunities.deposit" });
+    expect(deposit.hasAttribute("disabled")).toBe(false);
+    expect(deposit.getAttribute("data-modal-focus-fallback")).toBe(KAMINO.id);
+    await user.click(deposit);
+    expect(onVaultDeposit).toHaveBeenCalledWith(KAMINO);
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-program-data.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-program-data.ts
@@ -572,3 +572,55 @@ export function useEarnWithdrawalOutcomeToast(
     onSettledRef.current?.();
   }, [data, t]);
 }
+
+// --- Non-custodial vault deposits ------------------------------------------
+
+export interface EarnVaultDepositInput {
+  /** Catalogue strategy id; the API resolves it to a vault address. */
+  strategyId: string;
+  /**
+   * The wallet to deposit FROM, as its Solana public key.
+   *
+   * Public key rather than the `cwlt_…` row id, because that is what
+   * `resolveWalletAddress` accepts on every money-moving route in SDP (payments,
+   * private channels, and this one). The wallet picker hands back the row id, so
+   * the caller maps it — the mapping belongs at the call site, not in a second
+   * resolution rule inside the API.
+   */
+  walletId: string;
+  /** Decimal string in the vault token's units. */
+  amount: string;
+  /** REQUIRED: the chain has no request-id dedupe, so this is the only guard. */
+  requestId: string;
+}
+
+export interface EarnVaultDepositResult {
+  positionId: string;
+  movementId: string;
+  status: "pending" | "submitted" | "confirmed" | "failed";
+  signature: string | null;
+  failureReason: string | null;
+  /** The key had already been used — nothing was re-sent. */
+  replayed: boolean;
+  strategy: {
+    id: string;
+    name: string;
+    provider: string;
+    providerReference: string;
+    hostCluster: string;
+  };
+}
+
+/**
+ * Deposit into a non-custodial vault: SDP builds the instruction, signs it with
+ * the chosen custody wallet, and submits it. Unlike `createEarnProgram` this
+ * moves money on the call — there is no address to fund afterwards.
+ */
+export function createEarnVaultDeposit(
+  input: EarnVaultDepositInput
+): Promise<DashboardFetchResult<{ data: EarnVaultDepositResult }>> {
+  return dashboardFetch("/api/dashboard/markets/earn/vault-deposits", {
+    method: "POST",
+    body: input,
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-program-data.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-program-data.ts
@@ -579,15 +579,13 @@ export interface EarnVaultDepositInput {
   /** Catalogue strategy id; the API resolves it to a vault address. */
   strategyId: string;
   /**
-   * The wallet to deposit FROM, as its Solana public key.
+   * The wallet to deposit FROM, as its SDP custody-wallet row id.
    *
-   * Public key rather than the `cwlt_…` row id, because that is what
-   * `resolveWalletAddress` accepts on every money-moving route in SDP (payments,
-   * private channels, and this one). The wallet picker hands back the row id, so
-   * the caller maps it — the mapping belongs at the call site, not in a second
-   * resolution rule inside the API.
+   * Neither the provider-local `CustodyWalletSummary.walletId` nor the public
+   * key identifies a globally unique wallet. The API authorizes this exact row,
+   * then resolves the provider wallet id within its custody configuration.
    */
-  walletId: string;
+  custodyWalletId: string;
   /** Decimal string in the vault token's units. */
   amount: string;
   /** REQUIRED: the chain has no request-id dedupe, so this is the only guard. */
@@ -598,7 +596,8 @@ export interface EarnVaultDepositResult {
   positionId: string;
   movementId: string;
   status: "pending" | "submitted" | "confirmed" | "failed";
-  signature: string | null;
+  /** Signed transaction exists before the API creates the deposit intent. */
+  signature: string;
   failureReason: string | null;
   /** The key had already been used — nothing was re-sent. */
   replayed: boolean;

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-server-context.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-server-context.ts
@@ -1,0 +1,18 @@
+import type { OnboardingStatusResponse } from "@/app/dashboard/onboarding-status";
+import type { SdpApiClient } from "@/lib/sdp-api";
+
+/**
+ * Resolve Clerk's active organization to the SDP organization row used by
+ * organization-scoped API routes.
+ *
+ * The two identifiers are deliberately not interchangeable. Clerk's `orgId`
+ * authenticates the session; `/v1/onboarding/status` returns the linked SDP id
+ * that `/v1/organizations/:orgId/provider-access` authorizes and queries.
+ */
+export async function fetchEarnSdpOrganizationId(
+  organizationClient: Pick<SdpApiClient, "fetch">
+): Promise<string | null> {
+  const onboarding =
+    await organizationClient.fetch<OnboardingStatusResponse>("/v1/onboarding/status");
+  return onboarding.organization?.id ?? null;
+}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-server-context.unit.test.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-server-context.unit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SdpApiClient } from "@/lib/sdp-api";
+import { fetchEarnSdpOrganizationId } from "./earn-server-context";
+
+function organizationClientWith(response: unknown): Pick<SdpApiClient, "fetch"> {
+  return {
+    fetch: vi.fn().mockResolvedValue(response) as SdpApiClient["fetch"],
+  };
+}
+
+describe("fetchEarnSdpOrganizationId", () => {
+  it("returns the linked SDP organization id, not the Clerk organization id", async () => {
+    const client = organizationClientWith({
+      linked: true,
+      organization: { id: "org_sdp_123" },
+    });
+
+    await expect(fetchEarnSdpOrganizationId(client)).resolves.toBe("org_sdp_123");
+    expect(client.fetch).toHaveBeenCalledWith("/v1/onboarding/status");
+  });
+
+  it("returns null when onboarding has not linked an SDP organization", async () => {
+    const client = organizationClientWith({ linked: false, organization: null });
+
+    await expect(fetchEarnSdpOrganizationId(client)).resolves.toBeNull();
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-surfacing.ts
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-surfacing.ts
@@ -56,3 +56,29 @@ export const EARN_PROGRAM_CREATION_ENABLED = SURFACED_CUSTODIAL_EARN_PROVIDERS.l
  */
 export const EARN_PROGRAM_CREATE_PROVIDER: EarnProviderId | undefined =
   SURFACED_CUSTODIAL_EARN_PROVIDERS[0];
+
+/**
+ * Providers SDP offers whose vaults are NON-CUSTODIAL — the customer's own
+ * wallet deposits, and SDP signs that deposit from a custody wallet it controls.
+ *
+ * Derived the same way as the custodial list above: surfacing says what is
+ * offered, `earnDepositStyle` says which of those are `vault_direct`. It is
+ * `["kamino"]` today.
+ */
+export const SURFACED_VAULT_DIRECT_EARN_PROVIDERS: readonly EarnProviderId[] =
+  SURFACED_EARN_PROVIDERS.filter((provider) => earnDepositStyle(provider) === "vault_direct");
+
+/**
+ * Whether the dashboard offers the VAULT deposit run (wallet → amount → review
+ * → execute against `POST /v1/earn/vault-deposits`).
+ *
+ * True once a vault-direct provider is offered AND the flow behind the button
+ * exists — `EarnVaultDepositModal`, opened in place from an Opportunities row.
+ *
+ * It stayed pinned `false` while that modal was being built, precisely so an
+ * enabled Deposit link could never land the reader on `EarnDepositUnavailable`
+ * — the dead-end review caught on #1340, where cluster and token both passed and
+ * only the "is there an SDP route at all" question was missing. Keep that
+ * discipline: the affordance and the flow ship together.
+ */
+export const EARN_VAULT_DEPOSITS_ENABLED = SURFACED_VAULT_DIRECT_EARN_PROVIDERS.length > 0;

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-tabs.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-tabs.unit.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/i18n/provider", () => ({
   useLocale: () => "en",
 }));
 
+vi.mock("@/contexts/dashboard-workspace-context", () => ({
+  useDashboardWorkspace: () => ({ sdpEnvironment: "sandbox" }),
+}));
+
 // The panels each fetch; this suite is about the tab STRIP, so they are stubbed
 // down to markers. Their own behaviour is covered in earn-workspace.unit.test.
 vi.mock("./earn-program-data", () => ({

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from "@/i18n/provider";
 import { explorerTxUrl } from "@/lib/explorer";
 import { StepNotice, StepSection, SummaryRow } from "./deposit/earn-deposit-chrome";
 import {
+  shortenAddress,
   useEarnFundingWallets,
   walletDisplayName,
   walletUsdcAmount,
@@ -151,6 +152,25 @@ export function EarnVaultDepositModal({
               label={t("DashboardEarn.deposit.vaultFrom")}
               value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
             />
+            {/* Keyed off the STRATEGY's cluster, not an app-wide one: the
+                transaction landed on whichever cluster the vault lives on, and
+                `hostCluster` is the field that states it. A devnet signature on
+                a mainnet explorer link is a dead end. */}
+            {result.signature ? (
+              <SummaryRow
+                label={t("DashboardEarn.deposit.vaultTransaction")}
+                value={
+                  <a
+                    className="underline underline-offset-2"
+                    href={explorerTxUrl(result.signature, strategy.hostCluster)}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {shortenAddress(result.signature)}
+                  </a>
+                }
+              />
+            ) : null}
           </dl>
           <p className="mt-4 text-sm leading-6 text-secondary">
             {t("DashboardEarn.deposit.vaultSettlingNote")}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -13,10 +13,10 @@ import {
   shortenAddress,
   useEarnFundingWallets,
   walletDisplayName,
-  walletUsdcAmount,
+  walletTokenAmount,
 } from "./deposit/earn-funding-wallets";
 import { WalletStep } from "./deposit/wallet-step";
-import { formatUsd } from "./earn-format";
+import { formatTokenQuantity } from "./earn-format";
 import { createEarnVaultDeposit, type EarnVaultDepositResult } from "./earn-program-data";
 import { strategySourceLabel, strategyToken } from "./earn-program-presentation";
 
@@ -65,20 +65,19 @@ export function EarnVaultDepositModal({
 }) {
   const t = useTranslations();
   const { wallets, error: walletsError, isLoading: walletsLoading } = useEarnFundingWallets();
-  /**
-   * Initial focus, a focus trap, and focus returned to the Opportunities row
-   * that opened this — none of which the shared `Modal` provides. Keyed by the
-   * strategy id so that when the row remounts, focus lands on the button the
-   * reader actually pressed rather than on whichever row rendered first.
-   */
-  const contentRef = useModalFocus<HTMLDivElement>(strategy.id);
-
   const [step, setStep] = useState<VaultDepositStep>("wallet");
   const [walletRowId, setWalletRowId] = useState<string | null>(null);
   const [amount, setAmount] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<EarnVaultDepositResult | null>(null);
+  /**
+   * Trap/return live for the modal's whole lifetime; autofocus keys off the
+   * visible panel so replacing a focused Continue/Submit button cannot drop a
+   * keyboard reader onto the page behind the dialog.
+   */
+  const focusPanelKey = result ? `result:${result.status}` : step;
+  const contentRef = useModalFocus<HTMLDivElement>(strategy.id, focusPanelKey);
 
   /**
    * One idempotency key per (wallet, amount) attempt, held in a ref.
@@ -101,8 +100,10 @@ export function EarnVaultDepositModal({
     () => (wallets ?? []).find((wallet) => wallet.id === walletRowId),
     [wallets, walletRowId]
   );
-  const walletBalance = selectedWallet ? walletUsdcAmount(selectedWallet) : undefined;
   const token = strategyToken(strategy);
+  const tokenLabel = token?.toUpperCase() ?? "";
+  const walletBalance =
+    selectedWallet && token ? walletTokenAmount(selectedWallet, token) : undefined;
 
   const amountNumber = Number(amount);
   const amountValid = /^\d+(\.\d+)?$/.test(amount) && amountNumber > 0;
@@ -118,8 +119,9 @@ export function EarnVaultDepositModal({
     try {
       const response = await createEarnVaultDeposit({
         strategyId: strategy.id,
-        // Public key, not the row id — the form every SDP money route accepts.
-        walletId: selectedWallet.publicKey,
+        // SDP custody row id, not the provider-local id or public key: the API
+        // authorizes one exact row, then resolves that row's provider wallet.
+        custodyWalletId: selectedWallet.id,
         amount,
         requestId: requestIdFor(attemptToken),
       });
@@ -165,8 +167,8 @@ export function EarnVaultDepositModal({
 
     return (
       <Modal isOpen ariaLabel={title} onClose={onClose} size="md">
-        <div ref={contentRef}>
-          <StepSection title={title}>
+        <div data-modal-focus-panel={focusPanelKey} ref={contentRef}>
+          <StepSection focusHeading title={title}>
             <p className="mb-5 text-sm leading-6 text-secondary">
               {inFlight
                 ? t("DashboardEarn.deposit.vaultPendingBody")
@@ -186,26 +188,22 @@ export function EarnVaultDepositModal({
                 transaction landed on whichever cluster the vault lives on, and
                 `hostCluster` is the field that states it. A devnet signature on
                 a mainnet explorer link is a dead end. */}
-              {result.signature ? (
-                <SummaryRow
-                  label={t("DashboardEarn.deposit.vaultTransaction")}
-                  value={
-                    <a
-                      className="underline underline-offset-2"
-                      href={explorerTxUrl(result.signature, strategy.hostCluster)}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      {shortenAddress(result.signature)}
-                    </a>
-                  }
-                />
-              ) : null}
+              <SummaryRow
+                label={t("DashboardEarn.deposit.vaultTransaction")}
+                value={
+                  <a
+                    className="underline underline-offset-2"
+                    href={explorerTxUrl(result.signature, strategy.hostCluster)}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {shortenAddress(result.signature)}
+                  </a>
+                }
+              />
             </dl>
             <p className="mt-4 text-sm leading-6 text-secondary">
-              {inFlight && !result.signature
-                ? t("DashboardEarn.deposit.vaultPendingNoSignature")
-                : t("DashboardEarn.deposit.vaultSettlingNote")}
+              {t("DashboardEarn.deposit.vaultSettlingNote")}
             </p>
             <div className="mt-6 flex justify-end">
               <Button onClick={onClose}>{t("DashboardEarn.deposit.vaultDone")}</Button>
@@ -224,12 +222,13 @@ export function EarnVaultDepositModal({
         onClose={onClose}
         size="md"
       >
-        <div ref={contentRef}>
-          <StepSection title={t("DashboardEarn.deposit.vaultWalletTitle")}>
+        <div data-modal-focus-panel={focusPanelKey} ref={contentRef}>
+          <StepSection focusHeading title={t("DashboardEarn.deposit.vaultWalletTitle")}>
             <p className="mb-5 text-sm leading-6 text-secondary">
               {t("DashboardEarn.deposit.vaultWalletBody")}
             </p>
             <WalletStep
+              balanceToken={token}
               // Says what this flow actually does, instead of the custodial
               // note's promise of a provider-managed deposit address — which
               // directly contradicted the body immediately above.
@@ -266,15 +265,15 @@ export function EarnVaultDepositModal({
       onClose={onClose}
       size="md"
     >
-      <div ref={contentRef}>
-        <StepSection title={t("DashboardEarn.deposit.vaultAmountTitle")}>
+      <div data-modal-focus-panel={focusPanelKey} ref={contentRef}>
+        <StepSection focusHeading title={t("DashboardEarn.deposit.vaultAmountTitle")}>
           <p className="mb-5 text-sm leading-6 text-secondary">
             {t("DashboardEarn.deposit.vaultAmountBody")}
           </p>
           <div className="grid gap-5">
             <div className="grid gap-2">
               <label className="text-sm text-primary" htmlFor="vault-deposit-amount">
-                {t("DashboardEarn.deposit.vaultAmount")}
+                {t("DashboardEarn.deposit.vaultAmount", { token: tokenLabel })}
               </label>
               <Input
                 autoComplete="off"
@@ -288,7 +287,7 @@ export function EarnVaultDepositModal({
                 {walletBalance === undefined
                   ? t("DashboardEarn.deposit.vaultBalanceUnknown")
                   : t("DashboardEarn.deposit.vaultBalanceAvailable", {
-                      amount: formatUsd(walletBalance),
+                      amount: formatTokenQuantity(walletBalance, tokenLabel),
                     })}
               </p>
             </div>

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { useTranslations } from "@/i18n/provider";
 import { explorerTxUrl } from "@/lib/explorer";
+import { useModalFocus } from "@/lib/use-modal-focus";
 import { StepNotice, StepSection, SummaryRow } from "./deposit/earn-deposit-chrome";
 import {
   shortenAddress,
@@ -48,15 +49,29 @@ type VaultDepositStep = "wallet" | "amount";
 
 export function EarnVaultDepositModal({
   strategy,
+  fireblocksEnabled = false,
   onClose,
   onDeposited,
 }: {
   strategy: EarnStrategy;
+  /**
+   * Whether this organization actually has Fireblocks available, threaded from
+   * the same provider-availability read the custodial wizard uses. Defaulted
+   * false only so the prop is additive; the workspace passes the real value.
+   */
+  fireblocksEnabled?: boolean;
   onClose: () => void;
   onDeposited?: (result: EarnVaultDepositResult) => void;
 }) {
   const t = useTranslations();
   const { wallets, error: walletsError, isLoading: walletsLoading } = useEarnFundingWallets();
+  /**
+   * Initial focus, a focus trap, and focus returned to the Opportunities row
+   * that opened this — none of which the shared `Modal` provides. Keyed by the
+   * strategy id so that when the row remounts, focus lands on the button the
+   * reader actually pressed rather than on whichever row rendered first.
+   */
+  const contentRef = useModalFocus<HTMLDivElement>(strategy.id);
 
   const [step, setStep] = useState<VaultDepositStep>("wallet");
   const [walletRowId, setWalletRowId] = useState<string | null>(null);
@@ -131,54 +146,72 @@ export function EarnVaultDepositModal({
   }
 
   if (result) {
+    /**
+     * `pending` and `submitted` are DIFFERENT outcomes and must not share a
+     * screen. `submitted` means signed and broadcast — on the wire, not
+     * settled. `pending` means SDP holds a signed transaction whose fate it
+     * could not establish (an ambiguous send), which is precisely the state a
+     * reader must not be told is finished, and precisely the state where a
+     * blind retry can deposit twice.
+     *
+     * Neither is confirmation, so neither claims a holding: SDP has no
+     * confirmer for this path yet, and the Active tab reads custodial programs
+     * only, so "you will see it under Active" was false for both.
+     */
+    const inFlight = result.status === "pending";
+    const title = inFlight
+      ? t("DashboardEarn.deposit.vaultPendingTitle")
+      : t("DashboardEarn.deposit.vaultDoneTitle");
+
     return (
-      <Modal
-        isOpen
-        ariaLabel={t("DashboardEarn.deposit.vaultDoneTitle")}
-        onClose={onClose}
-        size="md"
-      >
-        <StepSection title={t("DashboardEarn.deposit.vaultDoneTitle")}>
-          <p className="mb-5 text-sm leading-6 text-secondary">
-            {t("DashboardEarn.deposit.vaultDoneBody")}
-          </p>
-          <dl className="grid gap-3 rounded-xl border border-border-default bg-surface-raised p-5">
-            <SummaryRow label={t("DashboardEarn.deposit.vaultStrategy")} value={strategy.name} />
-            <SummaryRow
-              label={t("DashboardEarn.deposit.vaultAmount")}
-              value={`${amount} ${token?.toUpperCase() ?? ""}`}
-            />
-            <SummaryRow
-              label={t("DashboardEarn.deposit.vaultFrom")}
-              value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
-            />
-            {/* Keyed off the STRATEGY's cluster, not an app-wide one: the
+      <Modal isOpen ariaLabel={title} onClose={onClose} size="md">
+        <div ref={contentRef}>
+          <StepSection title={title}>
+            <p className="mb-5 text-sm leading-6 text-secondary">
+              {inFlight
+                ? t("DashboardEarn.deposit.vaultPendingBody")
+                : t("DashboardEarn.deposit.vaultDoneBody")}
+            </p>
+            <dl className="grid gap-3 rounded-xl border border-border-default bg-surface-raised p-5">
+              <SummaryRow label={t("DashboardEarn.deposit.vaultStrategy")} value={strategy.name} />
+              <SummaryRow
+                label={t("DashboardEarn.deposit.vaultAmount")}
+                value={`${amount} ${token?.toUpperCase() ?? ""}`}
+              />
+              <SummaryRow
+                label={t("DashboardEarn.deposit.vaultFrom")}
+                value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
+              />
+              {/* Keyed off the STRATEGY's cluster, not an app-wide one: the
                 transaction landed on whichever cluster the vault lives on, and
                 `hostCluster` is the field that states it. A devnet signature on
                 a mainnet explorer link is a dead end. */}
-            {result.signature ? (
-              <SummaryRow
-                label={t("DashboardEarn.deposit.vaultTransaction")}
-                value={
-                  <a
-                    className="underline underline-offset-2"
-                    href={explorerTxUrl(result.signature, strategy.hostCluster)}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    {shortenAddress(result.signature)}
-                  </a>
-                }
-              />
-            ) : null}
-          </dl>
-          <p className="mt-4 text-sm leading-6 text-secondary">
-            {t("DashboardEarn.deposit.vaultSettlingNote")}
-          </p>
-          <div className="mt-6 flex justify-end">
-            <Button onClick={onClose}>{t("DashboardEarn.deposit.vaultDone")}</Button>
-          </div>
-        </StepSection>
+              {result.signature ? (
+                <SummaryRow
+                  label={t("DashboardEarn.deposit.vaultTransaction")}
+                  value={
+                    <a
+                      className="underline underline-offset-2"
+                      href={explorerTxUrl(result.signature, strategy.hostCluster)}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      {shortenAddress(result.signature)}
+                    </a>
+                  }
+                />
+              ) : null}
+            </dl>
+            <p className="mt-4 text-sm leading-6 text-secondary">
+              {inFlight && !result.signature
+                ? t("DashboardEarn.deposit.vaultPendingNoSignature")
+                : t("DashboardEarn.deposit.vaultSettlingNote")}
+            </p>
+            <div className="mt-6 flex justify-end">
+              <Button onClick={onClose}>{t("DashboardEarn.deposit.vaultDone")}</Button>
+            </div>
+          </StepSection>
+        </div>
       </Modal>
     );
   }
@@ -191,24 +224,34 @@ export function EarnVaultDepositModal({
         onClose={onClose}
         size="md"
       >
-        <StepSection title={t("DashboardEarn.deposit.vaultWalletTitle")}>
-          <p className="mb-5 text-sm leading-6 text-secondary">
-            {t("DashboardEarn.deposit.vaultWalletBody")}
-          </p>
-          <WalletStep
-            fireblocksEnabled={false}
-            hasError={Boolean(walletsError)}
-            isLoading={walletsLoading}
-            onSelect={setWalletRowId}
-            selectedWalletId={walletRowId}
-            wallets={wallets ?? []}
-          />
-          <div className="mt-6 flex justify-end">
-            <Button disabled={!walletRowId} onClick={() => setStep("amount")}>
-              {t("DashboardEarn.deposit.continueAction")}
-            </Button>
-          </div>
-        </StepSection>
+        <div ref={contentRef}>
+          <StepSection title={t("DashboardEarn.deposit.vaultWalletTitle")}>
+            <p className="mb-5 text-sm leading-6 text-secondary">
+              {t("DashboardEarn.deposit.vaultWalletBody")}
+            </p>
+            <WalletStep
+              // Says what this flow actually does, instead of the custodial
+              // note's promise of a provider-managed deposit address — which
+              // directly contradicted the body immediately above.
+              depositMode="vault_direct"
+              // Real availability, not a hard-coded `false`. Telling an entitled
+              // organization that Fireblocks is unavailable is a wrong statement
+              // about their own account, and it was only ever `false` here
+              // because this modal had nowhere to read it from.
+              fireblocksEnabled={fireblocksEnabled}
+              hasError={Boolean(walletsError)}
+              isLoading={walletsLoading}
+              onSelect={setWalletRowId}
+              selectedWalletId={walletRowId}
+              wallets={wallets ?? []}
+            />
+            <div className="mt-6 flex justify-end">
+              <Button disabled={!walletRowId} onClick={() => setStep("amount")}>
+                {t("DashboardEarn.deposit.continueAction")}
+              </Button>
+            </div>
+          </StepSection>
+        </div>
       </Modal>
     );
   }
@@ -223,72 +266,74 @@ export function EarnVaultDepositModal({
       onClose={onClose}
       size="md"
     >
-      <StepSection title={t("DashboardEarn.deposit.vaultAmountTitle")}>
-        <p className="mb-5 text-sm leading-6 text-secondary">
-          {t("DashboardEarn.deposit.vaultAmountBody")}
-        </p>
-        <div className="grid gap-5">
-          <div className="grid gap-2">
-            <label className="text-sm text-primary" htmlFor="vault-deposit-amount">
-              {t("DashboardEarn.deposit.vaultAmount")}
-            </label>
-            <Input
-              autoComplete="off"
-              id="vault-deposit-amount"
-              inputMode="decimal"
-              onChange={(event) => setAmount(event.target.value)}
-              placeholder="0.00"
-              value={amount}
-            />
-            <p className="text-xs text-tertiary tabular-nums">
-              {walletBalance === undefined
-                ? t("DashboardEarn.deposit.vaultBalanceUnknown")
-                : t("DashboardEarn.deposit.vaultBalanceAvailable", {
-                    amount: formatUsd(walletBalance),
-                  })}
-            </p>
-          </div>
+      <div ref={contentRef}>
+        <StepSection title={t("DashboardEarn.deposit.vaultAmountTitle")}>
+          <p className="mb-5 text-sm leading-6 text-secondary">
+            {t("DashboardEarn.deposit.vaultAmountBody")}
+          </p>
+          <div className="grid gap-5">
+            <div className="grid gap-2">
+              <label className="text-sm text-primary" htmlFor="vault-deposit-amount">
+                {t("DashboardEarn.deposit.vaultAmount")}
+              </label>
+              <Input
+                autoComplete="off"
+                id="vault-deposit-amount"
+                inputMode="decimal"
+                onChange={(event) => setAmount(event.target.value)}
+                placeholder="0.00"
+                value={amount}
+              />
+              <p className="text-xs text-tertiary tabular-nums">
+                {walletBalance === undefined
+                  ? t("DashboardEarn.deposit.vaultBalanceUnknown")
+                  : t("DashboardEarn.deposit.vaultBalanceAvailable", {
+                      amount: formatUsd(walletBalance),
+                    })}
+              </p>
+            </div>
 
-          <dl className="grid gap-3 rounded-xl border border-border-default bg-surface-raised p-5">
-            <SummaryRow label={t("DashboardEarn.deposit.vaultStrategy")} value={strategy.name} />
-            <SummaryRow
-              label={t("DashboardEarn.deposit.vaultBacking")}
-              value={strategySourceLabel(strategy)}
-            />
-            <SummaryRow
-              label={t("DashboardEarn.deposit.vaultFrom")}
-              value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
-            />
-          </dl>
+            <dl className="grid gap-3 rounded-xl border border-border-default bg-surface-raised p-5">
+              <SummaryRow label={t("DashboardEarn.deposit.vaultStrategy")} value={strategy.name} />
+              <SummaryRow
+                label={t("DashboardEarn.deposit.vaultBacking")}
+                value={strategySourceLabel(strategy)}
+              />
+              <SummaryRow
+                label={t("DashboardEarn.deposit.vaultFrom")}
+                value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
+              />
+            </dl>
 
-          {/* Over-balance is a WARNING, never a block — the balance is a live RPC
+            {/* Over-balance is a WARNING, never a block — the balance is a live RPC
             read and the chain decides. Blocking on it would refuse a deposit the
             wallet can fund whenever that read is stale or unavailable. */}
-          {overBalance ? (
-            <StepNotice>{t("DashboardEarn.deposit.vaultOverBalance")}</StepNotice>
-          ) : null}
-          {/* `tone="error"` is not decoration: it carries the error palette AND
+            {overBalance ? (
+              <StepNotice>{t("DashboardEarn.deposit.vaultOverBalance")}</StepNotice>
+            ) : null}
+            {/* `tone="error"` is not decoration: it carries the error palette AND
             `role="alert"`, so a refusal is announced to a screen reader instead
             of sitting silently in the flow. A refused deposit read as helper
             text without it. */}
-          {error ? <StepNotice tone="error">{error}</StepNotice> : null}
+            {error ? <StepNotice tone="error">{error}</StepNotice> : null}
 
-          <p className="text-sm leading-6 text-secondary">
-            {t("DashboardEarn.deposit.vaultConfirmNote")}
-          </p>
+            <p className="text-sm leading-6 text-secondary">
+              {t("DashboardEarn.deposit.vaultConfirmNote")}
+            </p>
 
-          <div className="flex justify-between gap-3">
-            <Button onClick={() => setStep("wallet")} variant="secondary">
-              {t("DashboardEarn.deposit.back")}
-            </Button>
-            <Button disabled={!amountValid || submitting} onClick={() => void submit()}>
-              {submitting
-                ? t("DashboardEarn.deposit.vaultSubmitting")
-                : t("DashboardEarn.deposit.vaultSubmit")}
-            </Button>
+            <div className="flex justify-between gap-3">
+              <Button onClick={() => setStep("wallet")} variant="secondary">
+                {t("DashboardEarn.deposit.back")}
+              </Button>
+              <Button disabled={!amountValid || submitting} onClick={() => void submit()}>
+                {submitting
+                  ? t("DashboardEarn.deposit.vaultSubmitting")
+                  : t("DashboardEarn.deposit.vaultSubmit")}
+              </Button>
+            </div>
           </div>
-        </div>
-      </StepSection>
+        </StepSection>
+      </div>
     </Modal>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import type { CustodyWalletSummary, EarnStrategy } from "@sdp/types";
+import { useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { useTranslations } from "@/i18n/provider";
+import { explorerTxUrl } from "@/lib/explorer";
+import { StepNotice, StepSection, SummaryRow } from "./deposit/earn-deposit-chrome";
+import {
+  useEarnFundingWallets,
+  walletDisplayName,
+  walletUsdcAmount,
+} from "./deposit/earn-funding-wallets";
+import { WalletStep } from "./deposit/wallet-step";
+import { formatUsd } from "./earn-format";
+import { createEarnVaultDeposit, type EarnVaultDepositResult } from "./earn-program-data";
+import { strategySourceLabel, strategyToken } from "./earn-program-presentation";
+
+/**
+ * Deposit into a NON-CUSTODIAL vault: wallet → amount → confirm, in a modal.
+ *
+ * A MODAL, not a page, and that is deliberate symmetry: `EarnWithdrawModal` is
+ * the money-OUT verb for the same position and is already a modal. Two halves of
+ * one position behaving differently is a difference a user cannot explain. The
+ * full-page wizard next door earns its shape because the CUSTODIAL run is a
+ * three-step provisioning flow that ends by creating a program; this is two short
+ * steps against a strategy the reader already chose by clicking its row, so
+ * navigating away from Opportunities would cost them their place for nothing.
+ *
+ * Three shapes make this different from that wizard, and all three are why it is
+ * a separate component rather than a fourth branch in it:
+ *
+ * - **The strategy is already chosen.** The reader arrives from an Opportunities
+ *   row, so there is no strategy step — picking one again would be asking a
+ *   question they just answered.
+ * - **Confirm MOVES MONEY.** The custodial run provisions a wallet and hands
+ *   back an address to fund later; this signs and submits on the spot. The
+ *   review copy has to say so plainly, and the button is the point of no return.
+ * - **There is no address, ever.** A K-Vault's account is a program account and
+ *   funds sent to it are destroyed, so nothing here may render a "send to"
+ *   target — the reason `vault_direct` exists as a distinct deposit style.
+ */
+
+type VaultDepositStep = "wallet" | "amount";
+
+export function EarnVaultDepositModal({
+  strategy,
+  onClose,
+  onDeposited,
+}: {
+  strategy: EarnStrategy;
+  onClose: () => void;
+  onDeposited?: (result: EarnVaultDepositResult) => void;
+}) {
+  const t = useTranslations();
+  const { wallets, error: walletsError, isLoading: walletsLoading } = useEarnFundingWallets();
+
+  const [step, setStep] = useState<VaultDepositStep>("wallet");
+  const [walletRowId, setWalletRowId] = useState<string | null>(null);
+  const [amount, setAmount] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<EarnVaultDepositResult | null>(null);
+
+  /**
+   * One idempotency key per (wallet, amount) attempt, held in a ref.
+   *
+   * A retry after a failed confirm must replay the SAME key — the chain has no
+   * request-id dedupe, so a fresh key on retry is how one deposit becomes two.
+   * Changing either input mints a new one, because reusing a key with a
+   * different payload is a different request.
+   */
+  const requestIdRef = useRef<{ key: string; token: string } | null>(null);
+  const attemptToken = `${walletRowId ?? ""}:${amount}`;
+  const requestIdFor = (token: string) => {
+    if (requestIdRef.current?.token !== token) {
+      requestIdRef.current = { key: crypto.randomUUID(), token };
+    }
+    return requestIdRef.current.key;
+  };
+
+  const selectedWallet: CustodyWalletSummary | undefined = useMemo(
+    () => (wallets ?? []).find((wallet) => wallet.id === walletRowId),
+    [wallets, walletRowId]
+  );
+  const walletBalance = selectedWallet ? walletUsdcAmount(selectedWallet) : undefined;
+  const token = strategyToken(strategy);
+
+  const amountNumber = Number(amount);
+  const amountValid = /^\d+(\.\d+)?$/.test(amount) && amountNumber > 0;
+  // Balance is CONTEXT, not a gate: it comes from a live RPC read that may be
+  // unavailable, and the chain is the real authority. An unreadable balance must
+  // never block a deposit the wallet can actually fund.
+  const overBalance = walletBalance !== undefined && amountNumber > walletBalance;
+
+  async function submit() {
+    if (!selectedWallet || !amountValid) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await createEarnVaultDeposit({
+        strategyId: strategy.id,
+        // Public key, not the row id — the form every SDP money route accepts.
+        walletId: selectedWallet.publicKey,
+        amount,
+        requestId: requestIdFor(attemptToken),
+      });
+      if (!response.ok) {
+        setError(response.error ?? t("DashboardEarn.deposit.vaultSubmitError"));
+        return;
+      }
+      const deposit = response.data.data;
+      if (deposit.status === "failed") {
+        // The API ledgers a failure and answers 200 — surface the provider's own
+        // reason rather than a generic message.
+        setError(deposit.failureReason ?? t("DashboardEarn.deposit.vaultSubmitError"));
+        return;
+      }
+      setResult(deposit);
+      onDeposited?.(deposit);
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : t("DashboardEarn.deposit.vaultSubmitError")
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (result) {
+    return (
+      <Modal
+        isOpen
+        ariaLabel={t("DashboardEarn.deposit.vaultDoneTitle")}
+        onClose={onClose}
+        size="md"
+      >
+        <StepSection title={t("DashboardEarn.deposit.vaultDoneTitle")}>
+          <p className="mb-5 text-sm leading-6 text-secondary">
+            {t("DashboardEarn.deposit.vaultDoneBody")}
+          </p>
+          <dl className="grid gap-3 rounded-xl border border-border-default bg-surface-raised p-5">
+            <SummaryRow label={t("DashboardEarn.deposit.vaultStrategy")} value={strategy.name} />
+            <SummaryRow
+              label={t("DashboardEarn.deposit.vaultAmount")}
+              value={`${amount} ${token?.toUpperCase() ?? ""}`}
+            />
+            <SummaryRow
+              label={t("DashboardEarn.deposit.vaultFrom")}
+              value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
+            />
+          </dl>
+          <p className="mt-4 text-sm leading-6 text-secondary">
+            {t("DashboardEarn.deposit.vaultSettlingNote")}
+          </p>
+          <div className="mt-6 flex justify-end">
+            <Button onClick={onClose}>{t("DashboardEarn.deposit.vaultDone")}</Button>
+          </div>
+        </StepSection>
+      </Modal>
+    );
+  }
+
+  if (step === "wallet") {
+    return (
+      <Modal
+        isOpen
+        ariaLabel={t("DashboardEarn.deposit.vaultWalletTitle")}
+        onClose={onClose}
+        size="md"
+      >
+        <StepSection title={t("DashboardEarn.deposit.vaultWalletTitle")}>
+          <p className="mb-5 text-sm leading-6 text-secondary">
+            {t("DashboardEarn.deposit.vaultWalletBody")}
+          </p>
+          <WalletStep
+            fireblocksEnabled={false}
+            hasError={Boolean(walletsError)}
+            isLoading={walletsLoading}
+            onSelect={setWalletRowId}
+            selectedWalletId={walletRowId}
+            wallets={wallets ?? []}
+          />
+          <div className="mt-6 flex justify-end">
+            <Button disabled={!walletRowId} onClick={() => setStep("amount")}>
+              {t("DashboardEarn.deposit.continueAction")}
+            </Button>
+          </div>
+        </StepSection>
+      </Modal>
+    );
+  }
+
+  return (
+    // `closeDisabled` while submitting: the transaction is already signed and in
+    // flight, so dismissing here would hide an outcome the reader needs.
+    <Modal
+      isOpen
+      ariaLabel={t("DashboardEarn.deposit.vaultAmountTitle")}
+      closeDisabled={submitting}
+      onClose={onClose}
+      size="md"
+    >
+      <StepSection title={t("DashboardEarn.deposit.vaultAmountTitle")}>
+        <p className="mb-5 text-sm leading-6 text-secondary">
+          {t("DashboardEarn.deposit.vaultAmountBody")}
+        </p>
+        <div className="grid gap-5">
+          <div className="grid gap-2">
+            <label className="text-sm text-primary" htmlFor="vault-deposit-amount">
+              {t("DashboardEarn.deposit.vaultAmount")}
+            </label>
+            <Input
+              autoComplete="off"
+              id="vault-deposit-amount"
+              inputMode="decimal"
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="0.00"
+              value={amount}
+            />
+            <p className="text-xs text-tertiary tabular-nums">
+              {walletBalance === undefined
+                ? t("DashboardEarn.deposit.vaultBalanceUnknown")
+                : t("DashboardEarn.deposit.vaultBalanceAvailable", {
+                    amount: formatUsd(walletBalance),
+                  })}
+            </p>
+          </div>
+
+          <dl className="grid gap-3 rounded-xl border border-border-default bg-surface-raised p-5">
+            <SummaryRow label={t("DashboardEarn.deposit.vaultStrategy")} value={strategy.name} />
+            <SummaryRow
+              label={t("DashboardEarn.deposit.vaultBacking")}
+              value={strategySourceLabel(strategy)}
+            />
+            <SummaryRow
+              label={t("DashboardEarn.deposit.vaultFrom")}
+              value={walletDisplayName(selectedWallet, selectedWallet?.publicKey ?? "")}
+            />
+          </dl>
+
+          {/* Over-balance is a WARNING, never a block — the balance is a live RPC
+            read and the chain decides. Blocking on it would refuse a deposit the
+            wallet can fund whenever that read is stale or unavailable. */}
+          {overBalance ? (
+            <StepNotice>{t("DashboardEarn.deposit.vaultOverBalance")}</StepNotice>
+          ) : null}
+          {/* `tone="error"` is not decoration: it carries the error palette AND
+            `role="alert"`, so a refusal is announced to a screen reader instead
+            of sitting silently in the flow. A refused deposit read as helper
+            text without it. */}
+          {error ? <StepNotice tone="error">{error}</StepNotice> : null}
+
+          <p className="text-sm leading-6 text-secondary">
+            {t("DashboardEarn.deposit.vaultConfirmNote")}
+          </p>
+
+          <div className="flex justify-between gap-3">
+            <Button onClick={() => setStep("wallet")} variant="secondary">
+              {t("DashboardEarn.deposit.back")}
+            </Button>
+            <Button disabled={!amountValid || submitting} onClick={() => void submit()}>
+              {submitting
+                ? t("DashboardEarn.deposit.vaultSubmitting")
+                : t("DashboardEarn.deposit.vaultSubmit")}
+            </Button>
+          </div>
+        </div>
+      </StepSection>
+    </Modal>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-vault-deposit-modal.unit.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import type { CustodyWalletSummary, EarnStrategy } from "@sdp/types";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const data = vi.hoisted(() => ({
+  createDeposit: vi.fn(),
+  wallet: {
+    id: "cwlt_exact_row",
+    custodyConfigId: "custody_config_one",
+    walletId: "provider_wallet_not_globally_unique",
+    publicKey: "7M6bFdwsXQZX9MjoD4PDxQJb9FZbwdQh6VS8sK7F3WcQ",
+    label: "Treasury Ops",
+    purpose: null,
+    status: "active",
+    createdAt: "2026-08-15T00:00:00.000Z",
+    provider: "fireblocks",
+    isRuntimeExecutionAllowed: true,
+    balances: [
+      {
+        token: "USDC",
+        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        amount: "9000000000",
+        uiAmount: "9000",
+        decimals: 6,
+      },
+      {
+        token: "USDT",
+        mint: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+        amount: "12500000",
+        uiAmount: "12.5",
+        decimals: 6,
+      },
+    ],
+  } satisfies CustodyWalletSummary,
+}));
+
+vi.mock("@/i18n/provider", () => ({
+  useTranslations: () => (key: string, values?: Record<string, string | number>) =>
+    values ? `${key}(${Object.values(values).join(",")})` : key,
+  useLocale: () => "en",
+}));
+
+vi.mock("./deposit/earn-funding-wallets", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./deposit/earn-funding-wallets")>();
+  return {
+    ...original,
+    useEarnFundingWallets: () => ({ wallets: [data.wallet], error: undefined, isLoading: false }),
+  };
+});
+
+vi.mock("./earn-program-data", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./earn-program-data")>();
+  return { ...original, createEarnVaultDeposit: data.createDeposit };
+});
+
+import { EarnVaultDepositModal } from "./earn-vault-deposit-modal";
+
+const USDT_STRATEGY: EarnStrategy = {
+  id: "kamino-usdt-vault",
+  provider: "kamino",
+  providerReference: "vault-usdt",
+  name: "Kamino USDT Vault",
+  sourceKind: "defi",
+  depositMints: ["Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"],
+  apyType: "variable",
+  currentApy: "0.05",
+  liquidityTerm: "instant",
+  status: "active",
+  hostCluster: "mainnet-beta",
+  fundable: true,
+  createdAt: "2026-08-15T00:00:00.000Z",
+  updatedAt: "2026-08-15T00:00:00.000Z",
+};
+
+afterEach(() => {
+  cleanup();
+  data.createDeposit.mockReset();
+});
+
+describe("EarnVaultDepositModal", () => {
+  it("quotes the strategy token and submits the exact SDP custody row", async () => {
+    data.createDeposit.mockResolvedValue({ ok: false, error: "Expected test refusal" });
+    const user = userEvent.setup();
+    render(<EarnVaultDepositModal onClose={() => {}} strategy={USDT_STRATEGY} />);
+
+    await user.click(await screen.findByRole("radio"));
+    await user.click(screen.getByRole("button", { name: "DashboardEarn.deposit.continueAction" }));
+
+    const amount = await screen.findByLabelText("DashboardEarn.deposit.vaultAmount(USDT)");
+    expect(
+      screen.getByText("DashboardEarn.deposit.vaultBalanceAvailable(12.5 USDT)")
+    ).not.toBeNull();
+    expect(screen.queryByText(/9,000 USDC/)).toBeNull();
+
+    await user.type(amount, "2");
+    await user.click(screen.getByRole("button", { name: "DashboardEarn.deposit.vaultSubmit" }));
+
+    await waitFor(() => expect(data.createDeposit).toHaveBeenCalledOnce());
+    expect(data.createDeposit).toHaveBeenCalledWith({
+      strategyId: USDT_STRATEGY.id,
+      custodyWalletId: data.wallet.id,
+      amount: "2",
+      requestId: expect.any(String),
+    });
+  });
+});

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-withdraw-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-withdraw-modal.tsx
@@ -16,11 +16,9 @@ import { Modal } from "@/components/ui/modal";
 import { Select, SelectItem } from "@/components/ui/select";
 import type { MessageKey } from "@/i18n/messages";
 import { useTranslations } from "@/i18n/provider";
+import { useModalFocus } from "@/lib/use-modal-focus";
 import { formatDurationRange, formatUsd, isoDurationDays } from "./earn-format";
 import { createEarnWithdrawal, previewEarnWithdrawal } from "./earn-program-data";
-
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /** Positive USD decimal with at most 6 decimal places (the API's contract). */
 const USD_AMOUNT_PATTERN = /^\d+(\.\d{1,6})?$/;
@@ -62,65 +60,15 @@ const WITHDRAWAL_STATUS_BADGES: Record<
 };
 
 /**
- * Scope focus to the portaled Earn dialog and return it to the trigger on
- * close. The fallback (trigger unmounted by a re-render) is scoped to THIS
- * program's card via the attribute value — with several cards on screen, an
- * unscoped query would land focus on whichever card renders first.
+ * Focus lifecycle, now SHARED with the vault deposit modal.
+ *
+ * Lifted verbatim into `src/lib/use-modal-focus.ts`: the two halves of one
+ * position — money in and money out — behaving differently for a keyboard user
+ * is a difference nobody can explain, and the deposit side had no focus
+ * management at all. The only behavioural change is the fallback attribute
+ * name, which is no longer withdraw-specific.
  */
-function useEarnModalFocus(programId: string) {
-  const contentRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const returnFocus =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    const focusFrame = window.requestAnimationFrame(() => {
-      contentRef.current
-        ?.querySelector<HTMLElement>('input:not([type="hidden"]):not([disabled])')
-        ?.focus();
-    });
-
-    const trapFocus = (event: KeyboardEvent) => {
-      if (event.key !== "Tab") return;
-      const dialog = contentRef.current?.closest<HTMLElement>('[role="dialog"]');
-      if (!dialog?.contains(document.activeElement)) return;
-      const focusable = [...dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
-        (element) => element.getAttribute("aria-hidden") !== "true"
-      );
-      const first = focusable[0];
-      const last = focusable.at(-1);
-      if (!first || !last) return;
-      if (!focusable.includes(document.activeElement as HTMLElement)) {
-        event.preventDefault();
-        (event.shiftKey ? last : first).focus();
-        return;
-      }
-
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    document.addEventListener("keydown", trapFocus);
-    return () => {
-      window.cancelAnimationFrame(focusFrame);
-      document.removeEventListener("keydown", trapFocus);
-      window.requestAnimationFrame(() => {
-        const focusTarget = returnFocus?.isConnected
-          ? returnFocus
-          : document.querySelector<HTMLElement>(
-              `[data-earn-withdraw-focus-fallback="${CSS.escape(programId)}"]`
-            );
-        focusTarget?.focus();
-      });
-    };
-  }, [programId]);
-
-  return contentRef;
-}
+const useEarnModalFocus = (programId: string) => useModalFocus<HTMLDivElement>(programId);
 
 type PreviewState =
   | { phase: "idle" }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.tsx
@@ -6,6 +6,7 @@ import type {
   EarnPortfolioWalletActivity,
   EarnPortfolioWalletStatus,
   EarnStrategy,
+  SdpEnvironment,
 } from "@sdp/types";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import Link from "next/link";
@@ -13,6 +14,7 @@ import { type KeyboardEvent, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SkeletonBlock } from "@/components/ui/skeleton-block";
+import { useDashboardWorkspace } from "@/contexts/dashboard-workspace-context";
 import type { MessageKey } from "@/i18n/messages";
 import { useTranslations } from "@/i18n/provider";
 import { useCopy } from "@/lib/use-copy";
@@ -671,11 +673,14 @@ function EarnTabBar({
  * visibility rule (a browser-side copy is what drifts).
  */
 export function EarnOpportunitiesPanel({
+  environment,
   fireblocksEnabled = false,
 }: {
+  /** Selected SDP project environment; it gates vault money-IN with the API. */
+  environment: SdpEnvironment;
   /** Passed through to the vault deposit modal's wallet step. */
   fireblocksEnabled?: boolean;
-} = {}) {
+}) {
   const t = useTranslations();
   const { strategies, error, isLoading } = useEarnStrategies();
   // Owned here rather than in the table so the table stays a pure presentation
@@ -708,6 +713,7 @@ export function EarnOpportunitiesPanel({
           </p>
         ) : (
           <EarnOpportunitiesTable
+            environment={environment}
             onVaultDeposit={setDepositStrategy}
             strategies={strategies ?? []}
           />
@@ -742,6 +748,7 @@ export function EarnWorkspace({
   /** Real custody-provider availability, resolved server-side in page.tsx. */
   fireblocksEnabled?: boolean;
 } = {}) {
+  const { sdpEnvironment } = useDashboardWorkspace();
   const [tab, setTab] = useState<EarnTab>("opportunities");
   const { state } = useEarnPrograms();
   const positionCount = state?.kind === "ready" ? state.programs.length : undefined;
@@ -751,7 +758,10 @@ export function EarnWorkspace({
     <div className="grid content-start gap-6">
       <EarnTabBar active={tab} onChange={setTab} positionCount={positionCount} />
       {tab === "opportunities" ? (
-        <EarnOpportunitiesPanel fireblocksEnabled={fireblocksEnabled} />
+        <EarnOpportunitiesPanel
+          environment={sdpEnvironment}
+          fireblocksEnabled={fireblocksEnabled}
+        />
       ) : null}
       {tab === "positions" ? (
         <div

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.tsx
@@ -353,7 +353,7 @@ function ProgramCard({
               disappears with the provider's surfacing. */}
           <Button
             className="flex-1 sm:flex-none"
-            data-earn-withdraw-focus-fallback={program.id}
+            data-modal-focus-fallback={program.id}
             disabled={Number(program.wallet.balance.withdrawableUsd) <= 0}
             onClick={onWithdraw}
             variant="secondary"
@@ -670,7 +670,12 @@ function EarnTabBar({
  * filtered to surfaced providers and visible sources; this never re-applies a
  * visibility rule (a browser-side copy is what drifts).
  */
-export function EarnOpportunitiesPanel() {
+export function EarnOpportunitiesPanel({
+  fireblocksEnabled = false,
+}: {
+  /** Passed through to the vault deposit modal's wallet step. */
+  fireblocksEnabled?: boolean;
+} = {}) {
   const t = useTranslations();
   const { strategies, error, isLoading } = useEarnStrategies();
   // Owned here rather than in the table so the table stays a pure presentation
@@ -715,6 +720,7 @@ export function EarnOpportunitiesPanel() {
 
       {depositStrategy ? (
         <EarnVaultDepositModal
+          fireblocksEnabled={fireblocksEnabled}
           // Remount per strategy so no draft amount, wallet choice, or minted
           // idempotency key can survive a switch between vaults.
           key={depositStrategy.id}
@@ -729,9 +735,12 @@ export function EarnOpportunitiesPanel() {
 export function EarnWorkspace({
   apiBaseUrl = null,
   apiKeys = [],
+  fireblocksEnabled = false,
 }: {
   apiBaseUrl?: string | null;
   apiKeys?: readonly PlaygroundApiKeyView[];
+  /** Real custody-provider availability, resolved server-side in page.tsx. */
+  fireblocksEnabled?: boolean;
 } = {}) {
   const [tab, setTab] = useState<EarnTab>("opportunities");
   const { state } = useEarnPrograms();
@@ -741,7 +750,9 @@ export function EarnWorkspace({
     // No root padding: the dashboard shell already pads non-viewport-locked routes.
     <div className="grid content-start gap-6">
       <EarnTabBar active={tab} onChange={setTab} positionCount={positionCount} />
-      {tab === "opportunities" ? <EarnOpportunitiesPanel /> : null}
+      {tab === "opportunities" ? (
+        <EarnOpportunitiesPanel fireblocksEnabled={fireblocksEnabled} />
+      ) : null}
       {tab === "positions" ? (
         <div
           aria-labelledby="earn-tab-positions"

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.tsx
@@ -37,6 +37,7 @@ import {
   strategySourceLabel,
   useLiquidityLabel,
 } from "./earn-program-presentation";
+import { EarnVaultDepositModal } from "./earn-vault-deposit-modal";
 import { EarnWithdrawModal } from "./earn-withdraw-modal";
 
 const DEPOSIT_PATH = "/dashboard/markets/earn/deposit";
@@ -672,6 +673,10 @@ function EarnTabBar({
 export function EarnOpportunitiesPanel() {
   const t = useTranslations();
   const { strategies, error, isLoading } = useEarnStrategies();
+  // Owned here rather than in the table so the table stays a pure presentation
+  // of what the API returned — the same reason it never re-applies a visibility
+  // rule.
+  const [depositStrategy, setDepositStrategy] = useState<EarnStrategy | undefined>(undefined);
 
   return (
     <section
@@ -697,13 +702,26 @@ export function EarnOpportunitiesPanel() {
             {t("DashboardEarn.overview.catalogueLoadError")}
           </p>
         ) : (
-          <EarnOpportunitiesTable strategies={strategies ?? []} />
+          <EarnOpportunitiesTable
+            onVaultDeposit={setDepositStrategy}
+            strategies={strategies ?? []}
+          />
         )}
       </div>
 
       <p className="mt-5 max-w-3xl text-xs leading-5 text-muted">
         {t("DashboardEarn.overview.rateDisclosure")}
       </p>
+
+      {depositStrategy ? (
+        <EarnVaultDepositModal
+          // Remount per strategy so no draft amount, wallet choice, or minted
+          // idempotency key can survive a switch between vaults.
+          key={depositStrategy.id}
+          onClose={() => setDepositStrategy(undefined)}
+          strategy={depositStrategy}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-workspace.unit.test.tsx
@@ -532,8 +532,8 @@ describe("EarnWorkspace with several programs", () => {
       expect(html).toContain("$300.00");
       // The withdraw modal's focus-return fallback has to survive the missing
       // change-strategy link that used to carry it.
-      expect(html).toContain('data-earn-withdraw-focus-fallback="p1"');
-      expect(html).toContain('data-earn-withdraw-focus-fallback="p2"');
+      expect(html).toContain('data-modal-focus-fallback="p1"');
+      expect(html).toContain('data-modal-focus-fallback="p2"');
     });
   });
 

--- a/apps/sdp-web/src/app/dashboard/markets/earn/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/page.tsx
@@ -6,6 +6,7 @@ import {
   resolvePlaygroundApiBaseUrl,
 } from "@/app/dashboard/playground-api-data";
 import { getAuthEntryPath } from "@/lib/auth-entry";
+import { fetchProviderAvailability } from "@/lib/provider-availability";
 import { createRequestScopedSdpApiClients } from "@/lib/sdp-api";
 import { EarnWorkspace } from "./earn-workspace";
 
@@ -30,6 +31,12 @@ export default async function EarnPage() {
   // playground. Best-effort: the API-key read failing must cost the reader the
   // playground's key selector, never the Opportunities and Active tabs beside it.
   let apiKeys: PlaygroundApiKeyView[] = [];
+  // Real custody-provider availability, read the same way the custodial deposit
+  // wizard reads it. The vault deposit modal reuses `WalletStep`, whose
+  // "connect Fireblocks" card is either an invitation or a locked notice — and
+  // hard-coding it to locked told entitled organizations something false about
+  // their own account.
+  let fireblocksEnabled = false;
   try {
     const { projectClient } = await createRequestScopedSdpApiClients();
     if (projectClient) {
@@ -37,11 +44,21 @@ export default async function EarnPage() {
       if (keysResult.ok && keysResult.data) {
         apiKeys = keysResult.data;
       }
+      const availability = await fetchProviderAvailability(projectClient.request, orgId).catch(
+        () => undefined
+      );
+      fireblocksEnabled = availability?.enabledCustodyProviders.includes("fireblocks") ?? false;
     }
   } catch {
     // Leaves apiKeys empty, which renders the playground's "needs an API key"
     // notice — the same state a project with no keys sees.
   }
 
-  return <EarnWorkspace apiBaseUrl={resolvePlaygroundApiBaseUrl()} apiKeys={apiKeys} />;
+  return (
+    <EarnWorkspace
+      apiBaseUrl={resolvePlaygroundApiBaseUrl()}
+      apiKeys={apiKeys}
+      fireblocksEnabled={fireblocksEnabled}
+    />
+  );
 }

--- a/apps/sdp-web/src/app/dashboard/markets/earn/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/page.tsx
@@ -8,6 +8,7 @@ import {
 import { getAuthEntryPath } from "@/lib/auth-entry";
 import { fetchProviderAvailability } from "@/lib/provider-availability";
 import { createRequestScopedSdpApiClients } from "@/lib/sdp-api";
+import { fetchEarnSdpOrganizationId } from "./earn-server-context";
 import { EarnWorkspace } from "./earn-workspace";
 
 export const dynamic = "force-dynamic";
@@ -38,15 +39,18 @@ export default async function EarnPage() {
   // their own account.
   let fireblocksEnabled = false;
   try {
-    const { projectClient } = await createRequestScopedSdpApiClients();
+    const { organizationClient, projectClient } = await createRequestScopedSdpApiClients();
     if (projectClient) {
       const keysResult = await fetchActiveApiKeys(projectClient.request);
       if (keysResult.ok && keysResult.data) {
         apiKeys = keysResult.data;
       }
-      const availability = await fetchProviderAvailability(projectClient.request, orgId).catch(
-        () => undefined
-      );
+      const organizationId = await fetchEarnSdpOrganizationId(organizationClient);
+      const availability = organizationId
+        ? await fetchProviderAvailability(projectClient.request, organizationId).catch(
+            () => undefined
+          )
+        : undefined;
       fireblocksEnabled = availability?.enabledCustodyProviders.includes("fireblocks") ?? false;
     }
   } catch {

--- a/apps/sdp-web/src/app/dashboard/markets/earn/page.unit.test.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/page.unit.test.tsx
@@ -1,0 +1,100 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  fetchActiveApiKeys: vi.fn(),
+  fetchProviderAvailability: vi.fn(),
+  organizationFetch: vi.fn(),
+  projectRequest: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`redirected to ${path}`);
+  }),
+}));
+vi.mock("@/lib/auth-entry", () => ({ getAuthEntryPath: vi.fn(async () => "/sign-in") }));
+vi.mock("@/app/dashboard/playground-api-data", () => ({
+  fetchActiveApiKeys: mocks.fetchActiveApiKeys,
+  resolvePlaygroundApiBaseUrl: () => "https://api.example.test",
+}));
+vi.mock("@/lib/provider-availability", () => ({
+  fetchProviderAvailability: mocks.fetchProviderAvailability,
+}));
+vi.mock("@/lib/sdp-api", () => ({
+  createRequestScopedSdpApiClients: vi.fn(async () => ({
+    organizationClient: { fetch: mocks.organizationFetch },
+    projectClient: { request: mocks.projectRequest },
+  })),
+}));
+vi.mock("./earn-workspace", () => ({
+  EarnWorkspace: ({
+    apiKeys,
+    fireblocksEnabled,
+  }: {
+    apiKeys: readonly unknown[];
+    fireblocksEnabled: boolean;
+  }) => (
+    <div data-api-key-count={apiKeys.length} data-fireblocks-enabled={String(fireblocksEnabled)} />
+  ),
+}));
+
+import EarnPage from "./page";
+
+beforeEach(() => {
+  mocks.auth.mockReset();
+  mocks.fetchActiveApiKeys.mockReset();
+  mocks.fetchProviderAvailability.mockReset();
+  mocks.organizationFetch.mockReset();
+  mocks.projectRequest.mockReset();
+
+  mocks.auth.mockResolvedValue({ userId: "user_one", orgId: "org_clerk_one" });
+  mocks.fetchActiveApiKeys.mockResolvedValue({
+    ok: true,
+    data: [{ id: "key_one", name: "Sandbox", keyPrefix: "sdp_", environment: "sandbox" }],
+  });
+  mocks.organizationFetch.mockResolvedValue({
+    linked: true,
+    organization: { id: "org_sdp_one" },
+  });
+  mocks.fetchProviderAvailability.mockResolvedValue({
+    enabledCustodyProviders: ["fireblocks"],
+  });
+});
+
+describe("EarnPage provider availability", () => {
+  it("uses the linked SDP organization id instead of Clerk's id", async () => {
+    const markup = renderToStaticMarkup(await EarnPage());
+
+    expect(mocks.organizationFetch).toHaveBeenCalledWith("/v1/onboarding/status");
+    expect(mocks.fetchProviderAvailability).toHaveBeenCalledWith(
+      mocks.projectRequest,
+      "org_sdp_one"
+    );
+    expect(mocks.fetchProviderAvailability).not.toHaveBeenCalledWith(
+      mocks.projectRequest,
+      "org_clerk_one"
+    );
+    expect(markup).toContain('data-fireblocks-enabled="true"');
+  });
+
+  it("keeps API-key context when provider availability is unavailable", async () => {
+    mocks.fetchProviderAvailability.mockRejectedValue(new Error("provider access unavailable"));
+
+    const markup = renderToStaticMarkup(await EarnPage());
+
+    expect(markup).toContain('data-api-key-count="1"');
+    expect(markup).toContain('data-fireblocks-enabled="false"');
+  });
+
+  it("keeps API-key context when onboarding lookup is unavailable", async () => {
+    mocks.organizationFetch.mockRejectedValue(new Error("onboarding unavailable"));
+
+    const markup = renderToStaticMarkup(await EarnPage());
+
+    expect(markup).toContain('data-api-key-count="1"');
+    expect(markup).toContain('data-fireblocks-enabled="false"');
+  });
+});

--- a/apps/sdp-web/src/lib/use-modal-focus.ts
+++ b/apps/sdp-web/src/lib/use-modal-focus.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+const PANEL_HEADING_SELECTOR = "[data-modal-focus-heading]";
 
 /**
  * The focus lifecycle a portaled dialog needs and the shared `Modal` does not
@@ -17,14 +18,17 @@ const FOCUSABLE_SELECTOR =
  * money-IN and money-OUT halves of the same position behave identically rather
  * than one of them silently going without.
  *
- * Three parts, and the fallback is the subtle one:
+ * Three parts, and the split between the first two is load-bearing:
  *
- * 1. **Initial focus** on the first enabled input inside the dialog, on the
- *    next frame — the portal's children are not in the document yet when the
- *    effect runs.
- * 2. **Trap** on Tab/Shift-Tab, cycling within the nearest `[role="dialog"]`
+ * 1. **Panel focus** runs on every `panelKey`, independently of the modal
+ *    lifecycle. A wizard keeps the same dialog mounted while replacing its
+ *    focused Continue/Submit button; without a second effect, focus falls to
+ *    `body` and the next panel is never announced.
+ * 2. **Trap** is mount-level and cycles Tab/Shift-Tab within the nearest
+ *    `[role="dialog"]`
  *    ancestor. Scoped to that ancestor rather than to the ref so that popovers
- *    portaled INSIDE the dialog (Select, Tooltip) stay reachable.
+ *    portaled INSIDE the dialog (Select, Tooltip) stay reachable. If focus has
+ *    already escaped, the next Tab recovers it into the dialog.
  * 3. **Return focus** to the element that had it, or — when that element was
  *    unmounted by a re-render while the dialog was open — to a trigger marked
  *    with `data-modal-focus-fallback="<fallbackId>"`. The id must be the
@@ -33,23 +37,22 @@ const FOCUSABLE_SELECTOR =
  *    different row than the one the reader was working in.
  *
  * @param fallbackId Identifies the trigger to return focus to if it remounts.
+ * @param panelKey Changes whenever the modal replaces its visible panel.
  */
-export function useModalFocus<T extends HTMLElement = HTMLDivElement>(fallbackId: string) {
+export function useModalFocus<T extends HTMLElement = HTMLDivElement>(
+  fallbackId: string,
+  panelKey: string = fallbackId
+) {
   const contentRef = useRef<T>(null);
 
   useEffect(() => {
     const returnFocus =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    const focusFrame = window.requestAnimationFrame(() => {
-      contentRef.current
-        ?.querySelector<HTMLElement>('input:not([type="hidden"]):not([disabled])')
-        ?.focus();
-    });
 
     const trapFocus = (event: KeyboardEvent) => {
       if (event.key !== "Tab") return;
       const dialog = contentRef.current?.closest<HTMLElement>('[role="dialog"]');
-      if (!dialog?.contains(document.activeElement)) return;
+      if (!dialog) return;
       const focusable = [...dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
         (element) => element.getAttribute("aria-hidden") !== "true"
       );
@@ -73,7 +76,6 @@ export function useModalFocus<T extends HTMLElement = HTMLDivElement>(fallbackId
 
     document.addEventListener("keydown", trapFocus);
     return () => {
-      window.cancelAnimationFrame(focusFrame);
       document.removeEventListener("keydown", trapFocus);
       window.requestAnimationFrame(() => {
         const focusTarget = returnFocus?.isConnected
@@ -85,6 +87,29 @@ export function useModalFocus<T extends HTMLElement = HTMLDivElement>(fallbackId
       });
     };
   }, [fallbackId]);
+
+  useEffect(() => {
+    // One frame lets Modal's portal mount and lets a state transition replace
+    // its panel before querying. Inputs are the most useful landing target for
+    // the two form panels; a marked heading is the semantic fallback for
+    // loading, empty, and result panels; the first ordinary control is last.
+    const focusFrame = window.requestAnimationFrame(() => {
+      const content = contentRef.current;
+      if (!content) return;
+      // A keyed panel can expose the same value on its root. This guards a
+      // queued frame from focusing a replacement that rendered after it was
+      // scheduled; unkeyed single-panel consumers remain supported.
+      const renderedPanelKey = content.dataset.modalFocusPanel;
+      if (renderedPanelKey !== undefined && renderedPanelKey !== panelKey) return;
+      const target =
+        content.querySelector<HTMLElement>('input:not([type="hidden"]):not([disabled])') ??
+        content.querySelector<HTMLElement>(PANEL_HEADING_SELECTOR) ??
+        content.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      target?.focus();
+    });
+
+    return () => window.cancelAnimationFrame(focusFrame);
+  }, [panelKey]);
 
   return contentRef;
 }

--- a/apps/sdp-web/src/lib/use-modal-focus.ts
+++ b/apps/sdp-web/src/lib/use-modal-focus.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * The focus lifecycle a portaled dialog needs and the shared `Modal` does not
+ * provide.
+ *
+ * `Modal` gives a portal, `role="dialog"`, `aria-modal`, Escape-to-close and a
+ * backdrop — but nothing about focus: no initial focus, no trap, no
+ * restoration. On its own that means keyboard focus stays on, or tabs into,
+ * page content the dialog visually covers, and never returns to whatever opened
+ * it. Lifted here from `EarnWithdrawModal`, where it was a private hook, so the
+ * money-IN and money-OUT halves of the same position behave identically rather
+ * than one of them silently going without.
+ *
+ * Three parts, and the fallback is the subtle one:
+ *
+ * 1. **Initial focus** on the first enabled input inside the dialog, on the
+ *    next frame — the portal's children are not in the document yet when the
+ *    effect runs.
+ * 2. **Trap** on Tab/Shift-Tab, cycling within the nearest `[role="dialog"]`
+ *    ancestor. Scoped to that ancestor rather than to the ref so that popovers
+ *    portaled INSIDE the dialog (Select, Tooltip) stay reachable.
+ * 3. **Return focus** to the element that had it, or — when that element was
+ *    unmounted by a re-render while the dialog was open — to a trigger marked
+ *    with `data-modal-focus-fallback="<fallbackId>"`. The id must be the
+ *    attribute's VALUE, not a bare attribute: with several cards on screen an
+ *    unscoped query lands focus on whichever rendered first, which is a
+ *    different row than the one the reader was working in.
+ *
+ * @param fallbackId Identifies the trigger to return focus to if it remounts.
+ */
+export function useModalFocus<T extends HTMLElement = HTMLDivElement>(fallbackId: string) {
+  const contentRef = useRef<T>(null);
+
+  useEffect(() => {
+    const returnFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusFrame = window.requestAnimationFrame(() => {
+      contentRef.current
+        ?.querySelector<HTMLElement>('input:not([type="hidden"]):not([disabled])')
+        ?.focus();
+    });
+
+    const trapFocus = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const dialog = contentRef.current?.closest<HTMLElement>('[role="dialog"]');
+      if (!dialog?.contains(document.activeElement)) return;
+      const focusable = [...dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
+        (element) => element.getAttribute("aria-hidden") !== "true"
+      );
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (!first || !last) return;
+      if (!focusable.includes(document.activeElement as HTMLElement)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", trapFocus);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", trapFocus);
+      window.requestAnimationFrame(() => {
+        const focusTarget = returnFocus?.isConnected
+          ? returnFocus
+          : document.querySelector<HTMLElement>(
+              `[data-modal-focus-fallback="${CSS.escape(fallbackId)}"]`
+            );
+        focusTarget?.focus();
+      });
+    };
+  }, [fallbackId]);
+
+  return contentRef;
+}

--- a/apps/sdp-web/src/lib/use-modal-focus.unit.test.tsx
+++ b/apps/sdp-web/src/lib/use-modal-focus.unit.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useModalFocus } from "./use-modal-focus";
+
+type Panel = "wallet" | "amount" | "result";
+
+function Dialog({ onClose }: { onClose: () => void }) {
+  const [panel, setPanel] = useState<Panel>("wallet");
+  const contentRef = useModalFocus<HTMLDivElement>("vault-one", panel);
+
+  return (
+    <div aria-label="Deposit" role="dialog">
+      <div data-modal-focus-panel={panel} ref={contentRef}>
+        {panel === "wallet" ? (
+          <>
+            <h2 data-modal-focus-heading tabIndex={-1}>
+              Choose wallet
+            </h2>
+            <input aria-label="Treasury wallet" type="radio" />
+            <button onClick={() => setPanel("amount")} type="button">
+              Continue
+            </button>
+          </>
+        ) : null}
+        {panel === "amount" ? (
+          <>
+            <h2 data-modal-focus-heading tabIndex={-1}>
+              Enter amount
+            </h2>
+            <input aria-label="Amount" />
+            <button onClick={() => setPanel("result")} type="button">
+              Submit
+            </button>
+          </>
+        ) : null}
+        {panel === "result" ? (
+          <>
+            <h2 data-modal-focus-heading tabIndex={-1}>
+              Deposit submitted
+            </h2>
+            <button onClick={onClose} type="button">
+              Done
+            </button>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Harness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button data-modal-focus-fallback="vault-one" onClick={() => setOpen(true)} type="button">
+        Open deposit
+      </button>
+      {open ? <Dialog onClose={() => setOpen(false)} /> : null}
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    return window.setTimeout(() => callback(performance.now()), 0);
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frame) => {
+    window.clearTimeout(frame);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useModalFocus", () => {
+  it("focuses each replacement panel and returns focus when the modal closes", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const trigger = screen.getByRole("button", { name: "Open deposit" });
+    await user.click(trigger);
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("radio")));
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("textbox")));
+
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+    const resultHeading = screen.getByRole("heading", { name: "Deposit submitted" });
+    await waitFor(() => expect(document.activeElement).toBe(resultHeading));
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("recovers focus into the dialog when it has escaped", async () => {
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Dialog onClose={() => {}} />
+      </>
+    );
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("radio")));
+
+    screen.getByRole("button", { name: "Outside" }).focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(screen.getByRole("radio"));
+
+    screen.getByRole("button", { name: "Outside" }).focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Continue" }));
+  });
+});

--- a/docs/architecture/earn-v1-data-flow.md
+++ b/docs/architecture/earn-v1-data-flow.md
@@ -105,11 +105,27 @@ V1 precisely because observing customer-initiated transfers from chain is
 indexer-shaped work. If V2 needs richer on-chain history (per-block share
 price, protocol events), that's the point to evaluate an indexer — not V1.
 
-## Execution era (PRO-1634 — not V1, and no longer in the tree)
+## Execution era (PRO-1634 — arrived for `vault_direct`)
 
-V1's funding model is "send stablecoins to the program's Solana deposit
-address"; there are no SDP-built deposit/withdrawal transactions, no custody
-signing, and no per-strategy movement ledger. The execution-era design that
+**This is now half true.** For the CUSTODIAL shape it still holds exactly: a
+Ground program is funded by sending stablecoins to its deposit address, with no
+SDP-built transaction and no custody signing.
+
+For the NON-CUSTODIAL (`vault_direct`) shape it no longer does. A K-Vault has no
+address to send to, so the only way money moves is SDP building an instruction,
+signing it with an organization custody wallet and submitting it. That path
+exists: `@sdp/kamino` builds the plan, `POST /v1/earn/vault-deposits` signs and
+submits, and `earn_vault_movements` (migration 0058) ledgers it — written at
+intent BEFORE signing, because the chain has no request-id dedupe and a crash
+between signing and recording is otherwise unrecoverable. `earn_vault_positions`
+records only WHICH (wallet, vault) pairs an org holds; shares and value stay live
+chain reads, so the ledger-vs-live rule above is unchanged.
+
+Still outstanding for that shape: the withdraw counterpart and the Active-tab
+snapshot. Until both land, a vault position can be entered and not exited through
+SDP — so Kamino must not become creatable on mainnet.
+
+The original V1 note, still accurate for the custodial model: The execution-era design that
 used to be diagrammed here (per-strategy `createDeposit`/`createWithdrawal`,
 `/movements/:id/submit`, movement webhooks + `getMovementStatus` reconcile
 polling) was **removed from the codebase by PRO-1628** because none of it had

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -14,13 +14,14 @@ This map is generated from the module-boundary check. It records the permitted w
 
 | Module | Purpose | Allowed workspace dependencies |
 | --- | --- | --- |
-| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
+| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
 | `@sdp/api-integration` | Maintainer integration harness for API endpoint and provider coverage. | `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types` |
 | `@sdp/custody` | Custody provider abstractions and keychain adapters. | `@sdp/types` |
 | `@sdp/earn` | Earn domain services, yield strategies, and vault-infra providers. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
 | `@sdp/env-config` | Runtime environment configuration and validation. | None |
 | `@sdp/helius-rings` | Helius Rings shielded-wallet domain types, state machine, and gateway port (devnet). | None |
 | `@sdp/issuance` | Token issuance domain services and Mosaic integration. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
+| `@sdp/kamino` | Kit-native Kamino K-Vault deposit/withdraw instruction plans over klend-sdk. | `@sdp/earn`, `@sdp/solana`, `@sdp/types` |
 | `@sdp/kit-augment` | Shared @solana/kit type augmentation for the generated Codama clients. | None |
 | `@sdp/payments` | Payment domain services, fee payment, and ramp providers. | `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
 | `@sdp/policy` | Wallet-operation policy engine: rule evaluation and enforcement orchestration. | `@sdp/solana`, `@sdp/types` |
@@ -35,13 +36,14 @@ This map is generated from the module-boundary check. It records the permitted w
 
 ## Declared Workspace Graph
 
-- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
+- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
 - `@sdp/api-integration` -> `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types`
 - `@sdp/custody` -> `@sdp/types`
 - `@sdp/earn` -> `@sdp/types`
 - `@sdp/env-config` -> None
 - `@sdp/helius-rings` -> None
 - `@sdp/issuance` -> `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types`
+- `@sdp/kamino` -> `@sdp/earn`, `@sdp/solana`, `@sdp/types`
 - `@sdp/kit-augment` -> None
 - `@sdp/payments` -> `@sdp/rpc`, `@sdp/solana`, `@sdp/types`
 - `@sdp/policy` -> `@sdp/solana`, `@sdp/types`

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
       "@solana/mosaic-sdk@0.1.1": "patches/@solana__mosaic-sdk@0.1.1.patch",
       "next-themes@0.4.6": "patches/next-themes@0.4.6.patch",
       "brace-expansion@5.0.9": "patches/brace-expansion@5.0.9.patch"
+    },
+    "packageExtensions": {
+      "@kamino-finance/klend-sdk@10.0.0": {
+        "dependencies": {
+          "@solana-program/compute-budget": "^0.8.0",
+          "@solana-program/memo": "^0.7.0"
+        }
+      }
     }
   },
   "scripts": {

--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -211,13 +211,25 @@ Ground is **custodial**: SDP provisions an omnibus portfolio wallet, the
 customer funds it, Ground spreads it across yield sources. Programs,
 withdrawals and the deposit wizard all assume that shape.
 
-Kamino is **non-custodial and catalogue-only**: a K-Vault is an on-chain vault
-the customer's own wallet deposits into, so there is no wallet for SDP to
-provision or pay out from. It implements the base `EarnVaultProvider` contract
-plus the live-metrics capability, and NONE of the portfolio-wallet capability —
-so every money-moving route answers 501 for it through `supportsPortfolioWallets`,
-never a provider-id check. Deposit/withdraw execution is not "not yet"; it is a
-different money model that V1 does not carry.
+Kamino is **non-custodial**: a K-Vault is an on-chain vault the customer's own
+wallet deposits into, so there is no wallet for SDP to provision or pay out
+from, and no address to hand out — the vault's account is a PROGRAM account and
+stablecoins sent to it are destroyed.
+
+It implements the base `EarnVaultProvider` contract, the live-metrics
+capability, and — since the vault-deposit change — the **vault-direct**
+capability (`EarnVaultDirectProvider`, `supportsVaultDirect`). It still
+implements NONE of the portfolio-wallet capability, so every portfolio route
+answers 501 for it through `supportsPortfolioWallets`, never a provider-id
+check. The two capabilities are asserted MUTUALLY EXCLUSIVE: a client claiming
+both would let a portfolio route render the vault account as a fundable
+address.
+
+Money moves for Kamino by SDP BUILDING an instruction, signing it with one of
+the organization's own custody wallets and submitting it — `@sdp/kamino` builds
+the plan, the API signs and submits (`POST /v1/earn/vault-deposits`). That
+package depends on this one, never the reverse: the hourly catalogue cron must
+not load a 13MB chain SDK it never calls.
 
 Three Kamino facts drive most of its code, all measured against the live API on
 2026-08-13 (Kamino publishes an agent-readable API index at

--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -218,7 +218,18 @@ stablecoins sent to it are destroyed.
 
 It implements the base `EarnVaultProvider` contract, the live-metrics
 capability, and — since the vault-deposit change — the **vault-direct**
-capability (`EarnVaultDirectProvider`, `supportsVaultDirect`). It still
+capability (`EarnVaultDirectProvider`, `supportsVaultDirect`), which is
+DEPOSIT + READ only.
+
+Money OUT is a separate capability, `EarnVaultWithdrawProvider` /
+`supportsVaultWithdraw`, and Kamino deliberately does NOT implement it yet. The
+split is not taxonomy: an exit may legitimately need several transactions (one
+withdraw instruction per reserve the vault draws from), which a deposit never
+does, so "can build a deposit" must not silently assert "can build a correctly
+BATCHED exit". Withholding it says the SDP route does not exist; it is never a
+permission gate, since ADR 0002 forbids money-out inheriting a money-in gate.
+
+It still
 implements NONE of the portfolio-wallet capability, so every portfolio route
 answers 501 for it through `supportsPortfolioWallets`, never a provider-id
 check. The two capabilities are asserted MUTUALLY EXCLUSIVE: a client claiming

--- a/packages/sdp-earn/src/capabilities.ts
+++ b/packages/sdp-earn/src/capabilities.ts
@@ -1,6 +1,7 @@
 import type {
   EarnLiveMetricsProvider,
   EarnPortfolioWalletProvider,
+  EarnVaultDirectProvider,
   EarnVaultProvider,
   EarnWithdrawalApprovalProvider,
 } from "./types";
@@ -63,6 +64,28 @@ export function supportsWithdrawalApprovals(
     Record<(typeof WITHDRAWAL_APPROVAL_METHODS)[number], unknown>
   >;
   return WITHDRAWAL_APPROVAL_METHODS.every((method) => typeof candidate[method] === "function");
+}
+
+const VAULT_DIRECT_METHODS = [
+  "buildVaultDeposit",
+  "buildVaultWithdrawal",
+  "readVaultPositions",
+] as const satisfies readonly Exclude<keyof EarnVaultDirectProvider, keyof EarnVaultProvider>[];
+
+/**
+ * Capability discovery for the optional vault-direct contract — same
+ * all-or-nothing method-presence rule as the guards above.
+ *
+ * Deliberately DISJOINT from `supportsPortfolioWallets`: the two describe
+ * opposite money models. A portfolio provider hands SDP a custodied wallet
+ * address to fund; a vault-direct provider has no such address at all, and the
+ * one it superficially resembles — the vault's own account — destroys funds sent
+ * to it. Nothing should ever be true of both, and a provider implementing both
+ * sets of methods is a bug in that client, not a richer provider.
+ */
+export function supportsVaultDirect(client: EarnVaultProvider): client is EarnVaultDirectProvider {
+  const candidate = client as Partial<Record<(typeof VAULT_DIRECT_METHODS)[number], unknown>>;
+  return VAULT_DIRECT_METHODS.every((method) => typeof candidate[method] === "function");
 }
 
 const LIVE_METRICS_METHODS = ["listStrategyMetrics"] as const satisfies readonly Exclude<

--- a/packages/sdp-earn/src/capabilities.ts
+++ b/packages/sdp-earn/src/capabilities.ts
@@ -3,6 +3,7 @@ import type {
   EarnPortfolioWalletProvider,
   EarnVaultDirectProvider,
   EarnVaultProvider,
+  EarnVaultWithdrawProvider,
   EarnWithdrawalApprovalProvider,
 } from "./types";
 
@@ -68,7 +69,6 @@ export function supportsWithdrawalApprovals(
 
 const VAULT_DIRECT_METHODS = [
   "buildVaultDeposit",
-  "buildVaultWithdrawal",
   "readVaultPositions",
 ] as const satisfies readonly Exclude<keyof EarnVaultDirectProvider, keyof EarnVaultProvider>[];
 
@@ -86,6 +86,33 @@ const VAULT_DIRECT_METHODS = [
 export function supportsVaultDirect(client: EarnVaultProvider): client is EarnVaultDirectProvider {
   const candidate = client as Partial<Record<(typeof VAULT_DIRECT_METHODS)[number], unknown>>;
   return VAULT_DIRECT_METHODS.every((method) => typeof candidate[method] === "function");
+}
+
+const VAULT_WITHDRAW_METHODS = ["buildVaultWithdrawal"] as const satisfies readonly Exclude<
+  keyof EarnVaultWithdrawProvider,
+  keyof EarnVaultDirectProvider
+>[];
+
+/**
+ * Capability discovery for the money-OUT half, asked SEPARATELY from money-in.
+ *
+ * `buildVaultDeposit` proves a provider can build one transaction; an exit may
+ * legitimately need several, one per reserve the vault draws from, and getting
+ * that batching right is the hard part. Keeping the question separate is what
+ * stops "this provider supports vault deposits" from silently also asserting
+ * "…and can build a correctly sized exit" — the exact conflation that let an
+ * unsized single-batch withdrawal plan look shippable.
+ *
+ * A provider that answers false here has no SDP exit route. That is a statement
+ * about SDP's plumbing, never about the customer's right to their money: the
+ * shares are in their own wallet and Kamino's own UI can always redeem them.
+ */
+export function supportsVaultWithdraw(
+  client: EarnVaultProvider
+): client is EarnVaultWithdrawProvider {
+  if (!supportsVaultDirect(client)) return false;
+  const candidate = client as Partial<Record<(typeof VAULT_WITHDRAW_METHODS)[number], unknown>>;
+  return VAULT_WITHDRAW_METHODS.every((method) => typeof candidate[method] === "function");
 }
 
 const LIVE_METRICS_METHODS = ["listStrategyMetrics"] as const satisfies readonly Exclude<

--- a/packages/sdp-earn/src/providers/kamino/devnet.ts
+++ b/packages/sdp-earn/src/providers/kamino/devnet.ts
@@ -1,3 +1,4 @@
+import { KAMINO_DEVNET_KVAULT_PROGRAM_ID } from "@sdp/types/kamino-programs";
 import { internalError, providerNotConfigured } from "../../errors";
 import { providerFetchJson } from "../../fetch";
 
@@ -35,9 +36,18 @@ import { providerFetchJson } from "../../fetch";
  * program per cluster, and mainnet's id also exists on devnet with ZERO
  * accounts under it, so pointing at the wrong one yields a confident empty
  * shelf rather than an error.
+ *
+ * Re-exported from `@sdp/types/kamino-programs`, which is the single home for
+ * every Kamino program address. It cannot live in `@sdp/kamino` (the package
+ * that builds deposit/withdraw instructions against the same program) because
+ * this module would then have to import it, and a `@sdp/earn → @sdp/kamino`
+ * edge is both a workspace cycle and a reason for the catalogue cron to load a
+ * 13MB SDK it never calls.
+ *
+ * Imported AND re-exported: `listKaminoDevnetVaults` below uses it as a value,
+ * which a bare `export … from` would not bind locally.
  */
-// biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
-export const KAMINO_DEVNET_KVAULT_PROGRAM_ID = "devkRngFnfp4gBc5a3LsadgbQKdPo8MSZ4prFiNSVmY";
+export { KAMINO_DEVNET_KVAULT_PROGRAM_ID };
 
 /**
  * `VaultState` account size, and the byte offsets of the fields SDP reads.

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -381,6 +381,26 @@ export interface EarnVaultTransactionPlan {
   transactions: EarnVaultInstruction[][];
   /** Address lookup tables the caller should apply when compiling. */
   lookupTables: string[];
+  /**
+   * The amounts the instructions above actually ENCODE, canonical to each
+   * mint's own precision.
+   *
+   * Separate from the request because they need not be the same number: a chain
+   * SDK converts decimals to mint atoms and typically FLOORS, so a request of
+   * `1.0000009` against a six-decimal mint encodes `1.000000`. A provider that
+   * refuses over-precise input (the right answer) still re-serialises here, so
+   * `"1.500"` returns as `"1.5"`. Ledger these rather than the raw request: only
+   * the builder knows the mint's decimals, and a movement row is a claim about
+   * what moved on chain.
+   */
+  accepted?: EarnVaultAcceptedAmounts;
+}
+
+/** What a built plan encodes, per mint. All values are decimal strings. */
+export interface EarnVaultAcceptedAmounts {
+  amount?: string;
+  minSharesOut?: string;
+  shares?: string;
 }
 
 export interface EarnVaultDepositInput {
@@ -441,10 +461,6 @@ export interface EarnVaultDirectProvider extends EarnVaultProvider {
     ctx: EarnRuntimeContext,
     input: EarnVaultDepositInput
   ): Promise<EarnVaultTransactionPlan>;
-  buildVaultWithdrawal(
-    ctx: EarnRuntimeContext,
-    input: EarnVaultWithdrawInput
-  ): Promise<EarnVaultTransactionPlan>;
   /**
    * Live positions. Read from chain per call and never persisted — positions are
    * provider truth (ADR 0002), and for a vault-direct provider "the provider" is
@@ -454,6 +470,31 @@ export interface EarnVaultDirectProvider extends EarnVaultProvider {
     ctx: EarnRuntimeContext,
     input: EarnVaultPositionInput
   ): Promise<EarnVaultPositionSnapshot[]>;
+}
+
+/**
+ * Optional capability: the money-OUT half of the vault-direct model, kept
+ * SEPARATE from money-in deliberately.
+ *
+ * Splitting it is not taxonomy for its own sake. A vault EXIT is the case that
+ * genuinely needs several transactions — one withdraw instruction per reserve
+ * the vault must draw from, each carrying the vault's full remaining-accounts
+ * list — so `transactions` having more than one entry is normal here and
+ * impossible on deposit. Folding both into one capability therefore made "can
+ * build a deposit" silently assert "can build a correctly BATCHED exit", which
+ * is a different and much harder claim.
+ *
+ * Discovered via `supportsVaultWithdraw` (capabilities.ts). A provider may
+ * implement `EarnVaultDirectProvider` alone, and an exit route must then refuse
+ * rather than assume. Note this says only whether the ROUTE CAN BE BUILT — it is
+ * never a permission gate, because ADR 0002 forbids money-out inheriting any
+ * money-in gate.
+ */
+export interface EarnVaultWithdrawProvider extends EarnVaultDirectProvider {
+  buildVaultWithdrawal(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultWithdrawInput
+  ): Promise<EarnVaultTransactionPlan>;
 }
 
 /**

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -382,6 +382,15 @@ export interface EarnVaultTransactionPlan {
   /** Address lookup tables the caller should apply when compiling. */
   lookupTables: string[];
   /**
+   * Asset addresses observed from the live vault state used to build this plan.
+   *
+   * Required so the execution layer can compare builder truth with catalogue
+   * metadata before signing. Amount validation alone is insufficient: a stale
+   * or poisoned catalogue row could otherwise apply policy and ledger labels to
+   * one mint while the instructions actually move another.
+   */
+  assetIdentity: EarnVaultAssetIdentity;
+  /**
    * The amounts the instructions above actually ENCODE, canonical to each
    * mint's own precision.
    *
@@ -394,6 +403,14 @@ export interface EarnVaultTransactionPlan {
    * what moved on chain.
    */
   accepted?: EarnVaultAcceptedAmounts;
+}
+
+/** Solana asset identity bound to an unsigned vault transaction plan. */
+export interface EarnVaultAssetIdentity {
+  /** Mint whose tokens the deposit instructions consume. */
+  depositTokenMint: string;
+  /** Mint whose receipt/share tokens the vault issues. */
+  shareMint: string;
 }
 
 /** What a built plan encodes, per mint. All values are decimal strings. */

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -347,6 +347,116 @@ export interface EarnPortfolioWalletProvider extends EarnVaultProvider {
 }
 
 /**
+ * One account slot in a built instruction.
+ *
+ * `role` mirrors `@solana/kit`'s `AccountRole` numeric enum (0 readonly,
+ * 1 writable, 2 readonly-signer, 3 writable-signer) WITHOUT importing it: this
+ * package's single dependency is `@sdp/types`, and taking `@solana/kit` here
+ * would put a chain SDK inside the hourly catalogue cron. The numbers are the
+ * wire format, and the provider client re-labels them at its own boundary.
+ */
+export interface EarnVaultAccountRef {
+  address: string;
+  role: number;
+}
+
+/** One built instruction, as plain data. `data` is base64. */
+export interface EarnVaultInstruction {
+  programAddress: string;
+  accounts: EarnVaultAccountRef[];
+  data: string;
+}
+
+/**
+ * Unsigned work for a non-custodial vault, ready for the API to compile.
+ *
+ * `transactions` is a list of TRANSACTION-SIZED batches, not one flat list: a
+ * multi-reserve vault exit emits several instructions each carrying the vault's
+ * full reserve account list and can exceed Solana's 1232-byte packet. Returning
+ * batches makes that the builder's problem, where the vault's shape is known,
+ * rather than the caller's at compile time.
+ */
+export interface EarnVaultTransactionPlan {
+  cluster: SolanaCluster;
+  transactions: EarnVaultInstruction[][];
+  /** Address lookup tables the caller should apply when compiling. */
+  lookupTables: string[];
+}
+
+export interface EarnVaultDepositInput {
+  /** Vault address — the strategy's `providerReference`. */
+  providerReference: string;
+  /** Address whose tokens move and whose shares are minted. */
+  owner: string;
+  /** Deposit amount in the vault token's own units, as a decimal string. */
+  amount: string;
+  /** Minimum shares to accept, as a decimal string — slippage floor. */
+  minSharesOut?: string;
+}
+
+export interface EarnVaultWithdrawInput {
+  providerReference: string;
+  owner: string;
+  /** Shares to redeem, as a decimal string. */
+  shares: string;
+}
+
+export interface EarnVaultPositionInput {
+  owner: string;
+  /** Vault addresses to read. Empty means "every vault this provider knows". */
+  providerReferences: readonly string[];
+}
+
+/** One owner's live holding in one vault. All amounts are decimal strings. */
+export interface EarnVaultPositionSnapshot {
+  providerReference: string;
+  owner: string;
+  cluster: SolanaCluster;
+  shares: string;
+  /** Value of those shares in the deposit token; omitted when unreadable. */
+  tokenValue?: string;
+  tokenMint: string;
+  shareMint: string;
+}
+
+/**
+ * Optional capability: NON-CUSTODIAL vaults the customer's own wallet deposits
+ * into (Kamino's K-Vaults; `earnDepositStyle` calls these `vault_direct`).
+ *
+ * The shape difference from `EarnPortfolioWalletProvider` is the whole point.
+ * A portfolio provider CUSTODIES: SDP asks it to provision a wallet and the
+ * customer funds that address. A vault-direct provider custodies nothing —
+ * there is no address to send to, and stablecoins sent to the vault's program
+ * account are LOST. Money moves only when a wallet SDP can sign for submits an
+ * instruction, so this capability builds unsigned plans and SDP's own custody
+ * and signing services do the rest.
+ *
+ * Everything crossing this contract is plain data (see the types above), so a
+ * provider client may speak whatever chain SDK it likes without that SDK
+ * reaching this package. Discovered via `supportsVaultDirect` (capabilities.ts),
+ * never provider-id checks.
+ */
+export interface EarnVaultDirectProvider extends EarnVaultProvider {
+  buildVaultDeposit(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultDepositInput
+  ): Promise<EarnVaultTransactionPlan>;
+  buildVaultWithdrawal(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultWithdrawInput
+  ): Promise<EarnVaultTransactionPlan>;
+  /**
+   * Live positions. Read from chain per call and never persisted — positions are
+   * provider truth (ADR 0002), and for a vault-direct provider "the provider" is
+   * the chain itself.
+   */
+  readVaultPositions(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultPositionInput
+  ): Promise<EarnVaultPositionSnapshot[]>;
+}
+
+/**
  * Optional capability: customer-approval flows for withdrawal payouts. Some
  * providers gate payout legs on a customer-side signature (Ground: Turnkey
  * consensus voting, engaged by an org-level approval policy rather than by

--- a/packages/sdp-kamino/CLAUDE.md
+++ b/packages/sdp-kamino/CLAUDE.md
@@ -62,7 +62,7 @@ cycle *and* would drag a 13MB SDK into the hourly catalogue cron).
   rewards), so a wrong value yields plausible WRONG NUMBERS with no error — the
   same silent class as the program trap, and one no instruction assertion catches.
   Measured 2026-08-15 over a 4,000-slot span: **mainnet ≈ 416 ms, devnet ≈ 265 ms**.
-  Both differ from klend-sdk's own default of 450. Re-measure rather than adjust
+  Both differ from klend-sdk's own default of 400. Re-measure rather than adjust
   by feel.
 - **`KAMINO_KVAULT_PROGRAM_IDS`** — the one address that DIFFERS per cluster.
   Mainnet's id also exists on devnet with zero accounts, so aiming at the wrong one
@@ -83,6 +83,12 @@ it for share-ATA rent — a spend its `FeePayerPolicy` may refuse and which
 here for exactly that reason, and it defaults to the owner.
 
 ## Plans are transaction-sized BATCHES
+
+Every plan also carries required `assetIdentity` with the deposit-token mint and
+share mint read from the same live vault state used to build its instructions.
+Catalogue metadata drives policy and ledger labels but is not builder truth; the
+API must compare both mints before signing so a stale or poisoned row cannot
+authorize one asset while the transaction moves another.
 
 `KaminoInstructionPlan.instructions` is `Instruction[][]`, one entry per
 transaction — not a flat list. A multi-reserve exit emits several withdraw
@@ -119,6 +125,9 @@ batching work, not the first (`client.test.ts` pins this).
   the live exchange rate. Passing `"0"` would be the appearance of slippage
   protection without the substance, so the caller computes a floor or passes
   nothing. The API requires one in PRODUCTION for exactly that reason.
+- **`lookupTables` is always empty today.** The field exists so callers compile
+  against the right shape; populating it from Kamino's per-vault LUT is the fix
+  when a plan stops fitting.
 
 ## Amounts are checked against the MINT, not just parsed
 
@@ -126,6 +135,8 @@ batching work, not the first (`client.test.ts` pins this).
 without loading klend-sdk) refuses any value finer than its mint can represent,
 and returns the canonical form the instruction actually encodes — surfaced as
 `KaminoInstructionPlan.accepted`, which is what the ledger should persist.
+Trailing fractional zeroes do not add precision (`1.5000000` is representable by
+a six-decimal mint); a non-zero sub-atom still fails rather than being floored.
 
 This exists because klend-sdk converts every `Decimal` to mint atoms and
 **floors, silently**. Two different bugs hide under that floor: `1.0000009` on a
@@ -144,10 +155,18 @@ from `vault.getUserShares`. The SDK's own path sums
 `getTokenAccountAmount` (`utils/ata.ts`), so above 2^53 base units the value has
 already lost precision and no amount of `Decimal`-wrapping downstream recovers
 it. The staked half comes from farm state as an exact `Decimal`, so it is safe
-to reuse.
-- **`lookupTables` is always empty today.** The field exists so callers compile
-  against the right shape; populating it from Kamino's per-vault LUT is the fix
-  when a plan stops fitting.
+to reuse. Every matching token account is summed; if any returned account lacks
+an exact raw amount, the entire position is unreadable rather than silently
+under-reported.
+
+## RPC reads are bounded
+
+`rpc.ts` applies a 30-second deadline at the transport boundary shared with
+klend-sdk, so vault, reserve, farm, token-account, exchange-rate and slot reads
+cannot hold an API worker forever. Caller cancellation is composed with that
+deadline and remains distinguishable from a timeout. A portfolio page reads one
+shared slot, then hydrates at most four vaults concurrently; the number of
+in-flight RPC sequences never scales without a bound from catalogue size.
 
 ## Tests
 

--- a/packages/sdp-kamino/CLAUDE.md
+++ b/packages/sdp-kamino/CLAUDE.md
@@ -1,0 +1,132 @@
+# @sdp/kamino — agent notes
+
+Kit-native deposit/withdraw **instruction building** for Kamino K-Vaults, plus
+the live position read. It builds unsigned plans and reads chain state; it never
+signs, never submits, never touches a database, and holds no credential —
+Kamino's data surface is public. Signing and submission belong to the API, which
+owns custody and the Kora fee-payment path.
+
+Read `packages/sdp-earn/CLAUDE.md` for the catalogue side (what a K-Vault row IS)
+and ADR 0002 for the pluggability invariants. Kamino's own docs are agent-readable
+and authoritative — start at <https://kamino.com/docs/skill.md>; every page is
+fetchable as raw markdown by appending `.md`. **Do not answer Kamino questions
+from memory**: this integration has already cost one durable wrong premise (see
+"mainnet only" in `@sdp/earn`).
+
+## The trap this package exists to contain
+
+`new KaminoVault(rpc, addr, state, programId)` applies `programId` to **account
+reads only**. Its constructor then builds its own `KaminoVaultClient` *without
+forwarding it*, and instruction building goes through that client — which
+defaults to **mainnet**. On devnet the result is a vault that reads `devkRng…`
+state and emits instructions addressed to `KvauGM…`, with no error at any layer.
+
+**Kamino's own published recipe uses that constructor**, so this is the default
+outcome for anyone following the docs. Measured 2026-08-15; it is not theoretical.
+
+Three layers hold the line, and none is redundant:
+
+1. `bindVault` (sdk.ts) is the ONLY place a vault is constructed, and it uses
+   `KaminoVault.loadWithClientAndState(client, addr, state)` — the one factory
+   that sets `vault.programId` **and** `vault.client` together.
+2. `assertPlanTargetsCluster` re-checks the **output** against a per-cluster
+   program allowlist. Layer 1 is a convention inside one function; only layer 2
+   is a property of what we actually emit, and only it survives an SDK upgrade
+   that reshuffles construction.
+3. `sdk-construction.test.ts` greps this package's own source, because both of
+   the above are invisible to the type checker.
+
+## The kit-version firewall
+
+klend-sdk is built against `@solana/kit` **^2.3.0**; this repo pins **6.8.0**, and
+both copies live in the tree (pnpm nests the SDK's own). Verified by a live round
+trip: instructions come back as plain objects with a numeric `AccountRole` and
+`Uint8Array` data, so kit 6.8 compiles and signs them unchanged — the boundary is
+real at the TYPE level and inert at RUNTIME.
+
+`src/sdk.ts` is the only module that may import `@kamino-finance/klend-sdk` or
+`decimal.js`. Everything crossing this package's surface is `@solana/kit` 6.8,
+`@sdp/types`, or a **decimal string**. A `Decimal` escaping would also drag in the
+instance-identity hazard: klend-sdk compares with `instanceof Decimal`, so two
+physical copies degrade to NaN rather than to a type error — which is why the root
+`package.json` pins `decimal.js` via `pnpm.overrides`.
+
+## Constants that are MEASUREMENTS, not protocol facts
+
+All in `@sdp/types/kamino-programs` (there, not here, because `@sdp/earn` needs the
+devnet kvault id too and an edge between the two packages would be a workspace
+cycle *and* would drag a 13MB SDK into the hourly catalogue cron).
+
+- **`KAMINO_SLOT_DURATION_MS`** — required by `KaminoVaultClient` and with no safe
+  default. It scales every accrual the SDK computes (exchange rate, APY, farm
+  rewards), so a wrong value yields plausible WRONG NUMBERS with no error — the
+  same silent class as the program trap, and one no instruction assertion catches.
+  Measured 2026-08-15 over a 4,000-slot span: **mainnet ≈ 416 ms, devnet ≈ 265 ms**.
+  Both differ from klend-sdk's own default of 450. Re-measure rather than adjust
+  by feel.
+- **`KAMINO_KVAULT_PROGRAM_IDS`** — the one address that DIFFERS per cluster.
+  Mainnet's id also exists on devnet with zero accounts, so aiming at the wrong one
+  yields a confident empty result rather than an error.
+- **klend and farms are the SAME id on both clusters** — verified deployed and
+  executable on each, explicitly, because a farms id that differed per cluster
+  would fail exactly the way kvault does. Both are still expressed as per-cluster
+  records so a future divergence is a data change here, not a hunt through callers.
+
+## `payer` is NOT the transaction fee payer
+
+klend-sdk's `payer?: TransactionSigner` is the **rent payer for created ATAs**,
+embedded in the instruction accounts as writable+signer. SDP's Kora path is
+different machinery: it sets the fee payer at compile time and signs post-compile
+via `signAsFeePayer(bytes)`. Naming a sponsor signer as `payer` would quietly bill
+it for share-ATA rent — a spend its `FeePayerPolicy` may refuse and which
+`sponsorship-budget.service.ts` does not account for. The field is `rentPayer`
+here for exactly that reason, and it defaults to the owner.
+
+## Plans are transaction-sized BATCHES
+
+`KaminoInstructionPlan.instructions` is `Instruction[][]`, one entry per
+transaction — not a flat list. A multi-reserve exit emits several withdraw
+instructions each carrying the vault's full reserve remaining-accounts list, and
+can exceed Solana's 1232-byte packet; Kamino publishes a per-vault lookup table
+(`SyncVaultLUTIxs`) precisely for this. Handing back a flat list would make the
+caller discover that at `compileTransaction`, far from the code that could fix it.
+
+The unstake → withdraw → post sequence stays in ONE batch deliberately: it must
+land atomically, since unstaking without the withdraw leaves the position in a
+state nobody asked for. If that stops fitting, the fix is the lookup table, not
+splitting the batch.
+
+## Known gaps (deliberate, and owed to the caller)
+
+- **Withdrawal penalties are not quoted.** Kamino charges
+  `max(bps × gross, flat)` **per withdraw instruction**, so a multi-reserve exit
+  can pay N × flat. The SDK exposes `getVaultWithdrawPenalties` /
+  `ShareExitLiquidityPlan`; until one is wired, this package returns no estimate
+  rather than a derived one. A wrong number here is worse than none — same rule as
+  the dashboard's "missing renders —, never a fabricated rate".
+- **`minSharesOut` is optional and unset by default.** Computing a real floor needs
+  the live exchange rate. Passing `"0"` would be the appearance of slippage
+  protection without the substance, so the caller computes a floor or passes
+  nothing.
+- **`lookupTables` is always empty today.** The field exists so callers compile
+  against the right shape; populating it from Kamino's per-vault LUT is the fix
+  when a plan stops fitting.
+
+## Tests
+
+`vitest run`, and **offline by default** — the repo rule is that package tests
+touch no network.
+
+`sdk.smoke.test.ts` is the exception: env-gated (`KAMINO_SMOKE_RPC_URL` +
+`KAMINO_SMOKE_SIGNER`), skipped when unset, so CI never runs it. Run it against a
+surfpool surfnet forking mainnet — real kvault program, real vault, no mainnet
+money at risk:
+
+```bash
+KAMINO_SMOKE_RPC_URL=http://127.0.0.1:8899 KAMINO_SMOKE_SIGNER=<64 hex chars> pnpm --filter @sdp/kamino test
+```
+
+Fund the signer first with SOL and the vault's deposit token via surfpool's
+`surfnet_setAccount` / `surfnet_setTokenAccount` cheatcodes. It proves what the
+offline tests cannot: that the emitted instructions simulate, land, and mint
+shares the position read then reports.

--- a/packages/sdp-kamino/CLAUDE.md
+++ b/packages/sdp-kamino/CLAUDE.md
@@ -96,6 +96,17 @@ land atomically, since unstaking without the withdraw leaves the position in a
 state nobody asked for. If that stops fitting, the fix is the lookup table, not
 splitting the batch.
 
+**`buildKaminoWithdrawPlan` does NOT yet honour this contract**, and that is why
+the WITHDRAW CAPABILITY IS WITHHELD. It flattens every instruction into one
+batch and returns no lookup table, while the pinned SDK documents that a
+multi-reserve exit "might have to be split in multiple transactions".
+`KaminoVaultDirectClient` therefore does not implement `buildVaultWithdrawal`,
+`supportsVaultWithdraw` answers false, and the builder is not re-exported from
+`index.ts` — its only callers are this package's smoke tests. Nothing is
+fund-trapped by that: the shares sit in the org's own custody wallet and
+Kamino's UI can redeem them. Implementing the method is the LAST step of the
+batching work, not the first (`client.test.ts` pins this).
+
 ## Known gaps (deliberate, and owed to the caller)
 
 - **Withdrawal penalties are not quoted.** Kamino charges
@@ -107,7 +118,33 @@ splitting the batch.
 - **`minSharesOut` is optional and unset by default.** Computing a real floor needs
   the live exchange rate. Passing `"0"` would be the appearance of slippage
   protection without the substance, so the caller computes a floor or passes
-  nothing.
+  nothing. The API requires one in PRODUCTION for exactly that reason.
+
+## Amounts are checked against the MINT, not just parsed
+
+`amounts.ts` (deliberately outside the SDK firewall, so it is unit-testable
+without loading klend-sdk) refuses any value finer than its mint can represent,
+and returns the canonical form the instruction actually encodes — surfaced as
+`KaminoInstructionPlan.accepted`, which is what the ledger should persist.
+
+This exists because klend-sdk converts every `Decimal` to mint atoms and
+**floors, silently**. Two different bugs hide under that floor: `1.0000009` on a
+six-decimal mint is RECORDED as 1.0000009 while 1.000000 moves, and a
+`minSharesOut` below one atom becomes `0` — a slippage floor that reads as
+protection everywhere and imposes none on chain. Validating the scale rather
+than clamping is the point: clamping would make SDP quietly move a different
+amount than it was asked for.
+
+## Share balances are read in base units, never `uiAmount`
+
+`readKaminoPosition` computes UNSTAKED shares itself, from
+`tokenAmount.amount` (the exact integer string), and takes only the STAKED half
+from `vault.getUserShares`. The SDK's own path sums
+`parsed.info.tokenAmount.uiAmount` — a JSON **number** — via
+`getTokenAccountAmount` (`utils/ata.ts`), so above 2^53 base units the value has
+already lost precision and no amount of `Decimal`-wrapping downstream recovers
+it. The staked half comes from farm state as an exact `Decimal`, so it is safe
+to reuse.
 - **`lookupTables` is always empty today.** The field exists so callers compile
   against the right shape; populating it from Kamino's per-vault LUT is the fix
   when a plan stops fitting.

--- a/packages/sdp-kamino/package.json
+++ b/packages/sdp-kamino/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@sdp/kamino",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./programs": {
+      "types": "./src/programs.ts",
+      "import": "./src/programs.ts",
+      "default": "./src/programs.ts"
+    },
+    "./types": {
+      "types": "./src/types.ts",
+      "import": "./src/types.ts",
+      "default": "./src/types.ts"
+    },
+    "./errors": {
+      "types": "./src/errors.ts",
+      "import": "./src/errors.ts",
+      "default": "./src/errors.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@kamino-finance/klend-sdk": "10.0.0",
+    "@sdp/earn": "workspace:*",
+    "@sdp/solana": "workspace:*",
+    "@sdp/types": "workspace:*",
+    "@solana/kit": "catalog:",
+    "decimal.js": "10.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.2",
+    "tsx": "4.23.5",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/sdp-kamino/src/amounts.test.ts
+++ b/packages/sdp-kamino/src/amounts.test.ts
@@ -9,6 +9,11 @@ describe("acceptAtMintScale", () => {
     // Trailing zeros are noise, not precision — "1.500" and "1.5" are the same
     // number of atoms, and the ledger should hold one spelling.
     expect(acceptAtMintScale("amount", "1.500000", 6)).toBe("1.5");
+    // The spelling may have more places than the mint when every extra place
+    // is zero. Precision is determined after insignificant zeros are removed.
+    expect(acceptAtMintScale("amount", "1.5000000", 6)).toBe("1.5");
+    expect(acceptAtMintScale("amount", "0.0000010", 6)).toBe("0.000001");
+    expect(acceptAtMintScale("amount", "1.000000000000", 6)).toBe("1");
     expect(acceptAtMintScale("amount", "  20  ", 6)).toBe("20");
     expect(acceptAtMintScale("amount", "0.000001", 6)).toBe("0.000001");
   });
@@ -25,6 +30,8 @@ describe("acceptAtMintScale", () => {
     expect(() => acceptAtMintScale("amount", "1.0000009", 6)).toThrow(/more precision/);
     // One decimal past the boundary is still past it.
     expect(() => acceptAtMintScale("amount", "0.0000001", 6)).toThrow(SdpKaminoError);
+    // A trailing zero does not erase the preceding non-zero sub-atom.
+    expect(() => acceptAtMintScale("amount", "0.00000010", 6)).toThrow(SdpKaminoError);
   });
 
   /**
@@ -55,6 +62,7 @@ describe("acceptAtMintScale", () => {
 
   it("handles a zero-decimal mint", () => {
     expect(acceptAtMintScale("amount", "7", 0)).toBe("7");
+    expect(acceptAtMintScale("amount", "7.000", 0)).toBe("7");
     expect(() => acceptAtMintScale("amount", "7.5", 0)).toThrow(/more precision/);
   });
 

--- a/packages/sdp-kamino/src/amounts.test.ts
+++ b/packages/sdp-kamino/src/amounts.test.ts
@@ -1,0 +1,108 @@
+import { formatDecimalAmount } from "@sdp/solana/amount";
+import { describe, expect, it } from "vitest";
+import { acceptAtMintScale, isZeroAmount, mintDecimals } from "./amounts";
+import { SdpKaminoError } from "./errors";
+
+describe("acceptAtMintScale", () => {
+  it("accepts a value the mint can represent exactly and canonicalises it", () => {
+    expect(acceptAtMintScale("amount", "1.5", 6)).toBe("1.5");
+    // Trailing zeros are noise, not precision — "1.500" and "1.5" are the same
+    // number of atoms, and the ledger should hold one spelling.
+    expect(acceptAtMintScale("amount", "1.500000", 6)).toBe("1.5");
+    expect(acceptAtMintScale("amount", "  20  ", 6)).toBe("20");
+    expect(acceptAtMintScale("amount", "0.000001", 6)).toBe("0.000001");
+  });
+
+  /**
+   * THE BUG THIS MODULE EXISTS FOR.
+   *
+   * klend-sdk floors to mint atoms, so `1.0000009` on a six-decimal mint would
+   * be recorded as 1.0000009 while 1.000000 actually moves. Refusing keeps the
+   * recorded number and the encoded number equal.
+   */
+  it("refuses a value finer than the mint's atom", () => {
+    expect(() => acceptAtMintScale("amount", "1.0000009", 6)).toThrow(SdpKaminoError);
+    expect(() => acceptAtMintScale("amount", "1.0000009", 6)).toThrow(/more precision/);
+    // One decimal past the boundary is still past it.
+    expect(() => acceptAtMintScale("amount", "0.0000001", 6)).toThrow(SdpKaminoError);
+  });
+
+  /**
+   * The sharper half: a sub-atom `minSharesOut` floors to zero, so a request
+   * that LOOKS protected gets no on-chain floor at all.
+   */
+  it("refuses a sub-atom slippage floor rather than letting it become zero", () => {
+    expect(() => acceptAtMintScale("minSharesOut", "0.0000000001", 6)).toThrow(
+      /more precision than its mint supports/
+    );
+  });
+
+  it("carries the error code the API maps to a 400", () => {
+    try {
+      acceptAtMintScale("amount", "1.0000009", 6);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SdpKaminoError);
+      expect((error as SdpKaminoError).code).toBe("INVALID_AMOUNT");
+    }
+  });
+
+  it("rejects non-decimal, signed and exponential input before scale is considered", () => {
+    for (const bad of ["-1", "1e5", "Infinity", "", "abc", "1.2.3"]) {
+      expect(() => acceptAtMintScale("amount", bad, 6), bad).toThrow(SdpKaminoError);
+    }
+  });
+
+  it("handles a zero-decimal mint", () => {
+    expect(acceptAtMintScale("amount", "7", 0)).toBe("7");
+    expect(() => acceptAtMintScale("amount", "7.5", 0)).toThrow(/more precision/);
+  });
+
+  /**
+   * The precision floor the reviewer asked to be tested: a share balance above
+   * 2^53 base units is exactly where `uiAmount`'s JSON number loses value.
+   * These helpers are `bigint` end to end, so the round trip is lossless.
+   */
+  it("survives a raw balance above 2^53 base units", () => {
+    const base = 9_007_199_254_740_993n; // Number.MAX_SAFE_INTEGER + 2
+    const asDecimal = formatDecimalAmount(base, 6);
+    expect(asDecimal).toBe("9007199254.740993");
+    // Round-tripping through the accept path must not perturb the last digit.
+    expect(acceptAtMintScale("shares", asDecimal, 6)).toBe("9007199254.740993");
+
+    // For contrast, the cost of the route this replaced. `getUserShares` sums
+    // `tokenAmount.uiAmount`, a JSON number; once the raw balance passes 2^53
+    // the base units are no longer representable, and the lost digit cannot be
+    // recovered by wrapping the result in `Decimal` afterwards.
+    expect(Number.isSafeInteger(Number(base))).toBe(false);
+    expect(BigInt(Number(base))).toBe(9_007_199_254_740_992n);
+  });
+});
+
+describe("isZeroAmount", () => {
+  it("recognises canonical zero and nothing else", () => {
+    expect(isZeroAmount(acceptAtMintScale("amount", "0", 6))).toBe(true);
+    expect(isZeroAmount(acceptAtMintScale("amount", "0.000000", 6))).toBe(true);
+    expect(isZeroAmount(acceptAtMintScale("amount", "0.000001", 6))).toBe(false);
+  });
+});
+
+describe("mintDecimals", () => {
+  it("normalises the shapes klend-sdk hands back", () => {
+    expect(mintDecimals(6, "tokenMintDecimals")).toBe(6);
+    expect(mintDecimals("6", "tokenMintDecimals")).toBe(6);
+    // A BN-like object stringifies to its digits; `Number(bn)` would be NaN.
+    expect(mintDecimals({ toString: () => "9" }, "tokenMintDecimals")).toBe(9);
+  });
+
+  /**
+   * Fails loudly rather than defaulting. A silent fallback would make every
+   * scale comparison above compare against the wrong mint — the check would
+   * still run and would still pass, which is the worst of both worlds.
+   */
+  it("throws on a value it cannot trust", () => {
+    for (const bad of [undefined, null, Number.NaN, -1, 1.5, 99, "abc"]) {
+      expect(() => mintDecimals(bad, "sharesMintDecimals"), String(bad)).toThrow(/unusable/);
+    }
+  });
+});

--- a/packages/sdp-kamino/src/amounts.ts
+++ b/packages/sdp-kamino/src/amounts.ts
@@ -64,12 +64,29 @@ export function acceptAtMintScale(field: string, value: string, decimals: number
   // digits and at most one dot, so "-1", "1e5" and "Infinity" are all rejected
   // here rather than needing a separate numeric parse.
   if (!isDecimalString(normalized)) throw invalidAmount(field, value);
-  if (decimalScale(normalized) > decimals) throw amountTooPrecise(field, value, decimals);
+  // Scale is a property of the VALUE, not its spelling. Zeros after the last
+  // non-zero fractional digit do not require mint atoms: `1.5000000` is exactly
+  // representable by a six-decimal mint even though its input text has seven
+  // places. Strip only those insignificant zeros; a non-zero sub-atom remains
+  // and is still rejected below (`1.0000001` stays seven-place precision).
+  const canonicalScaleInput = trimInsignificantFractionalZeroes(normalized);
+  if (decimalScale(canonicalScaleInput) > decimals) {
+    throw amountTooPrecise(field, value, decimals);
+  }
   // Re-serialised through the repo's fixed-point helpers so what leaves this
   // package is scaled exactly like every other amount in SDP ("1.500" -> "1.5").
   // Safe by construction: the scale check above is precisely
   // `parseDecimalAmount`'s own precondition, so it cannot throw here.
-  return formatDecimalAmount(parseDecimalAmount(normalized, decimals), decimals);
+  return formatDecimalAmount(parseDecimalAmount(canonicalScaleInput, decimals), decimals);
+}
+
+function trimInsignificantFractionalZeroes(value: string): string {
+  const dot = value.indexOf(".");
+  if (dot === -1) return value;
+
+  const whole = value.slice(0, dot);
+  const fraction = value.slice(dot + 1).replace(/0+$/, "");
+  return fraction === "" ? whole : `${whole}.${fraction}`;
 }
 
 /**

--- a/packages/sdp-kamino/src/amounts.ts
+++ b/packages/sdp-kamino/src/amounts.ts
@@ -1,0 +1,84 @@
+import {
+  decimalScale,
+  formatDecimalAmount,
+  isDecimalString,
+  parseDecimalAmount,
+} from "@sdp/solana/amount";
+import { amountTooPrecise, invalidAmount } from "./errors";
+
+/**
+ * Amount validation at the MINT's precision.
+ *
+ * A separate module from `./sdk.ts` for one reason: none of this needs
+ * klend-sdk or `decimal.js`, so keeping it out of the firewall module makes it
+ * unit-testable without loading a 13MB chain SDK. `@sdp/solana/amount` is the
+ * repo's fixed-point arithmetic and is exact — `bigint` base units throughout,
+ * never a float.
+ */
+
+/**
+ * Read a mint's decimals off vault state.
+ *
+ * The field arrives as a klend-sdk `BN`, a `Decimal`, or a number depending on
+ * the codec, so it is normalised through `String` before `Number`: `Number(BN)`
+ * is `NaN`, and a NaN scale would silently DISABLE the check below rather than
+ * fail it — the check would compare against NaN and always pass. Failing loudly
+ * on an unreadable value is the only safe direction for something whose whole
+ * job is to bound a money amount.
+ */
+export function mintDecimals(value: unknown, label: string): number {
+  const raw = String(value ?? "").trim();
+  // Matched as DIGITS rather than parsed with `Number`, because `Number("")` is
+  // 0 — so a missing field would otherwise arrive as a perfectly plausible
+  // "zero-decimal mint" and disable every scale check downstream.
+  const parsed = /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  if (!Number.isInteger(parsed) || parsed > 18) {
+    throw new Error(`Kamino vault state carried an unusable ${label} (${String(value)})`);
+  }
+  return parsed;
+}
+
+/**
+ * Refuse an amount finer than its mint can represent, and return the canonical
+ * form of what will actually be encoded.
+ *
+ * klend-sdk converts every `Decimal` to mint atoms and FLOORS, silently. Two
+ * distinct bugs hide under that floor, neither visible at the call site:
+ *
+ * - A deposit of `1.0000009` against a six-decimal mint is RECORDED as
+ *   1.0000009 while only 1.000000 moves. The ledger and the chain disagree, and
+ *   the ledger is the thing a customer is later shown.
+ * - A `minSharesOut` below one atom floors to `0`. That is a slippage floor
+ *   which reads as protection in the request, in the ledger and in the UI, and
+ *   imposes none on chain — strictly worse than sending no floor at all,
+ *   because it also suppresses anyone's suspicion that protection is missing.
+ *
+ * Validating the SCALE rather than clamping the value is deliberate: clamping
+ * would make SDP quietly move a different amount than it was asked for, which
+ * is the same class of bug wearing a friendlier costume. The caller gets a
+ * refusal it can surface, and the number it asked for is the number that moves.
+ */
+export function acceptAtMintScale(field: string, value: string, decimals: number): string {
+  const normalized = value.trim();
+  // `isDecimalString` is the syntax gate and also the SIGN gate: it accepts
+  // digits and at most one dot, so "-1", "1e5" and "Infinity" are all rejected
+  // here rather than needing a separate numeric parse.
+  if (!isDecimalString(normalized)) throw invalidAmount(field, value);
+  if (decimalScale(normalized) > decimals) throw amountTooPrecise(field, value, decimals);
+  // Re-serialised through the repo's fixed-point helpers so what leaves this
+  // package is scaled exactly like every other amount in SDP ("1.500" -> "1.5").
+  // Safe by construction: the scale check above is precisely
+  // `parseDecimalAmount`'s own precondition, so it cannot throw here.
+  return formatDecimalAmount(parseDecimalAmount(normalized, decimals), decimals);
+}
+
+/**
+ * True when a canonical amount is exactly zero.
+ *
+ * Only sound on the OUTPUT of `acceptAtMintScale`: that function collapses every
+ * spelling of nothing ("0", "0.00", "0.000000") to the single string "0", so a
+ * string compare is exact here and would not be on a raw caller value.
+ */
+export function isZeroAmount(canonical: string): boolean {
+  return canonical === "0";
+}

--- a/packages/sdp-kamino/src/asset-identity.test.ts
+++ b/packages/sdp-kamino/src/asset-identity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { vaultAssetIdentityFromState } from "./asset-identity";
+import { SdpKaminoError } from "./errors";
+
+const DEPOSIT_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
+
+describe("vaultAssetIdentityFromState", () => {
+  it("returns the token and share mints observed in live vault state", () => {
+    expect(
+      vaultAssetIdentityFromState({
+        tokenMint: DEPOSIT_TOKEN_MINT,
+        sharesMint: SHARE_MINT,
+      })
+    ).toEqual({
+      depositTokenMint: DEPOSIT_TOKEN_MINT,
+      shareMint: SHARE_MINT,
+    });
+  });
+
+  it("fails closed when either state mint is missing or malformed", () => {
+    for (const state of [
+      { sharesMint: SHARE_MINT },
+      { tokenMint: DEPOSIT_TOKEN_MINT },
+      { tokenMint: "not-a-mint", sharesMint: SHARE_MINT },
+      { tokenMint: DEPOSIT_TOKEN_MINT, sharesMint: "not-a-mint" },
+    ]) {
+      expect(() => vaultAssetIdentityFromState(state)).toThrow(SdpKaminoError);
+    }
+  });
+});

--- a/packages/sdp-kamino/src/asset-identity.ts
+++ b/packages/sdp-kamino/src/asset-identity.ts
@@ -1,0 +1,30 @@
+import { address } from "@solana/kit";
+import { SdpKaminoError } from "./errors";
+import type { KaminoVaultAssetIdentity } from "./types";
+
+type KaminoVaultMintState = {
+  tokenMint?: unknown;
+  sharesMint?: unknown;
+};
+
+/** Read and validate the asset mints from the live state used by the builder. */
+export function vaultAssetIdentityFromState(state: unknown): KaminoVaultAssetIdentity {
+  const mintState = state as KaminoVaultMintState | null;
+  return {
+    depositTokenMint: requiredMintAddress("tokenMint", mintState?.tokenMint),
+    shareMint: requiredMintAddress("sharesMint", mintState?.sharesMint),
+  };
+}
+
+function requiredMintAddress(field: string, value: unknown) {
+  const raw = typeof value === "string" ? value.trim() : "";
+  try {
+    return address(raw);
+  } catch (cause) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino vault state did not contain a valid ${field}`,
+      { cause }
+    );
+  }
+}

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -3,8 +3,34 @@ import {
   supportsVaultDirect,
   supportsVaultWithdraw,
 } from "@sdp/earn/capabilities";
-import { describe, expect, it } from "vitest";
-import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "./client";
+import { type Address, address } from "@solana/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertNotPortfolioProvider,
+  KAMINO_POSITION_READ_CONCURRENCY,
+  KaminoVaultDirectClient,
+  toEarnVaultTransactionPlan,
+} from "./client";
+import type { KaminoInstructionPlan, KaminoPosition, KaminoRuntime } from "./types";
+
+const DEPOSIT_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
+
+const mocks = vi.hoisted(() => ({
+  buildKaminoDepositPlan: vi.fn(),
+  createKaminoRpc: vi.fn(),
+  readKaminoPosition: vi.fn(),
+}));
+
+vi.mock("./rpc", () => ({ createKaminoRpc: mocks.createKaminoRpc }));
+vi.mock("./sdk", () => ({
+  buildKaminoDepositPlan: mocks.buildKaminoDepositPlan,
+  readKaminoPosition: mocks.readKaminoPosition,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 const client = new KaminoVaultDirectClient(() => "https://example.invalid");
 
@@ -87,5 +113,90 @@ describe("KaminoVaultDirectClient capabilities", () => {
     // sandbox -> devnet, production -> mainnet-beta, via CLUSTER_BY_SDP_ENVIRONMENT
     // rather than a second copy of that mapping.
     expect(seen).toEqual(["devnet", "mainnet-beta"]);
+  });
+
+  it("reads vaults with bounded concurrency against one shared slot", async () => {
+    const slot = 123n;
+    const getSlotSend = vi.fn().mockResolvedValue(slot);
+    mocks.createKaminoRpc.mockReturnValue({ getSlot: () => ({ send: getSlotSend }) });
+
+    let active = 0;
+    let maxActive = 0;
+    const releases: Array<() => void> = [];
+    mocks.readKaminoPosition.mockImplementation(
+      async (
+        runtime: KaminoRuntime,
+        input: { vault: Address; owner: Address; slot: bigint }
+      ): Promise<KaminoPosition> => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        active -= 1;
+        return {
+          vault: input.vault,
+          owner: input.owner,
+          cluster: runtime.cluster,
+          shares: "1",
+          tokenMint: input.vault,
+          sharesMint: input.vault,
+        };
+      }
+    );
+
+    const vault = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
+    const providerReferences = Array.from({ length: 9 }, () => vault);
+    const pending = client.readVaultPositions(
+      { env: {}, environment: "sandbox" },
+      {
+        owner: "11111111111111111111111111111112",
+        providerReferences,
+      }
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(KAMINO_POSITION_READ_CONCURRENCY)
+    );
+    for (const release of releases.splice(0)) release();
+
+    await vi.waitFor(() =>
+      expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(KAMINO_POSITION_READ_CONCURRENCY * 2)
+    );
+    for (const release of releases.splice(0)) release();
+
+    await vi.waitFor(() => expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(9));
+    for (const release of releases.splice(0)) release();
+
+    await expect(pending).resolves.toHaveLength(9);
+    expect(maxActive).toBe(KAMINO_POSITION_READ_CONCURRENCY);
+    expect(getSlotSend).toHaveBeenCalledOnce();
+    expect(mocks.readKaminoPosition.mock.calls.every(([, input]) => input.slot === slot)).toBe(
+      true
+    );
+  });
+});
+
+describe("toEarnVaultTransactionPlan", () => {
+  it("preserves the mint-scale amounts encoded by the SDK plan", () => {
+    const plan: KaminoInstructionPlan = {
+      cluster: "devnet",
+      instructions: [],
+      lookupTables: [],
+      assetIdentity: {
+        depositTokenMint: address(DEPOSIT_TOKEN_MINT),
+        shareMint: address(SHARE_MINT),
+      },
+      accepted: { amount: "1.5", minSharesOut: "1.49" },
+    };
+
+    expect(toEarnVaultTransactionPlan(plan)).toMatchObject({
+      cluster: "devnet",
+      transactions: [],
+      lookupTables: [],
+      assetIdentity: {
+        depositTokenMint: DEPOSIT_TOKEN_MINT,
+        shareMint: SHARE_MINT,
+      },
+      accepted: { amount: "1.5", minSharesOut: "1.49" },
+    });
   });
 });

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -1,0 +1,70 @@
+import { supportsPortfolioWallets, supportsVaultDirect } from "@sdp/earn/capabilities";
+import { describe, expect, it } from "vitest";
+import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "./client";
+
+const client = new KaminoVaultDirectClient(() => "https://example.invalid");
+
+describe("KaminoVaultDirectClient capabilities", () => {
+  it("reports the vault-direct capability", () => {
+    expect(supportsVaultDirect(client)).toBe(true);
+  });
+
+  /**
+   * THE INVARIANT THAT PROTECTS CUSTOMER FUNDS.
+   *
+   * The portfolio capability means "SDP can give you an address to send
+   * stablecoins to". Kamino has no such address — its vault is a program
+   * account, and tokens sent there are DESTROYED. If this client ever answered
+   * yes to both, a portfolio route could render that account as a deposit
+   * target. The two capabilities must stay mutually exclusive.
+   */
+  it("NEVER reports the portfolio-wallet capability", () => {
+    expect(supportsPortfolioWallets(client)).toBe(false);
+    expect(() => assertNotPortfolioProvider(client)).not.toThrow();
+  });
+
+  it("still catalogues — the execution client is a superset, not a replacement", () => {
+    expect(client.provider).toBe("kamino");
+    expect(client.declaredSupport.sourceKinds).toEqual(["defi"]);
+    expect(typeof client.listStrategies).toBe("function");
+  });
+
+  it("refuses to build when no RPC endpoint is configured for the cluster", async () => {
+    const unconfigured = new KaminoVaultDirectClient(() => "  ");
+    await expect(
+      unconfigured.buildVaultDeposit(
+        { env: {}, environment: "sandbox" },
+        {
+          providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+          owner: "11111111111111111111111111111112",
+          amount: "1",
+        }
+      )
+      // Fails before any network call, the same fail-closed rule @sdp/earn
+      // applies to a missing credential.
+    ).rejects.toThrow(/No Solana RPC endpoint configured for devnet/);
+  });
+
+  it("maps the SDP environment to the right cluster", async () => {
+    const seen: string[] = [];
+    const probe = new KaminoVaultDirectClient((cluster) => {
+      seen.push(cluster);
+      return "";
+    });
+    for (const environment of ["sandbox", "production"] as const) {
+      await probe
+        .buildVaultDeposit(
+          { env: {}, environment },
+          {
+            providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+            owner: "11111111111111111111111111111112",
+            amount: "1",
+          }
+        )
+        .catch(() => undefined);
+    }
+    // sandbox -> devnet, production -> mainnet-beta, via CLUSTER_BY_SDP_ENVIRONMENT
+    // rather than a second copy of that mapping.
+    expect(seen).toEqual(["devnet", "mainnet-beta"]);
+  });
+});

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -1,4 +1,8 @@
-import { supportsPortfolioWallets, supportsVaultDirect } from "@sdp/earn/capabilities";
+import {
+  supportsPortfolioWallets,
+  supportsVaultDirect,
+  supportsVaultWithdraw,
+} from "@sdp/earn/capabilities";
 import { describe, expect, it } from "vitest";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "./client";
 
@@ -7,6 +11,23 @@ const client = new KaminoVaultDirectClient(() => "https://example.invalid");
 describe("KaminoVaultDirectClient capabilities", () => {
   it("reports the vault-direct capability", () => {
     expect(supportsVaultDirect(client)).toBe(true);
+  });
+
+  /**
+   * The withdraw capability is WITHHELD on purpose, and this pins it so that
+   * implementing `buildVaultWithdrawal` cannot happen by accident.
+   *
+   * `buildKaminoWithdrawPlan` returns every unstake/withdraw/cleanup
+   * instruction in ONE batch with no lookup table, while the pinned SDK
+   * documents that a multi-reserve exit may need several transactions.
+   * Answering yes here would let a future exit route narrow onto this client
+   * and receive a plan the API submitter refuses — after the customer was told
+   * their withdrawal was prepared. Deleting this test is the wrong way to make
+   * it pass; batching the plan is the right way.
+   */
+  it("does NOT report the withdraw capability until the plan is batched", () => {
+    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect((client as unknown as Record<string, unknown>).buildVaultWithdrawal).toBeUndefined();
   });
 
   /**

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -1,0 +1,174 @@
+import { supportsPortfolioWallets } from "@sdp/earn/capabilities";
+import { KaminoEarnClient } from "@sdp/earn/providers/kamino/client";
+import type {
+  EarnRuntimeContext,
+  EarnVaultDepositInput,
+  EarnVaultDirectProvider,
+  EarnVaultInstruction,
+  EarnVaultPositionInput,
+  EarnVaultPositionSnapshot,
+  EarnVaultTransactionPlan,
+  EarnVaultWithdrawInput,
+} from "@sdp/earn/types";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
+import { type Address, address, createNoopSigner, createSolanaRpc } from "@solana/kit";
+import { SdpKaminoError } from "./errors";
+import { buildKaminoDepositPlan, buildKaminoWithdrawPlan, readKaminoPosition } from "./sdk";
+import type { KaminoInstructionPlan, KaminoRuntime } from "./types";
+
+/**
+ * Kamino as an EXECUTING provider: the catalogue client plus the vault-direct
+ * capability.
+ *
+ * Lives here rather than in `@sdp/earn` so that package keeps its single
+ * `@sdp/types` dependency — its hourly catalogue cron runs in both environments
+ * and must never load klend-sdk. The arrow points inward: `@sdp/kamino` depends
+ * on `@sdp/earn`, never the reverse.
+ *
+ * Registered by the API's execution registry, which prefers this class over the
+ * catalogue-only `KaminoEarnClient` when a route needs to move money. Callers
+ * still discover the capability with `supportsVaultDirect`, never a provider-id
+ * check.
+ */
+export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVaultDirectProvider {
+  /**
+   * Where the RPC endpoint comes from.
+   *
+   * Injected rather than read from `ctx.env.SOLANA_RPC_URL` directly, because
+   * that variable is PROCESS-level while the cluster is PER-REQUEST: syncing the
+   * sandbox environment inside a production deployment reaches this code with a
+   * MAINNET url. The API resolves the right endpoint for the cluster it is
+   * serving and hands it in; `listKaminoDevnetVaults` guards the same hazard
+   * with a genesis-hash check.
+   */
+  constructor(private readonly resolveRpcUrl: (cluster: SolanaCluster) => string) {
+    super();
+  }
+
+  private runtime(ctx: EarnRuntimeContext): KaminoRuntime {
+    const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
+    const rpcUrl = this.resolveRpcUrl(cluster);
+    if (!rpcUrl.trim()) {
+      throw new SdpKaminoError(
+        "VAULT_UNREADABLE",
+        `No Solana RPC endpoint configured for ${cluster}; Kamino cannot build a transaction.`
+      );
+    }
+    return { cluster, rpcUrl };
+  }
+
+  /**
+   * The owner arrives as an ADDRESS, not a signer — custody lives in the API and
+   * a private key must never reach a provider client. klend-sdk needs a signer
+   * shaped object to place the account correctly, so a noop signer stands in: it
+   * contributes the right address and role and signs nothing. The API attaches
+   * the real custody signer at compile time, where kit matches by address.
+   */
+  private owner(value: string) {
+    return createNoopSigner(address(value));
+  }
+
+  private static toWire(plan: KaminoInstructionPlan): EarnVaultTransactionPlan {
+    return {
+      cluster: plan.cluster,
+      transactions: plan.instructions.map((batch) =>
+        batch.map(
+          (instruction): EarnVaultInstruction => ({
+            programAddress: String(instruction.programAddress),
+            accounts: (instruction.accounts ?? []).map((account) => ({
+              address: String(account.address),
+              role: Number(account.role),
+            })),
+            // Base64 keeps the contract JSON-safe: a plan may cross a queue or a
+            // log before it is compiled, and a Uint8Array does not survive that.
+            data: Buffer.from(instruction.data ?? new Uint8Array()).toString("base64"),
+          })
+        )
+      ),
+      lookupTables: plan.lookupTables.map(String),
+    };
+  }
+
+  async buildVaultDeposit(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultDepositInput
+  ): Promise<EarnVaultTransactionPlan> {
+    const plan = await buildKaminoDepositPlan(this.runtime(ctx), {
+      vault: address(input.providerReference),
+      owner: this.owner(input.owner),
+      amount: input.amount,
+      ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
+    });
+    return KaminoVaultDirectClient.toWire(plan);
+  }
+
+  async buildVaultWithdrawal(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultWithdrawInput
+  ): Promise<EarnVaultTransactionPlan> {
+    const runtime = this.runtime(ctx);
+    const slot = await createSolanaRpc(runtime.rpcUrl).getSlot().send();
+    const plan = await buildKaminoWithdrawPlan(runtime, {
+      vault: address(input.providerReference),
+      owner: this.owner(input.owner),
+      shares: input.shares,
+      slot,
+    });
+    return KaminoVaultDirectClient.toWire(plan);
+  }
+
+  /**
+   * Reads every requested vault against ONE slot, so a multi-position page is
+   * priced consistently rather than drifting between reads.
+   *
+   * A vault that fails to read is DROPPED, not defaulted to zero: a zero would
+   * render as "you hold nothing here", which is a claim about someone's money
+   * that a failed RPC call does not support.
+   */
+  async readVaultPositions(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultPositionInput
+  ): Promise<EarnVaultPositionSnapshot[]> {
+    const runtime = this.runtime(ctx);
+    const slot = await createSolanaRpc(runtime.rpcUrl).getSlot().send();
+    const owner: Address = address(input.owner);
+
+    const results = await Promise.allSettled(
+      input.providerReferences.map((reference) =>
+        readKaminoPosition(runtime, { vault: address(reference), owner, slot })
+      )
+    );
+
+    return results.flatMap((result) => {
+      if (result.status !== "fulfilled") return [];
+      const position = result.value;
+      return [
+        {
+          providerReference: String(position.vault),
+          owner: String(position.owner),
+          cluster: position.cluster,
+          shares: position.shares,
+          ...(position.tokenValue === undefined ? {} : { tokenValue: position.tokenValue }),
+          tokenMint: String(position.tokenMint),
+          shareMint: String(position.sharesMint),
+        },
+      ];
+    });
+  }
+}
+
+/**
+ * Guard asserted at construction rather than trusted: the two capabilities
+ * describe opposite money models, and a client answering yes to both would let a
+ * portfolio route hand a customer the vault's own account as a deposit address —
+ * where funds are destroyed. Exported so the API can assert it at registry wiring.
+ */
+export function assertNotPortfolioProvider(client: KaminoVaultDirectClient): void {
+  if (supportsPortfolioWallets(client)) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      "Kamino must never report the portfolio-wallet capability: it custodies nothing, " +
+        "and its vault account is not a fundable address."
+    );
+  }
+}

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -10,10 +10,69 @@ import type {
   EarnVaultTransactionPlan,
 } from "@sdp/earn/types";
 import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
-import { type Address, address, createNoopSigner, createSolanaRpc } from "@solana/kit";
+import { type Address, address, createNoopSigner } from "@solana/kit";
 import { SdpKaminoError } from "./errors";
+import { createKaminoRpc } from "./rpc";
 import { buildKaminoDepositPlan, readKaminoPosition } from "./sdk";
 import type { KaminoInstructionPlan, KaminoRuntime } from "./types";
+
+/** One portfolio request may fan out over many vaults; never fan out the RPCs without a bound. */
+export const KAMINO_POSITION_READ_CONCURRENCY = 4;
+
+async function mapSettledWithConcurrency<T, U>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<U>
+): Promise<Array<PromiseSettledResult<U>>> {
+  const results = new Array<PromiseSettledResult<U>>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        try {
+          results[index] = { status: "fulfilled", value: await mapper(items[index] as T) };
+        } catch (reason) {
+          results[index] = { status: "rejected", reason };
+        }
+      }
+    })
+  );
+
+  return results;
+}
+
+/** Convert the kit-native plan to the dependency-free Earn wire contract. */
+export function toEarnVaultTransactionPlan(plan: KaminoInstructionPlan): EarnVaultTransactionPlan {
+  return {
+    cluster: plan.cluster,
+    transactions: plan.instructions.map((batch) =>
+      batch.map(
+        (instruction): EarnVaultInstruction => ({
+          programAddress: String(instruction.programAddress),
+          accounts: (instruction.accounts ?? []).map((account) => ({
+            address: String(account.address),
+            role: Number(account.role),
+          })),
+          // Base64 keeps the contract JSON-safe: a plan may cross a queue or a
+          // log before it is compiled, and a Uint8Array does not survive that.
+          data: Buffer.from(instruction.data ?? new Uint8Array()).toString("base64"),
+        })
+      )
+    ),
+    lookupTables: plan.lookupTables.map(String),
+    assetIdentity: {
+      depositTokenMint: String(plan.assetIdentity.depositTokenMint),
+      shareMint: String(plan.assetIdentity.shareMint),
+    },
+    // These are the mint-scale amounts the instructions actually encode. The
+    // API ledgers this shape; dropping it reintroduces raw-request drift.
+    accepted: { ...plan.accepted },
+  };
+}
 
 /**
  * Kamino as an EXECUTING provider: the catalogue client plus the vault-direct
@@ -67,27 +126,6 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     return createNoopSigner(address(value));
   }
 
-  private static toWire(plan: KaminoInstructionPlan): EarnVaultTransactionPlan {
-    return {
-      cluster: plan.cluster,
-      transactions: plan.instructions.map((batch) =>
-        batch.map(
-          (instruction): EarnVaultInstruction => ({
-            programAddress: String(instruction.programAddress),
-            accounts: (instruction.accounts ?? []).map((account) => ({
-              address: String(account.address),
-              role: Number(account.role),
-            })),
-            // Base64 keeps the contract JSON-safe: a plan may cross a queue or a
-            // log before it is compiled, and a Uint8Array does not survive that.
-            data: Buffer.from(instruction.data ?? new Uint8Array()).toString("base64"),
-          })
-        )
-      ),
-      lookupTables: plan.lookupTables.map(String),
-    };
-  }
-
   async buildVaultDeposit(
     ctx: EarnRuntimeContext,
     input: EarnVaultDepositInput
@@ -98,7 +136,7 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
       amount: input.amount,
       ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
     });
-    return KaminoVaultDirectClient.toWire(plan);
+    return toEarnVaultTransactionPlan(plan);
   }
 
   /*
@@ -136,13 +174,15 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     input: EarnVaultPositionInput
   ): Promise<EarnVaultPositionSnapshot[]> {
     const runtime = this.runtime(ctx);
-    const slot = await createSolanaRpc(runtime.rpcUrl).getSlot().send();
+    // One shared slot makes the page internally consistent. The client carries
+    // the same transport deadline as every nested Kamino SDK read below.
+    const slot = await createKaminoRpc(runtime.rpcUrl).getSlot().send();
     const owner: Address = address(input.owner);
 
-    const results = await Promise.allSettled(
-      input.providerReferences.map((reference) =>
-        readKaminoPosition(runtime, { vault: address(reference), owner, slot })
-      )
+    const results = await mapSettledWithConcurrency(
+      input.providerReferences,
+      KAMINO_POSITION_READ_CONCURRENCY,
+      (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
     );
 
     return results.flatMap((result) => {

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -8,12 +8,11 @@ import type {
   EarnVaultPositionInput,
   EarnVaultPositionSnapshot,
   EarnVaultTransactionPlan,
-  EarnVaultWithdrawInput,
 } from "@sdp/earn/types";
 import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
 import { type Address, address, createNoopSigner, createSolanaRpc } from "@solana/kit";
 import { SdpKaminoError } from "./errors";
-import { buildKaminoDepositPlan, buildKaminoWithdrawPlan, readKaminoPosition } from "./sdk";
+import { buildKaminoDepositPlan, readKaminoPosition } from "./sdk";
 import type { KaminoInstructionPlan, KaminoRuntime } from "./types";
 
 /**
@@ -102,20 +101,27 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     return KaminoVaultDirectClient.toWire(plan);
   }
 
-  async buildVaultWithdrawal(
-    ctx: EarnRuntimeContext,
-    input: EarnVaultWithdrawInput
-  ): Promise<EarnVaultTransactionPlan> {
-    const runtime = this.runtime(ctx);
-    const slot = await createSolanaRpc(runtime.rpcUrl).getSlot().send();
-    const plan = await buildKaminoWithdrawPlan(runtime, {
-      vault: address(input.providerReference),
-      owner: this.owner(input.owner),
-      shares: input.shares,
-      slot,
-    });
-    return KaminoVaultDirectClient.toWire(plan);
-  }
+  /*
+   * NO `buildVaultWithdrawal` — the withdraw capability is WITHHELD, and its
+   * absence is the mechanism, not an oversight.
+   *
+   * `buildKaminoWithdrawPlan` exists and is proven against a mainnet-forked
+   * surfnet, but it does not yet honour the plan contract: it flattens every
+   * unstake/withdraw/cleanup instruction into ONE batch and returns no lookup
+   * table, while the pinned SDK documents that a multi-reserve exit "might have
+   * to be split in multiple transactions". Implementing the method here would
+   * make `supportsVaultWithdraw` answer true, which is what a future exit route
+   * will narrow on — and it would then hand that route a plan that either
+   * exceeds the packet limit or is refused by the submitter, after the customer
+   * was told their withdrawal was prepared.
+   *
+   * Adding the method is therefore the LAST step of that work, not the first:
+   * load the vault LUT, compile-measure and split at protocol boundaries (an
+   * unstake must never land without its withdraw), and give the API a resumable
+   * multi-leg submission. Until then the honest answer is that SDP has no exit
+   * route — the shares are in the org's own wallet and Kamino's UI can redeem
+   * them, which is why withholding this is safe rather than fund-trapping.
+   */
 
   /**
    * Reads every requested vault against ONE slot, so a multi-position page is

--- a/packages/sdp-kamino/src/errors.ts
+++ b/packages/sdp-kamino/src/errors.ts
@@ -1,0 +1,54 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address } from "@solana/kit";
+
+/**
+ * Errors this package raises, mirroring `@sdp/earn/errors` in shape: a `code`
+ * the API can map to a status, and a message that says what was actually wrong.
+ * Deliberately NOT re-using `@sdp/earn`'s constructors — that would put an
+ * `@sdp/kamino → @sdp/earn` edge in place for three error shapes.
+ */
+export type SdpKaminoErrorCode = "INVALID_AMOUNT" | "VAULT_UNREADABLE" | "PROGRAM_MISMATCH";
+
+export class SdpKaminoError extends Error {
+  constructor(
+    readonly code: SdpKaminoErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = "SdpKaminoError";
+  }
+}
+
+/**
+ * A caller-supplied amount that is not a decimal string, is negative, or is
+ * zero. Raised BEFORE any RPC call — an unparseable amount is a programming
+ * error on the caller's side and must never reach the chain.
+ */
+export function invalidAmount(field: string, value: string): SdpKaminoError {
+  return new SdpKaminoError(
+    "INVALID_AMOUNT",
+    `Kamino ${field} must be a positive decimal string; received ${JSON.stringify(value)}`
+  );
+}
+
+/**
+ * The vault account could not be read on this cluster.
+ *
+ * The most likely cause is the RPC pointing at the wrong chain: Kamino's mainnet
+ * kvault program id ALSO exists on devnet with zero accounts under it, so a
+ * cluster/RPC mismatch presents as "this vault does not exist" rather than as a
+ * connection error. The message names both so the reader checks the right thing.
+ */
+export function vaultUnreadable(
+  vault: Address,
+  cluster: SolanaCluster,
+  cause: unknown
+): SdpKaminoError {
+  return new SdpKaminoError(
+    "VAULT_UNREADABLE",
+    `Kamino vault ${vault} could not be read on ${cluster}. ` +
+      "Check that the RPC endpoint serves that cluster — a mismatched RPC reports a missing vault, not a connection error.",
+    { cause }
+  );
+}

--- a/packages/sdp-kamino/src/errors.ts
+++ b/packages/sdp-kamino/src/errors.ts
@@ -33,6 +33,26 @@ export function invalidAmount(field: string, value: string): SdpKaminoError {
 }
 
 /**
+ * A caller-supplied amount that is finer than the mint can represent.
+ *
+ * Distinct from `invalidAmount` because the value IS a well-formed decimal — it
+ * simply carries more places than the mint has atoms, and klend-sdk FLOORS
+ * rather than rejects. Two different failures hide behind that floor: a deposit
+ * records more than it encodes (`1.0000009` on a 6-decimal mint moves
+ * `1.000000`), and a positive `minSharesOut` below one atom becomes `0`, which
+ * silently removes the very protection it was passed to provide. Refusing is
+ * the only answer that keeps the recorded number and the encoded number equal.
+ */
+export function amountTooPrecise(field: string, value: string, decimals: number): SdpKaminoError {
+  return new SdpKaminoError(
+    "INVALID_AMOUNT",
+    `Kamino ${field} ${JSON.stringify(value)} has more precision than its mint supports ` +
+      `(${decimals} decimals). The SDK would floor it, so the amount encoded on chain would not ` +
+      "match the amount requested."
+  );
+}
+
+/**
  * The vault account could not be read on this cluster.
  *
  * The most likely cause is the RPC pointing at the wrong chain: Kamino's mainnet

--- a/packages/sdp-kamino/src/guards.test.ts
+++ b/packages/sdp-kamino/src/guards.test.ts
@@ -25,6 +25,7 @@ function plan(
       })),
     ],
     lookupTables: [],
+    accepted: {},
   } as KaminoInstructionPlan;
 }
 
@@ -100,6 +101,7 @@ describe("assertPlanTargetsCluster", () => {
         ],
       ],
       lookupTables: [],
+      accepted: {},
     } as KaminoInstructionPlan;
     expect(() => assertPlanTargetsCluster(twoBatches)).toThrow(KaminoProgramMismatchError);
   });

--- a/packages/sdp-kamino/src/guards.test.ts
+++ b/packages/sdp-kamino/src/guards.test.ts
@@ -1,0 +1,116 @@
+import { KAMINO_KVAULT_PROGRAM_IDS } from "@sdp/types";
+import { address } from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import {
+  assertPlanTargetsCluster,
+  KaminoProgramMismatchError,
+  planProgramAddresses,
+} from "./guards";
+import { foreignKvaultProgramId, kaminoClusterConfig } from "./programs";
+import type { KaminoInstructionPlan } from "./types";
+
+const ATA_PROGRAM = address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+
+function plan(
+  cluster: KaminoInstructionPlan["cluster"],
+  programs: readonly string[]
+): KaminoInstructionPlan {
+  return {
+    cluster,
+    instructions: [
+      programs.map((programAddress) => ({
+        programAddress: address(programAddress),
+        accounts: [],
+        data: new Uint8Array(),
+      })),
+    ],
+    lookupTables: [],
+  } as KaminoInstructionPlan;
+}
+
+describe("assertPlanTargetsCluster", () => {
+  it("accepts a devnet plan naming the devnet kvault program", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    const accepted = assertPlanTargetsCluster(plan("devnet", [devnet.kvaultProgramId]));
+    expect(accepted.cluster).toBe("devnet");
+  });
+
+  /**
+   * THE REGRESSION THIS PACKAGE EXISTS FOR.
+   *
+   * klend-sdk's ordinary `new KaminoVault(rpc, addr, state, programId)` applies
+   * the program id to account reads only and builds its internal client without
+   * it, so a devnet vault emits MAINNET instructions — silently. That is the
+   * default outcome of following Kamino's own published recipe. If `sdk.ts`
+   * regresses to the plain constructor, this is the test that fails.
+   */
+  it("REJECTS a devnet plan carrying the mainnet kvault program", () => {
+    const mainnetKvault = KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"];
+    expect(() => assertPlanTargetsCluster(plan("devnet", [mainnetKvault]))).toThrow(
+      KaminoProgramMismatchError
+    );
+  });
+
+  it("rejects the mirror case — a mainnet plan carrying the devnet program", () => {
+    const devnetKvault = KAMINO_KVAULT_PROGRAM_IDS.devnet;
+    expect(() => assertPlanTargetsCluster(plan("mainnet-beta", [devnetKvault]))).toThrow(
+      KaminoProgramMismatchError
+    );
+  });
+
+  it("names the offending program and the cluster in the error", () => {
+    const foreign = foreignKvaultProgramId("devnet");
+    try {
+      assertPlanTargetsCluster(plan("devnet", [foreign]));
+      expect.unreachable("expected a program mismatch");
+    } catch (error) {
+      expect(error).toBeInstanceOf(KaminoProgramMismatchError);
+      const mismatch = error as KaminoProgramMismatchError;
+      expect(mismatch.cluster).toBe("devnet");
+      expect(mismatch.offendingProgram).toBe(foreign);
+    }
+  });
+
+  it("allows cluster-invariant programs such as the ATA program", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    expect(() =>
+      assertPlanTargetsCluster(plan("devnet", [ATA_PROGRAM, devnet.kvaultProgramId]))
+    ).not.toThrow();
+  });
+
+  it("rejects an unrecognized program rather than ignoring it", () => {
+    // A closed allowlist: an unexpected program is a finding, not noise.
+    expect(() =>
+      assertPlanTargetsCluster(plan("devnet", ["11111111111111111111111111111112"]))
+    ).toThrow(KaminoProgramMismatchError);
+  });
+
+  it("checks every batch, not just the first", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    const twoBatches: KaminoInstructionPlan = {
+      cluster: "devnet",
+      instructions: [
+        [{ programAddress: devnet.kvaultProgramId, accounts: [], data: new Uint8Array() }],
+        [
+          {
+            programAddress: address(KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"]),
+            accounts: [],
+            data: new Uint8Array(),
+          },
+        ],
+      ],
+      lookupTables: [],
+    } as KaminoInstructionPlan;
+    expect(() => assertPlanTargetsCluster(twoBatches)).toThrow(KaminoProgramMismatchError);
+  });
+});
+
+describe("planProgramAddresses", () => {
+  it("dedupes across batches — the shape a Kora allowlist assertion needs", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    const programs = planProgramAddresses(
+      plan("devnet", [devnet.kvaultProgramId, devnet.kvaultProgramId, ATA_PROGRAM])
+    );
+    expect([...programs].sort()).toEqual([ATA_PROGRAM, devnet.kvaultProgramId].sort());
+  });
+});

--- a/packages/sdp-kamino/src/guards.test.ts
+++ b/packages/sdp-kamino/src/guards.test.ts
@@ -10,6 +10,10 @@ import { foreignKvaultProgramId, kaminoClusterConfig } from "./programs";
 import type { KaminoInstructionPlan } from "./types";
 
 const ATA_PROGRAM = address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+const ASSET_IDENTITY = {
+  depositTokenMint: address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+  shareMint: address("So11111111111111111111111111111111111111112"),
+};
 
 function plan(
   cluster: KaminoInstructionPlan["cluster"],
@@ -25,6 +29,7 @@ function plan(
       })),
     ],
     lookupTables: [],
+    assetIdentity: ASSET_IDENTITY,
     accepted: {},
   } as KaminoInstructionPlan;
 }
@@ -101,6 +106,7 @@ describe("assertPlanTargetsCluster", () => {
         ],
       ],
       lookupTables: [],
+      assetIdentity: ASSET_IDENTITY,
       accepted: {},
     } as KaminoInstructionPlan;
     expect(() => assertPlanTargetsCluster(twoBatches)).toThrow(KaminoProgramMismatchError);

--- a/packages/sdp-kamino/src/guards.ts
+++ b/packages/sdp-kamino/src/guards.ts
@@ -1,0 +1,83 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address, Instruction } from "@solana/kit";
+import { kaminoProgramAllowlist } from "./programs";
+import type { KaminoInstructionPlan } from "./types";
+
+/**
+ * Programs that are the same on every cluster and may appear in a plan without
+ * being cluster-specific: system, both token programs, the ATA program, memo and
+ * compute budget. Listed explicitly rather than skipped, so the allowlist stays
+ * a closed set — an unexpected program is a finding, not noise.
+ */
+const CLUSTER_INVARIANT_PROGRAMS: readonly string[] = [
+  "11111111111111111111111111111111",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  "ComputeBudget111111111111111111111111111111",
+];
+
+export class KaminoProgramMismatchError extends Error {
+  constructor(
+    readonly cluster: SolanaCluster,
+    readonly offendingProgram: Address
+  ) {
+    super(
+      `Kamino instruction targets ${offendingProgram}, which is not a ${cluster} program. ` +
+        "This is the program-id override being silently dropped — see @sdp/kamino/sdk.ts."
+    );
+    this.name = "KaminoProgramMismatchError";
+  }
+}
+
+/**
+ * Refuse a plan whose instructions name a program that does not belong to this
+ * cluster. **The single most important check in this package.**
+ *
+ * Why it exists: klend-sdk's `new KaminoVault(rpc, addr, state, programId)`
+ * applies `programId` to account READS only and constructs its own internal
+ * client WITHOUT forwarding it. The result is a vault that reads devnet state
+ * and emits instructions addressed to the MAINNET kvault program — no error, no
+ * warning, and a transaction that fails on-chain or, worse, succeeds against the
+ * wrong deployment. Kamino's own published recipe uses that constructor, so this
+ * is the default outcome for anyone following the docs.
+ *
+ * `./sdk.ts` binds reads and writes together so the trap cannot spring, and this
+ * asserts that it worked. Belt AND braces, deliberately: the binding is a
+ * convention inside one function, while this is a property of the OUTPUT, and
+ * only the second one survives an SDK upgrade that reshuffles construction.
+ */
+export function assertPlanTargetsCluster(plan: KaminoInstructionPlan): KaminoInstructionPlan {
+  const allowed = kaminoProgramAllowlist(plan.cluster);
+  const invariant = new Set<string>(CLUSTER_INVARIANT_PROGRAMS);
+
+  for (const batch of plan.instructions) {
+    for (const instruction of batch) {
+      const program = instruction.programAddress;
+      if (allowed.has(program) || invariant.has(program)) continue;
+      throw new KaminoProgramMismatchError(plan.cluster, program);
+    }
+  }
+  return plan;
+}
+
+/** Flatten a plan for callers that genuinely want one transaction's worth. */
+export function planInstructionCount(plan: KaminoInstructionPlan): number {
+  return plan.instructions.reduce((total, batch) => total + batch.length, 0);
+}
+
+/** Every distinct program a plan touches — useful for Kora allowlist assertions. */
+export function planProgramAddresses(plan: KaminoInstructionPlan): readonly Address[] {
+  const seen = new Set<Address>();
+  for (const batch of plan.instructions) {
+    for (const instruction of batch as readonly Instruction[]) {
+      seen.add(instruction.programAddress);
+    }
+  }
+  return [...seen];
+}

--- a/packages/sdp-kamino/src/index.ts
+++ b/packages/sdp-kamino/src/index.ts
@@ -48,5 +48,6 @@ export type {
   KaminoInstructionPlan,
   KaminoPosition,
   KaminoRuntime,
+  KaminoVaultAssetIdentity,
   KaminoWithdrawInput,
 } from "./types";

--- a/packages/sdp-kamino/src/index.ts
+++ b/packages/sdp-kamino/src/index.ts
@@ -1,0 +1,46 @@
+/**
+ * `@sdp/kamino` — kit-native deposit/withdraw instruction building for Kamino
+ * K-Vaults.
+ *
+ * Scope: this package BUILDS unsigned instruction plans and READS positions. It
+ * never signs, never submits, never touches a database, and holds no credential
+ * (Kamino's data surface is public). Signing and submission belong to the API,
+ * which owns custody and the Kora fee-payment path.
+ *
+ * Two invariants make it safe to use:
+ *
+ * - **Cluster binding.** Kamino deploys a DIFFERENT kvault program per cluster,
+ *   and the SDK's ordinary constructor binds only reads to it. Everything here
+ *   goes through one bind helper, and every plan is re-checked against a
+ *   per-cluster program allowlist before it is returned.
+ * - **A closed dependency boundary.** `@kamino-finance/klend-sdk` (built against
+ *   `@solana/kit` 2.x, while this repo pins 6.8) and `decimal.js` are confined
+ *   to `./sdk.ts`. Everything crossing this module's surface is `@solana/kit`
+ *   6.8, `@sdp/types`, or a decimal string.
+ *
+ * See `packages/sdp-kamino/CLAUDE.md` for the traps and the measurements behind
+ * the constants.
+ */
+
+export { assertNotPortfolioProvider, KaminoVaultDirectClient } from "./client";
+export { SdpKaminoError, type SdpKaminoErrorCode } from "./errors";
+export {
+  assertPlanTargetsCluster,
+  KaminoProgramMismatchError,
+  planInstructionCount,
+  planProgramAddresses,
+} from "./guards";
+export {
+  foreignKvaultProgramId,
+  type KaminoClusterConfig,
+  kaminoClusterConfig,
+  kaminoProgramAllowlist,
+} from "./programs";
+export { buildKaminoDepositPlan, buildKaminoWithdrawPlan, readKaminoPosition } from "./sdk";
+export type {
+  KaminoDepositInput,
+  KaminoInstructionPlan,
+  KaminoPosition,
+  KaminoRuntime,
+  KaminoWithdrawInput,
+} from "./types";

--- a/packages/sdp-kamino/src/index.ts
+++ b/packages/sdp-kamino/src/index.ts
@@ -36,8 +36,14 @@ export {
   kaminoClusterConfig,
   kaminoProgramAllowlist,
 } from "./programs";
-export { buildKaminoDepositPlan, buildKaminoWithdrawPlan, readKaminoPosition } from "./sdk";
+// `buildKaminoWithdrawPlan` is deliberately NOT re-exported. It builds a single
+// unsized batch with no lookup table, which does not honour
+// `KaminoInstructionPlan`'s transaction-sized-batch contract for a multi-reserve
+// exit — so it stays package-private (smoke tests only) until that lands, and
+// `KaminoVaultDirectClient` withholds the withdraw capability to match.
+export { buildKaminoDepositPlan, readKaminoPosition } from "./sdk";
 export type {
+  KaminoAcceptedAmounts,
   KaminoDepositInput,
   KaminoInstructionPlan,
   KaminoPosition,

--- a/packages/sdp-kamino/src/observed-amounts.test.ts
+++ b/packages/sdp-kamino/src/observed-amounts.test.ts
@@ -1,0 +1,24 @@
+import Decimal from "decimal.js";
+import { describe, expect, it } from "vitest";
+import { SdpKaminoError } from "./errors";
+import { requireNonNegativeFiniteDecimal } from "./sdk";
+
+describe("requireNonNegativeFiniteDecimal", () => {
+  it.each([
+    [new Decimal("1.25"), "1.25"],
+    ["9007199254740993.000001", "9007199254740993.000001"],
+    [0, "0"],
+  ])("accepts observed non-negative values exactly", (value, expected) => {
+    expect(requireNonNegativeFiniteDecimal("test value", value).toFixed()).toBe(expected);
+  });
+
+  it.each([undefined, null, "NaN", Number.POSITIVE_INFINITY, "-0.1"])(
+    "rejects malformed or negative observed value %s",
+    (value) => {
+      expect(() => requireNonNegativeFiniteDecimal("test value", value)).toThrow(SdpKaminoError);
+      expect(() => requireNonNegativeFiniteDecimal("test value", value)).toThrow(
+        /finite non-negative decimal/
+      );
+    }
+  );
+});

--- a/packages/sdp-kamino/src/programs.test.ts
+++ b/packages/sdp-kamino/src/programs.test.ts
@@ -46,9 +46,9 @@ describe("kaminoClusterConfig", () => {
     expect(devnet).toBe(KAMINO_SLOT_DURATION_MS.devnet);
     expect(mainnet).toBe(KAMINO_SLOT_DURATION_MS["mainnet-beta"]);
     expect(devnet).not.toBe(mainnet);
-    // 450 is klend-sdk's DEFAULT_RECENT_SLOT_DURATION_MS; neither cluster is it.
-    expect(devnet).not.toBe(450);
-    expect(mainnet).not.toBe(450);
+    // 400 is klend-sdk's DEFAULT_RECENT_SLOT_DURATION_MS; neither cluster is it.
+    expect(devnet).not.toBe(400);
+    expect(mainnet).not.toBe(400);
   });
 });
 

--- a/packages/sdp-kamino/src/programs.test.ts
+++ b/packages/sdp-kamino/src/programs.test.ts
@@ -1,0 +1,71 @@
+import {
+  KAMINO_DEVNET_KVAULT_PROGRAM_ID,
+  KAMINO_KVAULT_PROGRAM_IDS,
+  KAMINO_SLOT_DURATION_MS,
+} from "@sdp/types";
+import { describe, expect, it } from "vitest";
+import { foreignKvaultProgramId, kaminoClusterConfig, kaminoProgramAllowlist } from "./programs";
+
+describe("kaminoClusterConfig", () => {
+  it("binds each cluster to its OWN kvault program", () => {
+    expect(String(kaminoClusterConfig("devnet").kvaultProgramId)).toBe(
+      KAMINO_KVAULT_PROGRAM_IDS.devnet
+    );
+    expect(String(kaminoClusterConfig("mainnet-beta").kvaultProgramId)).toBe(
+      KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"]
+    );
+  });
+
+  it("keeps the two kvault programs distinct — the whole premise of the table", () => {
+    expect(String(kaminoClusterConfig("devnet").kvaultProgramId)).not.toBe(
+      String(kaminoClusterConfig("mainnet-beta").kvaultProgramId)
+    );
+  });
+
+  it("shares one klend program across clusters (verified deployed on both)", () => {
+    expect(String(kaminoClusterConfig("devnet").klendProgramId)).toBe(
+      String(kaminoClusterConfig("mainnet-beta").klendProgramId)
+    );
+  });
+
+  it("shares one farms program across clusters, so farms is not a second trap", () => {
+    expect(String(kaminoClusterConfig("devnet").farmsProgramId)).toBe(
+      String(kaminoClusterConfig("mainnet-beta").farmsProgramId)
+    );
+  });
+
+  /**
+   * Slot duration scales every accrual figure the SDK computes and fails
+   * SILENTLY when wrong. These are measurements (2026-08-15, `getBlockTime` over
+   * a 4,000-slot span), not protocol constants — this test pins that they were
+   * measured per cluster rather than defaulted to one value.
+   */
+  it("carries a MEASURED, per-cluster slot duration that is not the SDK default", () => {
+    const devnet = kaminoClusterConfig("devnet").slotDurationMs;
+    const mainnet = kaminoClusterConfig("mainnet-beta").slotDurationMs;
+    expect(devnet).toBe(KAMINO_SLOT_DURATION_MS.devnet);
+    expect(mainnet).toBe(KAMINO_SLOT_DURATION_MS["mainnet-beta"]);
+    expect(devnet).not.toBe(mainnet);
+    // 450 is klend-sdk's DEFAULT_RECENT_SLOT_DURATION_MS; neither cluster is it.
+    expect(devnet).not.toBe(450);
+    expect(mainnet).not.toBe(450);
+  });
+});
+
+describe("kaminoProgramAllowlist", () => {
+  it("never contains the other cluster's kvault program", () => {
+    for (const cluster of ["devnet", "mainnet-beta"] as const) {
+      const allowed = kaminoProgramAllowlist(cluster);
+      expect(allowed.has(foreignKvaultProgramId(cluster))).toBe(false);
+      expect(allowed.has(kaminoClusterConfig(cluster).kvaultProgramId)).toBe(true);
+    }
+  });
+});
+
+describe("@sdp/types re-export", () => {
+  it("keeps the named devnet constant identical to the table entry", () => {
+    // @sdp/earn imports the named constant; @sdp/kamino reads the table. They
+    // must never drift, which is why one is derived from the other.
+    expect(KAMINO_DEVNET_KVAULT_PROGRAM_ID).toBe(KAMINO_KVAULT_PROGRAM_IDS.devnet);
+  });
+});

--- a/packages/sdp-kamino/src/programs.ts
+++ b/packages/sdp-kamino/src/programs.ts
@@ -1,0 +1,84 @@
+import {
+  KAMINO_FARMS_PROGRAM_IDS,
+  KAMINO_KLEND_PROGRAM_IDS,
+  KAMINO_KVAULT_PROGRAM_IDS,
+  KAMINO_SLOT_DURATION_MS,
+  type SolanaCluster,
+} from "@sdp/types";
+import { type Address, address } from "@solana/kit";
+
+/**
+ * Kamino's per-cluster runtime configuration, as `@solana/kit` addresses.
+ *
+ * The address TABLE itself lives in `@sdp/types/kamino-programs` because
+ * `@sdp/earn` needs the devnet kvault id too and may not depend on this package
+ * (see that file's header). This module is the thin typing layer: it turns those
+ * strings into branded `Address`es once, at module load, so no call site
+ * re-parses them and no code path can pass a raw string where an address is
+ * required.
+ */
+export interface KaminoClusterConfig {
+  cluster: SolanaCluster;
+  kvaultProgramId: Address;
+  klendProgramId: Address;
+  farmsProgramId: Address;
+  /**
+   * Required by `KaminoVaultClient` and measured per cluster — never the SDK
+   * default. See `KAMINO_SLOT_DURATION_MS` for the measurement and why a wrong
+   * value fails silently rather than loudly.
+   */
+  slotDurationMs: number;
+}
+
+const CONFIG_BY_CLUSTER: Readonly<Record<SolanaCluster, KaminoClusterConfig>> = {
+  "mainnet-beta": {
+    cluster: "mainnet-beta",
+    kvaultProgramId: address(KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"]),
+    klendProgramId: address(KAMINO_KLEND_PROGRAM_IDS["mainnet-beta"]),
+    farmsProgramId: address(KAMINO_FARMS_PROGRAM_IDS["mainnet-beta"]),
+    slotDurationMs: KAMINO_SLOT_DURATION_MS["mainnet-beta"],
+  },
+  devnet: {
+    cluster: "devnet",
+    kvaultProgramId: address(KAMINO_KVAULT_PROGRAM_IDS.devnet),
+    klendProgramId: address(KAMINO_KLEND_PROGRAM_IDS.devnet),
+    farmsProgramId: address(KAMINO_FARMS_PROGRAM_IDS.devnet),
+    slotDurationMs: KAMINO_SLOT_DURATION_MS.devnet,
+  },
+};
+
+/**
+ * The programs and timing Kamino runs under on one cluster.
+ *
+ * Takes a CLUSTER, never an `SdpEnvironment`. Callers holding an environment
+ * convert with `CLUSTER_BY_SDP_ENVIRONMENT` (@sdp/types) at the boundary — this
+ * package refuses to make that leap itself, because "environment implies
+ * cluster" is exactly the assumption migration 0057 and `host_cluster` exist to
+ * stop. A strategy row states the cluster its instrument lives on; that is the
+ * value that belongs here.
+ */
+export function kaminoClusterConfig(cluster: SolanaCluster): KaminoClusterConfig {
+  return CONFIG_BY_CLUSTER[cluster];
+}
+
+/**
+ * Every program address this package may legitimately emit an instruction for,
+ * on one cluster.
+ *
+ * Consumed by `assertPlanTargetsCluster` (see ./guards) as an ALLOWLIST rather
+ * than a denylist: the failure being guarded against is an instruction quietly
+ * addressed to the OTHER cluster's kvault program, and the only robust way to
+ * catch that is to enumerate what is permitted. System/token/ATA programs are
+ * cluster-invariant and are added by the guard, not here.
+ */
+export function kaminoProgramAllowlist(cluster: SolanaCluster): ReadonlySet<Address> {
+  const config = kaminoClusterConfig(cluster);
+  return new Set([config.kvaultProgramId, config.klendProgramId, config.farmsProgramId]);
+}
+
+/** The other cluster's kvault program — the one an instruction must never name. */
+export function foreignKvaultProgramId(cluster: SolanaCluster): Address {
+  return cluster === "devnet"
+    ? CONFIG_BY_CLUSTER["mainnet-beta"].kvaultProgramId
+    : CONFIG_BY_CLUSTER.devnet.kvaultProgramId;
+}

--- a/packages/sdp-kamino/src/rpc.test.ts
+++ b/packages/sdp-kamino/src/rpc.test.ts
@@ -1,0 +1,92 @@
+import type { RpcTransport } from "@solana/kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withKaminoRpcTimeout } from "./rpc";
+
+type RpcRequest = Parameters<RpcTransport>[0];
+
+const request = {
+  payload: { id: "1", jsonrpc: "2.0", method: "getSlot", params: [] },
+} as unknown as RpcRequest;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withKaminoRpcTimeout", () => {
+  it("aborts a stalled transport at the package deadline", async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | undefined;
+    const stalled: RpcTransport = async <TResponse>(config: RpcRequest) => {
+      observedSignal = config.signal;
+      return await new Promise<TResponse>((_resolve, reject) => {
+        config.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("The operation was aborted", "AbortError")),
+          { once: true }
+        );
+      });
+    };
+
+    const result = withKaminoRpcTimeout(stalled, 25)<unknown>(request);
+    const rejected = expect(result).rejects.toThrow("Kamino RPC request timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
+  it("keeps the package deadline when the caller also supplies a signal", async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const stalled: RpcTransport = async <TResponse>(config: RpcRequest) =>
+      await new Promise<TResponse>((_resolve, reject) => {
+        config.signal?.addEventListener("abort", () => reject(config.signal?.reason), {
+          once: true,
+        });
+      });
+
+    const result = withKaminoRpcTimeout(
+      stalled,
+      25
+    )<unknown>({
+      ...request,
+      signal: caller.signal,
+    });
+    const rejected = expect(result).rejects.toThrow("Kamino RPC request timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  it("preserves caller cancellation instead of relabelling it as a timeout", async () => {
+    const caller = new AbortController();
+    const callerReason = new Error("request cancelled by caller");
+    const stalled: RpcTransport = async <TResponse>(config: RpcRequest) =>
+      await new Promise<TResponse>((_resolve, reject) => {
+        config.signal?.addEventListener("abort", () => reject(config.signal?.reason), {
+          once: true,
+        });
+      });
+
+    const result = withKaminoRpcTimeout(
+      stalled,
+      30_000
+    )<unknown>({
+      ...request,
+      signal: caller.signal,
+    });
+    caller.abort(callerReason);
+
+    await expect(result).rejects.toBe(callerReason);
+  });
+
+  it("does not relabel an upstream failure as a timeout", async () => {
+    const upstream = new Error("429 Too Many Requests");
+    const transport = vi.fn(async () => {
+      throw upstream;
+    }) as unknown as RpcTransport;
+
+    await expect(withKaminoRpcTimeout(transport, 30_000)<unknown>(request)).rejects.toBe(upstream);
+  });
+});

--- a/packages/sdp-kamino/src/rpc.ts
+++ b/packages/sdp-kamino/src/rpc.ts
@@ -1,0 +1,49 @@
+import {
+  createDefaultRpcTransport,
+  createSolanaRpcFromTransport,
+  type RpcTransport,
+} from "@solana/kit";
+
+/**
+ * Maximum time a single Kamino RPC request may hold a worker open.
+ *
+ * This deadline is applied at the transport boundary, not only to the reads
+ * this package issues directly. klend-sdk receives the same RPC client, so its
+ * vault, reserve, farm and exchange-rate reads are bounded too.
+ */
+export const KAMINO_RPC_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Package-local so the SDK gets a deadline without adding a new workspace dependency edge. */
+export function withKaminoRpcTimeout(
+  transport: RpcTransport,
+  timeoutMs = KAMINO_RPC_REQUEST_TIMEOUT_MS
+): RpcTransport {
+  return async <TResponse>(config: Parameters<RpcTransport>[0]) => {
+    const controller = new AbortController();
+    // A distinct reason lets the catch path tell our deadline from a caller
+    // cancellation even if both signals become aborted before transport rejects.
+    const deadlineReason = new Error("Kamino RPC deadline elapsed");
+    const timer = setTimeout(() => controller.abort(deadlineReason), timeoutMs);
+    const signal = config.signal
+      ? AbortSignal.any([config.signal, controller.signal])
+      : controller.signal;
+    try {
+      return await transport<TResponse>({ ...config, signal });
+    } catch (cause) {
+      if (signal.aborted && signal.reason === deadlineReason) {
+        // "timed out" deliberately matches the API's transient-error
+        // classifier: a deadline is retryable, never a permanent vault fact.
+        throw new Error(`Kamino RPC request timed out after ${timeoutMs}ms`, { cause });
+      }
+      throw cause;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/** One deadline-aware RPC client shared by the package and the pinned SDK. */
+export function createKaminoRpc(rpcUrl: string, timeoutMs = KAMINO_RPC_REQUEST_TIMEOUT_MS) {
+  const transport = createDefaultRpcTransport({ url: rpcUrl });
+  return createSolanaRpcFromTransport(withKaminoRpcTimeout(transport, timeoutMs));
+}

--- a/packages/sdp-kamino/src/sdk-construction.test.ts
+++ b/packages/sdp-kamino/src/sdk-construction.test.ts
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+const sourceFiles = readdirSync(SRC).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+const read = (file: string) => readFileSync(join(SRC, file), "utf8");
+
+/**
+ * Structural tests over this package's own source.
+ *
+ * Both properties below are invisible to the type checker and to any runtime
+ * assertion — they are facts about how the code is WRITTEN, and each guards a
+ * failure that is silent in production. A source grep is the honest tool.
+ */
+/**
+ * Match a real module IMPORT, not a mention. The doc comments in `index.ts` and
+ * `types.ts` name klend-sdk deliberately — explaining the boundary is the point
+ * — so a naive substring scan flags exactly the files that document the rule.
+ */
+function importsModule(body: string, moduleName: string): boolean {
+  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:from|import|require\\()\\s*["']${escaped}["']`).test(body);
+}
+
+describe("the klend-sdk firewall", () => {
+  it("confines klend-sdk and decimal.js imports to sdk.ts", () => {
+    const offenders = sourceFiles.filter((file) => {
+      if (file === "sdk.ts") return false;
+      const body = read(file);
+      // Anywhere else, these drag klend-sdk's kit-2 copy (and a 13MB
+      // dependency) into modules that must stay on this repo's kit 6.8.
+      return importsModule(body, "@kamino-finance/klend-sdk") || importsModule(body, "decimal.js");
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the SDK out of the package's public entry point", () => {
+    expect(importsModule(read("index.ts"), "@kamino-finance/klend-sdk")).toBe(false);
+  });
+
+  it("still detects a real import — the guard is not vacuous", () => {
+    expect(
+      importsModule('import { X } from "@kamino-finance/klend-sdk";', "@kamino-finance/klend-sdk")
+    ).toBe(true);
+    expect(
+      importsModule("// mentions @kamino-finance/klend-sdk in prose", "@kamino-finance/klend-sdk")
+    ).toBe(false);
+  });
+});
+
+describe("vault construction", () => {
+  /**
+   * THE TRAP, ASSERTED AT THE SOURCE LEVEL.
+   *
+   * `new KaminoVault(rpc, addr, state, programId)` binds the program id to
+   * account READS only — its constructor builds an internal KaminoVaultClient
+   * without forwarding it, so instructions come out addressed to MAINNET. On
+   * devnet that means reading `devkRng…` state and emitting `KvauGM…`
+   * instructions, with no error at any layer.
+   *
+   * `loadWithClientAndState` is the only factory that binds both. The one
+   * permitted `new KaminoVault(` is the state probe, which is never used to
+   * build anything — so this asserts the safe factory is present rather than
+   * banning the constructor outright.
+   */
+  it("uses loadWithClientAndState to bind reads and writes together", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain("KaminoVault.loadWithClientAndState");
+  });
+
+  it("passes an explicit kvault program id to KaminoVaultClient", () => {
+    const sdk = read("sdk.ts");
+    // The client is what builds instructions; leaving its program id to the
+    // SDK default is precisely how the mainnet id leaks onto devnet.
+    expect(sdk).toMatch(/new KaminoVaultClient\([\s\S]*?kvaultProgramId/);
+  });
+
+  it("routes every entry point through the single bind helper", () => {
+    const sdk = read("sdk.ts");
+    for (const entry of [
+      "buildKaminoDepositPlan",
+      "buildKaminoWithdrawPlan",
+      "readKaminoPosition",
+    ]) {
+      const body = sdk.slice(sdk.indexOf(`export async function ${entry}`));
+      const fnBody = body.slice(0, body.indexOf("\n}\n") + 3);
+      expect(fnBody, `${entry} must construct its vault via bindVault`).toContain("bindVault(");
+    }
+  });
+
+  it("re-checks emitted instructions against the cluster allowlist", () => {
+    const sdk = read("sdk.ts");
+    const builders = sdk.match(/assertPlanTargetsCluster\(/g) ?? [];
+    // Both plan builders must guard their output; the bind helper's correctness
+    // is a convention inside one call, the assertion is a property of the output.
+    expect(builders.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/sdp-kamino/src/sdk-construction.test.ts
+++ b/packages/sdp-kamino/src/sdk-construction.test.ts
@@ -97,4 +97,26 @@ describe("vault construction", () => {
     // is a convention inside one call, the assertion is a property of the output.
     expect(builders.length).toBeGreaterThanOrEqual(2);
   });
+
+  it("binds every plan to the asset mints read from live vault state", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain("vaultAssetIdentityFromState(state)");
+    // Deposit and withdrawal must both return the identity produced by the
+    // shared bind path; omitting either would reopen catalogue-only trust.
+    expect(
+      sdk.match(/lookupTables:\s*\[\],\s*assetIdentity,/g)?.length ?? 0
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("fails closed on invalid observed shares but only withholds an invalid valuation", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain(
+      'requireNonNegativeFiniteDecimal("staked share balance", staked.stakedShares)'
+    );
+    expect(sdk).toMatch(/requireNonNegativeFiniteDecimal\(\s*"total share balance"/);
+    expect(sdk).toMatch(/requireNonNegativeFiniteDecimal\(\s*"vault exchange rate"/);
+    expect(sdk).toMatch(
+      /let tokenValue:[\s\S]*?try\s*\{[\s\S]*?requireNonNegativeFiniteDecimal\(\s*"vault exchange rate"/
+    );
+  });
 });

--- a/packages/sdp-kamino/src/sdk.smoke.test.ts
+++ b/packages/sdp-kamino/src/sdk.smoke.test.ts
@@ -1,0 +1,131 @@
+import {
+  address,
+  appendTransactionMessageInstructions,
+  createKeyPairSignerFromPrivateKeyBytes,
+  createSolanaRpc,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+} from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import { planProgramAddresses } from "./guards";
+import { kaminoClusterConfig } from "./programs";
+import { buildKaminoDepositPlan, buildKaminoWithdrawPlan, readKaminoPosition } from "./sdk";
+
+/**
+ * On-chain smoke test. **Opt-in, and never runs in CI** — the package's other
+ * tests are pure and offline, per the repo rule that package tests touch no
+ * network.
+ *
+ * Run it against a surfpool surfnet forking mainnet, which gives a real kvault
+ * program and a real vault with no mainnet money at risk:
+ *
+ *   KAMINO_SMOKE_RPC_URL=http://127.0.0.1:8899 \
+ *   KAMINO_SMOKE_SIGNER=<64 hex chars: 32 private key bytes> \
+ *   pnpm --filter @sdp/kamino test
+ *
+ * Fund the signer first with SOL and the vault's deposit token
+ * (`surfnet_setTokenAccount`). What this proves that the offline tests cannot:
+ * the instructions the package emits actually SIMULATE and LAND, and the
+ * position read reports what the chain holds.
+ */
+const RPC_URL = process.env.KAMINO_SMOKE_RPC_URL;
+const SIGNER_HEX = process.env.KAMINO_SMOKE_SIGNER;
+// Mainnet USDC K-Vault — the vault Kamino's own deposit doc uses.
+const VAULT = address(
+  process.env.KAMINO_SMOKE_VAULT ?? "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E"
+);
+
+describe.skipIf(!RPC_URL || !SIGNER_HEX)("Kamino plans against a live chain", () => {
+  const runtime = { cluster: "mainnet-beta" as const, rpcUrl: RPC_URL ?? "" };
+
+  async function signer() {
+    const bytes = Uint8Array.from(
+      (SIGNER_HEX ?? "").match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []
+    );
+    return await createKeyPairSignerFromPrivateKeyBytes(bytes);
+  }
+
+  it("builds a deposit that simulates cleanly and lands", async () => {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const owner = await signer();
+
+    const plan = await buildKaminoDepositPlan(runtime, {
+      vault: VAULT,
+      owner,
+      amount: "25",
+    });
+
+    // The guard already ran inside the builder; assert the property directly too.
+    const programs = planProgramAddresses(plan);
+    expect(programs).toContain(kaminoClusterConfig("mainnet-beta").kvaultProgramId);
+    expect(programs).not.toContain(kaminoClusterConfig("devnet").kvaultProgramId);
+
+    const batch = plan.instructions[0];
+    expect(batch, "deposit plan must carry one transaction's worth").toBeDefined();
+
+    const { value: latest } = await rpc.getLatestBlockhash({ commitment: "confirmed" }).send();
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latest, m),
+      (m) => appendTransactionMessageInstructions([...(batch ?? [])], m)
+    );
+    const signed = await signTransactionMessageWithSigners(message);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    const sim = await rpc
+      .simulateTransaction(wire, { encoding: "base64", replaceRecentBlockhash: true })
+      .send();
+    expect(sim.value.err, `simulation failed: ${JSON.stringify(sim.value.logs)}`).toBeNull();
+
+    const signature = await rpc.sendTransaction(wire, { encoding: "base64" }).send();
+    expect(signature).toBeTruthy();
+  });
+
+  it("reads back the position it just created", async () => {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const owner = await signer();
+    const slot = await rpc.getSlot().send();
+
+    const position = await readKaminoPosition(runtime, {
+      vault: VAULT,
+      owner: owner.address,
+      slot,
+    });
+
+    expect(position.cluster).toBe("mainnet-beta");
+    expect(Number(position.shares)).toBeGreaterThan(0);
+    // Value may legitimately be absent if the rate read failed; when present it
+    // must be a plain decimal string, never a float artefact.
+    if (position.tokenValue !== undefined) {
+      expect(position.tokenValue).toMatch(/^\d+(\.\d+)?$/);
+    }
+  });
+
+  it("builds a withdrawal for the full position", async () => {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const owner = await signer();
+    const slot = await rpc.getSlot().send();
+    const position = await readKaminoPosition(runtime, {
+      vault: VAULT,
+      owner: owner.address,
+      slot,
+    });
+
+    const plan = await buildKaminoWithdrawPlan(runtime, {
+      vault: VAULT,
+      owner,
+      shares: position.shares,
+      slot,
+    });
+
+    expect(planProgramAddresses(plan)).toContain(
+      kaminoClusterConfig("mainnet-beta").kvaultProgramId
+    );
+    expect(plan.instructions[0]?.length ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/packages/sdp-kamino/src/sdk.ts
+++ b/packages/sdp-kamino/src/sdk.ts
@@ -1,0 +1,234 @@
+import { KaminoVault, KaminoVaultClient } from "@kamino-finance/klend-sdk";
+import { formatDecimalAmount, isDecimalString, parseDecimalAmount } from "@sdp/solana/amount";
+import { type Address, address, createSolanaRpc, type Instruction } from "@solana/kit";
+import Decimal from "decimal.js";
+import { invalidAmount, vaultUnreadable } from "./errors";
+import { assertPlanTargetsCluster } from "./guards";
+import { kaminoClusterConfig } from "./programs";
+import type {
+  KaminoDepositInput,
+  KaminoInstructionPlan,
+  KaminoPosition,
+  KaminoRuntime,
+  KaminoWithdrawInput,
+} from "./types";
+
+/**
+ * ════════════════════════════════════════════════════════════════════════════
+ *  THE KIT-VERSION FIREWALL. This is the ONLY module in the package — source or
+ *  test — that may import `@kamino-finance/klend-sdk` or `decimal.js`.
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ * klend-sdk is built against `@solana/kit` **^2.3.0**; this repo pins **6.8.0**.
+ * Both copies coexist in the tree (pnpm nests the SDK's own). Verified by a live
+ * round trip on 2026-08-15: instructions come back as plain objects with a
+ * numeric `AccountRole` and `Uint8Array` data, and kit 6.8 compiles and signs
+ * them unchanged — so the boundary is real at the TYPE level but inert at
+ * RUNTIME. Every cast below is therefore a structural re-label, not a coercion,
+ * and each is annotated with what makes it safe.
+ *
+ * Keeping the SDK behind this one module is also what keeps the 13MB dependency
+ * out of `@sdp/earn`, whose catalogue cron runs hourly in both environments and
+ * never builds a transaction.
+ */
+
+/** klend-sdk's kit-2 surface, as far as this module needs to name it. */
+// biome-ignore lint/suspicious/noExplicitAny: the kit-2 <-> kit-6.8 seam; see the header.
+type Kit2 = any;
+
+/**
+ * Bind a vault so that READS AND WRITES USE THE SAME PROGRAM. Every entry point
+ * in this file goes through here; nothing else may construct a vault.
+ *
+ * ── The trap, stated once ───────────────────────────────────────────────────
+ * `new KaminoVault(rpc, addr, state, programId)` looks like it binds the vault
+ * to `programId`, and it half does: the id is used to FETCH `VaultState`, then
+ * the constructor builds its own `KaminoVaultClient` **without forwarding it**.
+ * Instruction building goes through that internal client, which defaults to
+ * MAINNET. On devnet the result is a vault that reads `devkRng…` state and emits
+ * instructions addressed to `KvauGM…` — silently, with no error.
+ *
+ * Kamino's own published recipe uses exactly that constructor, so this is the
+ * default outcome for anyone following the docs. `loadWithClientAndState` is the
+ * only factory that sets `vault.programId` AND `vault.client` together.
+ *
+ * `assertPlanTargetsCluster` independently re-checks the OUTPUT, because this
+ * function's correctness is a convention inside one call and that assertion is a
+ * property of what we actually emit.
+ */
+async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
+  const config = kaminoClusterConfig(runtime.cluster);
+  const rpc = createSolanaRpc(runtime.rpcUrl) as Kit2;
+
+  const client = new KaminoVaultClient(
+    rpc,
+    config.slotDurationMs,
+    config.kvaultProgramId as Kit2,
+    config.klendProgramId as Kit2,
+    undefined,
+    config.farmsProgramId as Kit2
+  );
+
+  // The probe exists only to fetch state under the right program id; it is never
+  // used to build anything.
+  const probe = new KaminoVault(
+    rpc,
+    vaultAddress as Kit2,
+    undefined,
+    config.kvaultProgramId as Kit2,
+    config.slotDurationMs
+  );
+
+  let state: Kit2;
+  try {
+    state = await probe.getState();
+  } catch (cause) {
+    throw vaultUnreadable(vaultAddress, runtime.cluster, cause);
+  }
+
+  const vault = KaminoVault.loadWithClientAndState(client, vaultAddress as Kit2, state);
+  if (String(vault.programId) !== String(config.kvaultProgramId)) {
+    // Unreachable unless the SDK changes `loadWithClientAndState`. Cheap to
+    // assert, and the failure it guards is invisible otherwise.
+    throw vaultUnreadable(vaultAddress, runtime.cluster, "vault bound to the wrong kvault program");
+  }
+  return { client, vault, state, config, rpc };
+}
+
+/** Decimal strings are the boundary currency; `Decimal` never escapes this file. */
+function toDecimal(value: string, label: string): Decimal {
+  if (!isDecimalString(value)) throw invalidAmount(label, value);
+  const parsed = new Decimal(value);
+  if (!parsed.isFinite() || parsed.isNegative()) throw invalidAmount(label, value);
+  return parsed;
+}
+
+/** Re-label kit-2 instructions as this repo's kit-6.8 `Instruction`. Structural. */
+function asInstructions(raw: readonly Kit2[]): readonly Instruction[] {
+  return (raw ?? []).filter(Boolean) as readonly Instruction[];
+}
+
+/**
+ * Build a deposit.
+ *
+ * Returned as a single batch: a deposit touches one vault and creates at most
+ * the user's share ATA, which has always fit one transaction in measurement.
+ * Withdrawals are the multi-batch case (see below).
+ */
+export async function buildKaminoDepositPlan(
+  runtime: KaminoRuntime,
+  input: KaminoDepositInput
+): Promise<KaminoInstructionPlan> {
+  const { client, vault, state, config } = await bindVault(runtime, input.vault);
+  const amount = toDecimal(input.amount, "amount");
+  if (amount.isZero()) throw invalidAmount("amount", input.amount);
+
+  const reserves = await client.loadVaultReserves(state);
+  const minSharesOut =
+    input.minSharesOut === undefined ? undefined : toDecimal(input.minSharesOut, "minSharesOut");
+
+  const bundle = await vault.depositIxs(
+    input.owner as Kit2,
+    amount,
+    reserves,
+    null,
+    null,
+    (input.rentPayer ?? input.owner) as Kit2,
+    undefined,
+    minSharesOut
+  );
+
+  const instructions = asInstructions([
+    ...(bundle.depositIxs ?? []),
+    ...(bundle.stakeInFarmIfNeededIxs ?? []),
+    ...(bundle.stakeInFlcFarmIfNeededIxs ?? []),
+  ]);
+
+  return assertPlanTargetsCluster({
+    cluster: config.cluster,
+    instructions: [instructions],
+    lookupTables: [],
+  });
+}
+
+/**
+ * Build a withdrawal.
+ *
+ * `unstake → withdraw → post` are returned as ONE batch because they must land
+ * atomically: unstaking without the withdraw leaves the position in a state the
+ * user did not ask for. If a future vault's reserve set makes that exceed the
+ * 1232-byte packet, the fix is a lookup table (Kamino publishes one per vault),
+ * NOT splitting these apart — which is why the plan carries `lookupTables` and
+ * why the caller is handed batches rather than a flat list.
+ */
+export async function buildKaminoWithdrawPlan(
+  runtime: KaminoRuntime,
+  input: KaminoWithdrawInput
+): Promise<KaminoInstructionPlan> {
+  const { client, vault, state, config } = await bindVault(runtime, input.vault);
+  const shares = toDecimal(input.shares, "shares");
+  if (shares.isZero()) throw invalidAmount("shares", input.shares);
+
+  const reserves = await client.loadVaultReserves(state);
+  const bundle = await vault.withdrawIxs(
+    input.owner as Kit2,
+    shares,
+    input.slot as Kit2,
+    reserves,
+    null,
+    null,
+    (input.rentPayer ?? input.owner) as Kit2
+  );
+
+  const instructions = asInstructions([
+    ...(bundle.unstakeFromFarmIfNeededIxs ?? []),
+    ...(bundle.withdrawIxs ?? []),
+    ...(bundle.postWithdrawIxs ?? []),
+  ]);
+
+  return assertPlanTargetsCluster({
+    cluster: config.cluster,
+    instructions: [instructions],
+    lookupTables: [],
+  });
+}
+
+/**
+ * One wallet's holding in one vault, read live.
+ *
+ * `tokenValue` is shares × exchange rate. The rate read is allowed to fail
+ * independently of the share read: a position whose size is known but whose
+ * value is not renders "—" for the value, which is the module rule everywhere
+ * else in Earn and strictly better than a fabricated number.
+ */
+export async function readKaminoPosition(
+  runtime: KaminoRuntime,
+  input: { vault: Address; owner: Address; slot: bigint }
+): Promise<KaminoPosition> {
+  const { vault, state, config } = await bindVault(runtime, input.vault);
+
+  const userShares = await vault.getUserShares(input.owner as Kit2);
+  const shares = new Decimal(String(userShares.totalShares ?? 0));
+
+  let tokenValue: string | undefined;
+  try {
+    const rate: Decimal = await vault.getExchangeRate(input.slot as Kit2);
+    const decimals = Number(state.tokenMintDecimals ?? 6);
+    // Round-trip through the repo's own fixed-point helpers so the string that
+    // leaves this package is scaled exactly like every other amount in SDP.
+    const raw = shares.mul(rate).toFixed(decimals, Decimal.ROUND_DOWN);
+    tokenValue = formatDecimalAmount(parseDecimalAmount(raw, decimals), decimals);
+  } catch {
+    tokenValue = undefined;
+  }
+
+  return {
+    vault: input.vault,
+    owner: input.owner,
+    cluster: config.cluster,
+    shares: shares.toFixed(),
+    ...(tokenValue === undefined ? {} : { tokenValue }),
+    tokenMint: address(String(state.tokenMint)),
+    sharesMint: address(String(state.sharesMint)),
+  };
+}

--- a/packages/sdp-kamino/src/sdk.ts
+++ b/packages/sdp-kamino/src/sdk.ts
@@ -2,6 +2,7 @@ import { KaminoVault, KaminoVaultClient } from "@kamino-finance/klend-sdk";
 import { formatDecimalAmount, isDecimalString, parseDecimalAmount } from "@sdp/solana/amount";
 import { type Address, address, createSolanaRpc, type Instruction } from "@solana/kit";
 import Decimal from "decimal.js";
+import { acceptAtMintScale, isZeroAmount, mintDecimals } from "./amounts";
 import { invalidAmount, vaultUnreadable } from "./errors";
 import { assertPlanTargetsCluster } from "./guards";
 import { kaminoClusterConfig } from "./programs";
@@ -120,12 +121,35 @@ export async function buildKaminoDepositPlan(
   input: KaminoDepositInput
 ): Promise<KaminoInstructionPlan> {
   const { client, vault, state, config } = await bindVault(runtime, input.vault);
-  const amount = toDecimal(input.amount, "amount");
-  if (amount.isZero()) throw invalidAmount("amount", input.amount);
+
+  // Precision is checked against the MINT, so it can only be checked once the
+  // vault has been read — the token and share mints have independent decimals
+  // and neither is knowable at the API boundary.
+  const acceptedAmount = acceptAtMintScale(
+    "amount",
+    input.amount,
+    mintDecimals(state.tokenMintDecimals, "tokenMintDecimals")
+  );
+  if (isZeroAmount(acceptedAmount)) throw invalidAmount("amount", input.amount);
+  const amount = toDecimal(acceptedAmount, "amount");
 
   const reserves = await client.loadVaultReserves(state);
-  const minSharesOut =
-    input.minSharesOut === undefined ? undefined : toDecimal(input.minSharesOut, "minSharesOut");
+
+  let acceptedMinSharesOut: string | undefined;
+  let minSharesOut: Decimal | undefined;
+  if (input.minSharesOut !== undefined) {
+    acceptedMinSharesOut = acceptAtMintScale(
+      "minSharesOut",
+      input.minSharesOut,
+      mintDecimals(state.sharesMintDecimals, "sharesMintDecimals")
+    );
+    // A floor that rounds to nothing is worse than no floor: it reads as
+    // protection in the request and the ledger while imposing none on chain.
+    // The scale check above already refuses sub-atom values, so reaching zero
+    // here means the caller literally passed "0".
+    if (isZeroAmount(acceptedMinSharesOut)) throw invalidAmount("minSharesOut", input.minSharesOut);
+    minSharesOut = toDecimal(acceptedMinSharesOut, "minSharesOut");
+  }
 
   const bundle = await vault.depositIxs(
     input.owner as Kit2,
@@ -148,26 +172,54 @@ export async function buildKaminoDepositPlan(
     cluster: config.cluster,
     instructions: [instructions],
     lookupTables: [],
+    accepted: {
+      amount: acceptedAmount,
+      ...(acceptedMinSharesOut === undefined ? {} : { minSharesOut: acceptedMinSharesOut }),
+    },
   });
 }
 
 /**
- * Build a withdrawal.
+ * Build a withdrawal. **NOT CONTRACT-COMPLETE — see the warning below.**
  *
- * `unstake → withdraw → post` are returned as ONE batch because they must land
- * atomically: unstaking without the withdraw leaves the position in a state the
- * user did not ask for. If a future vault's reserve set makes that exceed the
- * 1232-byte packet, the fix is a lookup table (Kamino publishes one per vault),
- * NOT splitting these apart — which is why the plan carries `lookupTables` and
- * why the caller is handed batches rather than a flat list.
+ * ── Why this is not exported as a capability ────────────────────────────────
+ * `KaminoInstructionPlan.instructions` promises TRANSACTION-SIZED batches: one
+ * entry, one transaction. This function cannot honour that promise yet. It
+ * flattens `unstake → withdraw → post` into a single batch and returns no
+ * lookup table, while the pinned SDK documents the opposite — `withdrawIxs`
+ * returns "one or multiple withdraw instructions, based on how many reserves
+ * it's needed to withdraw from. This might have to be split in multiple
+ * transactions". A multi-reserve exit therefore builds a plan that can exceed
+ * Solana's 1232-byte packet, and the API's submitter refuses any plan with more
+ * than one transaction — so the failure lands at submit, after the caller has
+ * been told a withdrawal was prepared.
+ *
+ * Honouring the contract needs three things this does not do: load the vault's
+ * published lookup table, compile-measure and split at valid protocol
+ * boundaries (an unstake must never land without its withdraw), and give the
+ * API a resumable multi-leg submission with per-leg ledger rows.
+ *
+ * Until then the WITHDRAW CAPABILITY IS WITHHELD: `KaminoVaultDirectClient` does
+ * not implement `buildVaultWithdrawal`, so `supportsVaultWithdraw` answers false
+ * and no route can move money out through an unsized plan. This builder stays in
+ * the package because it is proven against a mainnet-forked surfnet and is the
+ * starting point for that work — it is deliberately NOT re-exported from
+ * `index.ts`, so the only callers are this package's own smoke tests.
+ *
+ * Tracked as the exit half of the vault-direct path; see `CLAUDE.md`.
  */
 export async function buildKaminoWithdrawPlan(
   runtime: KaminoRuntime,
   input: KaminoWithdrawInput
 ): Promise<KaminoInstructionPlan> {
   const { client, vault, state, config } = await bindVault(runtime, input.vault);
-  const shares = toDecimal(input.shares, "shares");
-  if (shares.isZero()) throw invalidAmount("shares", input.shares);
+  const acceptedShares = acceptAtMintScale(
+    "shares",
+    input.shares,
+    mintDecimals(state.sharesMintDecimals, "sharesMintDecimals")
+  );
+  if (isZeroAmount(acceptedShares)) throw invalidAmount("shares", input.shares);
+  const shares = toDecimal(acceptedShares, "shares");
 
   const reserves = await client.loadVaultReserves(state);
   const bundle = await vault.withdrawIxs(
@@ -190,7 +242,39 @@ export async function buildKaminoWithdrawPlan(
     cluster: config.cluster,
     instructions: [instructions],
     lookupTables: [],
+    accepted: { shares: acceptedShares },
   });
+}
+
+/**
+ * Sum an owner's share-token accounts in EXACT base units.
+ *
+ * Deliberately reads `tokenAmount.amount` — the raw integer string — and never
+ * `uiAmount`, which the RPC serialises as a JSON number and which therefore
+ * cannot represent a balance above 2^53 base units without rounding. Returns
+ * `bigint` so nothing between here and the mint's decimals can go lossy.
+ *
+ * Sums ALL matching accounts rather than just the ATA, matching what the SDK
+ * counts: a wallet may legitimately hold the same share mint in more than one
+ * token account, and ignoring the others would under-report someone's position.
+ */
+async function readUnstakedShareBaseUnits(
+  rpc: Kit2,
+  owner: Address,
+  sharesMint: Address
+): Promise<bigint> {
+  const response = await rpc
+    .getTokenAccountsByOwner(owner, { mint: sharesMint }, { encoding: "jsonParsed" })
+    .send();
+
+  let total = 0n;
+  for (const entry of response?.value ?? []) {
+    const raw = entry?.account?.data?.parsed?.info?.tokenAmount?.amount;
+    // A non-numeric `amount` means the account was not the parsed shape we
+    // expect; skipping it is right, because guessing a balance is not.
+    if (typeof raw === "string" && /^\d+$/.test(raw)) total += BigInt(raw);
+  }
+  return total;
 }
 
 /**
@@ -205,15 +289,34 @@ export async function readKaminoPosition(
   runtime: KaminoRuntime,
   input: { vault: Address; owner: Address; slot: bigint }
 ): Promise<KaminoPosition> {
-  const { vault, state, config } = await bindVault(runtime, input.vault);
+  const { vault, state, config, rpc } = await bindVault(runtime, input.vault);
+  const shareDecimals = mintDecimals(state.sharesMintDecimals, "sharesMintDecimals");
 
-  const userShares = await vault.getUserShares(input.owner as Kit2);
-  const shares = new Decimal(String(userShares.totalShares ?? 0));
+  // UNSTAKED shares are counted here rather than taken from the SDK, and that is
+  // the whole point of this block. `vault.getUserShares` sums its token accounts
+  // through `getTokenAccountAmount`, which returns
+  // `parsed.info.tokenAmount.uiAmount` — a JavaScript NUMBER. Above 2^53 base
+  // units that has already lost value, and no amount of `Decimal`-wrapping
+  // downstream can put it back. `amount` on the same parsed account is the exact
+  // base-unit string, so this reads that and scales it by the share mint itself.
+  //
+  // STAKED shares still come from the SDK: that half is derived from farm state
+  // as an exact `Decimal`, never through `uiAmount`, so re-implementing it would
+  // duplicate the farm lookup for no precision gain.
+  const staked = await vault.getUserShares(input.owner as Kit2);
+  const unstakedBase = await readUnstakedShareBaseUnits(
+    rpc,
+    input.owner,
+    address(String(state.sharesMint))
+  );
+  const shares = new Decimal(formatDecimalAmount(unstakedBase, shareDecimals)).add(
+    new Decimal(String(staked.stakedShares ?? 0))
+  );
 
   let tokenValue: string | undefined;
   try {
     const rate: Decimal = await vault.getExchangeRate(input.slot as Kit2);
-    const decimals = Number(state.tokenMintDecimals ?? 6);
+    const decimals = mintDecimals(state.tokenMintDecimals, "tokenMintDecimals");
     // Round-trip through the repo's own fixed-point helpers so the string that
     // leaves this package is scaled exactly like every other amount in SDP.
     const raw = shares.mul(rate).toFixed(decimals, Decimal.ROUND_DOWN);

--- a/packages/sdp-kamino/src/sdk.ts
+++ b/packages/sdp-kamino/src/sdk.ts
@@ -1,11 +1,14 @@
 import { KaminoVault, KaminoVaultClient } from "@kamino-finance/klend-sdk";
 import { formatDecimalAmount, isDecimalString, parseDecimalAmount } from "@sdp/solana/amount";
-import { type Address, address, createSolanaRpc, type Instruction } from "@solana/kit";
+import type { Address, Instruction } from "@solana/kit";
 import Decimal from "decimal.js";
 import { acceptAtMintScale, isZeroAmount, mintDecimals } from "./amounts";
-import { invalidAmount, vaultUnreadable } from "./errors";
+import { vaultAssetIdentityFromState } from "./asset-identity";
+import { invalidAmount, SdpKaminoError, vaultUnreadable } from "./errors";
 import { assertPlanTargetsCluster } from "./guards";
 import { kaminoClusterConfig } from "./programs";
+import { createKaminoRpc } from "./rpc";
+import { sumRawTokenAccountBaseUnits } from "./share-balances";
 import type {
   KaminoDepositInput,
   KaminoInstructionPlan,
@@ -59,7 +62,9 @@ type Kit2 = any;
  */
 async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
   const config = kaminoClusterConfig(runtime.cluster);
-  const rpc = createSolanaRpc(runtime.rpcUrl) as Kit2;
+  // The transport deadline covers both our direct reads and every nested
+  // reserve/farm/vault request klend-sdk performs with this same client.
+  const rpc = createKaminoRpc(runtime.rpcUrl) as Kit2;
 
   const client = new KaminoVaultClient(
     rpc,
@@ -93,7 +98,12 @@ async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
     // assert, and the failure it guards is invisible otherwise.
     throw vaultUnreadable(vaultAddress, runtime.cluster, "vault bound to the wrong kvault program");
   }
-  return { client, vault, state, config, rpc };
+
+  // Bind the asset identity to the same live state snapshot used for decimals,
+  // reserve loading and instruction construction. The API compares these
+  // builder-observed mints with catalogue metadata before it signs anything.
+  const assetIdentity = vaultAssetIdentityFromState(state);
+  return { client, vault, state, config, rpc, assetIdentity };
 }
 
 /** Decimal strings are the boundary currency; `Decimal` never escapes this file. */
@@ -101,6 +111,31 @@ function toDecimal(value: string, label: string): Decimal {
   if (!isDecimalString(value)) throw invalidAmount(label, value);
   const parsed = new Decimal(value);
   if (!parsed.isFinite() || parsed.isNegative()) throw invalidAmount(label, value);
+  return parsed;
+}
+
+/**
+ * Validate numeric state observed from klend-sdk without trusting its physical
+ * `decimal.js` instance. The SDK carries a nested copy, so normalize through a
+ * string and rebuild with this package's pinned Decimal before checking it.
+ */
+export function requireNonNegativeFiniteDecimal(label: string, value: unknown): Decimal {
+  let parsed: Decimal;
+  try {
+    parsed = new Decimal(String(value));
+  } catch (cause) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino ${label} was not a finite non-negative decimal`,
+      { cause }
+    );
+  }
+  if (!parsed.isFinite() || parsed.isNegative()) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino ${label} was not a finite non-negative decimal`
+    );
+  }
   return parsed;
 }
 
@@ -120,7 +155,7 @@ export async function buildKaminoDepositPlan(
   runtime: KaminoRuntime,
   input: KaminoDepositInput
 ): Promise<KaminoInstructionPlan> {
-  const { client, vault, state, config } = await bindVault(runtime, input.vault);
+  const { client, vault, state, config, assetIdentity } = await bindVault(runtime, input.vault);
 
   // Precision is checked against the MINT, so it can only be checked once the
   // vault has been read — the token and share mints have independent decimals
@@ -172,6 +207,7 @@ export async function buildKaminoDepositPlan(
     cluster: config.cluster,
     instructions: [instructions],
     lookupTables: [],
+    assetIdentity,
     accepted: {
       amount: acceptedAmount,
       ...(acceptedMinSharesOut === undefined ? {} : { minSharesOut: acceptedMinSharesOut }),
@@ -212,7 +248,7 @@ export async function buildKaminoWithdrawPlan(
   runtime: KaminoRuntime,
   input: KaminoWithdrawInput
 ): Promise<KaminoInstructionPlan> {
-  const { client, vault, state, config } = await bindVault(runtime, input.vault);
+  const { client, vault, state, config, assetIdentity } = await bindVault(runtime, input.vault);
   const acceptedShares = acceptAtMintScale(
     "shares",
     input.shares,
@@ -242,6 +278,7 @@ export async function buildKaminoWithdrawPlan(
     cluster: config.cluster,
     instructions: [instructions],
     lookupTables: [],
+    assetIdentity,
     accepted: { shares: acceptedShares },
   });
 }
@@ -267,14 +304,10 @@ async function readUnstakedShareBaseUnits(
     .getTokenAccountsByOwner(owner, { mint: sharesMint }, { encoding: "jsonParsed" })
     .send();
 
-  let total = 0n;
-  for (const entry of response?.value ?? []) {
-    const raw = entry?.account?.data?.parsed?.info?.tokenAmount?.amount;
-    // A non-numeric `amount` means the account was not the parsed shape we
-    // expect; skipping it is right, because guessing a balance is not.
-    if (typeof raw === "string" && /^\d+$/.test(raw)) total += BigInt(raw);
-  }
-  return total;
+  // The RPC filter says every entry is part of this balance. A malformed entry
+  // therefore makes the whole position unreadable; summing only the readable
+  // subset would silently under-report funds.
+  return sumRawTokenAccountBaseUnits(response?.value);
 }
 
 /**
@@ -289,7 +322,7 @@ export async function readKaminoPosition(
   runtime: KaminoRuntime,
   input: { vault: Address; owner: Address; slot: bigint }
 ): Promise<KaminoPosition> {
-  const { vault, state, config, rpc } = await bindVault(runtime, input.vault);
+  const { vault, state, config, rpc, assetIdentity } = await bindVault(runtime, input.vault);
   const shareDecimals = mintDecimals(state.sharesMintDecimals, "sharesMintDecimals");
 
   // UNSTAKED shares are counted here rather than taken from the SDK, and that is
@@ -304,22 +337,27 @@ export async function readKaminoPosition(
   // as an exact `Decimal`, never through `uiAmount`, so re-implementing it would
   // duplicate the farm lookup for no precision gain.
   const staked = await vault.getUserShares(input.owner as Kit2);
-  const unstakedBase = await readUnstakedShareBaseUnits(
-    rpc,
-    input.owner,
-    address(String(state.sharesMint))
-  );
-  const shares = new Decimal(formatDecimalAmount(unstakedBase, shareDecimals)).add(
-    new Decimal(String(staked.stakedShares ?? 0))
+  const unstakedBase = await readUnstakedShareBaseUnits(rpc, input.owner, assetIdentity.shareMint);
+  const shares = requireNonNegativeFiniteDecimal(
+    "total share balance",
+    new Decimal(formatDecimalAmount(unstakedBase, shareDecimals)).add(
+      requireNonNegativeFiniteDecimal("staked share balance", staked.stakedShares)
+    )
   );
 
   let tokenValue: string | undefined;
   try {
-    const rate: Decimal = await vault.getExchangeRate(input.slot as Kit2);
+    const rate = requireNonNegativeFiniteDecimal(
+      "vault exchange rate",
+      await vault.getExchangeRate(input.slot as Kit2)
+    );
     const decimals = mintDecimals(state.tokenMintDecimals, "tokenMintDecimals");
     // Round-trip through the repo's own fixed-point helpers so the string that
     // leaves this package is scaled exactly like every other amount in SDP.
-    const raw = shares.mul(rate).toFixed(decimals, Decimal.ROUND_DOWN);
+    const raw = requireNonNegativeFiniteDecimal("vault token value", shares.mul(rate)).toFixed(
+      decimals,
+      Decimal.ROUND_DOWN
+    );
     tokenValue = formatDecimalAmount(parseDecimalAmount(raw, decimals), decimals);
   } catch {
     tokenValue = undefined;
@@ -331,7 +369,7 @@ export async function readKaminoPosition(
     cluster: config.cluster,
     shares: shares.toFixed(),
     ...(tokenValue === undefined ? {} : { tokenValue }),
-    tokenMint: address(String(state.tokenMint)),
-    sharesMint: address(String(state.sharesMint)),
+    tokenMint: assetIdentity.depositTokenMint,
+    sharesMint: assetIdentity.shareMint,
   };
 }

--- a/packages/sdp-kamino/src/share-balances.test.ts
+++ b/packages/sdp-kamino/src/share-balances.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { SdpKaminoError } from "./errors";
+import { sumRawTokenAccountBaseUnits } from "./share-balances";
+
+function tokenAccount(amount: unknown) {
+  return {
+    account: {
+      data: {
+        parsed: {
+          info: { tokenAmount: { amount } },
+        },
+      },
+    },
+  };
+}
+
+describe("sumRawTokenAccountBaseUnits", () => {
+  it("sums every matching account exactly above 2^53", () => {
+    expect(
+      sumRawTokenAccountBaseUnits([
+        tokenAccount("9007199254740993"),
+        tokenAccount("9007199254740995"),
+        tokenAccount("12"),
+      ])
+    ).toBe(18_014_398_509_482_000n);
+  });
+
+  it("fails closed when any matching account has a malformed raw amount", () => {
+    for (const malformed of [tokenAccount(undefined), tokenAccount(12), tokenAccount("1.5"), {}]) {
+      expect(() =>
+        sumRawTokenAccountBaseUnits([tokenAccount("9007199254740993"), malformed])
+      ).toThrow(SdpKaminoError);
+      expect(() =>
+        sumRawTokenAccountBaseUnits([tokenAccount("9007199254740993"), malformed])
+      ).toThrow(/did not contain an exact raw amount/);
+    }
+  });
+
+  it("rejects a response with no account list", () => {
+    expect(() => sumRawTokenAccountBaseUnits(undefined)).toThrow(/did not contain an account list/);
+  });
+});

--- a/packages/sdp-kamino/src/share-balances.ts
+++ b/packages/sdp-kamino/src/share-balances.ts
@@ -1,0 +1,45 @@
+import { SdpKaminoError } from "./errors";
+
+type ParsedTokenAccount = {
+  account?: {
+    data?: {
+      parsed?: {
+        info?: {
+          tokenAmount?: {
+            amount?: unknown;
+          };
+        };
+      };
+    };
+  };
+};
+
+/**
+ * Sum every matching token account from its exact raw amount.
+ *
+ * The RPC filter already selected this mint, so each returned account is part
+ * of the owner's balance. If even one result is malformed, returning the sum of
+ * the readable subset would make a confident but false claim about custody.
+ */
+export function sumRawTokenAccountBaseUnits(entries: unknown): bigint {
+  if (!Array.isArray(entries)) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      "Kamino share-token RPC response did not contain an account list"
+    );
+  }
+
+  let total = 0n;
+  for (const [index, entry] of entries.entries()) {
+    const raw = (entry as ParsedTokenAccount | null)?.account?.data?.parsed?.info?.tokenAmount
+      ?.amount;
+    if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+      throw new SdpKaminoError(
+        "VAULT_UNREADABLE",
+        `Kamino share-token account ${index} did not contain an exact raw amount`
+      );
+    }
+    total += BigInt(raw);
+  }
+  return total;
+}

--- a/packages/sdp-kamino/src/types.ts
+++ b/packages/sdp-kamino/src/types.ts
@@ -50,6 +50,29 @@ export interface KaminoInstructionPlan {
    * publishes a per-vault LUT precisely because these account lists are large.
    */
   lookupTables: readonly Address[];
+  /** What the instructions above actually encode. See `KaminoAcceptedAmounts`. */
+  accepted: KaminoAcceptedAmounts;
+}
+
+/**
+ * The amounts as ENCODED, canonicalised to each mint's own precision.
+ *
+ * Exists because the requested amount and the encoded amount are not
+ * necessarily the same number: klend-sdk converts every `Decimal` to mint atoms
+ * and FLOORS. This package refuses anything that would lose value to that floor
+ * (`amountTooPrecise`), so these values are always exactly equal to the request
+ * in magnitude — but they are re-serialised from the mint's decimals, so
+ * `"1.500"` comes back as `"1.5"`. The ledger should persist THESE, not the raw
+ * request string: a movement row is a claim about what moved on chain, and only
+ * this side of the boundary knows the mint's precision.
+ */
+export interface KaminoAcceptedAmounts {
+  /** Deposit amount, canonical to the vault token mint's decimals. */
+  amount?: string;
+  /** Share floor, canonical to the share mint's decimals. */
+  minSharesOut?: string;
+  /** Shares redeemed, canonical to the share mint's decimals. */
+  shares?: string;
 }
 
 export interface KaminoDepositInput {

--- a/packages/sdp-kamino/src/types.ts
+++ b/packages/sdp-kamino/src/types.ts
@@ -1,0 +1,115 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address, Instruction, Slot, TransactionSigner } from "@solana/kit";
+
+/**
+ * The boundary contract for `@sdp/kamino`.
+ *
+ * TWO RULES HOLD FOR EVERY TYPE IN THIS FILE, and both are load-bearing:
+ *
+ * 1. **Money is a decimal string, never a float and never a `Decimal`.** The
+ *    repo-wide rule (`@sdp/earn` CLAUDE.md → Contracts) is that USD/amount
+ *    values in contract types are decimal strings, converted at the provider
+ *    boundary. `decimal.js` is klend-sdk's currency, so it lives strictly inside
+ *    `./sdk.ts` — a `Decimal` crossing this boundary would also drag in the
+ *    instance-identity hazard (two physical copies of decimal.js make
+ *    klend-sdk's `instanceof` checks fail as NaN rather than as a type error).
+ * 2. **Nothing here references a klend-sdk type.** Every type is either from
+ *    `@solana/kit` (the version THIS repo pins) or from `@sdp/types`. That is
+ *    what makes `./sdk.ts` a firewall rather than a convention.
+ */
+
+/** Which cluster a call runs against, and how to reach it. */
+export interface KaminoRuntime {
+  cluster: SolanaCluster;
+  /**
+   * RPC endpoint for `cluster`. Supplied by the caller rather than read from
+   * env: `syncEarnCatalogue` walks both environments inside ONE process with
+   * one env object, so a process-level `SOLANA_RPC_URL` cannot be trusted to
+   * match the cluster being served — the mistake `listKaminoDevnetVaults` guards
+   * with a genesis-hash check.
+   */
+  rpcUrl: string;
+}
+
+/**
+ * A built, unsigned unit of work: instructions plus what the caller needs to
+ * compile them.
+ *
+ * `instructions` is deliberately `Instruction[][]` — TRANSACTION-SIZED BATCHES,
+ * not one flat list. A multi-reserve K-Vault exit emits several withdraw
+ * instructions, each carrying the vault's full reserve remaining-accounts list,
+ * and routinely exceeds Solana's 1232-byte packet. Handing back a flat list
+ * makes the caller discover that at `compileTransaction`, far from the code that
+ * could split it. One entry means one transaction.
+ */
+export interface KaminoInstructionPlan {
+  cluster: SolanaCluster;
+  instructions: readonly (readonly Instruction[])[];
+  /**
+   * Address lookup tables the caller SHOULD apply when compiling. Kamino
+   * publishes a per-vault LUT precisely because these account lists are large.
+   */
+  lookupTables: readonly Address[];
+}
+
+export interface KaminoDepositInput {
+  /** The K-Vault's own account address — its `providerReference` in the catalogue. */
+  vault: Address;
+  /**
+   * The wallet whose tokens move and whose shares are minted. An SDP custody
+   * wallet's `TransactionSigner`, resolved by the API's signing service.
+   */
+  owner: TransactionSigner;
+  /**
+   * Rent payer for any associated token account this deposit has to create.
+   *
+   * NOT the transaction fee payer. klend-sdk embeds this signer INSIDE the
+   * instruction accounts as writable+signer, so whoever is named here funds ATA
+   * rent — a real, separate spend. SDP's Kora path sets the fee payer at compile
+   * time and signs post-compile via `signAsFeePayer`, which is a different
+   * mechanism entirely; passing a sponsor signer here would quietly bill it for
+   * rent it never agreed to. Defaults to `owner` when omitted.
+   */
+  rentPayer?: TransactionSigner;
+  /** Deposit amount in the vault token's own units, as a decimal string. */
+  amount: string;
+  /**
+   * Minimum shares to accept, as a decimal string — slippage protection.
+   * Omitted means no floor, which is what Kamino's own examples do; the API
+   * should compute one from the live exchange rate rather than pass `"0"` and
+   * call it protection.
+   */
+  minSharesOut?: string;
+}
+
+export interface KaminoWithdrawInput {
+  vault: Address;
+  owner: TransactionSigner;
+  rentPayer?: TransactionSigner;
+  /** Shares to redeem, as a decimal string. */
+  shares: string;
+  /**
+   * Slot the withdrawal is priced against. Required by klend-sdk and by the
+   * reserve math; the caller reads it once so a multi-position pass prices every
+   * leg against the same slot.
+   */
+  slot: Slot;
+}
+
+/** One wallet's holding in one K-Vault, read live from chain. */
+export interface KaminoPosition {
+  vault: Address;
+  owner: Address;
+  cluster: SolanaCluster;
+  /** Shares held, as a decimal string. */
+  shares: string;
+  /**
+   * Current value of those shares in the vault's deposit token, as a decimal
+   * string. Undefined when the exchange rate could not be read — the caller
+   * renders "—" rather than a fabricated figure.
+   */
+  tokenValue?: string;
+  /** The vault's deposit-token mint, so callers need no second lookup. */
+  tokenMint: Address;
+  sharesMint: Address;
+}

--- a/packages/sdp-kamino/src/types.ts
+++ b/packages/sdp-kamino/src/types.ts
@@ -50,8 +50,18 @@ export interface KaminoInstructionPlan {
    * publishes a per-vault LUT precisely because these account lists are large.
    */
   lookupTables: readonly Address[];
+  /** Asset mints observed from the same live vault state used to build. */
+  assetIdentity: KaminoVaultAssetIdentity;
   /** What the instructions above actually encode. See `KaminoAcceptedAmounts`. */
   accepted: KaminoAcceptedAmounts;
+}
+
+/** Live K-Vault asset identity carried with a built instruction plan. */
+export interface KaminoVaultAssetIdentity {
+  /** Mint consumed by a deposit. */
+  depositTokenMint: Address;
+  /** Mint issued as the vault receipt/share token. */
+  shareMint: Address;
 }
 
 /**

--- a/packages/sdp-kamino/tsconfig.json
+++ b/packages/sdp-kamino/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // Mirrors packages/sdp-earn: this package typechecks @sdp/earn's sources
+    // through its workspace import, and `fetch.ts` there references the DOM's
+    // `HeadersInit` / `BodyInit`. Without these libs the failure surfaces here
+    // rather than in the package that owns the code.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sdp-types/package.json
+++ b/packages/sdp-types/package.json
@@ -34,6 +34,11 @@
       "import": "./src/earn.ts",
       "default": "./src/earn.ts"
     },
+    "./kamino-programs": {
+      "types": "./src/kamino-programs.ts",
+      "import": "./src/kamino-programs.ts",
+      "default": "./src/kamino-programs.ts"
+    },
     "./payments": {
       "types": "./src/payments.ts",
       "import": "./src/payments.ts",

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -11,6 +11,7 @@ export * from "./countries";
 export * from "./custody";
 export * from "./earn";
 export * from "./generated/ramp-support.generated";
+export * from "./kamino-programs";
 export * from "./kyc";
 export * from "./organizations";
 export * from "./pagination";

--- a/packages/sdp-types/src/kamino-programs.ts
+++ b/packages/sdp-types/src/kamino-programs.ts
@@ -82,7 +82,7 @@ export const KAMINO_FARMS_PROGRAM_IDS = {
  *   devnet        264.5 ms/slot
  *
  * Devnet is materially faster than mainnet, and both differ from klend-sdk's own
- * `DEFAULT_RECENT_SLOT_DURATION_MS` (450) — which is why this is never left to
+ * `DEFAULT_RECENT_SLOT_DURATION_MS` (400) — which is why this is never left to
  * the SDK default. Re-measure and update the date above if figures look off;
  * these are observations, not protocol constants.
  */

--- a/packages/sdp-types/src/kamino-programs.ts
+++ b/packages/sdp-types/src/kamino-programs.ts
@@ -1,0 +1,100 @@
+import type { SolanaCluster } from "./well-known-tokens";
+
+/**
+ * Kamino's on-chain program addresses, per cluster.
+ *
+ * ── Why this table lives in `@sdp/types` ────────────────────────────────────
+ * Two packages need it and neither may depend on the other: `@sdp/earn` reads
+ * the devnet kvault program directly (`providers/kamino/devnet.ts` filters
+ * `getProgramAccounts` by it) while `@sdp/kamino` builds instructions against
+ * it. Putting it in `@sdp/kamino` would force `@sdp/earn` to import the 13MB
+ * klend-sdk package — a workspace cycle `scripts/check-module-boundaries.mjs`
+ * rejects outright. `@sdp/types` is the leaf both already depend on, and it
+ * already owns third-party on-chain addresses (`SPL_TOKEN_PROGRAMS`, `SOL_MINT`,
+ * every well-known mint).
+ *
+ * ── The trap this table exists to prevent ───────────────────────────────────
+ * KAMINO DEPLOYS A SEPARATE KVAULT PROGRAM PER CLUSTER, and mainnet's id ALSO
+ * exists on devnet carrying ZERO accounts — so pointing at the wrong one yields
+ * a confident empty shelf rather than an error. Worse, klend-sdk's own
+ * `new KaminoVault(rpc, address, state, programId)` applies `programId` to
+ * account READS only and builds its internal client without forwarding it, so
+ * the naive construction (which is what Kamino's published recipe uses) reads
+ * devnet state and emits MAINNET instructions. `@sdp/kamino` is the only place
+ * allowed to construct a vault, and it must bind reads and writes together.
+ *
+ * Every address below was verified on-chain 2026-08-15.
+ */
+
+/**
+ * K-Vault program — THE ONE THAT DIFFERS PER CLUSTER. Never collapse these to a
+ * single constant, and never derive one from the environment without stating
+ * the cluster (migration 0057 exists because environment does not imply cluster).
+ */
+export const KAMINO_KVAULT_PROGRAM_IDS = {
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "mainnet-beta": "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  devnet: "devkRngFnfp4gBc5a3LsadgbQKdPo8MSZ4prFiNSVmY",
+} as const satisfies Record<SolanaCluster, string>;
+
+/**
+ * Kamino Lending (klend) — the program every K-Vault allocates into. Deployed at
+ * the SAME address on both clusters (verified 2026-08-15), so it takes no
+ * per-cluster branch. Stated as a record anyway so a future divergence is a data
+ * change here rather than a hunt through call sites.
+ */
+export const KAMINO_KLEND_PROGRAM_IDS = {
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "mainnet-beta": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  devnet: "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+} as const satisfies Record<SolanaCluster, string>;
+
+/**
+ * Kamino Farms — reward staking attached to some vaults.
+ *
+ * Verified 2026-08-15: deployed and executable at the same address on BOTH
+ * clusters, so unlike the kvault program this is NOT a second silent-mismatch
+ * trap. Checked explicitly rather than assumed, because a farms id that differed
+ * per cluster would fail exactly the way the kvault one does.
+ */
+export const KAMINO_FARMS_PROGRAM_IDS = {
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "mainnet-beta": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  devnet: "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+} as const satisfies Record<SolanaCluster, string>;
+
+/**
+ * Average slot duration per cluster, in milliseconds — a REQUIRED input to
+ * klend-sdk's `KaminoVaultClient`, and one with no safe default.
+ *
+ * It scales every accrual the SDK computes: exchange rate, APY, farm rewards. A
+ * wrong value produces plausible WRONG NUMBERS with no error — the same
+ * silent-failure class as the program-id trap above, and one no instruction
+ * assertion can catch.
+ *
+ * MEASURED 2026-08-15 via `getBlockTime` across a 4,000-slot span on each
+ * cluster's public RPC:
+ *
+ *   mainnet-beta  415.8 ms/slot
+ *   devnet        264.5 ms/slot
+ *
+ * Devnet is materially faster than mainnet, and both differ from klend-sdk's own
+ * `DEFAULT_RECENT_SLOT_DURATION_MS` (450) — which is why this is never left to
+ * the SDK default. Re-measure and update the date above if figures look off;
+ * these are observations, not protocol constants.
+ */
+export const KAMINO_SLOT_DURATION_MS = {
+  "mainnet-beta": 416,
+  devnet: 265,
+} as const satisfies Record<SolanaCluster, number>;
+
+/**
+ * The devnet kvault program id, kept as a NAMED export because
+ * `@sdp/earn/providers/kamino/devnet.ts` reads it directly for its
+ * `getProgramAccounts` size filter and reads nothing else from this module.
+ * Re-exported from the table so the two can never drift apart.
+ */
+export const KAMINO_DEVNET_KVAULT_PROGRAM_ID = KAMINO_KVAULT_PROGRAM_IDS.devnet;

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -1,3 +1,4 @@
+import type { SdpEnvironment } from "./api-keys";
 import { CUSTODY_PROVIDERS, type CustodyProvider } from "./custody";
 import {
   normalizeOrganizationTier,
@@ -144,6 +145,39 @@ export function earnDepositStyle(provider: string): EarnDepositStyle {
 export const SURFACED_EARN_PROVIDERS: readonly EarnProviderId[] = EARN_PROVIDERS.filter(
   (provider) => EARN_PROVIDER_SURFACING[provider]
 );
+
+/**
+ * Environments where a `vault_direct` deposit may be OPENED.
+ *
+ * ── Why production is closed ────────────────────────────────────────────────
+ * SDP can currently move money INTO a K-Vault and not back out. There is no
+ * vault-withdraw route (the Kamino client withholds the capability because its
+ * plan is not yet batched), and the dashboard's Active tab reads custodial
+ * `earn_provider_wallets` only, so a vault position does not even appear there.
+ * Entitlement will not save us: it is org-scoped, not environment-scoped, so an
+ * entitled org would otherwise reach mainnet with real funds.
+ *
+ * Nothing here traps money that is already deposited. The shares sit in the
+ * org's OWN custody wallet and Kamino's UI can always redeem them — this closes
+ * the door IN, which is the only direction ADR 0002 ever permits closing.
+ *
+ * Shared rather than duplicated on purpose: this is the single fact the API
+ * refuses on and the dashboard hides the affordance on, and a UI that offered a
+ * button the server refuses is the specific failure this replaces.
+ *
+ * TO OPEN PRODUCTION: land the withdraw path and the Active-tab surface, then
+ * add "production" here. It is one line precisely so it cannot be forgotten,
+ * and it is not a flag flip precisely because the work is real.
+ */
+export const VAULT_DIRECT_DEPOSIT_ENVIRONMENTS: readonly SdpEnvironment[] = ["sandbox"];
+
+/**
+ * Whether a non-custodial vault deposit may be opened in this environment.
+ * Fail-closed: an unrecognized environment answers false.
+ */
+export function isVaultDirectDepositEnabled(environment: string): boolean {
+  return (VAULT_DIRECT_DEPOSIT_ENVIRONMENTS as readonly string[]).includes(environment);
+}
 
 /**
  * Fail-closed surfacing check for an OPEN string.

--- a/packages/sdp-types/src/well-known-tokens.ts
+++ b/packages/sdp-types/src/well-known-tokens.ts
@@ -309,6 +309,29 @@ export const CLUSTER_BY_SDP_ENVIRONMENT = {
   production: "mainnet-beta",
 } as const satisfies Record<SdpEnvironment, SolanaCluster>;
 
+/**
+ * Each cluster's genesis hash — the only honest way to ask an RPC endpoint
+ * WHICH CHAIN it actually serves.
+ *
+ * Needed because a cluster mismatch is invisible in exactly the wrong
+ * direction. Kamino's mainnet kvault program id also resolves on devnet with
+ * zero accounts under it, so aiming a devnet request at a mainnet endpoint (or
+ * the reverse) does not error — it reports "no such vault", or worse, succeeds
+ * against the wrong deployment. Inferring the cluster from the URL is no
+ * substitute: provider URLs are opaque, and a mainnet endpoint need not contain
+ * the word "mainnet".
+ *
+ * Lives here because both `@sdp/earn` (catalogue sync) and the API's execution
+ * registry need it and neither may depend on the other — the same argument the
+ * Kamino program tables make.
+ */
+export const GENESIS_HASH_BY_CLUSTER = {
+  // biome-ignore lint/security/noSecrets: Solana mainnet-beta's public genesis hash
+  "mainnet-beta": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  // biome-ignore lint/security/noSecrets: Solana devnet's public genesis hash
+  devnet: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+} as const satisfies Record<SolanaCluster, string>;
+
 export function isWellKnownTokenSymbol(value: string): value is WellKnownTokenSymbol {
   return Object.hasOwn(WELL_KNOWN_TOKENS, value);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,8 @@ overrides:
   vite: 7.3.6
   ws: 8.21.0
 
+packageExtensionsChecksum: sha256-Hq4aG11euVLISXl/NBcyj4016UlEcDZd8BZXkelHdyM=
+
 patchedDependencies:
   '@solana/mosaic-sdk@0.1.1':
     hash: b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689
@@ -85,7 +87,7 @@ importers:
         version: 3.15.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@coinbase/cdp-sdk':
         specifier: 1.54.0
-        version: 1.54.0(typescript@6.0.3)
+        version: 1.54.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@hono/node-server':
         specifier: 2.0.12
         version: 2.0.12(hono@4.12.34)
@@ -107,6 +109,9 @@ importers:
       '@sdp/issuance':
         specifier: workspace:*
         version: link:../../packages/sdp-issuance
+      '@sdp/kamino':
+        specifier: workspace:*
+        version: link:../../packages/sdp-kamino
       '@sdp/payments':
         specifier: workspace:*
         version: link:../../packages/sdp-payments
@@ -136,64 +141,64 @@ importers:
         version: 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-core':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-fireblocks':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-privy':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-turnkey':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-utila':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kora':
         specifier: 0.3.0-beta.2
-        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)
+        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/pay':
         specifier: 1.0.26
-        version: 1.0.26(@solana-program/memo@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-api@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-spec@6.10.0(typescript@6.0.3))(typescript@6.0.3)
+        version: 1.0.26(49d490c75e5ddb07f3b4c93d353dbc05)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscriptions':
         specifier: 0.4.0
-        version: 0.4.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)
+        version: 0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/token-acl-gate-sdk':
         specifier: 0.3.0
-        version: 0.3.0(typescript@6.0.3)
+        version: 0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/transactions':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       hono:
         specifier: 4.12.34
         version: 4.12.34
@@ -333,7 +338,7 @@ importers:
         version: 7.6.4(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@flags-sdk/vercel':
         specifier: 1.4.6
-        version: 1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)
+        version: 1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@sdp/issuance':
         specifier: workspace:*
         version: link:../../packages/sdp-issuance
@@ -363,7 +368,7 @@ importers:
         version: 1.6.0
       '@vercel/flags-core':
         specifier: 1.7.1
-        version: 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)
+        version: 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -427,13 +432,13 @@ importers:
         version: 1.62.1
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kora':
         specifier: 0.3.0-beta.2
-        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
@@ -487,7 +492,7 @@ importers:
     dependencies:
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   packages/sdp-api-integration:
     dependencies:
@@ -505,26 +510,26 @@ importers:
         version: link:../sdp-types
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       '@sdp/api':
         specifier: workspace:*
         version: link:../../apps/sdp-api
       '@solana/surfpool':
         specifier: 1.5.0
-        version: 1.5.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 1.5.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -542,40 +547,40 @@ importers:
         version: link:../sdp-types
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-core':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-fireblocks':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-privy':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-turnkey':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-utila':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose:
         specifier: 6.2.8
         version: 6.2.8
@@ -630,22 +635,22 @@ importers:
         version: link:../sdp-types
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@6.8.0(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)
+        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/token-acl-gate-sdk':
         specifier: 0.3.0
-        version: 0.3.0(typescript@6.0.3)
+        version: 0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       tsx:
         specifier: 4.23.5
@@ -654,11 +659,45 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/sdp-kamino:
+    dependencies:
+      '@kamino-finance/klend-sdk':
+        specifier: 10.0.0
+        version: 10.0.0(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@sdp/earn':
+        specifier: workspace:*
+        version: link:../sdp-earn
+      '@sdp/solana':
+        specifier: workspace:*
+        version: link:../sdp-solana
+      '@sdp/types':
+        specifier: workspace:*
+        version: link:../sdp-types
+      '@solana/kit':
+        specifier: 'catalog:'
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      decimal.js:
+        specifier: 10.6.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: 26.1.2
+        version: 26.1.2
+      tsx:
+        specifier: 4.23.5
+        version: 4.23.5
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))
+
   packages/sdp-payments:
     dependencies:
       '@coinbase/cdp-sdk':
         specifier: 1.54.0
-        version: 1.54.0(typescript@6.0.3)
+        version: 1.54.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@sdp/rpc':
         specifier: workspace:*
         version: link:../sdp-rpc
@@ -670,19 +709,19 @@ importers:
         version: link:../sdp-types
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/fixed-points':
         specifier: 7.0.0
         version: 7.0.0(typescript@6.0.3)
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kora':
         specifier: 0.3.0-beta.2
-        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -723,10 +762,10 @@ importers:
         version: link:../sdp-types
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -742,10 +781,10 @@ importers:
         version: link:../sdp-types
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   packages/sdp-solana:
     dependencies:
@@ -757,19 +796,19 @@ importers:
         version: link:../sdp-types
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@6.8.0(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)
+        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     devDependencies:
       tsx:
         specifier: 4.23.5
@@ -782,14 +821,14 @@ importers:
         version: link:../kit-augment
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       '@codama/renderers-js':
         specifier: 2.3.1
-        version: 2.3.1(typescript@6.0.3)
+        version: 2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       codama:
         specifier: 1.10.0
         version: 1.10.0
@@ -807,14 +846,14 @@ importers:
         version: link:../kit-augment
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       '@codama/renderers-js':
         specifier: 2.3.1
-        version: 2.3.1(typescript@6.0.3)
+        version: 2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       codama:
         specifier: 1.10.0
         version: 1.10.0
@@ -829,7 +868,7 @@ importers:
     dependencies:
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -1122,6 +1161,32 @@ packages:
         optional: true
       '@x402/svm':
         optional: true
+
+  '@coral-xyz/anchor@0.28.0':
+    resolution: {integrity: sha512-kQ02Hv2ZqxtWP30WN1d4xxT4QqlOXYDxmEd3k/bbneqhV3X5QMO4LAtoUFs7otxyivOgoqam5Il5qx81FuI4vw==}
+    engines: {node: '>=11'}
+
+  '@coral-xyz/anchor@0.29.0':
+    resolution: {integrity: sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==}
+    engines: {node: '>=11'}
+
+  '@coral-xyz/borsh@0.28.0':
+    resolution: {integrity: sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
+
+  '@coral-xyz/borsh@0.29.0':
+    resolution: {integrity: sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
+
+  '@coral-xyz/borsh@0.30.1':
+    resolution: {integrity: sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
 
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
@@ -1436,6 +1501,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hubbleprotocol/hubble-config@5.0.0':
+    resolution: {integrity: sha512-oLdS2SwdYN8sggZhIesN+Kk8KQXGrbYn0kvnvTnk5Wh4pck1kR458ze5gh0XrMDpRVTdgwItf4mXhqiLXvQCKQ==}
+    peerDependencies:
+      '@solana/web3.js': ^1.78.4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1651,6 +1721,27 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@jup-ag/api@6.0.39':
+    resolution: {integrity: sha512-cejW4IWf3dKM5ucmqu5jWtlPZ46LJJOCrx3s5vKmEIB+0X9ykSZsKkcIHFBCOqf3/lSbGyU7THZqXuxjKK9//g==}
+
+  '@kamino-finance/farms-sdk@3.2.26':
+    resolution: {integrity: sha512-G6aziMz0ounatUEGlkiul14ERPXZD/RtzG21b72E/PKVBiFhKP/4fmpolHJjcgJWF4V4i+ITSXevi9oQ0EkLCA==}
+
+  '@kamino-finance/klend-sdk@10.0.0':
+    resolution: {integrity: sha512-U00zrm4jgZzctfGvRZw56kfZUmVXoKtiu9ZaP4CnZ0kg/QdxkyD5TTqJA/v8fThKWr0+uqlCJ6zV+F7QUZl/PA==}
+
+  '@kamino-finance/kliquidity-sdk@11.0.3':
+    resolution: {integrity: sha512-U/wEzDS14Kukd/uEO2HPmPL0c0E0K1agpRyHPdK9u6j4TKLjr4DqGeKXMppzV56dlonyN8upE++SXAGbTdSx6Q==}
+
+  '@kamino-finance/kliquidity-sdk@8.5.10':
+    resolution: {integrity: sha512-E+e4TR4JWdolivMsA956eamfcG5rd1+Wtr1N/iJRmdqrN5cKVln9xX2JAGmw0yGmcwOgxcJfe1joG16AnwKx3A==}
+
+  '@kamino-finance/scope-sdk@10.2.6':
+    resolution: {integrity: sha512-E/e4D4EhfR589ifrOjp6OhfOVXSorcL+m3gF2pElZjmHAlkuJdbl2tuM+m/3LEN4K1toGNjwhhKlA67z/QUNAg==}
+
+  '@kamino-finance/scope-sdk@9.1.0':
+    resolution: {integrity: sha512-/fsk00u64/IJx2iRYceo6K3J9tNSR6qv1SakU79lwURVrQuD4XtKf0HpDXWbJ0bxAxsa5/s28kwSWUG2J0AKWA==}
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -1809,6 +1900,30 @@ packages:
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
+
+  '@orca-so/common-sdk@0.6.11':
+    resolution: {integrity: sha512-7MJs71F8XJsYCx3+agsLc3MMGnzAC8l3FDbUq0qP3lEPI6B5IS/u2iKU4rWkK3IqIkynWcvuYL6WCi+90vu52w==}
+    peerDependencies:
+      '@solana/spl-token': ^0.4.12
+      '@solana/web3.js': ^1.90.0
+
+  '@orca-so/tx-sender@1.0.2':
+    resolution: {integrity: sha512-6PlGx4wwF9Q/XxfND43TtZsjiCJs6Ho5yIYBAkiXXaBOcIfqNTqKRhzhX598xv19TJl4DaldWhgx36m+nqmN8Q==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@orca-so/whirlpools-client@2.0.0':
+    resolution: {integrity: sha512-6/2CdK5aAypA2cT/01l28WLN4Avb55rCuUM9qNyv69NOKnCXRT3byv7FxXkFcJ5GzqoAYaR/fPsZimvi2ndkUg==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@orca-so/whirlpools-core@2.0.0':
+    resolution: {integrity: sha512-SzX9Jd9QDRk6UvUdM114Onq4woFVTl3rrx2Iu0IsnwBbA4lzFLPRYDxdsoyyRHceOgIrbhgpRU3IZc9jCRS8eg==}
+
+  '@orca-so/whirlpools@2.2.0':
+    resolution: {integrity: sha512-a43HQ+yZ8jnzmrVJ0lgJojnIjbvOIi+NlqBcawDhvwtnLz1uHsI1HaQawN3LJZLNrJtTowHdLT6GUCu4o0X0bA==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2539,6 +2654,9 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
+  '@raydium-io/raydium-sdk-v2@0.1.126-alpha':
+    resolution: {integrity: sha512-wpCb1rDvlENO+nfdjC1QVh6P4ImzgF/uhApw5194ycU1i8OSJrb0iZc1Egy5chafcn4i3gY2B1ivMdEeaNsSzA==}
+
   '@react-email/body@0.3.0':
     resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
     engines: {node: '>=20.0.0'}
@@ -3230,15 +3348,45 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@solana-program/address-lookup-table@0.7.0':
+    resolution: {integrity: sha512-dzCeIO5LtiK3bIg0AwO+TPeGURjSG2BKt0c4FRx7105AgLy7uzTktpUzUj6NXAK9SzbirI8HyvHUvw1uvL8O9A==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/address-lookup-table@0.8.0':
+    resolution: {integrity: sha512-ZTSlGj+4hPM6ssBquc8eOeqHR12/DkTDFoqvZqpikLKNHRPgBMFdat56CDBb5G1MCmviPWJ7ij4BUE3fzBz4MA==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/compute-budget@0.14.0':
     resolution: {integrity: sha512-tgvey/2bT35gUlb1lC84Hh2VqkOLoSa6KvaVz5DT037Mg8ECM+f2Q5Prv6V9yKQjRGGF2Y8BZgpOoUg6lTUl/Q==}
     peerDependencies:
       '@solana/kit': ^6.1.0
 
+  '@solana-program/compute-budget@0.7.0':
+    resolution: {integrity: sha512-/JJSE1fKO5zx7Z55Z2tLGWBDDi7tUE+xMlK8qqkHlY51KpqksMsIBzQMkG9Dqhoe2Cnn5/t3QK1nJKqW6eHzpg==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/compute-budget@0.8.0':
+    resolution: {integrity: sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/compute-budget@0.9.0':
+    resolution: {integrity: sha512-on7Cs1V48X9E2x1yVmfM6N6Xv0r4oGruXPcWnI50D3D3CIsHNWJ4gsvL4qZ4iey7zAP73FdM21K2CZBi1a/jzg==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/memo@0.10.0':
     resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
     peerDependencies:
       '@solana/kit': ^5.0
+
+  '@solana-program/memo@0.7.0':
+    resolution: {integrity: sha512-3T9iUjWSYtN/5S5jzJuasD2yQfVfFAQ9yTwIE25+P9peWqz4oarn6ZQvRj/FLcBqaMLtSqLhU1hN2cyVBS6hyg==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
 
   '@solana-program/record@0.3.0':
     resolution: {integrity: sha512-q8z86INfXRQ5357qgVBrw05vC+u3xg8Vb4E1gEwnYUvAkL3cbJSjWVfTlGRiGWYmPNq/FYIWbsFrhsxXyhaJ+w==}
@@ -3261,6 +3409,16 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
+  '@solana-program/system@0.7.0':
+    resolution: {integrity: sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/system@0.8.1':
+    resolution: {integrity: sha512-71U9Mzdpw8HQtfgfJSL5xKZbLMRnza2Llsfk7gGnmg2waqK+o8MMH4YNma8xXS1UmOBptXIiNvoZ3p7cmOVktg==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/token-2022@0.14.0':
     resolution: {integrity: sha512-SXZ3EcYC7DV/TLg0SEfCW/MoDkNzdazSzf4EBAQ1BOMMEhF/BXusbsTpgIXPlgGst+EMR9BH9tHGU37RAVJ8uQ==}
     engines: {node: '>=24.0.0'}
@@ -3271,6 +3429,18 @@ packages:
     peerDependenciesMeta:
       '@solana/zk-sdk':
         optional: true
+
+  '@solana-program/token-2022@0.4.2':
+    resolution: {integrity: sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+      '@solana/sysvars': ^2.1.0
+
+  '@solana-program/token-2022@0.5.0':
+    resolution: {integrity: sha512-CJcFU2bXeXh2da7GAsBRBbmYbmMCBb7uQye0ePsv9pKbWm7r4sqMLoNEi5B+bHRIx9urTKAbmYlGnvWxC9htNg==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+      '@solana/sysvars': ^3.0
 
   '@solana-program/token-2022@0.6.1':
     resolution: {integrity: sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==}
@@ -3295,6 +3465,16 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
+  '@solana-program/token@0.5.1':
+    resolution: {integrity: sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/token@0.6.0':
+    resolution: {integrity: sha512-omkZh4Tt9rre4wzWHNOhOEHyenXQku3xyc/UrKvShexA/Qlhza67q7uRwmwEDUs4QqoDBidSZPooOmepnA/jig==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
     peerDependencies:
@@ -3304,6 +3484,12 @@ packages:
     resolution: {integrity: sha512-bCiRVKtqYZpajgC2RVypZL4A0xHjQYVEsVSNMTtPJ1jjE5KOUvsXhnngGMYShK6BHv+fQP4F8QKvEVW/HOSFAg==}
     peerDependencies:
       '@solana/kit': ^7.0.0
+
+  '@solana/accounts@2.3.0':
+    resolution: {integrity: sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/accounts@5.5.1':
     resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
@@ -3331,6 +3517,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/addresses@2.3.0':
+    resolution: {integrity: sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/addresses@5.5.1':
     resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
@@ -3368,6 +3560,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/assertions@2.3.0':
+    resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/assertions@5.5.1':
     resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
     engines: {node: '>=20.18.0'}
@@ -3403,6 +3601,29 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/buffer-layout-utils@0.2.0':
+    resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
+    engines: {node: '>= 10'}
+
+  '@solana/buffer-layout-utils@0.3.0':
+    resolution: {integrity: sha512-MuQOCC1j0np1xH9yAv0ZWWfwvr7Bt7Sz4LId11Wi4wDdAmJ+lobE+vHg/mZmGcihF0BIkqVBNxGmlv8QE5DrtA==}
+    engines: {node: '>= 10'}
+
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-core@2.3.0':
+    resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/codecs-core@5.5.1':
     resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
@@ -3449,6 +3670,17 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-data-structures@2.0.0-rc.1':
+    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-data-structures@2.3.0':
+    resolution: {integrity: sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-data-structures@5.5.1':
     resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
     engines: {node: '>=20.18.0'}
@@ -3484,6 +3716,17 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.3.0':
+    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@5.5.1':
     resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
@@ -3529,6 +3772,19 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
+  '@solana/codecs-strings@2.3.0':
+    resolution: {integrity: sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.3.3'
 
   '@solana/codecs-strings@5.5.1':
     resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
@@ -3590,6 +3846,17 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs@2.0.0-rc.1':
+    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs@2.3.0':
+    resolution: {integrity: sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs@5.5.1':
     resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
     engines: {node: '>=20.18.0'}
@@ -3608,6 +3875,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/compat@2.3.0':
+    resolution: {integrity: sha512-3dbkQ0eymj1Il7KFAhA6X6LSI4d3uoHcp/WWoE7EIz9NS0ZZ8u27QmfYe5b0IcO2OFkmfReG79RVAm1xYY+7rA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/design-system@1.0.1':
     resolution: {integrity: sha512-8kkrxVyH+9zOfswREYm1mQqVmiQNMF4ANB7XdZCz8QLdqMfRX2FZUrxysnfFOlNPSXFHFI2scSBF8vPWLvRqwg==}
     peerDependencies:
@@ -3616,6 +3889,19 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
       tailwindcss: ^4.0.0
+
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.3.0':
+    resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/errors@5.5.1':
     resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
@@ -3667,6 +3953,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/fast-stable-stringify@2.3.0':
+    resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/fast-stable-stringify@5.5.1':
     resolution: {integrity: sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==}
     engines: {node: '>=20.18.0'}
@@ -3711,6 +4003,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/functional@2.3.0':
+    resolution: {integrity: sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/functional@5.5.1':
     resolution: {integrity: sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==}
@@ -3774,6 +4072,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/instructions@2.3.0':
+    resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/instructions@5.5.1':
     resolution: {integrity: sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==}
@@ -3878,6 +4182,12 @@ packages:
       '@solana/signers': '>=6.0.1'
       '@solana/transactions': '>=6.0.1'
 
+  '@solana/keys@2.3.0':
+    resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/keys@5.5.1':
     resolution: {integrity: sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==}
     engines: {node: '>=20.18.0'}
@@ -3929,6 +4239,12 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.8.0
 
+  '@solana/kit@2.3.0':
+    resolution: {integrity: sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/kit@5.5.1':
     resolution: {integrity: sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==}
     engines: {node: '>=20.18.0'}
@@ -3961,6 +4277,12 @@ packages:
     resolution: {integrity: sha512-SsZ9PMMBhFuZo9z+vCTyQ8lC+/FJ2OxiVJXkXOnB0atLDRwk4n64JSmSIykvKzZeWFX3CSxuX54OOv4QU9nuXg==}
     peerDependencies:
       typescript: ^5.0.0
+
+  '@solana/nominal-types@2.3.0':
+    resolution: {integrity: sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/nominal-types@5.5.1':
     resolution: {integrity: sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==}
@@ -4033,6 +4355,17 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/options@2.0.0-rc.1':
+    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/options@2.3.0':
+    resolution: {integrity: sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/options@5.5.1':
     resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
@@ -4123,6 +4456,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/programs@2.3.0':
+    resolution: {integrity: sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/programs@5.5.1':
     resolution: {integrity: sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==}
     engines: {node: '>=20.18.0'}
@@ -4140,6 +4479,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/promises@2.3.0':
+    resolution: {integrity: sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/promises@5.5.1':
     resolution: {integrity: sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==}
@@ -4180,6 +4525,12 @@ packages:
   '@solana/qr-code-styling@1.6.0':
     resolution: {integrity: sha512-KyBmyFKPxQPhUkP0jjnxV2ZeF1R1guTD8Hrd0YvHvMnhtrNEoEEdv4Jpp4W0GN4qCGG2KYOM5d3TgoLD+CNf9Q==}
 
+  '@solana/rpc-api@2.3.0':
+    resolution: {integrity: sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-api@5.5.1':
     resolution: {integrity: sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==}
     engines: {node: '>=20.18.0'}
@@ -4206,6 +4557,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-parsed-types@2.3.0':
+    resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-parsed-types@5.5.1':
     resolution: {integrity: sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==}
@@ -4234,6 +4591,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-spec-types@2.3.0':
+    resolution: {integrity: sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-spec-types@5.5.1':
     resolution: {integrity: sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==}
     engines: {node: '>=20.18.0'}
@@ -4260,6 +4623,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-spec@2.3.0':
+    resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-spec@5.5.1':
     resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
@@ -4288,6 +4657,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-api@2.3.0':
+    resolution: {integrity: sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-subscriptions-api@5.5.1':
     resolution: {integrity: sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==}
     engines: {node: '>=20.18.0'}
@@ -4306,6 +4681,13 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0':
+    resolution: {integrity: sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+      ws: 8.21.0
+
   '@solana/rpc-subscriptions-channel-websocket@5.5.1':
     resolution: {integrity: sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==}
     engines: {node: '>=20.18.0'}
@@ -4323,6 +4705,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-subscriptions-spec@2.3.0':
+    resolution: {integrity: sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-subscriptions-spec@5.5.1':
     resolution: {integrity: sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==}
@@ -4351,6 +4739,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions@2.3.0':
+    resolution: {integrity: sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-subscriptions@5.5.1':
     resolution: {integrity: sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==}
     engines: {node: '>=20.18.0'}
@@ -4368,6 +4762,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-transformers@2.3.0':
+    resolution: {integrity: sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-transformers@5.5.1':
     resolution: {integrity: sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==}
@@ -4396,6 +4796,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-transport-http@2.3.0':
+    resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-transport-http@5.5.1':
     resolution: {integrity: sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==}
     engines: {node: '>=20.18.0'}
@@ -4413,6 +4819,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-types@2.3.0':
+    resolution: {integrity: sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-types@5.5.1':
     resolution: {integrity: sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==}
@@ -4450,6 +4862,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc@2.3.0':
+    resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc@5.5.1':
     resolution: {integrity: sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==}
     engines: {node: '>=20.18.0'}
@@ -4467,6 +4885,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/signers@2.3.0':
+    resolution: {integrity: sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/signers@5.5.1':
     resolution: {integrity: sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==}
@@ -4503,6 +4927,39 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/spl-stake-pool@1.1.8':
+    resolution: {integrity: sha512-g/d8pFPI9NI1QWObSCkzMz4QpEUepWRLSERGV3gaAwfxWb3mG5I0KQqDW5UgZ8iT9srhzg7me+gG4ad9toQsNg==}
+
+  '@solana/spl-token-group@0.0.7':
+    resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token-metadata@0.1.6':
+    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.15':
+    resolution: {integrity: sha512-3Lof3mNov8NVQ3PalIWb1Jgr/TZ6lYM+/sexv2TLqdhNFVth2OfWmH3d7QucgMjSbokkjNiNlRr6I8Fd269uaw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
+
+  '@solana/spl-token@0.4.9':
+    resolution: {integrity: sha512-g3wbj4F4gq82YQlwqhPB0gHFXfgsC6UmyGMxtSLf/BozT/oKd59465DbnlUK8L8EcimKMavxsVAMoLcEdeCicg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/subscribable@2.3.0':
+    resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/subscribable@5.5.1':
     resolution: {integrity: sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==}
@@ -4570,6 +5027,12 @@ packages:
       '@solana/kit-plugin-signer':
         optional: true
 
+  '@solana/sysvars@2.3.0':
+    resolution: {integrity: sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/sysvars@5.5.1':
     resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
     engines: {node: '>=20.18.0'}
@@ -4598,6 +5061,12 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
 
+  '@solana/transaction-confirmation@2.3.0':
+    resolution: {integrity: sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/transaction-confirmation@5.5.1':
     resolution: {integrity: sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==}
     engines: {node: '>=20.18.0'}
@@ -4615,6 +5084,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/transaction-messages@2.3.0':
+    resolution: {integrity: sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/transaction-messages@5.5.1':
     resolution: {integrity: sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==}
@@ -4652,6 +5127,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/transactions@2.3.0':
+    resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/transactions@5.5.1':
     resolution: {integrity: sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==}
     engines: {node: '>=20.18.0'}
@@ -4687,6 +5168,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/web3.js@1.98.4':
+    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -4865,6 +5349,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -4913,6 +5400,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -4947,6 +5437,15 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.61.0':
     resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
@@ -5378,6 +5877,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -5575,19 +6078,22 @@ packages:
   bare-url@2.4.3:
     resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.11:
-    resolution: {integrity: sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==}
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.11.8:
-    resolution: {integrity: sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==}
+  baseline-browser-mapping@2.11.11:
+    resolution: {integrity: sha512-/yImnXwyTvgMkhgekLHok/Rx5vO6E0BmStWlSqKWMVm2a2ITuZ1Tn+9bgLS+gZRdZmWtd8nxuhHpdmCUOWsTQQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5597,8 +6103,27 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  big.js@6.2.2:
+    resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
+
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bn.js@5.2.5:
+    resolution: {integrity: sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -5618,6 +6143,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
@@ -5628,11 +6156,19 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-layout@1.2.2:
+    resolution: {integrity: sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==}
+    engines: {node: '>=4.5'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
@@ -5657,6 +6193,10 @@ packages:
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
@@ -5750,6 +6290,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -5764,6 +6308,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -5794,12 +6342,19 @@ packages:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  crypto-hash@1.3.0:
+    resolution: {integrity: sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==}
+    engines: {node: '>=8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -5833,6 +6388,9 @@ packages:
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -5854,6 +6412,9 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -5874,6 +6435,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -5931,6 +6496,9 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -6016,6 +6584,12 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  es6-promisify@5.0.0:
+    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -6195,6 +6769,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -6213,8 +6790,15 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
 
   fast-copy@4.0.4:
     resolution: {integrity: sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==}
@@ -6241,8 +6825,14 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6259,6 +6849,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -6470,6 +7063,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  fzstd@0.1.1:
+    resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -6641,6 +7237,9 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -6824,6 +7423,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: 8.21.0
+
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
@@ -6847,6 +7451,11 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jayson@4.3.0:
+    resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -6872,6 +7481,9 @@ packages:
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
+
+  js-sha256@0.9.0:
+    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6913,6 +7525,9 @@ packages:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
     engines: {node: '>= 0.4'}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -6921,6 +7536,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
@@ -7055,6 +7673,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -7406,6 +8027,9 @@ packages:
       sass:
         optional: true
 
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
   node-cron@4.6.0:
     resolution: {integrity: sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==}
     engines: {node: '>=20'}
@@ -7422,6 +8046,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
@@ -7537,6 +8165,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -7960,6 +8591,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rpc-websockets@9.3.9:
+    resolution: {integrity: sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -8091,6 +8725,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -8154,6 +8791,12 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -8236,6 +8879,13 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  superstruct@0.15.5:
+    resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
+
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -8337,9 +8987,15 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8375,6 +9031,12 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toformat@2.0.0:
+    resolution: {integrity: sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==}
+
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -8400,6 +9062,10 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -8502,6 +9168,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -8539,8 +9209,21 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8829,6 +9512,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zstddec@0.1.0:
+    resolution: {integrity: sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -9132,13 +9818,13 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
 
-  '@codama/renderers-js@2.3.1(typescript@6.0.3)':
+  '@codama/renderers-js@2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@codama/errors': 1.10.0
       '@codama/nodes': 1.10.0
       '@codama/renderers-core': 1.3.11
       '@codama/visitors-core': 1.10.0
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       prettier: 3.8.1
       semver: 7.8.5
     transitivePeerDependencies:
@@ -9163,11 +9849,11 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
 
-  '@coinbase/cdp-sdk@1.54.0(typescript@6.0.3)':
+  '@coinbase/cdp-sdk@1.54.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@6.0.3)(zod@3.25.76)
       axios: 1.18.1
       axios-retry: 4.5.0(axios@1.18.1)
@@ -9175,7 +9861,7 @@ snapshots:
       jose: 6.2.8
       md5: 2.3.0
       uncrypto: 0.1.3
-      viem: 2.53.1(typescript@6.0.3)(zod@3.25.76)
+      viem: 2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -9184,6 +9870,69 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  '@coral-xyz/anchor@0.28.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      base64-js: 1.5.1
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0
+      crypto-hash: 1.3.0
+      eventemitter3: 4.0.7
+      js-sha256: 0.9.0
+      pako: 2.2.0
+      snake-case: 3.0.4
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/anchor@0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0
+      crypto-hash: 1.3.0
+      eventemitter3: 4.0.7
+      pako: 2.2.0
+      snake-case: 3.0.4
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/borsh@0.28.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+
+  '@coral-xyz/borsh@0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+
+  '@coral-xyz/borsh@0.30.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -9346,9 +10095,9 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@flags-sdk/vercel@1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)':
+  '@flags-sdk/vercel@1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@vercel/flags-core': 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)
+      '@vercel/flags-core': 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       flags: 4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
@@ -9410,6 +10159,10 @@ snapshots:
   '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
+
+  '@hubbleprotocol/hubble-config@5.0.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -9573,6 +10326,181 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@jup-ag/api@6.0.39': {}
+
+  '@kamino-finance/farms-sdk@3.2.26(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@kamino-finance/kliquidity-sdk': 8.5.10(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@kamino-finance/scope-sdk': 9.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/address-lookup-table': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      decimal.js: 10.6.0
+      exponential-backoff: 3.1.3
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/klend-sdk@10.0.0(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.28.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@kamino-finance/farms-sdk': 3.2.26(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@kamino-finance/kliquidity-sdk': 11.0.3(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@kamino-finance/scope-sdk': 10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/address-lookup-table': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/memo': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/spl-stake-pool': 1.1.8(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      axios: 1.18.1
+      bn.js: 5.2.5
+      buffer: 6.0.3
+      commander: 9.5.0
+      decimal.js: 10.6.0
+      exponential-backoff: 3.1.3
+      zstddec: 0.1.0
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - '@solana/web3.js'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/kliquidity-sdk@11.0.3(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@hubbleprotocol/hubble-config': 5.0.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@jup-ag/api': 6.0.39
+      '@kamino-finance/scope-sdk': 10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@orca-so/common-sdk': 0.6.11(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@orca-so/whirlpools': 2.2.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@orca-so/whirlpools-core': 2.0.0
+      '@raydium-io/raydium-sdk-v2': 0.1.126-alpha(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana-program/address-lookup-table': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      axios: 1.18.1
+      bn.js: 5.2.5
+      bs58: 6.0.0
+      decimal.js: 10.6.0
+      fzstd: 0.1.1
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - '@solana/web3.js'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/kliquidity-sdk@8.5.10(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.30.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@hubbleprotocol/hubble-config': 5.0.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@jup-ag/api': 6.0.39
+      '@kamino-finance/scope-sdk': 10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@orca-so/common-sdk': 0.6.11(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@orca-so/whirlpools': 2.2.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@orca-so/whirlpools-core': 2.0.0
+      '@raydium-io/raydium-sdk-v2': 0.1.126-alpha(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana-program/address-lookup-table': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      axios: 1.18.1
+      bn.js: 5.2.5
+      bs58: 6.0.0
+      buffer-layout: 1.2.2
+      decimal.js: 10.6.0
+      fzstd: 0.1.1
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - '@solana/web3.js'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/scope-sdk@10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+      decimal.js: 10.6.0
+    transitivePeerDependencies:
+      - '@solana/web3.js'
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/scope-sdk@9.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+      decimal.js: 10.6.0
+    transitivePeerDependencies:
+      - '@solana/web3.js'
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -9723,6 +10651,41 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@orca-so/common-sdk@0.6.11(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/spl-token': 0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      decimal.js: 10.6.0
+      tiny-invariant: 1.3.3
+
+  '@orca-so/tx-sender@1.0.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana-program/address-lookup-table': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@orca-so/whirlpools-client@2.0.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@orca-so/whirlpools-core@2.0.0': {}
+
+  '@orca-so/whirlpools@2.2.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@orca-so/tx-sender': 1.0.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@orca-so/whirlpools-client': 2.0.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@orca-so/whirlpools-core': 2.0.0
+      '@solana-program/memo': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
 
   '@pinojs/redact@0.4.0': {}
 
@@ -10500,6 +11463,29 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
+  '@raydium-io/raydium-sdk-v2@0.1.126-alpha(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/spl-token': 0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      axios: 1.18.1
+      big.js: 6.2.2
+      bn.js: 5.2.5
+      dayjs: 1.11.21
+      decimal.js-light: 2.5.1
+      jsonfile: 6.2.1
+      lodash: 4.18.1
+      toformat: 2.0.0
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   '@react-email/body@0.3.0(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -11079,123 +12065,196 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/address-lookup-table@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/memo@0.10.0(@solana/kit@5.5.1(typescript@6.0.3))':
+  '@solana-program/address-lookup-table@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/memo@0.10.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/record@0.3.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.10.0(@solana/kit@5.5.1(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.12.2(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/memo@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))':
+  '@solana-program/memo@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/memo@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/record@0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.12.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/system@0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 1.9.7
-      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
+      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@6.8.0(typescript@6.0.3))':
+  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 1.9.7
-      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 6.8.0(typescript@6.0.3)
+      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.9.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))':
+  '@solana-program/token-2022@0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token@0.13.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana-program/system': 0.12.2(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/token-2022@0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token@0.9.0(@solana/kit@5.5.1(typescript@6.0.3))':
+  '@solana-program/token@0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana-program/system': 0.12.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana/accounts@5.5.1(typescript@6.0.3)':
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token@0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/accounts@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/accounts@6.10.0(typescript@6.0.3)':
+  '@solana/accounts@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/accounts@6.8.0(typescript@6.0.3)':
+  '@solana/accounts@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.5.1(typescript@6.0.3)':
+  '@solana/addresses@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/assertions': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
@@ -11203,11 +12262,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.10.0(typescript@6.0.3)':
+  '@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.10.0(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
     optionalDependencies:
@@ -11215,11 +12274,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.8.0(typescript@6.0.3)':
+  '@solana/addresses@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.8.0(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
     optionalDependencies:
@@ -11227,17 +12286,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.9.0(typescript@6.0.3)':
+  '@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.9.0(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/assertions@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -11261,6 +12325,44 @@ snapshots:
     dependencies:
       '@solana/errors': 6.9.0(typescript@6.0.3)
     optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@solana/buffer-layout-utils@0.3.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/codecs-core@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@solana/codecs-core@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
 
   '@solana/codecs-core@5.5.1(typescript@6.0.3)':
@@ -11293,6 +12395,20 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@solana/codecs-data-structures@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+
   '@solana/codecs-data-structures@5.5.1(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
@@ -11323,6 +12439,18 @@ snapshots:
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
     optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@solana/codecs-numbers@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
 
   '@solana/codecs-numbers@5.5.1(typescript@6.0.3)':
@@ -11360,66 +12488,121 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/codecs-strings@5.5.1(typescript@6.0.3)':
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 6.0.3
+
+  '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 6.0.3
+
+  '@solana/codecs-strings@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@6.10.0(typescript@6.0.3)':
+  '@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@6.8.0(typescript@6.0.3)':
+  '@solana/codecs-strings@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@6.9.0(typescript@6.0.3)':
+  '@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@7.0.0(typescript@6.0.3)':
+  '@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
       '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
       '@solana/errors': 7.0.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs@5.5.1(typescript@6.0.3)':
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
-      '@solana/options': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/codecs@6.8.0(typescript@6.0.3)':
+  '@solana/codecs@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
-      '@solana/options': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/compat@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -11436,6 +12619,18 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       shiki: 3.23.0
       tailwindcss: 4.3.0
+
+  '@solana/errors@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
+      typescript: 6.0.3
+
+  '@solana/errors@2.3.0(typescript@6.0.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      typescript: 6.0.3
 
   '@solana/errors@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -11472,6 +12667,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/fast-stable-stringify@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
   '@solana/fast-stable-stringify@5.5.1(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
@@ -11501,6 +12700,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/functional@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
   '@solana/functional@5.5.1(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
@@ -11517,44 +12720,50 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/instruction-plans@5.5.1(typescript@6.0.3)':
+  '@solana/instruction-plans@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instruction-plans@6.10.0(typescript@6.0.3)':
+  '@solana/instruction-plans@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instruction-plans@6.8.0(typescript@6.0.3)':
+  '@solana/instruction-plans@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/instructions@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/instructions@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -11584,118 +12793,129 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))':
+  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-fireblocks@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-fireblocks@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose: 6.2.8
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-para@1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))':
+  '@solana/keychain-para@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-para@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-para@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-privy@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-privy@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-turnkey@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-turnkey@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 2.2.0
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-utila@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-utila@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose: 6.2.8
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keys@5.5.1(typescript@6.0.3)':
+  '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/assertions': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
@@ -11703,11 +12923,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.10.0(typescript@6.0.3)':
+  '@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.10.0(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
       '@solana/promises': 6.10.0(typescript@6.0.3)
@@ -11716,11 +12936,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.8.0(typescript@6.0.3)':
+  '@solana/keys@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.8.0(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
@@ -11729,11 +12949,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.9.0(typescript@6.0.3)':
+  '@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.9.0(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
       '@solana/promises': 6.9.0(typescript@6.0.3)
@@ -11742,43 +12962,68 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
 
-  '@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana/kit@5.5.1(typescript@6.0.3)':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/accounts': 5.5.1(typescript@6.0.3)
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
-      '@solana/codecs': 5.5.1(typescript@6.0.3)
+      '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/programs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-parsed-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
-      '@solana/instruction-plans': 5.5.1(typescript@6.0.3)
+      '@solana/instruction-plans': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
-      '@solana/offchain-messages': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/plugin-core': 5.5.1(typescript@6.0.3)
-      '@solana/programs': 5.5.1(typescript@6.0.3)
-      '@solana/rpc': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-api': 5.5.1(typescript@6.0.3)
+      '@solana/programs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/signers': 5.5.1(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-confirmation': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -11786,33 +13031,33 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/kit@6.8.0(typescript@6.0.3)':
+  '@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/accounts': 6.8.0(typescript@6.0.3)
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/codecs': 6.8.0(typescript@6.0.3)
+      '@solana/accounts': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.8.0(typescript@6.0.3)
+      '@solana/instruction-plans': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/offchain-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/plugin-core': 6.8.0(typescript@6.0.3)
-      '@solana/plugin-interfaces': 6.8.0(typescript@6.0.3)
-      '@solana/program-client-core': 6.8.0(typescript@6.0.3)
-      '@solana/programs': 6.8.0(typescript@6.0.3)
-      '@solana/rpc': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.8.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/program-client-core': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/programs': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/signers': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-confirmation': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/sysvars': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -11820,29 +13065,33 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/kora@0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kora@0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/compute-budget': 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
+      '@solana-program/compute-budget': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
 
-  '@solana/mosaic-sdk@0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)':
+  '@solana/mosaic-sdk@0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-program/memo': 0.10.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/kit': 5.5.1(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
-      '@token-acl/abl-sdk': '@solana/token-acl-gate-sdk@0.2.0(typescript@6.0.3)'
-      '@token-acl/sdk': 0.2.7(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)
+      '@solana-program/memo': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@token-acl/abl-sdk': '@solana/token-acl-gate-sdk@0.2.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)'
+      '@token-acl/sdk': 0.2.7(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
+
+  '@solana/nominal-types@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@solana/nominal-types@5.5.1(typescript@6.0.3)':
     optionalDependencies:
@@ -11860,103 +13109,125 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/offchain-messages@5.5.1(typescript@6.0.3)':
+  '@solana/offchain-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@6.10.0(typescript@6.0.3)':
+  '@solana/offchain-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@6.8.0(typescript@6.0.3)':
+  '@solana/offchain-messages@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@6.9.0(typescript@6.0.3)':
+  '@solana/offchain-messages@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
-      '@solana/keys': 6.9.0(typescript@6.0.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@5.5.1(typescript@6.0.3)':
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@6.8.0(typescript@6.0.3)':
+  '@solana/options@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/pay@1.0.26(@solana-program/memo@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-api@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-spec@6.10.0(typescript@6.0.3))(typescript@6.0.3)':
+  '@solana/pay@1.0.26(49d490c75e5ddb07f3b4c93d353dbc05)':
     dependencies:
-      '@solana-program/memo': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token-2022': 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/plugin-interfaces': 6.10.0(typescript@6.0.3)
+      '@solana-program/memo': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/qr-code-styling': 1.6.0
-      '@solana/rpc-subscriptions-api': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.10.0(typescript@6.0.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -11970,83 +13241,95 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/plugin-interfaces@6.10.0(typescript@6.0.3)':
+  '@solana/plugin-interfaces@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 6.10.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-interfaces@6.8.0(typescript@6.0.3)':
+  '@solana/plugin-interfaces@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instruction-plans': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/signers': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/program-client-core@6.10.0(typescript@6.0.3)':
+  '@solana/program-client-core@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 6.10.0(typescript@6.0.3)
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/accounts': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.10.0(typescript@6.0.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/plugin-interfaces': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/program-client-core@6.8.0(typescript@6.0.3)':
+  '@solana/program-client-core@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 6.8.0(typescript@6.0.3)
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/accounts': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.8.0(typescript@6.0.3)
+      '@solana/instruction-plans': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/plugin-interfaces': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.8.0(typescript@6.0.3)
-      '@solana/signers': 6.8.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@5.5.1(typescript@6.0.3)':
+  '@solana/programs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/programs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@6.8.0(typescript@6.0.3)':
+  '@solana/programs@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@solana/promises@5.5.1(typescript@6.0.3)':
     optionalDependencies:
@@ -12068,59 +13351,80 @@ snapshots:
     dependencies:
       qrcode-generator: 1.5.2
 
-  '@solana/rpc-api@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-parsed-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@6.10.0(typescript@6.0.3)':
+  '@solana/rpc-api@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 6.10.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-api@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@solana/rpc-parsed-types@5.5.1(typescript@6.0.3)':
     optionalDependencies:
@@ -12134,6 +13438,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/rpc-spec-types@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
   '@solana/rpc-spec-types@5.5.1(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
@@ -12144,6 +13452,12 @@ snapshots:
 
   '@solana/rpc-spec-types@6.8.0(typescript@6.0.3)':
     optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/rpc-spec@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
 
   '@solana/rpc-spec@5.5.1(typescript@6.0.3)':
@@ -12168,59 +13482,89 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-subscriptions-api@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-api@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-api@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@6.0.3)
+      '@solana/subscribable': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@6.0.3)
       '@solana/subscribable': 5.5.1(typescript@6.0.3)
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-channel-websocket@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.8.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@solana/rpc-subscriptions-spec@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/promises': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/subscribable': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/rpc-subscriptions-spec@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -12249,18 +13593,36 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-subscriptions@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/fast-stable-stringify': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/promises': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/subscribable': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/rpc-subscriptions@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/fast-stable-stringify': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/promises': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions-api': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscribable': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
@@ -12269,18 +13631,18 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-subscriptions@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-subscriptions@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/fast-stable-stringify': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions-api': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.8.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
@@ -12289,41 +13651,60 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-transformers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transformers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transformers@6.10.0(typescript@6.0.3)':
+  '@solana/rpc-transformers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/functional': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transformers@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-transformers@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transport-http@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      undici-types: 7.27.2
 
   '@solana/rpc-transport-http@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -12343,12 +13724,24 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-types@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-types@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
@@ -12356,12 +13749,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@6.10.0(typescript@6.0.3)':
+  '@solana/rpc-types@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/fixed-points': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
@@ -12370,12 +13763,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-types@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
     optionalDependencies:
@@ -12383,12 +13776,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@6.9.0(typescript@6.0.3)':
+  '@solana/rpc-types@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/fixed-points': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
@@ -12397,101 +13790,197 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@5.5.1(typescript@6.0.3)':
+  '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/fast-stable-stringify': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-transport-http': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/fast-stable-stringify': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-api': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-transport-http': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@6.8.0(typescript@6.0.3)':
+  '@solana/rpc@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/fast-stable-stringify': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-transport-http': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@5.5.1(typescript@6.0.3)':
+  '@solana/signers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
-      '@solana/offchain-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.10.0(typescript@6.0.3)':
+  '@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/offchain-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.8.0(typescript@6.0.3)':
+  '@solana/signers@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/offchain-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.9.0(typescript@6.0.3)':
+  '@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/instructions': 6.9.0(typescript@6.0.3)
-      '@solana/keys': 6.9.0(typescript@6.0.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.9.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/offchain-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/spl-stake-pool@1.1.8(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/spl-token': 0.4.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer: 6.0.3
+      buffer-layout: 1.2.2
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.3.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-token@0.4.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/subscribable@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/subscribable@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -12512,14 +14001,14 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/subscriptions@0.4.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)':
+  '@solana/subscriptions@0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana-program/token': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token-2022': 0.9.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/program-client-core': 6.10.0(typescript@6.0.3)
+      '@solana-program/token': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/program-client-core': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/sysvars'
       - fastestsmallesttextencoderdecoder
@@ -12534,67 +14023,94 @@ snapshots:
   '@solana/surfpool-linux-x64-gnu@1.5.0':
     optional: true
 
-  '@solana/surfpool@1.5.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/surfpool@1.5.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     optionalDependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/surfpool-darwin-arm64': 1.5.0
       '@solana/surfpool-darwin-x64': 1.5.0
       '@solana/surfpool-linux-x64-gnu': 1.5.0
 
-  '@solana/sysvars@5.5.1(typescript@6.0.3)':
+  '@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 5.5.1(typescript@6.0.3)
-      '@solana/codecs': 5.5.1(typescript@6.0.3)
+      '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@6.8.0(typescript@6.0.3)':
+  '@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 6.8.0(typescript@6.0.3)
+      '@solana/accounts': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/token-acl-gate-sdk@0.2.0(typescript@6.0.3)':
+  '@solana/token-acl-gate-sdk@0.2.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/token-acl-gate-sdk@0.3.0(typescript@6.0.3)':
+  '@solana/token-acl-gate-sdk@0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-confirmation@5.5.1(typescript@6.0.3)':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/promises': 2.3.0(typescript@6.0.3)
+      '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/transaction-confirmation@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 5.5.1(typescript@6.0.3)
-      '@solana/rpc': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12602,18 +14118,18 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-confirmation@6.8.0(typescript@6.0.3)':
+  '@solana/transaction-confirmation@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
-      '@solana/rpc': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/rpc': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12621,9 +14137,24 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@5.5.1(typescript@6.0.3)':
+  '@solana/transaction-messages@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
@@ -12631,15 +14162,15 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@6.10.0(typescript@6.0.3)':
+  '@solana/transaction-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
@@ -12647,15 +14178,15 @@ snapshots:
       '@solana/functional': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@6.8.0(typescript@6.0.3)':
+  '@solana/transaction-messages@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
@@ -12663,15 +14194,15 @@ snapshots:
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@6.9.0(typescript@6.0.3)':
+  '@solana/transaction-messages@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
@@ -12679,87 +14210,128 @@ snapshots:
       '@solana/functional': 6.9.0(typescript@6.0.3)
       '@solana/instructions': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.9.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@5.5.1(typescript@6.0.3)':
+  '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.10.0(typescript@6.0.3)':
+  '@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/functional': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.8.0(typescript@6.0.3)':
+  '@solana/transactions@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.9.0(typescript@6.0.3)':
+  '@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/functional': 6.9.0(typescript@6.0.3)
       '@solana/instructions': 6.9.0(typescript@6.0.3)
-      '@solana/keys': 6.9.0(typescript@6.0.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.9.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.9.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/buffer-layout': 4.0.1
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      agentkeepalive: 4.6.0
+      bn.js: 5.2.5
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.3.9
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
 
   '@stablelib/base64@1.0.1': {}
 
@@ -12883,10 +14455,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@token-acl/sdk@0.2.7(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)':
+  '@token-acl/sdk@0.2.7(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@solana/sysvars'
       - bufferutil
@@ -12923,6 +14495,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.1.2
 
   '@types/debug@4.1.13':
     dependencies:
@@ -12979,6 +14555,8 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@12.20.55': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -13021,6 +14599,16 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 26.1.2
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.2
 
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -13194,9 +14782,9 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/flags-core@1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)':
+  '@vercel/flags-core@1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@vercel/functions': 3.7.5(ws@8.21.0)
+      '@vercel/functions': 3.7.5(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@vercel/oidc': 3.5.0
       jose: 5.2.1
       js-xxhash: 4.0.0
@@ -13206,11 +14794,11 @@ snapshots:
       - '@aws-sdk/credential-provider-web-identity'
       - ws
 
-  '@vercel/functions@3.7.5(ws@8.21.0)':
+  '@vercel/functions@3.7.5(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@vercel/oidc@3.5.0': {}
 
@@ -13431,6 +15019,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -13648,13 +15240,17 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.11: {}
+  baseline-browser-mapping@2.10.43: {}
 
-  baseline-browser-mapping@2.11.8: {}
+  baseline-browser-mapping@2.11.11: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -13664,11 +15260,31 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  big.js@6.2.2: {}
+
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
+
+  bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bn.js@5.2.5: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
 
   brace-expansion@5.0.9(patch_hash=cb7f184e2dafcba994a55ee67b21ef5a2cb11e980f3bce73203d9d93f42018c3):
     dependencies:
@@ -13680,7 +15296,7 @@ snapshots:
 
   browserslist@4.28.5:
     dependencies:
-      baseline-browser-mapping: 2.11.8
+      baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.389
       node-releases: 2.0.51
@@ -13694,6 +15310,10 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
+
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
@@ -13701,6 +15321,8 @@ snapshots:
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-layout@1.2.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -13711,6 +15333,11 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
 
   buildcheck@0.0.7:
     optional: true
@@ -13735,6 +15362,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001806: {}
 
@@ -13812,6 +15441,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@12.1.0: {}
+
   commander@14.0.2: {}
 
   commander@14.0.3: {}
@@ -13819,6 +15450,8 @@ snapshots:
   commander@15.0.0: {}
 
   commander@2.20.3: {}
+
+  commander@9.5.0: {}
 
   commondir@1.0.1: {}
 
@@ -13849,6 +15482,12 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -13856,6 +15495,8 @@ snapshots:
       which: 2.0.2
 
   crypt@0.0.2: {}
+
+  crypto-hash@1.3.0: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -13895,6 +15536,8 @@ snapshots:
 
   dateformat@4.6.3: {}
 
+  dayjs@1.11.21: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -13904,6 +15547,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -13926,6 +15571,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delay@5.0.0: {}
 
   delayed-stream@1.0.0: {}
 
@@ -13990,6 +15637,11 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
 
   dotenv@16.6.1: {}
 
@@ -14133,6 +15785,12 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-promise@4.2.8: {}
+
+  es6-promisify@5.0.0:
+    dependencies:
+      es6-promise: 4.2.8
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -14432,6 +16090,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   events-universal@1.0.1:
@@ -14456,7 +16116,11 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   extend@3.0.2: {}
+
+  eyes@0.1.8: {}
 
   fast-copy@4.0.4: {}
 
@@ -14480,7 +16144,11 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
+  fast-stable-stringify@1.0.0: {}
+
   fast-uri@3.1.5: {}
+
+  fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.20.1:
     dependencies:
@@ -14493,6 +16161,8 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -14675,6 +16345,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fzstd@0.1.1: {}
 
   generator-function@2.0.1: {}
 
@@ -14930,6 +16602,10 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -15111,9 +16787,13 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.21.0):
+  isomorphic-ws@4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -15143,6 +16823,24 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      json-stringify-safe: 5.0.1
+      stream-json: 1.9.1
+      uuid: 8.3.2
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 26.1.2
@@ -15160,6 +16858,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-cookie@3.0.7: {}
+
+  js-sha256@0.9.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -15211,11 +16911,19 @@ snapshots:
       jsonify: 0.0.1
       object-keys: 1.1.1
 
+  json-stringify-safe@5.0.1: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonify@0.0.1: {}
 
@@ -15319,6 +17027,10 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
 
   lru-cache@10.4.3: {}
 
@@ -15907,6 +17619,11 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
   node-cron@4.6.0: {}
 
   node-exports-info@1.6.0:
@@ -15919,6 +17636,9 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-releases@2.0.51: {}
 
@@ -16047,6 +17767,8 @@ snapshots:
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  pako@2.2.0: {}
 
   parse-entities@4.0.2:
     dependencies:
@@ -16649,6 +18371,19 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  rpc-websockets@9.3.9:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/uuid': 10.0.0
+      '@types/ws': 8.18.1
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      uuid: 14.0.1
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -16833,6 +18568,11 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -16893,6 +18633,12 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
 
   streamx@2.25.0:
     dependencies:
@@ -17005,6 +18751,10 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
+
+  superstruct@0.15.5: {}
+
+  superstruct@2.0.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -17121,9 +18871,13 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  text-encoding-utf-8@1.0.2: {}
+
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -17150,6 +18904,10 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toformat@2.0.0: {}
+
+  toml@3.0.0: {}
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.10
@@ -17172,6 +18930,12 @@ snapshots:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 
@@ -17309,6 +19073,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@2.0.1: {}
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -17371,7 +19137,16 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.1: {}
+
+  uuid@8.3.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -17388,16 +19163,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.53.1(typescript@6.0.3)(zod@3.25.76):
+  viem@2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.21.0)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.14.29(typescript@6.0.3)(zod@3.25.76)
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17606,7 +19381,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.0: {}
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   xdg-app-paths@5.5.1:
     dependencies:
@@ -17703,5 +19481,7 @@ snapshots:
   zod@4.1.11: {}
 
   zod@4.4.3: {}
+
+  zstddec@0.1.0: {}
 
   zwitch@2.0.4: {}

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -24,6 +24,7 @@ const MODULE_METADATA = [
       "@sdp/earn",
       "@sdp/env-config",
       "@sdp/issuance",
+      "@sdp/kamino",
       "@sdp/payments",
       "@sdp/policy",
       "@sdp/private-channels",
@@ -95,6 +96,18 @@ const MODULE_METADATA = [
     directory: "packages/sdp-issuance",
     purpose: "Token issuance domain services and Mosaic integration.",
     allowedDependencies: ["@sdp/payments", "@sdp/rpc", "@sdp/solana", "@sdp/types"],
+  },
+  {
+    name: "@sdp/kamino",
+    directory: "packages/sdp-kamino",
+    purpose: "Kit-native Kamino K-Vault deposit/withdraw instruction plans over klend-sdk.",
+    // The arrow points INWARD and only inward: this package depends on
+    // @sdp/earn (for the provider contract and the catalogue client it extends),
+    // and @sdp/earn must never depend back — its hourly catalogue cron would
+    // then load klend-sdk (13MB, built against a different @solana/kit major).
+    // That one-way edge is also why the Kamino program-id table lives in
+    // @sdp/types, which both reach without a cycle.
+    allowedDependencies: ["@sdp/earn", "@sdp/solana", "@sdp/types"],
   },
   {
     name: "@sdp/payments",

--- a/scripts/secret-keys.mjs
+++ b/scripts/secret-keys.mjs
@@ -33,6 +33,11 @@ export const API_LOCAL_ENV_KEYS = [
   "ALLOWLIST_ADMIN_KEY",
   "ALLOWLIST_ADMIN_ORG_ID",
   "SOLANA_RPC_URL",
+  // Optional per-cluster overrides. One API process serves sandbox (devnet) and
+  // production (mainnet-beta), so the Earn execution path resolves its endpoint
+  // by cluster and falls back to SOLANA_RPC_URL when these are unset.
+  "SOLANA_DEVNET_RPC_URL",
+  "SOLANA_MAINNET_RPC_URL",
   "SOLANA_RPC_DEFAULT_PROVIDER",
   "SOLANA_RPC_TRITON_URL",
   "SOLANA_RPC_TRITON_API_KEY",


### PR DESCRIPTION
> [!NOTE]
> This monolithic draft has been superseded by five smaller draft PRs. Review and merge them bottom-up:
>
> 1. #1350 — Kamino SDK and neutral contracts
> 2. #1351 — SQL movement ledger
> 3. #1352 — execution runtime
> 4. #1353 — policy-gated API
> 5. #1354 — dashboard experience
>
> All five remain drafts. The replacement stack's top tree is byte-for-byte identical to this PR's reviewed head. This closed PR is retained only for its historical security and SQL review record.

---

Stacked on #1340 — **base is `claude/provider-surfacing-config-68f58a`, not `main`.** Review that PR first.

## Purpose

Kamino strategies are real catalogue entries, but a K-Vault is not a custodial Earn program and it has no deposit address. Sending stablecoins to the vault account would destroy them: deposits must be expressed as program instructions, signed by an SDP custody wallet, and submitted on chain.

This PR adds that second Earn money model:

1. resolve an admitted catalogue strategy and an exact SDP custody-wallet row;
2. build and independently validate the provider's transaction plan;
3. enforce wallet policy and API-key wallet scope;
4. simulate and sign with the selected custody wallet;
5. atomically persist the signed outbox, movement, position claim, idempotency winner, and approved-operation effect;
6. let only that winner broadcast;
7. read position balances live from chain while keeping SDP's movement audit durable.

Production deposits remain fail-closed. The same shared capability disables the dashboard action and rejects the API until withdrawal, Active-position, live-quote, and recovery prerequisites land.

## Why this is a substantial change

- **No address exists to fund.** Existing Earn providers provision a custodial wallet; Kamino requires an execution path.
- **The persistence model is different.** Many organizations can hold the same public vault, so the global provider-wallet uniqueness used by custodial Earn is invalid. Migration `0058` adds separate `earn_vault_positions` and `earn_vault_movements` tables.
- **The provider SDK is behind a firewall.** `@kamino-finance/klend-sdk` uses an older Solana Kit and brings a large runtime/WASM dependency graph. `packages/sdp-kamino` keeps that implementation out of the neutral `@sdp/earn` contract and hourly catalogue job.
- **Cluster defaults are unsafe.** The SDK can read devnet state while emitting mainnet K-Vault instructions unless program ids are rebound and output is independently checked. Every execution/read now also proves the RPC endpoint's genesis hash.
- **Signed broadcasts need an outbox.** An RPC timeout does not prove that no money moved. Exact signed bytes, signature, and last-valid block height are stored before broadcast so ambiguous outcomes remain observable and replayable.

## What ships

### `packages/sdp-kamino`

- Kit-native deposit plans and position reads over the pinned Kamino SDK.
- Per-cluster K-Vault, lending, and farms program bindings plus output allowlist checks.
- Required live `assetIdentity` (`depositTokenMint`, `shareMint`) carried with every plan.
- Exact mint-scale validation and canonical accepted amount/floor values; insignificant trailing zeroes are accepted, non-zero sub-atoms are rejected.
- Exact raw share-account reads above `2^53`, finite/non-negative share and valuation guards, bounded RPC deadlines, shared-slot reads, and hydration concurrency capped at four.
- Measured slot durations: mainnet ≈416 ms, devnet ≈265 ms; both differ from klend-sdk's default of 400 ms.
- Withdrawal capability remains withheld until multi-transaction/LUT execution and resumability exist.

### API and PostgreSQL

- `POST /v1/earn/vault-deposits` and `GET /v1/earn/vault-positions`.
- Route order: global `earn:write` + `wallets:read` → wallet policy → selected-wallet `earn:write` → handler.
- Request identity is the exact `custodyWalletId` (`cwlt_…`), not a provider-local wallet id or public key; ambiguous provider ids fail closed.
- Production capability, strategy status/surfacing/entitlement, catalogue admission, cluster, live asset identity, signer address, requested amount, accepted amount, and slippage-floor semantics all fail closed before signing.
- Required request fingerprint returns `409` on key reuse with a different wallet/vault/environment/amount/floor. A memo makes independently keyed otherwise-identical Solana messages distinct.
- Build → simulate → sign completes before persistence. One PostgreSQL transaction fences the approved effect and inserts the immutable position identity, signed movement/outbox, and idempotency winner; only the winner broadcasts.
- Ambiguous sends remain `pending`; guarded CAS prevents stale writers from overwriting terminal observations.
- Position reads are project/wallet isolated, keyset-paginated, capped at 100, grouped linearly, and hydrated with bounded concurrency. Live snapshots attach only when provider, cluster, owner, reference, token mint, and share mint all match persisted identity.

Migration `0058` is new-table-only and transactional. It includes:

- nullable forensic project attribution with `ON DELETE SET NULL`, preserving shared organization-wallet claims and movement history;
- a composite movement→position foreign key across tenant/environment/provider/vault/wallet identity;
- immutable asset identity on position re-entry;
- exact positive decimal-string and requested/canonical equality checks;
- strict unsigned-integer block height as bounded `NUMERIC`;
- terminal status metadata checks and an enforced repository transition graph;
- position-first locking for concurrent failed-movement cleanup;
- planner-aligned narrow/global position indexes, live-evidence probes, and deterministic unsettled paging for both `pending` and `submitted` rows.

### Dashboard

- A two-step vault-direct modal opened from Opportunities.
- Production rows remain visible but show an explanatory disabled state; sandbox rows are actionable.
- Token-aware USDC/USDT wallet balances and the exact custody row id are submitted.
- Shared onboarding/provider-access bootstrap uses the linked SDP organization id.
- Mount-level focus trapping/return plus wallet → amount → result autofocus and escaped-focus recovery.
- Pending/submitted copy is explicit and every signed response exposes the cluster-correct explorer link.

## Funds and security invariants

- Wallet policy and selected-wallet binding authorization run before custody signing.
- Catalogue metadata never overrides builder-observed asset identity.
- The policy-approved amount/floor must exactly match the instruction plan's accepted values.
- No unsigned intent or phantom position is persisted after build, simulation, signer, or signing failure.
- Position activation and signed intent persistence are atomic; divergent idempotency losers leave no claim.
- Mint identity cannot be rewritten on re-entry.
- Concurrent failures cannot leave an activated ghost position, and a prior confirmed holding remains active.
- A broadcast exception is **unknown**, never proof of failure.
- `confirmed` and `failed` are terminal states and require their audit metadata.
- Production remains unavailable in both API and web until the exit/recovery work below lands.

## Review outcome

At signed commit [`11bcfee6`](https://github.com/solana-foundation/solana-developer-platform/commit/11bcfee685f5103e6320c02a3d5cf7ff93d70843), this PR has **31 review threads: 30 resolved, 1 deliberately open**.

The open thread is PRO-1690. This PR now provides its durable foundation (exact signed bytes, signature, block height, guarded movement state, and deterministic unsettled index), but it does **not** implement the confirmation/rebroadcast worker or movement-status surface.

Independent final SQL and adversarial fund-flow audits found no remaining merge-blocking P0–P2 findings.

## Verified on devnet, end to end

```text
POST /v1/earn/vault-deposits  → submitted
on-chain                      → finalized, err=null
wallet USDC                   → 20 → 19
shares                        → 1 minted
ledger                        → deposit / submitted / cwlt_795d7f19…
```

The UI flow was also exercised through Privy custody: Opportunities → Deposit → wallet → amount → confirm.

## Required outside this PR

Production is currently fail-closed with `VAULT_DIRECT_DEPOSIT_ENVIRONMENTS = ["sandbox"]`. Before adding `production`:

| # | Requirement | Tracking |
|---|---|---|
| 1 | Configure `SOLANA_DEVNET_RPC_URL` and `SOLANA_MAINNET_RPC_URL`, or ensure the fallback endpoint proves the requested cluster. | Doppler / deploy |
| 2 | Land vault withdrawal, Active-position rendering, tenant-scoped movement status, exact-byte rebroadcast/confirmation, and terminal outbox retention/cleanup. | **PRO-1690** |
| 3 | Compute and display a live, bounded `minSharesOut`; reject stale quotes. Production already rejects deposits without a floor. | **PRO-1691** |
| 4 | Persist in-flight modal attempts and poll durable status across reloads. | **PRO-1692** |
| 5 | Finish USDG/general multi-token balance resolution in the web flow. USDT is handled here. | **PRO-1693** |
| 6 | Propagate an operation-scoped `AbortSignal` through the Earn runtime/provider/RPC stack so the 20-second API deadline cancels underlying work while preserving ambiguous-broadcast semantics. | New follow-up ticket required |
| 7 | Add K-Vault/lending/farms programs to both Kora relay allowlists only if sponsorship is desired, and preserve record-before-broadcast signature recovery. | `sdp-infra` |
| 8 | Apply migration `0058`. It has not been deployed, so all integrity changes remain folded into the unreleased migration. | deploy |

## Validation

```text
full workspace typecheck                 19/19 packages
API build                                passed (including WASM asset)
module boundaries                        passed
Biome on all 54 changed source files     passed
@sdp/kamino                              59 passed, 3 live smoke skipped
@sdp/earn                                141 passed
web Earn + focus                         167 passed
focused API/PostgreSQL funds suite       56 passed
value-moving security conformance        21 passed
full API suite                           2,898 passed, 14 skipped, 1 unrelated auth test flaked
isolated failed auth test rerun           passed
git diff --check                         passed
```

On-chain smoke tests are environment-gated; run them against a Surfpool surfnet that forks mainnet as documented in `packages/sdp-kamino/CLAUDE.md`.

