### PR TITLE
feat(earn): add Kamino vault execution contracts

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,12 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
+      - name: Check Kamino dependency boundary
+        run: node scripts/check-kamino-dependency-boundary.mjs
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
-          # klend-sdk declares bigint-buffer@1.1.5 transitively, but the API
-          # runner ships only its esbuild output and no native .node artifacts.
-          # build-node.mjs fails if the advisory's native loader ever enters a
-          # shipped bundle. No patched bigint-buffer release exists today.
+          # The preceding check confines this path to API -> @sdp/kamino ->
+          # klend-sdk, and build-node.mjs replaces bigint-buffer with its pure-JS
+          # browser entry before scanning every shipped API bundle for the native
+          # loader. No patched bigint-buffer release exists today.
           allow-ghsas: GHSA-3gc7-fjrx-p6mg
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,9 @@ jobs:
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
+          # klend-sdk declares bigint-buffer@1.1.5 transitively, but the API
+          # runner ships only its esbuild output and no native .node artifacts.
+          # build-node.mjs fails if the advisory's native loader ever enters a
+          # shipped bundle. No patched bigint-buffer release exists today.
+          allow-ghsas: GHSA-3gc7-fjrx-p6mg
           comment-summary-in-pr: on-failure

--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -30,6 +30,7 @@ COPY packages/sdp-private-channels/package.json ./packages/sdp-private-channels/
 COPY packages/sdp-spc-escrow/package.json ./packages/sdp-spc-escrow/
 COPY packages/sdp-spc-withdraw/package.json ./packages/sdp-spc-withdraw/
 COPY packages/kit-augment/package.json ./packages/kit-augment/
+COPY packages/sdp-kamino/package.json ./packages/sdp-kamino/
 COPY patches ./patches
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
@@ -53,6 +54,7 @@ COPY packages/sdp-private-channels ./packages/sdp-private-channels
 COPY packages/sdp-spc-escrow ./packages/sdp-spc-escrow
 COPY packages/sdp-spc-withdraw ./packages/sdp-spc-withdraw
 COPY packages/kit-augment ./packages/kit-augment
+COPY packages/sdp-kamino ./packages/sdp-kamino
 
 WORKDIR /repo/apps/sdp-api
 RUN node scripts/build-node.mjs

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -29,6 +29,7 @@ packages/*
 !packages/sdp-spc-escrow
 !packages/sdp-spc-withdraw
 !packages/kit-augment
+!packages/sdp-kamino
 docs
 infra
 scripts

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@clerk/backend": "3.15.0",
+    "@coinbase/cdp-sdk": "1.54.0",
     "@hono/node-server": "2.0.12",
     "@react-email/components": "1.0.12",
     "@react-email/render": "2.1.0",
@@ -51,13 +52,14 @@
     "@sdp/earn": "workspace:*",
     "@sdp/env-config": "workspace:*",
     "@sdp/issuance": "workspace:*",
+    "@sdp/kamino": "workspace:*",
     "@sdp/payments": "workspace:*",
     "@sdp/policy": "workspace:*",
     "@sdp/private-channels": "workspace:*",
     "@sdp/rpc": "workspace:*",
+    "@sdp/solana": "workspace:*",
     "@sdp/spc-escrow": "workspace:*",
     "@sdp/spc-withdraw": "workspace:*",
-    "@sdp/solana": "workspace:*",
     "@sdp/types": "workspace:*",
     "@sentry/node": "10.70.0",
     "@solana-program/system": "catalog:",
@@ -89,8 +91,7 @@
     "pino": "10.3.1",
     "react": "19.2.8",
     "resend": "6.18.1",
-    "zod": "4.4.3",
-    "@coinbase/cdp-sdk": "1.54.0"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@asteasolutions/zod-to-openapi": "9.1.0",

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -1,5 +1,5 @@
 /* biome-ignore-all lint/security/noSecrets: file contains the esbuild banner template, which trips the high-entropy heuristic */
-import { copyFileSync, existsSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import esbuild from "esbuild";
@@ -42,19 +42,21 @@ const banner =
   "const __filename=__furl(import.meta.url);" +
   "const __dirname=__path.dirname(__filename);";
 
+// migrate.js lets the prebuilt image apply migrations without the source tree.
+const entryPoints = {
+  server: "src/server.ts",
+  job: "src/job.ts",
+  migrate: "scripts/migrate-postgres.mjs",
+  // custody-backfill.js re-encrypts legacy custody rows to KMS envelopes from the prebuilt image.
+  "custody-backfill": "scripts/migrate-custody-encryption.ts",
+  // counterparty-pii-migrate.js performs the gated PII backfill/cutover lifecycle.
+  "counterparty-pii-migrate": "scripts/counterparty-pii-migrate.ts",
+  // configure.js generates a self-hosted .env in the terminal from the prebuilt image.
+  configure: "scripts/configure.ts",
+};
+
 await esbuild.build({
-  // migrate.js lets the prebuilt image apply migrations without the source tree.
-  entryPoints: {
-    server: "src/server.ts",
-    job: "src/job.ts",
-    migrate: "scripts/migrate-postgres.mjs",
-    // custody-backfill.js re-encrypts legacy custody rows to KMS envelopes from the prebuilt image.
-    "custody-backfill": "scripts/migrate-custody-encryption.ts",
-    // counterparty-pii-migrate.js performs the gated PII backfill/cutover lifecycle.
-    "counterparty-pii-migrate": "scripts/counterparty-pii-migrate.ts",
-    // configure.js generates a self-hosted .env in the terminal from the prebuilt image.
-    configure: "scripts/configure.ts",
-  },
+  entryPoints,
   bundle: true,
   platform: "node",
   target: "node22",
@@ -63,6 +65,22 @@ await esbuild.build({
   external: ["pg-native", "@sentry/profiling-node"],
   banner: { js: banner },
 });
+
+// klend-sdk's dependency graph declares bigint-buffer@1.1.5, whose native
+// `toBigIntLE` binding has GHSA-3gc7-fjrx-p6mg and no patched release. The API
+// runner ships dist/ alone (never node_modules or native .node artifacts), and
+// esbuild currently removes this unused transitive package entirely. Keep the
+// workflow's one-advisory exception honest: fail the build if a future import
+// pulls the vulnerable native loader into ANY shipped JavaScript entry point.
+for (const entryPoint of Object.keys(entryPoints)) {
+  const output = path.join("dist", `${entryPoint}.js`);
+  if (readFileSync(output, "utf8").includes("bigint_buffer")) {
+    throw new Error(
+      `${output} contains bigint-buffer's vulnerable native binding loader ` +
+        "(GHSA-3gc7-fjrx-p6mg). Remove or replace that runtime path before shipping it."
+    );
+  }
+}
 
 const wasmSource = resolveOrcaWasm();
 if (!existsSync(wasmSource)) {

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -32,6 +32,22 @@ function resolveOrcaWasm() {
   return path.join(path.dirname(orca), "orca_whirlpools_core_js_bindings_bg.wasm");
 }
 
+/**
+ * Resolve bigint-buffer's browser build, which is its pure-JavaScript
+ * implementation and never attempts to load the vulnerable native binding.
+ *
+ * The package is transitive, so walk the real klend -> Raydium -> buffer-layout
+ * dependency path instead of relying on pnpm hoisting. If that graph moves, the
+ * build fails here and the dependency-boundary check must be reviewed too.
+ */
+function resolveSafeBigintBuffer() {
+  const kaminoAnchor = path.resolve("../../packages/sdp-kamino/package.json");
+  const klend = createRequire(kaminoAnchor).resolve("@kamino-finance/klend-sdk");
+  const raydium = createRequire(klend).resolve("@raydium-io/raydium-sdk-v2");
+  const bufferLayoutUtils = createRequire(raydium).resolve("@solana/buffer-layout-utils");
+  return createRequire(bufferLayoutUtils).resolve("bigint-buffer/dist/browser.js");
+}
+
 // CJS interop banner for ESM output: pg and other native-backed deps still
 // reach for require/__filename/__dirname even when bundled as ESM.
 const banner =
@@ -63,18 +79,24 @@ await esbuild.build({
   format: "esm",
   outdir: "dist",
   external: ["pg-native", "@sentry/profiling-node"],
+  // bigint-buffer@1.1.5 has no patched release. Its browser entry is the
+  // package's pure-JS implementation, so execution can be registered without
+  // placing the vulnerable native loader in any API artifact.
+  alias: { "bigint-buffer": resolveSafeBigintBuffer() },
   banner: { js: banner },
 });
 
 // klend-sdk's dependency graph declares bigint-buffer@1.1.5, whose native
-// `toBigIntLE` binding has GHSA-3gc7-fjrx-p6mg and no patched release. The API
-// runner ships dist/ alone (never node_modules or native .node artifacts), and
-// esbuild currently removes this unused transitive package entirely. Keep the
-// workflow's one-advisory exception honest: fail the build if a future import
-// pulls the vulnerable native loader into ANY shipped JavaScript entry point.
+// binding has GHSA-3gc7-fjrx-p6mg and no patched release. The alias above forces
+// its pure-JS browser implementation. Keep that replacement honest: fail the
+// build if a future graph change pulls the native loader into ANY shipped
+// JavaScript entry point.
 for (const entryPoint of Object.keys(entryPoints)) {
   const output = path.join("dist", `${entryPoint}.js`);
-  if (readFileSync(output, "utf8").includes("bigint_buffer")) {
+  // The safe browser implementation can retain a harmless generated variable
+  // named `bigint_buffer_1`; match the native entry's unique warning instead
+  // of rejecting that identifier.
+  if (readFileSync(output, "utf8").includes("Failed to load bindings, pure JS will be used")) {
     throw new Error(
       `${output} contains bigint-buffer's vulnerable native binding loader ` +
         "(GHSA-3gc7-fjrx-p6mg). Remove or replace that runtime path before shipping it."

--- a/apps/sdp-api/scripts/build-node.mjs
+++ b/apps/sdp-api/scripts/build-node.mjs
@@ -1,5 +1,36 @@
 /* biome-ignore-all lint/security/noSecrets: file contains the esbuild banner template, which trips the high-entropy heuristic */
+import { copyFileSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
 import esbuild from "esbuild";
+
+/**
+ * WASM binaries that must sit BESIDE the bundle.
+ *
+ * esbuild inlines JavaScript, but a wasm-bindgen module loads its binary at
+ * MODULE SCOPE with `readFileSync(path.join(__dirname, "<name>.wasm"))`. After
+ * bundling, `__dirname` is the output directory — `/app` in the runner image,
+ * which ships `dist/` alone with no `node_modules` — so without this the API
+ * dies ON STARTUP, not on first use, with
+ * `ENOENT: ... orca_whirlpools_core_js_bindings_bg.wasm`.
+ *
+ * The dependency is transitive and non-obvious: `@sdp/kamino` →
+ * `@kamino-finance/klend-sdk` → `@orca-so/whirlpools-core`. Nothing in the API
+ * imports Orca directly.
+ *
+ * Resolved by walking that chain rather than hard-coding a path, because pnpm's
+ * strict layout does not expose a transitive package to `apps/sdp-api` and the
+ * `.pnpm` directory name carries a version hash. A version bump therefore moves
+ * the file and this still finds it — or fails the BUILD, loudly, instead of the
+ * container at boot.
+ */
+function resolveOrcaWasm() {
+  // Anchor on the workspace package that actually depends on klend-sdk.
+  const kaminoAnchor = path.resolve("../../packages/sdp-kamino/package.json");
+  const klend = createRequire(kaminoAnchor).resolve("@kamino-finance/klend-sdk");
+  const orca = createRequire(klend).resolve("@orca-so/whirlpools-core");
+  return path.join(path.dirname(orca), "orca_whirlpools_core_js_bindings_bg.wasm");
+}
 
 // CJS interop banner for ESM output: pg and other native-backed deps still
 // reach for require/__filename/__dirname even when bundled as ESM.
@@ -32,3 +63,13 @@ await esbuild.build({
   external: ["pg-native", "@sentry/profiling-node"],
   banner: { js: banner },
 });
+
+const wasmSource = resolveOrcaWasm();
+if (!existsSync(wasmSource)) {
+  throw new Error(
+    `Expected the Orca wasm binary at ${wasmSource}. klend-sdk loads it at module scope, so a ` +
+      "missing file here means the built image dies on startup. Check whether " +
+      "@orca-so/whirlpools-core moved or renamed it."
+  );
+}
+copyFileSync(wasmSource, path.join("dist", path.basename(wasmSource)));

--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -1,8 +1,4 @@
-import {
-  isClusterFundableInEnvironment,
-  resolveEarnProviderClient,
-  supportsPortfolioWallets,
-} from "@sdp/earn";
+import { isClusterFundableInEnvironment, supportsPortfolioWallets } from "@sdp/earn";
 import { notImplemented } from "@sdp/earn/errors";
 import type { EarnPortfolioWalletProvider } from "@sdp/earn/types";
 import type {
@@ -34,6 +30,7 @@ import {
 import { success } from "@/lib/response";
 import { IDEMPOTENCY_KEY_HEADER } from "@/middleware/idempotency-key";
 import { getLogger } from "@/runtime/logger";
+import { resolveEarnProviderClient } from "@/services/earn-provider-registry";
 import {
   applyEarnWithdrawalObservationByReference,
   applyEarnWithdrawalObservationToRow,

--- a/apps/sdp-api/src/services/earn-provider-registry.test.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.test.ts
@@ -1,0 +1,17 @@
+import { supportsPortfolioWallets, supportsVaultDirect } from "@sdp/earn/capabilities";
+import { describe, expect, it } from "vitest";
+import { EARN_PROVIDER_CLIENTS, resolveEarnProviderClient } from "./earn-provider-registry";
+
+describe("API Earn provider registry", () => {
+  it("registers Kamino's executable vault-direct client", () => {
+    const client = resolveEarnProviderClient("kamino");
+
+    expect(client).toBe(EARN_PROVIDER_CLIENTS.kamino);
+    expect(supportsVaultDirect(client)).toBe(true);
+    expect(supportsPortfolioWallets(client)).toBe(false);
+  });
+
+  it("keeps the non-Kamino provider singletons", () => {
+    expect(resolveEarnProviderClient("ground")).toBe(EARN_PROVIDER_CLIENTS.ground);
+  });
+});

--- a/apps/sdp-api/src/services/earn-provider-registry.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.ts
@@ -1,0 +1,42 @@
+import {
+  EARN_PROVIDER_CLIENTS as CATALOGUE_PROVIDER_CLIENTS,
+  isEarnProviderId,
+  providerNotConfigured,
+} from "@sdp/earn";
+import type { EarnRuntimeContext, EarnVaultProvider } from "@sdp/earn/types";
+import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
+import type { EarnProviderId, SolanaCluster } from "@sdp/types";
+
+/**
+ * Resolve the process RPC only when it is not known to serve the other cluster.
+ * The runtime context is request-scoped; reading it here avoids capturing one
+ * process-level URL inside the provider while serving both SDP environments.
+ */
+function resolveKaminoRpcUrl(ctx: EarnRuntimeContext, cluster: SolanaCluster): string {
+  const configuredCluster = ctx.env.SOLANA_NETWORK?.trim();
+  if (configuredCluster && configuredCluster !== cluster) return "";
+  return ctx.env.SOLANA_RPC_URL ?? "";
+}
+
+const kamino = new KaminoVaultDirectClient(resolveKaminoRpcUrl);
+assertNotPortfolioProvider(kamino);
+
+/**
+ * API composition root for Earn providers.
+ *
+ * `@sdp/earn` intentionally owns the lightweight catalogue registry so its
+ * cron can list Kamino without loading klend-sdk. The API owns execution, so it
+ * replaces only Kamino with the vault-direct superset. Routes must resolve
+ * through this registry when they need provider capabilities.
+ */
+export const EARN_PROVIDER_CLIENTS = {
+  ...CATALOGUE_PROVIDER_CLIENTS,
+  kamino,
+} as const satisfies Record<EarnProviderId, EarnVaultProvider>;
+
+export function resolveEarnProviderClient(provider: string): EarnVaultProvider {
+  if (!isEarnProviderId(provider)) {
+    throw providerNotConfigured(`Earn provider ${provider} is not available in this deployment`);
+  }
+  return EARN_PROVIDER_CLIENTS[provider];
+}

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -14,13 +14,14 @@ This map is generated from the module-boundary check. It records the permitted w
 
 | Module | Purpose | Allowed workspace dependencies |
 | --- | --- | --- |
-| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
+| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
 | `@sdp/api-integration` | Maintainer integration harness for API endpoint and provider coverage. | `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types` |
 | `@sdp/custody` | Custody provider abstractions and keychain adapters. | `@sdp/types` |
 | `@sdp/earn` | Earn domain services, yield strategies, and vault-infra providers. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
 | `@sdp/env-config` | Runtime environment configuration and validation. | None |
 | `@sdp/helius-rings` | Helius Rings shielded-wallet domain types, state machine, and gateway port (devnet). | None |
 | `@sdp/issuance` | Token issuance domain services and Mosaic integration. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
+| `@sdp/kamino` | Kit-native Kamino K-Vault deposit/withdraw instruction plans over klend-sdk. | `@sdp/earn`, `@sdp/solana`, `@sdp/types` |
 | `@sdp/kit-augment` | Shared @solana/kit type augmentation for the generated Codama clients. | None |
 | `@sdp/payments` | Payment domain services, fee payment, and ramp providers. | `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
 | `@sdp/policy` | Wallet-operation policy engine: rule evaluation and enforcement orchestration. | `@sdp/solana`, `@sdp/types` |
@@ -35,13 +36,14 @@ This map is generated from the module-boundary check. It records the permitted w
 
 ## Declared Workspace Graph
 
-- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
+- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
 - `@sdp/api-integration` -> `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types`
 - `@sdp/custody` -> `@sdp/types`
 - `@sdp/earn` -> `@sdp/types`
 - `@sdp/env-config` -> None
 - `@sdp/helius-rings` -> None
 - `@sdp/issuance` -> `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types`
+- `@sdp/kamino` -> `@sdp/earn`, `@sdp/solana`, `@sdp/types`
 - `@sdp/kit-augment` -> None
 - `@sdp/payments` -> `@sdp/rpc`, `@sdp/solana`, `@sdp/types`
 - `@sdp/policy` -> `@sdp/solana`, `@sdp/types`

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "check:env-configurator-drift": "node scripts/check-env-configurator-drift.mjs",
     "check:module-boundaries": "node scripts/check-module-boundaries.mjs",
     "check:pinned-dependencies": "node scripts/check-pinned-dependency-versions.mjs",
+    "check:kamino-dependency-boundary": "node scripts/check-kamino-dependency-boundary.mjs",
     "check:well-known-mints": "pnpm --filter @sdp/api exec tsx ../../scripts/check-well-known-mints.mjs",
     "check:api-playground": "pnpm -C apps/sdp-api playground:check",
     "generate:api-playground": "pnpm -C apps/sdp-api playground:generate",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
       "@solana/mosaic-sdk@0.1.1": "patches/@solana__mosaic-sdk@0.1.1.patch",
       "next-themes@0.4.6": "patches/next-themes@0.4.6.patch",
       "brace-expansion@5.0.9": "patches/brace-expansion@5.0.9.patch"
+    },
+    "packageExtensions": {
+      "@kamino-finance/klend-sdk@10.0.0": {
+        "dependencies": {
+          "@solana-program/compute-budget": "^0.8.0",
+          "@solana-program/memo": "^0.7.0"
+        }
+      }
     }
   },
   "scripts": {

--- a/packages/sdp-earn/CLAUDE.md
+++ b/packages/sdp-earn/CLAUDE.md
@@ -211,13 +211,36 @@ Ground is **custodial**: SDP provisions an omnibus portfolio wallet, the
 customer funds it, Ground spreads it across yield sources. Programs,
 withdrawals and the deposit wizard all assume that shape.
 
-Kamino is **non-custodial and catalogue-only**: a K-Vault is an on-chain vault
-the customer's own wallet deposits into, so there is no wallet for SDP to
-provision or pay out from. It implements the base `EarnVaultProvider` contract
-plus the live-metrics capability, and NONE of the portfolio-wallet capability —
-so every money-moving route answers 501 for it through `supportsPortfolioWallets`,
-never a provider-id check. Deposit/withdraw execution is not "not yet"; it is a
-different money model that V1 does not carry.
+Kamino is **non-custodial**: a K-Vault is an on-chain vault the customer's own
+wallet deposits into, so there is no wallet for SDP to provision or pay out
+from, and no address to hand out — the vault's account is a PROGRAM account and
+stablecoins sent to it are destroyed.
+
+It implements the base `EarnVaultProvider` contract, the live-metrics
+capability, and — since the vault-deposit change — the **vault-direct**
+capability (`EarnVaultDirectProvider`, `supportsVaultDirect`), which is
+DEPOSIT + READ only.
+
+Money OUT is a separate capability, `EarnVaultWithdrawProvider` /
+`supportsVaultWithdraw`, and Kamino deliberately does NOT implement it yet. The
+split is not taxonomy: an exit may legitimately need several transactions (one
+withdraw instruction per reserve the vault draws from), which a deposit never
+does, so "can build a deposit" must not silently assert "can build a correctly
+BATCHED exit". Withholding it says the SDP route does not exist; it is never a
+permission gate, since ADR 0002 forbids money-out inheriting a money-in gate.
+
+It still
+implements NONE of the portfolio-wallet capability, so every portfolio route
+answers 501 for it through `supportsPortfolioWallets`, never a provider-id
+check. The two capabilities are asserted MUTUALLY EXCLUSIVE: a client claiming
+both would let a portfolio route render the vault account as a fundable
+address.
+
+Money moves for Kamino by SDP BUILDING an instruction, signing it with one of
+the organization's own custody wallets and submitting it — `@sdp/kamino` builds
+the plan, the API signs and submits (`POST /v1/earn/vault-deposits`). That
+package depends on this one, never the reverse: the hourly catalogue cron must
+not load a 13MB chain SDK it never calls.
 
 Three Kamino facts drive most of its code, all measured against the live API on
 2026-08-13 (Kamino publishes an agent-readable API index at

--- a/packages/sdp-earn/src/capabilities.ts
+++ b/packages/sdp-earn/src/capabilities.ts
@@ -1,7 +1,9 @@
 import type {
   EarnLiveMetricsProvider,
   EarnPortfolioWalletProvider,
+  EarnVaultDirectProvider,
   EarnVaultProvider,
+  EarnVaultWithdrawProvider,
   EarnWithdrawalApprovalProvider,
 } from "./types";
 
@@ -63,6 +65,54 @@ export function supportsWithdrawalApprovals(
     Record<(typeof WITHDRAWAL_APPROVAL_METHODS)[number], unknown>
   >;
   return WITHDRAWAL_APPROVAL_METHODS.every((method) => typeof candidate[method] === "function");
+}
+
+const VAULT_DIRECT_METHODS = [
+  "buildVaultDeposit",
+  "readVaultPositions",
+] as const satisfies readonly Exclude<keyof EarnVaultDirectProvider, keyof EarnVaultProvider>[];
+
+/**
+ * Capability discovery for the optional vault-direct contract — same
+ * all-or-nothing method-presence rule as the guards above.
+ *
+ * Deliberately DISJOINT from `supportsPortfolioWallets`: the two describe
+ * opposite money models. A portfolio provider hands SDP a custodied wallet
+ * address to fund; a vault-direct provider has no such address at all, and the
+ * one it superficially resembles — the vault's own account — destroys funds sent
+ * to it. Nothing should ever be true of both, and a provider implementing both
+ * sets of methods is a bug in that client, not a richer provider.
+ */
+export function supportsVaultDirect(client: EarnVaultProvider): client is EarnVaultDirectProvider {
+  const candidate = client as Partial<Record<(typeof VAULT_DIRECT_METHODS)[number], unknown>>;
+  return VAULT_DIRECT_METHODS.every((method) => typeof candidate[method] === "function");
+}
+
+const VAULT_WITHDRAW_METHODS = ["buildVaultWithdrawal"] as const satisfies readonly Exclude<
+  keyof EarnVaultWithdrawProvider,
+  keyof EarnVaultDirectProvider
+>[];
+
+/**
+ * Capability discovery for the money-OUT half, asked SEPARATELY from money-in.
+ *
+ * `buildVaultDeposit` proves a provider can build one transaction; an exit may
+ * legitimately need several, one per reserve the vault draws from, and getting
+ * that batching right is the hard part. Keeping the question separate is what
+ * stops "this provider supports vault deposits" from silently also asserting
+ * "…and can build a correctly sized exit" — the exact conflation that let an
+ * unsized single-batch withdrawal plan look shippable.
+ *
+ * A provider that answers false here has no SDP exit route. That is a statement
+ * about SDP's plumbing, never about the customer's right to their money: the
+ * shares are in their own wallet and Kamino's own UI can always redeem them.
+ */
+export function supportsVaultWithdraw(
+  client: EarnVaultProvider
+): client is EarnVaultWithdrawProvider {
+  if (!supportsVaultDirect(client)) return false;
+  const candidate = client as Partial<Record<(typeof VAULT_WITHDRAW_METHODS)[number], unknown>>;
+  return VAULT_WITHDRAW_METHODS.every((method) => typeof candidate[method] === "function");
 }
 
 const LIVE_METRICS_METHODS = ["listStrategyMetrics"] as const satisfies readonly Exclude<

--- a/packages/sdp-earn/src/providers/kamino/devnet.ts
+++ b/packages/sdp-earn/src/providers/kamino/devnet.ts
@@ -1,3 +1,4 @@
+import { KAMINO_DEVNET_KVAULT_PROGRAM_ID } from "@sdp/types/kamino-programs";
 import { internalError, providerNotConfigured } from "../../errors";
 import { providerFetchJson } from "../../fetch";
 
@@ -35,9 +36,18 @@ import { providerFetchJson } from "../../fetch";
  * program per cluster, and mainnet's id also exists on devnet with ZERO
  * accounts under it, so pointing at the wrong one yields a confident empty
  * shelf rather than an error.
+ *
+ * Re-exported from `@sdp/types/kamino-programs`, which is the single home for
+ * every Kamino program address. It cannot live in `@sdp/kamino` (the package
+ * that builds deposit/withdraw instructions against the same program) because
+ * this module would then have to import it, and a `@sdp/earn → @sdp/kamino`
+ * edge is both a workspace cycle and a reason for the catalogue cron to load a
+ * 13MB SDK it never calls.
+ *
+ * Imported AND re-exported: `listKaminoDevnetVaults` below uses it as a value,
+ * which a bare `export … from` would not bind locally.
  */
-// biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
-export const KAMINO_DEVNET_KVAULT_PROGRAM_ID = "devkRngFnfp4gBc5a3LsadgbQKdPo8MSZ4prFiNSVmY";
+export { KAMINO_DEVNET_KVAULT_PROGRAM_ID };
 
 /**
  * `VaultState` account size, and the byte offsets of the fields SDP reads.

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -347,6 +347,174 @@ export interface EarnPortfolioWalletProvider extends EarnVaultProvider {
 }
 
 /**
+ * One account slot in a built instruction.
+ *
+ * `role` mirrors `@solana/kit`'s `AccountRole` numeric enum (0 readonly,
+ * 1 writable, 2 readonly-signer, 3 writable-signer) WITHOUT importing it: this
+ * package's single dependency is `@sdp/types`, and taking `@solana/kit` here
+ * would put a chain SDK inside the hourly catalogue cron. The numbers are the
+ * wire format, and the provider client re-labels them at its own boundary.
+ */
+export interface EarnVaultAccountRef {
+  address: string;
+  role: number;
+}
+
+/** One built instruction, as plain data. `data` is base64. */
+export interface EarnVaultInstruction {
+  programAddress: string;
+  accounts: EarnVaultAccountRef[];
+  data: string;
+}
+
+/**
+ * Unsigned work for a non-custodial vault, ready for the API to compile.
+ *
+ * `transactions` is a list of TRANSACTION-SIZED batches, not one flat list: a
+ * multi-reserve vault exit emits several instructions each carrying the vault's
+ * full reserve account list and can exceed Solana's 1232-byte packet. Returning
+ * batches makes that the builder's problem, where the vault's shape is known,
+ * rather than the caller's at compile time.
+ */
+export interface EarnVaultTransactionPlan {
+  cluster: SolanaCluster;
+  transactions: EarnVaultInstruction[][];
+  /** Address lookup tables the caller should apply when compiling. */
+  lookupTables: string[];
+  /**
+   * Asset addresses observed from the live vault state used to build this plan.
+   *
+   * Required so the execution layer can compare builder truth with catalogue
+   * metadata before signing. Amount validation alone is insufficient: a stale
+   * or poisoned catalogue row could otherwise apply policy and ledger labels to
+   * one mint while the instructions actually move another.
+   */
+  assetIdentity: EarnVaultAssetIdentity;
+  /**
+   * The amounts the instructions above actually ENCODE, canonical to each
+   * mint's own precision.
+   *
+   * Separate from the request because they need not be the same number: a chain
+   * SDK converts decimals to mint atoms and typically FLOORS, so a request of
+   * `1.0000009` against a six-decimal mint encodes `1.000000`. A provider that
+   * refuses over-precise input (the right answer) still re-serialises here, so
+   * `"1.500"` returns as `"1.5"`. Ledger these rather than the raw request: only
+   * the builder knows the mint's decimals, and a movement row is a claim about
+   * what moved on chain.
+   */
+  accepted?: EarnVaultAcceptedAmounts;
+}
+
+/** Solana asset identity bound to an unsigned vault transaction plan. */
+export interface EarnVaultAssetIdentity {
+  /** Mint whose tokens the deposit instructions consume. */
+  depositTokenMint: string;
+  /** Mint whose receipt/share tokens the vault issues. */
+  shareMint: string;
+}
+
+/** What a built plan encodes, per mint. All values are decimal strings. */
+export interface EarnVaultAcceptedAmounts {
+  amount?: string;
+  minSharesOut?: string;
+  shares?: string;
+}
+
+export interface EarnVaultDepositInput {
+  /** Vault address — the strategy's `providerReference`. */
+  providerReference: string;
+  /** Address whose tokens move and whose shares are minted. */
+  owner: string;
+  /** Deposit amount in the vault token's own units, as a decimal string. */
+  amount: string;
+  /** Minimum shares to accept, as a decimal string — slippage floor. */
+  minSharesOut?: string;
+}
+
+export interface EarnVaultWithdrawInput {
+  providerReference: string;
+  owner: string;
+  /** Shares to redeem, as a decimal string. */
+  shares: string;
+}
+
+export interface EarnVaultPositionInput {
+  owner: string;
+  /** Vault addresses to read. Empty means "every vault this provider knows". */
+  providerReferences: readonly string[];
+}
+
+/** One owner's live holding in one vault. All amounts are decimal strings. */
+export interface EarnVaultPositionSnapshot {
+  providerReference: string;
+  owner: string;
+  cluster: SolanaCluster;
+  shares: string;
+  /** Value of those shares in the deposit token; omitted when unreadable. */
+  tokenValue?: string;
+  tokenMint: string;
+  shareMint: string;
+}
+
+/**
+ * Optional capability: NON-CUSTODIAL vaults the customer's own wallet deposits
+ * into (Kamino's K-Vaults; `earnDepositStyle` calls these `vault_direct`).
+ *
+ * The shape difference from `EarnPortfolioWalletProvider` is the whole point.
+ * A portfolio provider CUSTODIES: SDP asks it to provision a wallet and the
+ * customer funds that address. A vault-direct provider custodies nothing —
+ * there is no address to send to, and stablecoins sent to the vault's program
+ * account are LOST. Money moves only when a wallet SDP can sign for submits an
+ * instruction, so this capability builds unsigned plans and SDP's own custody
+ * and signing services do the rest.
+ *
+ * Everything crossing this contract is plain data (see the types above), so a
+ * provider client may speak whatever chain SDK it likes without that SDK
+ * reaching this package. Discovered via `supportsVaultDirect` (capabilities.ts),
+ * never provider-id checks.
+ */
+export interface EarnVaultDirectProvider extends EarnVaultProvider {
+  buildVaultDeposit(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultDepositInput
+  ): Promise<EarnVaultTransactionPlan>;
+  /**
+   * Live positions. Read from chain per call and never persisted — positions are
+   * provider truth (ADR 0002), and for a vault-direct provider "the provider" is
+   * the chain itself.
+   */
+  readVaultPositions(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultPositionInput
+  ): Promise<EarnVaultPositionSnapshot[]>;
+}
+
+/**
+ * Optional capability: the money-OUT half of the vault-direct model, kept
+ * SEPARATE from money-in deliberately.
+ *
+ * Splitting it is not taxonomy for its own sake. A vault EXIT is the case that
+ * genuinely needs several transactions — one withdraw instruction per reserve
+ * the vault must draw from, each carrying the vault's full remaining-accounts
+ * list — so `transactions` having more than one entry is normal here and
+ * impossible on deposit. Folding both into one capability therefore made "can
+ * build a deposit" silently assert "can build a correctly BATCHED exit", which
+ * is a different and much harder claim.
+ *
+ * Discovered via `supportsVaultWithdraw` (capabilities.ts). A provider may
+ * implement `EarnVaultDirectProvider` alone, and an exit route must then refuse
+ * rather than assume. Note this says only whether the ROUTE CAN BE BUILT — it is
+ * never a permission gate, because ADR 0002 forbids money-out inheriting any
+ * money-in gate.
+ */
+export interface EarnVaultWithdrawProvider extends EarnVaultDirectProvider {
+  buildVaultWithdrawal(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultWithdrawInput
+  ): Promise<EarnVaultTransactionPlan>;
+}
+
+/**
  * Optional capability: customer-approval flows for withdrawal payouts. Some
  * providers gate payout legs on a customer-side signature (Ground: Turnkey
  * consensus voting, engaged by an org-level approval policy rather than by

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -440,7 +440,7 @@ export interface EarnVaultWithdrawInput {
 
 export interface EarnVaultPositionInput {
   owner: string;
-  /** Vault addresses to read. Empty means "every vault this provider knows". */
+  /** Vault addresses to read. Empty means every strategy currently listed by the provider. */
   providerReferences: readonly string[];
 }
 

--- a/packages/sdp-earn/src/types.ts
+++ b/packages/sdp-earn/src/types.ts
@@ -440,7 +440,7 @@ export interface EarnVaultWithdrawInput {
 
 export interface EarnVaultPositionInput {
   owner: string;
-  /** Vault addresses to read. Empty means every strategy currently listed by the provider. */
+  /** Vault addresses to read. Empty means every owner-held vault the provider can discover. */
   providerReferences: readonly string[];
 }
 

--- a/packages/sdp-kamino/CLAUDE.md
+++ b/packages/sdp-kamino/CLAUDE.md
@@ -1,0 +1,188 @@
+# @sdp/kamino — agent notes
+
+Kit-native deposit/withdraw **instruction building** for Kamino K-Vaults, plus
+the live position read. It builds unsigned plans and reads chain state; it never
+signs, never submits, never touches a database, and holds no credential —
+Kamino's data surface is public. Signing and submission belong to the API, which
+owns custody and the Kora fee-payment path.
+
+Read `packages/sdp-earn/CLAUDE.md` for the catalogue side (what a K-Vault row IS)
+and ADR 0002 for the pluggability invariants. Kamino's own docs are agent-readable
+and authoritative — start at <https://kamino.com/docs/skill.md>; every page is
+fetchable as raw markdown by appending `.md`. **Do not answer Kamino questions
+from memory**: this integration has already cost one durable wrong premise (see
+"mainnet only" in `@sdp/earn`).
+
+## The trap this package exists to contain
+
+`new KaminoVault(rpc, addr, state, programId)` applies `programId` to **account
+reads only**. Its constructor then builds its own `KaminoVaultClient` *without
+forwarding it*, and instruction building goes through that client — which
+defaults to **mainnet**. On devnet the result is a vault that reads `devkRng…`
+state and emits instructions addressed to `KvauGM…`, with no error at any layer.
+
+**Kamino's own published recipe uses that constructor**, so this is the default
+outcome for anyone following the docs. Measured 2026-08-15; it is not theoretical.
+
+Three layers hold the line, and none is redundant:
+
+1. `bindVault` (sdk.ts) is the ONLY place a vault is constructed, and it uses
+   `KaminoVault.loadWithClientAndState(client, addr, state)` — the one factory
+   that sets `vault.programId` **and** `vault.client` together.
+2. `assertPlanTargetsCluster` re-checks the **output** against a per-cluster
+   program allowlist. Layer 1 is a convention inside one function; only layer 2
+   is a property of what we actually emit, and only it survives an SDK upgrade
+   that reshuffles construction.
+3. `sdk-construction.test.ts` greps this package's own source, because both of
+   the above are invisible to the type checker.
+
+## The kit-version firewall
+
+klend-sdk is built against `@solana/kit` **^2.3.0**; this repo pins **6.8.0**, and
+both copies live in the tree (pnpm nests the SDK's own). Verified by a live round
+trip: instructions come back as plain objects with a numeric `AccountRole` and
+`Uint8Array` data, so kit 6.8 compiles and signs them unchanged — the boundary is
+real at the TYPE level and inert at RUNTIME.
+
+`src/sdk.ts` is the only module that may import `@kamino-finance/klend-sdk` or
+`decimal.js`. Everything crossing this package's surface is `@solana/kit` 6.8,
+`@sdp/types`, or a **decimal string**. A `Decimal` escaping would also drag in the
+instance-identity hazard: klend-sdk compares with `instanceof Decimal`, so two
+physical copies degrade to NaN rather than to a type error — which is why the root
+`package.json` pins `decimal.js` via `pnpm.overrides`.
+
+## Constants that are MEASUREMENTS, not protocol facts
+
+All in `@sdp/types/kamino-programs` (there, not here, because `@sdp/earn` needs the
+devnet kvault id too and an edge between the two packages would be a workspace
+cycle *and* would drag a 13MB SDK into the hourly catalogue cron).
+
+- **`KAMINO_SLOT_DURATION_MS`** — required by `KaminoVaultClient` and with no safe
+  default. It scales every accrual the SDK computes (exchange rate, APY, farm
+  rewards), so a wrong value yields plausible WRONG NUMBERS with no error — the
+  same silent class as the program trap, and one no instruction assertion catches.
+  Measured 2026-08-15 over a 4,000-slot span: **mainnet ≈ 416 ms, devnet ≈ 265 ms**.
+  Both differ from klend-sdk's own default of 400. Re-measure rather than adjust
+  by feel.
+- **`KAMINO_KVAULT_PROGRAM_IDS`** — the one address that DIFFERS per cluster.
+  Mainnet's id also exists on devnet with zero accounts, so aiming at the wrong one
+  yields a confident empty result rather than an error.
+- **klend and farms are the SAME id on both clusters** — verified deployed and
+  executable on each, explicitly, because a farms id that differed per cluster
+  would fail exactly the way kvault does. Both are still expressed as per-cluster
+  records so a future divergence is a data change here, not a hunt through callers.
+
+## `payer` is NOT the transaction fee payer
+
+klend-sdk's `payer?: TransactionSigner` is the **rent payer for created ATAs**,
+embedded in the instruction accounts as writable+signer. SDP's Kora path is
+different machinery: it sets the fee payer at compile time and signs post-compile
+via `signAsFeePayer(bytes)`. Naming a sponsor signer as `payer` would quietly bill
+it for share-ATA rent — a spend its `FeePayerPolicy` may refuse and which
+`sponsorship-budget.service.ts` does not account for. The field is `rentPayer`
+here for exactly that reason, and it defaults to the owner.
+
+## Plans are transaction-sized BATCHES
+
+Every plan also carries required `assetIdentity` with the deposit-token mint and
+share mint read from the same live vault state used to build its instructions.
+Catalogue metadata drives policy and ledger labels but is not builder truth; the
+API must compare both mints before signing so a stale or poisoned row cannot
+authorize one asset while the transaction moves another.
+
+`KaminoInstructionPlan.instructions` is `Instruction[][]`, one entry per
+transaction — not a flat list. A multi-reserve exit emits several withdraw
+instructions each carrying the vault's full reserve remaining-accounts list, and
+can exceed Solana's 1232-byte packet; Kamino publishes a per-vault lookup table
+(`SyncVaultLUTIxs`) precisely for this. Handing back a flat list would make the
+caller discover that at `compileTransaction`, far from the code that could fix it.
+
+The unstake → withdraw → post sequence stays in ONE batch deliberately: it must
+land atomically, since unstaking without the withdraw leaves the position in a
+state nobody asked for. If that stops fitting, the fix is the lookup table, not
+splitting the batch.
+
+**`buildKaminoWithdrawPlan` does NOT yet honour this contract**, and that is why
+the WITHDRAW CAPABILITY IS WITHHELD. It flattens every instruction into one
+batch and returns no lookup table, while the pinned SDK documents that a
+multi-reserve exit "might have to be split in multiple transactions".
+`KaminoVaultDirectClient` therefore does not implement `buildVaultWithdrawal`,
+`supportsVaultWithdraw` answers false, and the builder is not re-exported from
+`index.ts` — its only callers are this package's smoke tests. Nothing is
+fund-trapped by that: the shares sit in the org's own custody wallet and
+Kamino's UI can redeem them. Implementing the method is the LAST step of the
+batching work, not the first (`client.test.ts` pins this).
+
+## Known gaps (deliberate, and owed to the caller)
+
+- **Withdrawal penalties are not quoted.** Kamino charges
+  `max(bps × gross, flat)` **per withdraw instruction**, so a multi-reserve exit
+  can pay N × flat. The SDK exposes `getVaultWithdrawPenalties` /
+  `ShareExitLiquidityPlan`; until one is wired, this package returns no estimate
+  rather than a derived one. A wrong number here is worse than none — same rule as
+  the dashboard's "missing renders —, never a fabricated rate".
+- **`minSharesOut` is optional and unset by default.** Computing a real floor needs
+  the live exchange rate. Passing `"0"` would be the appearance of slippage
+  protection without the substance, so the caller computes a floor or passes
+  nothing. The API requires one in PRODUCTION for exactly that reason.
+- **`lookupTables` is always empty today.** The field exists so callers compile
+  against the right shape; populating it from Kamino's per-vault LUT is the fix
+  when a plan stops fitting.
+
+## Amounts are checked against the MINT, not just parsed
+
+`amounts.ts` (deliberately outside the SDK firewall, so it is unit-testable
+without loading klend-sdk) refuses any value finer than its mint can represent,
+and returns the canonical form the instruction actually encodes — surfaced as
+`KaminoInstructionPlan.accepted`, which is what the ledger should persist.
+Trailing fractional zeroes do not add precision (`1.5000000` is representable by
+a six-decimal mint); a non-zero sub-atom still fails rather than being floored.
+
+This exists because klend-sdk converts every `Decimal` to mint atoms and
+**floors, silently**. Two different bugs hide under that floor: `1.0000009` on a
+six-decimal mint is RECORDED as 1.0000009 while 1.000000 moves, and a
+`minSharesOut` below one atom becomes `0` — a slippage floor that reads as
+protection everywhere and imposes none on chain. Validating the scale rather
+than clamping is the point: clamping would make SDP quietly move a different
+amount than it was asked for.
+
+## Share balances are read in base units, never `uiAmount`
+
+`readKaminoPosition` computes UNSTAKED shares itself, from
+`tokenAmount.amount` (the exact integer string), and takes only the STAKED half
+from `vault.getUserShares`. The SDK's own path sums
+`parsed.info.tokenAmount.uiAmount` — a JSON **number** — via
+`getTokenAccountAmount` (`utils/ata.ts`), so above 2^53 base units the value has
+already lost precision and no amount of `Decimal`-wrapping downstream recovers
+it. The staked half comes from farm state as an exact `Decimal`, so it is safe
+to reuse. Every matching token account is summed; if any returned account lacks
+an exact raw amount, the entire position is unreadable rather than silently
+under-reported.
+
+## RPC reads are bounded
+
+`rpc.ts` applies a 30-second deadline at the transport boundary shared with
+klend-sdk, so vault, reserve, farm, token-account, exchange-rate and slot reads
+cannot hold an API worker forever. Caller cancellation is composed with that
+deadline and remains distinguishable from a timeout. A portfolio page reads one
+shared slot, then hydrates at most four vaults concurrently; the number of
+in-flight RPC sequences never scales without a bound from catalogue size.
+
+## Tests
+
+`vitest run`, and **offline by default** — the repo rule is that package tests
+touch no network.
+
+`sdk.smoke.test.ts` is the exception: env-gated (`KAMINO_SMOKE_RPC_URL` +
+`KAMINO_SMOKE_SIGNER`), skipped when unset, so CI never runs it. Run it against a
+surfpool surfnet forking mainnet — real kvault program, real vault, no mainnet
+money at risk:
+
+```bash
+KAMINO_SMOKE_RPC_URL=http://127.0.0.1:8899 KAMINO_SMOKE_SIGNER=<64 hex chars> pnpm --filter @sdp/kamino test
+```
+
+Fund the signer first with SOL and the vault's deposit token via surfpool's
+`surfnet_setAccount` / `surfnet_setTokenAccount` cheatcodes. It proves what the
+offline tests cannot: that the emitted instructions simulate, land, and mint
+shares the position read then reports.

--- a/packages/sdp-kamino/CLAUDE.md
+++ b/packages/sdp-kamino/CLAUDE.md
@@ -159,14 +159,25 @@ to reuse. Every matching token account is summed; if any returned account lacks
 an exact raw amount, the entire position is unreadable rather than silently
 under-reported.
 
+An empty portfolio request first calls the SDK's on-chain
+`getUserSharesBalanceAllVaults` only to discover candidate vault ADDRESSES. That
+helper enumerates the configured kvault program plus the owner's farm and token
+accounts, so catalogue admission gates cannot hide an existing holding. Never
+return its balance values: they use the same lossy `uiAmount` path and overwrite
+rather than sum multiple token accounts. Every candidate is re-hydrated through
+`readKaminoPosition`, and exact zeroes are removed only after that read.
+
 ## RPC reads are bounded
 
 `rpc.ts` applies a 30-second deadline at the transport boundary shared with
 klend-sdk, so vault, reserve, farm, token-account, exchange-rate and slot reads
 cannot hold an API worker forever. Caller cancellation is composed with that
 deadline and remains distinguishable from a timeout. A portfolio page reads one
-shared slot, then hydrates at most four vaults concurrently; the number of
-in-flight RPC sequences never scales without a bound from catalogue size.
+shared slot, then hydrates at most four candidate holdings concurrently. An
+empty request pays one on-chain program/owner census up front, then fans out only
+over vaults for which the SDK found a share-token account or farm position — not
+the whole raw registry and not the curated catalogue. Census failures propagate
+rather than becoming a false empty portfolio.
 
 ## Tests
 

--- a/packages/sdp-kamino/package.json
+++ b/packages/sdp-kamino/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@sdp/kamino",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./programs": {
+      "types": "./src/programs.ts",
+      "import": "./src/programs.ts",
+      "default": "./src/programs.ts"
+    },
+    "./types": {
+      "types": "./src/types.ts",
+      "import": "./src/types.ts",
+      "default": "./src/types.ts"
+    },
+    "./errors": {
+      "types": "./src/errors.ts",
+      "import": "./src/errors.ts",
+      "default": "./src/errors.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@kamino-finance/klend-sdk": "10.0.0",
+    "@sdp/earn": "workspace:*",
+    "@sdp/solana": "workspace:*",
+    "@sdp/types": "workspace:*",
+    "@solana/kit": "catalog:",
+    "decimal.js": "10.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.2",
+    "tsx": "4.23.5",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/sdp-kamino/src/amounts.test.ts
+++ b/packages/sdp-kamino/src/amounts.test.ts
@@ -66,6 +66,30 @@ describe("acceptAtMintScale", () => {
     expect(() => acceptAtMintScale("amount", "7.5", 0)).toThrow(/more precision/);
   });
 
+  it("enforces the on-chain u64 range for every encoded amount field", () => {
+    const maxU64 = "18446744073709551615";
+    const overU64 = "18446744073709551616";
+
+    for (const field of ["amount", "minSharesOut", "shares"]) {
+      expect(acceptAtMintScale(field, maxU64, 0), field).toBe(maxU64);
+      expect(() => acceptAtMintScale(field, overU64, 0), field).toThrow(SdpKaminoError);
+      try {
+        acceptAtMintScale(field, overU64, 0);
+        expect.unreachable("should have rejected an amount above u64");
+      } catch (error) {
+        expect(error).toBeInstanceOf(SdpKaminoError);
+        expect((error as SdpKaminoError).code).toBe("INVALID_AMOUNT");
+        expect((error as Error).message).toMatch(/unsigned 64-bit base-unit/);
+      }
+    }
+
+    // The bound applies after mint scaling, not to the whole-number spelling.
+    expect(acceptAtMintScale("amount", "18446744073709.551615", 6)).toBe("18446744073709.551615");
+    expect(() => acceptAtMintScale("amount", "18446744073709.551616", 6)).toThrow(
+      /unsigned 64-bit base-unit/
+    );
+  });
+
   it("handles long zero runs in linear time without changing scale semantics", () => {
     const zeroRun = "0".repeat(50_000);
 

--- a/packages/sdp-kamino/src/amounts.test.ts
+++ b/packages/sdp-kamino/src/amounts.test.ts
@@ -1,0 +1,116 @@
+import { formatDecimalAmount } from "@sdp/solana/amount";
+import { describe, expect, it } from "vitest";
+import { acceptAtMintScale, isZeroAmount, mintDecimals } from "./amounts";
+import { SdpKaminoError } from "./errors";
+
+describe("acceptAtMintScale", () => {
+  it("accepts a value the mint can represent exactly and canonicalises it", () => {
+    expect(acceptAtMintScale("amount", "1.5", 6)).toBe("1.5");
+    // Trailing zeros are noise, not precision — "1.500" and "1.5" are the same
+    // number of atoms, and the ledger should hold one spelling.
+    expect(acceptAtMintScale("amount", "1.500000", 6)).toBe("1.5");
+    // The spelling may have more places than the mint when every extra place
+    // is zero. Precision is determined after insignificant zeros are removed.
+    expect(acceptAtMintScale("amount", "1.5000000", 6)).toBe("1.5");
+    expect(acceptAtMintScale("amount", "0.0000010", 6)).toBe("0.000001");
+    expect(acceptAtMintScale("amount", "1.000000000000", 6)).toBe("1");
+    expect(acceptAtMintScale("amount", "  20  ", 6)).toBe("20");
+    expect(acceptAtMintScale("amount", "0.000001", 6)).toBe("0.000001");
+  });
+
+  /**
+   * THE BUG THIS MODULE EXISTS FOR.
+   *
+   * klend-sdk floors to mint atoms, so `1.0000009` on a six-decimal mint would
+   * be recorded as 1.0000009 while 1.000000 actually moves. Refusing keeps the
+   * recorded number and the encoded number equal.
+   */
+  it("refuses a value finer than the mint's atom", () => {
+    expect(() => acceptAtMintScale("amount", "1.0000009", 6)).toThrow(SdpKaminoError);
+    expect(() => acceptAtMintScale("amount", "1.0000009", 6)).toThrow(/more precision/);
+    // One decimal past the boundary is still past it.
+    expect(() => acceptAtMintScale("amount", "0.0000001", 6)).toThrow(SdpKaminoError);
+    // A trailing zero does not erase the preceding non-zero sub-atom.
+    expect(() => acceptAtMintScale("amount", "0.00000010", 6)).toThrow(SdpKaminoError);
+  });
+
+  /**
+   * The sharper half: a sub-atom `minSharesOut` floors to zero, so a request
+   * that LOOKS protected gets no on-chain floor at all.
+   */
+  it("refuses a sub-atom slippage floor rather than letting it become zero", () => {
+    expect(() => acceptAtMintScale("minSharesOut", "0.0000000001", 6)).toThrow(
+      /more precision than its mint supports/
+    );
+  });
+
+  it("carries the error code the API maps to a 400", () => {
+    try {
+      acceptAtMintScale("amount", "1.0000009", 6);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SdpKaminoError);
+      expect((error as SdpKaminoError).code).toBe("INVALID_AMOUNT");
+    }
+  });
+
+  it("rejects non-decimal, signed and exponential input before scale is considered", () => {
+    for (const bad of ["-1", "1e5", "Infinity", "", "abc", "1.2.3"]) {
+      expect(() => acceptAtMintScale("amount", bad, 6), bad).toThrow(SdpKaminoError);
+    }
+  });
+
+  it("handles a zero-decimal mint", () => {
+    expect(acceptAtMintScale("amount", "7", 0)).toBe("7");
+    expect(acceptAtMintScale("amount", "7.000", 0)).toBe("7");
+    expect(() => acceptAtMintScale("amount", "7.5", 0)).toThrow(/more precision/);
+  });
+
+  /**
+   * The precision floor the reviewer asked to be tested: a share balance above
+   * 2^53 base units is exactly where `uiAmount`'s JSON number loses value.
+   * These helpers are `bigint` end to end, so the round trip is lossless.
+   */
+  it("survives a raw balance above 2^53 base units", () => {
+    const base = 9_007_199_254_740_993n; // Number.MAX_SAFE_INTEGER + 2
+    const asDecimal = formatDecimalAmount(base, 6);
+    expect(asDecimal).toBe("9007199254.740993");
+    // Round-tripping through the accept path must not perturb the last digit.
+    expect(acceptAtMintScale("shares", asDecimal, 6)).toBe("9007199254.740993");
+
+    // For contrast, the cost of the route this replaced. `getUserShares` sums
+    // `tokenAmount.uiAmount`, a JSON number; once the raw balance passes 2^53
+    // the base units are no longer representable, and the lost digit cannot be
+    // recovered by wrapping the result in `Decimal` afterwards.
+    expect(Number.isSafeInteger(Number(base))).toBe(false);
+    expect(BigInt(Number(base))).toBe(9_007_199_254_740_992n);
+  });
+});
+
+describe("isZeroAmount", () => {
+  it("recognises canonical zero and nothing else", () => {
+    expect(isZeroAmount(acceptAtMintScale("amount", "0", 6))).toBe(true);
+    expect(isZeroAmount(acceptAtMintScale("amount", "0.000000", 6))).toBe(true);
+    expect(isZeroAmount(acceptAtMintScale("amount", "0.000001", 6))).toBe(false);
+  });
+});
+
+describe("mintDecimals", () => {
+  it("normalises the shapes klend-sdk hands back", () => {
+    expect(mintDecimals(6, "tokenMintDecimals")).toBe(6);
+    expect(mintDecimals("6", "tokenMintDecimals")).toBe(6);
+    // A BN-like object stringifies to its digits; `Number(bn)` would be NaN.
+    expect(mintDecimals({ toString: () => "9" }, "tokenMintDecimals")).toBe(9);
+  });
+
+  /**
+   * Fails loudly rather than defaulting. A silent fallback would make every
+   * scale comparison above compare against the wrong mint — the check would
+   * still run and would still pass, which is the worst of both worlds.
+   */
+  it("throws on a value it cannot trust", () => {
+    for (const bad of [undefined, null, Number.NaN, -1, 1.5, 99, "abc"]) {
+      expect(() => mintDecimals(bad, "sharesMintDecimals"), String(bad)).toThrow(/unusable/);
+    }
+  });
+});

--- a/packages/sdp-kamino/src/amounts.test.ts
+++ b/packages/sdp-kamino/src/amounts.test.ts
@@ -66,6 +66,13 @@ describe("acceptAtMintScale", () => {
     expect(() => acceptAtMintScale("amount", "7.5", 0)).toThrow(/more precision/);
   });
 
+  it("handles long zero runs in linear time without changing scale semantics", () => {
+    const zeroRun = "0".repeat(50_000);
+
+    expect(acceptAtMintScale("amount", `1.${zeroRun}`, 6)).toBe("1");
+    expect(() => acceptAtMintScale("amount", `1.${zeroRun}1`, 6)).toThrow(/more precision/);
+  });
+
   /**
    * The precision floor the reviewer asked to be tested: a share balance above
    * 2^53 base units is exactly where `uiAmount`'s JSON number loses value.

--- a/packages/sdp-kamino/src/amounts.ts
+++ b/packages/sdp-kamino/src/amounts.ts
@@ -4,7 +4,10 @@ import {
   isDecimalString,
   parseDecimalAmount,
 } from "@sdp/solana/amount";
-import { amountTooPrecise, invalidAmount } from "./errors";
+import { amountOutOfRange, amountTooPrecise, invalidAmount } from "./errors";
+
+/** Every amount Kamino serializes into an instruction is an unsigned 64-bit integer. */
+const MAX_U64_BASE_UNITS = (1n << 64n) - 1n;
 
 /**
  * Amount validation at the MINT's precision.
@@ -73,11 +76,17 @@ export function acceptAtMintScale(field: string, value: string, decimals: number
   if (decimalScale(canonicalScaleInput) > decimals) {
     throw amountTooPrecise(field, value, decimals);
   }
+  // Parse once and retain the exact atom count. Scale-valid decimals can still
+  // overflow the u64 encoded by Kamino instructions; letting those through
+  // defers the failure until Borsh emits an opaque byte-length error after RPC
+  // work. This shared gate covers deposit amount, minSharesOut and withdrawal
+  // shares before any of them reaches the SDK.
+  const baseUnits = parseDecimalAmount(canonicalScaleInput, decimals);
+  if (baseUnits > MAX_U64_BASE_UNITS) throw amountOutOfRange(field, value);
+
   // Re-serialised through the repo's fixed-point helpers so what leaves this
   // package is scaled exactly like every other amount in SDP ("1.500" -> "1.5").
-  // Safe by construction: the scale check above is precisely
-  // `parseDecimalAmount`'s own precondition, so it cannot throw here.
-  return formatDecimalAmount(parseDecimalAmount(canonicalScaleInput, decimals), decimals);
+  return formatDecimalAmount(baseUnits, decimals);
 }
 
 function trimInsignificantFractionalZeroes(value: string): string {

--- a/packages/sdp-kamino/src/amounts.ts
+++ b/packages/sdp-kamino/src/amounts.ts
@@ -85,8 +85,15 @@ function trimInsignificantFractionalZeroes(value: string): string {
   if (dot === -1) return value;
 
   const whole = value.slice(0, dot);
-  const fraction = value.slice(dot + 1).replace(/0+$/, "");
-  return fraction === "" ? whole : `${whole}.${fraction}`;
+  let fractionEnd = value.length;
+  // Scan once from the end instead of applying an end-anchored repetition to
+  // caller-controlled input. The latter can retry from every zero when a long
+  // run ends in a non-zero digit, turning validation into quadratic work.
+  while (fractionEnd > dot + 1 && value[fractionEnd - 1] === "0") {
+    fractionEnd -= 1;
+  }
+
+  return fractionEnd === dot + 1 ? whole : value.slice(0, fractionEnd);
 }
 
 /**

--- a/packages/sdp-kamino/src/amounts.ts
+++ b/packages/sdp-kamino/src/amounts.ts
@@ -1,0 +1,101 @@
+import {
+  decimalScale,
+  formatDecimalAmount,
+  isDecimalString,
+  parseDecimalAmount,
+} from "@sdp/solana/amount";
+import { amountTooPrecise, invalidAmount } from "./errors";
+
+/**
+ * Amount validation at the MINT's precision.
+ *
+ * A separate module from `./sdk.ts` for one reason: none of this needs
+ * klend-sdk or `decimal.js`, so keeping it out of the firewall module makes it
+ * unit-testable without loading a 13MB chain SDK. `@sdp/solana/amount` is the
+ * repo's fixed-point arithmetic and is exact — `bigint` base units throughout,
+ * never a float.
+ */
+
+/**
+ * Read a mint's decimals off vault state.
+ *
+ * The field arrives as a klend-sdk `BN`, a `Decimal`, or a number depending on
+ * the codec, so it is normalised through `String` before `Number`: `Number(BN)`
+ * is `NaN`, and a NaN scale would silently DISABLE the check below rather than
+ * fail it — the check would compare against NaN and always pass. Failing loudly
+ * on an unreadable value is the only safe direction for something whose whole
+ * job is to bound a money amount.
+ */
+export function mintDecimals(value: unknown, label: string): number {
+  const raw = String(value ?? "").trim();
+  // Matched as DIGITS rather than parsed with `Number`, because `Number("")` is
+  // 0 — so a missing field would otherwise arrive as a perfectly plausible
+  // "zero-decimal mint" and disable every scale check downstream.
+  const parsed = /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  if (!Number.isInteger(parsed) || parsed > 18) {
+    throw new Error(`Kamino vault state carried an unusable ${label} (${String(value)})`);
+  }
+  return parsed;
+}
+
+/**
+ * Refuse an amount finer than its mint can represent, and return the canonical
+ * form of what will actually be encoded.
+ *
+ * klend-sdk converts every `Decimal` to mint atoms and FLOORS, silently. Two
+ * distinct bugs hide under that floor, neither visible at the call site:
+ *
+ * - A deposit of `1.0000009` against a six-decimal mint is RECORDED as
+ *   1.0000009 while only 1.000000 moves. The ledger and the chain disagree, and
+ *   the ledger is the thing a customer is later shown.
+ * - A `minSharesOut` below one atom floors to `0`. That is a slippage floor
+ *   which reads as protection in the request, in the ledger and in the UI, and
+ *   imposes none on chain — strictly worse than sending no floor at all,
+ *   because it also suppresses anyone's suspicion that protection is missing.
+ *
+ * Validating the SCALE rather than clamping the value is deliberate: clamping
+ * would make SDP quietly move a different amount than it was asked for, which
+ * is the same class of bug wearing a friendlier costume. The caller gets a
+ * refusal it can surface, and the number it asked for is the number that moves.
+ */
+export function acceptAtMintScale(field: string, value: string, decimals: number): string {
+  const normalized = value.trim();
+  // `isDecimalString` is the syntax gate and also the SIGN gate: it accepts
+  // digits and at most one dot, so "-1", "1e5" and "Infinity" are all rejected
+  // here rather than needing a separate numeric parse.
+  if (!isDecimalString(normalized)) throw invalidAmount(field, value);
+  // Scale is a property of the VALUE, not its spelling. Zeros after the last
+  // non-zero fractional digit do not require mint atoms: `1.5000000` is exactly
+  // representable by a six-decimal mint even though its input text has seven
+  // places. Strip only those insignificant zeros; a non-zero sub-atom remains
+  // and is still rejected below (`1.0000001` stays seven-place precision).
+  const canonicalScaleInput = trimInsignificantFractionalZeroes(normalized);
+  if (decimalScale(canonicalScaleInput) > decimals) {
+    throw amountTooPrecise(field, value, decimals);
+  }
+  // Re-serialised through the repo's fixed-point helpers so what leaves this
+  // package is scaled exactly like every other amount in SDP ("1.500" -> "1.5").
+  // Safe by construction: the scale check above is precisely
+  // `parseDecimalAmount`'s own precondition, so it cannot throw here.
+  return formatDecimalAmount(parseDecimalAmount(canonicalScaleInput, decimals), decimals);
+}
+
+function trimInsignificantFractionalZeroes(value: string): string {
+  const dot = value.indexOf(".");
+  if (dot === -1) return value;
+
+  const whole = value.slice(0, dot);
+  const fraction = value.slice(dot + 1).replace(/0+$/, "");
+  return fraction === "" ? whole : `${whole}.${fraction}`;
+}
+
+/**
+ * True when a canonical amount is exactly zero.
+ *
+ * Only sound on the OUTPUT of `acceptAtMintScale`: that function collapses every
+ * spelling of nothing ("0", "0.00", "0.000000") to the single string "0", so a
+ * string compare is exact here and would not be on a raw caller value.
+ */
+export function isZeroAmount(canonical: string): boolean {
+  return canonical === "0";
+}

--- a/packages/sdp-kamino/src/asset-identity.test.ts
+++ b/packages/sdp-kamino/src/asset-identity.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { vaultAssetIdentityFromState } from "./asset-identity";
+import { SdpKaminoError } from "./errors";
+
+const DEPOSIT_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
+
+describe("vaultAssetIdentityFromState", () => {
+  it("returns the token and share mints observed in live vault state", () => {
+    expect(
+      vaultAssetIdentityFromState({
+        tokenMint: DEPOSIT_TOKEN_MINT,
+        sharesMint: SHARE_MINT,
+      })
+    ).toEqual({
+      depositTokenMint: DEPOSIT_TOKEN_MINT,
+      shareMint: SHARE_MINT,
+    });
+  });
+
+  it("fails closed when either state mint is missing or malformed", () => {
+    for (const state of [
+      { sharesMint: SHARE_MINT },
+      { tokenMint: DEPOSIT_TOKEN_MINT },
+      { tokenMint: "not-a-mint", sharesMint: SHARE_MINT },
+      { tokenMint: DEPOSIT_TOKEN_MINT, sharesMint: "not-a-mint" },
+    ]) {
+      expect(() => vaultAssetIdentityFromState(state)).toThrow(SdpKaminoError);
+    }
+  });
+});

--- a/packages/sdp-kamino/src/asset-identity.ts
+++ b/packages/sdp-kamino/src/asset-identity.ts
@@ -1,0 +1,30 @@
+import { address } from "@solana/kit";
+import { SdpKaminoError } from "./errors";
+import type { KaminoVaultAssetIdentity } from "./types";
+
+type KaminoVaultMintState = {
+  tokenMint?: unknown;
+  sharesMint?: unknown;
+};
+
+/** Read and validate the asset mints from the live state used by the builder. */
+export function vaultAssetIdentityFromState(state: unknown): KaminoVaultAssetIdentity {
+  const mintState = state as KaminoVaultMintState | null;
+  return {
+    depositTokenMint: requiredMintAddress("tokenMint", mintState?.tokenMint),
+    shareMint: requiredMintAddress("sharesMint", mintState?.sharesMint),
+  };
+}
+
+function requiredMintAddress(field: string, value: unknown) {
+  const raw = typeof value === "string" ? value.trim() : "";
+  try {
+    return address(raw);
+  } catch (cause) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino vault state did not contain a valid ${field}`,
+      { cause }
+    );
+  }
+}

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -3,6 +3,7 @@ import {
   supportsVaultDirect,
   supportsVaultWithdraw,
 } from "@sdp/earn/capabilities";
+import type { ProviderStrategySnapshot } from "@sdp/earn/types";
 import { type Address, address } from "@solana/kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -115,6 +116,124 @@ describe("KaminoVaultDirectClient capabilities", () => {
     expect(seen).toEqual(["devnet", "mainnet-beta"]);
   });
 
+  it("reads every provider-known vault when no references are supplied", async () => {
+    const resolvedRpcUrl = "https://devnet.example.invalid";
+    const resolveRpcUrl = vi.fn(() => resolvedRpcUrl);
+    const probe = new KaminoVaultDirectClient(resolveRpcUrl);
+    const slot = 123n;
+    const getSlotSend = vi.fn().mockResolvedValue(slot);
+    mocks.createKaminoRpc.mockReturnValue({ getSlot: () => ({ send: getSlotSend }) });
+
+    const providerReferences = ["7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx", SHARE_MINT];
+    const strategies = providerReferences.map(
+      (providerReference, index): ProviderStrategySnapshot => ({
+        providerReference,
+        name: `Vault ${index + 1}`,
+        sourceKind: "defi",
+        underlyingSource: "klend",
+        depositMints: [DEPOSIT_TOKEN_MINT],
+        shareMint: SHARE_MINT,
+        hostCluster: "devnet",
+        apyType: "variable",
+        liquidityTerm: "instant",
+      })
+    );
+    const listStrategies = vi.spyOn(probe, "listStrategies").mockResolvedValue(strategies);
+    mocks.readKaminoPosition.mockImplementation(
+      async (
+        runtime: KaminoRuntime,
+        input: { vault: Address; owner: Address; slot: bigint }
+      ): Promise<KaminoPosition> => ({
+        vault: input.vault,
+        owner: input.owner,
+        cluster: runtime.cluster,
+        shares: String(input.vault) === providerReferences[1] ? "0" : "1",
+        tokenMint: address(DEPOSIT_TOKEN_MINT),
+        sharesMint: address(SHARE_MINT),
+      })
+    );
+
+    const positions = await probe.readVaultPositions(
+      {
+        environment: "sandbox",
+        env: {
+          SOLANA_RPC_URL: "https://process-mainnet.example.invalid",
+          UNRELATED: "preserved",
+        },
+      },
+      {
+        owner: "11111111111111111111111111111112",
+        providerReferences: [],
+      }
+    );
+
+    expect(resolveRpcUrl).toHaveBeenCalledWith("devnet");
+    expect(listStrategies).toHaveBeenCalledWith({
+      environment: "sandbox",
+      env: {
+        SOLANA_RPC_URL: resolvedRpcUrl,
+        UNRELATED: "preserved",
+      },
+    });
+    expect(mocks.createKaminoRpc).toHaveBeenCalledWith(resolvedRpcUrl);
+    expect(getSlotSend).toHaveBeenCalledOnce();
+    expect(positions.map((position) => position.providerReference)).toEqual([
+      providerReferences[0],
+    ]);
+    expect(
+      mocks.readKaminoPosition.mock.calls.map(([runtime, input]) => ({
+        cluster: runtime.cluster,
+        rpcUrl: runtime.rpcUrl,
+        vault: String(input.vault),
+        slot: input.slot,
+      }))
+    ).toEqual(
+      providerReferences.map((vault) => ({
+        cluster: "devnet",
+        rpcUrl: resolvedRpcUrl,
+        vault,
+        slot,
+      }))
+    );
+  });
+
+  it("returns an empty snapshot without chain reads when the known shelf is empty", async () => {
+    const probe = new KaminoVaultDirectClient(() => "https://devnet.example.invalid");
+    vi.spyOn(probe, "listStrategies").mockResolvedValue([]);
+
+    await expect(
+      probe.readVaultPositions(
+        { env: {}, environment: "sandbox" },
+        {
+          owner: "11111111111111111111111111111112",
+          providerReferences: [],
+        }
+      )
+    ).resolves.toEqual([]);
+
+    expect(mocks.createKaminoRpc).not.toHaveBeenCalled();
+    expect(mocks.readKaminoPosition).not.toHaveBeenCalled();
+  });
+
+  it("propagates known-vault discovery failures instead of reporting no holdings", async () => {
+    const probe = new KaminoVaultDirectClient(() => "https://devnet.example.invalid");
+    const discoveryError = new Error("catalogue unavailable");
+    vi.spyOn(probe, "listStrategies").mockRejectedValue(discoveryError);
+
+    await expect(
+      probe.readVaultPositions(
+        { env: {}, environment: "sandbox" },
+        {
+          owner: "11111111111111111111111111111112",
+          providerReferences: [],
+        }
+      )
+    ).rejects.toBe(discoveryError);
+
+    expect(mocks.createKaminoRpc).not.toHaveBeenCalled();
+    expect(mocks.readKaminoPosition).not.toHaveBeenCalled();
+  });
+
   it("reads vaults with bounded concurrency against one shared slot", async () => {
     const slot = 123n;
     const getSlotSend = vi.fn().mockResolvedValue(slot);
@@ -145,6 +264,7 @@ describe("KaminoVaultDirectClient capabilities", () => {
 
     const vault = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
     const providerReferences = Array.from({ length: 9 }, () => vault);
+    const listStrategies = vi.spyOn(client, "listStrategies");
     const pending = client.readVaultPositions(
       { env: {}, environment: "sandbox" },
       {
@@ -169,6 +289,7 @@ describe("KaminoVaultDirectClient capabilities", () => {
     await expect(pending).resolves.toHaveLength(9);
     expect(maxActive).toBe(KAMINO_POSITION_READ_CONCURRENCY);
     expect(getSlotSend).toHaveBeenCalledOnce();
+    expect(listStrategies).not.toHaveBeenCalled();
     expect(mocks.readKaminoPosition.mock.calls.every(([, input]) => input.slot === slot)).toBe(
       true
     );

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -3,7 +3,6 @@ import {
   supportsVaultDirect,
   supportsVaultWithdraw,
 } from "@sdp/earn/capabilities";
-import type { ProviderStrategySnapshot } from "@sdp/earn/types";
 import { type Address, address } from "@solana/kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -20,12 +19,14 @@ const SHARE_MINT = "So11111111111111111111111111111111111111112";
 const mocks = vi.hoisted(() => ({
   buildKaminoDepositPlan: vi.fn(),
   createKaminoRpc: vi.fn(),
+  discoverKaminoPositionVaults: vi.fn(),
   readKaminoPosition: vi.fn(),
 }));
 
 vi.mock("./rpc", () => ({ createKaminoRpc: mocks.createKaminoRpc }));
 vi.mock("./sdk", () => ({
   buildKaminoDepositPlan: mocks.buildKaminoDepositPlan,
+  discoverKaminoPositionVaults: mocks.discoverKaminoPositionVaults,
   readKaminoPosition: mocks.readKaminoPosition,
 }));
 
@@ -116,7 +117,7 @@ describe("KaminoVaultDirectClient capabilities", () => {
     expect(seen).toEqual(["devnet", "mainnet-beta"]);
   });
 
-  it("reads every provider-known vault when no references are supplied", async () => {
+  it("discovers owner-held vaults on chain without consulting the curated shelf", async () => {
     const resolvedRpcUrl = "https://devnet.example.invalid";
     const resolveRpcUrl = vi.fn(() => resolvedRpcUrl);
     const probe = new KaminoVaultDirectClient(resolveRpcUrl);
@@ -125,20 +126,9 @@ describe("KaminoVaultDirectClient capabilities", () => {
     mocks.createKaminoRpc.mockReturnValue({ getSlot: () => ({ send: getSlotSend }) });
 
     const providerReferences = ["7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx", SHARE_MINT];
-    const strategies = providerReferences.map(
-      (providerReference, index): ProviderStrategySnapshot => ({
-        providerReference,
-        name: `Vault ${index + 1}`,
-        sourceKind: "defi",
-        underlyingSource: "klend",
-        depositMints: [DEPOSIT_TOKEN_MINT],
-        shareMint: SHARE_MINT,
-        hostCluster: "devnet",
-        apyType: "variable",
-        liquidityTerm: "instant",
-      })
-    );
-    const listStrategies = vi.spyOn(probe, "listStrategies").mockResolvedValue(strategies);
+    const owner = "11111111111111111111111111111112";
+    mocks.discoverKaminoPositionVaults.mockResolvedValue(providerReferences.map(address));
+    const listStrategies = vi.spyOn(probe, "listStrategies");
     mocks.readKaminoPosition.mockImplementation(
       async (
         runtime: KaminoRuntime,
@@ -162,19 +152,17 @@ describe("KaminoVaultDirectClient capabilities", () => {
         },
       },
       {
-        owner: "11111111111111111111111111111112",
+        owner,
         providerReferences: [],
       }
     );
 
     expect(resolveRpcUrl).toHaveBeenCalledWith("devnet");
-    expect(listStrategies).toHaveBeenCalledWith({
-      environment: "sandbox",
-      env: {
-        SOLANA_RPC_URL: resolvedRpcUrl,
-        UNRELATED: "preserved",
-      },
-    });
+    expect(mocks.discoverKaminoPositionVaults).toHaveBeenCalledWith(
+      { cluster: "devnet", rpcUrl: resolvedRpcUrl },
+      address(owner)
+    );
+    expect(listStrategies).not.toHaveBeenCalled();
     expect(mocks.createKaminoRpc).toHaveBeenCalledWith(resolvedRpcUrl);
     expect(getSlotSend).toHaveBeenCalledOnce();
     expect(positions.map((position) => position.providerReference)).toEqual([
@@ -197,9 +185,9 @@ describe("KaminoVaultDirectClient capabilities", () => {
     );
   });
 
-  it("returns an empty snapshot without chain reads when the known shelf is empty", async () => {
+  it("returns an empty snapshot without slot or hydration reads when discovery finds no holdings", async () => {
     const probe = new KaminoVaultDirectClient(() => "https://devnet.example.invalid");
-    vi.spyOn(probe, "listStrategies").mockResolvedValue([]);
+    mocks.discoverKaminoPositionVaults.mockResolvedValue([]);
 
     await expect(
       probe.readVaultPositions(
@@ -211,14 +199,15 @@ describe("KaminoVaultDirectClient capabilities", () => {
       )
     ).resolves.toEqual([]);
 
+    expect(mocks.discoverKaminoPositionVaults).toHaveBeenCalledOnce();
     expect(mocks.createKaminoRpc).not.toHaveBeenCalled();
     expect(mocks.readKaminoPosition).not.toHaveBeenCalled();
   });
 
-  it("propagates known-vault discovery failures instead of reporting no holdings", async () => {
+  it("propagates on-chain discovery failures instead of reporting no holdings", async () => {
     const probe = new KaminoVaultDirectClient(() => "https://devnet.example.invalid");
-    const discoveryError = new Error("catalogue unavailable");
-    vi.spyOn(probe, "listStrategies").mockRejectedValue(discoveryError);
+    const discoveryError = new Error("program census unavailable");
+    mocks.discoverKaminoPositionVaults.mockRejectedValue(discoveryError);
 
     await expect(
       probe.readVaultPositions(
@@ -264,7 +253,6 @@ describe("KaminoVaultDirectClient capabilities", () => {
 
     const vault = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
     const providerReferences = Array.from({ length: 9 }, () => vault);
-    const listStrategies = vi.spyOn(client, "listStrategies");
     const pending = client.readVaultPositions(
       { env: {}, environment: "sandbox" },
       {
@@ -289,7 +277,7 @@ describe("KaminoVaultDirectClient capabilities", () => {
     await expect(pending).resolves.toHaveLength(9);
     expect(maxActive).toBe(KAMINO_POSITION_READ_CONCURRENCY);
     expect(getSlotSend).toHaveBeenCalledOnce();
-    expect(listStrategies).not.toHaveBeenCalled();
+    expect(mocks.discoverKaminoPositionVaults).not.toHaveBeenCalled();
     expect(mocks.readKaminoPosition.mock.calls.every(([, input]) => input.slot === slot)).toBe(
       true
     );

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -1,0 +1,202 @@
+import {
+  supportsPortfolioWallets,
+  supportsVaultDirect,
+  supportsVaultWithdraw,
+} from "@sdp/earn/capabilities";
+import { type Address, address } from "@solana/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertNotPortfolioProvider,
+  KAMINO_POSITION_READ_CONCURRENCY,
+  KaminoVaultDirectClient,
+  toEarnVaultTransactionPlan,
+} from "./client";
+import type { KaminoInstructionPlan, KaminoPosition, KaminoRuntime } from "./types";
+
+const DEPOSIT_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "So11111111111111111111111111111111111111112";
+
+const mocks = vi.hoisted(() => ({
+  buildKaminoDepositPlan: vi.fn(),
+  createKaminoRpc: vi.fn(),
+  readKaminoPosition: vi.fn(),
+}));
+
+vi.mock("./rpc", () => ({ createKaminoRpc: mocks.createKaminoRpc }));
+vi.mock("./sdk", () => ({
+  buildKaminoDepositPlan: mocks.buildKaminoDepositPlan,
+  readKaminoPosition: mocks.readKaminoPosition,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const client = new KaminoVaultDirectClient(() => "https://example.invalid");
+
+describe("KaminoVaultDirectClient capabilities", () => {
+  it("reports the vault-direct capability", () => {
+    expect(supportsVaultDirect(client)).toBe(true);
+  });
+
+  /**
+   * The withdraw capability is WITHHELD on purpose, and this pins it so that
+   * implementing `buildVaultWithdrawal` cannot happen by accident.
+   *
+   * `buildKaminoWithdrawPlan` returns every unstake/withdraw/cleanup
+   * instruction in ONE batch with no lookup table, while the pinned SDK
+   * documents that a multi-reserve exit may need several transactions.
+   * Answering yes here would let a future exit route narrow onto this client
+   * and receive a plan the API submitter refuses — after the customer was told
+   * their withdrawal was prepared. Deleting this test is the wrong way to make
+   * it pass; batching the plan is the right way.
+   */
+  it("does NOT report the withdraw capability until the plan is batched", () => {
+    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect((client as unknown as Record<string, unknown>).buildVaultWithdrawal).toBeUndefined();
+  });
+
+  /**
+   * THE INVARIANT THAT PROTECTS CUSTOMER FUNDS.
+   *
+   * The portfolio capability means "SDP can give you an address to send
+   * stablecoins to". Kamino has no such address — its vault is a program
+   * account, and tokens sent there are DESTROYED. If this client ever answered
+   * yes to both, a portfolio route could render that account as a deposit
+   * target. The two capabilities must stay mutually exclusive.
+   */
+  it("NEVER reports the portfolio-wallet capability", () => {
+    expect(supportsPortfolioWallets(client)).toBe(false);
+    expect(() => assertNotPortfolioProvider(client)).not.toThrow();
+  });
+
+  it("still catalogues — the execution client is a superset, not a replacement", () => {
+    expect(client.provider).toBe("kamino");
+    expect(client.declaredSupport.sourceKinds).toEqual(["defi"]);
+    expect(typeof client.listStrategies).toBe("function");
+  });
+
+  it("refuses to build when no RPC endpoint is configured for the cluster", async () => {
+    const unconfigured = new KaminoVaultDirectClient(() => "  ");
+    await expect(
+      unconfigured.buildVaultDeposit(
+        { env: {}, environment: "sandbox" },
+        {
+          providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+          owner: "11111111111111111111111111111112",
+          amount: "1",
+        }
+      )
+      // Fails before any network call, the same fail-closed rule @sdp/earn
+      // applies to a missing credential.
+    ).rejects.toThrow(/No Solana RPC endpoint configured for devnet/);
+  });
+
+  it("maps the SDP environment to the right cluster", async () => {
+    const seen: string[] = [];
+    const probe = new KaminoVaultDirectClient((cluster) => {
+      seen.push(cluster);
+      return "";
+    });
+    for (const environment of ["sandbox", "production"] as const) {
+      await probe
+        .buildVaultDeposit(
+          { env: {}, environment },
+          {
+            providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+            owner: "11111111111111111111111111111112",
+            amount: "1",
+          }
+        )
+        .catch(() => undefined);
+    }
+    // sandbox -> devnet, production -> mainnet-beta, via CLUSTER_BY_SDP_ENVIRONMENT
+    // rather than a second copy of that mapping.
+    expect(seen).toEqual(["devnet", "mainnet-beta"]);
+  });
+
+  it("reads vaults with bounded concurrency against one shared slot", async () => {
+    const slot = 123n;
+    const getSlotSend = vi.fn().mockResolvedValue(slot);
+    mocks.createKaminoRpc.mockReturnValue({ getSlot: () => ({ send: getSlotSend }) });
+
+    let active = 0;
+    let maxActive = 0;
+    const releases: Array<() => void> = [];
+    mocks.readKaminoPosition.mockImplementation(
+      async (
+        runtime: KaminoRuntime,
+        input: { vault: Address; owner: Address; slot: bigint }
+      ): Promise<KaminoPosition> => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        active -= 1;
+        return {
+          vault: input.vault,
+          owner: input.owner,
+          cluster: runtime.cluster,
+          shares: "1",
+          tokenMint: input.vault,
+          sharesMint: input.vault,
+        };
+      }
+    );
+
+    const vault = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
+    const providerReferences = Array.from({ length: 9 }, () => vault);
+    const pending = client.readVaultPositions(
+      { env: {}, environment: "sandbox" },
+      {
+        owner: "11111111111111111111111111111112",
+        providerReferences,
+      }
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(KAMINO_POSITION_READ_CONCURRENCY)
+    );
+    for (const release of releases.splice(0)) release();
+
+    await vi.waitFor(() =>
+      expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(KAMINO_POSITION_READ_CONCURRENCY * 2)
+    );
+    for (const release of releases.splice(0)) release();
+
+    await vi.waitFor(() => expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(9));
+    for (const release of releases.splice(0)) release();
+
+    await expect(pending).resolves.toHaveLength(9);
+    expect(maxActive).toBe(KAMINO_POSITION_READ_CONCURRENCY);
+    expect(getSlotSend).toHaveBeenCalledOnce();
+    expect(mocks.readKaminoPosition.mock.calls.every(([, input]) => input.slot === slot)).toBe(
+      true
+    );
+  });
+});
+
+describe("toEarnVaultTransactionPlan", () => {
+  it("preserves the mint-scale amounts encoded by the SDK plan", () => {
+    const plan: KaminoInstructionPlan = {
+      cluster: "devnet",
+      instructions: [],
+      lookupTables: [],
+      assetIdentity: {
+        depositTokenMint: address(DEPOSIT_TOKEN_MINT),
+        shareMint: address(SHARE_MINT),
+      },
+      accepted: { amount: "1.5", minSharesOut: "1.49" },
+    };
+
+    expect(toEarnVaultTransactionPlan(plan)).toMatchObject({
+      cluster: "devnet",
+      transactions: [],
+      lookupTables: [],
+      assetIdentity: {
+        depositTokenMint: DEPOSIT_TOKEN_MINT,
+        shareMint: SHARE_MINT,
+      },
+      accepted: { amount: "1.5", minSharesOut: "1.49" },
+    });
+  });
+});

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -96,7 +96,7 @@ describe("KaminoVaultDirectClient capabilities", () => {
 
   it("maps the SDP environment to the right cluster", async () => {
     const seen: string[] = [];
-    const probe = new KaminoVaultDirectClient((cluster) => {
+    const probe = new KaminoVaultDirectClient((_ctx, cluster) => {
       seen.push(cluster);
       return "";
     });
@@ -157,7 +157,16 @@ describe("KaminoVaultDirectClient capabilities", () => {
       }
     );
 
-    expect(resolveRpcUrl).toHaveBeenCalledWith("devnet");
+    expect(resolveRpcUrl).toHaveBeenCalledWith(
+      {
+        environment: "sandbox",
+        env: {
+          SOLANA_RPC_URL: "https://process-mainnet.example.invalid",
+          UNRELATED: "preserved",
+        },
+      },
+      "devnet"
+    );
     expect(mocks.discoverKaminoPositionVaults).toHaveBeenCalledWith(
       { cluster: "devnet", rpcUrl: resolvedRpcUrl },
       address(owner)
@@ -221,6 +230,44 @@ describe("KaminoVaultDirectClient capabilities", () => {
 
     expect(mocks.createKaminoRpc).not.toHaveBeenCalled();
     expect(mocks.readKaminoPosition).not.toHaveBeenCalled();
+  });
+
+  it("fails the whole snapshot when any discovered vault cannot be hydrated", async () => {
+    const slot = 123n;
+    mocks.createKaminoRpc.mockReturnValue({
+      getSlot: () => ({ send: vi.fn().mockResolvedValue(slot) }),
+    });
+
+    const owner = "11111111111111111111111111111112";
+    const providerReferences = ["7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx", SHARE_MINT];
+    mocks.discoverKaminoPositionVaults.mockResolvedValue(providerReferences.map(address));
+    mocks.readKaminoPosition.mockImplementation(
+      async (
+        runtime: KaminoRuntime,
+        input: { vault: Address; owner: Address }
+      ): Promise<KaminoPosition> => {
+        if (String(input.vault) === SHARE_MINT) throw new Error("RPC unavailable");
+        return {
+          vault: input.vault,
+          owner: input.owner,
+          cluster: runtime.cluster,
+          shares: "1",
+          tokenMint: address(DEPOSIT_TOKEN_MINT),
+          sharesMint: address(SHARE_MINT),
+        };
+      }
+    );
+
+    await expect(
+      client.readVaultPositions(
+        { env: {}, environment: "sandbox" },
+        { owner, providerReferences: [] }
+      )
+    ).rejects.toMatchObject({
+      code: "VAULT_UNREADABLE",
+      message: expect.stringMatching(/refusing to return a partial portfolio/),
+    });
+    expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(2);
   });
 
   it("reads vaults with bounded concurrency against one shared slot", async () => {

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -99,13 +99,15 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
    * serving and hands it in; `listKaminoDevnetVaults` guards the same hazard
    * with a genesis-hash check.
    */
-  constructor(private readonly resolveRpcUrl: (cluster: SolanaCluster) => string) {
+  constructor(
+    private readonly resolveRpcUrl: (ctx: EarnRuntimeContext, cluster: SolanaCluster) => string
+  ) {
     super();
   }
 
   private runtime(ctx: EarnRuntimeContext): KaminoRuntime {
     const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
-    const rpcUrl = this.resolveRpcUrl(cluster);
+    const rpcUrl = this.resolveRpcUrl(ctx, cluster);
     if (!rpcUrl.trim()) {
       throw new SdpKaminoError(
         "VAULT_UNREADABLE",
@@ -169,9 +171,9 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
    * kvault program, not the curated deposit catalogue: a visibility or TVL
    * gate may stop new money without hiding an existing position.
    *
-   * A vault that fails to read is DROPPED, not defaulted to zero: a zero would
-   * render as "you hold nothing here", which is a claim about someone's money
-   * that a failed RPC call does not support.
+   * A vault that fails to read fails the WHOLE snapshot. Returning every other
+   * vault would make the failed holding indistinguishable from no holding at
+   * all; a partial portfolio is not a truthful portfolio.
    */
   async readVaultPositions(
     ctx: EarnRuntimeContext,
@@ -195,7 +197,33 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
       (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
     );
 
+    const failures = results.flatMap((result, index) =>
+      result.status === "rejected"
+        ? [{ providerReference: providerReferences[index], cause: result.reason }]
+        : []
+    );
+    if (failures.length > 0) {
+      throw new SdpKaminoError(
+        "VAULT_UNREADABLE",
+        `Kamino could not read ${failures.length} of ${providerReferences.length} requested ` +
+          "vault positions; refusing to return a partial portfolio.",
+        {
+          cause: new AggregateError(
+            failures.map(({ providerReference, cause }) =>
+              cause instanceof Error
+                ? new Error(`Kamino vault ${providerReference} read failed`, { cause })
+                : new Error(`Kamino vault ${providerReference} read failed: ${String(cause)}`)
+            ),
+            "Kamino vault position reads failed"
+          ),
+        }
+      );
+    }
+
     return results.flatMap((result) => {
+      // All rejected results were handled above, so only fulfilled values can
+      // reach the serializer. Keep the guard for TypeScript's settled-result
+      // narrowing and as a defensive assertion if this block is later moved.
       if (result.status !== "fulfilled") return [];
       const position = result.value;
       // Exact reads serialize zero canonically as "0". A full-portfolio read

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -1,0 +1,220 @@
+import { supportsPortfolioWallets } from "@sdp/earn/capabilities";
+import { KaminoEarnClient } from "@sdp/earn/providers/kamino/client";
+import type {
+  EarnRuntimeContext,
+  EarnVaultDepositInput,
+  EarnVaultDirectProvider,
+  EarnVaultInstruction,
+  EarnVaultPositionInput,
+  EarnVaultPositionSnapshot,
+  EarnVaultTransactionPlan,
+} from "@sdp/earn/types";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
+import { type Address, address, createNoopSigner } from "@solana/kit";
+import { SdpKaminoError } from "./errors";
+import { createKaminoRpc } from "./rpc";
+import { buildKaminoDepositPlan, readKaminoPosition } from "./sdk";
+import type { KaminoInstructionPlan, KaminoRuntime } from "./types";
+
+/** One portfolio request may fan out over many vaults; never fan out the RPCs without a bound. */
+export const KAMINO_POSITION_READ_CONCURRENCY = 4;
+
+async function mapSettledWithConcurrency<T, U>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<U>
+): Promise<Array<PromiseSettledResult<U>>> {
+  const results = new Array<PromiseSettledResult<U>>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        try {
+          results[index] = { status: "fulfilled", value: await mapper(items[index] as T) };
+        } catch (reason) {
+          results[index] = { status: "rejected", reason };
+        }
+      }
+    })
+  );
+
+  return results;
+}
+
+/** Convert the kit-native plan to the dependency-free Earn wire contract. */
+export function toEarnVaultTransactionPlan(plan: KaminoInstructionPlan): EarnVaultTransactionPlan {
+  return {
+    cluster: plan.cluster,
+    transactions: plan.instructions.map((batch) =>
+      batch.map(
+        (instruction): EarnVaultInstruction => ({
+          programAddress: String(instruction.programAddress),
+          accounts: (instruction.accounts ?? []).map((account) => ({
+            address: String(account.address),
+            role: Number(account.role),
+          })),
+          // Base64 keeps the contract JSON-safe: a plan may cross a queue or a
+          // log before it is compiled, and a Uint8Array does not survive that.
+          data: Buffer.from(instruction.data ?? new Uint8Array()).toString("base64"),
+        })
+      )
+    ),
+    lookupTables: plan.lookupTables.map(String),
+    assetIdentity: {
+      depositTokenMint: String(plan.assetIdentity.depositTokenMint),
+      shareMint: String(plan.assetIdentity.shareMint),
+    },
+    // These are the mint-scale amounts the instructions actually encode. The
+    // API ledgers this shape; dropping it reintroduces raw-request drift.
+    accepted: { ...plan.accepted },
+  };
+}
+
+/**
+ * Kamino as an EXECUTING provider: the catalogue client plus the vault-direct
+ * capability.
+ *
+ * Lives here rather than in `@sdp/earn` so that package keeps its single
+ * `@sdp/types` dependency — its hourly catalogue cron runs in both environments
+ * and must never load klend-sdk. The arrow points inward: `@sdp/kamino` depends
+ * on `@sdp/earn`, never the reverse.
+ *
+ * Registered by the API's execution registry, which prefers this class over the
+ * catalogue-only `KaminoEarnClient` when a route needs to move money. Callers
+ * still discover the capability with `supportsVaultDirect`, never a provider-id
+ * check.
+ */
+export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVaultDirectProvider {
+  /**
+   * Where the RPC endpoint comes from.
+   *
+   * Injected rather than read from `ctx.env.SOLANA_RPC_URL` directly, because
+   * that variable is PROCESS-level while the cluster is PER-REQUEST: syncing the
+   * sandbox environment inside a production deployment reaches this code with a
+   * MAINNET url. The API resolves the right endpoint for the cluster it is
+   * serving and hands it in; `listKaminoDevnetVaults` guards the same hazard
+   * with a genesis-hash check.
+   */
+  constructor(private readonly resolveRpcUrl: (cluster: SolanaCluster) => string) {
+    super();
+  }
+
+  private runtime(ctx: EarnRuntimeContext): KaminoRuntime {
+    const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
+    const rpcUrl = this.resolveRpcUrl(cluster);
+    if (!rpcUrl.trim()) {
+      throw new SdpKaminoError(
+        "VAULT_UNREADABLE",
+        `No Solana RPC endpoint configured for ${cluster}; Kamino cannot build a transaction.`
+      );
+    }
+    return { cluster, rpcUrl };
+  }
+
+  /**
+   * The owner arrives as an ADDRESS, not a signer — custody lives in the API and
+   * a private key must never reach a provider client. klend-sdk needs a signer
+   * shaped object to place the account correctly, so a noop signer stands in: it
+   * contributes the right address and role and signs nothing. The API attaches
+   * the real custody signer at compile time, where kit matches by address.
+   */
+  private owner(value: string) {
+    return createNoopSigner(address(value));
+  }
+
+  async buildVaultDeposit(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultDepositInput
+  ): Promise<EarnVaultTransactionPlan> {
+    const plan = await buildKaminoDepositPlan(this.runtime(ctx), {
+      vault: address(input.providerReference),
+      owner: this.owner(input.owner),
+      amount: input.amount,
+      ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
+    });
+    return toEarnVaultTransactionPlan(plan);
+  }
+
+  /*
+   * NO `buildVaultWithdrawal` — the withdraw capability is WITHHELD, and its
+   * absence is the mechanism, not an oversight.
+   *
+   * `buildKaminoWithdrawPlan` exists and is proven against a mainnet-forked
+   * surfnet, but it does not yet honour the plan contract: it flattens every
+   * unstake/withdraw/cleanup instruction into ONE batch and returns no lookup
+   * table, while the pinned SDK documents that a multi-reserve exit "might have
+   * to be split in multiple transactions". Implementing the method here would
+   * make `supportsVaultWithdraw` answer true, which is what a future exit route
+   * will narrow on — and it would then hand that route a plan that either
+   * exceeds the packet limit or is refused by the submitter, after the customer
+   * was told their withdrawal was prepared.
+   *
+   * Adding the method is therefore the LAST step of that work, not the first:
+   * load the vault LUT, compile-measure and split at protocol boundaries (an
+   * unstake must never land without its withdraw), and give the API a resumable
+   * multi-leg submission. Until then the honest answer is that SDP has no exit
+   * route — the shares are in the org's own wallet and Kamino's UI can redeem
+   * them, which is why withholding this is safe rather than fund-trapping.
+   */
+
+  /**
+   * Reads every requested vault against ONE slot, so a multi-position page is
+   * priced consistently rather than drifting between reads.
+   *
+   * A vault that fails to read is DROPPED, not defaulted to zero: a zero would
+   * render as "you hold nothing here", which is a claim about someone's money
+   * that a failed RPC call does not support.
+   */
+  async readVaultPositions(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultPositionInput
+  ): Promise<EarnVaultPositionSnapshot[]> {
+    const runtime = this.runtime(ctx);
+    // One shared slot makes the page internally consistent. The client carries
+    // the same transport deadline as every nested Kamino SDK read below.
+    const slot = await createKaminoRpc(runtime.rpcUrl).getSlot().send();
+    const owner: Address = address(input.owner);
+
+    const results = await mapSettledWithConcurrency(
+      input.providerReferences,
+      KAMINO_POSITION_READ_CONCURRENCY,
+      (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
+    );
+
+    return results.flatMap((result) => {
+      if (result.status !== "fulfilled") return [];
+      const position = result.value;
+      return [
+        {
+          providerReference: String(position.vault),
+          owner: String(position.owner),
+          cluster: position.cluster,
+          shares: position.shares,
+          ...(position.tokenValue === undefined ? {} : { tokenValue: position.tokenValue }),
+          tokenMint: String(position.tokenMint),
+          shareMint: String(position.sharesMint),
+        },
+      ];
+    });
+  }
+}
+
+/**
+ * Guard asserted at construction rather than trusted: the two capabilities
+ * describe opposite money models, and a client answering yes to both would let a
+ * portfolio route hand a customer the vault's own account as a deposit address —
+ * where funds are destroyed. Exported so the API can assert it at registry wiring.
+ */
+export function assertNotPortfolioProvider(client: KaminoVaultDirectClient): void {
+  if (supportsPortfolioWallets(client)) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      "Kamino must never report the portfolio-wallet capability: it custodies nothing, " +
+        "and its vault account is not a fundable address."
+    );
+  }
+}

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -174,13 +174,27 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     input: EarnVaultPositionInput
   ): Promise<EarnVaultPositionSnapshot[]> {
     const runtime = this.runtime(ctx);
+    const owner: Address = address(input.owner);
+    const readAllKnownVaults = input.providerReferences.length === 0;
+    const providerReferences = readAllKnownVaults
+      ? (
+          await this.listStrategies({
+            ...ctx,
+            // Catalogue discovery reads this process-level key on devnet.
+            // Use the same per-cluster endpoint as the position reads so an
+            // empty request cannot discover on one chain and hydrate another.
+            env: { ...ctx.env, SOLANA_RPC_URL: runtime.rpcUrl },
+          })
+        ).map((strategy) => strategy.providerReference)
+      : input.providerReferences;
+    if (providerReferences.length === 0) return [];
+
     // One shared slot makes the page internally consistent. The client carries
     // the same transport deadline as every nested Kamino SDK read below.
     const slot = await createKaminoRpc(runtime.rpcUrl).getSlot().send();
-    const owner: Address = address(input.owner);
 
     const results = await mapSettledWithConcurrency(
-      input.providerReferences,
+      providerReferences,
       KAMINO_POSITION_READ_CONCURRENCY,
       (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
     );
@@ -188,6 +202,10 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     return results.flatMap((result) => {
       if (result.status !== "fulfilled") return [];
       const position = result.value;
+      // Exact reads serialize zero canonically as "0". A full-portfolio read
+      // reports holdings, while an explicitly requested vault may still return
+      // a truthful zero balance.
+      if (readAllKnownVaults && position.shares === "0") return [];
       return [
         {
           providerReference: String(position.vault),

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -13,7 +13,7 @@ import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
 import { type Address, address, createNoopSigner } from "@solana/kit";
 import { SdpKaminoError } from "./errors";
 import { createKaminoRpc } from "./rpc";
-import { buildKaminoDepositPlan, readKaminoPosition } from "./sdk";
+import { buildKaminoDepositPlan, discoverKaminoPositionVaults, readKaminoPosition } from "./sdk";
 import type { KaminoInstructionPlan, KaminoRuntime } from "./types";
 
 /** One portfolio request may fan out over many vaults; never fan out the RPCs without a bound. */
@@ -165,6 +165,10 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
    * Reads every requested vault against ONE slot, so a multi-position page is
    * priced consistently rather than drifting between reads.
    *
+   * An empty reference list discovers owner-held vaults from the on-chain
+   * kvault program, not the curated deposit catalogue: a visibility or TVL
+   * gate may stop new money without hiding an existing position.
+   *
    * A vault that fails to read is DROPPED, not defaulted to zero: a zero would
    * render as "you hold nothing here", which is a claim about someone's money
    * that a failed RPC call does not support.
@@ -175,17 +179,9 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
   ): Promise<EarnVaultPositionSnapshot[]> {
     const runtime = this.runtime(ctx);
     const owner: Address = address(input.owner);
-    const readAllKnownVaults = input.providerReferences.length === 0;
-    const providerReferences = readAllKnownVaults
-      ? (
-          await this.listStrategies({
-            ...ctx,
-            // Catalogue discovery reads this process-level key on devnet.
-            // Use the same per-cluster endpoint as the position reads so an
-            // empty request cannot discover on one chain and hydrate another.
-            env: { ...ctx.env, SOLANA_RPC_URL: runtime.rpcUrl },
-          })
-        ).map((strategy) => strategy.providerReference)
+    const readAllHoldings = input.providerReferences.length === 0;
+    const providerReferences = readAllHoldings
+      ? await discoverKaminoPositionVaults(runtime, owner)
       : input.providerReferences;
     if (providerReferences.length === 0) return [];
 
@@ -205,7 +201,7 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
       // Exact reads serialize zero canonically as "0". A full-portfolio read
       // reports holdings, while an explicitly requested vault may still return
       // a truthful zero balance.
-      if (readAllKnownVaults && position.shares === "0") return [];
+      if (readAllHoldings && position.shares === "0") return [];
       return [
         {
           providerReference: String(position.vault),

--- a/packages/sdp-kamino/src/errors.ts
+++ b/packages/sdp-kamino/src/errors.ts
@@ -52,6 +52,14 @@ export function amountTooPrecise(field: string, value: string, decimals: number)
   );
 }
 
+/** A decimal whose mint-scaled integer cannot fit Kamino's on-chain u64 field. */
+export function amountOutOfRange(field: string, value: string): SdpKaminoError {
+  return new SdpKaminoError(
+    "INVALID_AMOUNT",
+    `Kamino ${field} ${JSON.stringify(value)} exceeds the maximum unsigned 64-bit base-unit amount`
+  );
+}
+
 /**
  * The vault account could not be read on this cluster.
  *

--- a/packages/sdp-kamino/src/errors.ts
+++ b/packages/sdp-kamino/src/errors.ts
@@ -1,0 +1,74 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address } from "@solana/kit";
+
+/**
+ * Errors this package raises, mirroring `@sdp/earn/errors` in shape: a `code`
+ * the API can map to a status, and a message that says what was actually wrong.
+ * Deliberately NOT re-using `@sdp/earn`'s constructors — that would put an
+ * `@sdp/kamino → @sdp/earn` edge in place for three error shapes.
+ */
+export type SdpKaminoErrorCode = "INVALID_AMOUNT" | "VAULT_UNREADABLE" | "PROGRAM_MISMATCH";
+
+export class SdpKaminoError extends Error {
+  constructor(
+    readonly code: SdpKaminoErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = "SdpKaminoError";
+  }
+}
+
+/**
+ * A caller-supplied amount that is not a decimal string, is negative, or is
+ * zero. Raised BEFORE any RPC call — an unparseable amount is a programming
+ * error on the caller's side and must never reach the chain.
+ */
+export function invalidAmount(field: string, value: string): SdpKaminoError {
+  return new SdpKaminoError(
+    "INVALID_AMOUNT",
+    `Kamino ${field} must be a positive decimal string; received ${JSON.stringify(value)}`
+  );
+}
+
+/**
+ * A caller-supplied amount that is finer than the mint can represent.
+ *
+ * Distinct from `invalidAmount` because the value IS a well-formed decimal — it
+ * simply carries more places than the mint has atoms, and klend-sdk FLOORS
+ * rather than rejects. Two different failures hide behind that floor: a deposit
+ * records more than it encodes (`1.0000009` on a 6-decimal mint moves
+ * `1.000000`), and a positive `minSharesOut` below one atom becomes `0`, which
+ * silently removes the very protection it was passed to provide. Refusing is
+ * the only answer that keeps the recorded number and the encoded number equal.
+ */
+export function amountTooPrecise(field: string, value: string, decimals: number): SdpKaminoError {
+  return new SdpKaminoError(
+    "INVALID_AMOUNT",
+    `Kamino ${field} ${JSON.stringify(value)} has more precision than its mint supports ` +
+      `(${decimals} decimals). The SDK would floor it, so the amount encoded on chain would not ` +
+      "match the amount requested."
+  );
+}
+
+/**
+ * The vault account could not be read on this cluster.
+ *
+ * The most likely cause is the RPC pointing at the wrong chain: Kamino's mainnet
+ * kvault program id ALSO exists on devnet with zero accounts under it, so a
+ * cluster/RPC mismatch presents as "this vault does not exist" rather than as a
+ * connection error. The message names both so the reader checks the right thing.
+ */
+export function vaultUnreadable(
+  vault: Address,
+  cluster: SolanaCluster,
+  cause: unknown
+): SdpKaminoError {
+  return new SdpKaminoError(
+    "VAULT_UNREADABLE",
+    `Kamino vault ${vault} could not be read on ${cluster}. ` +
+      "Check that the RPC endpoint serves that cluster — a mismatched RPC reports a missing vault, not a connection error.",
+    { cause }
+  );
+}

--- a/packages/sdp-kamino/src/guards.test.ts
+++ b/packages/sdp-kamino/src/guards.test.ts
@@ -1,0 +1,124 @@
+import { KAMINO_KVAULT_PROGRAM_IDS } from "@sdp/types";
+import { address } from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import {
+  assertPlanTargetsCluster,
+  KaminoProgramMismatchError,
+  planProgramAddresses,
+} from "./guards";
+import { foreignKvaultProgramId, kaminoClusterConfig } from "./programs";
+import type { KaminoInstructionPlan } from "./types";
+
+const ATA_PROGRAM = address("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+const ASSET_IDENTITY = {
+  depositTokenMint: address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+  shareMint: address("So11111111111111111111111111111111111111112"),
+};
+
+function plan(
+  cluster: KaminoInstructionPlan["cluster"],
+  programs: readonly string[]
+): KaminoInstructionPlan {
+  return {
+    cluster,
+    instructions: [
+      programs.map((programAddress) => ({
+        programAddress: address(programAddress),
+        accounts: [],
+        data: new Uint8Array(),
+      })),
+    ],
+    lookupTables: [],
+    assetIdentity: ASSET_IDENTITY,
+    accepted: {},
+  } as KaminoInstructionPlan;
+}
+
+describe("assertPlanTargetsCluster", () => {
+  it("accepts a devnet plan naming the devnet kvault program", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    const accepted = assertPlanTargetsCluster(plan("devnet", [devnet.kvaultProgramId]));
+    expect(accepted.cluster).toBe("devnet");
+  });
+
+  /**
+   * THE REGRESSION THIS PACKAGE EXISTS FOR.
+   *
+   * klend-sdk's ordinary `new KaminoVault(rpc, addr, state, programId)` applies
+   * the program id to account reads only and builds its internal client without
+   * it, so a devnet vault emits MAINNET instructions — silently. That is the
+   * default outcome of following Kamino's own published recipe. If `sdk.ts`
+   * regresses to the plain constructor, this is the test that fails.
+   */
+  it("REJECTS a devnet plan carrying the mainnet kvault program", () => {
+    const mainnetKvault = KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"];
+    expect(() => assertPlanTargetsCluster(plan("devnet", [mainnetKvault]))).toThrow(
+      KaminoProgramMismatchError
+    );
+  });
+
+  it("rejects the mirror case — a mainnet plan carrying the devnet program", () => {
+    const devnetKvault = KAMINO_KVAULT_PROGRAM_IDS.devnet;
+    expect(() => assertPlanTargetsCluster(plan("mainnet-beta", [devnetKvault]))).toThrow(
+      KaminoProgramMismatchError
+    );
+  });
+
+  it("names the offending program and the cluster in the error", () => {
+    const foreign = foreignKvaultProgramId("devnet");
+    try {
+      assertPlanTargetsCluster(plan("devnet", [foreign]));
+      expect.unreachable("expected a program mismatch");
+    } catch (error) {
+      expect(error).toBeInstanceOf(KaminoProgramMismatchError);
+      const mismatch = error as KaminoProgramMismatchError;
+      expect(mismatch.cluster).toBe("devnet");
+      expect(mismatch.offendingProgram).toBe(foreign);
+    }
+  });
+
+  it("allows cluster-invariant programs such as the ATA program", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    expect(() =>
+      assertPlanTargetsCluster(plan("devnet", [ATA_PROGRAM, devnet.kvaultProgramId]))
+    ).not.toThrow();
+  });
+
+  it("rejects an unrecognized program rather than ignoring it", () => {
+    // A closed allowlist: an unexpected program is a finding, not noise.
+    expect(() =>
+      assertPlanTargetsCluster(plan("devnet", ["11111111111111111111111111111112"]))
+    ).toThrow(KaminoProgramMismatchError);
+  });
+
+  it("checks every batch, not just the first", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    const twoBatches: KaminoInstructionPlan = {
+      cluster: "devnet",
+      instructions: [
+        [{ programAddress: devnet.kvaultProgramId, accounts: [], data: new Uint8Array() }],
+        [
+          {
+            programAddress: address(KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"]),
+            accounts: [],
+            data: new Uint8Array(),
+          },
+        ],
+      ],
+      lookupTables: [],
+      assetIdentity: ASSET_IDENTITY,
+      accepted: {},
+    } as KaminoInstructionPlan;
+    expect(() => assertPlanTargetsCluster(twoBatches)).toThrow(KaminoProgramMismatchError);
+  });
+});
+
+describe("planProgramAddresses", () => {
+  it("dedupes across batches — the shape a Kora allowlist assertion needs", () => {
+    const devnet = kaminoClusterConfig("devnet");
+    const programs = planProgramAddresses(
+      plan("devnet", [devnet.kvaultProgramId, devnet.kvaultProgramId, ATA_PROGRAM])
+    );
+    expect([...programs].sort()).toEqual([ATA_PROGRAM, devnet.kvaultProgramId].sort());
+  });
+});

--- a/packages/sdp-kamino/src/guards.ts
+++ b/packages/sdp-kamino/src/guards.ts
@@ -1,0 +1,83 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address, Instruction } from "@solana/kit";
+import { kaminoProgramAllowlist } from "./programs";
+import type { KaminoInstructionPlan } from "./types";
+
+/**
+ * Programs that are the same on every cluster and may appear in a plan without
+ * being cluster-specific: system, both token programs, the ATA program, memo and
+ * compute budget. Listed explicitly rather than skipped, so the allowlist stays
+ * a closed set — an unexpected program is a finding, not noise.
+ */
+const CLUSTER_INVARIANT_PROGRAMS: readonly string[] = [
+  "11111111111111111111111111111111",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  "ComputeBudget111111111111111111111111111111",
+];
+
+export class KaminoProgramMismatchError extends Error {
+  constructor(
+    readonly cluster: SolanaCluster,
+    readonly offendingProgram: Address
+  ) {
+    super(
+      `Kamino instruction targets ${offendingProgram}, which is not a ${cluster} program. ` +
+        "This is the program-id override being silently dropped — see @sdp/kamino/sdk.ts."
+    );
+    this.name = "KaminoProgramMismatchError";
+  }
+}
+
+/**
+ * Refuse a plan whose instructions name a program that does not belong to this
+ * cluster. **The single most important check in this package.**
+ *
+ * Why it exists: klend-sdk's `new KaminoVault(rpc, addr, state, programId)`
+ * applies `programId` to account READS only and constructs its own internal
+ * client WITHOUT forwarding it. The result is a vault that reads devnet state
+ * and emits instructions addressed to the MAINNET kvault program — no error, no
+ * warning, and a transaction that fails on-chain or, worse, succeeds against the
+ * wrong deployment. Kamino's own published recipe uses that constructor, so this
+ * is the default outcome for anyone following the docs.
+ *
+ * `./sdk.ts` binds reads and writes together so the trap cannot spring, and this
+ * asserts that it worked. Belt AND braces, deliberately: the binding is a
+ * convention inside one function, while this is a property of the OUTPUT, and
+ * only the second one survives an SDK upgrade that reshuffles construction.
+ */
+export function assertPlanTargetsCluster(plan: KaminoInstructionPlan): KaminoInstructionPlan {
+  const allowed = kaminoProgramAllowlist(plan.cluster);
+  const invariant = new Set<string>(CLUSTER_INVARIANT_PROGRAMS);
+
+  for (const batch of plan.instructions) {
+    for (const instruction of batch) {
+      const program = instruction.programAddress;
+      if (allowed.has(program) || invariant.has(program)) continue;
+      throw new KaminoProgramMismatchError(plan.cluster, program);
+    }
+  }
+  return plan;
+}
+
+/** Flatten a plan for callers that genuinely want one transaction's worth. */
+export function planInstructionCount(plan: KaminoInstructionPlan): number {
+  return plan.instructions.reduce((total, batch) => total + batch.length, 0);
+}
+
+/** Every distinct program a plan touches — useful for Kora allowlist assertions. */
+export function planProgramAddresses(plan: KaminoInstructionPlan): readonly Address[] {
+  const seen = new Set<Address>();
+  for (const batch of plan.instructions) {
+    for (const instruction of batch as readonly Instruction[]) {
+      seen.add(instruction.programAddress);
+    }
+  }
+  return [...seen];
+}

--- a/packages/sdp-kamino/src/index.ts
+++ b/packages/sdp-kamino/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * `@sdp/kamino` — kit-native deposit/withdraw instruction building for Kamino
+ * K-Vaults.
+ *
+ * Scope: this package BUILDS unsigned instruction plans and READS positions. It
+ * never signs, never submits, never touches a database, and holds no credential
+ * (Kamino's data surface is public). Signing and submission belong to the API,
+ * which owns custody and the Kora fee-payment path.
+ *
+ * Two invariants make it safe to use:
+ *
+ * - **Cluster binding.** Kamino deploys a DIFFERENT kvault program per cluster,
+ *   and the SDK's ordinary constructor binds only reads to it. Everything here
+ *   goes through one bind helper, and every plan is re-checked against a
+ *   per-cluster program allowlist before it is returned.
+ * - **A closed dependency boundary.** `@kamino-finance/klend-sdk` (built against
+ *   `@solana/kit` 2.x, while this repo pins 6.8) and `decimal.js` are confined
+ *   to `./sdk.ts`. Everything crossing this module's surface is `@solana/kit`
+ *   6.8, `@sdp/types`, or a decimal string.
+ *
+ * See `packages/sdp-kamino/CLAUDE.md` for the traps and the measurements behind
+ * the constants.
+ */
+
+export { assertNotPortfolioProvider, KaminoVaultDirectClient } from "./client";
+export { SdpKaminoError, type SdpKaminoErrorCode } from "./errors";
+export {
+  assertPlanTargetsCluster,
+  KaminoProgramMismatchError,
+  planInstructionCount,
+  planProgramAddresses,
+} from "./guards";
+export {
+  foreignKvaultProgramId,
+  type KaminoClusterConfig,
+  kaminoClusterConfig,
+  kaminoProgramAllowlist,
+} from "./programs";
+// `buildKaminoWithdrawPlan` is deliberately NOT re-exported. It builds a single
+// unsized batch with no lookup table, which does not honour
+// `KaminoInstructionPlan`'s transaction-sized-batch contract for a multi-reserve
+// exit — so it stays package-private (smoke tests only) until that lands, and
+// `KaminoVaultDirectClient` withholds the withdraw capability to match.
+export { buildKaminoDepositPlan, readKaminoPosition } from "./sdk";
+export type {
+  KaminoAcceptedAmounts,
+  KaminoDepositInput,
+  KaminoInstructionPlan,
+  KaminoPosition,
+  KaminoRuntime,
+  KaminoVaultAssetIdentity,
+  KaminoWithdrawInput,
+} from "./types";

--- a/packages/sdp-kamino/src/observed-amounts.test.ts
+++ b/packages/sdp-kamino/src/observed-amounts.test.ts
@@ -1,0 +1,24 @@
+import Decimal from "decimal.js";
+import { describe, expect, it } from "vitest";
+import { SdpKaminoError } from "./errors";
+import { requireNonNegativeFiniteDecimal } from "./sdk";
+
+describe("requireNonNegativeFiniteDecimal", () => {
+  it.each([
+    [new Decimal("1.25"), "1.25"],
+    ["9007199254740993.000001", "9007199254740993.000001"],
+    [0, "0"],
+  ])("accepts observed non-negative values exactly", (value, expected) => {
+    expect(requireNonNegativeFiniteDecimal("test value", value).toFixed()).toBe(expected);
+  });
+
+  it.each([undefined, null, "NaN", Number.POSITIVE_INFINITY, "-0.1"])(
+    "rejects malformed or negative observed value %s",
+    (value) => {
+      expect(() => requireNonNegativeFiniteDecimal("test value", value)).toThrow(SdpKaminoError);
+      expect(() => requireNonNegativeFiniteDecimal("test value", value)).toThrow(
+        /finite non-negative decimal/
+      );
+    }
+  );
+});

--- a/packages/sdp-kamino/src/programs.test.ts
+++ b/packages/sdp-kamino/src/programs.test.ts
@@ -1,0 +1,71 @@
+import {
+  KAMINO_DEVNET_KVAULT_PROGRAM_ID,
+  KAMINO_KVAULT_PROGRAM_IDS,
+  KAMINO_SLOT_DURATION_MS,
+} from "@sdp/types";
+import { describe, expect, it } from "vitest";
+import { foreignKvaultProgramId, kaminoClusterConfig, kaminoProgramAllowlist } from "./programs";
+
+describe("kaminoClusterConfig", () => {
+  it("binds each cluster to its OWN kvault program", () => {
+    expect(String(kaminoClusterConfig("devnet").kvaultProgramId)).toBe(
+      KAMINO_KVAULT_PROGRAM_IDS.devnet
+    );
+    expect(String(kaminoClusterConfig("mainnet-beta").kvaultProgramId)).toBe(
+      KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"]
+    );
+  });
+
+  it("keeps the two kvault programs distinct — the whole premise of the table", () => {
+    expect(String(kaminoClusterConfig("devnet").kvaultProgramId)).not.toBe(
+      String(kaminoClusterConfig("mainnet-beta").kvaultProgramId)
+    );
+  });
+
+  it("shares one klend program across clusters (verified deployed on both)", () => {
+    expect(String(kaminoClusterConfig("devnet").klendProgramId)).toBe(
+      String(kaminoClusterConfig("mainnet-beta").klendProgramId)
+    );
+  });
+
+  it("shares one farms program across clusters, so farms is not a second trap", () => {
+    expect(String(kaminoClusterConfig("devnet").farmsProgramId)).toBe(
+      String(kaminoClusterConfig("mainnet-beta").farmsProgramId)
+    );
+  });
+
+  /**
+   * Slot duration scales every accrual figure the SDK computes and fails
+   * SILENTLY when wrong. These are measurements (2026-08-15, `getBlockTime` over
+   * a 4,000-slot span), not protocol constants — this test pins that they were
+   * measured per cluster rather than defaulted to one value.
+   */
+  it("carries a MEASURED, per-cluster slot duration that is not the SDK default", () => {
+    const devnet = kaminoClusterConfig("devnet").slotDurationMs;
+    const mainnet = kaminoClusterConfig("mainnet-beta").slotDurationMs;
+    expect(devnet).toBe(KAMINO_SLOT_DURATION_MS.devnet);
+    expect(mainnet).toBe(KAMINO_SLOT_DURATION_MS["mainnet-beta"]);
+    expect(devnet).not.toBe(mainnet);
+    // 400 is klend-sdk's DEFAULT_RECENT_SLOT_DURATION_MS; neither cluster is it.
+    expect(devnet).not.toBe(400);
+    expect(mainnet).not.toBe(400);
+  });
+});
+
+describe("kaminoProgramAllowlist", () => {
+  it("never contains the other cluster's kvault program", () => {
+    for (const cluster of ["devnet", "mainnet-beta"] as const) {
+      const allowed = kaminoProgramAllowlist(cluster);
+      expect(allowed.has(foreignKvaultProgramId(cluster))).toBe(false);
+      expect(allowed.has(kaminoClusterConfig(cluster).kvaultProgramId)).toBe(true);
+    }
+  });
+});
+
+describe("@sdp/types re-export", () => {
+  it("keeps the named devnet constant identical to the table entry", () => {
+    // @sdp/earn imports the named constant; @sdp/kamino reads the table. They
+    // must never drift, which is why one is derived from the other.
+    expect(KAMINO_DEVNET_KVAULT_PROGRAM_ID).toBe(KAMINO_KVAULT_PROGRAM_IDS.devnet);
+  });
+});

--- a/packages/sdp-kamino/src/programs.ts
+++ b/packages/sdp-kamino/src/programs.ts
@@ -1,0 +1,84 @@
+import {
+  KAMINO_FARMS_PROGRAM_IDS,
+  KAMINO_KLEND_PROGRAM_IDS,
+  KAMINO_KVAULT_PROGRAM_IDS,
+  KAMINO_SLOT_DURATION_MS,
+  type SolanaCluster,
+} from "@sdp/types";
+import { type Address, address } from "@solana/kit";
+
+/**
+ * Kamino's per-cluster runtime configuration, as `@solana/kit` addresses.
+ *
+ * The address TABLE itself lives in `@sdp/types/kamino-programs` because
+ * `@sdp/earn` needs the devnet kvault id too and may not depend on this package
+ * (see that file's header). This module is the thin typing layer: it turns those
+ * strings into branded `Address`es once, at module load, so no call site
+ * re-parses them and no code path can pass a raw string where an address is
+ * required.
+ */
+export interface KaminoClusterConfig {
+  cluster: SolanaCluster;
+  kvaultProgramId: Address;
+  klendProgramId: Address;
+  farmsProgramId: Address;
+  /**
+   * Required by `KaminoVaultClient` and measured per cluster — never the SDK
+   * default. See `KAMINO_SLOT_DURATION_MS` for the measurement and why a wrong
+   * value fails silently rather than loudly.
+   */
+  slotDurationMs: number;
+}
+
+const CONFIG_BY_CLUSTER: Readonly<Record<SolanaCluster, KaminoClusterConfig>> = {
+  "mainnet-beta": {
+    cluster: "mainnet-beta",
+    kvaultProgramId: address(KAMINO_KVAULT_PROGRAM_IDS["mainnet-beta"]),
+    klendProgramId: address(KAMINO_KLEND_PROGRAM_IDS["mainnet-beta"]),
+    farmsProgramId: address(KAMINO_FARMS_PROGRAM_IDS["mainnet-beta"]),
+    slotDurationMs: KAMINO_SLOT_DURATION_MS["mainnet-beta"],
+  },
+  devnet: {
+    cluster: "devnet",
+    kvaultProgramId: address(KAMINO_KVAULT_PROGRAM_IDS.devnet),
+    klendProgramId: address(KAMINO_KLEND_PROGRAM_IDS.devnet),
+    farmsProgramId: address(KAMINO_FARMS_PROGRAM_IDS.devnet),
+    slotDurationMs: KAMINO_SLOT_DURATION_MS.devnet,
+  },
+};
+
+/**
+ * The programs and timing Kamino runs under on one cluster.
+ *
+ * Takes a CLUSTER, never an `SdpEnvironment`. Callers holding an environment
+ * convert with `CLUSTER_BY_SDP_ENVIRONMENT` (@sdp/types) at the boundary — this
+ * package refuses to make that leap itself, because "environment implies
+ * cluster" is exactly the assumption migration 0057 and `host_cluster` exist to
+ * stop. A strategy row states the cluster its instrument lives on; that is the
+ * value that belongs here.
+ */
+export function kaminoClusterConfig(cluster: SolanaCluster): KaminoClusterConfig {
+  return CONFIG_BY_CLUSTER[cluster];
+}
+
+/**
+ * Every program address this package may legitimately emit an instruction for,
+ * on one cluster.
+ *
+ * Consumed by `assertPlanTargetsCluster` (see ./guards) as an ALLOWLIST rather
+ * than a denylist: the failure being guarded against is an instruction quietly
+ * addressed to the OTHER cluster's kvault program, and the only robust way to
+ * catch that is to enumerate what is permitted. System/token/ATA programs are
+ * cluster-invariant and are added by the guard, not here.
+ */
+export function kaminoProgramAllowlist(cluster: SolanaCluster): ReadonlySet<Address> {
+  const config = kaminoClusterConfig(cluster);
+  return new Set([config.kvaultProgramId, config.klendProgramId, config.farmsProgramId]);
+}
+
+/** The other cluster's kvault program — the one an instruction must never name. */
+export function foreignKvaultProgramId(cluster: SolanaCluster): Address {
+  return cluster === "devnet"
+    ? CONFIG_BY_CLUSTER["mainnet-beta"].kvaultProgramId
+    : CONFIG_BY_CLUSTER.devnet.kvaultProgramId;
+}

--- a/packages/sdp-kamino/src/rpc.test.ts
+++ b/packages/sdp-kamino/src/rpc.test.ts
@@ -1,0 +1,92 @@
+import type { RpcTransport } from "@solana/kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withKaminoRpcTimeout } from "./rpc";
+
+type RpcRequest = Parameters<RpcTransport>[0];
+
+const request = {
+  payload: { id: "1", jsonrpc: "2.0", method: "getSlot", params: [] },
+} as unknown as RpcRequest;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withKaminoRpcTimeout", () => {
+  it("aborts a stalled transport at the package deadline", async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | undefined;
+    const stalled: RpcTransport = async <TResponse>(config: RpcRequest) => {
+      observedSignal = config.signal;
+      return await new Promise<TResponse>((_resolve, reject) => {
+        config.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("The operation was aborted", "AbortError")),
+          { once: true }
+        );
+      });
+    };
+
+    const result = withKaminoRpcTimeout(stalled, 25)<unknown>(request);
+    const rejected = expect(result).rejects.toThrow("Kamino RPC request timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
+  it("keeps the package deadline when the caller also supplies a signal", async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const stalled: RpcTransport = async <TResponse>(config: RpcRequest) =>
+      await new Promise<TResponse>((_resolve, reject) => {
+        config.signal?.addEventListener("abort", () => reject(config.signal?.reason), {
+          once: true,
+        });
+      });
+
+    const result = withKaminoRpcTimeout(
+      stalled,
+      25
+    )<unknown>({
+      ...request,
+      signal: caller.signal,
+    });
+    const rejected = expect(result).rejects.toThrow("Kamino RPC request timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejected;
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  it("preserves caller cancellation instead of relabelling it as a timeout", async () => {
+    const caller = new AbortController();
+    const callerReason = new Error("request cancelled by caller");
+    const stalled: RpcTransport = async <TResponse>(config: RpcRequest) =>
+      await new Promise<TResponse>((_resolve, reject) => {
+        config.signal?.addEventListener("abort", () => reject(config.signal?.reason), {
+          once: true,
+        });
+      });
+
+    const result = withKaminoRpcTimeout(
+      stalled,
+      30_000
+    )<unknown>({
+      ...request,
+      signal: caller.signal,
+    });
+    caller.abort(callerReason);
+
+    await expect(result).rejects.toBe(callerReason);
+  });
+
+  it("does not relabel an upstream failure as a timeout", async () => {
+    const upstream = new Error("429 Too Many Requests");
+    const transport = vi.fn(async () => {
+      throw upstream;
+    }) as unknown as RpcTransport;
+
+    await expect(withKaminoRpcTimeout(transport, 30_000)<unknown>(request)).rejects.toBe(upstream);
+  });
+});

--- a/packages/sdp-kamino/src/rpc.ts
+++ b/packages/sdp-kamino/src/rpc.ts
@@ -1,0 +1,49 @@
+import {
+  createDefaultRpcTransport,
+  createSolanaRpcFromTransport,
+  type RpcTransport,
+} from "@solana/kit";
+
+/**
+ * Maximum time a single Kamino RPC request may hold a worker open.
+ *
+ * This deadline is applied at the transport boundary, not only to the reads
+ * this package issues directly. klend-sdk receives the same RPC client, so its
+ * vault, reserve, farm and exchange-rate reads are bounded too.
+ */
+export const KAMINO_RPC_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Package-local so the SDK gets a deadline without adding a new workspace dependency edge. */
+export function withKaminoRpcTimeout(
+  transport: RpcTransport,
+  timeoutMs = KAMINO_RPC_REQUEST_TIMEOUT_MS
+): RpcTransport {
+  return async <TResponse>(config: Parameters<RpcTransport>[0]) => {
+    const controller = new AbortController();
+    // A distinct reason lets the catch path tell our deadline from a caller
+    // cancellation even if both signals become aborted before transport rejects.
+    const deadlineReason = new Error("Kamino RPC deadline elapsed");
+    const timer = setTimeout(() => controller.abort(deadlineReason), timeoutMs);
+    const signal = config.signal
+      ? AbortSignal.any([config.signal, controller.signal])
+      : controller.signal;
+    try {
+      return await transport<TResponse>({ ...config, signal });
+    } catch (cause) {
+      if (signal.aborted && signal.reason === deadlineReason) {
+        // "timed out" deliberately matches the API's transient-error
+        // classifier: a deadline is retryable, never a permanent vault fact.
+        throw new Error(`Kamino RPC request timed out after ${timeoutMs}ms`, { cause });
+      }
+      throw cause;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/** One deadline-aware RPC client shared by the package and the pinned SDK. */
+export function createKaminoRpc(rpcUrl: string, timeoutMs = KAMINO_RPC_REQUEST_TIMEOUT_MS) {
+  const transport = createDefaultRpcTransport({ url: rpcUrl });
+  return createSolanaRpcFromTransport(withKaminoRpcTimeout(transport, timeoutMs));
+}

--- a/packages/sdp-kamino/src/sdk-construction.test.ts
+++ b/packages/sdp-kamino/src/sdk-construction.test.ts
@@ -1,0 +1,122 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+const sourceFiles = readdirSync(SRC).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+const read = (file: string) => readFileSync(join(SRC, file), "utf8");
+
+/**
+ * Structural tests over this package's own source.
+ *
+ * Both properties below are invisible to the type checker and to any runtime
+ * assertion — they are facts about how the code is WRITTEN, and each guards a
+ * failure that is silent in production. A source grep is the honest tool.
+ */
+/**
+ * Match a real module IMPORT, not a mention. The doc comments in `index.ts` and
+ * `types.ts` name klend-sdk deliberately — explaining the boundary is the point
+ * — so a naive substring scan flags exactly the files that document the rule.
+ */
+function importsModule(body: string, moduleName: string): boolean {
+  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:from|import|require\\()\\s*["']${escaped}["']`).test(body);
+}
+
+describe("the klend-sdk firewall", () => {
+  it("confines klend-sdk and decimal.js imports to sdk.ts", () => {
+    const offenders = sourceFiles.filter((file) => {
+      if (file === "sdk.ts") return false;
+      const body = read(file);
+      // Anywhere else, these drag klend-sdk's kit-2 copy (and a 13MB
+      // dependency) into modules that must stay on this repo's kit 6.8.
+      return importsModule(body, "@kamino-finance/klend-sdk") || importsModule(body, "decimal.js");
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the SDK out of the package's public entry point", () => {
+    expect(importsModule(read("index.ts"), "@kamino-finance/klend-sdk")).toBe(false);
+  });
+
+  it("still detects a real import — the guard is not vacuous", () => {
+    expect(
+      importsModule('import { X } from "@kamino-finance/klend-sdk";', "@kamino-finance/klend-sdk")
+    ).toBe(true);
+    expect(
+      importsModule("// mentions @kamino-finance/klend-sdk in prose", "@kamino-finance/klend-sdk")
+    ).toBe(false);
+  });
+});
+
+describe("vault construction", () => {
+  /**
+   * THE TRAP, ASSERTED AT THE SOURCE LEVEL.
+   *
+   * `new KaminoVault(rpc, addr, state, programId)` binds the program id to
+   * account READS only — its constructor builds an internal KaminoVaultClient
+   * without forwarding it, so instructions come out addressed to MAINNET. On
+   * devnet that means reading `devkRng…` state and emitting `KvauGM…`
+   * instructions, with no error at any layer.
+   *
+   * `loadWithClientAndState` is the only factory that binds both. The one
+   * permitted `new KaminoVault(` is the state probe, which is never used to
+   * build anything — so this asserts the safe factory is present rather than
+   * banning the constructor outright.
+   */
+  it("uses loadWithClientAndState to bind reads and writes together", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain("KaminoVault.loadWithClientAndState");
+  });
+
+  it("passes an explicit kvault program id to KaminoVaultClient", () => {
+    const sdk = read("sdk.ts");
+    // The client is what builds instructions; leaving its program id to the
+    // SDK default is precisely how the mainnet id leaks onto devnet.
+    expect(sdk).toMatch(/new KaminoVaultClient\([\s\S]*?kvaultProgramId/);
+  });
+
+  it("routes every entry point through the single bind helper", () => {
+    const sdk = read("sdk.ts");
+    for (const entry of [
+      "buildKaminoDepositPlan",
+      "buildKaminoWithdrawPlan",
+      "readKaminoPosition",
+    ]) {
+      const body = sdk.slice(sdk.indexOf(`export async function ${entry}`));
+      const fnBody = body.slice(0, body.indexOf("\n}\n") + 3);
+      expect(fnBody, `${entry} must construct its vault via bindVault`).toContain("bindVault(");
+    }
+  });
+
+  it("re-checks emitted instructions against the cluster allowlist", () => {
+    const sdk = read("sdk.ts");
+    const builders = sdk.match(/assertPlanTargetsCluster\(/g) ?? [];
+    // Both plan builders must guard their output; the bind helper's correctness
+    // is a convention inside one call, the assertion is a property of the output.
+    expect(builders.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("binds every plan to the asset mints read from live vault state", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain("vaultAssetIdentityFromState(state)");
+    // Deposit and withdrawal must both return the identity produced by the
+    // shared bind path; omitting either would reopen catalogue-only trust.
+    expect(
+      sdk.match(/lookupTables:\s*\[\],\s*assetIdentity,/g)?.length ?? 0
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("fails closed on invalid observed shares but only withholds an invalid valuation", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain(
+      'requireNonNegativeFiniteDecimal("staked share balance", staked.stakedShares)'
+    );
+    expect(sdk).toMatch(/requireNonNegativeFiniteDecimal\(\s*"total share balance"/);
+    expect(sdk).toMatch(/requireNonNegativeFiniteDecimal\(\s*"vault exchange rate"/);
+    expect(sdk).toMatch(
+      /let tokenValue:[\s\S]*?try\s*\{[\s\S]*?requireNonNegativeFiniteDecimal\(\s*"vault exchange rate"/
+    );
+  });
+});

--- a/packages/sdp-kamino/src/sdk-discovery.test.ts
+++ b/packages/sdp-kamino/src/sdk-discovery.test.ts
@@ -1,0 +1,78 @@
+import { address } from "@solana/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { kaminoClusterConfig } from "./programs";
+import { discoverKaminoPositionVaults } from "./sdk";
+import type { KaminoRuntime } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  constructVaultClient: vi.fn(),
+  createKaminoRpc: vi.fn(),
+  getUserSharesBalanceAllVaults: vi.fn(),
+}));
+
+vi.mock("@kamino-finance/klend-sdk", () => ({
+  KaminoVault: class {},
+  KaminoVaultClient: class {
+    constructor(...args: unknown[]) {
+      mocks.constructVaultClient(...args);
+    }
+
+    getUserSharesBalanceAllVaults(...args: unknown[]) {
+      return mocks.getUserSharesBalanceAllVaults(...args);
+    }
+  },
+}));
+
+vi.mock("./rpc", () => ({ createKaminoRpc: mocks.createKaminoRpc }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("discoverKaminoPositionVaults", () => {
+  const owner = address("11111111111111111111111111111112");
+  const runtime: KaminoRuntime = {
+    cluster: "devnet",
+    rpcUrl: "https://devnet.example.invalid",
+  };
+
+  it("uses the cluster-bound all-vault census and returns only its candidate keys", async () => {
+    const rpc = { transport: "sentinel" };
+    mocks.createKaminoRpc.mockReturnValue(rpc);
+    const vaults = [
+      address("7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx"),
+      address("So11111111111111111111111111111111111111112"),
+    ];
+    // The values are intentionally unusable: discovery must never trust the
+    // SDK's lossy uiAmount-derived balances, only the vault-address keys.
+    mocks.getUserSharesBalanceAllVaults.mockResolvedValue(
+      new Map(vaults.map((vault) => [vault, { unsafeBalance: Symbol("do-not-read") }]))
+    );
+
+    await expect(discoverKaminoPositionVaults(runtime, owner)).resolves.toEqual(vaults);
+
+    const config = kaminoClusterConfig("devnet");
+    expect(mocks.createKaminoRpc).toHaveBeenCalledWith(runtime.rpcUrl);
+    expect(mocks.constructVaultClient).toHaveBeenCalledWith(
+      rpc,
+      config.slotDurationMs,
+      config.kvaultProgramId,
+      config.klendProgramId,
+      undefined,
+      config.farmsProgramId
+    );
+    expect(mocks.getUserSharesBalanceAllVaults).toHaveBeenCalledWith(owner);
+  });
+
+  it("fails closed when the on-chain holdings census is unreadable", async () => {
+    const cause = new Error("rpc unavailable");
+    mocks.createKaminoRpc.mockReturnValue({});
+    mocks.getUserSharesBalanceAllVaults.mockRejectedValue(cause);
+
+    await expect(discoverKaminoPositionVaults(runtime, owner)).rejects.toMatchObject({
+      name: "SdpKaminoError",
+      code: "VAULT_UNREADABLE",
+      cause,
+    });
+  });
+});

--- a/packages/sdp-kamino/src/sdk.smoke.test.ts
+++ b/packages/sdp-kamino/src/sdk.smoke.test.ts
@@ -1,0 +1,131 @@
+import {
+  address,
+  appendTransactionMessageInstructions,
+  createKeyPairSignerFromPrivateKeyBytes,
+  createSolanaRpc,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+} from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import { planProgramAddresses } from "./guards";
+import { kaminoClusterConfig } from "./programs";
+import { buildKaminoDepositPlan, buildKaminoWithdrawPlan, readKaminoPosition } from "./sdk";
+
+/**
+ * On-chain smoke test. **Opt-in, and never runs in CI** — the package's other
+ * tests are pure and offline, per the repo rule that package tests touch no
+ * network.
+ *
+ * Run it against a surfpool surfnet forking mainnet, which gives a real kvault
+ * program and a real vault with no mainnet money at risk:
+ *
+ *   KAMINO_SMOKE_RPC_URL=http://127.0.0.1:8899 \
+ *   KAMINO_SMOKE_SIGNER=<64 hex chars: 32 private key bytes> \
+ *   pnpm --filter @sdp/kamino test
+ *
+ * Fund the signer first with SOL and the vault's deposit token
+ * (`surfnet_setTokenAccount`). What this proves that the offline tests cannot:
+ * the instructions the package emits actually SIMULATE and LAND, and the
+ * position read reports what the chain holds.
+ */
+const RPC_URL = process.env.KAMINO_SMOKE_RPC_URL;
+const SIGNER_HEX = process.env.KAMINO_SMOKE_SIGNER;
+// Mainnet USDC K-Vault — the vault Kamino's own deposit doc uses.
+const VAULT = address(
+  process.env.KAMINO_SMOKE_VAULT ?? "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E"
+);
+
+describe.skipIf(!RPC_URL || !SIGNER_HEX)("Kamino plans against a live chain", () => {
+  const runtime = { cluster: "mainnet-beta" as const, rpcUrl: RPC_URL ?? "" };
+
+  async function signer() {
+    const bytes = Uint8Array.from(
+      (SIGNER_HEX ?? "").match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []
+    );
+    return await createKeyPairSignerFromPrivateKeyBytes(bytes);
+  }
+
+  it("builds a deposit that simulates cleanly and lands", async () => {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const owner = await signer();
+
+    const plan = await buildKaminoDepositPlan(runtime, {
+      vault: VAULT,
+      owner,
+      amount: "25",
+    });
+
+    // The guard already ran inside the builder; assert the property directly too.
+    const programs = planProgramAddresses(plan);
+    expect(programs).toContain(kaminoClusterConfig("mainnet-beta").kvaultProgramId);
+    expect(programs).not.toContain(kaminoClusterConfig("devnet").kvaultProgramId);
+
+    const batch = plan.instructions[0];
+    expect(batch, "deposit plan must carry one transaction's worth").toBeDefined();
+
+    const { value: latest } = await rpc.getLatestBlockhash({ commitment: "confirmed" }).send();
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(owner, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash(latest, m),
+      (m) => appendTransactionMessageInstructions([...(batch ?? [])], m)
+    );
+    const signed = await signTransactionMessageWithSigners(message);
+    const wire = getBase64EncodedWireTransaction(signed);
+
+    const sim = await rpc
+      .simulateTransaction(wire, { encoding: "base64", replaceRecentBlockhash: true })
+      .send();
+    expect(sim.value.err, `simulation failed: ${JSON.stringify(sim.value.logs)}`).toBeNull();
+
+    const signature = await rpc.sendTransaction(wire, { encoding: "base64" }).send();
+    expect(signature).toBeTruthy();
+  });
+
+  it("reads back the position it just created", async () => {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const owner = await signer();
+    const slot = await rpc.getSlot().send();
+
+    const position = await readKaminoPosition(runtime, {
+      vault: VAULT,
+      owner: owner.address,
+      slot,
+    });
+
+    expect(position.cluster).toBe("mainnet-beta");
+    expect(Number(position.shares)).toBeGreaterThan(0);
+    // Value may legitimately be absent if the rate read failed; when present it
+    // must be a plain decimal string, never a float artefact.
+    if (position.tokenValue !== undefined) {
+      expect(position.tokenValue).toMatch(/^\d+(\.\d+)?$/);
+    }
+  });
+
+  it("builds a withdrawal for the full position", async () => {
+    const rpc = createSolanaRpc(runtime.rpcUrl);
+    const owner = await signer();
+    const slot = await rpc.getSlot().send();
+    const position = await readKaminoPosition(runtime, {
+      vault: VAULT,
+      owner: owner.address,
+      slot,
+    });
+
+    const plan = await buildKaminoWithdrawPlan(runtime, {
+      vault: VAULT,
+      owner,
+      shares: position.shares,
+      slot,
+    });
+
+    expect(planProgramAddresses(plan)).toContain(
+      kaminoClusterConfig("mainnet-beta").kvaultProgramId
+    );
+    expect(plan.instructions[0]?.length ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/packages/sdp-kamino/src/sdk.ts
+++ b/packages/sdp-kamino/src/sdk.ts
@@ -1,0 +1,375 @@
+import { KaminoVault, KaminoVaultClient } from "@kamino-finance/klend-sdk";
+import { formatDecimalAmount, isDecimalString, parseDecimalAmount } from "@sdp/solana/amount";
+import type { Address, Instruction } from "@solana/kit";
+import Decimal from "decimal.js";
+import { acceptAtMintScale, isZeroAmount, mintDecimals } from "./amounts";
+import { vaultAssetIdentityFromState } from "./asset-identity";
+import { invalidAmount, SdpKaminoError, vaultUnreadable } from "./errors";
+import { assertPlanTargetsCluster } from "./guards";
+import { kaminoClusterConfig } from "./programs";
+import { createKaminoRpc } from "./rpc";
+import { sumRawTokenAccountBaseUnits } from "./share-balances";
+import type {
+  KaminoDepositInput,
+  KaminoInstructionPlan,
+  KaminoPosition,
+  KaminoRuntime,
+  KaminoWithdrawInput,
+} from "./types";
+
+/**
+ * ════════════════════════════════════════════════════════════════════════════
+ *  THE KIT-VERSION FIREWALL. This is the ONLY module in the package — source or
+ *  test — that may import `@kamino-finance/klend-sdk` or `decimal.js`.
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ * klend-sdk is built against `@solana/kit` **^2.3.0**; this repo pins **6.8.0**.
+ * Both copies coexist in the tree (pnpm nests the SDK's own). Verified by a live
+ * round trip on 2026-08-15: instructions come back as plain objects with a
+ * numeric `AccountRole` and `Uint8Array` data, and kit 6.8 compiles and signs
+ * them unchanged — so the boundary is real at the TYPE level but inert at
+ * RUNTIME. Every cast below is therefore a structural re-label, not a coercion,
+ * and each is annotated with what makes it safe.
+ *
+ * Keeping the SDK behind this one module is also what keeps the 13MB dependency
+ * out of `@sdp/earn`, whose catalogue cron runs hourly in both environments and
+ * never builds a transaction.
+ */
+
+/** klend-sdk's kit-2 surface, as far as this module needs to name it. */
+// biome-ignore lint/suspicious/noExplicitAny: the kit-2 <-> kit-6.8 seam; see the header.
+type Kit2 = any;
+
+/**
+ * Bind a vault so that READS AND WRITES USE THE SAME PROGRAM. Every entry point
+ * in this file goes through here; nothing else may construct a vault.
+ *
+ * ── The trap, stated once ───────────────────────────────────────────────────
+ * `new KaminoVault(rpc, addr, state, programId)` looks like it binds the vault
+ * to `programId`, and it half does: the id is used to FETCH `VaultState`, then
+ * the constructor builds its own `KaminoVaultClient` **without forwarding it**.
+ * Instruction building goes through that internal client, which defaults to
+ * MAINNET. On devnet the result is a vault that reads `devkRng…` state and emits
+ * instructions addressed to `KvauGM…` — silently, with no error.
+ *
+ * Kamino's own published recipe uses exactly that constructor, so this is the
+ * default outcome for anyone following the docs. `loadWithClientAndState` is the
+ * only factory that sets `vault.programId` AND `vault.client` together.
+ *
+ * `assertPlanTargetsCluster` independently re-checks the OUTPUT, because this
+ * function's correctness is a convention inside one call and that assertion is a
+ * property of what we actually emit.
+ */
+async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
+  const config = kaminoClusterConfig(runtime.cluster);
+  // The transport deadline covers both our direct reads and every nested
+  // reserve/farm/vault request klend-sdk performs with this same client.
+  const rpc = createKaminoRpc(runtime.rpcUrl) as Kit2;
+
+  const client = new KaminoVaultClient(
+    rpc,
+    config.slotDurationMs,
+    config.kvaultProgramId as Kit2,
+    config.klendProgramId as Kit2,
+    undefined,
+    config.farmsProgramId as Kit2
+  );
+
+  // The probe exists only to fetch state under the right program id; it is never
+  // used to build anything.
+  const probe = new KaminoVault(
+    rpc,
+    vaultAddress as Kit2,
+    undefined,
+    config.kvaultProgramId as Kit2,
+    config.slotDurationMs
+  );
+
+  let state: Kit2;
+  try {
+    state = await probe.getState();
+  } catch (cause) {
+    throw vaultUnreadable(vaultAddress, runtime.cluster, cause);
+  }
+
+  const vault = KaminoVault.loadWithClientAndState(client, vaultAddress as Kit2, state);
+  if (String(vault.programId) !== String(config.kvaultProgramId)) {
+    // Unreachable unless the SDK changes `loadWithClientAndState`. Cheap to
+    // assert, and the failure it guards is invisible otherwise.
+    throw vaultUnreadable(vaultAddress, runtime.cluster, "vault bound to the wrong kvault program");
+  }
+
+  // Bind the asset identity to the same live state snapshot used for decimals,
+  // reserve loading and instruction construction. The API compares these
+  // builder-observed mints with catalogue metadata before it signs anything.
+  const assetIdentity = vaultAssetIdentityFromState(state);
+  return { client, vault, state, config, rpc, assetIdentity };
+}
+
+/** Decimal strings are the boundary currency; `Decimal` never escapes this file. */
+function toDecimal(value: string, label: string): Decimal {
+  if (!isDecimalString(value)) throw invalidAmount(label, value);
+  const parsed = new Decimal(value);
+  if (!parsed.isFinite() || parsed.isNegative()) throw invalidAmount(label, value);
+  return parsed;
+}
+
+/**
+ * Validate numeric state observed from klend-sdk without trusting its physical
+ * `decimal.js` instance. The SDK carries a nested copy, so normalize through a
+ * string and rebuild with this package's pinned Decimal before checking it.
+ */
+export function requireNonNegativeFiniteDecimal(label: string, value: unknown): Decimal {
+  let parsed: Decimal;
+  try {
+    parsed = new Decimal(String(value));
+  } catch (cause) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino ${label} was not a finite non-negative decimal`,
+      { cause }
+    );
+  }
+  if (!parsed.isFinite() || parsed.isNegative()) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino ${label} was not a finite non-negative decimal`
+    );
+  }
+  return parsed;
+}
+
+/** Re-label kit-2 instructions as this repo's kit-6.8 `Instruction`. Structural. */
+function asInstructions(raw: readonly Kit2[]): readonly Instruction[] {
+  return (raw ?? []).filter(Boolean) as readonly Instruction[];
+}
+
+/**
+ * Build a deposit.
+ *
+ * Returned as a single batch: a deposit touches one vault and creates at most
+ * the user's share ATA, which has always fit one transaction in measurement.
+ * Withdrawals are the multi-batch case (see below).
+ */
+export async function buildKaminoDepositPlan(
+  runtime: KaminoRuntime,
+  input: KaminoDepositInput
+): Promise<KaminoInstructionPlan> {
+  const { client, vault, state, config, assetIdentity } = await bindVault(runtime, input.vault);
+
+  // Precision is checked against the MINT, so it can only be checked once the
+  // vault has been read — the token and share mints have independent decimals
+  // and neither is knowable at the API boundary.
+  const acceptedAmount = acceptAtMintScale(
+    "amount",
+    input.amount,
+    mintDecimals(state.tokenMintDecimals, "tokenMintDecimals")
+  );
+  if (isZeroAmount(acceptedAmount)) throw invalidAmount("amount", input.amount);
+  const amount = toDecimal(acceptedAmount, "amount");
+
+  const reserves = await client.loadVaultReserves(state);
+
+  let acceptedMinSharesOut: string | undefined;
+  let minSharesOut: Decimal | undefined;
+  if (input.minSharesOut !== undefined) {
+    acceptedMinSharesOut = acceptAtMintScale(
+      "minSharesOut",
+      input.minSharesOut,
+      mintDecimals(state.sharesMintDecimals, "sharesMintDecimals")
+    );
+    // A floor that rounds to nothing is worse than no floor: it reads as
+    // protection in the request and the ledger while imposing none on chain.
+    // The scale check above already refuses sub-atom values, so reaching zero
+    // here means the caller literally passed "0".
+    if (isZeroAmount(acceptedMinSharesOut)) throw invalidAmount("minSharesOut", input.minSharesOut);
+    minSharesOut = toDecimal(acceptedMinSharesOut, "minSharesOut");
+  }
+
+  const bundle = await vault.depositIxs(
+    input.owner as Kit2,
+    amount,
+    reserves,
+    null,
+    null,
+    (input.rentPayer ?? input.owner) as Kit2,
+    undefined,
+    minSharesOut
+  );
+
+  const instructions = asInstructions([
+    ...(bundle.depositIxs ?? []),
+    ...(bundle.stakeInFarmIfNeededIxs ?? []),
+    ...(bundle.stakeInFlcFarmIfNeededIxs ?? []),
+  ]);
+
+  return assertPlanTargetsCluster({
+    cluster: config.cluster,
+    instructions: [instructions],
+    lookupTables: [],
+    assetIdentity,
+    accepted: {
+      amount: acceptedAmount,
+      ...(acceptedMinSharesOut === undefined ? {} : { minSharesOut: acceptedMinSharesOut }),
+    },
+  });
+}
+
+/**
+ * Build a withdrawal. **NOT CONTRACT-COMPLETE — see the warning below.**
+ *
+ * ── Why this is not exported as a capability ────────────────────────────────
+ * `KaminoInstructionPlan.instructions` promises TRANSACTION-SIZED batches: one
+ * entry, one transaction. This function cannot honour that promise yet. It
+ * flattens `unstake → withdraw → post` into a single batch and returns no
+ * lookup table, while the pinned SDK documents the opposite — `withdrawIxs`
+ * returns "one or multiple withdraw instructions, based on how many reserves
+ * it's needed to withdraw from. This might have to be split in multiple
+ * transactions". A multi-reserve exit therefore builds a plan that can exceed
+ * Solana's 1232-byte packet, and the API's submitter refuses any plan with more
+ * than one transaction — so the failure lands at submit, after the caller has
+ * been told a withdrawal was prepared.
+ *
+ * Honouring the contract needs three things this does not do: load the vault's
+ * published lookup table, compile-measure and split at valid protocol
+ * boundaries (an unstake must never land without its withdraw), and give the
+ * API a resumable multi-leg submission with per-leg ledger rows.
+ *
+ * Until then the WITHDRAW CAPABILITY IS WITHHELD: `KaminoVaultDirectClient` does
+ * not implement `buildVaultWithdrawal`, so `supportsVaultWithdraw` answers false
+ * and no route can move money out through an unsized plan. This builder stays in
+ * the package because it is proven against a mainnet-forked surfnet and is the
+ * starting point for that work — it is deliberately NOT re-exported from
+ * `index.ts`, so the only callers are this package's own smoke tests.
+ *
+ * Tracked as the exit half of the vault-direct path; see `CLAUDE.md`.
+ */
+export async function buildKaminoWithdrawPlan(
+  runtime: KaminoRuntime,
+  input: KaminoWithdrawInput
+): Promise<KaminoInstructionPlan> {
+  const { client, vault, state, config, assetIdentity } = await bindVault(runtime, input.vault);
+  const acceptedShares = acceptAtMintScale(
+    "shares",
+    input.shares,
+    mintDecimals(state.sharesMintDecimals, "sharesMintDecimals")
+  );
+  if (isZeroAmount(acceptedShares)) throw invalidAmount("shares", input.shares);
+  const shares = toDecimal(acceptedShares, "shares");
+
+  const reserves = await client.loadVaultReserves(state);
+  const bundle = await vault.withdrawIxs(
+    input.owner as Kit2,
+    shares,
+    input.slot as Kit2,
+    reserves,
+    null,
+    null,
+    (input.rentPayer ?? input.owner) as Kit2
+  );
+
+  const instructions = asInstructions([
+    ...(bundle.unstakeFromFarmIfNeededIxs ?? []),
+    ...(bundle.withdrawIxs ?? []),
+    ...(bundle.postWithdrawIxs ?? []),
+  ]);
+
+  return assertPlanTargetsCluster({
+    cluster: config.cluster,
+    instructions: [instructions],
+    lookupTables: [],
+    assetIdentity,
+    accepted: { shares: acceptedShares },
+  });
+}
+
+/**
+ * Sum an owner's share-token accounts in EXACT base units.
+ *
+ * Deliberately reads `tokenAmount.amount` — the raw integer string — and never
+ * `uiAmount`, which the RPC serialises as a JSON number and which therefore
+ * cannot represent a balance above 2^53 base units without rounding. Returns
+ * `bigint` so nothing between here and the mint's decimals can go lossy.
+ *
+ * Sums ALL matching accounts rather than just the ATA, matching what the SDK
+ * counts: a wallet may legitimately hold the same share mint in more than one
+ * token account, and ignoring the others would under-report someone's position.
+ */
+async function readUnstakedShareBaseUnits(
+  rpc: Kit2,
+  owner: Address,
+  sharesMint: Address
+): Promise<bigint> {
+  const response = await rpc
+    .getTokenAccountsByOwner(owner, { mint: sharesMint }, { encoding: "jsonParsed" })
+    .send();
+
+  // The RPC filter says every entry is part of this balance. A malformed entry
+  // therefore makes the whole position unreadable; summing only the readable
+  // subset would silently under-report funds.
+  return sumRawTokenAccountBaseUnits(response?.value);
+}
+
+/**
+ * One wallet's holding in one vault, read live.
+ *
+ * `tokenValue` is shares × exchange rate. The rate read is allowed to fail
+ * independently of the share read: a position whose size is known but whose
+ * value is not renders "—" for the value, which is the module rule everywhere
+ * else in Earn and strictly better than a fabricated number.
+ */
+export async function readKaminoPosition(
+  runtime: KaminoRuntime,
+  input: { vault: Address; owner: Address; slot: bigint }
+): Promise<KaminoPosition> {
+  const { vault, state, config, rpc, assetIdentity } = await bindVault(runtime, input.vault);
+  const shareDecimals = mintDecimals(state.sharesMintDecimals, "sharesMintDecimals");
+
+  // UNSTAKED shares are counted here rather than taken from the SDK, and that is
+  // the whole point of this block. `vault.getUserShares` sums its token accounts
+  // through `getTokenAccountAmount`, which returns
+  // `parsed.info.tokenAmount.uiAmount` — a JavaScript NUMBER. Above 2^53 base
+  // units that has already lost value, and no amount of `Decimal`-wrapping
+  // downstream can put it back. `amount` on the same parsed account is the exact
+  // base-unit string, so this reads that and scales it by the share mint itself.
+  //
+  // STAKED shares still come from the SDK: that half is derived from farm state
+  // as an exact `Decimal`, never through `uiAmount`, so re-implementing it would
+  // duplicate the farm lookup for no precision gain.
+  const staked = await vault.getUserShares(input.owner as Kit2);
+  const unstakedBase = await readUnstakedShareBaseUnits(rpc, input.owner, assetIdentity.shareMint);
+  const shares = requireNonNegativeFiniteDecimal(
+    "total share balance",
+    new Decimal(formatDecimalAmount(unstakedBase, shareDecimals)).add(
+      requireNonNegativeFiniteDecimal("staked share balance", staked.stakedShares)
+    )
+  );
+
+  let tokenValue: string | undefined;
+  try {
+    const rate = requireNonNegativeFiniteDecimal(
+      "vault exchange rate",
+      await vault.getExchangeRate(input.slot as Kit2)
+    );
+    const decimals = mintDecimals(state.tokenMintDecimals, "tokenMintDecimals");
+    // Round-trip through the repo's own fixed-point helpers so the string that
+    // leaves this package is scaled exactly like every other amount in SDP.
+    const raw = requireNonNegativeFiniteDecimal("vault token value", shares.mul(rate)).toFixed(
+      decimals,
+      Decimal.ROUND_DOWN
+    );
+    tokenValue = formatDecimalAmount(parseDecimalAmount(raw, decimals), decimals);
+  } catch {
+    tokenValue = undefined;
+  }
+
+  return {
+    vault: input.vault,
+    owner: input.owner,
+    cluster: config.cluster,
+    shares: shares.toFixed(),
+    ...(tokenValue === undefined ? {} : { tokenValue }),
+    tokenMint: assetIdentity.depositTokenMint,
+    sharesMint: assetIdentity.shareMint,
+  };
+}

--- a/packages/sdp-kamino/src/sdk.ts
+++ b/packages/sdp-kamino/src/sdk.ts
@@ -60,7 +60,7 @@ type Kit2 = any;
  * function's correctness is a convention inside one call and that assertion is a
  * property of what we actually emit.
  */
-async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
+function createVaultClient(runtime: KaminoRuntime) {
   const config = kaminoClusterConfig(runtime.cluster);
   // The transport deadline covers both our direct reads and every nested
   // reserve/farm/vault request klend-sdk performs with this same client.
@@ -74,6 +74,12 @@ async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
     undefined,
     config.farmsProgramId as Kit2
   );
+
+  return { client, config, rpc };
+}
+
+async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
+  const { client, config, rpc } = createVaultClient(runtime);
 
   // The probe exists only to fetch state under the right program id; it is never
   // used to build anything.
@@ -281,6 +287,37 @@ export async function buildKaminoWithdrawPlan(
     assetIdentity,
     accepted: { shares: acceptedShares },
   });
+}
+
+/**
+ * Discover every K-Vault in which an owner may hold shares.
+ *
+ * This deliberately uses the on-chain kvault program census rather than the
+ * curated strategy catalogue. Catalogue admission filters (known mint,
+ * metrics, TVL) decide what SDP offers for NEW deposits; they must never hide
+ * money the owner already holds in a filtered or delisted vault.
+ *
+ * klend-sdk's bulk helper is safe only as a CANDIDATE INDEX. Its unstaked
+ * balances pass through JSON `uiAmount` and it overwrites rather than sums
+ * multiple token accounts. We therefore consume only the returned vault keys;
+ * `readKaminoPosition` re-reads every candidate in exact base units below and
+ * is the sole source of balances returned to callers.
+ */
+export async function discoverKaminoPositionVaults(
+  runtime: KaminoRuntime,
+  owner: Address
+): Promise<Address[]> {
+  const { client } = createVaultClient(runtime);
+  try {
+    const candidateBalances = await client.getUserSharesBalanceAllVaults(owner as Kit2);
+    return [...candidateBalances.keys()].map((vault) => vault as Address);
+  } catch (cause) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      `Kamino holdings could not be discovered on ${runtime.cluster}; refusing to report an empty portfolio.`,
+      { cause }
+    );
+  }
 }
 
 /**

--- a/packages/sdp-kamino/src/share-balances.test.ts
+++ b/packages/sdp-kamino/src/share-balances.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { SdpKaminoError } from "./errors";
+import { sumRawTokenAccountBaseUnits } from "./share-balances";
+
+function tokenAccount(amount: unknown) {
+  return {
+    account: {
+      data: {
+        parsed: {
+          info: { tokenAmount: { amount } },
+        },
+      },
+    },
+  };
+}
+
+describe("sumRawTokenAccountBaseUnits", () => {
+  it("sums every matching account exactly above 2^53", () => {
+    expect(
+      sumRawTokenAccountBaseUnits([
+        tokenAccount("9007199254740993"),
+        tokenAccount("9007199254740995"),
+        tokenAccount("12"),
+      ])
+    ).toBe(18_014_398_509_482_000n);
+  });
+
+  it("fails closed when any matching account has a malformed raw amount", () => {
+    for (const malformed of [tokenAccount(undefined), tokenAccount(12), tokenAccount("1.5"), {}]) {
+      expect(() =>
+        sumRawTokenAccountBaseUnits([tokenAccount("9007199254740993"), malformed])
+      ).toThrow(SdpKaminoError);
+      expect(() =>
+        sumRawTokenAccountBaseUnits([tokenAccount("9007199254740993"), malformed])
+      ).toThrow(/did not contain an exact raw amount/);
+    }
+  });
+
+  it("rejects a response with no account list", () => {
+    expect(() => sumRawTokenAccountBaseUnits(undefined)).toThrow(/did not contain an account list/);
+  });
+});

--- a/packages/sdp-kamino/src/share-balances.ts
+++ b/packages/sdp-kamino/src/share-balances.ts
@@ -1,0 +1,45 @@
+import { SdpKaminoError } from "./errors";
+
+type ParsedTokenAccount = {
+  account?: {
+    data?: {
+      parsed?: {
+        info?: {
+          tokenAmount?: {
+            amount?: unknown;
+          };
+        };
+      };
+    };
+  };
+};
+
+/**
+ * Sum every matching token account from its exact raw amount.
+ *
+ * The RPC filter already selected this mint, so each returned account is part
+ * of the owner's balance. If even one result is malformed, returning the sum of
+ * the readable subset would make a confident but false claim about custody.
+ */
+export function sumRawTokenAccountBaseUnits(entries: unknown): bigint {
+  if (!Array.isArray(entries)) {
+    throw new SdpKaminoError(
+      "VAULT_UNREADABLE",
+      "Kamino share-token RPC response did not contain an account list"
+    );
+  }
+
+  let total = 0n;
+  for (const [index, entry] of entries.entries()) {
+    const raw = (entry as ParsedTokenAccount | null)?.account?.data?.parsed?.info?.tokenAmount
+      ?.amount;
+    if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+      throw new SdpKaminoError(
+        "VAULT_UNREADABLE",
+        `Kamino share-token account ${index} did not contain an exact raw amount`
+      );
+    }
+    total += BigInt(raw);
+  }
+  return total;
+}

--- a/packages/sdp-kamino/src/types.ts
+++ b/packages/sdp-kamino/src/types.ts
@@ -1,0 +1,148 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address, Instruction, Slot, TransactionSigner } from "@solana/kit";
+
+/**
+ * The boundary contract for `@sdp/kamino`.
+ *
+ * TWO RULES HOLD FOR EVERY TYPE IN THIS FILE, and both are load-bearing:
+ *
+ * 1. **Money is a decimal string, never a float and never a `Decimal`.** The
+ *    repo-wide rule (`@sdp/earn` CLAUDE.md → Contracts) is that USD/amount
+ *    values in contract types are decimal strings, converted at the provider
+ *    boundary. `decimal.js` is klend-sdk's currency, so it lives strictly inside
+ *    `./sdk.ts` — a `Decimal` crossing this boundary would also drag in the
+ *    instance-identity hazard (two physical copies of decimal.js make
+ *    klend-sdk's `instanceof` checks fail as NaN rather than as a type error).
+ * 2. **Nothing here references a klend-sdk type.** Every type is either from
+ *    `@solana/kit` (the version THIS repo pins) or from `@sdp/types`. That is
+ *    what makes `./sdk.ts` a firewall rather than a convention.
+ */
+
+/** Which cluster a call runs against, and how to reach it. */
+export interface KaminoRuntime {
+  cluster: SolanaCluster;
+  /**
+   * RPC endpoint for `cluster`. Supplied by the caller rather than read from
+   * env: `syncEarnCatalogue` walks both environments inside ONE process with
+   * one env object, so a process-level `SOLANA_RPC_URL` cannot be trusted to
+   * match the cluster being served — the mistake `listKaminoDevnetVaults` guards
+   * with a genesis-hash check.
+   */
+  rpcUrl: string;
+}
+
+/**
+ * A built, unsigned unit of work: instructions plus what the caller needs to
+ * compile them.
+ *
+ * `instructions` is deliberately `Instruction[][]` — TRANSACTION-SIZED BATCHES,
+ * not one flat list. A multi-reserve K-Vault exit emits several withdraw
+ * instructions, each carrying the vault's full reserve remaining-accounts list,
+ * and routinely exceeds Solana's 1232-byte packet. Handing back a flat list
+ * makes the caller discover that at `compileTransaction`, far from the code that
+ * could split it. One entry means one transaction.
+ */
+export interface KaminoInstructionPlan {
+  cluster: SolanaCluster;
+  instructions: readonly (readonly Instruction[])[];
+  /**
+   * Address lookup tables the caller SHOULD apply when compiling. Kamino
+   * publishes a per-vault LUT precisely because these account lists are large.
+   */
+  lookupTables: readonly Address[];
+  /** Asset mints observed from the same live vault state used to build. */
+  assetIdentity: KaminoVaultAssetIdentity;
+  /** What the instructions above actually encode. See `KaminoAcceptedAmounts`. */
+  accepted: KaminoAcceptedAmounts;
+}
+
+/** Live K-Vault asset identity carried with a built instruction plan. */
+export interface KaminoVaultAssetIdentity {
+  /** Mint consumed by a deposit. */
+  depositTokenMint: Address;
+  /** Mint issued as the vault receipt/share token. */
+  shareMint: Address;
+}
+
+/**
+ * The amounts as ENCODED, canonicalised to each mint's own precision.
+ *
+ * Exists because the requested amount and the encoded amount are not
+ * necessarily the same number: klend-sdk converts every `Decimal` to mint atoms
+ * and FLOORS. This package refuses anything that would lose value to that floor
+ * (`amountTooPrecise`), so these values are always exactly equal to the request
+ * in magnitude — but they are re-serialised from the mint's decimals, so
+ * `"1.500"` comes back as `"1.5"`. The ledger should persist THESE, not the raw
+ * request string: a movement row is a claim about what moved on chain, and only
+ * this side of the boundary knows the mint's precision.
+ */
+export interface KaminoAcceptedAmounts {
+  /** Deposit amount, canonical to the vault token mint's decimals. */
+  amount?: string;
+  /** Share floor, canonical to the share mint's decimals. */
+  minSharesOut?: string;
+  /** Shares redeemed, canonical to the share mint's decimals. */
+  shares?: string;
+}
+
+export interface KaminoDepositInput {
+  /** The K-Vault's own account address — its `providerReference` in the catalogue. */
+  vault: Address;
+  /**
+   * The wallet whose tokens move and whose shares are minted. An SDP custody
+   * wallet's `TransactionSigner`, resolved by the API's signing service.
+   */
+  owner: TransactionSigner;
+  /**
+   * Rent payer for any associated token account this deposit has to create.
+   *
+   * NOT the transaction fee payer. klend-sdk embeds this signer INSIDE the
+   * instruction accounts as writable+signer, so whoever is named here funds ATA
+   * rent — a real, separate spend. SDP's Kora path sets the fee payer at compile
+   * time and signs post-compile via `signAsFeePayer`, which is a different
+   * mechanism entirely; passing a sponsor signer here would quietly bill it for
+   * rent it never agreed to. Defaults to `owner` when omitted.
+   */
+  rentPayer?: TransactionSigner;
+  /** Deposit amount in the vault token's own units, as a decimal string. */
+  amount: string;
+  /**
+   * Minimum shares to accept, as a decimal string — slippage protection.
+   * Omitted means no floor, which is what Kamino's own examples do; the API
+   * should compute one from the live exchange rate rather than pass `"0"` and
+   * call it protection.
+   */
+  minSharesOut?: string;
+}
+
+export interface KaminoWithdrawInput {
+  vault: Address;
+  owner: TransactionSigner;
+  rentPayer?: TransactionSigner;
+  /** Shares to redeem, as a decimal string. */
+  shares: string;
+  /**
+   * Slot the withdrawal is priced against. Required by klend-sdk and by the
+   * reserve math; the caller reads it once so a multi-position pass prices every
+   * leg against the same slot.
+   */
+  slot: Slot;
+}
+
+/** One wallet's holding in one K-Vault, read live from chain. */
+export interface KaminoPosition {
+  vault: Address;
+  owner: Address;
+  cluster: SolanaCluster;
+  /** Shares held, as a decimal string. */
+  shares: string;
+  /**
+   * Current value of those shares in the vault's deposit token, as a decimal
+   * string. Undefined when the exchange rate could not be read — the caller
+   * renders "—" rather than a fabricated figure.
+   */
+  tokenValue?: string;
+  /** The vault's deposit-token mint, so callers need no second lookup. */
+  tokenMint: Address;
+  sharesMint: Address;
+}

--- a/packages/sdp-kamino/tsconfig.json
+++ b/packages/sdp-kamino/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // Mirrors packages/sdp-earn: this package typechecks @sdp/earn's sources
+    // through its workspace import, and `fetch.ts` there references the DOM's
+    // `HeadersInit` / `BodyInit`. Without these libs the failure surfaces here
+    // rather than in the package that owns the code.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sdp-types/package.json
+++ b/packages/sdp-types/package.json
@@ -34,6 +34,11 @@
       "import": "./src/earn.ts",
       "default": "./src/earn.ts"
     },
+    "./kamino-programs": {
+      "types": "./src/kamino-programs.ts",
+      "import": "./src/kamino-programs.ts",
+      "default": "./src/kamino-programs.ts"
+    },
     "./payments": {
       "types": "./src/payments.ts",
       "import": "./src/payments.ts",

--- a/packages/sdp-types/src/index.ts
+++ b/packages/sdp-types/src/index.ts
@@ -11,6 +11,7 @@ export * from "./countries";
 export * from "./custody";
 export * from "./earn";
 export * from "./generated/ramp-support.generated";
+export * from "./kamino-programs";
 export * from "./kyc";
 export * from "./organizations";
 export * from "./pagination";

--- a/packages/sdp-types/src/kamino-programs.ts
+++ b/packages/sdp-types/src/kamino-programs.ts
@@ -1,0 +1,100 @@
+import type { SolanaCluster } from "./well-known-tokens";
+
+/**
+ * Kamino's on-chain program addresses, per cluster.
+ *
+ * ── Why this table lives in `@sdp/types` ────────────────────────────────────
+ * Two packages need it and neither may depend on the other: `@sdp/earn` reads
+ * the devnet kvault program directly (`providers/kamino/devnet.ts` filters
+ * `getProgramAccounts` by it) while `@sdp/kamino` builds instructions against
+ * it. Putting it in `@sdp/kamino` would force `@sdp/earn` to import the 13MB
+ * klend-sdk package — a workspace cycle `scripts/check-module-boundaries.mjs`
+ * rejects outright. `@sdp/types` is the leaf both already depend on, and it
+ * already owns third-party on-chain addresses (`SPL_TOKEN_PROGRAMS`, `SOL_MINT`,
+ * every well-known mint).
+ *
+ * ── The trap this table exists to prevent ───────────────────────────────────
+ * KAMINO DEPLOYS A SEPARATE KVAULT PROGRAM PER CLUSTER, and mainnet's id ALSO
+ * exists on devnet carrying ZERO accounts — so pointing at the wrong one yields
+ * a confident empty shelf rather than an error. Worse, klend-sdk's own
+ * `new KaminoVault(rpc, address, state, programId)` applies `programId` to
+ * account READS only and builds its internal client without forwarding it, so
+ * the naive construction (which is what Kamino's published recipe uses) reads
+ * devnet state and emits MAINNET instructions. `@sdp/kamino` is the only place
+ * allowed to construct a vault, and it must bind reads and writes together.
+ *
+ * Every address below was verified on-chain 2026-08-15.
+ */
+
+/**
+ * K-Vault program — THE ONE THAT DIFFERS PER CLUSTER. Never collapse these to a
+ * single constant, and never derive one from the environment without stating
+ * the cluster (migration 0057 exists because environment does not imply cluster).
+ */
+export const KAMINO_KVAULT_PROGRAM_IDS = {
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "mainnet-beta": "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  devnet: "devkRngFnfp4gBc5a3LsadgbQKdPo8MSZ4prFiNSVmY",
+} as const satisfies Record<SolanaCluster, string>;
+
+/**
+ * Kamino Lending (klend) — the program every K-Vault allocates into. Deployed at
+ * the SAME address on both clusters (verified 2026-08-15), so it takes no
+ * per-cluster branch. Stated as a record anyway so a future divergence is a data
+ * change here rather than a hunt through call sites.
+ */
+export const KAMINO_KLEND_PROGRAM_IDS = {
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "mainnet-beta": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  devnet: "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+} as const satisfies Record<SolanaCluster, string>;
+
+/**
+ * Kamino Farms — reward staking attached to some vaults.
+ *
+ * Verified 2026-08-15: deployed and executable at the same address on BOTH
+ * clusters, so unlike the kvault program this is NOT a second silent-mismatch
+ * trap. Checked explicitly rather than assumed, because a farms id that differed
+ * per cluster would fail exactly the way the kvault one does.
+ */
+export const KAMINO_FARMS_PROGRAM_IDS = {
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "mainnet-beta": "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  devnet: "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+} as const satisfies Record<SolanaCluster, string>;
+
+/**
+ * Average slot duration per cluster, in milliseconds — a REQUIRED input to
+ * klend-sdk's `KaminoVaultClient`, and one with no safe default.
+ *
+ * It scales every accrual the SDK computes: exchange rate, APY, farm rewards. A
+ * wrong value produces plausible WRONG NUMBERS with no error — the same
+ * silent-failure class as the program-id trap above, and one no instruction
+ * assertion can catch.
+ *
+ * MEASURED 2026-08-15 via `getBlockTime` across a 4,000-slot span on each
+ * cluster's public RPC:
+ *
+ *   mainnet-beta  415.8 ms/slot
+ *   devnet        264.5 ms/slot
+ *
+ * Devnet is materially faster than mainnet, and both differ from klend-sdk's own
+ * `DEFAULT_RECENT_SLOT_DURATION_MS` (400) — which is why this is never left to
+ * the SDK default. Re-measure and update the date above if figures look off;
+ * these are observations, not protocol constants.
+ */
+export const KAMINO_SLOT_DURATION_MS = {
+  "mainnet-beta": 416,
+  devnet: 265,
+} as const satisfies Record<SolanaCluster, number>;
+
+/**
+ * The devnet kvault program id, kept as a NAMED export because
+ * `@sdp/earn/providers/kamino/devnet.ts` reads it directly for its
+ * `getProgramAccounts` size filter and reads nothing else from this module.
+ * Re-exported from the table so the two can never drift apart.
+ */
+export const KAMINO_DEVNET_KVAULT_PROGRAM_ID = KAMINO_KVAULT_PROGRAM_IDS.devnet;

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -1,3 +1,4 @@
+import type { SdpEnvironment } from "./api-keys";
 import { CUSTODY_PROVIDERS, type CustodyProvider } from "./custody";
 import {
   normalizeOrganizationTier,
@@ -144,6 +145,39 @@ export function earnDepositStyle(provider: string): EarnDepositStyle {
 export const SURFACED_EARN_PROVIDERS: readonly EarnProviderId[] = EARN_PROVIDERS.filter(
   (provider) => EARN_PROVIDER_SURFACING[provider]
 );
+
+/**
+ * Environments where a `vault_direct` deposit may be OPENED.
+ *
+ * ── Why production is closed ────────────────────────────────────────────────
+ * SDP can currently move money INTO a K-Vault and not back out. There is no
+ * vault-withdraw route (the Kamino client withholds the capability because its
+ * plan is not yet batched), and the dashboard's Active tab reads custodial
+ * `earn_provider_wallets` only, so a vault position does not even appear there.
+ * Entitlement will not save us: it is org-scoped, not environment-scoped, so an
+ * entitled org would otherwise reach mainnet with real funds.
+ *
+ * Nothing here traps money that is already deposited. The shares sit in the
+ * org's OWN custody wallet and Kamino's UI can always redeem them — this closes
+ * the door IN, which is the only direction ADR 0002 ever permits closing.
+ *
+ * Shared rather than duplicated on purpose: this is the single fact the API
+ * refuses on and the dashboard hides the affordance on, and a UI that offered a
+ * button the server refuses is the specific failure this replaces.
+ *
+ * TO OPEN PRODUCTION: land the withdraw path and the Active-tab surface, then
+ * add "production" here. It is one line precisely so it cannot be forgotten,
+ * and it is not a flag flip precisely because the work is real.
+ */
+export const VAULT_DIRECT_DEPOSIT_ENVIRONMENTS: readonly SdpEnvironment[] = ["sandbox"];
+
+/**
+ * Whether a non-custodial vault deposit may be opened in this environment.
+ * Fail-closed: an unrecognized environment answers false.
+ */
+export function isVaultDirectDepositEnabled(environment: string): boolean {
+  return (VAULT_DIRECT_DEPOSIT_ENVIRONMENTS as readonly string[]).includes(environment);
+}
 
 /**
  * Fail-closed surfacing check for an OPEN string.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,8 @@ overrides:
   vite: 7.3.6
   ws: 8.21.0
 
+packageExtensionsChecksum: sha256-Hq4aG11euVLISXl/NBcyj4016UlEcDZd8BZXkelHdyM=
+
 patchedDependencies:
   '@solana/mosaic-sdk@0.1.1':
     hash: b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689
@@ -85,7 +87,7 @@ importers:
         version: 3.15.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@coinbase/cdp-sdk':
         specifier: 1.54.0
-        version: 1.54.0(typescript@6.0.3)
+        version: 1.54.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@hono/node-server':
         specifier: 2.0.12
         version: 2.0.12(hono@4.12.34)
@@ -107,6 +109,9 @@ importers:
       '@sdp/issuance':
         specifier: workspace:*
         version: link:../../packages/sdp-issuance
+      '@sdp/kamino':
+        specifier: workspace:*
+        version: link:../../packages/sdp-kamino
       '@sdp/payments':
         specifier: workspace:*
         version: link:../../packages/sdp-payments
@@ -136,64 +141,64 @@ importers:
         version: 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-core':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-fireblocks':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-privy':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-turnkey':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-utila':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kora':
         specifier: 0.3.0-beta.2
-        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)
+        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/pay':
         specifier: 1.0.26
-        version: 1.0.26(@solana-program/memo@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-api@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-spec@6.10.0(typescript@6.0.3))(typescript@6.0.3)
+        version: 1.0.26(49d490c75e5ddb07f3b4c93d353dbc05)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscriptions':
         specifier: 0.4.0
-        version: 0.4.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)
+        version: 0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/token-acl-gate-sdk':
         specifier: 0.3.0
-        version: 0.3.0(typescript@6.0.3)
+        version: 0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/transactions':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       hono:
         specifier: 4.12.34
         version: 4.12.34
@@ -333,7 +338,7 @@ importers:
         version: 7.6.4(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@flags-sdk/vercel':
         specifier: 1.4.6
-        version: 1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)
+        version: 1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@sdp/issuance':
         specifier: workspace:*
         version: link:../../packages/sdp-issuance
@@ -363,7 +368,7 @@ importers:
         version: 1.6.0
       '@vercel/flags-core':
         specifier: 1.7.1
-        version: 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)
+        version: 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -427,13 +432,13 @@ importers:
         version: 1.62.1
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kora':
         specifier: 0.3.0-beta.2
-        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
@@ -487,7 +492,7 @@ importers:
     dependencies:
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   packages/sdp-api-integration:
     dependencies:
@@ -505,26 +510,26 @@ importers:
         version: link:../sdp-types
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       '@sdp/api':
         specifier: workspace:*
         version: link:../../apps/sdp-api
       '@solana/surfpool':
         specifier: 1.5.0
-        version: 1.5.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 1.5.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -542,40 +547,40 @@ importers:
         version: link:../sdp-types
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-core':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-fireblocks':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-privy':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-turnkey':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-utila':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose:
         specifier: 6.2.8
         version: 6.2.8
@@ -630,22 +635,22 @@ importers:
         version: link:../sdp-types
       '@solana-program/system':
         specifier: 'catalog:'
-        version: 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@6.8.0(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)
+        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/token-acl-gate-sdk':
         specifier: 0.3.0
-        version: 0.3.0(typescript@6.0.3)
+        version: 0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       tsx:
         specifier: 4.23.5
@@ -654,11 +659,45 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/sdp-kamino:
+    dependencies:
+      '@kamino-finance/klend-sdk':
+        specifier: 10.0.0
+        version: 10.0.0(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@sdp/earn':
+        specifier: workspace:*
+        version: link:../sdp-earn
+      '@sdp/solana':
+        specifier: workspace:*
+        version: link:../sdp-solana
+      '@sdp/types':
+        specifier: workspace:*
+        version: link:../sdp-types
+      '@solana/kit':
+        specifier: 'catalog:'
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      decimal.js:
+        specifier: 10.6.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: 26.1.2
+        version: 26.1.2
+      tsx:
+        specifier: 4.23.5
+        version: 4.23.5
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))
+
   packages/sdp-payments:
     dependencies:
       '@coinbase/cdp-sdk':
         specifier: 1.54.0
-        version: 1.54.0(typescript@6.0.3)
+        version: 1.54.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@sdp/rpc':
         specifier: workspace:*
         version: link:../sdp-rpc
@@ -670,19 +709,19 @@ importers:
         version: link:../sdp-types
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/fixed-points':
         specifier: 7.0.0
         version: 7.0.0(typescript@6.0.3)
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kora':
         specifier: 0.3.0-beta.2
-        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -723,10 +762,10 @@ importers:
         version: link:../sdp-types
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -742,10 +781,10 @@ importers:
         version: link:../sdp-types
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   packages/sdp-solana:
     dependencies:
@@ -757,19 +796,19 @@ importers:
         version: link:../sdp-types
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@6.8.0(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/mosaic-sdk':
         specifier: 'catalog:'
-        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)
+        version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/signers':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     devDependencies:
       tsx:
         specifier: 4.23.5
@@ -782,14 +821,14 @@ importers:
         version: link:../kit-augment
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       '@codama/renderers-js':
         specifier: 2.3.1
-        version: 2.3.1(typescript@6.0.3)
+        version: 2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       codama:
         specifier: 1.10.0
         version: 1.10.0
@@ -807,14 +846,14 @@ importers:
         version: link:../kit-augment
       '@solana-program/token':
         specifier: 'catalog:'
-        version: 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
+        version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit':
         specifier: 'catalog:'
-        version: 6.8.0(typescript@6.0.3)
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     devDependencies:
       '@codama/renderers-js':
         specifier: 2.3.1
-        version: 2.3.1(typescript@6.0.3)
+        version: 2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       codama:
         specifier: 1.10.0
         version: 1.10.0
@@ -829,7 +868,7 @@ importers:
     dependencies:
       '@solana/addresses':
         specifier: 'catalog:'
-        version: 6.9.0(typescript@6.0.3)
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 6.0.3
@@ -1122,6 +1161,32 @@ packages:
         optional: true
       '@x402/svm':
         optional: true
+
+  '@coral-xyz/anchor@0.28.0':
+    resolution: {integrity: sha512-kQ02Hv2ZqxtWP30WN1d4xxT4QqlOXYDxmEd3k/bbneqhV3X5QMO4LAtoUFs7otxyivOgoqam5Il5qx81FuI4vw==}
+    engines: {node: '>=11'}
+
+  '@coral-xyz/anchor@0.29.0':
+    resolution: {integrity: sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==}
+    engines: {node: '>=11'}
+
+  '@coral-xyz/borsh@0.28.0':
+    resolution: {integrity: sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
+
+  '@coral-xyz/borsh@0.29.0':
+    resolution: {integrity: sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
+
+  '@coral-xyz/borsh@0.30.1':
+    resolution: {integrity: sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.68.0
 
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
@@ -1436,6 +1501,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hubbleprotocol/hubble-config@5.0.0':
+    resolution: {integrity: sha512-oLdS2SwdYN8sggZhIesN+Kk8KQXGrbYn0kvnvTnk5Wh4pck1kR458ze5gh0XrMDpRVTdgwItf4mXhqiLXvQCKQ==}
+    peerDependencies:
+      '@solana/web3.js': ^1.78.4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1651,6 +1721,27 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@jup-ag/api@6.0.39':
+    resolution: {integrity: sha512-cejW4IWf3dKM5ucmqu5jWtlPZ46LJJOCrx3s5vKmEIB+0X9ykSZsKkcIHFBCOqf3/lSbGyU7THZqXuxjKK9//g==}
+
+  '@kamino-finance/farms-sdk@3.2.26':
+    resolution: {integrity: sha512-G6aziMz0ounatUEGlkiul14ERPXZD/RtzG21b72E/PKVBiFhKP/4fmpolHJjcgJWF4V4i+ITSXevi9oQ0EkLCA==}
+
+  '@kamino-finance/klend-sdk@10.0.0':
+    resolution: {integrity: sha512-U00zrm4jgZzctfGvRZw56kfZUmVXoKtiu9ZaP4CnZ0kg/QdxkyD5TTqJA/v8fThKWr0+uqlCJ6zV+F7QUZl/PA==}
+
+  '@kamino-finance/kliquidity-sdk@11.0.3':
+    resolution: {integrity: sha512-U/wEzDS14Kukd/uEO2HPmPL0c0E0K1agpRyHPdK9u6j4TKLjr4DqGeKXMppzV56dlonyN8upE++SXAGbTdSx6Q==}
+
+  '@kamino-finance/kliquidity-sdk@8.5.10':
+    resolution: {integrity: sha512-E+e4TR4JWdolivMsA956eamfcG5rd1+Wtr1N/iJRmdqrN5cKVln9xX2JAGmw0yGmcwOgxcJfe1joG16AnwKx3A==}
+
+  '@kamino-finance/scope-sdk@10.2.6':
+    resolution: {integrity: sha512-E/e4D4EhfR589ifrOjp6OhfOVXSorcL+m3gF2pElZjmHAlkuJdbl2tuM+m/3LEN4K1toGNjwhhKlA67z/QUNAg==}
+
+  '@kamino-finance/scope-sdk@9.1.0':
+    resolution: {integrity: sha512-/fsk00u64/IJx2iRYceo6K3J9tNSR6qv1SakU79lwURVrQuD4XtKf0HpDXWbJ0bxAxsa5/s28kwSWUG2J0AKWA==}
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -1809,6 +1900,30 @@ packages:
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
+
+  '@orca-so/common-sdk@0.6.11':
+    resolution: {integrity: sha512-7MJs71F8XJsYCx3+agsLc3MMGnzAC8l3FDbUq0qP3lEPI6B5IS/u2iKU4rWkK3IqIkynWcvuYL6WCi+90vu52w==}
+    peerDependencies:
+      '@solana/spl-token': ^0.4.12
+      '@solana/web3.js': ^1.90.0
+
+  '@orca-so/tx-sender@1.0.2':
+    resolution: {integrity: sha512-6PlGx4wwF9Q/XxfND43TtZsjiCJs6Ho5yIYBAkiXXaBOcIfqNTqKRhzhX598xv19TJl4DaldWhgx36m+nqmN8Q==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@orca-so/whirlpools-client@2.0.0':
+    resolution: {integrity: sha512-6/2CdK5aAypA2cT/01l28WLN4Avb55rCuUM9qNyv69NOKnCXRT3byv7FxXkFcJ5GzqoAYaR/fPsZimvi2ndkUg==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@orca-so/whirlpools-core@2.0.0':
+    resolution: {integrity: sha512-SzX9Jd9QDRk6UvUdM114Onq4woFVTl3rrx2Iu0IsnwBbA4lzFLPRYDxdsoyyRHceOgIrbhgpRU3IZc9jCRS8eg==}
+
+  '@orca-so/whirlpools@2.2.0':
+    resolution: {integrity: sha512-a43HQ+yZ8jnzmrVJ0lgJojnIjbvOIi+NlqBcawDhvwtnLz1uHsI1HaQawN3LJZLNrJtTowHdLT6GUCu4o0X0bA==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2539,6 +2654,9 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
+  '@raydium-io/raydium-sdk-v2@0.1.126-alpha':
+    resolution: {integrity: sha512-wpCb1rDvlENO+nfdjC1QVh6P4ImzgF/uhApw5194ycU1i8OSJrb0iZc1Egy5chafcn4i3gY2B1ivMdEeaNsSzA==}
+
   '@react-email/body@0.3.0':
     resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
     engines: {node: '>=20.0.0'}
@@ -3092,15 +3210,45 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@solana-program/address-lookup-table@0.7.0':
+    resolution: {integrity: sha512-dzCeIO5LtiK3bIg0AwO+TPeGURjSG2BKt0c4FRx7105AgLy7uzTktpUzUj6NXAK9SzbirI8HyvHUvw1uvL8O9A==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/address-lookup-table@0.8.0':
+    resolution: {integrity: sha512-ZTSlGj+4hPM6ssBquc8eOeqHR12/DkTDFoqvZqpikLKNHRPgBMFdat56CDBb5G1MCmviPWJ7ij4BUE3fzBz4MA==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/compute-budget@0.14.0':
     resolution: {integrity: sha512-tgvey/2bT35gUlb1lC84Hh2VqkOLoSa6KvaVz5DT037Mg8ECM+f2Q5Prv6V9yKQjRGGF2Y8BZgpOoUg6lTUl/Q==}
     peerDependencies:
       '@solana/kit': ^6.1.0
 
+  '@solana-program/compute-budget@0.7.0':
+    resolution: {integrity: sha512-/JJSE1fKO5zx7Z55Z2tLGWBDDi7tUE+xMlK8qqkHlY51KpqksMsIBzQMkG9Dqhoe2Cnn5/t3QK1nJKqW6eHzpg==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/compute-budget@0.8.0':
+    resolution: {integrity: sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/compute-budget@0.9.0':
+    resolution: {integrity: sha512-on7Cs1V48X9E2x1yVmfM6N6Xv0r4oGruXPcWnI50D3D3CIsHNWJ4gsvL4qZ4iey7zAP73FdM21K2CZBi1a/jzg==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/memo@0.10.0':
     resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
     peerDependencies:
       '@solana/kit': ^5.0
+
+  '@solana-program/memo@0.7.0':
+    resolution: {integrity: sha512-3T9iUjWSYtN/5S5jzJuasD2yQfVfFAQ9yTwIE25+P9peWqz4oarn6ZQvRj/FLcBqaMLtSqLhU1hN2cyVBS6hyg==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
 
   '@solana-program/record@0.3.0':
     resolution: {integrity: sha512-q8z86INfXRQ5357qgVBrw05vC+u3xg8Vb4E1gEwnYUvAkL3cbJSjWVfTlGRiGWYmPNq/FYIWbsFrhsxXyhaJ+w==}
@@ -3123,6 +3271,16 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
+  '@solana-program/system@0.7.0':
+    resolution: {integrity: sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/system@0.8.1':
+    resolution: {integrity: sha512-71U9Mzdpw8HQtfgfJSL5xKZbLMRnza2Llsfk7gGnmg2waqK+o8MMH4YNma8xXS1UmOBptXIiNvoZ3p7cmOVktg==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/token-2022@0.14.0':
     resolution: {integrity: sha512-SXZ3EcYC7DV/TLg0SEfCW/MoDkNzdazSzf4EBAQ1BOMMEhF/BXusbsTpgIXPlgGst+EMR9BH9tHGU37RAVJ8uQ==}
     engines: {node: '>=24.0.0'}
@@ -3133,6 +3291,18 @@ packages:
     peerDependenciesMeta:
       '@solana/zk-sdk':
         optional: true
+
+  '@solana-program/token-2022@0.4.2':
+    resolution: {integrity: sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+      '@solana/sysvars': ^2.1.0
+
+  '@solana-program/token-2022@0.5.0':
+    resolution: {integrity: sha512-CJcFU2bXeXh2da7GAsBRBbmYbmMCBb7uQye0ePsv9pKbWm7r4sqMLoNEi5B+bHRIx9urTKAbmYlGnvWxC9htNg==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+      '@solana/sysvars': ^3.0
 
   '@solana-program/token-2022@0.6.1':
     resolution: {integrity: sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==}
@@ -3157,6 +3327,16 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
+  '@solana-program/token@0.5.1':
+    resolution: {integrity: sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==}
+    peerDependencies:
+      '@solana/kit': ^2.1.0
+
+  '@solana-program/token@0.6.0':
+    resolution: {integrity: sha512-omkZh4Tt9rre4wzWHNOhOEHyenXQku3xyc/UrKvShexA/Qlhza67q7uRwmwEDUs4QqoDBidSZPooOmepnA/jig==}
+    peerDependencies:
+      '@solana/kit': ^3.0
+
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
     peerDependencies:
@@ -3166,6 +3346,12 @@ packages:
     resolution: {integrity: sha512-bCiRVKtqYZpajgC2RVypZL4A0xHjQYVEsVSNMTtPJ1jjE5KOUvsXhnngGMYShK6BHv+fQP4F8QKvEVW/HOSFAg==}
     peerDependencies:
       '@solana/kit': ^7.0.0
+
+  '@solana/accounts@2.3.0':
+    resolution: {integrity: sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/accounts@5.5.1':
     resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
@@ -3193,6 +3379,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/addresses@2.3.0':
+    resolution: {integrity: sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/addresses@5.5.1':
     resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
@@ -3230,6 +3422,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/assertions@2.3.0':
+    resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/assertions@5.5.1':
     resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
     engines: {node: '>=20.18.0'}
@@ -3265,6 +3463,29 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/buffer-layout-utils@0.2.0':
+    resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
+    engines: {node: '>= 10'}
+
+  '@solana/buffer-layout-utils@0.3.0':
+    resolution: {integrity: sha512-MuQOCC1j0np1xH9yAv0ZWWfwvr7Bt7Sz4LId11Wi4wDdAmJ+lobE+vHg/mZmGcihF0BIkqVBNxGmlv8QE5DrtA==}
+    engines: {node: '>= 10'}
+
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-core@2.3.0':
+    resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/codecs-core@5.5.1':
     resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
@@ -3311,6 +3532,17 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-data-structures@2.0.0-rc.1':
+    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-data-structures@2.3.0':
+    resolution: {integrity: sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs-data-structures@5.5.1':
     resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
     engines: {node: '>=20.18.0'}
@@ -3346,6 +3578,17 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.3.0':
+    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@5.5.1':
     resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
@@ -3391,6 +3634,19 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
+  '@solana/codecs-strings@2.3.0':
+    resolution: {integrity: sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.3.3'
 
   '@solana/codecs-strings@5.5.1':
     resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
@@ -3452,6 +3708,17 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs@2.0.0-rc.1':
+    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs@2.3.0':
+    resolution: {integrity: sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/codecs@5.5.1':
     resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
     engines: {node: '>=20.18.0'}
@@ -3470,6 +3737,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/compat@2.3.0':
+    resolution: {integrity: sha512-3dbkQ0eymj1Il7KFAhA6X6LSI4d3uoHcp/WWoE7EIz9NS0ZZ8u27QmfYe5b0IcO2OFkmfReG79RVAm1xYY+7rA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/design-system@1.0.1':
     resolution: {integrity: sha512-8kkrxVyH+9zOfswREYm1mQqVmiQNMF4ANB7XdZCz8QLdqMfRX2FZUrxysnfFOlNPSXFHFI2scSBF8vPWLvRqwg==}
     peerDependencies:
@@ -3478,6 +3751,19 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
       tailwindcss: ^4.0.0
+
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.3.0':
+    resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/errors@5.5.1':
     resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
@@ -3529,6 +3815,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/fast-stable-stringify@2.3.0':
+    resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/fast-stable-stringify@5.5.1':
     resolution: {integrity: sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==}
     engines: {node: '>=20.18.0'}
@@ -3573,6 +3865,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/functional@2.3.0':
+    resolution: {integrity: sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/functional@5.5.1':
     resolution: {integrity: sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==}
@@ -3636,6 +3934,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/instructions@2.3.0':
+    resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/instructions@5.5.1':
     resolution: {integrity: sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==}
@@ -3740,6 +4044,12 @@ packages:
       '@solana/signers': '>=6.0.1'
       '@solana/transactions': '>=6.0.1'
 
+  '@solana/keys@2.3.0':
+    resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/keys@5.5.1':
     resolution: {integrity: sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==}
     engines: {node: '>=20.18.0'}
@@ -3791,6 +4101,12 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.8.0
 
+  '@solana/kit@2.3.0':
+    resolution: {integrity: sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/kit@5.5.1':
     resolution: {integrity: sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==}
     engines: {node: '>=20.18.0'}
@@ -3823,6 +4139,12 @@ packages:
     resolution: {integrity: sha512-SsZ9PMMBhFuZo9z+vCTyQ8lC+/FJ2OxiVJXkXOnB0atLDRwk4n64JSmSIykvKzZeWFX3CSxuX54OOv4QU9nuXg==}
     peerDependencies:
       typescript: ^5.0.0
+
+  '@solana/nominal-types@2.3.0':
+    resolution: {integrity: sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/nominal-types@5.5.1':
     resolution: {integrity: sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==}
@@ -3895,6 +4217,17 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/options@2.0.0-rc.1':
+    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/options@2.3.0':
+    resolution: {integrity: sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/options@5.5.1':
     resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
@@ -3985,6 +4318,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/programs@2.3.0':
+    resolution: {integrity: sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/programs@5.5.1':
     resolution: {integrity: sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==}
     engines: {node: '>=20.18.0'}
@@ -4002,6 +4341,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/promises@2.3.0':
+    resolution: {integrity: sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/promises@5.5.1':
     resolution: {integrity: sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==}
@@ -4042,6 +4387,12 @@ packages:
   '@solana/qr-code-styling@1.6.0':
     resolution: {integrity: sha512-KyBmyFKPxQPhUkP0jjnxV2ZeF1R1guTD8Hrd0YvHvMnhtrNEoEEdv4Jpp4W0GN4qCGG2KYOM5d3TgoLD+CNf9Q==}
 
+  '@solana/rpc-api@2.3.0':
+    resolution: {integrity: sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-api@5.5.1':
     resolution: {integrity: sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==}
     engines: {node: '>=20.18.0'}
@@ -4068,6 +4419,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-parsed-types@2.3.0':
+    resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-parsed-types@5.5.1':
     resolution: {integrity: sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==}
@@ -4096,6 +4453,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-spec-types@2.3.0':
+    resolution: {integrity: sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-spec-types@5.5.1':
     resolution: {integrity: sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==}
     engines: {node: '>=20.18.0'}
@@ -4122,6 +4485,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-spec@2.3.0':
+    resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-spec@5.5.1':
     resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
@@ -4150,6 +4519,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-api@2.3.0':
+    resolution: {integrity: sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-subscriptions-api@5.5.1':
     resolution: {integrity: sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==}
     engines: {node: '>=20.18.0'}
@@ -4168,6 +4543,13 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0':
+    resolution: {integrity: sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+      ws: 8.21.0
+
   '@solana/rpc-subscriptions-channel-websocket@5.5.1':
     resolution: {integrity: sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==}
     engines: {node: '>=20.18.0'}
@@ -4185,6 +4567,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-subscriptions-spec@2.3.0':
+    resolution: {integrity: sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-subscriptions-spec@5.5.1':
     resolution: {integrity: sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==}
@@ -4213,6 +4601,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions@2.3.0':
+    resolution: {integrity: sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-subscriptions@5.5.1':
     resolution: {integrity: sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==}
     engines: {node: '>=20.18.0'}
@@ -4230,6 +4624,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-transformers@2.3.0':
+    resolution: {integrity: sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-transformers@5.5.1':
     resolution: {integrity: sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==}
@@ -4258,6 +4658,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-transport-http@2.3.0':
+    resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc-transport-http@5.5.1':
     resolution: {integrity: sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==}
     engines: {node: '>=20.18.0'}
@@ -4275,6 +4681,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/rpc-types@2.3.0':
+    resolution: {integrity: sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/rpc-types@5.5.1':
     resolution: {integrity: sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==}
@@ -4312,6 +4724,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc@2.3.0':
+    resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/rpc@5.5.1':
     resolution: {integrity: sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==}
     engines: {node: '>=20.18.0'}
@@ -4329,6 +4747,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/signers@2.3.0':
+    resolution: {integrity: sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/signers@5.5.1':
     resolution: {integrity: sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==}
@@ -4365,6 +4789,39 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/spl-stake-pool@1.1.8':
+    resolution: {integrity: sha512-g/d8pFPI9NI1QWObSCkzMz4QpEUepWRLSERGV3gaAwfxWb3mG5I0KQqDW5UgZ8iT9srhzg7me+gG4ad9toQsNg==}
+
+  '@solana/spl-token-group@0.0.7':
+    resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token-metadata@0.1.6':
+    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.15':
+    resolution: {integrity: sha512-3Lof3mNov8NVQ3PalIWb1Jgr/TZ6lYM+/sexv2TLqdhNFVth2OfWmH3d7QucgMjSbokkjNiNlRr6I8Fd269uaw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
+
+  '@solana/spl-token@0.4.9':
+    resolution: {integrity: sha512-g3wbj4F4gq82YQlwqhPB0gHFXfgsC6UmyGMxtSLf/BozT/oKd59465DbnlUK8L8EcimKMavxsVAMoLcEdeCicg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/subscribable@2.3.0':
+    resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/subscribable@5.5.1':
     resolution: {integrity: sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==}
@@ -4432,6 +4889,12 @@ packages:
       '@solana/kit-plugin-signer':
         optional: true
 
+  '@solana/sysvars@2.3.0':
+    resolution: {integrity: sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/sysvars@5.5.1':
     resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
     engines: {node: '>=20.18.0'}
@@ -4460,6 +4923,12 @@ packages:
     peerDependencies:
       typescript: ^5.0.0
 
+  '@solana/transaction-confirmation@2.3.0':
+    resolution: {integrity: sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/transaction-confirmation@5.5.1':
     resolution: {integrity: sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==}
     engines: {node: '>=20.18.0'}
@@ -4477,6 +4946,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/transaction-messages@2.3.0':
+    resolution: {integrity: sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/transaction-messages@5.5.1':
     resolution: {integrity: sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==}
@@ -4514,6 +4989,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/transactions@2.3.0':
+    resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
   '@solana/transactions@5.5.1':
     resolution: {integrity: sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==}
     engines: {node: '>=20.18.0'}
@@ -4549,6 +5030,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/web3.js@1.98.4':
+    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -4727,6 +5211,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -4775,6 +5262,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -4809,6 +5299,15 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.61.0':
     resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
@@ -5235,6 +5734,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -5432,6 +5935,9 @@ packages:
   bare-url@2.4.3:
     resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
@@ -5449,8 +5955,27 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  big.js@6.2.2:
+    resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
+
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bn.js@5.2.5:
+    resolution: {integrity: sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -5465,6 +5990,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
@@ -5475,11 +6003,19 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-layout@1.2.2:
+    resolution: {integrity: sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==}
+    engines: {node: '>=4.5'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
@@ -5504,6 +6040,10 @@ packages:
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
@@ -5597,6 +6137,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -5611,6 +6155,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -5641,12 +6189,19 @@ packages:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  crypto-hash@1.3.0:
+    resolution: {integrity: sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==}
+    engines: {node: '>=8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -5680,6 +6235,9 @@ packages:
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -5701,6 +6259,9 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -5721,6 +6282,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -5778,6 +6343,9 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -5856,6 +6424,12 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  es6-promisify@5.0.0:
+    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -6035,6 +6609,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -6053,8 +6630,15 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
 
   fast-copy@4.0.4:
     resolution: {integrity: sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==}
@@ -6081,8 +6665,14 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6099,6 +6689,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -6310,6 +6903,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  fzstd@0.1.1:
+    resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -6481,6 +7077,9 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -6664,6 +7263,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: 8.21.0
+
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
@@ -6687,6 +7291,11 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jayson@4.3.0:
+    resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -6712,6 +7321,9 @@ packages:
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
+
+  js-sha256@0.9.0:
+    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6753,6 +7365,9 @@ packages:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
     engines: {node: '>= 0.4'}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -6761,6 +7376,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
@@ -6895,6 +7513,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -7246,6 +7867,9 @@ packages:
       sass:
         optional: true
 
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
   node-cron@4.6.0:
     resolution: {integrity: sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==}
     engines: {node: '>=20'}
@@ -7262,6 +7886,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
@@ -7377,6 +8005,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -7795,6 +8426,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rpc-websockets@9.3.9:
+    resolution: {integrity: sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -7926,6 +8560,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -7989,6 +8626,12 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -8071,6 +8714,13 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  superstruct@0.15.5:
+    resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
+
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -8172,9 +8822,15 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8210,6 +8866,12 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toformat@2.0.0:
+    resolution: {integrity: sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==}
+
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -8235,6 +8897,10 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -8337,6 +9003,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
@@ -8374,8 +9044,21 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8664,6 +9347,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zstddec@0.1.0:
+    resolution: {integrity: sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8967,13 +9653,13 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
 
-  '@codama/renderers-js@2.3.1(typescript@6.0.3)':
+  '@codama/renderers-js@2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@codama/errors': 1.10.0
       '@codama/nodes': 1.10.0
       '@codama/renderers-core': 1.3.11
       '@codama/visitors-core': 1.10.0
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       prettier: 3.8.1
       semver: 7.8.5
     transitivePeerDependencies:
@@ -8998,11 +9684,11 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
 
-  '@coinbase/cdp-sdk@1.54.0(typescript@6.0.3)':
+  '@coinbase/cdp-sdk@1.54.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@6.0.3)(zod@3.25.76)
       axios: 1.18.1
       axios-retry: 4.5.0(axios@1.18.1)
@@ -9010,7 +9696,7 @@ snapshots:
       jose: 6.2.8
       md5: 2.3.0
       uncrypto: 0.1.3
-      viem: 2.53.1(typescript@6.0.3)(zod@3.25.76)
+      viem: 2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -9019,6 +9705,69 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  '@coral-xyz/anchor@0.28.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      base64-js: 1.5.1
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0
+      crypto-hash: 1.3.0
+      eventemitter3: 4.0.7
+      js-sha256: 0.9.0
+      pako: 2.2.0
+      snake-case: 3.0.4
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/anchor@0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0
+      crypto-hash: 1.3.0
+      eventemitter3: 4.0.7
+      pako: 2.2.0
+      snake-case: 3.0.4
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/borsh@0.28.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+
+  '@coral-xyz/borsh@0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+
+  '@coral-xyz/borsh@0.30.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -9181,9 +9930,9 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@flags-sdk/vercel@1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)':
+  '@flags-sdk/vercel@1.4.6(flags@4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@vercel/flags-core': 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)
+      '@vercel/flags-core': 1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       flags: 4.2.4(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
@@ -9245,6 +9994,10 @@ snapshots:
   '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
+
+  '@hubbleprotocol/hubble-config@5.0.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -9408,6 +10161,181 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@jup-ag/api@6.0.39': {}
+
+  '@kamino-finance/farms-sdk@3.2.26(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@kamino-finance/kliquidity-sdk': 8.5.10(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@kamino-finance/scope-sdk': 9.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/address-lookup-table': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      decimal.js: 10.6.0
+      exponential-backoff: 3.1.3
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/klend-sdk@10.0.0(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.28.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.28.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@kamino-finance/farms-sdk': 3.2.26(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@kamino-finance/kliquidity-sdk': 11.0.3(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@kamino-finance/scope-sdk': 10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana-program/address-lookup-table': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/memo': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/spl-stake-pool': 1.1.8(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      axios: 1.18.1
+      bn.js: 5.2.5
+      buffer: 6.0.3
+      commander: 9.5.0
+      decimal.js: 10.6.0
+      exponential-backoff: 3.1.3
+      zstddec: 0.1.0
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - '@solana/web3.js'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/kliquidity-sdk@11.0.3(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@hubbleprotocol/hubble-config': 5.0.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@jup-ag/api': 6.0.39
+      '@kamino-finance/scope-sdk': 10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@orca-so/common-sdk': 0.6.11(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@orca-so/whirlpools': 2.2.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@orca-so/whirlpools-core': 2.0.0
+      '@raydium-io/raydium-sdk-v2': 0.1.126-alpha(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana-program/address-lookup-table': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      axios: 1.18.1
+      bn.js: 5.2.5
+      bs58: 6.0.0
+      decimal.js: 10.6.0
+      fzstd: 0.1.1
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - '@solana/web3.js'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/kliquidity-sdk@8.5.10(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.30.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@hubbleprotocol/hubble-config': 5.0.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@jup-ag/api': 6.0.39
+      '@kamino-finance/scope-sdk': 10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@orca-so/common-sdk': 0.6.11(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@orca-so/whirlpools': 2.2.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@orca-so/whirlpools-core': 2.0.0
+      '@raydium-io/raydium-sdk-v2': 0.1.126-alpha(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana-program/address-lookup-table': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/compat': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      axios: 1.18.1
+      bn.js: 5.2.5
+      bs58: 6.0.0
+      buffer-layout: 1.2.2
+      decimal.js: 10.6.0
+      fzstd: 0.1.1
+    transitivePeerDependencies:
+      - '@solana/spl-token'
+      - '@solana/web3.js'
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/scope-sdk@10.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+      decimal.js: 10.6.0
+    transitivePeerDependencies:
+      - '@solana/web3.js'
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+
+  '@kamino-finance/scope-sdk@9.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@coral-xyz/anchor': 0.29.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      bn.js: 5.2.5
+      buffer-layout: 1.2.2
+      decimal.js: 10.6.0
+    transitivePeerDependencies:
+      - '@solana/web3.js'
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -9558,6 +10486,41 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@orca-so/common-sdk@0.6.11(@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/spl-token': 0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      decimal.js: 10.6.0
+      tiny-invariant: 1.3.3
+
+  '@orca-so/tx-sender@1.0.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana-program/address-lookup-table': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/compute-budget': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@orca-so/whirlpools-client@2.0.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@orca-so/whirlpools-core@2.0.0': {}
+
+  '@orca-so/whirlpools@2.2.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@orca-so/tx-sender': 1.0.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@orca-so/whirlpools-client': 2.0.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@orca-so/whirlpools-core': 2.0.0
+      '@solana-program/memo': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/system': 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
 
   '@pinojs/redact@0.4.0': {}
 
@@ -10335,6 +11298,29 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
+  '@raydium-io/raydium-sdk-v2@0.1.126-alpha(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/spl-token': 0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      axios: 1.18.1
+      big.js: 6.2.2
+      bn.js: 5.2.5
+      dayjs: 1.11.21
+      decimal.js-light: 2.5.1
+      jsonfile: 6.2.1
+      lodash: 4.18.1
+      toformat: 2.0.0
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   '@react-email/body@0.3.0(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -10839,123 +11825,196 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/address-lookup-table@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/memo@0.10.0(@solana/kit@5.5.1(typescript@6.0.3))':
+  '@solana-program/address-lookup-table@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/memo@0.10.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/record@0.3.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.10.0(@solana/kit@5.5.1(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.12.2(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/compute-budget@0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/memo@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))':
+  '@solana-program/memo@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/memo@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/record@0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.12.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/system@0.8.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 1.9.7
-      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
+      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@6.8.0(typescript@6.0.3))':
+  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 1.9.7
-      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 6.8.0(typescript@6.0.3)
+      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.9.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))':
+  '@solana-program/token-2022@0.5.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token@0.13.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana-program/system': 0.12.2(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/token-2022@0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token@0.9.0(@solana/kit@5.5.1(typescript@6.0.3))':
+  '@solana-program/token@0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana-program/system': 0.12.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana/accounts@5.5.1(typescript@6.0.3)':
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token@0.6.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/accounts@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/accounts@6.10.0(typescript@6.0.3)':
+  '@solana/accounts@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/accounts@6.8.0(typescript@6.0.3)':
+  '@solana/accounts@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.5.1(typescript@6.0.3)':
+  '@solana/addresses@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/assertions': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
@@ -10963,11 +12022,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.10.0(typescript@6.0.3)':
+  '@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.10.0(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
     optionalDependencies:
@@ -10975,11 +12034,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.8.0(typescript@6.0.3)':
+  '@solana/addresses@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.8.0(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
     optionalDependencies:
@@ -10987,17 +12046,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.9.0(typescript@6.0.3)':
+  '@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.9.0(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/assertions@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -11021,6 +12085,44 @@ snapshots:
     dependencies:
       '@solana/errors': 6.9.0(typescript@6.0.3)
     optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@solana/buffer-layout-utils@0.3.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/codecs-core@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@solana/codecs-core@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
 
   '@solana/codecs-core@5.5.1(typescript@6.0.3)':
@@ -11053,6 +12155,20 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@solana/codecs-data-structures@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+
   '@solana/codecs-data-structures@5.5.1(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
@@ -11083,6 +12199,18 @@ snapshots:
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
     optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@solana/codecs-numbers@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
 
   '@solana/codecs-numbers@5.5.1(typescript@6.0.3)':
@@ -11120,66 +12248,121 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/codecs-strings@5.5.1(typescript@6.0.3)':
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 6.0.3
+
+  '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 6.0.3
+
+  '@solana/codecs-strings@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@6.10.0(typescript@6.0.3)':
+  '@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@6.8.0(typescript@6.0.3)':
+  '@solana/codecs-strings@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@6.9.0(typescript@6.0.3)':
+  '@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs-strings@7.0.0(typescript@6.0.3)':
+  '@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
       '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
       '@solana/errors': 7.0.0(typescript@6.0.3)
     optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 6.0.3
 
-  '@solana/codecs@5.5.1(typescript@6.0.3)':
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
-      '@solana/options': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/codecs@6.8.0(typescript@6.0.3)':
+  '@solana/codecs@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
-      '@solana/options': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/options': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/compat@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -11196,6 +12379,18 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       shiki: 3.23.0
       tailwindcss: 4.3.0
+
+  '@solana/errors@2.0.0-rc.1(typescript@6.0.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
+      typescript: 6.0.3
+
+  '@solana/errors@2.3.0(typescript@6.0.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      typescript: 6.0.3
 
   '@solana/errors@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -11232,6 +12427,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/fast-stable-stringify@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
   '@solana/fast-stable-stringify@5.5.1(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
@@ -11261,6 +12460,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/functional@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
   '@solana/functional@5.5.1(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
@@ -11277,44 +12480,50 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/instruction-plans@5.5.1(typescript@6.0.3)':
+  '@solana/instruction-plans@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instruction-plans@6.10.0(typescript@6.0.3)':
+  '@solana/instruction-plans@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instruction-plans@6.8.0(typescript@6.0.3)':
+  '@solana/instruction-plans@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/instructions@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/instructions@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -11344,118 +12553,129 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))':
+  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-fireblocks@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-fireblocks@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose: 6.2.8
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-para@1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))':
+  '@solana/keychain-para@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.10.0(typescript@6.0.3))(@solana/transactions@6.10.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-para@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-para@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-privy@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-privy@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-turnkey@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-turnkey@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 2.2.0
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-utila@1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))':
+  '@solana/keychain-utila@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(typescript@6.0.3))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/signers@6.9.0(typescript@6.0.3))(@solana/transactions@6.9.0(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose: 6.2.8
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keys@5.5.1(typescript@6.0.3)':
+  '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/assertions': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 5.5.1(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
@@ -11463,11 +12683,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.10.0(typescript@6.0.3)':
+  '@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.10.0(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
       '@solana/promises': 6.10.0(typescript@6.0.3)
@@ -11476,11 +12696,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.8.0(typescript@6.0.3)':
+  '@solana/keys@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.8.0(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
@@ -11489,11 +12709,11 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.9.0(typescript@6.0.3)':
+  '@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/assertions': 6.9.0(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
       '@solana/promises': 6.9.0(typescript@6.0.3)
@@ -11502,43 +12722,68 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
 
-  '@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
-  '@solana/kit@5.5.1(typescript@6.0.3)':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/accounts': 5.5.1(typescript@6.0.3)
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
-      '@solana/codecs': 5.5.1(typescript@6.0.3)
+      '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/programs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-parsed-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
-      '@solana/instruction-plans': 5.5.1(typescript@6.0.3)
+      '@solana/instruction-plans': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
-      '@solana/offchain-messages': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/plugin-core': 5.5.1(typescript@6.0.3)
-      '@solana/programs': 5.5.1(typescript@6.0.3)
-      '@solana/rpc': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-api': 5.5.1(typescript@6.0.3)
+      '@solana/programs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/signers': 5.5.1(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-confirmation': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -11546,33 +12791,33 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/kit@6.8.0(typescript@6.0.3)':
+  '@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/accounts': 6.8.0(typescript@6.0.3)
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/codecs': 6.8.0(typescript@6.0.3)
+      '@solana/accounts': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.8.0(typescript@6.0.3)
+      '@solana/instruction-plans': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/offchain-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/plugin-core': 6.8.0(typescript@6.0.3)
-      '@solana/plugin-interfaces': 6.8.0(typescript@6.0.3)
-      '@solana/program-client-core': 6.8.0(typescript@6.0.3)
-      '@solana/programs': 6.8.0(typescript@6.0.3)
-      '@solana/rpc': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.8.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/program-client-core': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/programs': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/signers': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
-      '@solana/sysvars': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-confirmation': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/sysvars': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -11580,29 +12825,33 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/kora@0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/kora@0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana-program/compute-budget': 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
+      '@solana-program/compute-budget': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
 
-  '@solana/mosaic-sdk@0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(typescript@6.0.3)':
+  '@solana/mosaic-sdk@0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-program/memo': 0.10.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(typescript@6.0.3))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/kit': 5.5.1(typescript@6.0.3)
-      '@solana/sysvars': 5.5.1(typescript@6.0.3)
-      '@token-acl/abl-sdk': '@solana/token-acl-gate-sdk@0.2.0(typescript@6.0.3)'
-      '@token-acl/sdk': 0.2.7(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)
+      '@solana-program/memo': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@token-acl/abl-sdk': '@solana/token-acl-gate-sdk@0.2.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)'
+      '@token-acl/sdk': 0.2.7(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
+
+  '@solana/nominal-types@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@solana/nominal-types@5.5.1(typescript@6.0.3)':
     optionalDependencies:
@@ -11620,103 +12869,125 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/offchain-messages@5.5.1(typescript@6.0.3)':
+  '@solana/offchain-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@6.10.0(typescript@6.0.3)':
+  '@solana/offchain-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@6.8.0(typescript@6.0.3)':
+  '@solana/offchain-messages@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@6.9.0(typescript@6.0.3)':
+  '@solana/offchain-messages@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
-      '@solana/keys': 6.9.0(typescript@6.0.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@5.5.1(typescript@6.0.3)':
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@6.0.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@6.8.0(typescript@6.0.3)':
+  '@solana/options@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/pay@1.0.26(@solana-program/memo@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/system@0.13.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/keys@6.10.0(typescript@6.0.3))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(typescript@6.0.3)))(@solana/kit@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-api@6.8.0(typescript@6.0.3))(@solana/rpc-subscriptions-spec@6.10.0(typescript@6.0.3))(typescript@6.0.3)':
+  '@solana/pay@1.0.26(49d490c75e5ddb07f3b4c93d353dbc05)':
     dependencies:
-      '@solana-program/memo': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token-2022': 0.14.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/keys': 6.10.0(typescript@6.0.3)
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/plugin-interfaces': 6.10.0(typescript@6.0.3)
+      '@solana-program/memo': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/qr-code-styling': 1.6.0
-      '@solana/rpc-subscriptions-api': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.10.0(typescript@6.0.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -11730,83 +13001,95 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/plugin-interfaces@6.10.0(typescript@6.0.3)':
+  '@solana/plugin-interfaces@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 6.10.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-interfaces@6.8.0(typescript@6.0.3)':
+  '@solana/plugin-interfaces@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instruction-plans': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/signers': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/program-client-core@6.10.0(typescript@6.0.3)':
+  '@solana/program-client-core@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 6.10.0(typescript@6.0.3)
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/accounts': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.10.0(typescript@6.0.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/plugin-interfaces': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.10.0(typescript@6.0.3)
-      '@solana/signers': 6.10.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/program-client-core@6.8.0(typescript@6.0.3)':
+  '@solana/program-client-core@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 6.8.0(typescript@6.0.3)
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/accounts': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/instruction-plans': 6.8.0(typescript@6.0.3)
+      '@solana/instruction-plans': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/plugin-interfaces': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.8.0(typescript@6.0.3)
-      '@solana/signers': 6.8.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@5.5.1(typescript@6.0.3)':
+  '@solana/programs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/programs@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@6.8.0(typescript@6.0.3)':
+  '@solana/programs@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@solana/promises@5.5.1(typescript@6.0.3)':
     optionalDependencies:
@@ -11828,59 +13111,80 @@ snapshots:
     dependencies:
       qrcode-generator: 1.5.2
 
-  '@solana/rpc-api@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-parsed-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@6.10.0(typescript@6.0.3)':
+  '@solana/rpc-api@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 6.10.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-api@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-parsed-types': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
 
   '@solana/rpc-parsed-types@5.5.1(typescript@6.0.3)':
     optionalDependencies:
@@ -11894,6 +13198,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/rpc-spec-types@2.3.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
   '@solana/rpc-spec-types@5.5.1(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
@@ -11904,6 +13212,12 @@ snapshots:
 
   '@solana/rpc-spec-types@6.8.0(typescript@6.0.3)':
     optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/rpc-spec@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
       typescript: 6.0.3
 
   '@solana/rpc-spec@5.5.1(typescript@6.0.3)':
@@ -11928,59 +13242,89 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-subscriptions-api@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-api@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-api@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-api@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@6.0.3)
+      '@solana/subscribable': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@6.0.3)
       '@solana/subscribable': 5.5.1(typescript@6.0.3)
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-channel-websocket@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.8.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@solana/rpc-subscriptions-spec@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/promises': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/subscribable': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/rpc-subscriptions-spec@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -12009,18 +13353,36 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-subscriptions@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/fast-stable-stringify': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/promises': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/subscribable': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/rpc-subscriptions@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/fast-stable-stringify': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/promises': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions-api': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscribable': 5.5.1(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
@@ -12029,18 +13391,18 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-subscriptions@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-subscriptions@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/fast-stable-stringify': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions-api': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.8.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
@@ -12049,41 +13411,60 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-transformers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transformers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transformers@6.10.0(typescript@6.0.3)':
+  '@solana/rpc-transformers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/functional': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transformers@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-transformers@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-transport-http@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+      undici-types: 7.27.2
 
   '@solana/rpc-transport-http@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -12103,12 +13484,24 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/rpc-types@5.5.1(typescript@6.0.3)':
+  '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-types@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
     optionalDependencies:
@@ -12116,12 +13509,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@6.10.0(typescript@6.0.3)':
+  '@solana/rpc-types@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/fixed-points': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
@@ -12130,12 +13523,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@6.8.0(typescript@6.0.3)':
+  '@solana/rpc-types@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
     optionalDependencies:
@@ -12143,12 +13536,12 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@6.9.0(typescript@6.0.3)':
+  '@solana/rpc-types@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/fixed-points': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
@@ -12157,101 +13550,197 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@5.5.1(typescript@6.0.3)':
+  '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/fast-stable-stringify': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-spec': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-transport-http': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/fast-stable-stringify': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-api': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-api': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 5.5.1(typescript@6.0.3)
       '@solana/rpc-spec-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-transformers': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-transformers': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-transport-http': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@6.8.0(typescript@6.0.3)':
+  '@solana/rpc@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/fast-stable-stringify': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-api': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-transformers': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-transport-http': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@5.5.1(typescript@6.0.3)':
+  '@solana/signers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
-      '@solana/offchain-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/offchain-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.10.0(typescript@6.0.3)':
+  '@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(typescript@6.0.3)
+      '@solana/offchain-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.8.0(typescript@6.0.3)':
+  '@solana/signers@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/offchain-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.9.0(typescript@6.0.3)':
+  '@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/instructions': 6.9.0(typescript@6.0.3)
-      '@solana/keys': 6.9.0(typescript@6.0.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
-      '@solana/offchain-messages': 6.9.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.9.0(typescript@6.0.3)
-      '@solana/transactions': 6.9.0(typescript@6.0.3)
+      '@solana/offchain-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/spl-stake-pool@1.1.8(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/spl-token': 0.4.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.5
+      buffer: 6.0.3
+      buffer-layout: 1.2.2
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token@0.4.15(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.3.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-token@0.4.9(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/subscribable@2.3.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   '@solana/subscribable@5.5.1(typescript@6.0.3)':
     dependencies:
@@ -12272,14 +13761,14 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/subscriptions@0.4.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)':
+  '@solana/subscriptions@0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana-program/token': 0.13.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana-program/token-2022': 0.9.0(@solana/kit@6.8.0(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/kit': 6.8.0(typescript@6.0.3)
-      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(typescript@6.0.3))
-      '@solana/program-client-core': 6.10.0(typescript@6.0.3)
+      '@solana-program/token': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/program-client-core': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/sysvars'
       - fastestsmallesttextencoderdecoder
@@ -12294,67 +13783,94 @@ snapshots:
   '@solana/surfpool-linux-x64-gnu@1.5.0':
     optional: true
 
-  '@solana/surfpool@1.5.0(@solana/kit@6.8.0(typescript@6.0.3))':
+  '@solana/surfpool@1.5.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     optionalDependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/surfpool-darwin-arm64': 1.5.0
       '@solana/surfpool-darwin-x64': 1.5.0
       '@solana/surfpool-linux-x64-gnu': 1.5.0
 
-  '@solana/sysvars@5.5.1(typescript@6.0.3)':
+  '@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 5.5.1(typescript@6.0.3)
-      '@solana/codecs': 5.5.1(typescript@6.0.3)
+      '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/accounts': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/sysvars@6.8.0(typescript@6.0.3)':
+  '@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/accounts': 6.8.0(typescript@6.0.3)
+      '@solana/accounts': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/token-acl-gate-sdk@0.2.0(typescript@6.0.3)':
+  '@solana/token-acl-gate-sdk@0.2.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/token-acl-gate-sdk@0.3.0(typescript@6.0.3)':
+  '@solana/token-acl-gate-sdk@0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/kit': 6.8.0(typescript@6.0.3)
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-confirmation@5.5.1(typescript@6.0.3)':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/promises': 2.3.0(typescript@6.0.3)
+      '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/transaction-confirmation@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 5.5.1(typescript@6.0.3)
-      '@solana/rpc': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
-      '@solana/transactions': 5.5.1(typescript@6.0.3)
+      '@solana/rpc': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12362,18 +13878,18 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-confirmation@6.8.0(typescript@6.0.3)':
+  '@solana/transaction-confirmation@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/promises': 6.8.0(typescript@6.0.3)
-      '@solana/rpc': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-subscriptions': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
-      '@solana/transactions': 6.8.0(typescript@6.0.3)
+      '@solana/rpc': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12381,9 +13897,24 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@5.5.1(typescript@6.0.3)':
+  '@solana/transaction-messages@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-messages@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
@@ -12391,15 +13922,15 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@6.10.0(typescript@6.0.3)':
+  '@solana/transaction-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
@@ -12407,15 +13938,15 @@ snapshots:
       '@solana/functional': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@6.8.0(typescript@6.0.3)':
+  '@solana/transaction-messages@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
@@ -12423,15 +13954,15 @@ snapshots:
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@6.9.0(typescript@6.0.3)':
+  '@solana/transaction-messages@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
@@ -12439,87 +13970,128 @@ snapshots:
       '@solana/functional': 6.9.0(typescript@6.0.3)
       '@solana/instructions': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.9.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@5.5.1(typescript@6.0.3)':
+  '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 5.5.1(typescript@6.0.3)
+      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 2.3.0(typescript@6.0.3)
+      '@solana/functional': 2.3.0(typescript@6.0.3)
+      '@solana/instructions': 2.3.0(typescript@6.0.3)
+      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 2.3.0(typescript@6.0.3)
+      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 5.5.1(typescript@6.0.3)
       '@solana/codecs-data-structures': 5.5.1(typescript@6.0.3)
       '@solana/codecs-numbers': 5.5.1(typescript@6.0.3)
-      '@solana/codecs-strings': 5.5.1(typescript@6.0.3)
+      '@solana/codecs-strings': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 5.5.1(typescript@6.0.3)
       '@solana/functional': 5.5.1(typescript@6.0.3)
       '@solana/instructions': 5.5.1(typescript@6.0.3)
-      '@solana/keys': 5.5.1(typescript@6.0.3)
+      '@solana/keys': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 5.5.1(typescript@6.0.3)
-      '@solana/rpc-types': 5.5.1(typescript@6.0.3)
-      '@solana/transaction-messages': 5.5.1(typescript@6.0.3)
+      '@solana/rpc-types': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.10.0(typescript@6.0.3)':
+  '@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(typescript@6.0.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.10.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.10.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.10.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.10.0(typescript@6.0.3)
       '@solana/functional': 6.10.0(typescript@6.0.3)
       '@solana/instructions': 6.10.0(typescript@6.0.3)
-      '@solana/keys': 6.10.0(typescript@6.0.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.10.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.10.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.8.0(typescript@6.0.3)':
+  '@solana/transactions@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.8.0(typescript@6.0.3)
+      '@solana/addresses': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.8.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.8.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.8.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/instructions': 6.8.0(typescript@6.0.3)
-      '@solana/keys': 6.8.0(typescript@6.0.3)
+      '@solana/keys': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.8.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.8.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.8.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.9.0(typescript@6.0.3)':
+  '@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.9.0(typescript@6.0.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-data-structures': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
-      '@solana/codecs-strings': 6.9.0(typescript@6.0.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/functional': 6.9.0(typescript@6.0.3)
       '@solana/instructions': 6.9.0(typescript@6.0.3)
-      '@solana/keys': 6.9.0(typescript@6.0.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
-      '@solana/rpc-types': 6.9.0(typescript@6.0.3)
-      '@solana/transaction-messages': 6.9.0(typescript@6.0.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/buffer-layout': 4.0.1
+      '@solana/codecs-numbers': 2.3.0(typescript@6.0.3)
+      agentkeepalive: 4.6.0
+      bn.js: 5.2.5
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.3.9
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
 
   '@stablelib/base64@1.0.1': {}
 
@@ -12643,10 +14215,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@token-acl/sdk@0.2.7(@solana/sysvars@5.5.1(typescript@6.0.3))(typescript@6.0.3)':
+  '@token-acl/sdk@0.2.7(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(typescript@6.0.3))(@solana/sysvars@5.5.1(typescript@6.0.3))
-      '@solana/kit': 5.5.1(typescript@6.0.3)
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@solana/sysvars'
       - bufferutil
@@ -12683,6 +14255,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.1.2
 
   '@types/debug@4.1.13':
     dependencies:
@@ -12739,6 +14315,8 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@12.20.55': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -12781,6 +14359,16 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 26.1.2
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.2
 
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -12954,9 +14542,9 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/flags-core@1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0)':
+  '@vercel/flags-core@1.7.1(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      '@vercel/functions': 3.7.5(ws@8.21.0)
+      '@vercel/functions': 3.7.5(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@vercel/oidc': 3.5.0
       jose: 5.2.1
       js-xxhash: 4.0.0
@@ -12966,11 +14554,11 @@ snapshots:
       - '@aws-sdk/credential-provider-web-identity'
       - ws
 
-  '@vercel/functions@3.7.5(ws@8.21.0)':
+  '@vercel/functions@3.7.5(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@vercel/oidc@3.5.0': {}
 
@@ -13189,6 +14777,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -13406,6 +14998,10 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
@@ -13420,11 +15016,31 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  big.js@6.2.2: {}
+
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
+
+  bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bn.js@5.2.5: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.5
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
 
   brace-expansion@5.0.9(patch_hash=cb7f184e2dafcba994a55ee67b21ef5a2cb11e980f3bce73203d9d93f42018c3):
     dependencies:
@@ -13442,6 +15058,10 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
+
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
@@ -13449,6 +15069,8 @@ snapshots:
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-layout@1.2.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -13459,6 +15081,11 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
 
   buildcheck@0.0.7:
     optional: true
@@ -13483,6 +15110,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001806: {}
 
@@ -13560,6 +15189,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@12.1.0: {}
+
   commander@14.0.2: {}
 
   commander@14.0.3: {}
@@ -13567,6 +15198,8 @@ snapshots:
   commander@15.0.0: {}
 
   commander@2.20.3: {}
+
+  commander@9.5.0: {}
 
   commondir@1.0.1: {}
 
@@ -13597,6 +15230,12 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -13604,6 +15243,8 @@ snapshots:
       which: 2.0.2
 
   crypt@0.0.2: {}
+
+  crypto-hash@1.3.0: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -13643,6 +15284,8 @@ snapshots:
 
   dateformat@4.6.3: {}
 
+  dayjs@1.11.21: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -13652,6 +15295,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -13674,6 +15319,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delay@5.0.0: {}
 
   delayed-stream@1.0.0: {}
 
@@ -13738,6 +15385,11 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
 
   dotenv@16.6.1: {}
 
@@ -13874,6 +15526,12 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-promise@4.2.8: {}
+
+  es6-promisify@5.0.0:
+    dependencies:
+      es6-promise: 4.2.8
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -14173,6 +15831,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   events-universal@1.0.1:
@@ -14197,7 +15857,11 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   extend@3.0.2: {}
+
+  eyes@0.1.8: {}
 
   fast-copy@4.0.4: {}
 
@@ -14221,7 +15885,11 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
+  fast-stable-stringify@1.0.0: {}
+
   fast-uri@3.1.5: {}
+
+  fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.20.1:
     dependencies:
@@ -14234,6 +15902,8 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -14416,6 +16086,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fzstd@0.1.1: {}
 
   generator-function@2.0.1: {}
 
@@ -14671,6 +16343,10 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -14852,9 +16528,13 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.21.0):
+  isomorphic-ws@4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -14884,6 +16564,24 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      json-stringify-safe: 5.0.1
+      stream-json: 1.9.1
+      uuid: 8.3.2
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 26.1.2
@@ -14901,6 +16599,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-cookie@3.0.7: {}
+
+  js-sha256@0.9.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -14952,11 +16652,19 @@ snapshots:
       jsonify: 0.0.1
       object-keys: 1.1.1
 
+  json-stringify-safe@5.0.1: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonify@0.0.1: {}
 
@@ -15060,6 +16768,10 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
 
   lru-cache@10.4.3: {}
 
@@ -15648,6 +17360,11 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
   node-cron@4.6.0: {}
 
   node-exports-info@1.6.0:
@@ -15660,6 +17377,9 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-releases@2.0.51: {}
 
@@ -15788,6 +17508,8 @@ snapshots:
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  pako@2.2.0: {}
 
   parse-entities@4.0.2:
     dependencies:
@@ -16359,6 +18081,19 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  rpc-websockets@9.3.9:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/uuid': 10.0.0
+      '@types/ws': 8.18.1
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      uuid: 14.0.1
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -16543,6 +18278,11 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -16603,6 +18343,12 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
 
   streamx@2.25.0:
     dependencies:
@@ -16715,6 +18461,10 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
+
+  superstruct@0.15.5: {}
+
+  superstruct@2.0.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -16831,9 +18581,13 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  text-encoding-utf-8@1.0.2: {}
+
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -16860,6 +18614,10 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toformat@2.0.0: {}
+
+  toml@3.0.0: {}
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.10
@@ -16882,6 +18640,12 @@ snapshots:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 
@@ -17019,6 +18783,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@2.0.1: {}
+
   unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
@@ -17075,7 +18841,16 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.1: {}
+
+  uuid@8.3.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -17092,16 +18867,16 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.53.1(typescript@6.0.3)(zod@3.25.76):
+  viem@2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.21.0)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.14.29(typescript@6.0.3)(zod@3.25.76)
-      ws: 8.21.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17310,7 +19085,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.0: {}
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   xdg-app-paths@5.5.1:
     dependencies:
@@ -17407,5 +19185,7 @@ snapshots:
   zod@4.1.11: {}
 
   zod@4.4.3: {}
+
+  zstddec@0.1.0: {}
 
   zwitch@2.0.4: {}

--- a/scripts/check-kamino-dependency-boundary.mjs
+++ b/scripts/check-kamino-dependency-boundary.mjs
@@ -1,0 +1,116 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const LOCKFILE = "pnpm-lock.yaml";
+const KAMINO_PACKAGE = "packages/sdp-kamino/package.json";
+const API_PACKAGE = "apps/sdp-api/package.json";
+
+function packageJsonFiles(parent) {
+  return readdirSync(path.join(ROOT, parent), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(parent, entry.name, "package.json"))
+    .filter((file) => {
+      try {
+        readFileSync(path.join(ROOT, file));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+}
+
+const manifests = ["package.json", ...packageJsonFiles("apps"), ...packageJsonFiles("packages")];
+
+function directConsumers(dependency) {
+  return manifests.filter((file) => {
+    const manifest = JSON.parse(readFileSync(path.join(ROOT, file), "utf8"));
+    return [manifest.dependencies, manifest.devDependencies, manifest.optionalDependencies].some(
+      (dependencies) => dependencies && Object.hasOwn(dependencies, dependency)
+    );
+  });
+}
+
+function assertExactConsumers(dependency, expected) {
+  const actual = directConsumers(dependency).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    throw new Error(
+      `${dependency} dependency boundary changed. Expected ${wanted.join(", ")}; found ${
+        actual.join(", ") || "none"
+      }.`
+    );
+  }
+}
+
+// Only the private Kamino package may own klend-sdk, and only the API may ship
+// that package. A new web/docs/package consumer would create an artifact not
+// protected by the API bundle's pure-JS bigint-buffer replacement.
+assertExactConsumers("@kamino-finance/klend-sdk", [KAMINO_PACKAGE]);
+assertExactConsumers("@sdp/kamino", [API_PACKAGE]);
+
+const lines = readFileSync(path.join(ROOT, LOCKFILE), "utf8").split(/\r?\n/);
+const bigintVersions = new Set();
+const directParents = new Map();
+let inSnapshots = false;
+let snapshot = "";
+
+for (const line of lines) {
+  const packageHeader = line.match(/^ {2}['"]?bigint-buffer@([^:'"]+)['"]?:$/);
+  if (packageHeader) bigintVersions.add(packageHeader[1]);
+
+  if (line === "snapshots:") {
+    inSnapshots = true;
+    continue;
+  }
+  if (!inSnapshots) continue;
+
+  const snapshotHeader = line.match(/^ {2}(\S.+):$/);
+  if (snapshotHeader) {
+    snapshot = snapshotHeader[1].replace(/^['"]|['"]$/g, "");
+    continue;
+  }
+
+  const bigintDependency = line.match(/^ {6}bigint-buffer:\s+([^\s]+)$/);
+  if (bigintDependency) directParents.set(snapshot, bigintDependency[1]);
+}
+
+if (bigintVersions.size !== 1 || !bigintVersions.has("1.1.5")) {
+  throw new Error(
+    `Expected only bigint-buffer@1.1.5 in ${LOCKFILE}; found ${
+      [...bigintVersions].join(", ") || "none"
+    }.`
+  );
+}
+
+const allowedParents = new Set([
+  "@solana/buffer-layout-utils@0.2.0",
+  "@solana/buffer-layout-utils@0.3.0",
+]);
+const normalizedParents = new Set();
+for (const [parent, version] of directParents) {
+  if (version !== "1.1.5") {
+    throw new Error(`${parent} resolves bigint-buffer to unexpected version ${version}.`);
+  }
+  const normalized = parent.replace(/\(.+$/, "");
+  normalizedParents.add(normalized);
+  if (!allowedParents.has(normalized)) {
+    throw new Error(`Unexpected bigint-buffer dependency path through ${parent}.`);
+  }
+}
+
+if (
+  normalizedParents.size !== allowedParents.size ||
+  [...allowedParents].some((parent) => !normalizedParents.has(parent))
+) {
+  throw new Error(
+    `bigint-buffer parent set changed. Expected ${[...allowedParents].join(", ")}; found ${
+      [...normalizedParents].join(", ") || "none"
+    }.`
+  );
+}
+
+console.log(
+  "Kamino dependency boundary OK: API -> @sdp/kamino -> klend-sdk -> " +
+    "@solana/buffer-layout-utils -> bigint-buffer@1.1.5"
+);

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -24,6 +24,7 @@ const MODULE_METADATA = [
       "@sdp/earn",
       "@sdp/env-config",
       "@sdp/issuance",
+      "@sdp/kamino",
       "@sdp/payments",
       "@sdp/policy",
       "@sdp/private-channels",
@@ -95,6 +96,18 @@ const MODULE_METADATA = [
     directory: "packages/sdp-issuance",
     purpose: "Token issuance domain services and Mosaic integration.",
     allowedDependencies: ["@sdp/payments", "@sdp/rpc", "@sdp/solana", "@sdp/types"],
+  },
+  {
+    name: "@sdp/kamino",
+    directory: "packages/sdp-kamino",
+    purpose: "Kit-native Kamino K-Vault deposit/withdraw instruction plans over klend-sdk.",
+    // The arrow points INWARD and only inward: this package depends on
+    // @sdp/earn (for the provider contract and the catalogue client it extends),
+    // and @sdp/earn must never depend back — its hourly catalogue cron would
+    // then load klend-sdk (13MB, built against a different @solana/kit major).
+    // That one-way edge is also why the Kamino program-id table lives in
+    // @sdp/types, which both reach without a cycle.
+    allowedDependencies: ["@sdp/earn", "@sdp/solana", "@sdp/types"],
   },
   {
     name: "@sdp/payments",


### PR DESCRIPTION
## Stack

1. **#1350 — Kamino SDK and neutral contracts (this PR)**
2. #1351 — SQL movement ledger
3. #1352 — execution runtime
4. #1353 — policy-gated API
5. #1354 — dashboard experience

All five PRs are drafts and merge bottom-up. This PR is based on #1340.


## Why

Kamino K-Vaults require program instructions rather than a custodial deposit address. This layer establishes the provider-neutral vault-direct contract and isolates Kamino's older Solana dependency graph behind a dedicated package before any API route, database writer, or dashboard action exists.

## What changes

- Add the neutral `EarnVaultDirectProvider`, transaction-plan, accepted-amount, asset-identity, and live-position contracts.
- Add `@sdp/kamino` as the SDK firewall around the pinned Kamino client.
- Bind per-cluster K-Vault, lending, and farms program ids and validate emitted instructions.
- Validate mint scale, accepted amounts, share balances above `2^53`, and finite/non-negative values.
- Bound provider RPC calls and position hydration concurrency.
- Add the workspace dependency, lockfile, API container package copying, and Orca WASM packaging required to build the package safely.
- Update module-boundary enforcement and generated module documentation.

## Safety boundary

This PR exposes no API route and moves no funds. Withdrawal execution remains deliberately unexported until transaction sizing/LUT and resumability support exist.

## Validation

- frozen-lockfile install: passed
- `@sdp/kamino`: 59 passed, 3 live smoke tests skipped
- `@sdp/kamino` typecheck: passed
- `@sdp/earn` typecheck: passed
- module boundaries: passed
- API build, including WASM packaging: passed
