### PR TITLE
feat(helius): add rings schema migration

### DIFF
--- a/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
@@ -1,0 +1,537 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "@/test/helpers/env";
+
+// The test database is already fully migrated by src/test/node-global-setup.ts,
+// so 0057's tables exist before this file runs. That makes the assertions here
+// behavioural rather than structural-only: every test opens a transaction,
+// inserts real rows against the real schema, and rolls back.
+
+const migrationPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "postgres/0057_helius_rings.sql"
+);
+const migrationSql = readFileSync(migrationPath, "utf8");
+
+const TABLES = [
+  "helius_rings_wallets",
+  "helius_rings_key_refs",
+  "helius_rings_zones",
+  "helius_rings_operations",
+  "helius_rings_timelocks",
+  "helius_rings_events",
+  "helius_rings_asset_allowlist",
+  "helius_rings_runtime_health",
+];
+
+let client: Client;
+
+/** Postgres SQLSTATEs the constraint assertions below distinguish between. */
+const UNIQUE_VIOLATION = "23505";
+const FK_VIOLATION = "23503";
+const CHECK_VIOLATION = "23514";
+
+/**
+ * Runs a statement expected to violate a constraint. The savepoint is taken
+ * immediately before the statement — a failed statement poisons the whole
+ * transaction, and rolling back to a savepoint created any earlier would
+ * discard the fixtures the caller just seeded.
+ *
+ * Takes a thunk rather than a promise so the statement cannot be queued on the
+ * client ahead of the SAVEPOINT.
+ */
+async function expectSqlstate(work: () => Promise<unknown>, sqlstate: string): Promise<void> {
+  await client.query("SAVEPOINT probe");
+  await expect(work()).rejects.toMatchObject({ code: sqlstate });
+  await client.query("ROLLBACK TO SAVEPOINT probe");
+}
+
+/**
+ * Seeds an org, project and Rings wallet, returning their ids. `tag` keeps the
+ * org slug unique across tests since only the transaction is rolled back, not
+ * the sequence of ids.
+ */
+async function seedWallet(tag: string): Promise<{
+  organizationId: string;
+  projectId: string;
+  walletId: string;
+}> {
+  const organizationId = `org_${tag}`;
+  const projectId = `proj_${tag}`;
+  const userId = `user_${tag}`;
+  const walletId = `hrw_${tag}`;
+
+  await client.query("INSERT INTO organizations (id, name, slug) VALUES ($1, $1, $1)", [
+    organizationId,
+  ]);
+  await client.query("INSERT INTO users (id, email) VALUES ($1, $2)", [
+    userId,
+    `${tag}@example.test`,
+  ]);
+  await client.query(
+    "INSERT INTO projects (id, organization_id, name, slug, created_by) VALUES ($1, $2, $1, $1, $3)",
+    [projectId, organizationId, userId]
+  );
+  await client.query(
+    `INSERT INTO helius_rings_wallets (id, organization_id, project_id, sdp_wallet_id, name)
+     VALUES ($1, $2, $3, $4, 'Treasury')`,
+    [walletId, organizationId, projectId, `sdpw_${tag}`]
+  );
+
+  return { organizationId, projectId, walletId };
+}
+
+async function insertOperation(
+  overrides: Record<string, string | boolean | null> & {
+    id: string;
+    organization_id: string;
+    project_id: string;
+    wallet_id: string;
+    intent_key: string;
+  }
+): Promise<void> {
+  const row: Record<string, string | boolean | null> = { op_type: "shield", ...overrides };
+  const columns = Object.keys(row);
+  const placeholders = columns.map((_, index) => `$${index + 1}`).join(", ");
+  await client.query(
+    `INSERT INTO helius_rings_operations (${columns.join(", ")}) VALUES (${placeholders})`,
+    columns.map((column) => row[column])
+  );
+}
+
+beforeAll(async () => {
+  client = new Client({ connectionString: env.DATABASE_URL });
+  await client.connect();
+});
+
+afterAll(async () => {
+  await client.end();
+});
+
+beforeEach(async () => {
+  await client.query("BEGIN");
+});
+
+afterEach(async () => {
+  await client.query("ROLLBACK");
+});
+
+describe("0057_helius_rings schema", () => {
+  it("creates every table and the indexes the module reads through", async () => {
+    const tables = await client.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = ANY($1)
+       ORDER BY table_name`,
+      [TABLES]
+    );
+    expect(tables.rows.map((row) => row.table_name)).toEqual([...TABLES].sort());
+
+    const indexes = await client.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename LIKE 'helius_rings%'`
+    );
+    const names = indexes.rows.map((row) => row.indexname);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "idx_helius_rings_wallets_project_sdp",
+        "idx_helius_rings_key_refs_wallet_kind",
+        "helius_rings_zones_wallet_name_key",
+        "idx_helius_rings_operations_intent_key",
+        "idx_helius_rings_operations_wallet_created",
+        "idx_helius_rings_operations_in_flight",
+        "idx_helius_rings_timelocks_pending",
+        "idx_helius_rings_events_operation_created",
+      ])
+    );
+  });
+
+  it("re-running the migration is a no-op", async () => {
+    const before = await client.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM helius_rings_asset_allowlist"
+    );
+
+    // Every statement is IF NOT EXISTS and the seed is ON CONFLICT DO NOTHING,
+    // so a second application must neither throw nor duplicate the seed.
+    await expect(client.query(migrationSql)).resolves.toBeDefined();
+
+    const after = await client.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM helius_rings_asset_allowlist"
+    );
+    expect(after.rows[0]?.count).toBe(before.rows[0]?.count);
+  });
+
+  it("seeds the allowlist with SOL and devnet USDC only", async () => {
+    const seeded = await client.query<{ mint: string; symbol: string; decimals: number }>(
+      "SELECT mint, symbol, decimals FROM helius_rings_asset_allowlist ORDER BY symbol"
+    );
+    expect(seeded.rows).toEqual([
+      { mint: "So11111111111111111111111111111111111111112", symbol: "SOL", decimals: 9 },
+      { mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", symbol: "USDC", decimals: 6 },
+    ]);
+  });
+});
+
+describe("0057_helius_rings idempotency contract", () => {
+  it("rejects a second operation reusing an intent_key", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("intent");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "intent_abc",
+    };
+
+    await insertOperation({ id: "hro_first", ...base });
+    await expectSqlstate(() => insertOperation({ id: "hro_second", ...base }), UNIQUE_VIOLATION);
+
+    // The reserved row is untouched — this is what lets reserveIntent() return
+    // the pre-existing operation instead of creating a ghost duplicate.
+    const rows = await client.query<{ id: string }>(
+      "SELECT id FROM helius_rings_operations WHERE intent_key = $1",
+      ["intent_abc"]
+    );
+    expect(rows.rows.map((row) => row.id)).toEqual(["hro_first"]);
+  });
+
+  it("keeps the retry chain when a retried operation is deleted", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("lineage");
+    const base = { organization_id: organizationId, project_id: projectId, wallet_id: walletId };
+
+    await insertOperation({ id: "hro_original", intent_key: "intent_original", ...base });
+    await insertOperation({
+      id: "hro_retry",
+      intent_key: "intent_retry",
+      retry_of_operation_id: "hro_original",
+      ...base,
+    });
+
+    await client.query("DELETE FROM helius_rings_operations WHERE id = 'hro_original'");
+
+    // SET NULL, not CASCADE: the retry survives its parent's deletion so the
+    // audit trail does not evaporate.
+    const retry = await client.query<{ id: string; retry_of_operation_id: string | null }>(
+      "SELECT id, retry_of_operation_id FROM helius_rings_operations WHERE id = 'hro_retry'"
+    );
+    expect(retry.rows).toEqual([{ id: "hro_retry", retry_of_operation_id: null }]);
+  });
+
+  it("refuses an operation that is its own retry", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("selfretry");
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_self",
+          organization_id: organizationId,
+          project_id: projectId,
+          wallet_id: walletId,
+          intent_key: "intent_self",
+          retry_of_operation_id: "hro_self",
+        }),
+      CHECK_VIOLATION
+    );
+  });
+});
+
+describe("0057_helius_rings tenant isolation", () => {
+  it("refuses an operation pointing at a wallet in another project", async () => {
+    const owner = await seedWallet("owner");
+    const other = await seedWallet("other");
+
+    // The composite (wallet_id, organization_id, project_id) FK is what makes
+    // this a foreign-key error rather than a silently accepted cross-tenant row.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_crosstenant",
+          organization_id: other.organizationId,
+          project_id: other.projectId,
+          wallet_id: owner.walletId,
+          intent_key: "intent_crosstenant",
+        }),
+      FK_VIOLATION
+    );
+  });
+
+  it("cascades wallets, key refs, operations and events when the project goes", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("cascade");
+    await insertOperation({
+      id: "hro_cascade",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "intent_cascade",
+    });
+    await client.query(
+      `INSERT INTO helius_rings_key_refs (id, wallet_id, kind, ciphertext, key_version, material_tag)
+       VALUES ('hrk_cascade', $1, 'viewing', 'ct', 'v1', 'simulated')`,
+      [walletId]
+    );
+    await client.query(
+      `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+       VALUES ('hre_cascade', 'hro_cascade', 'created', '{"note":"ok"}'::jsonb)`
+    );
+
+    await client.query("DELETE FROM projects WHERE id = $1", [projectId]);
+
+    for (const table of ["helius_rings_wallets", "helius_rings_operations"]) {
+      const rows = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM ${table} WHERE project_id = $1`,
+        [projectId]
+      );
+      expect(rows.rows[0]?.count).toBe("0");
+    }
+    for (const table of ["helius_rings_key_refs", "helius_rings_events"]) {
+      const rows = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM ${table}`
+      );
+      expect(rows.rows[0]?.count).toBe("0");
+    }
+  });
+
+  it("holds one Rings wallet per SDP custody wallet per project", async () => {
+    const { organizationId, projectId } = await seedWallet("onewallet");
+    await expectSqlstate(
+      () =>
+        client.query(
+          `INSERT INTO helius_rings_wallets (id, organization_id, project_id, sdp_wallet_id, name)
+         VALUES ('hrw_dupe', $1, $2, 'sdpw_onewallet', 'Second')`,
+          [organizationId, projectId]
+        ),
+      UNIQUE_VIOLATION
+    );
+  });
+
+  it("holds one viewing key and one nullifier key per wallet", async () => {
+    const { walletId } = await seedWallet("keyrefs");
+    const insert = (id: string, kind: string) =>
+      client.query(
+        `INSERT INTO helius_rings_key_refs (id, wallet_id, kind, ciphertext, key_version, material_tag)
+         VALUES ($1, $2, $3, 'ct', 'v1', 'simulated')`,
+        [id, walletId, kind]
+      );
+
+    await insert("hrk_viewing", "viewing");
+    await insert("hrk_nullifier", "nullifier");
+    await expectSqlstate(() => insert("hrk_viewing_dupe", "viewing"), UNIQUE_VIOLATION);
+  });
+});
+
+describe("0057_helius_rings value-set and coherence constraints", () => {
+  it("pins network to devnet", async () => {
+    const { organizationId, projectId } = await seedWallet("network");
+    await expectSqlstate(
+      () =>
+        client.query(
+          `INSERT INTO helius_rings_wallets (id, organization_id, project_id, sdp_wallet_id, name, network)
+         VALUES ('hrw_mainnet', $1, $2, 'sdpw_mainnet', 'Mainnet', 'mainnet-beta')`,
+          [organizationId, projectId]
+        ),
+      CHECK_VIOLATION
+    );
+  });
+
+  it("rejects states and op types outside the domain constants", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("valuesets");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+    };
+
+    await expectSqlstate(
+      () =>
+        insertOperation({ id: "hro_badstate", intent_key: "i1", state: "teleporting", ...base }),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () => insertOperation({ id: "hro_badtype", intent_key: "i2", op_type: "rugpull", ...base }),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_badproof",
+          intent_key: "i3",
+          proof_source: "vibes",
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+  });
+
+  it("keeps transfer_mode consistent with op_type", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("mode");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+    };
+
+    // An anonymous transfer recorded as registered would tell the operator
+    // their counterparty was disclosed when it was not.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_mismatch",
+          intent_key: "m1",
+          op_type: "transfer_anonymous",
+          transfer_mode: "registered",
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+    // A shield carries no transfer mode at all.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_straymode",
+          intent_key: "m2",
+          op_type: "shield",
+          transfer_mode: "registered",
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+
+    await insertOperation({
+      id: "hro_anon",
+      intent_key: "m3",
+      op_type: "transfer_anonymous",
+      transfer_mode: "anonymous",
+      ...base,
+    });
+    const stored = await client.query<{ transfer_mode: string }>(
+      "SELECT transfer_mode FROM helius_rings_operations WHERE id = 'hro_anon'"
+    );
+    expect(stored.rows).toEqual([{ transfer_mode: "anonymous" }]);
+  });
+
+  it("ties failure detail to the failed state", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("failure");
+    const base = {
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+    };
+
+    // failed without a code is unactionable in the recovery UI.
+    await expectSqlstate(
+      () => insertOperation({ id: "hro_bare", intent_key: "f1", state: "failed", ...base }),
+      CHECK_VIOLATION
+    );
+    // A live operation carrying failure text misreports itself as broken.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_stale",
+          intent_key: "f2",
+          state: "proving",
+          failure_code: "proof_failed",
+          failure_message: "boom",
+          retryable: true,
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_unknowncode",
+          intent_key: "f3",
+          state: "failed",
+          failure_code: "cosmic_rays",
+          failure_message: "boom",
+          retryable: false,
+          ...base,
+        }),
+      CHECK_VIOLATION
+    );
+
+    await insertOperation({
+      id: "hro_failed",
+      intent_key: "f4",
+      state: "failed",
+      failure_code: "indexing_timeout",
+      failure_message: "photon did not index in time",
+      retryable: true,
+      ...base,
+    });
+    const stored = await client.query<{ failure_code: string; retryable: boolean }>(
+      "SELECT failure_code, retryable FROM helius_rings_operations WHERE id = 'hro_failed'"
+    );
+    expect(stored.rows).toEqual([{ failure_code: "indexing_timeout", retryable: true }]);
+  });
+
+  it("refuses a timelock released before it unlocks", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("timelock");
+    await insertOperation({
+      id: "hro_timelock",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "t1",
+      op_type: "timelock_create",
+    });
+
+    const insertTimelock = (releasedAt: string | null) =>
+      client.query(
+        `INSERT INTO helius_rings_timelocks (operation_id, unlock_at, released_at, beneficiary_addr)
+         VALUES ('hro_timelock', '2026-09-01T00:00:00.000Z', $1, 'beneficiary')`,
+        [releasedAt]
+      );
+
+    await expectSqlstate(() => insertTimelock("2026-08-01T00:00:00.000Z"), CHECK_VIOLATION);
+    await expect(insertTimelock("2026-09-02T00:00:00.000Z")).resolves.toBeDefined();
+  });
+
+  it("requires event payloads to be JSON objects", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("events");
+    await insertOperation({
+      id: "hro_events",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "e1",
+    });
+
+    await expectSqlstate(
+      () =>
+        client.query(
+          `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+         VALUES ('hre_scalar', 'hro_events', 'noted', '"just a string"'::jsonb)`
+        ),
+      CHECK_VIOLATION
+    );
+    await expect(
+      client.query(
+        `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+         VALUES ('hre_null', 'hro_events', 'noted', NULL)`
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("stores one runtime health row per project and component", async () => {
+    const { projectId } = await seedWallet("health");
+    const upsert = (component: string, status: string) =>
+      client.query(
+        `INSERT INTO helius_rings_runtime_health (project_id, component, status)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (project_id, component) DO UPDATE SET status = EXCLUDED.status`,
+        [projectId, component, status]
+      );
+
+    await upsert("photon", "green");
+    await upsert("photon", "red");
+    await expectSqlstate(() => upsert("telepathy", "green"), CHECK_VIOLATION);
+    await expectSqlstate(() => upsert("photon", "chartreuse"), CHECK_VIOLATION);
+
+    const rows = await client.query<{ component: string; status: string }>(
+      "SELECT component, status FROM helius_rings_runtime_health WHERE project_id = $1",
+      [projectId]
+    );
+    expect(rows.rows).toEqual([{ component: "photon", status: "red" }]);
+  });
+});

--- a/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
+++ b/apps/sdp-api/src/db/migrations/0057_helius_rings.migration.test.ts
@@ -255,6 +255,64 @@ describe("0057_helius_rings tenant isolation", () => {
     );
   });
 
+  it("refuses an operation pointing at another wallet's zone", async () => {
+    const owner = await seedWallet("zoneowner");
+    const other = await seedWallet("zoneother");
+    await client.query(
+      "INSERT INTO helius_rings_zones (id, wallet_id, name) VALUES ('hrz_owner', $1, 'Payroll')",
+      [owner.walletId]
+    );
+
+    // The composite (zone_id, wallet_id) FK rejects the cross-wallet reference.
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_crosszone",
+          organization_id: other.organizationId,
+          project_id: other.projectId,
+          wallet_id: other.walletId,
+          zone_id: "hrz_owner",
+          intent_key: "intent_crosszone",
+        }),
+      FK_VIOLATION
+    );
+
+    await expect(
+      insertOperation({
+        id: "hro_ownzone",
+        organization_id: owner.organizationId,
+        project_id: owner.projectId,
+        wallet_id: owner.walletId,
+        zone_id: "hrz_owner",
+        intent_key: "intent_ownzone",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("clears only zone_id when a referenced zone is deleted", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("zonedel");
+    await client.query(
+      "INSERT INTO helius_rings_zones (id, wallet_id, name) VALUES ('hrz_del', $1, 'Payroll')",
+      [walletId]
+    );
+    await insertOperation({
+      id: "hro_zonedel",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      zone_id: "hrz_del",
+      intent_key: "intent_zonedel",
+    });
+
+    await client.query("DELETE FROM helius_rings_zones WHERE id = 'hrz_del'");
+
+    // The SET NULL column list must not null wallet_id along with zone_id.
+    const { rows } = await client.query(
+      "SELECT wallet_id, zone_id FROM helius_rings_operations WHERE id = 'hro_zonedel'"
+    );
+    expect(rows[0]).toEqual({ wallet_id: walletId, zone_id: null });
+  });
+
   it("cascades wallets, key refs, operations and events when the project goes", async () => {
     const { organizationId, projectId, walletId } = await seedWallet("cascade");
     await insertOperation({
@@ -485,6 +543,50 @@ describe("0057_helius_rings value-set and coherence constraints", () => {
 
     await expectSqlstate(() => insertTimelock("2026-08-01T00:00:00.000Z"), CHECK_VIOLATION);
     await expect(insertTimelock("2026-09-02T00:00:00.000Z")).resolves.toBeDefined();
+  });
+
+  it("rejects timelock timestamps that are not fixed-width UTC", async () => {
+    const { organizationId, projectId, walletId } = await seedWallet("tlformat");
+    await insertOperation({
+      id: "hro_tlformat",
+      organization_id: organizationId,
+      project_id: projectId,
+      wallet_id: walletId,
+      intent_key: "tf1",
+      op_type: "timelock_create",
+    });
+
+    const insertTimelock = (unlockAt: string, releasedAt: string | null) =>
+      client.query(
+        `INSERT INTO helius_rings_timelocks (operation_id, unlock_at, released_at, beneficiary_addr)
+         VALUES ('hro_tlformat', $1, $2, 'beneficiary')`,
+        [unlockAt, releasedAt]
+      );
+
+    // An offset value sorts lexically before a Z value it chronologically follows.
+    await expectSqlstate(
+      () => insertTimelock("2026-08-31T23:30:00.000-01:00", null),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(
+      () => insertTimelock("2026-09-01T00:00:00.000Z", "2026-09-01T23:30:00.000-01:00"),
+      CHECK_VIOLATION
+    );
+    await expectSqlstate(() => insertTimelock("2026-09-01T00:00:00Z", null), CHECK_VIOLATION);
+
+    await expectSqlstate(
+      () =>
+        insertOperation({
+          id: "hro_tlformat2",
+          organization_id: organizationId,
+          project_id: projectId,
+          wallet_id: walletId,
+          intent_key: "tf2",
+          op_type: "timelock_create",
+          timelock_unlock_at: "2026-08-31T23:30:00.000-01:00",
+        }),
+      CHECK_VIOLATION
+    );
   });
 
   it("requires event payloads to be JSON objects", async () => {

--- a/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
@@ -279,8 +279,16 @@ CREATE TABLE IF NOT EXISTS helius_rings_operations (
 );
 
 -- The idempotency contract. This index is what makes retry-safety real:
--- reserveIntent() is an INSERT ... ON CONFLICT (intent_key) DO NOTHING that
--- returns the pre-existing row, and that only works because of this index.
+-- reserveIntent() inserts with ON CONFLICT (intent_key), and on a replay it has
+-- to hand back the operation already reserved rather than a second one.
+--
+-- Note for whoever writes that query: the conflict action must be a no-op
+-- DO UPDATE, not DO NOTHING. `ON CONFLICT DO NOTHING ... RETURNING *` emits
+-- zero rows on conflict, so a retry would read back null and look like a failure
+-- instead of an already-reserved intent. The idiom the repo already uses for
+-- this is `DO UPDATE SET updated_at = helius_rings_operations.updated_at
+-- RETURNING *` — see the approval_requests insert in
+-- db/repositories/policy.repository.postgres.ts.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_operations_intent_key
     ON helius_rings_operations(intent_key);
 

--- a/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
@@ -141,6 +141,9 @@ CREATE TABLE IF NOT EXISTS helius_rings_zones (
     created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
     CONSTRAINT helius_rings_zones_kind_check
         CHECK (kind IN ('treasury', 'public')),
+    -- Lets operations FK on (zone_id, wallet_id) so an operation cannot
+    -- reference another wallet's zone.
+    CONSTRAINT helius_rings_zones_id_wallet_key UNIQUE (id, wallet_id),
     FOREIGN KEY (wallet_id) REFERENCES helius_rings_wallets(id) ON DELETE CASCADE
 );
 
@@ -267,12 +270,23 @@ CREATE TABLE IF NOT EXISTS helius_rings_operations (
     -- the retry-depth cap in A21 loop forever.
     CONSTRAINT helius_rings_operations_retry_not_self_check
         CHECK (retry_of_operation_id IS NULL OR retry_of_operation_id <> id),
+    -- Same fixed-width-UTC pin as helius_rings_timelocks; the Activity table
+    -- sorts on this column.
+    CONSTRAINT helius_rings_operations_timelock_unlock_at_format_check
+        CHECK (
+            timelock_unlock_at IS NULL
+            OR timelock_unlock_at ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+        ),
     FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
     FOREIGN KEY (wallet_id, organization_id, project_id)
         REFERENCES helius_rings_wallets(id, organization_id, project_id)
         ON DELETE CASCADE,
-    FOREIGN KEY (zone_id) REFERENCES helius_rings_zones(id) ON DELETE SET NULL,
+    -- Composite: the zone must belong to this operation's wallet. The SET
+    -- NULL column list (Postgres 15+) clears only zone_id, not wallet_id.
+    FOREIGN KEY (zone_id, wallet_id)
+        REFERENCES helius_rings_zones(id, wallet_id)
+        ON DELETE SET NULL (zone_id),
     -- SET NULL, never CASCADE: see decision 2 in the header.
     FOREIGN KEY (retry_of_operation_id)
         REFERENCES helius_rings_operations(id) ON DELETE SET NULL
@@ -331,9 +345,17 @@ CREATE TABLE IF NOT EXISTS helius_rings_timelocks (
     unlock_at TEXT NOT NULL,
     released_at TEXT,
     beneficiary_addr TEXT NOT NULL,
-    -- ISO-8601 UTC strings from sdp_iso_now() are fixed-width, so lexical
-    -- comparison is chronological. Releasing before the unlock time is the
-    -- whole failure this table exists to prevent.
+    -- The ordering check compares text; lexical order is only chronological
+    -- when every value is the fixed-width UTC shape sdp_iso_now() emits. A
+    -- caller-supplied offset value ('...T23:30:00.000-01:00') would sort
+    -- wrong and let an early release through, so the format is a constraint.
+    CONSTRAINT helius_rings_timelocks_unlock_at_format_check
+        CHECK (unlock_at ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'),
+    CONSTRAINT helius_rings_timelocks_released_at_format_check
+        CHECK (
+            released_at IS NULL
+            OR released_at ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+        ),
     CONSTRAINT helius_rings_timelocks_released_after_unlock_check
         CHECK (released_at IS NULL OR released_at >= unlock_at),
     FOREIGN KEY (operation_id)

--- a/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0057_helius_rings.sql
@@ -1,0 +1,430 @@
+-- Helius Rings: the whole module's schema, in one migration.
+--
+-- Rings is the shielded-transfer module: a private wallet is bound to an SDP
+-- custody wallet, and every shielded action runs through a persisted state
+-- machine (draft -> preparing -> approval_required -> proving -> ready_to_sign
+-- -> submitted -> indexing -> completed, with a typed `failed` edge from every
+-- non-terminal state).
+--
+-- Tables are declared in dependency order — the wallet, then its key material
+-- and zones, then operations, their timelocks and event feed, then the
+-- platform-level asset allowlist and runtime health board. Every statement is
+-- IF NOT EXISTS, so re-running is a no-op.
+--
+-- Three decisions worth stating up front, because they are the ones that are
+-- expensive to retrofit:
+--
+--   1. `intent_key` carries a UNIQUE index. It is the idempotency contract:
+--      hash(walletId, opType, canonical(inputs), clientNonce). Without the
+--      index, a retried request creates a ghost duplicate operation that only
+--      ever surfaces in production, on the money path, under load.
+--
+--   2. `retry_of_operation_id` is ON DELETE SET NULL, never CASCADE. A retry
+--      chain is audit evidence; cascading would let the deletion of one
+--      operation recursively erase the whole lineage that explains it.
+--
+--   3. Operations reference their wallet through the composite
+--      (wallet_id, organization_id, project_id) key, following the pattern
+--      0048_earn.sql established for earn_movements. A plain wallet_id FK
+--      would happily let an operation in project A point at a wallet in
+--      project B; for a privacy module that is a tenant-isolation break, not
+--      merely a data-quality one.
+--
+-- Closed value sets are named CHECK constraints on TEXT rather than
+-- CREATE TYPE enums — the repo has no enums anywhere. Each set below mirrors an
+-- `as const` array in packages/sdp-helius-rings/src/constants.ts, which is the
+-- runtime source of truth; the CHECK is the schema-level twin. These sets are
+-- closed by compile-time unions, so widening one already requires a code
+-- change, and pairing it with a migration is the point rather than the cost.
+-- (Contrast the ADR 0001 asset-profiles pattern used for open registries like
+-- earn providers, which deliberately carry no CHECK.)
+--
+-- Timestamps are TEXT ISO-8601 via sdp_iso_now() — never NOW(), never
+-- timestamptz. Amounts are string-encoded u64, never numeric/float.
+
+
+-- ==========================================================================
+-- Wallets
+-- ==========================================================================
+
+-- Binds one Rings shielded identity to one SDP custody wallet within a project.
+--   status: pending until the identity is provisioned, ready once it is,
+--   paused when runtime health goes red and the module stops accepting work.
+--   material_tag records whether the key material behind this wallet is real
+--   ('live') or a placeholder from a pre-integration environment
+--   ('simulated'), so a simulated wallet can never be mistaken for a funded one.
+CREATE TABLE IF NOT EXISTS helius_rings_wallets (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    sdp_wallet_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    network TEXT NOT NULL DEFAULT 'devnet',
+    status TEXT NOT NULL DEFAULT 'pending',
+    shielded_address TEXT,
+    sync_cursor TEXT,
+    material_tag TEXT NOT NULL DEFAULT 'simulated',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    -- The schema-level twin of the runtime devnet guard in HeliusRingsService.
+    -- Rings is devnet-only for this scope; going to mainnet is a deliberate
+    -- forward migration that drops this constraint, not a config flip.
+    CONSTRAINT helius_rings_wallets_network_check CHECK (network = 'devnet'),
+    CONSTRAINT helius_rings_wallets_status_check
+        CHECK (status IN ('pending', 'ready', 'paused')),
+    CONSTRAINT helius_rings_wallets_material_tag_check
+        CHECK (material_tag IN ('simulated', 'live')),
+    -- Lets helius_rings_operations FK on (wallet_id, organization_id,
+    -- project_id) so an operation can never point at a wallet in a different
+    -- org/project. Mirrors earn_positions_id_org_project_key in 0048.
+    CONSTRAINT helius_rings_wallets_id_org_project_key
+        UNIQUE (id, organization_id, project_id),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+-- One Rings wallet per SDP custody wallet per project: provisioning is
+-- idempotent, and a second shielded identity over the same custody wallet
+-- would split its shielded balance across two identities that cannot see
+-- each other.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_wallets_project_sdp
+    ON helius_rings_wallets(project_id, sdp_wallet_id);
+
+CREATE INDEX IF NOT EXISTS idx_helius_rings_wallets_project_created
+    ON helius_rings_wallets(project_id, created_at DESC, id DESC);
+
+
+-- ==========================================================================
+-- Key material
+-- ==========================================================================
+
+-- Ciphertext blobs holding viewing and nullifier material, encrypted with
+-- custody-cipher (AES-256-GCM under CUSTODY_ENCRYPTION_KEY). Plaintext key
+-- material never lands in this table, and repositories pass ciphertext
+-- through untouched — ciphertext in, ciphertext out, never SecretRef.reveal.
+--
+-- key_version is the cipher key generation that sealed this blob, so a key
+-- rotation can re-wrap rows without guessing which generation each one used.
+CREATE TABLE IF NOT EXISTS helius_rings_key_refs (
+    id TEXT PRIMARY KEY,
+    wallet_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    ciphertext TEXT NOT NULL,
+    key_version TEXT NOT NULL,
+    material_tag TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_key_refs_kind_check
+        CHECK (kind IN ('viewing', 'nullifier')),
+    CONSTRAINT helius_rings_key_refs_material_tag_check
+        CHECK (material_tag IN ('simulated', 'live')),
+    FOREIGN KEY (wallet_id) REFERENCES helius_rings_wallets(id) ON DELETE CASCADE
+);
+
+-- Exactly one viewing key and one nullifier key per wallet. Provisioning
+-- returns both together, so a duplicate here means a re-provision raced and
+-- one of the two identities is now unreachable.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_key_refs_wallet_kind
+    ON helius_rings_key_refs(wallet_id, kind);
+
+
+-- ==========================================================================
+-- Zones
+-- ==========================================================================
+
+-- Named destinations within a wallet. A treasury zone holds shielded value;
+-- a public zone is the declared exit point back to transparent addresses.
+CREATE TABLE IF NOT EXISTS helius_rings_zones (
+    id TEXT PRIMARY KEY,
+    wallet_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'treasury',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_zones_kind_check
+        CHECK (kind IN ('treasury', 'public')),
+    FOREIGN KEY (wallet_id) REFERENCES helius_rings_wallets(id) ON DELETE CASCADE
+);
+
+-- Zone names are the operator's handle for a destination; two zones sharing a
+-- name inside one wallet makes the Send composer ambiguous.
+CREATE UNIQUE INDEX IF NOT EXISTS helius_rings_zones_wallet_name_key
+    ON helius_rings_zones(wallet_id, name);
+
+
+-- ==========================================================================
+-- Operations — the state machine
+-- ==========================================================================
+
+-- One row per shielded action, carrying its whole lifecycle. `state` is the
+-- persisted state machine; transitions are applied under SELECT ... FOR UPDATE
+-- inside a transaction so two workers cannot advance the same operation twice.
+--
+-- proof_ref is an opaque handle the gateway hands back, not proof material —
+-- it is wrapped in SecretRef at the API boundary and must never be logged or
+-- serialized into a response.
+CREATE TABLE IF NOT EXISTS helius_rings_operations (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    wallet_id TEXT NOT NULL,
+    op_type TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'draft',
+    asset_mint TEXT,
+    amount_raw TEXT,
+    from_addr TEXT,
+    to_addr TEXT,
+    zone_id TEXT,
+    transfer_mode TEXT,
+    intent_key TEXT NOT NULL,
+    approval_request_id TEXT,
+    policy_evaluation_id TEXT,
+    proof_source TEXT,
+    proof_ref TEXT,
+    outer_tx_signature TEXT,
+    photon_indexed_at TEXT,
+    failure_code TEXT,
+    failure_message TEXT,
+    retryable BOOLEAN,
+    retry_of_operation_id TEXT,
+    -- Denormalized from helius_rings_timelocks so the Activity table can sort
+    -- and filter by unlock time without joining. The timelocks row remains
+    -- the authority; this column is a read optimization.
+    timelock_unlock_at TEXT,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_operations_op_type_check
+        CHECK (op_type IN (
+            'shield',
+            'transfer_registered',
+            'transfer_anonymous',
+            'withdraw',
+            'merge',
+            'timelock_create',
+            'timelock_settle',
+            'zone_create'
+        )),
+    CONSTRAINT helius_rings_operations_state_check
+        CHECK (state IN (
+            'draft',
+            'preparing',
+            'approval_required',
+            'proving',
+            'ready_to_sign',
+            'submitted',
+            'indexing',
+            'completed',
+            'failed'
+        )),
+    CONSTRAINT helius_rings_operations_proof_source_check
+        CHECK (proof_source IS NULL OR proof_source IN ('simulated', 'live')),
+    -- transfer_mode is derivable from op_type, and the two disagreeing is a
+    -- privacy bug rather than a cosmetic one: an anonymous transfer rendered
+    -- as registered tells the operator their counterparty was disclosed when
+    -- it was not, or the reverse. Pin them together.
+    CONSTRAINT helius_rings_operations_transfer_mode_check
+        CHECK (
+            (op_type = 'transfer_registered' AND transfer_mode = 'registered')
+            OR (op_type = 'transfer_anonymous' AND transfer_mode = 'anonymous')
+            OR (
+                op_type NOT IN ('transfer_registered', 'transfer_anonymous')
+                AND transfer_mode IS NULL
+            )
+        ),
+    -- Failure detail exists exactly when the operation failed. The three
+    -- columns move together: a `failed` row without a code is unactionable in
+    -- the recovery UI, and a live row carrying stale failure text misreports
+    -- a healthy operation as broken.
+    CONSTRAINT helius_rings_operations_failure_check
+        CHECK (
+            (
+                state = 'failed'
+                AND failure_code IS NOT NULL
+                AND failure_message IS NOT NULL
+                AND retryable IS NOT NULL
+            )
+            OR (
+                state <> 'failed'
+                AND failure_code IS NULL
+                AND failure_message IS NULL
+                AND retryable IS NULL
+            )
+        ),
+    CONSTRAINT helius_rings_operations_failure_code_check
+        CHECK (
+            failure_code IS NULL
+            OR failure_code IN (
+                'policy_denied',
+                'approval_rejected',
+                'proof_failed',
+                'signer_failed',
+                'submit_failed',
+                'indexing_timeout',
+                'gateway_unavailable',
+                'invalid_input',
+                'insufficient_balance'
+            )
+        ),
+    -- An operation cannot be its own retry; a self-referencing lineage makes
+    -- the retry-depth cap in A21 loop forever.
+    CONSTRAINT helius_rings_operations_retry_not_self_check
+        CHECK (retry_of_operation_id IS NULL OR retry_of_operation_id <> id),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (wallet_id, organization_id, project_id)
+        REFERENCES helius_rings_wallets(id, organization_id, project_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY (zone_id) REFERENCES helius_rings_zones(id) ON DELETE SET NULL,
+    -- SET NULL, never CASCADE: see decision 2 in the header.
+    FOREIGN KEY (retry_of_operation_id)
+        REFERENCES helius_rings_operations(id) ON DELETE SET NULL
+);
+
+-- The idempotency contract. This index is what makes retry-safety real:
+-- reserveIntent() is an INSERT ... ON CONFLICT (intent_key) DO NOTHING that
+-- returns the pre-existing row, and that only works because of this index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_helius_rings_operations_intent_key
+    ON helius_rings_operations(intent_key);
+
+-- Activity table: newest first. The id tiebreaker matters because operations
+-- created in one request share a single sdp_iso_now() value — the lesson of
+-- payment_transfers 0028-0031.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_wallet_created
+    ON helius_rings_operations(wallet_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_project_created
+    ON helius_rings_operations(project_id, created_at DESC, id DESC);
+
+-- Partial index for the resume/poll sweep, which only ever looks at operations
+-- still in flight. Terminal rows accumulate forever and would otherwise
+-- dominate the index.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_in_flight
+    ON helius_rings_operations(state, updated_at)
+    WHERE state IN (
+        'preparing',
+        'approval_required',
+        'proving',
+        'ready_to_sign',
+        'submitted',
+        'indexing'
+    );
+
+CREATE INDEX IF NOT EXISTS idx_helius_rings_operations_retry_of
+    ON helius_rings_operations(retry_of_operation_id)
+    WHERE retry_of_operation_id IS NOT NULL;
+
+
+-- ==========================================================================
+-- Timelocks
+-- ==========================================================================
+
+-- Escrow leg of a timelock operation. One row per timelock_create operation;
+-- released_at is stamped when the matching timelock_settle completes.
+CREATE TABLE IF NOT EXISTS helius_rings_timelocks (
+    operation_id TEXT PRIMARY KEY,
+    unlock_at TEXT NOT NULL,
+    released_at TEXT,
+    beneficiary_addr TEXT NOT NULL,
+    -- ISO-8601 UTC strings from sdp_iso_now() are fixed-width, so lexical
+    -- comparison is chronological. Releasing before the unlock time is the
+    -- whole failure this table exists to prevent.
+    CONSTRAINT helius_rings_timelocks_released_after_unlock_check
+        CHECK (released_at IS NULL OR released_at >= unlock_at),
+    FOREIGN KEY (operation_id)
+        REFERENCES helius_rings_operations(id) ON DELETE CASCADE
+);
+
+-- The release sweep only cares about escrows still held.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_timelocks_pending
+    ON helius_rings_timelocks(unlock_at)
+    WHERE released_at IS NULL;
+
+
+-- ==========================================================================
+-- Event feed
+-- ==========================================================================
+
+-- Immutable, append-only timeline powering the operation detail panel.
+--
+-- payload is JSONB rather than the TEXT the design sketch called for: the
+-- domain type is `payload?: unknown`, and JSONB both validates the JSON on
+-- write and stays queryable. It must never contain SecretRef material —
+-- event.service.ts in private-channels is the precedent, redacting the payload
+-- before persist. `kind` is intentionally open TEXT: event kinds are additive
+-- documentation of what happened, and gating each new one behind a migration
+-- would be the reason someone logs it somewhere worse instead.
+CREATE TABLE IF NOT EXISTS helius_rings_events (
+    id TEXT PRIMARY KEY,
+    operation_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload JSONB,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_events_payload_is_object_check
+        CHECK (payload IS NULL OR jsonb_typeof(payload) = 'object'),
+    FOREIGN KEY (operation_id)
+        REFERENCES helius_rings_operations(id) ON DELETE CASCADE
+);
+
+-- Timeline order, oldest first, with the id tiebreaker for events appended
+-- inside a single transition.
+CREATE INDEX IF NOT EXISTS idx_helius_rings_events_operation_created
+    ON helius_rings_events(operation_id, created_at, id);
+
+
+-- ==========================================================================
+-- Asset allowlist (platform-level)
+-- ==========================================================================
+
+-- Which mints Rings will move. Platform-level, not tenant-scoped: the
+-- constraint is what the shielded pool and prover actually support, which is a
+-- property of the deployment rather than of a customer. Adding a mint requires
+-- joint validation with Helius — an unsupported mint does not fail loudly, it
+-- produces an operation that proves and submits and then never indexes.
+CREATE TABLE IF NOT EXISTS helius_rings_asset_allowlist (
+    mint TEXT PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    decimals INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    CONSTRAINT helius_rings_asset_allowlist_status_check
+        CHECK (status IN ('active', 'disabled')),
+    CONSTRAINT helius_rings_asset_allowlist_decimals_check
+        CHECK (decimals BETWEEN 0 AND 18)
+);
+
+-- Seed: wrapped SOL and devnet USDC only. Both mints and their decimals are
+-- taken from packages/sdp-types/src/well-known-tokens.ts (SOL_MINT at 9
+-- decimals; USDC devnet at 6) rather than retyped, so the allowlist cannot
+-- drift from the registry the rest of the platform resolves against.
+--
+-- ON CONFLICT DO NOTHING keeps the re-run a no-op and, more importantly, means
+-- this migration never revives a mint an operator has since disabled.
+INSERT INTO helius_rings_asset_allowlist (mint, symbol, decimals, status)
+VALUES
+    ('So11111111111111111111111111111111111111112', 'SOL', 9, 'active'),
+    ('4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU', 'USDC', 6, 'active')
+ON CONFLICT (mint) DO NOTHING;
+
+
+-- ==========================================================================
+-- Runtime health
+-- ==========================================================================
+
+-- Latest observed health of each upstream Rings depends on, one row per
+-- component per project. Overwritten in place rather than appended: this is a
+-- status board the diagnostics page and the red-state action gate read, not a
+-- history. The event feed is where durable history lives.
+CREATE TABLE IF NOT EXISTS helius_rings_runtime_health (
+    project_id TEXT NOT NULL,
+    component TEXT NOT NULL,
+    status TEXT NOT NULL,
+    observed_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    detail JSONB,
+    PRIMARY KEY (project_id, component),
+    CONSTRAINT helius_rings_runtime_health_component_check
+        CHECK (component IN ('rpc', 'prover', 'photon', 'gateway')),
+    CONSTRAINT helius_rings_runtime_health_status_check
+        CHECK (status IN ('green', 'amber', 'red')),
+    CONSTRAINT helius_rings_runtime_health_detail_is_object_check
+        CHECK (detail IS NULL OR jsonb_typeof(detail) = 'object'),
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
Supersedes #1330 (closed as erroneous push); incorporates its review findings.

- Adds `0057_helius_rings.sql`: 8 tables (wallets, key_refs, zones, operations, timelocks, events, asset_allowlist, runtime_health)
- `intent_key` unique index = the idempotency contract for `reserveIntent`
- Tenant integrity via composite FKs: operations→wallets on `(id, org, project)`, operations→zones on `(id, wallet_id)` — a cross-tenant/cross-wallet reference is an FK error
- Timelock timestamps CHECK-pinned to the fixed-width `sdp_iso_now()` UTC shape so lexical ordering is chronological
- Failure triple tied to `failed` state; `transfer_mode` pinned to `op_type`; retry lineage `ON DELETE SET NULL`
- 20 behavioral migration tests (constraint violations by SQLSTATE, cascade, re-run no-op, seed)
