### PR TITLE
feat(api): add the Earn vault execution runtime

### DIFF
--- a/apps/sdp-api/src/lib/solana.test.ts
+++ b/apps/sdp-api/src/lib/solana.test.ts
@@ -1,4 +1,5 @@
 import { getSolanaConfig, resolveDefaultSolanaRpcUrl } from "@sdp/rpc";
+import { createRpc } from "@sdp/rpc/solana";
 import { describe, expect, it } from "vitest";
 import type { Env } from "@/types/env";
 
@@ -66,5 +67,13 @@ describe("solana config resolution", () => {
     expect(() => getSolanaConfig({ SOLANA_NETWORK: "devnet" } as Partial<Env> as Env)).toThrow(
       "No Solana RPC endpoint is configured"
     );
+  });
+
+  it("constructs an explicit endpoint without requiring a legacy default", () => {
+    const explicitOnly = { SOLANA_NETWORK: "devnet" } as Partial<Env> as Env;
+
+    expect(() =>
+      createRpc(explicitOnly, { rpcUrl: "https://devnet.example.invalid" })
+    ).not.toThrow();
   });
 });

--- a/apps/sdp-api/src/services/earn-provider-registry.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.ts
@@ -27,9 +27,10 @@ async function resolveKaminoRpcUrl(
   return rpcUrl;
 }
 
-const kamino = new KaminoVaultDirectClient(resolveKaminoRpcUrl, (label, operation) =>
-  createVaultDeadline().run(label, operation)
-);
+const kamino = new KaminoVaultDirectClient(resolveKaminoRpcUrl, (label, operation) => {
+  const deadline = createVaultDeadline();
+  return deadline.run(label, () => operation(() => deadline.assertActive(label)));
+});
 assertNotPortfolioProvider(kamino);
 
 /**

--- a/apps/sdp-api/src/services/earn-provider-registry.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.ts
@@ -6,19 +6,30 @@ import {
 import type { EarnRuntimeContext, EarnVaultProvider } from "@sdp/earn/types";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
 import type { EarnProviderId, SolanaCluster } from "@sdp/types";
+import type { Env } from "@/types/env";
+import { assertClusterEndpoint, resolveClusterRpcUrl } from "./earn/execution-registry";
+import { createVaultDeadline } from "./earn/vault-deadline";
 
 /**
- * Resolve the process RPC only when it is not known to serve the other cluster.
- * The runtime context is request-scoped; reading it here avoids capturing one
- * process-level URL inside the provider while serving both SDP environments.
+ * Resolve the request's cluster-specific RPC and prove its genesis before the
+ * singleton provider performs any chain work. The runtime context is
+ * request-scoped, so one API process can safely serve both SDP environments.
  */
-function resolveKaminoRpcUrl(ctx: EarnRuntimeContext, cluster: SolanaCluster): string {
-  const configuredCluster = ctx.env.SOLANA_NETWORK?.trim();
-  if (configuredCluster && configuredCluster !== cluster) return "";
-  return ctx.env.SOLANA_RPC_URL ?? "";
+async function resolveKaminoRpcUrl(
+  ctx: EarnRuntimeContext,
+  cluster: SolanaCluster
+): Promise<string> {
+  // The API constructs this runtime from `Env`; the shared provider contract
+  // deliberately narrows it to a dependency-free string record.
+  const env = ctx.env as unknown as Env;
+  const rpcUrl = resolveClusterRpcUrl(env, cluster);
+  await assertClusterEndpoint(env, cluster, rpcUrl);
+  return rpcUrl;
 }
 
-const kamino = new KaminoVaultDirectClient(resolveKaminoRpcUrl);
+const kamino = new KaminoVaultDirectClient(resolveKaminoRpcUrl, (label, operation) =>
+  createVaultDeadline().run(label, operation)
+);
 assertNotPortfolioProvider(kamino);
 
 /**

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -6,6 +6,7 @@ import {
   assertClusterEndpoint,
   CLUSTER_ENDPOINT_PROOF_TTL_MS,
   resetClusterEndpointProofs,
+  resolveClusterRpcUrl,
   resolveVaultDirectClient,
 } from "./execution-registry";
 import { createVaultDeadline } from "./vault-deadline";
@@ -100,6 +101,48 @@ describe("assertClusterEndpoint", () => {
   });
 });
 
+describe("resolveClusterRpcUrl", () => {
+  it("prefers an explicit per-cluster endpoint", () => {
+    expect(
+      resolveClusterRpcUrl(
+        {
+          SOLANA_NETWORK: "devnet",
+          SOLANA_RPC_URL: "https://public.example.invalid",
+          SOLANA_DEVNET_RPC_URL: " https://earn-devnet.example.invalid ",
+        } as Env,
+        "devnet"
+      )
+    ).toBe("https://earn-devnet.example.invalid");
+  });
+
+  it("preserves the canonical managed-provider selection and API-key expansion", () => {
+    expect(
+      resolveClusterRpcUrl(
+        {
+          SOLANA_NETWORK: "devnet",
+          SOLANA_RPC_URL: "https://public.example.invalid",
+          SOLANA_RPC_DEFAULT_PROVIDER: "helius",
+          SOLANA_RPC_HELIUS_URL: "https://helius.example.invalid/?api-key={API_KEY}",
+          SOLANA_RPC_HELIUS_API_KEY: "secret key",
+        } as Env,
+        "devnet"
+      )
+    ).toBe("https://helius.example.invalid/?api-key=secret%20key");
+  });
+
+  it("does not reuse a canonical default for the other cluster", () => {
+    expect(
+      resolveClusterRpcUrl(
+        {
+          SOLANA_NETWORK: "devnet",
+          SOLANA_RPC_URL: "https://devnet.example.invalid",
+        } as Env,
+        "mainnet-beta"
+      )
+    ).toBe("");
+  });
+});
+
 describe("resolveVaultDirectClient", () => {
   it("keeps resolution I/O-free and preserves inherited provider capabilities", () => {
     const createRpc = vi.spyOn(solanaRpc, "createRpc");
@@ -139,7 +182,7 @@ describe("resolveVaultDirectClient", () => {
 
     const result = client.buildVaultDeposit(runtime, depositInput);
     const rejection = expect(result).rejects.toThrow(
-      "Verifying the devnet RPC endpoint timed out after 25ms"
+      "Building the vault deposit timed out after 25ms"
     );
     await vi.advanceTimersByTimeAsync(25);
     await rejection;

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -1,0 +1,92 @@
+import * as solanaRpc from "@sdp/rpc/solana";
+import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "@/types/env";
+import {
+  assertClusterEndpoint,
+  CLUSTER_ENDPOINT_PROOF_TTL_MS,
+  resetClusterEndpointProofs,
+} from "./execution-registry";
+
+const env = {} as Env;
+const rpcUrl = "https://rpc.example.invalid";
+
+function mockGenesisSend() {
+  const send = vi.fn();
+  vi.spyOn(solanaRpc, "createRpc").mockReturnValue({
+    getGenesisHash: () => ({ send }),
+  } as never);
+  return send;
+}
+
+beforeEach(() => {
+  resetClusterEndpointProofs();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("assertClusterEndpoint", () => {
+  it("evicts a transient probe rejection so the endpoint can recover", async () => {
+    const send = mockGenesisSend()
+      .mockRejectedValueOnce(new Error("RPC request timed out after 30000ms"))
+      .mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
+
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/Could not verify/);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    // The successful observation is cached only for the short trust window.
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches an observed mismatch only within the short trust window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-16T00:00:00.000Z"));
+    const send = mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
+    expect(send).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(CLUSTER_ENDPOINT_PROOF_TTL_MS);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).rejects.toThrow(/reports genesis/);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent probes and caches the successful observation", async () => {
+    let resolveGenesis!: (hash: string) => void;
+    const send = mockGenesisSend().mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveGenesis = resolve;
+      })
+    );
+
+    const first = assertClusterEndpoint(env, "devnet", rpcUrl);
+    const second = assertClusterEndpoint(env, "devnet", rpcUrl);
+    expect(send).toHaveBeenCalledOnce();
+
+    resolveGenesis(GENESIS_HASH_BY_CLUSTER.devnet);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("re-proves a successful URL after its trust window expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-16T00:00:00.000Z"));
+    const send = mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
+
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    vi.advanceTimersByTime(CLUSTER_ENDPOINT_PROOF_TTL_MS - 1);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(1);
+    await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -6,10 +6,19 @@ import {
   assertClusterEndpoint,
   CLUSTER_ENDPOINT_PROOF_TTL_MS,
   resetClusterEndpointProofs,
+  resolveVaultDirectClient,
 } from "./execution-registry";
+import { createVaultDeadline } from "./vault-deadline";
 
 const env = {} as Env;
 const rpcUrl = "https://rpc.example.invalid";
+const executionEnv = { SOLANA_DEVNET_RPC_URL: rpcUrl } as Env;
+const runtime = { env: {}, environment: "sandbox" } as const;
+const depositInput = {
+  providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+  owner: "11111111111111111111111111111112",
+  amount: "1",
+};
 
 function mockGenesisSend() {
   const send = vi.fn();
@@ -88,5 +97,51 @@ describe("assertClusterEndpoint", () => {
     vi.advanceTimersByTime(1);
     await expect(assertClusterEndpoint(env, "devnet", rpcUrl)).resolves.toBeUndefined();
     expect(send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("resolveVaultDirectClient", () => {
+  it("keeps resolution I/O-free and preserves inherited provider capabilities", () => {
+    const createRpc = vi.spyOn(solanaRpc, "createRpc");
+
+    const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline());
+
+    expect(client).not.toBeNull();
+    expect(typeof (client as unknown as Record<string, unknown>).listStrategyMetrics).toBe(
+      "function"
+    );
+    expect(createRpc).not.toHaveBeenCalled();
+  });
+
+  it("refuses build and position work before the SDK when genesis is wrong", async () => {
+    mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+    const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline());
+    expect(client).not.toBeNull();
+    if (!client) throw new Error("expected Kamino vault-direct client");
+
+    await expect(client.buildVaultDeposit(runtime, depositInput)).rejects.toThrow(
+      /reports genesis/
+    );
+    await expect(
+      client.readVaultPositions(runtime, {
+        owner: depositInput.owner,
+        providerReferences: [depositInput.providerReference],
+      })
+    ).rejects.toThrow(/reports genesis/);
+  });
+
+  it("does not start provider work after endpoint proof exhausts the shared deadline", async () => {
+    vi.useFakeTimers();
+    mockGenesisSend().mockReturnValue(new Promise<never>(() => undefined));
+    const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline(25));
+    expect(client).not.toBeNull();
+    if (!client) throw new Error("expected Kamino vault-direct client");
+
+    const result = client.buildVaultDeposit(runtime, depositInput);
+    const rejection = expect(result).rejects.toThrow(
+      "Verifying the devnet RPC endpoint timed out after 25ms"
+    );
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
   });
 });

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -1,0 +1,169 @@
+import { supportsVaultDirect } from "@sdp/earn/capabilities";
+import { providerNotConfigured } from "@sdp/earn/errors";
+import type { EarnVaultDirectProvider, EarnVaultProvider } from "@sdp/earn/types";
+import { KaminoVaultDirectClient } from "@sdp/kamino";
+import * as solanaRpc from "@sdp/rpc/solana";
+import {
+  CLUSTER_BY_SDP_ENVIRONMENT,
+  GENESIS_HASH_BY_CLUSTER,
+  type SdpEnvironment,
+  type SolanaCluster,
+} from "@sdp/types";
+import type { Env } from "@/types/env";
+
+/**
+ * Which providers this deployment can EXECUTE for, as opposed to merely
+ * catalogue.
+ *
+ * `EARN_PROVIDER_CLIENTS` in `@sdp/earn` stays the catalogue registry — it is
+ * what the hourly sync resolves through, and it must remain free of chain SDKs
+ * so that cron keeps its small dependency surface. This overlay is consulted
+ * only by routes that move money, and it is the ONE place a provider id is
+ * mapped to an executing client. Everything downstream narrows with
+ * `supportsVaultDirect`, never an id check.
+ */
+
+/**
+ * The RPC endpoint used to build instructions for `cluster`.
+ *
+ * Per-cluster by construction, because one API process serves BOTH — a sandbox
+ * project is devnet and a production project is mainnet-beta, and the same
+ * deployment answers requests for each. Reading one process-level
+ * `SOLANA_RPC_URL` for both meant whichever chain that endpoint served, the
+ * other environment silently built and read against the wrong one.
+ *
+ * `SOLANA_DEVNET_RPC_URL` / `SOLANA_MAINNET_RPC_URL` are optional overrides;
+ * `SOLANA_RPC_URL` stays the fallback so an existing single-cluster deployment
+ * keeps working unchanged. What makes the fallback SAFE rather than the same
+ * bug with more steps is `assertClusterEndpoint` below: the endpoint has to
+ * prove which chain it serves before anything is built against it.
+ */
+export function resolveClusterRpcUrl(env: Env, cluster: SolanaCluster): string {
+  const perCluster = cluster === "devnet" ? env.SOLANA_DEVNET_RPC_URL : env.SOLANA_MAINNET_RPC_URL;
+  const url = perCluster ?? env.SOLANA_RPC_URL;
+  return typeof url === "string" ? url.trim() : "";
+}
+
+/**
+ * Briefly memoised genesis observations, keyed by `cluster\nurl`.
+ *
+ * The genesis hash returned by one backend is immutable, but a URL is not: DNS,
+ * a load balancer, or deployment configuration can repoint the same string at a
+ * different cluster. Cache only a short burst so concurrent/page fan-out stays
+ * affordable without turning one old observation into a process-lifetime funds
+ * authorization.
+ *
+ * A rejected RPC call is NOT an observation. Timeouts, 429s and network failures
+ * are evicted immediately; successful matches and mismatches share the same
+ * short TTL.
+ */
+export const CLUSTER_ENDPOINT_PROOF_TTL_MS = 30_000;
+
+interface ClusterEndpointProof {
+  promise: Promise<string>;
+  /** Null while the shared probe is still in flight. */
+  expiresAt: number | null;
+}
+
+const clusterProofs = new Map<string, ClusterEndpointProof>();
+
+/**
+ * Refuse to build against an endpoint that has not proved it serves `cluster`.
+ *
+ * This is the check the execution path was missing. The catalogue path already
+ * had it — `listKaminoDevnetVaults` verifies genesis before returning anything —
+ * but the money path trusted its URL, and a cluster mismatch does NOT surface as
+ * an error: Kamino's mainnet kvault program id also resolves on devnet with no
+ * accounts under it, so the failure mode is "this vault does not exist", or a
+ * transaction built for the wrong deployment.
+ *
+ * Called before every build and every position read. Concurrent calls coalesce,
+ * and a later call re-proves the URL after the short trust window expires.
+ */
+export async function assertClusterEndpoint(
+  env: Env,
+  cluster: SolanaCluster,
+  rpcUrl: string
+): Promise<void> {
+  if (rpcUrl === "") {
+    throw providerNotConfigured(
+      `No Solana RPC endpoint is configured for ${cluster}. Set SOLANA_${
+        cluster === "devnet" ? "DEVNET" : "MAINNET"
+      }_RPC_URL, or point SOLANA_RPC_URL at a ${cluster} endpoint.`
+    );
+  }
+
+  const key = `${cluster}\n${rpcUrl}`;
+  let proof = clusterProofs.get(key);
+  if (proof && proof.expiresAt !== null && proof.expiresAt <= Date.now()) {
+    clusterProofs.delete(key);
+    proof = undefined;
+  }
+  if (!proof) {
+    proof = { promise: getGenesisHash(env, rpcUrl), expiresAt: null };
+    clusterProofs.set(key, proof);
+  }
+
+  let observed: string;
+  try {
+    observed = await proof.promise;
+    if (clusterProofs.get(key) === proof && proof.expiresAt === null) {
+      proof.expiresAt = Date.now() + CLUSTER_ENDPOINT_PROOF_TTL_MS;
+    }
+  } catch (cause) {
+    // Delete only if this is still the promise stored for the key. Concurrent
+    // callers may all observe the same rejection; none may delete a newer probe
+    // started after this one failed.
+    if (clusterProofs.get(key) === proof) clusterProofs.delete(key);
+    throw providerNotConfigured(
+      `Could not verify that the configured ${cluster} RPC endpoint serves ${cluster}: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`
+    );
+  }
+
+  const expected = GENESIS_HASH_BY_CLUSTER[cluster];
+  if (observed !== expected) {
+    throw providerNotConfigured(
+      `The RPC endpoint configured for ${cluster} reports genesis ${observed}, not ${expected}. ` +
+        "Building against it would address the wrong chain — refusing. Set " +
+        `SOLANA_${cluster === "devnet" ? "DEVNET" : "MAINNET"}_RPC_URL to a ${cluster} endpoint.`
+    );
+  }
+}
+
+async function getGenesisHash(env: Env, rpcUrl: string): Promise<string> {
+  const rpc = solanaRpc.createRpc(env, { rpcUrl });
+  return String(await rpc.getGenesisHash().send());
+}
+
+/** Test seam: forget cached genesis verdicts. */
+export function resetClusterEndpointProofs(): void {
+  clusterProofs.clear();
+}
+
+export function earnClusterFor(environment: SdpEnvironment): SolanaCluster {
+  return CLUSTER_BY_SDP_ENVIRONMENT[environment];
+}
+
+/**
+ * Build the executing client for a provider, or `null` when this deployment has
+ * none. Fail-closed: an unrecognized provider id answers null rather than
+ * throwing, so a row written by a newer deploy degrades to "cannot execute"
+ * instead of 500ing a read that happens to touch it.
+ */
+export function resolveEarnExecutionClient(env: Env, provider: string): EarnVaultProvider | null {
+  if (provider === "kamino") {
+    return new KaminoVaultDirectClient((cluster) => resolveClusterRpcUrl(env, cluster));
+  }
+  return null;
+}
+
+/** The executing client narrowed to the vault-direct capability, or null. */
+export function resolveVaultDirectClient(
+  env: Env,
+  provider: string
+): EarnVaultDirectProvider | null {
+  const client = resolveEarnExecutionClient(env, provider);
+  if (!client) return null;
+  return supportsVaultDirect(client) ? client : null;
+}

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -1,7 +1,7 @@
 import { supportsVaultDirect } from "@sdp/earn/capabilities";
 import { providerNotConfigured } from "@sdp/earn/errors";
 import type { EarnVaultDirectProvider, EarnVaultProvider } from "@sdp/earn/types";
-import { KaminoVaultDirectClient } from "@sdp/kamino";
+import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
 import * as solanaRpc from "@sdp/rpc/solana";
 import {
   CLUSTER_BY_SDP_ENVIRONMENT,
@@ -10,6 +10,7 @@ import {
   type SolanaCluster,
 } from "@sdp/types";
 import type { Env } from "@/types/env";
+import { type VaultDeadline, withVaultDeadline } from "./vault-deadline";
 
 /**
  * Which providers this deployment can EXECUTE for, as opposed to merely
@@ -100,7 +101,13 @@ export async function assertClusterEndpoint(
     proof = undefined;
   }
   if (!proof) {
-    proof = { promise: getGenesisHash(env, rpcUrl), expiresAt: null };
+    proof = {
+      promise: withVaultDeadline(
+        getGenesisHash(env, rpcUrl),
+        `Verifying the ${cluster} RPC endpoint`
+      ),
+      expiresAt: null,
+    };
     clusterProofs.set(key, proof);
   }
 
@@ -151,9 +158,27 @@ export function earnClusterFor(environment: SdpEnvironment): SolanaCluster {
  * throwing, so a row written by a newer deploy degrades to "cannot execute"
  * instead of 500ing a read that happens to touch it.
  */
-export function resolveEarnExecutionClient(env: Env, provider: string): EarnVaultProvider | null {
+export function resolveEarnExecutionClient(
+  env: Env,
+  provider: string,
+  deadline: VaultDeadline
+): EarnVaultProvider | null {
   if (provider === "kamino") {
-    return new KaminoVaultDirectClient((cluster) => resolveClusterRpcUrl(env, cluster));
+    // Construction remains synchronous and I/O-free. The client awaits this
+    // resolver only when a chain method is invoked, so an idempotent replay can
+    // return from durable state during an RPC outage.
+    const client = new KaminoVaultDirectClient(
+      async (_ctx, cluster) => {
+        const rpcUrl = resolveClusterRpcUrl(env, cluster);
+        await deadline.run(`Verifying the ${cluster} RPC endpoint`, () =>
+          assertClusterEndpoint(env, cluster, rpcUrl)
+        );
+        return rpcUrl;
+      },
+      (label, operation) => deadline.run(label, operation)
+    );
+    assertNotPortfolioProvider(client);
+    return client;
   }
   return null;
 }
@@ -161,9 +186,10 @@ export function resolveEarnExecutionClient(env: Env, provider: string): EarnVaul
 /** The executing client narrowed to the vault-direct capability, or null. */
 export function resolveVaultDirectClient(
   env: Env,
-  provider: string
+  provider: string,
+  deadline: VaultDeadline
 ): EarnVaultDirectProvider | null {
-  const client = resolveEarnExecutionClient(env, provider);
+  const client = resolveEarnExecutionClient(env, provider, deadline);
   if (!client) return null;
   return supportsVaultDirect(client) ? client : null;
 }

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -2,6 +2,7 @@ import { supportsVaultDirect } from "@sdp/earn/capabilities";
 import { providerNotConfigured } from "@sdp/earn/errors";
 import type { EarnVaultDirectProvider, EarnVaultProvider } from "@sdp/earn/types";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
+import { resolveDefaultSolanaRpcUrl } from "@sdp/rpc";
 import * as solanaRpc from "@sdp/rpc/solana";
 import {
   CLUSTER_BY_SDP_ENVIRONMENT,
@@ -10,7 +11,7 @@ import {
   type SolanaCluster,
 } from "@sdp/types";
 import type { Env } from "@/types/env";
-import { type VaultDeadline, withVaultDeadline } from "./vault-deadline";
+import type { VaultDeadline } from "./vault-deadline";
 
 /**
  * Which providers this deployment can EXECUTE for, as opposed to merely
@@ -33,16 +34,22 @@ import { type VaultDeadline, withVaultDeadline } from "./vault-deadline";
  * `SOLANA_RPC_URL` for both meant whichever chain that endpoint served, the
  * other environment silently built and read against the wrong one.
  *
- * `SOLANA_DEVNET_RPC_URL` / `SOLANA_MAINNET_RPC_URL` are optional overrides;
- * `SOLANA_RPC_URL` stays the fallback so an existing single-cluster deployment
- * keeps working unchanged. What makes the fallback SAFE rather than the same
- * bug with more steps is `assertClusterEndpoint` below: the endpoint has to
- * prove which chain it serves before anything is built against it.
+ * `SOLANA_DEVNET_RPC_URL` / `SOLANA_MAINNET_RPC_URL` are optional overrides.
+ * The configured cluster may fall back through the canonical default resolver,
+ * preserving managed-provider selection and API-key expansion; the other
+ * cluster requires an explicit override. `assertClusterEndpoint` still makes
+ * every selected URL prove which chain it serves before work begins.
  */
 export function resolveClusterRpcUrl(env: Env, cluster: SolanaCluster): string {
   const perCluster = cluster === "devnet" ? env.SOLANA_DEVNET_RPC_URL : env.SOLANA_MAINNET_RPC_URL;
-  const url = perCluster ?? env.SOLANA_RPC_URL;
-  return typeof url === "string" ? url.trim() : "";
+  if (typeof perCluster === "string" && perCluster.trim() !== "") return perCluster.trim();
+
+  // The canonical default may be a managed provider with URL/API-key template
+  // expansion. It is safe only for the cluster the process config names; the
+  // other cluster needs an explicit override and must fail closed without one.
+  const defaultCluster = env.SOLANA_NETWORK ?? "devnet";
+  if (defaultCluster !== cluster) return "";
+  return resolveDefaultSolanaRpcUrl(env)?.trim() ?? "";
 }
 
 /**
@@ -90,7 +97,7 @@ export async function assertClusterEndpoint(
     throw providerNotConfigured(
       `No Solana RPC endpoint is configured for ${cluster}. Set SOLANA_${
         cluster === "devnet" ? "DEVNET" : "MAINNET"
-      }_RPC_URL, or point SOLANA_RPC_URL at a ${cluster} endpoint.`
+      }_RPC_URL, or configure the canonical default for ${cluster}.`
     );
   }
 
@@ -101,13 +108,7 @@ export async function assertClusterEndpoint(
     proof = undefined;
   }
   if (!proof) {
-    proof = {
-      promise: withVaultDeadline(
-        getGenesisHash(env, rpcUrl),
-        `Verifying the ${cluster} RPC endpoint`
-      ),
-      expiresAt: null,
-    };
+    proof = { promise: getGenesisHash(env, rpcUrl), expiresAt: null };
     clusterProofs.set(key, proof);
   }
 
@@ -170,12 +171,10 @@ export function resolveEarnExecutionClient(
     const client = new KaminoVaultDirectClient(
       async (_ctx, cluster) => {
         const rpcUrl = resolveClusterRpcUrl(env, cluster);
-        await deadline.run(`Verifying the ${cluster} RPC endpoint`, () =>
-          assertClusterEndpoint(env, cluster, rpcUrl)
-        );
+        await assertClusterEndpoint(env, cluster, rpcUrl);
         return rpcUrl;
       },
-      (label, operation) => deadline.run(label, operation)
+      (label, operation) => deadline.run(label, () => operation(() => deadline.assertActive(label)))
     );
     assertNotPortfolioProvider(client);
     return client;

--- a/apps/sdp-api/src/services/earn/vault-deadline.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { withVaultDeadline } from "./vault-deadline";
+import { createVaultDeadline, withVaultDeadline } from "./vault-deadline";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -18,5 +18,61 @@ describe("withVaultDeadline", () => {
     await vi.advanceTimersByTimeAsync(25);
 
     await rejection;
+  });
+
+  it("shares one absolute budget across sequential operations", async () => {
+    vi.useFakeTimers();
+    const deadline = createVaultDeadline(25);
+    const first = deadline.run(
+      "first call",
+      () => new Promise<string>((resolve) => setTimeout(() => resolve("ok"), 15))
+    );
+
+    await vi.advanceTimersByTimeAsync(15);
+    await expect(first).resolves.toBe("ok");
+
+    const second = deadline.run("second call", () => new Promise<never>(() => undefined));
+    const rejection = expect(second).rejects.toThrow("second call timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(10);
+    await rejection;
+  });
+
+  it("does not start another operation after the absolute deadline", async () => {
+    vi.useFakeTimers();
+    const deadline = createVaultDeadline(25);
+    const operation = vi.fn(async () => "too late");
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(deadline.run("late call", operation)).rejects.toThrow(
+      "late call timed out after 25ms"
+    );
+    expect(operation).not.toHaveBeenCalled();
+  });
+
+  it("preserves an operation's own rejection", async () => {
+    const deadline = createVaultDeadline(25);
+    const cause = new Error("upstream failed");
+
+    await expect(deadline.run("failing call", () => Promise.reject(cause))).rejects.toBe(cause);
+  });
+
+  it("consumes a rejection that arrives after the caller timed out", async () => {
+    vi.useFakeTimers();
+    let rejectOperation!: (cause: Error) => void;
+    const operation = new Promise<never>((_resolve, reject) => {
+      rejectOperation = reject;
+    });
+    const result = createVaultDeadline(25).run("late rejection", () => operation);
+    const rejection = expect(result).rejects.toThrow("late rejection timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+
+    // Vitest reports unhandled promise rejections as suite failures. This late
+    // rejection is deliberately consumed by `VaultDeadline.run`.
+    rejectOperation(new Error("settled too late"));
+    await Promise.resolve();
   });
 });

--- a/apps/sdp-api/src/services/earn/vault-deadline.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.test.ts
@@ -51,6 +51,17 @@ describe("withVaultDeadline", () => {
     expect(operation).not.toHaveBeenCalled();
   });
 
+  it("exposes the same expiry check to nested provider boundaries", () => {
+    vi.useFakeTimers();
+    const deadline = createVaultDeadline(25);
+
+    vi.advanceTimersByTime(25);
+
+    expect(() => deadline.assertActive("nested provider read")).toThrow(
+      "nested provider read timed out after 25ms"
+    );
+  });
+
   it("preserves an operation's own rejection", async () => {
     const deadline = createVaultDeadline(25);
     const cause = new Error("upstream failed");

--- a/apps/sdp-api/src/services/earn/vault-deadline.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withVaultDeadline } from "./vault-deadline";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withVaultDeadline", () => {
+  it("returns an external result before the deadline", async () => {
+    await expect(withVaultDeadline(Promise.resolve("ok"), "test call", 25)).resolves.toBe("ok");
+  });
+
+  it("rejects a call that never settles within its bound", async () => {
+    vi.useFakeTimers();
+    const result = withVaultDeadline(new Promise<never>(() => undefined), "test call", 25);
+    const rejection = expect(result).rejects.toThrow("test call timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+  });
+});

--- a/apps/sdp-api/src/services/earn/vault-deadline.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.ts
@@ -2,28 +2,72 @@
 export const VAULT_EXTERNAL_CALL_TIMEOUT_MS = 20_000;
 
 /**
- * Bound an external call even when its SDK does not expose an AbortSignal.
- * Consume a late rejection so a timed-out operation cannot become unhandled.
+ * One absolute budget for a vault workflow.
+ *
+ * Race each awaited external boundary separately through this handle. Racing a
+ * whole multi-step async function is unsafe: if its first RPC settles after the
+ * timeout, that orphaned function can continue into signing or broadcasting.
+ * A thunk also means an already-expired workflow cannot start its next side
+ * effect.
+ *
+ * This bounds caller latency; it cannot cancel an SDK that exposes no
+ * AbortSignal. A timed-out broadcast or combined fee-payment `signAndSend`
+ * therefore remains ambiguous and must never be treated as a definite failure.
  */
-export async function withVaultDeadline<T>(
+export class VaultDeadline {
+  readonly timeoutMs: number;
+  private readonly expiresAt: number;
+
+  constructor(timeoutMs = VAULT_EXTERNAL_CALL_TIMEOUT_MS) {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("Vault deadline must be a positive number of milliseconds");
+    }
+    this.timeoutMs = timeoutMs;
+    this.expiresAt = Date.now() + timeoutMs;
+  }
+
+  /** Run one external stage inside the workflow's remaining absolute budget. */
+  async run<T>(label: string, operation: () => Promise<T>): Promise<T> {
+    const remainingMs = this.expiresAt - Date.now();
+    if (remainingMs <= 0) throw this.timeoutError(label);
+
+    // Invoke only after the expiry check. A synchronous throw remains the
+    // operation's own error and never gets relabelled as a timeout.
+    const pending = operation();
+    // SDKs without AbortSignal support may reject after our race is over.
+    void pending.catch(() => undefined);
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        pending,
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(() => reject(this.timeoutError(label)), remainingMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
+  }
+
+  private timeoutError(label: string): Error {
+    return new Error(`${label} timed out after ${this.timeoutMs}ms`);
+  }
+}
+
+export function createVaultDeadline(timeoutMs = VAULT_EXTERNAL_CALL_TIMEOUT_MS): VaultDeadline {
+  return new VaultDeadline(timeoutMs);
+}
+
+/**
+ * Backward-compatible convenience for one already-created external operation.
+ * Multi-stage workflows must share one `VaultDeadline` and call `run` with
+ * thunks so expiry can prevent later work from starting.
+ */
+export function withVaultDeadline<T>(
   operation: Promise<T>,
   label: string,
   timeoutMs = VAULT_EXTERNAL_CALL_TIMEOUT_MS
 ): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  void operation.catch(() => undefined);
-
-  try {
-    return await Promise.race([
-      operation,
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
-          timeoutMs
-        );
-      }),
-    ]);
-  } finally {
-    if (timeoutId !== undefined) clearTimeout(timeoutId);
-  }
+  return createVaultDeadline(timeoutMs).run(label, () => operation);
 }

--- a/apps/sdp-api/src/services/earn/vault-deadline.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.ts
@@ -1,0 +1,29 @@
+/** Default ceiling for API-owned vault RPC, provider, and custody calls. */
+export const VAULT_EXTERNAL_CALL_TIMEOUT_MS = 20_000;
+
+/**
+ * Bound an external call even when its SDK does not expose an AbortSignal.
+ * Consume a late rejection so a timed-out operation cannot become unhandled.
+ */
+export async function withVaultDeadline<T>(
+  operation: Promise<T>,
+  label: string,
+  timeoutMs = VAULT_EXTERNAL_CALL_TIMEOUT_MS
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  void operation.catch(() => undefined);
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}

--- a/apps/sdp-api/src/services/earn/vault-deadline.ts
+++ b/apps/sdp-api/src/services/earn/vault-deadline.ts
@@ -11,8 +11,8 @@ export const VAULT_EXTERNAL_CALL_TIMEOUT_MS = 20_000;
  * effect.
  *
  * This bounds caller latency; it cannot cancel an SDK that exposes no
- * AbortSignal. A timed-out broadcast or combined fee-payment `signAndSend`
- * therefore remains ambiguous and must never be treated as a definite failure.
+ * AbortSignal. A timed-out broadcast therefore remains ambiguous and must
+ * never be treated as a definite failure; callers persist signed intent first.
  */
 export class VaultDeadline {
   readonly timeoutMs: number;
@@ -26,10 +26,15 @@ export class VaultDeadline {
     this.expiresAt = Date.now() + timeoutMs;
   }
 
+  /** Refuse to start another external boundary after this budget expired. */
+  assertActive(label: string): void {
+    if (this.expiresAt - Date.now() <= 0) throw this.timeoutError(label);
+  }
+
   /** Run one external stage inside the workflow's remaining absolute budget. */
   async run<T>(label: string, operation: () => Promise<T>): Promise<T> {
+    this.assertActive(label);
     const remainingMs = this.expiresAt - Date.now();
-    if (remainingMs <= 0) throw this.timeoutError(label);
 
     // Invoke only after the expiry check. A synchronous throw remains the
     // operation's own error and never gets relabelled as a timeout.

--- a/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
@@ -1,0 +1,206 @@
+import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
+import * as solanaRpc from "@sdp/rpc/solana";
+import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
+import {
+  type Address,
+  address,
+  type Blockhash,
+  createNoopSigner,
+  type Signature,
+} from "@solana/kit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FeePaymentPort } from "@/services/ports";
+import type { Env } from "@/types/env";
+import { resetClusterEndpointProofs } from "./execution-registry";
+import { createVaultDeadline } from "./vault-deadline";
+import {
+  broadcastVaultTransaction,
+  signVaultPlan,
+  simulateVaultPlan,
+  submitVaultPlan,
+} from "./vault-execution.service";
+
+const env = {} as Env;
+const rpcUrl = "https://rpc.example.invalid";
+const ownerAddress = address("11111111111111111111111111111112");
+const feePayerAddress = address("4YhMUz8xDgHMPAevvfMpnJX9TJmw9DTNDA1sNWPRZG9q");
+const blockhash = "29d2S7vB453rNYFdR5Ycwt7y9haRT5fwVwL9zTmBhfV2" as Blockhash;
+const signature =
+  "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature;
+
+const plan: EarnVaultTransactionPlan = {
+  cluster: "devnet",
+  transactions: [
+    [
+      {
+        programAddress: "11111111111111111111111111111111",
+        accounts: [],
+        data: "",
+      },
+    ],
+  ],
+  lookupTables: [],
+  assetIdentity: {
+    depositTokenMint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    shareMint: "So11111111111111111111111111111111111111112",
+  },
+};
+
+const genesisSend = vi.fn();
+const simulateSend = vi.fn();
+const rpc = {
+  getGenesisHash: () => ({ send: genesisSend }),
+  simulateTransaction: () => ({ send: simulateSend }),
+};
+
+function feePayment(overrides: Partial<FeePaymentPort> = {}): FeePaymentPort {
+  return {
+    providerId: "test",
+    getFeePayer: vi.fn().mockResolvedValue(feePayerAddress),
+    signAsFeePayer: vi.fn(),
+    signAndSend: vi.fn().mockResolvedValue(signature),
+    ...overrides,
+  } as FeePaymentPort;
+}
+
+beforeEach(() => {
+  resetClusterEndpointProofs();
+  genesisSend.mockReset().mockResolvedValue(GENESIS_HASH_BY_CLUSTER.devnet);
+  simulateSend.mockReset().mockResolvedValue({ value: { err: null, logs: [] } });
+  vi.spyOn(solanaRpc, "createRpc").mockReturnValue(rpc as never);
+  vi.spyOn(solanaRpc, "getRecentBlockhash").mockResolvedValue({
+    blockhash,
+    lastValidBlockHeight: 100n,
+  });
+  vi.spyOn(solanaRpc, "sendTransaction").mockResolvedValue(signature);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("vault execution cluster proof", () => {
+  it("blocks every raw execution path before RPC, signing, or fee payment on wrong genesis", async () => {
+    genesisSend.mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
+    const sponsor = feePayment();
+    const owner = createNoopSigner(ownerAddress);
+
+    await expect(
+      signVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        plan,
+        owner,
+        rpcUrl,
+      })
+    ).rejects.toThrow(/reports genesis/);
+    await expect(
+      simulateVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        plan,
+        owner: ownerAddress,
+        rpcUrl,
+      })
+    ).rejects.toThrow(/reports genesis/);
+    await expect(
+      submitVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        plan,
+        owner,
+        rpcUrl,
+        fee: { kind: "sponsored", feePayment: sponsor },
+      })
+    ).rejects.toThrow(/reports genesis/);
+    await expect(
+      broadcastVaultTransaction(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        bytes: new Uint8Array(),
+        rpcUrl,
+      })
+    ).rejects.toThrow(/reports genesis/);
+
+    expect(solanaRpc.getRecentBlockhash).not.toHaveBeenCalled();
+    expect(solanaRpc.sendTransaction).not.toHaveBeenCalled();
+    expect(simulateSend).not.toHaveBeenCalled();
+    expect(sponsor.getFeePayer).not.toHaveBeenCalled();
+    expect(sponsor.signAndSend).not.toHaveBeenCalled();
+  });
+
+  it("rejects a provider plan that disagrees with the environment-derived cluster", async () => {
+    const mainnetPlan = { ...plan, cluster: "mainnet-beta" } as const;
+
+    await expect(
+      signVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        plan: mainnetPlan,
+        owner: createNoopSigner(ownerAddress),
+        rpcUrl,
+      })
+    ).rejects.toThrow("Vault plan targets mainnet-beta, not the expected devnet cluster");
+
+    expect(solanaRpc.createRpc).not.toHaveBeenCalled();
+  });
+});
+
+describe("vault execution deadline", () => {
+  it("shares one absolute budget across blockhash and sponsored fee-payer work", async () => {
+    vi.useFakeTimers();
+    vi.mocked(solanaRpc.getRecentBlockhash).mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ blockhash, lastValidBlockHeight: 100n }), 15)
+        )
+    );
+    let resolveFeePayer!: (address: Address) => void;
+    const getFeePayer = vi.fn<() => Promise<Address>>(
+      () =>
+        new Promise((resolve) => {
+          resolveFeePayer = resolve;
+        })
+    );
+    const signAndSend = vi.fn<(_bytes: Uint8Array) => Promise<Signature>>();
+    const sponsor = feePayment({ getFeePayer, signAndSend });
+    const result = submitVaultPlan(env, {
+      cluster: "devnet",
+      deadline: createVaultDeadline(25),
+      plan,
+      owner: createNoopSigner(ownerAddress),
+      rpcUrl,
+      fee: { kind: "sponsored", feePayment: sponsor },
+    });
+    const rejection = expect(result).rejects.toThrow(
+      "Resolving the sponsored fee payer timed out after 25ms"
+    );
+
+    await vi.advanceTimersByTimeAsync(15);
+    expect(getFeePayer).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(10);
+    await rejection;
+
+    resolveFeePayer(feePayerAddress);
+    await Promise.resolve();
+    expect(signAndSend).not.toHaveBeenCalled();
+  });
+
+  it("bounds broadcast with the same stage-labelled deadline", async () => {
+    vi.useFakeTimers();
+    vi.mocked(solanaRpc.sendTransaction).mockReturnValue(new Promise(() => undefined));
+    const result = broadcastVaultTransaction(env, {
+      cluster: "devnet",
+      deadline: createVaultDeadline(25),
+      bytes: new Uint8Array([1, 2, 3]),
+      rpcUrl,
+    });
+    const rejection = expect(result).rejects.toThrow(
+      "Broadcasting the vault transaction timed out after 25ms"
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+  });
+});

--- a/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.test.ts
@@ -2,10 +2,16 @@ import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
 import * as solanaRpc from "@sdp/rpc/solana";
 import { GENESIS_HASH_BY_CLUSTER } from "@sdp/types";
 import {
+  AccountRole,
   type Address,
   address,
   type Blockhash,
   createNoopSigner,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+  getTransactionEncoder,
+  partiallySignTransaction,
   type Signature,
 } from "@solana/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,7 +23,6 @@ import {
   broadcastVaultTransaction,
   signVaultPlan,
   simulateVaultPlan,
-  submitVaultPlan,
 } from "./vault-execution.service";
 
 const env = {} as Env;
@@ -57,10 +62,25 @@ function feePayment(overrides: Partial<FeePaymentPort> = {}): FeePaymentPort {
   return {
     providerId: "test",
     getFeePayer: vi.fn().mockResolvedValue(feePayerAddress),
-    signAsFeePayer: vi.fn(),
+    signAsFeePayer: vi.fn().mockImplementation(async (bytes: Uint8Array) => bytes),
     signAndSend: vi.fn().mockResolvedValue(signature),
     ...overrides,
   } as FeePaymentPort;
+}
+
+function planForOwner(owner: Address): EarnVaultTransactionPlan {
+  return {
+    ...plan,
+    transactions: [
+      [
+        {
+          programAddress: "11111111111111111111111111111111",
+          accounts: [{ address: owner, role: AccountRole.READONLY_SIGNER }],
+          data: "",
+        },
+      ],
+    ],
+  };
 }
 
 beforeEach(() => {
@@ -80,38 +100,30 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("vault execution cluster proof", () => {
-  it("blocks every raw execution path before RPC, signing, or fee payment on wrong genesis", async () => {
+describe("vault execution validation", () => {
+  it("blocks every raw execution path before RPC or signing on wrong genesis", async () => {
     genesisSend.mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
-    const sponsor = feePayment();
     const owner = createNoopSigner(ownerAddress);
 
     await expect(
       signVaultPlan(env, {
         cluster: "devnet",
         deadline: createVaultDeadline(),
+        expectedAssetIdentity: plan.assetIdentity,
         plan,
         owner,
         rpcUrl,
+        fee: { kind: "wallet-pays" },
       })
     ).rejects.toThrow(/reports genesis/);
     await expect(
       simulateVaultPlan(env, {
         cluster: "devnet",
         deadline: createVaultDeadline(),
+        expectedAssetIdentity: plan.assetIdentity,
         plan,
         owner: ownerAddress,
         rpcUrl,
-      })
-    ).rejects.toThrow(/reports genesis/);
-    await expect(
-      submitVaultPlan(env, {
-        cluster: "devnet",
-        deadline: createVaultDeadline(),
-        plan,
-        owner,
-        rpcUrl,
-        fee: { kind: "sponsored", feePayment: sponsor },
       })
     ).rejects.toThrow(/reports genesis/);
     await expect(
@@ -126,8 +138,6 @@ describe("vault execution cluster proof", () => {
     expect(solanaRpc.getRecentBlockhash).not.toHaveBeenCalled();
     expect(solanaRpc.sendTransaction).not.toHaveBeenCalled();
     expect(simulateSend).not.toHaveBeenCalled();
-    expect(sponsor.getFeePayer).not.toHaveBeenCalled();
-    expect(sponsor.signAndSend).not.toHaveBeenCalled();
   });
 
   it("rejects a provider plan that disagrees with the environment-derived cluster", async () => {
@@ -137,13 +147,104 @@ describe("vault execution cluster proof", () => {
       signVaultPlan(env, {
         cluster: "devnet",
         deadline: createVaultDeadline(),
+        expectedAssetIdentity: plan.assetIdentity,
         plan: mainnetPlan,
         owner: createNoopSigner(ownerAddress),
         rpcUrl,
+        fee: { kind: "wallet-pays" },
       })
     ).rejects.toThrow("Vault plan targets mainnet-beta, not the expected devnet cluster");
 
     expect(solanaRpc.createRpc).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale or poisoned asset identity before simulation or signing", async () => {
+    const expectedAssetIdentity = {
+      ...plan.assetIdentity,
+      shareMint: "11111111111111111111111111111112",
+    };
+
+    await expect(
+      signVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        expectedAssetIdentity,
+        plan,
+        owner: createNoopSigner(ownerAddress),
+        rpcUrl,
+        fee: { kind: "wallet-pays" },
+      })
+    ).rejects.toThrow(/share mint.*does not match/);
+    await expect(
+      simulateVaultPlan(env, {
+        cluster: "devnet",
+        deadline: createVaultDeadline(),
+        expectedAssetIdentity,
+        plan,
+        owner: ownerAddress,
+        rpcUrl,
+      })
+    ).rejects.toThrow(/share mint.*does not match/);
+
+    expect(solanaRpc.createRpc).not.toHaveBeenCalled();
+    expect(solanaRpc.getRecentBlockhash).not.toHaveBeenCalled();
+  });
+});
+
+describe("vault signing lifecycle", () => {
+  it("fully signs a sponsored transaction without sending it", async () => {
+    const owner = await generateKeyPairSigner();
+    const sponsor = await generateKeyPairSigner();
+    const signAndSend = vi.fn();
+    const signAsFeePayer = vi.fn(async (ownerSignedBytes: Uint8Array) => {
+      const ownerSigned = getTransactionDecoder().decode(ownerSignedBytes);
+      expect(ownerSigned.signatures[owner.address]).not.toBeNull();
+      expect(ownerSigned.signatures[sponsor.address]).toBeNull();
+      const fullySigned = await partiallySignTransaction([sponsor.keyPair], ownerSigned);
+      return new Uint8Array(getTransactionEncoder().encode(fullySigned));
+    });
+    const fee = feePayment({
+      getFeePayer: vi.fn().mockResolvedValue(sponsor.address),
+      signAsFeePayer,
+      signAndSend,
+    });
+
+    const result = await signVaultPlan(env, {
+      cluster: "devnet",
+      deadline: createVaultDeadline(),
+      expectedAssetIdentity: plan.assetIdentity,
+      plan: planForOwner(owner.address),
+      owner,
+      rpcUrl,
+      fee: { kind: "sponsored", feePayment: fee },
+    });
+
+    const decoded = getTransactionDecoder().decode(result.bytes);
+    expect(decoded.signatures[owner.address]).not.toBeNull();
+    expect(decoded.signatures[sponsor.address]).not.toBeNull();
+    expect(result.signature).toBe(getSignatureFromTransaction(decoded));
+    expect(signAsFeePayer).toHaveBeenCalledOnce();
+    expect(signAndSend).not.toHaveBeenCalled();
+    expect(solanaRpc.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("signs wallet-paid bytes without broadcasting before durable persistence", async () => {
+    const owner = await generateKeyPairSigner();
+
+    const result = await signVaultPlan(env, {
+      cluster: "devnet",
+      deadline: createVaultDeadline(),
+      expectedAssetIdentity: plan.assetIdentity,
+      plan: planForOwner(owner.address),
+      owner,
+      rpcUrl,
+      fee: { kind: "wallet-pays" },
+    });
+
+    const decoded = getTransactionDecoder().decode(result.bytes);
+    expect(decoded.signatures[owner.address]).not.toBeNull();
+    expect(result.signature).toBe(getSignatureFromTransaction(decoded));
+    expect(solanaRpc.sendTransaction).not.toHaveBeenCalled();
   });
 });
 
@@ -156,18 +257,19 @@ describe("vault execution deadline", () => {
           setTimeout(() => resolve({ blockhash, lastValidBlockHeight: 100n }), 15)
         )
     );
-    let resolveFeePayer!: (address: Address) => void;
+    let resolveFeePayer!: (value: Address) => void;
     const getFeePayer = vi.fn<() => Promise<Address>>(
       () =>
         new Promise((resolve) => {
           resolveFeePayer = resolve;
         })
     );
-    const signAndSend = vi.fn<(_bytes: Uint8Array) => Promise<Signature>>();
-    const sponsor = feePayment({ getFeePayer, signAndSend });
-    const result = submitVaultPlan(env, {
+    const signAsFeePayer = vi.fn<(_bytes: Uint8Array) => Promise<Uint8Array>>();
+    const sponsor = feePayment({ getFeePayer, signAsFeePayer });
+    const result = signVaultPlan(env, {
       cluster: "devnet",
       deadline: createVaultDeadline(25),
+      expectedAssetIdentity: plan.assetIdentity,
       plan,
       owner: createNoopSigner(ownerAddress),
       rpcUrl,
@@ -184,7 +286,7 @@ describe("vault execution deadline", () => {
 
     resolveFeePayer(feePayerAddress);
     await Promise.resolve();
-    expect(signAndSend).not.toHaveBeenCalled();
+    expect(signAsFeePayer).not.toHaveBeenCalled();
   });
 
   it("bounds broadcast with the same stage-labelled deadline", async () => {

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -1,5 +1,6 @@
 import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
 import * as solanaRpc from "@sdp/rpc/solana";
+import type { SolanaCluster } from "@sdp/types";
 import {
   type Address,
   address,
@@ -23,6 +24,8 @@ import {
 } from "@solana/signers";
 import type { FeePaymentPort } from "@/services/ports";
 import type { Env } from "@/types/env";
+import { assertClusterEndpoint } from "./execution-registry";
+import type { VaultDeadline } from "./vault-deadline";
 
 /**
  * Turn a provider's unsigned plan into a landed transaction, signed by an SDP
@@ -50,7 +53,14 @@ export type VaultFeeMode =
   | { kind: "sponsored"; feePayment: FeePaymentPort }
   | { kind: "wallet-pays" };
 
-export interface SubmitVaultPlanInput {
+export interface VaultExecutionScope {
+  /** Cluster derived from the authenticated SDP project environment. */
+  cluster: SolanaCluster;
+  /** One absolute budget shared by every stage in this vault workflow. */
+  deadline: VaultDeadline;
+}
+
+export interface SubmitVaultPlanInput extends VaultExecutionScope {
   plan: EarnVaultTransactionPlan;
   /** The custody wallet signer — the vault `user`, and the only real signer. */
   owner: TransactionSigner;
@@ -75,6 +85,26 @@ export interface SignedVaultTransaction {
   lastValidBlockHeight: string;
 }
 
+function assertExpectedPlanCluster(
+  plan: EarnVaultTransactionPlan,
+  expectedCluster: SolanaCluster
+): void {
+  if (plan.cluster !== expectedCluster) {
+    throw new Error(
+      `Vault plan targets ${plan.cluster}, not the expected ${expectedCluster} cluster`
+    );
+  }
+}
+
+async function verifyVaultRpc(
+  env: Env,
+  input: Pick<VaultExecutionScope, "cluster" | "deadline"> & { rpcUrl: string }
+): Promise<void> {
+  await input.deadline.run(`Verifying the ${input.cluster} RPC endpoint`, () =>
+    assertClusterEndpoint(env, input.cluster, input.rpcUrl)
+  );
+}
+
 /**
  * Sign, WITHOUT sending.
  *
@@ -91,11 +121,20 @@ export interface SignedVaultTransaction {
  */
 export async function signVaultPlan(
   env: Env,
-  input: { plan: EarnVaultTransactionPlan; owner: TransactionSigner; rpcUrl: string }
+  input: VaultExecutionScope & {
+    plan: EarnVaultTransactionPlan;
+    owner: TransactionSigner;
+    rpcUrl: string;
+  }
 ): Promise<SignedVaultTransaction> {
+  assertExpectedPlanCluster(input.plan, input.cluster);
   const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
+  await verifyVaultRpc(env, input);
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
-  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const { blockhash, lastValidBlockHeight } = await input.deadline.run(
+    "Fetching the vault transaction blockhash",
+    () => solanaRpc.getRecentBlockhash(rpc, "confirmed")
+  );
 
   const message = pipe(
     createTransactionMessage({ version: 0 }),
@@ -103,7 +142,9 @@ export async function signVaultPlan(
     (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
     (m) => appendTransactionMessageInstructions(instructions, m)
   );
-  const signed = await signTransactionMessageWithSigners(message);
+  const signed = await input.deadline.run("Signing the vault transaction", () =>
+    signTransactionMessageWithSigners(message)
+  );
   return {
     bytes: new Uint8Array(getTransactionEncoder().encode(signed)),
     signature: getSignatureFromTransaction(signed),
@@ -121,10 +162,13 @@ export async function signVaultPlan(
  */
 export async function broadcastVaultTransaction(
   env: Env,
-  input: { bytes: Uint8Array; rpcUrl: string }
+  input: VaultExecutionScope & { bytes: Uint8Array; rpcUrl: string }
 ): Promise<void> {
+  await verifyVaultRpc(env, input);
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
-  await solanaRpc.sendTransaction(rpc, input.bytes);
+  await input.deadline.run("Broadcasting the vault transaction", () =>
+    solanaRpc.sendTransaction(rpc, input.bytes)
+  );
 }
 
 /** The single batch a deposit plan carries, with the multi-transaction refusal. */
@@ -169,24 +213,37 @@ export async function submitVaultPlan(
   env: Env,
   input: SubmitVaultPlanInput
 ): Promise<SubmitVaultPlanResult> {
+  assertExpectedPlanCluster(input.plan, input.cluster);
   const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
+  await verifyVaultRpc(env, input);
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
-  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const { blockhash, lastValidBlockHeight } = await input.deadline.run(
+    "Fetching the vault transaction blockhash",
+    () => solanaRpc.getRecentBlockhash(rpc, "confirmed")
+  );
 
   if (input.fee.kind === "sponsored") {
     // Sponsored: the relay's address is the fee payer and signs AFTER us, so the
     // message carries a noop signer for it and the custody wallet signs its own
     // slots only.
-    const feePayer = await input.fee.feePayment.getFeePayer();
+    const { feePayment } = input.fee;
+    const feePayer = await input.deadline.run("Resolving the sponsored fee payer", () =>
+      feePayment.getFeePayer()
+    );
     const message = pipe(
       createTransactionMessage({ version: 0 }),
       (m) => setTransactionMessageFeePayerSigner(createNoopSigner(feePayer), m),
       (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
       (m) => appendTransactionMessageInstructions(instructions, m)
     );
-    const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+    const partiallySigned = await input.deadline.run(
+      "Signing the sponsored vault transaction",
+      () => partiallySignTransactionMessageWithSigners(message)
+    );
     const bytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
-    const signature = await input.fee.feePayment.signAndSend(bytes);
+    const signature = await input.deadline.run("Submitting the sponsored vault transaction", () =>
+      feePayment.signAndSend(bytes)
+    );
     return { signature };
   }
 
@@ -198,9 +255,13 @@ export async function submitVaultPlan(
     (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
     (m) => appendTransactionMessageInstructions(instructions, m)
   );
-  const signed = await signTransactionMessageWithSigners(message);
+  const signed = await input.deadline.run("Signing the vault transaction", () =>
+    signTransactionMessageWithSigners(message)
+  );
   const bytes = new Uint8Array(getTransactionEncoder().encode(signed));
-  const signature = await solanaRpc.sendTransaction(rpc, bytes);
+  const signature = await input.deadline.run("Broadcasting the vault transaction", () =>
+    solanaRpc.sendTransaction(rpc, bytes)
+  );
   return { signature };
 }
 
@@ -214,8 +275,9 @@ export async function submitVaultPlan(
  */
 export async function simulateVaultPlan(
   env: Env,
-  input: { plan: EarnVaultTransactionPlan; owner: Address; rpcUrl: string }
+  input: VaultExecutionScope & { plan: EarnVaultTransactionPlan; owner: Address; rpcUrl: string }
 ): Promise<{ ok: true } | { ok: false; error: string; logs: readonly string[] }> {
+  assertExpectedPlanCluster(input.plan, input.cluster);
   let batch: ReturnType<typeof singleBatchInstructions>;
   try {
     batch = singleBatchInstructions(input.plan);
@@ -227,8 +289,12 @@ export async function simulateVaultPlan(
     };
   }
 
+  await verifyVaultRpc(env, input);
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
-  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const { blockhash, lastValidBlockHeight } = await input.deadline.run(
+    "Fetching the vault simulation blockhash",
+    () => solanaRpc.getRecentBlockhash(rpc, "confirmed")
+  );
   const message = pipe(
     createTransactionMessage({ version: 0 }),
     (m) => setTransactionMessageFeePayer(input.owner, m),
@@ -238,15 +304,19 @@ export async function simulateVaultPlan(
 
   // `sigVerify: false` + `replaceRecentBlockhash` so an unsigned message can be
   // simulated: we want the PROGRAM's verdict, not a signature check.
-  const compiled = await partiallySignTransactionMessageWithSigners(message);
+  const compiled = await input.deadline.run("Compiling the vault simulation", () =>
+    partiallySignTransactionMessageWithSigners(message)
+  );
   const wire = getBase64EncodedWireTransaction(compiled);
-  const result = await rpc
-    .simulateTransaction(wire, {
-      encoding: "base64",
-      sigVerify: false,
-      replaceRecentBlockhash: true,
-    })
-    .send();
+  const result = await input.deadline.run("Simulating the vault transaction", () =>
+    rpc
+      .simulateTransaction(wire, {
+        encoding: "base64",
+        sigVerify: false,
+        replaceRecentBlockhash: true,
+      })
+      .send()
+  );
 
   if (result.value.err) {
     return {

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -1,14 +1,15 @@
-import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
+import type { EarnVaultAssetIdentity, EarnVaultTransactionPlan } from "@sdp/earn/types";
 import * as solanaRpc from "@sdp/rpc/solana";
 import type { SolanaCluster } from "@sdp/types";
 import {
   type Address,
   address,
+  addSignersToTransactionMessage,
   appendTransactionMessageInstructions,
-  createNoopSigner,
   createTransactionMessage,
   getBase64EncodedWireTransaction,
   getSignatureFromTransaction,
+  getTransactionDecoder,
   getTransactionEncoder,
   type Instruction,
   pipe,
@@ -60,16 +61,17 @@ export interface VaultExecutionScope {
   deadline: VaultDeadline;
 }
 
-export interface SubmitVaultPlanInput extends VaultExecutionScope {
+export interface VaultPlanExecutionScope extends VaultExecutionScope {
+  /** Catalogue identity authorized by the route before provider plan creation. */
+  expectedAssetIdentity: EarnVaultAssetIdentity;
+}
+
+export interface SignVaultPlanInput extends VaultPlanExecutionScope {
   plan: EarnVaultTransactionPlan;
   /** The custody wallet signer — the vault `user`, and the only real signer. */
   owner: TransactionSigner;
   rpcUrl: string;
   fee: VaultFeeMode;
-}
-
-export interface SubmitVaultPlanResult {
-  signature: Signature;
 }
 
 export interface SignedVaultTransaction {
@@ -85,13 +87,26 @@ export interface SignedVaultTransaction {
   lastValidBlockHeight: string;
 }
 
-function assertExpectedPlanCluster(
+function assertExpectedPlan(
   plan: EarnVaultTransactionPlan,
-  expectedCluster: SolanaCluster
+  expectedCluster: SolanaCluster,
+  expectedAssetIdentity: EarnVaultAssetIdentity
 ): void {
   if (plan.cluster !== expectedCluster) {
     throw new Error(
       `Vault plan targets ${plan.cluster}, not the expected ${expectedCluster} cluster`
+    );
+  }
+  if (plan.assetIdentity.depositTokenMint !== expectedAssetIdentity.depositTokenMint) {
+    throw new Error(
+      `Vault plan deposit token mint ${plan.assetIdentity.depositTokenMint} does not match ` +
+        `the expected ${expectedAssetIdentity.depositTokenMint}`
+    );
+  }
+  if (plan.assetIdentity.shareMint !== expectedAssetIdentity.shareMint) {
+    throw new Error(
+      `Vault plan share mint ${plan.assetIdentity.shareMint} does not match ` +
+        `the expected ${expectedAssetIdentity.shareMint}`
     );
   }
 }
@@ -115,19 +130,16 @@ async function verifyVaultRpc(
  * with money moved, and without the signature there is nothing to reconcile it
  * against — SDP would not know the transfer exists.
  *
- * Wallet-pays only. In the sponsored path the relay signs as fee payer AFTER
- * us, so the final signature is not knowable here; that path keeps the combined
- * `submitVaultPlan` and owes the same treatment before it is switched on.
+ * Works for both fee modes. Sponsored signing is deliberately sign-only: the
+ * custody owner signs first, the fee-payment port adds the fee-payer signature
+ * without broadcasting, and the fully signed bytes plus deterministic
+ * signature return to the caller for durable intent persistence.
  */
 export async function signVaultPlan(
   env: Env,
-  input: VaultExecutionScope & {
-    plan: EarnVaultTransactionPlan;
-    owner: TransactionSigner;
-    rpcUrl: string;
-  }
+  input: SignVaultPlanInput
 ): Promise<SignedVaultTransaction> {
-  assertExpectedPlanCluster(input.plan, input.cluster);
+  assertExpectedPlan(input.plan, input.cluster, input.expectedAssetIdentity);
   const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
   await verifyVaultRpc(env, input);
   const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
@@ -136,17 +148,49 @@ export async function signVaultPlan(
     () => solanaRpc.getRecentBlockhash(rpc, "confirmed")
   );
 
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayerSigner(input.owner, m),
-    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-    (m) => appendTransactionMessageInstructions(instructions, m)
-  );
-  const signed = await input.deadline.run("Signing the vault transaction", () =>
-    signTransactionMessageWithSigners(message)
-  );
+  let signedBytes: Uint8Array;
+  if (input.fee.kind === "sponsored") {
+    const { feePayment } = input.fee;
+    const feePayer = await input.deadline.run("Resolving the sponsored fee payer", () =>
+      feePayment.getFeePayer()
+    );
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayer(feePayer, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions(instructions, m),
+      (m) => addSignersToTransactionMessage([input.owner], m)
+    );
+    const ownerSigned = await input.deadline.run("Signing the vault transaction", () =>
+      partiallySignTransactionMessageWithSigners(message)
+    );
+    const ownerSignedBytes = new Uint8Array(getTransactionEncoder().encode(ownerSigned));
+    signedBytes = await input.deadline.run("Signing the sponsored vault fee", () =>
+      feePayment.signAsFeePayer(ownerSignedBytes)
+    );
+  } else {
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(input.owner, m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions(instructions, m),
+      (m) => addSignersToTransactionMessage([input.owner], m)
+    );
+    const signed = await input.deadline.run("Signing the vault transaction", () =>
+      signTransactionMessageWithSigners(message)
+    );
+    signedBytes = new Uint8Array(getTransactionEncoder().encode(signed));
+  }
+
+  const signed = getTransactionDecoder().decode(signedBytes);
+  if (
+    signed.signatures[input.owner.address] === null ||
+    signed.signatures[input.owner.address] === undefined
+  ) {
+    throw new Error("Vault transaction is missing the custody-owner signature");
+  }
   return {
-    bytes: new Uint8Array(getTransactionEncoder().encode(signed)),
+    bytes: signedBytes,
     signature: getSignatureFromTransaction(signed),
     lastValidBlockHeight: String(lastValidBlockHeight),
   };
@@ -195,77 +239,6 @@ function singleBatchInstructions(plan: EarnVaultTransactionPlan) {
 }
 
 /**
- * Decide who pays the transaction fee.
- *
- * Kora only sponsors transactions whose programs are on its allowlist, and the
- * Kamino kvault/klend programs are not on it (the Private Channels escrow hit
- * the same wall and still pays its own fee). Rather than fail at submit with an
- * opaque relay rejection, callers pass `wallet-pays` when sponsorship is not
- * available for the programs in the plan.
- *
- * NOTE the distinction that is easy to lose: klend-sdk also has a `payer`
- * concept, but that is the RENT payer for created ATAs, embedded in the
- * instruction accounts. This function is about the TRANSACTION FEE payer, which
- * is a property of the message. They are different spends and must not be
- * conflated — a sponsor that agreed to fees has not agreed to fund rent.
- */
-export async function submitVaultPlan(
-  env: Env,
-  input: SubmitVaultPlanInput
-): Promise<SubmitVaultPlanResult> {
-  assertExpectedPlanCluster(input.plan, input.cluster);
-  const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
-  await verifyVaultRpc(env, input);
-  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
-  const { blockhash, lastValidBlockHeight } = await input.deadline.run(
-    "Fetching the vault transaction blockhash",
-    () => solanaRpc.getRecentBlockhash(rpc, "confirmed")
-  );
-
-  if (input.fee.kind === "sponsored") {
-    // Sponsored: the relay's address is the fee payer and signs AFTER us, so the
-    // message carries a noop signer for it and the custody wallet signs its own
-    // slots only.
-    const { feePayment } = input.fee;
-    const feePayer = await input.deadline.run("Resolving the sponsored fee payer", () =>
-      feePayment.getFeePayer()
-    );
-    const message = pipe(
-      createTransactionMessage({ version: 0 }),
-      (m) => setTransactionMessageFeePayerSigner(createNoopSigner(feePayer), m),
-      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-      (m) => appendTransactionMessageInstructions(instructions, m)
-    );
-    const partiallySigned = await input.deadline.run(
-      "Signing the sponsored vault transaction",
-      () => partiallySignTransactionMessageWithSigners(message)
-    );
-    const bytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
-    const signature = await input.deadline.run("Submitting the sponsored vault transaction", () =>
-      feePayment.signAndSend(bytes)
-    );
-    return { signature };
-  }
-
-  // Wallet pays: the custody wallet is both the vault `user` and the fee payer,
-  // so it signs once for both and we broadcast directly.
-  const message = pipe(
-    createTransactionMessage({ version: 0 }),
-    (m) => setTransactionMessageFeePayerSigner(input.owner, m),
-    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
-    (m) => appendTransactionMessageInstructions(instructions, m)
-  );
-  const signed = await input.deadline.run("Signing the vault transaction", () =>
-    signTransactionMessageWithSigners(message)
-  );
-  const bytes = new Uint8Array(getTransactionEncoder().encode(signed));
-  const signature = await input.deadline.run("Broadcasting the vault transaction", () =>
-    solanaRpc.sendTransaction(rpc, bytes)
-  );
-  return { signature };
-}
-
-/**
  * Simulate before signing.
  *
  * Worth the extra round trip on this path specifically: the instructions were
@@ -275,9 +248,13 @@ export async function submitVaultPlan(
  */
 export async function simulateVaultPlan(
   env: Env,
-  input: VaultExecutionScope & { plan: EarnVaultTransactionPlan; owner: Address; rpcUrl: string }
+  input: VaultPlanExecutionScope & {
+    plan: EarnVaultTransactionPlan;
+    owner: Address;
+    rpcUrl: string;
+  }
 ): Promise<{ ok: true } | { ok: false; error: string; logs: readonly string[] }> {
-  assertExpectedPlanCluster(input.plan, input.cluster);
+  assertExpectedPlan(input.plan, input.cluster, input.expectedAssetIdentity);
   let batch: ReturnType<typeof singleBatchInstructions>;
   try {
     batch = singleBatchInstructions(input.plan);

--- a/apps/sdp-api/src/services/earn/vault-execution.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-execution.service.ts
@@ -1,0 +1,261 @@
+import type { EarnVaultTransactionPlan } from "@sdp/earn/types";
+import * as solanaRpc from "@sdp/rpc/solana";
+import {
+  type Address,
+  address,
+  appendTransactionMessageInstructions,
+  createNoopSigner,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  getSignatureFromTransaction,
+  getTransactionEncoder,
+  type Instruction,
+  pipe,
+  type Signature,
+  setTransactionMessageFeePayer,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type TransactionSigner,
+} from "@solana/kit";
+import {
+  partiallySignTransactionMessageWithSigners,
+  signTransactionMessageWithSigners,
+} from "@solana/signers";
+import type { FeePaymentPort } from "@/services/ports";
+import type { Env } from "@/types/env";
+
+/**
+ * Turn a provider's unsigned plan into a landed transaction, signed by an SDP
+ * custody wallet.
+ *
+ * This is the seam the whole vault-direct model rests on: a `vault_direct`
+ * provider custodies nothing and hands back instructions, so the ONLY thing
+ * that moves money is SDP signing with a wallet it controls. Nothing here is
+ * Kamino-specific — it consumes the neutral `EarnVaultTransactionPlan`.
+ */
+
+/** A plain-data instruction from the provider contract, back in kit form. */
+function toKitInstruction(instruction: EarnVaultTransactionPlan["transactions"][number][number]) {
+  return {
+    programAddress: address(instruction.programAddress),
+    accounts: instruction.accounts.map((account) => ({
+      address: address(account.address),
+      role: account.role,
+    })),
+    data: Uint8Array.from(Buffer.from(instruction.data, "base64")),
+  } as unknown as Instruction;
+}
+
+export type VaultFeeMode =
+  | { kind: "sponsored"; feePayment: FeePaymentPort }
+  | { kind: "wallet-pays" };
+
+export interface SubmitVaultPlanInput {
+  plan: EarnVaultTransactionPlan;
+  /** The custody wallet signer — the vault `user`, and the only real signer. */
+  owner: TransactionSigner;
+  rpcUrl: string;
+  fee: VaultFeeMode;
+}
+
+export interface SubmitVaultPlanResult {
+  signature: Signature;
+}
+
+export interface SignedVaultTransaction {
+  /** The wire bytes, ready to broadcast. */
+  bytes: Uint8Array;
+  /**
+   * The signature this transaction WILL have on chain, known before it is
+   * sent — a Solana signature is the fee payer's signature over the message,
+   * so signing determines it and broadcasting only publishes it.
+   */
+  signature: Signature;
+  /** Inclusive block height after which these exact bytes cannot land. */
+  lastValidBlockHeight: string;
+}
+
+/**
+ * Sign, WITHOUT sending.
+ *
+ * Split from the broadcast so the caller can durably record the signature
+ * before the transaction can possibly land. That ordering is the only thing
+ * that makes an ambiguous send recoverable: once bytes are on the wire, a
+ * timeout, a crash or a lost DB write leaves a transaction that may be on chain
+ * with money moved, and without the signature there is nothing to reconcile it
+ * against — SDP would not know the transfer exists.
+ *
+ * Wallet-pays only. In the sponsored path the relay signs as fee payer AFTER
+ * us, so the final signature is not knowable here; that path keeps the combined
+ * `submitVaultPlan` and owes the same treatment before it is switched on.
+ */
+export async function signVaultPlan(
+  env: Env,
+  input: { plan: EarnVaultTransactionPlan; owner: TransactionSigner; rpcUrl: string }
+): Promise<SignedVaultTransaction> {
+  const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayerSigner(input.owner, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(instructions, m)
+  );
+  const signed = await signTransactionMessageWithSigners(message);
+  return {
+    bytes: new Uint8Array(getTransactionEncoder().encode(signed)),
+    signature: getSignatureFromTransaction(signed),
+    lastValidBlockHeight: String(lastValidBlockHeight),
+  };
+}
+
+/**
+ * Broadcast bytes whose signature the caller has already recorded.
+ *
+ * Throwing here does NOT mean the transaction failed — it may have landed and
+ * the response been lost. The caller must treat a throw as UNKNOWN and leave
+ * the ledger row reconcilable against its recorded signature, never mark it
+ * failed.
+ */
+export async function broadcastVaultTransaction(
+  env: Env,
+  input: { bytes: Uint8Array; rpcUrl: string }
+): Promise<void> {
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  await solanaRpc.sendTransaction(rpc, input.bytes);
+}
+
+/** The single batch a deposit plan carries, with the multi-transaction refusal. */
+function singleBatchInstructions(plan: EarnVaultTransactionPlan) {
+  if (plan.lookupTables.length > 0) {
+    // Address lookup tables require a different compilation path. Refuse them
+    // at the shared boundary so simulation, signing and submission cannot each
+    // make a different assumption about the same provider plan.
+    throw new Error("Vault plans with address lookup tables are not implemented");
+  }
+  const batch = plan.transactions[0];
+  if (!batch || batch.length === 0) {
+    throw new Error("Vault plan carried no instructions");
+  }
+  if (plan.transactions.length > 1) {
+    // Multi-transaction plans need per-leg ledger rows and a resume story; the
+    // deposit path never produces one today, so refuse rather than silently
+    // land only the first leg.
+    throw new Error(
+      `Vault plan needs ${plan.transactions.length} transactions; multi-transaction submission is not implemented`
+    );
+  }
+  return batch;
+}
+
+/**
+ * Decide who pays the transaction fee.
+ *
+ * Kora only sponsors transactions whose programs are on its allowlist, and the
+ * Kamino kvault/klend programs are not on it (the Private Channels escrow hit
+ * the same wall and still pays its own fee). Rather than fail at submit with an
+ * opaque relay rejection, callers pass `wallet-pays` when sponsorship is not
+ * available for the programs in the plan.
+ *
+ * NOTE the distinction that is easy to lose: klend-sdk also has a `payer`
+ * concept, but that is the RENT payer for created ATAs, embedded in the
+ * instruction accounts. This function is about the TRANSACTION FEE payer, which
+ * is a property of the message. They are different spends and must not be
+ * conflated — a sponsor that agreed to fees has not agreed to fund rent.
+ */
+export async function submitVaultPlan(
+  env: Env,
+  input: SubmitVaultPlanInput
+): Promise<SubmitVaultPlanResult> {
+  const instructions = singleBatchInstructions(input.plan).map(toKitInstruction);
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+
+  if (input.fee.kind === "sponsored") {
+    // Sponsored: the relay's address is the fee payer and signs AFTER us, so the
+    // message carries a noop signer for it and the custody wallet signs its own
+    // slots only.
+    const feePayer = await input.fee.feePayment.getFeePayer();
+    const message = pipe(
+      createTransactionMessage({ version: 0 }),
+      (m) => setTransactionMessageFeePayerSigner(createNoopSigner(feePayer), m),
+      (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+      (m) => appendTransactionMessageInstructions(instructions, m)
+    );
+    const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
+    const bytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
+    const signature = await input.fee.feePayment.signAndSend(bytes);
+    return { signature };
+  }
+
+  // Wallet pays: the custody wallet is both the vault `user` and the fee payer,
+  // so it signs once for both and we broadcast directly.
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayerSigner(input.owner, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(instructions, m)
+  );
+  const signed = await signTransactionMessageWithSigners(message);
+  const bytes = new Uint8Array(getTransactionEncoder().encode(signed));
+  const signature = await solanaRpc.sendTransaction(rpc, bytes);
+  return { signature };
+}
+
+/**
+ * Simulate before signing.
+ *
+ * Worth the extra round trip on this path specifically: the instructions were
+ * assembled by a third-party SDK against live vault state, so a stale reserve
+ * set or a changed vault config surfaces here as a readable program error
+ * instead of a landed, failed transaction the customer still paid for.
+ */
+export async function simulateVaultPlan(
+  env: Env,
+  input: { plan: EarnVaultTransactionPlan; owner: Address; rpcUrl: string }
+): Promise<{ ok: true } | { ok: false; error: string; logs: readonly string[] }> {
+  let batch: ReturnType<typeof singleBatchInstructions>;
+  try {
+    batch = singleBatchInstructions(input.plan);
+  } catch (cause) {
+    return {
+      ok: false,
+      error: cause instanceof Error ? cause.message : "invalid vault plan",
+      logs: [],
+    };
+  }
+
+  const rpc = solanaRpc.createRpc(env, { rpcUrl: input.rpcUrl });
+  const { blockhash, lastValidBlockHeight } = await solanaRpc.getRecentBlockhash(rpc, "confirmed");
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (m) => setTransactionMessageFeePayer(input.owner, m),
+    (m) => setTransactionMessageLifetimeUsingBlockhash({ blockhash, lastValidBlockHeight }, m),
+    (m) => appendTransactionMessageInstructions(batch.map(toKitInstruction), m)
+  );
+
+  // `sigVerify: false` + `replaceRecentBlockhash` so an unsigned message can be
+  // simulated: we want the PROGRAM's verdict, not a signature check.
+  const compiled = await partiallySignTransactionMessageWithSigners(message);
+  const wire = getBase64EncodedWireTransaction(compiled);
+  const result = await rpc
+    .simulateTransaction(wire, {
+      encoding: "base64",
+      sigVerify: false,
+      replaceRecentBlockhash: true,
+    })
+    .send();
+
+  if (result.value.err) {
+    return {
+      ok: false,
+      error: JSON.stringify(result.value.err, (_key, value) =>
+        typeof value === "bigint" ? value.toString() : value
+      ),
+      logs: result.value.logs ?? [],
+    };
+  }
+  return { ok: true };
+}

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -84,6 +84,18 @@ export interface Env {
 
   // Solana configuration
   SOLANA_RPC_URL?: string;
+  /**
+   * Optional PER-CLUSTER overrides for the Earn execution path.
+   *
+   * One API process serves both clusters — sandbox projects are devnet,
+   * production projects are mainnet-beta — so a single `SOLANA_RPC_URL` cannot
+   * be correct for both. Unset falls back to `SOLANA_RPC_URL`, which must then
+   * prove its chain by genesis hash before anything is built against it
+   * (`assertClusterEndpoint`), so a single-cluster deployment keeps working and
+   * a mismatch is a refusal rather than a confidently wrong transaction.
+   */
+  SOLANA_DEVNET_RPC_URL?: string;
+  SOLANA_MAINNET_RPC_URL?: string;
   SOLANA_RPC_DEFAULT_PROVIDER?: OrganizationRpcProvider;
   SOLANA_RPC_TRITON_URL?: string;
   SOLANA_RPC_TRITON_API_KEY?: string;

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const runOperation: KaminoVaultOperationRunner = (_label, operation) => operation();
+const runOperation: KaminoVaultOperationRunner = (_label, operation) => operation(() => undefined);
 const client = new KaminoVaultDirectClient(async () => "https://example.invalid", runOperation);
 
 describe("KaminoVaultDirectClient capabilities", () => {
@@ -151,6 +151,37 @@ describe("KaminoVaultDirectClient capabilities", () => {
     expect(mocks.readKaminoPosition).not.toHaveBeenCalled();
   });
 
+  it("does not start provider work when endpoint proof finishes after expiry", async () => {
+    let resolveRpc!: (url: string) => void;
+    let expired = false;
+    const probe = new KaminoVaultDirectClient(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRpc = resolve;
+        }),
+      (_label, operation) =>
+        operation(() => {
+          if (expired) throw new Error("vault operation expired");
+        })
+    );
+
+    const pending = probe.buildVaultDeposit(
+      { env: {}, environment: "sandbox" },
+      {
+        providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+        owner: "11111111111111111111111111111112",
+        amount: "1",
+      }
+    );
+    await vi.waitFor(() => expect(resolveRpc).toBeTypeOf("function"));
+
+    expired = true;
+    resolveRpc("https://devnet.example.invalid");
+
+    await expect(pending).rejects.toThrow("vault operation expired");
+    expect(mocks.buildKaminoDepositPlan).not.toHaveBeenCalled();
+  });
+
   it("discovers owner-held vaults on chain without consulting the curated shelf", async () => {
     const resolvedRpcUrl = "https://devnet.example.invalid";
     const resolveRpcUrl = vi.fn(async () => resolvedRpcUrl);
@@ -203,7 +234,8 @@ describe("KaminoVaultDirectClient capabilities", () => {
     );
     expect(mocks.discoverKaminoPositionVaults).toHaveBeenCalledWith(
       { cluster: "devnet", rpcUrl: resolvedRpcUrl },
-      address(owner)
+      address(owner),
+      expect.any(Function)
     );
     expect(listStrategies).not.toHaveBeenCalled();
     expect(mocks.createKaminoRpc).toHaveBeenCalledWith(resolvedRpcUrl);
@@ -368,6 +400,42 @@ describe("KaminoVaultDirectClient capabilities", () => {
     expect(mocks.readKaminoPosition.mock.calls.every(([, input]) => input.slot === slot)).toBe(
       true
     );
+  });
+
+  it("does not dequeue more position reads after the operation expires", async () => {
+    let expired = false;
+    const probe = new KaminoVaultDirectClient(
+      async () => "https://devnet.example.invalid",
+      (_label, operation) =>
+        operation(() => {
+          if (expired) throw new Error("vault operation expired");
+        })
+    );
+    mocks.createKaminoRpc.mockReturnValue({
+      getSlot: () => ({ send: vi.fn().mockResolvedValue(123n) }),
+    });
+    const releases: Array<() => void> = [];
+    mocks.readKaminoPosition.mockImplementation(
+      () => new Promise<KaminoPosition>((resolve) => releases.push(() => resolve({} as never)))
+    );
+    const providerReference = "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx";
+
+    const pending = probe.readVaultPositions(
+      { env: {}, environment: "sandbox" },
+      {
+        owner: "11111111111111111111111111111112",
+        providerReferences: Array.from({ length: 9 }, () => providerReference),
+      }
+    );
+    await vi.waitFor(() =>
+      expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(KAMINO_POSITION_READ_CONCURRENCY)
+    );
+
+    expired = true;
+    for (const release of releases.splice(0)) release();
+
+    await expect(pending).rejects.toThrow("vault operation expired");
+    expect(mocks.readKaminoPosition).toHaveBeenCalledTimes(KAMINO_POSITION_READ_CONCURRENCY);
   });
 });
 

--- a/packages/sdp-kamino/src/client.test.ts
+++ b/packages/sdp-kamino/src/client.test.ts
@@ -9,6 +9,7 @@ import {
   assertNotPortfolioProvider,
   KAMINO_POSITION_READ_CONCURRENCY,
   KaminoVaultDirectClient,
+  type KaminoVaultOperationRunner,
   toEarnVaultTransactionPlan,
 } from "./client";
 import type { KaminoInstructionPlan, KaminoPosition, KaminoRuntime } from "./types";
@@ -34,7 +35,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const client = new KaminoVaultDirectClient(() => "https://example.invalid");
+const runOperation: KaminoVaultOperationRunner = (_label, operation) => operation();
+const client = new KaminoVaultDirectClient(async () => "https://example.invalid", runOperation);
 
 describe("KaminoVaultDirectClient capabilities", () => {
   it("reports the vault-direct capability", () => {
@@ -79,7 +81,7 @@ describe("KaminoVaultDirectClient capabilities", () => {
   });
 
   it("refuses to build when no RPC endpoint is configured for the cluster", async () => {
-    const unconfigured = new KaminoVaultDirectClient(() => "  ");
+    const unconfigured = new KaminoVaultDirectClient(async () => "  ", runOperation);
     await expect(
       unconfigured.buildVaultDeposit(
         { env: {}, environment: "sandbox" },
@@ -96,10 +98,10 @@ describe("KaminoVaultDirectClient capabilities", () => {
 
   it("maps the SDP environment to the right cluster", async () => {
     const seen: string[] = [];
-    const probe = new KaminoVaultDirectClient((_ctx, cluster) => {
+    const probe = new KaminoVaultDirectClient(async (_ctx, cluster) => {
       seen.push(cluster);
       return "";
-    });
+    }, runOperation);
     for (const environment of ["sandbox", "production"] as const) {
       await probe
         .buildVaultDeposit(
@@ -117,10 +119,42 @@ describe("KaminoVaultDirectClient capabilities", () => {
     expect(seen).toEqual(["devnet", "mainnet-beta"]);
   });
 
+  it("requires the proven RPC resolver before any chain work", async () => {
+    const resolverError = new Error("RPC endpoint was not proven");
+    const unproven = new KaminoVaultDirectClient(async () => {
+      throw resolverError;
+    }, runOperation);
+
+    await expect(
+      unproven.buildVaultDeposit(
+        { env: {}, environment: "sandbox" },
+        {
+          providerReference: "7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx",
+          owner: "11111111111111111111111111111112",
+          amount: "1",
+        }
+      )
+    ).rejects.toBe(resolverError);
+    await expect(
+      unproven.readVaultPositions(
+        { env: {}, environment: "sandbox" },
+        {
+          owner: "11111111111111111111111111111112",
+          providerReferences: ["7uib8xGAwkaPz4ZGCA6t8sSEid5Yp9ty13PHUweTypx"],
+        }
+      )
+    ).rejects.toBe(resolverError);
+
+    expect(mocks.buildKaminoDepositPlan).not.toHaveBeenCalled();
+    expect(mocks.discoverKaminoPositionVaults).not.toHaveBeenCalled();
+    expect(mocks.createKaminoRpc).not.toHaveBeenCalled();
+    expect(mocks.readKaminoPosition).not.toHaveBeenCalled();
+  });
+
   it("discovers owner-held vaults on chain without consulting the curated shelf", async () => {
     const resolvedRpcUrl = "https://devnet.example.invalid";
-    const resolveRpcUrl = vi.fn(() => resolvedRpcUrl);
-    const probe = new KaminoVaultDirectClient(resolveRpcUrl);
+    const resolveRpcUrl = vi.fn(async () => resolvedRpcUrl);
+    const probe = new KaminoVaultDirectClient(resolveRpcUrl, runOperation);
     const slot = 123n;
     const getSlotSend = vi.fn().mockResolvedValue(slot);
     mocks.createKaminoRpc.mockReturnValue({ getSlot: () => ({ send: getSlotSend }) });
@@ -195,7 +229,10 @@ describe("KaminoVaultDirectClient capabilities", () => {
   });
 
   it("returns an empty snapshot without slot or hydration reads when discovery finds no holdings", async () => {
-    const probe = new KaminoVaultDirectClient(() => "https://devnet.example.invalid");
+    const probe = new KaminoVaultDirectClient(
+      async () => "https://devnet.example.invalid",
+      runOperation
+    );
     mocks.discoverKaminoPositionVaults.mockResolvedValue([]);
 
     await expect(
@@ -214,7 +251,10 @@ describe("KaminoVaultDirectClient capabilities", () => {
   });
 
   it("propagates on-chain discovery failures instead of reporting no holdings", async () => {
-    const probe = new KaminoVaultDirectClient(() => "https://devnet.example.invalid");
+    const probe = new KaminoVaultDirectClient(
+      async () => "https://devnet.example.invalid",
+      runOperation
+    );
     const discoveryError = new Error("program census unavailable");
     mocks.discoverKaminoPositionVaults.mockRejectedValue(discoveryError);
 

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -26,12 +26,13 @@ export const KAMINO_POSITION_READ_CONCURRENCY = 4;
  */
 export type KaminoVaultOperationRunner = <T>(
   label: string,
-  operation: () => Promise<T>
+  operation: (assertActive: () => void) => Promise<T>
 ) => Promise<T>;
 
 async function mapSettledWithConcurrency<T, U>(
   items: readonly T[],
   concurrency: number,
+  assertActive: () => void,
   mapper: (item: T) => Promise<U>
 ): Promise<Array<PromiseSettledResult<U>>> {
   const results = new Array<PromiseSettledResult<U>>(items.length);
@@ -41,6 +42,9 @@ async function mapSettledWithConcurrency<T, U>(
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
       while (nextIndex < items.length) {
+        // A timed-out aggregate read cannot cancel an in-flight SDK request,
+        // but it must never dequeue another vault after the budget expires.
+        assertActive();
         const index = nextIndex;
         nextIndex += 1;
         try {
@@ -136,10 +140,15 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
   private async withRuntime<T>(
     ctx: EarnRuntimeContext,
     label: string,
-    operation: (runtime: KaminoRuntime) => Promise<T>
+    operation: (runtime: KaminoRuntime, assertActive: () => void) => Promise<T>
   ): Promise<T> {
-    const runtime = await this.runtime(ctx);
-    return this.runOperation(label, () => operation(runtime));
+    return this.runOperation(label, async (assertActive) => {
+      // Endpoint resolution/proof and provider work are one operation, so they
+      // consume one deadline rather than receiving independent budgets.
+      const runtime = await this.runtime(ctx);
+      assertActive();
+      return operation(runtime, assertActive);
+    });
   }
 
   /**
@@ -157,13 +166,20 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     ctx: EarnRuntimeContext,
     input: EarnVaultDepositInput
   ): Promise<EarnVaultTransactionPlan> {
-    const plan = await this.withRuntime(ctx, "Building the vault deposit", (runtime) =>
-      buildKaminoDepositPlan(runtime, {
-        vault: address(input.providerReference),
-        owner: this.owner(input.owner),
-        amount: input.amount,
-        ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
-      })
+    const plan = await this.withRuntime(
+      ctx,
+      "Building the vault deposit",
+      (runtime, assertActive) =>
+        buildKaminoDepositPlan(
+          runtime,
+          {
+            vault: address(input.providerReference),
+            owner: this.owner(input.owner),
+            amount: input.amount,
+            ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
+          },
+          assertActive
+        )
     );
     return toEarnVaultTransactionPlan(plan);
   }
@@ -206,22 +222,26 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     ctx: EarnRuntimeContext,
     input: EarnVaultPositionInput
   ): Promise<EarnVaultPositionSnapshot[]> {
-    return this.withRuntime(ctx, "Reading vault positions", async (runtime) => {
+    return this.withRuntime(ctx, "Reading vault positions", async (runtime, assertActive) => {
       const owner: Address = address(input.owner);
       const readAllHoldings = input.providerReferences.length === 0;
       const providerReferences = readAllHoldings
-        ? await discoverKaminoPositionVaults(runtime, owner)
+        ? await discoverKaminoPositionVaults(runtime, owner, assertActive)
         : input.providerReferences;
+      assertActive();
       if (providerReferences.length === 0) return [];
 
       // One shared slot makes the page internally consistent. The client carries
       // the same transport deadline as every nested Kamino SDK read below.
       const slot = await createKaminoRpc(runtime.rpcUrl).getSlot().send();
+      assertActive();
 
       const results = await mapSettledWithConcurrency(
         providerReferences,
         KAMINO_POSITION_READ_CONCURRENCY,
-        (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
+        assertActive,
+        (reference) =>
+          readKaminoPosition(runtime, { vault: address(reference), owner, slot }, assertActive)
       );
 
       const failures = results.flatMap((result, index) =>

--- a/packages/sdp-kamino/src/client.ts
+++ b/packages/sdp-kamino/src/client.ts
@@ -19,6 +19,16 @@ import type { KaminoInstructionPlan, KaminoRuntime } from "./types";
 /** One portfolio request may fan out over many vaults; never fan out the RPCs without a bound. */
 export const KAMINO_POSITION_READ_CONCURRENCY = 4;
 
+/**
+ * API-owned execution guard for one provider operation. The API injects its
+ * absolute vault deadline here without creating a dependency from this package
+ * back to the application layer.
+ */
+export type KaminoVaultOperationRunner = <T>(
+  label: string,
+  operation: () => Promise<T>
+) => Promise<T>;
+
 async function mapSettledWithConcurrency<T, U>(
   items: readonly T[],
   concurrency: number,
@@ -90,24 +100,29 @@ export function toEarnVaultTransactionPlan(plan: KaminoInstructionPlan): EarnVau
  */
 export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVaultDirectProvider {
   /**
-   * Where the RPC endpoint comes from.
+   * Where a PROVEN RPC endpoint comes from and how its operation is bounded.
    *
    * Injected rather than read from `ctx.env.SOLANA_RPC_URL` directly, because
    * that variable is PROCESS-level while the cluster is PER-REQUEST: syncing the
    * sandbox environment inside a production deployment reaches this code with a
-   * MAINNET url. The API resolves the right endpoint for the cluster it is
-   * serving and hands it in; `listKaminoDevnetVaults` guards the same hazard
-   * with a genesis-hash check.
+   * MAINNET url. The API must prove the resolved URL's genesis before returning
+   * it. Keeping that resolver inside `runtime` makes proof a class invariant for
+   * deposit, positions, and future chain capabilities rather than something a
+   * route has to remember.
    */
   constructor(
-    private readonly resolveRpcUrl: (ctx: EarnRuntimeContext, cluster: SolanaCluster) => string
+    private readonly resolveProvenRpcUrl: (
+      ctx: EarnRuntimeContext,
+      cluster: SolanaCluster
+    ) => Promise<string>,
+    private readonly runOperation: KaminoVaultOperationRunner
   ) {
     super();
   }
 
-  private runtime(ctx: EarnRuntimeContext): KaminoRuntime {
+  private async runtime(ctx: EarnRuntimeContext): Promise<KaminoRuntime> {
     const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
-    const rpcUrl = this.resolveRpcUrl(ctx, cluster);
+    const rpcUrl = await this.resolveProvenRpcUrl(ctx, cluster);
     if (!rpcUrl.trim()) {
       throw new SdpKaminoError(
         "VAULT_UNREADABLE",
@@ -115,6 +130,16 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
       );
     }
     return { cluster, rpcUrl };
+  }
+
+  /** Every chain capability enters through this proof-then-deadline boundary. */
+  private async withRuntime<T>(
+    ctx: EarnRuntimeContext,
+    label: string,
+    operation: (runtime: KaminoRuntime) => Promise<T>
+  ): Promise<T> {
+    const runtime = await this.runtime(ctx);
+    return this.runOperation(label, () => operation(runtime));
   }
 
   /**
@@ -132,12 +157,14 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     ctx: EarnRuntimeContext,
     input: EarnVaultDepositInput
   ): Promise<EarnVaultTransactionPlan> {
-    const plan = await buildKaminoDepositPlan(this.runtime(ctx), {
-      vault: address(input.providerReference),
-      owner: this.owner(input.owner),
-      amount: input.amount,
-      ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
-    });
+    const plan = await this.withRuntime(ctx, "Building the vault deposit", (runtime) =>
+      buildKaminoDepositPlan(runtime, {
+        vault: address(input.providerReference),
+        owner: this.owner(input.owner),
+        amount: input.amount,
+        ...(input.minSharesOut === undefined ? {} : { minSharesOut: input.minSharesOut }),
+      })
+    );
     return toEarnVaultTransactionPlan(plan);
   }
 
@@ -179,68 +206,69 @@ export class KaminoVaultDirectClient extends KaminoEarnClient implements EarnVau
     ctx: EarnRuntimeContext,
     input: EarnVaultPositionInput
   ): Promise<EarnVaultPositionSnapshot[]> {
-    const runtime = this.runtime(ctx);
-    const owner: Address = address(input.owner);
-    const readAllHoldings = input.providerReferences.length === 0;
-    const providerReferences = readAllHoldings
-      ? await discoverKaminoPositionVaults(runtime, owner)
-      : input.providerReferences;
-    if (providerReferences.length === 0) return [];
+    return this.withRuntime(ctx, "Reading vault positions", async (runtime) => {
+      const owner: Address = address(input.owner);
+      const readAllHoldings = input.providerReferences.length === 0;
+      const providerReferences = readAllHoldings
+        ? await discoverKaminoPositionVaults(runtime, owner)
+        : input.providerReferences;
+      if (providerReferences.length === 0) return [];
 
-    // One shared slot makes the page internally consistent. The client carries
-    // the same transport deadline as every nested Kamino SDK read below.
-    const slot = await createKaminoRpc(runtime.rpcUrl).getSlot().send();
+      // One shared slot makes the page internally consistent. The client carries
+      // the same transport deadline as every nested Kamino SDK read below.
+      const slot = await createKaminoRpc(runtime.rpcUrl).getSlot().send();
 
-    const results = await mapSettledWithConcurrency(
-      providerReferences,
-      KAMINO_POSITION_READ_CONCURRENCY,
-      (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
-    );
-
-    const failures = results.flatMap((result, index) =>
-      result.status === "rejected"
-        ? [{ providerReference: providerReferences[index], cause: result.reason }]
-        : []
-    );
-    if (failures.length > 0) {
-      throw new SdpKaminoError(
-        "VAULT_UNREADABLE",
-        `Kamino could not read ${failures.length} of ${providerReferences.length} requested ` +
-          "vault positions; refusing to return a partial portfolio.",
-        {
-          cause: new AggregateError(
-            failures.map(({ providerReference, cause }) =>
-              cause instanceof Error
-                ? new Error(`Kamino vault ${providerReference} read failed`, { cause })
-                : new Error(`Kamino vault ${providerReference} read failed: ${String(cause)}`)
-            ),
-            "Kamino vault position reads failed"
-          ),
-        }
+      const results = await mapSettledWithConcurrency(
+        providerReferences,
+        KAMINO_POSITION_READ_CONCURRENCY,
+        (reference) => readKaminoPosition(runtime, { vault: address(reference), owner, slot })
       );
-    }
 
-    return results.flatMap((result) => {
-      // All rejected results were handled above, so only fulfilled values can
-      // reach the serializer. Keep the guard for TypeScript's settled-result
-      // narrowing and as a defensive assertion if this block is later moved.
-      if (result.status !== "fulfilled") return [];
-      const position = result.value;
-      // Exact reads serialize zero canonically as "0". A full-portfolio read
-      // reports holdings, while an explicitly requested vault may still return
-      // a truthful zero balance.
-      if (readAllHoldings && position.shares === "0") return [];
-      return [
-        {
-          providerReference: String(position.vault),
-          owner: String(position.owner),
-          cluster: position.cluster,
-          shares: position.shares,
-          ...(position.tokenValue === undefined ? {} : { tokenValue: position.tokenValue }),
-          tokenMint: String(position.tokenMint),
-          shareMint: String(position.sharesMint),
-        },
-      ];
+      const failures = results.flatMap((result, index) =>
+        result.status === "rejected"
+          ? [{ providerReference: providerReferences[index], cause: result.reason }]
+          : []
+      );
+      if (failures.length > 0) {
+        throw new SdpKaminoError(
+          "VAULT_UNREADABLE",
+          `Kamino could not read ${failures.length} of ${providerReferences.length} requested ` +
+            "vault positions; refusing to return a partial portfolio.",
+          {
+            cause: new AggregateError(
+              failures.map(({ providerReference, cause }) =>
+                cause instanceof Error
+                  ? new Error(`Kamino vault ${providerReference} read failed`, { cause })
+                  : new Error(`Kamino vault ${providerReference} read failed: ${String(cause)}`)
+              ),
+              "Kamino vault position reads failed"
+            ),
+          }
+        );
+      }
+
+      return results.flatMap((result) => {
+        // All rejected results were handled above, so only fulfilled values can
+        // reach the serializer. Keep the guard for TypeScript's settled-result
+        // narrowing and as a defensive assertion if this block is later moved.
+        if (result.status !== "fulfilled") return [];
+        const position = result.value;
+        // Exact reads serialize zero canonically as "0". A full-portfolio read
+        // reports holdings, while an explicitly requested vault may still return
+        // a truthful zero balance.
+        if (readAllHoldings && position.shares === "0") return [];
+        return [
+          {
+            providerReference: String(position.vault),
+            owner: String(position.owner),
+            cluster: position.cluster,
+            shares: position.shares,
+            ...(position.tokenValue === undefined ? {} : { tokenValue: position.tokenValue }),
+            tokenMint: String(position.tokenMint),
+            shareMint: String(position.sharesMint),
+          },
+        ];
+      });
     });
   }
 }

--- a/packages/sdp-kamino/src/index.ts
+++ b/packages/sdp-kamino/src/index.ts
@@ -22,7 +22,11 @@
  * the constants.
  */
 
-export { assertNotPortfolioProvider, KaminoVaultDirectClient } from "./client";
+export {
+  assertNotPortfolioProvider,
+  KaminoVaultDirectClient,
+  type KaminoVaultOperationRunner,
+} from "./client";
 export { SdpKaminoError, type SdpKaminoErrorCode } from "./errors";
 export {
   assertPlanTargetsCluster,

--- a/packages/sdp-kamino/src/sdk.ts
+++ b/packages/sdp-kamino/src/sdk.ts
@@ -39,6 +39,8 @@ import type {
 /** klend-sdk's kit-2 surface, as far as this module needs to name it. */
 // biome-ignore lint/suspicious/noExplicitAny: the kit-2 <-> kit-6.8 seam; see the header.
 type Kit2 = any;
+type AssertActive = () => void;
+const alwaysActive: AssertActive = () => undefined;
 
 /**
  * Bind a vault so that READS AND WRITES USE THE SAME PROGRAM. Every entry point
@@ -78,7 +80,12 @@ function createVaultClient(runtime: KaminoRuntime) {
   return { client, config, rpc };
 }
 
-async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
+async function bindVault(
+  runtime: KaminoRuntime,
+  vaultAddress: Address,
+  assertActive: AssertActive = alwaysActive
+) {
+  assertActive();
   const { client, config, rpc } = createVaultClient(runtime);
 
   // The probe exists only to fetch state under the right program id; it is never
@@ -97,6 +104,7 @@ async function bindVault(runtime: KaminoRuntime, vaultAddress: Address) {
   } catch (cause) {
     throw vaultUnreadable(vaultAddress, runtime.cluster, cause);
   }
+  assertActive();
 
   const vault = KaminoVault.loadWithClientAndState(client, vaultAddress as Kit2, state);
   if (String(vault.programId) !== String(config.kvaultProgramId)) {
@@ -159,9 +167,14 @@ function asInstructions(raw: readonly Kit2[]): readonly Instruction[] {
  */
 export async function buildKaminoDepositPlan(
   runtime: KaminoRuntime,
-  input: KaminoDepositInput
+  input: KaminoDepositInput,
+  assertActive: AssertActive = alwaysActive
 ): Promise<KaminoInstructionPlan> {
-  const { client, vault, state, config, assetIdentity } = await bindVault(runtime, input.vault);
+  const { client, vault, state, config, assetIdentity } = await bindVault(
+    runtime,
+    input.vault,
+    assertActive
+  );
 
   // Precision is checked against the MINT, so it can only be checked once the
   // vault has been read — the token and share mints have independent decimals
@@ -174,7 +187,9 @@ export async function buildKaminoDepositPlan(
   if (isZeroAmount(acceptedAmount)) throw invalidAmount("amount", input.amount);
   const amount = toDecimal(acceptedAmount, "amount");
 
+  assertActive();
   const reserves = await client.loadVaultReserves(state);
+  assertActive();
 
   let acceptedMinSharesOut: string | undefined;
   let minSharesOut: Decimal | undefined;
@@ -202,6 +217,7 @@ export async function buildKaminoDepositPlan(
     undefined,
     minSharesOut
   );
+  assertActive();
 
   const instructions = asInstructions([
     ...(bundle.depositIxs ?? []),
@@ -305,12 +321,14 @@ export async function buildKaminoWithdrawPlan(
  */
 export async function discoverKaminoPositionVaults(
   runtime: KaminoRuntime,
-  owner: Address
+  owner: Address,
+  assertActive: AssertActive = alwaysActive
 ): Promise<Address[]> {
+  assertActive();
   const { client } = createVaultClient(runtime);
+  let candidateBalances: Map<Kit2, Kit2>;
   try {
-    const candidateBalances = await client.getUserSharesBalanceAllVaults(owner as Kit2);
-    return [...candidateBalances.keys()].map((vault) => vault as Address);
+    candidateBalances = await client.getUserSharesBalanceAllVaults(owner as Kit2);
   } catch (cause) {
     throw new SdpKaminoError(
       "VAULT_UNREADABLE",
@@ -318,6 +336,8 @@ export async function discoverKaminoPositionVaults(
       { cause }
     );
   }
+  assertActive();
+  return [...candidateBalances.keys()].map((vault) => vault as Address);
 }
 
 /**
@@ -357,9 +377,14 @@ async function readUnstakedShareBaseUnits(
  */
 export async function readKaminoPosition(
   runtime: KaminoRuntime,
-  input: { vault: Address; owner: Address; slot: bigint }
+  input: { vault: Address; owner: Address; slot: bigint },
+  assertActive: AssertActive = alwaysActive
 ): Promise<KaminoPosition> {
-  const { vault, state, config, rpc, assetIdentity } = await bindVault(runtime, input.vault);
+  const { vault, state, config, rpc, assetIdentity } = await bindVault(
+    runtime,
+    input.vault,
+    assertActive
+  );
   const shareDecimals = mintDecimals(state.sharesMintDecimals, "sharesMintDecimals");
 
   // UNSTAKED shares are counted here rather than taken from the SDK, and that is
@@ -373,8 +398,11 @@ export async function readKaminoPosition(
   // STAKED shares still come from the SDK: that half is derived from farm state
   // as an exact `Decimal`, never through `uiAmount`, so re-implementing it would
   // duplicate the farm lookup for no precision gain.
+  assertActive();
   const staked = await vault.getUserShares(input.owner as Kit2);
+  assertActive();
   const unstakedBase = await readUnstakedShareBaseUnits(rpc, input.owner, assetIdentity.shareMint);
+  assertActive();
   const shares = requireNonNegativeFiniteDecimal(
     "total share balance",
     new Decimal(formatDecimalAmount(unstakedBase, shareDecimals)).add(
@@ -383,11 +411,16 @@ export async function readKaminoPosition(
   );
 
   let tokenValue: string | undefined;
+  let rawRate: unknown;
   try {
-    const rate = requireNonNegativeFiniteDecimal(
-      "vault exchange rate",
-      await vault.getExchangeRate(input.slot as Kit2)
-    );
+    rawRate = await vault.getExchangeRate(input.slot as Kit2);
+  } catch {
+    rawRate = undefined;
+  }
+  assertActive();
+  try {
+    if (rawRate === undefined) throw new Error("vault exchange rate unavailable");
+    const rate = requireNonNegativeFiniteDecimal("vault exchange rate", rawRate);
     const decimals = mintDecimals(state.tokenMintDecimals, "tokenMintDecimals");
     // Round-trip through the repo's own fixed-point helpers so the string that
     // leaves this package is scaled exactly like every other amount in SDP.

--- a/packages/sdp-rpc/src/solana.ts
+++ b/packages/sdp-rpc/src/solana.ts
@@ -170,8 +170,10 @@ function withRequestTimeout(transport: RpcTransport, timeoutMs: number): RpcTran
  * Create a configured Solana RPC client from environment
  */
 export function createRpc(env: RpcEnv, options?: RpcClientOptions): SolanaRpc {
-  const config = getSolanaConfig(env);
-  const rpcUrl = options?.rpcUrl ?? config.rpcUrl;
+  // An explicit URL is already the complete endpoint selection. Do not force
+  // callers with a per-request/per-cluster URL to also configure the legacy
+  // process default merely to construct a client for that explicit endpoint.
+  const rpcUrl = options?.rpcUrl ?? getSolanaConfig(env).rpcUrl;
   const timeoutMs = options?.requestTimeoutMs ?? DEFAULT_RPC_REQUEST_TIMEOUT_MS;
 
   let transport: RpcTransport;

--- a/packages/sdp-types/src/well-known-tokens.ts
+++ b/packages/sdp-types/src/well-known-tokens.ts
@@ -309,6 +309,29 @@ export const CLUSTER_BY_SDP_ENVIRONMENT = {
   production: "mainnet-beta",
 } as const satisfies Record<SdpEnvironment, SolanaCluster>;
 
+/**
+ * Each cluster's genesis hash — the only honest way to ask an RPC endpoint
+ * WHICH CHAIN it actually serves.
+ *
+ * Needed because a cluster mismatch is invisible in exactly the wrong
+ * direction. Kamino's mainnet kvault program id also resolves on devnet with
+ * zero accounts under it, so aiming a devnet request at a mainnet endpoint (or
+ * the reverse) does not error — it reports "no such vault", or worse, succeeds
+ * against the wrong deployment. Inferring the cluster from the URL is no
+ * substitute: provider URLs are opaque, and a mainnet endpoint need not contain
+ * the word "mainnet".
+ *
+ * Lives here because both `@sdp/earn` (catalogue sync) and the API's execution
+ * registry need it and neither may depend on the other — the same argument the
+ * Kamino program tables make.
+ */
+export const GENESIS_HASH_BY_CLUSTER = {
+  // biome-ignore lint/security/noSecrets: Solana mainnet-beta's public genesis hash
+  "mainnet-beta": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d",
+  // biome-ignore lint/security/noSecrets: Solana devnet's public genesis hash
+  devnet: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+} as const satisfies Record<SolanaCluster, string>;
+
 export function isWellKnownTokenSymbol(value: string): value is WellKnownTokenSymbol {
   return Object.hasOwn(WELL_KNOWN_TOKENS, value);
 }

--- a/scripts/secret-keys.mjs
+++ b/scripts/secret-keys.mjs
@@ -33,6 +33,11 @@ export const API_LOCAL_ENV_KEYS = [
   "ALLOWLIST_ADMIN_KEY",
   "ALLOWLIST_ADMIN_ORG_ID",
   "SOLANA_RPC_URL",
+  // Optional per-cluster overrides. One API process serves sandbox (devnet) and
+  // production (mainnet-beta), so the Earn execution path resolves its endpoint
+  // by cluster and falls back to SOLANA_RPC_URL when these are unset.
+  "SOLANA_DEVNET_RPC_URL",
+  "SOLANA_MAINNET_RPC_URL",
   "SOLANA_RPC_DEFAULT_PROVIDER",
   "SOLANA_RPC_TRITON_URL",
   "SOLANA_RPC_TRITON_API_KEY",


### PR DESCRIPTION
## Stack

1. #1350 — Kamino SDK and neutral contracts
2. #1351 — SQL movement ledger
3. **#1352 — execution runtime (this PR)**
4. #1353 — policy-gated API
5. #1354 — dashboard experience

All five PRs are drafts and merge bottom-up.


## Why

The API needs a cluster-proven, provider-neutral execution boundary before a route is allowed to ask custody to sign anything. This layer adds that runtime without registering a public read or write endpoint.

## What changes

- Add the execution-only provider registry, separate from the lightweight catalogue registry.
- Resolve devnet/mainnet RPC endpoints per SDP environment and prove their genesis hash with a short-lived cache.
- Evict transient proof failures and re-prove URLs after the trust window.
- Convert neutral plans to Solana Kit instructions, simulate them, sign exact bytes, derive the pre-broadcast signature, and broadcast separately.
- Add bounded provider deadlines and the environment/secret-key declarations required by the runtime.
- Keep sponsored execution unreachable from the deposit path because a relay cannot yet satisfy record-before-broadcast signature recovery.

## Safety boundary

No route imports this runtime yet. The layer can build and sign only when called by a later consumer, and it does not introduce a customer-reachable operation.

## Validation

- API typecheck: passed
- execution registry/deadline tests: 6 passed
- API build, including WASM packaging: passed
