### PR TITLE
feat(helius): redact rings key material in logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,12 @@ jobs:
       - name: Scripts tests
         run: pnpm test:scripts
 
+      # Runs here rather than in the Module Boundaries job because it parses
+      # TypeScript with the compiler's own parser, and that job installs no
+      # dependencies.
+      - name: Check SecretRef serialization
+        run: pnpm check:secretref-serialization
+
   build_api:
     name: Build API
     runs-on: ubuntu-latest

--- a/apps/sdp-api/src/runtime/log-redaction.test.ts
+++ b/apps/sdp-api/src/runtime/log-redaction.test.ts
@@ -1,0 +1,132 @@
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+import {
+  LOG_REDACTION_PATHS,
+  REDACTED_LEAF_FIELDS,
+  REDACTED_NESTED_PATHS,
+  REDACTION_CENSOR,
+} from "./log-redaction";
+import { baseLoggerOptions } from "./logger";
+
+/**
+ * Stands in for `SecretRef` from `@sdp/helius-rings`, which sdp-api does not yet
+ * depend on — A5 adds that dependency when the repositories need the domain
+ * types. What matters here is the contract pino relies on, `toJSON()` returning
+ * the censor; that `SecretRef` honours it is asserted in
+ * packages/sdp-helius-rings/src/secrets.test.ts.
+ */
+class WrappedSecret {
+  readonly #value: string;
+  constructor(value: string) {
+    this.#value = value;
+  }
+  reveal(): string {
+    return this.#value;
+  }
+  toJSON(): string {
+    return REDACTION_CENSOR;
+  }
+}
+
+/** Captures what the real logger options would actually emit to a sink. */
+function captureLogs(write: (logger: pino.Logger) => void): string {
+  const lines: string[] = [];
+  const logger = pino(
+    { ...baseLoggerOptions(), transport: undefined, timestamp: false },
+    { write: (line: string) => lines.push(line) }
+  );
+  write(logger);
+  return lines.join("\n");
+}
+
+describe("log redaction registry", () => {
+  it("expands every registered field to the root and one level deep", () => {
+    for (const field of [...REDACTED_LEAF_FIELDS, ...REDACTED_NESTED_PATHS]) {
+      expect(LOG_REDACTION_PATHS).toContain(field);
+      expect(LOG_REDACTION_PATHS).toContain(`*.${field}`);
+    }
+  });
+
+  it("is accepted by pino — an unsupported path shape throws at construction", () => {
+    expect(() => captureLogs((logger) => logger.info("ok"))).not.toThrow();
+  });
+
+  it("censors the Rings key domain at the root of a log object", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ viewingKey: "vk-plaintext", nullifierKey: "nk-plaintext" }, "provisioned");
+    });
+
+    expect(output).not.toContain("vk-plaintext");
+    expect(output).not.toContain("nk-plaintext");
+    expect(output).toContain(REDACTION_CENSOR);
+  });
+
+  it("censors the Rings key domain one level deep, where callers actually put it", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ wallet: { id: "hrw_1", viewingKey: "vk-plaintext" } }, "wallet ready");
+    });
+
+    expect(output).not.toContain("vk-plaintext");
+    expect(output).toContain("hrw_1");
+  });
+
+  it("censors proof internals and key ref material", () => {
+    const output = captureLogs((logger) => {
+      logger.info(
+        {
+          operation: {
+            id: "hro_1",
+            proof: { ref: "proof-handle", internal: "witness-bytes" },
+          },
+          keyRefs: [{ material: "blob-a" }, { material: "blob-b" }],
+        },
+        "proof received"
+      );
+    });
+
+    expect(output).not.toContain("proof-handle");
+    expect(output).not.toContain("witness-bytes");
+    expect(output).not.toContain("blob-a");
+    expect(output).not.toContain("blob-b");
+    expect(output).toContain("hro_1");
+  });
+
+  it("censors the gateway metadata envelope", () => {
+    const output = captureLogs((logger) => {
+      logger.info({ ringsMetadata: { anything: "opaque-upstream-detail" } }, "gateway replied");
+    });
+
+    expect(output).not.toContain("opaque-upstream-detail");
+  });
+
+  it("leaves a wrapped secret redacted by the wrapper, at any depth", () => {
+    // This is why the one-level limit on the registry is tolerable: a wrapped
+    // secret redacts itself through toJSON(), so depth does not matter for
+    // wrapped material. The registry only has to cover plaintext that escaped
+    // wrapping.
+    const output = captureLogs((logger) => {
+      logger.info(
+        { a: { b: { c: { secret: new WrappedSecret("hunter2"), note: "deeply nested" } } } },
+        "deep"
+      );
+    });
+
+    expect(output).not.toContain("hunter2");
+    expect(output).toContain(REDACTION_CENSOR);
+    expect(output).toContain("deeply nested");
+  });
+
+  it("keeps ordinary operational fields readable", () => {
+    const output = captureLogs((logger) => {
+      logger.info(
+        { operation: { id: "hro_2", state: "proving", opType: "transfer_anonymous" } },
+        "advanced"
+      );
+    });
+
+    expect(output).toContain("hro_2");
+    expect(output).toContain("proving");
+    expect(output).toContain("transfer_anonymous");
+    expect(output).not.toContain(REDACTION_CENSOR);
+  });
+});

--- a/apps/sdp-api/src/runtime/log-redaction.ts
+++ b/apps/sdp-api/src/runtime/log-redaction.ts
@@ -1,0 +1,73 @@
+/**
+ * The log redaction registry: field paths pino censors before anything reaches
+ * a log sink.
+ *
+ * This is the belt, not the braces. The primary defence against secret material
+ * in logs is the type layer — `SecretRef<T>` in `@sdp/helius-rings` overrides
+ * `toJSON()`/`toString()` to `"[REDACTED]"`, so a wrapped secret is already safe
+ * wherever it is serialized. This registry catches the case the type layer
+ * cannot: a *plaintext* value that reached a log object without ever being
+ * wrapped, because someone called `reveal()` upstream, read a column straight
+ * out of the database, or destructured a gateway response.
+ *
+ * A known limit, verified against pino 10: the `*.` prefix matches exactly one
+ * intermediate key, not arbitrary depth. `{ wallet: { viewingKey } }` is
+ * censored; `{ a: { b: { viewingKey } } }` is not. fast-redact has no
+ * recursive-descent wildcard, so the alternative would be a hand-rolled deep
+ * walk on every log call — a cost paid on every log line in production to cover
+ * a shape that only appears if secret material is being passed around
+ * unwrapped, which is the thing `SecretRef` and
+ * `scripts/check-secretref-serialization.mjs` exist to prevent. Keep log objects
+ * shallow, and keep secrets wrapped.
+ *
+ * To register a field: add the key to `REDACTED_LEAF_FIELDS` if it can appear
+ * anywhere under its own name, or the full path to `REDACTED_NESTED_PATHS` if it
+ * is only meaningful inside a parent object. Both forms are expanded to cover
+ * the top level and one nesting level.
+ */
+
+/** What a censored value is replaced with. */
+export const REDACTION_CENSOR = "[REDACTED]";
+
+/**
+ * Keys that are sensitive wherever they appear, regardless of parent.
+ *
+ * `viewingKey` and `nullifierKey` are the Helius Rings key domain: a viewing key
+ * deanonymizes every transfer a shielded wallet has ever received, and a
+ * nullifier key can spend from it. `ringsMetadata` is the catch-all envelope the
+ * gateway attaches to operations, whose contents are not ours to audit.
+ */
+export const REDACTED_LEAF_FIELDS: readonly string[] = [
+  "viewingKey",
+  "nullifierKey",
+  "ringsMetadata",
+];
+
+/**
+ * Paths that are only sensitive in context.
+ *
+ * `proof.ref` is the gateway's opaque handle to a proof and `proof.internal` its
+ * witness data — neither is a secret about SDP, but both are a secret about the
+ * customer's transfer graph. `keyRefs[*].material` is the encrypted key blob as
+ * it travels in memory between the key authority and the signer.
+ */
+export const REDACTED_NESTED_PATHS: readonly string[] = [
+  "proof.ref",
+  "proof.internal",
+  "keyRefs[*].material",
+];
+
+/**
+ * Expands a registered field into the shapes pino can actually match: the path
+ * at the root of the log object, and the same path one key deeper (the common
+ * case, where the caller logs `{ operation: {...} }` or `{ wallet: {...} }`).
+ */
+function withOneLevelOfNesting(path: string): string[] {
+  return [path, `*.${path}`];
+}
+
+/** Paths handed to pino's `redact` option. */
+export const LOG_REDACTION_PATHS: readonly string[] = [
+  ...REDACTED_LEAF_FIELDS.flatMap(withOneLevelOfNesting),
+  ...REDACTED_NESTED_PATHS.flatMap(withOneLevelOfNesting),
+];

--- a/apps/sdp-api/src/runtime/logger.ts
+++ b/apps/sdp-api/src/runtime/logger.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import pino, { type Logger, type LoggerOptions } from "pino";
+import { LOG_REDACTION_PATHS, REDACTION_CENSOR } from "./log-redaction";
 
 export interface LogContext {
   request_id?: string;
@@ -43,6 +44,7 @@ export function baseLoggerOptions(): LoggerOptions {
       },
     },
     serializers: { error: serializeError, err: serializeError },
+    redact: { paths: [...LOG_REDACTION_PATHS], censor: REDACTION_CENSOR },
     mixin: () => ({ ...getLogContext() }),
     ...(process.env.LOG_FORMAT === "pretty" ? { transport: { target: "pino-pretty" } } : {}),
   };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:module-boundaries": "node scripts/check-module-boundaries.mjs",
     "check:pinned-dependencies": "node scripts/check-pinned-dependency-versions.mjs",
     "check:kamino-dependency-boundary": "node scripts/check-kamino-dependency-boundary.mjs",
+    "check:secretref-serialization": "node scripts/check-secretref-serialization.mjs",
     "check:well-known-mints": "pnpm --filter @sdp/api exec tsx ../../scripts/check-well-known-mints.mjs",
     "check:api-playground": "pnpm -C apps/sdp-api playground:check",
     "generate:api-playground": "pnpm -C apps/sdp-api playground:generate",

--- a/packages/sdp-helius-rings/src/secrets.ts
+++ b/packages/sdp-helius-rings/src/secrets.ts
@@ -1,10 +1,16 @@
 /**
  * Wraps a secret value so it never leaks through logs, JSON serialization, or
- * template literals. `reveal()` is the only path to the raw value; the scope
- * argument is a documentation-level contract for reviewers, not enforced at
- * runtime. A lint rule (A23) will forbid `JSON.stringify` on any value typed
- * `SecretRef<*>`; until then the `toJSON`/`toString` overrides are the safety
- * net.
+ * template literals. The `toJSON`/`toString` overrides mean a wrapped secret is
+ * safe wherever it is serialized or interpolated, at any depth.
+ *
+ * `reveal()` is the only path to the raw value, and the only real leak vector:
+ * the result is an ordinary string or Uint8Array with no redaction behaviour.
+ * The scope argument is a documentation-level contract for reviewers, not
+ * enforced at runtime. `scripts/check-secretref-serialization.mjs` fails the
+ * build if a `reveal()` result reaches `JSON.stringify`, a logger, `String()`,
+ * or a template literal — test files excepted, which is what the "test" scope is
+ * for. Plaintext key material that never got wrapped is caught separately by the
+ * log redaction registry in `apps/sdp-api/src/runtime/log-redaction.ts`.
  */
 export type RevealScope = "adapter" | "signer" | "test";
 

--- a/scripts/check-secretref-serialization.mjs
+++ b/scripts/check-secretref-serialization.mjs
@@ -18,6 +18,12 @@
  *   2. a logger or console call
  *   3. a template literal or String()
  *
+ * "Flowing into" covers the direct call and one indirection: identifiers
+ * assigned a reveal() result (or an alias of one) are tracked per file and
+ * flagged at the same sinks. Aliasing is deliberately direct-only — a value
+ * that passed through another call (a hash, an encryptor) is considered
+ * transformed and is the sanctioned way to log.
+ *
  * It also flags `JSON.stringify` applied directly to a `SecretRef` construction,
  * which is harmless at runtime but always means the author misunderstood the
  * wrapper.
@@ -115,6 +121,58 @@ function isSecretRefConstruction(node) {
   );
 }
 
+/** Strips wrappers that do not change what a value is. */
+function unwrapExpression(node) {
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAwaitExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/**
+ * Names bound to a reveal() result in this file, direct aliases included
+ * (`const v = ref.reveal(...)`, `w = v`). Name-based and file-scoped — a
+ * same-named variable elsewhere in the file is treated as tainted too, which
+ * errs toward flagging.
+ */
+function collectRevealedAliases(sourceFile) {
+  const aliases = new Set();
+  const taintsFrom = (initializer) => {
+    const value = unwrapExpression(initializer);
+    return isRevealCall(value) || (ts.isIdentifier(value) && aliases.has(value.text));
+  };
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const visit = (node) => {
+      let name = null;
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        if (taintsFrom(node.initializer)) name = node.name.text;
+      } else if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isIdentifier(node.left)
+      ) {
+        if (taintsFrom(node.right)) name = node.left.text;
+      }
+      if (name && !aliases.has(name)) {
+        aliases.add(name);
+        changed = true;
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(sourceFile, visit);
+  }
+  return aliases;
+}
+
 /** Walks `root` (inclusive) looking for any node satisfying `predicate`. */
 function containsNode(root, predicate) {
   let found = false;
@@ -134,9 +192,9 @@ function lineOf(sourceFile, node) {
   return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
 }
 
-/** True when any argument of a call contains a reveal(). */
-function hasRevealedArgument(node) {
-  return node.arguments.some((argument) => containsNode(argument, isRevealCall));
+/** True when any argument of a call contains a revealed value. */
+function hasRevealedArgument(node, isRevealedValue) {
+  return node.arguments.some((argument) => containsNode(argument, isRevealedValue));
 }
 
 /**
@@ -145,11 +203,11 @@ function hasRevealedArgument(node) {
  * adding a rule does not push the walker past the repo's complexity ceiling.
  */
 const RULES = [
-  function serialization(node) {
+  function serialization(node, isRevealedValue) {
     if (!isJsonStringifyCall(node)) return null;
     const [argument] = node.arguments;
     if (!argument) return null;
-    if (containsNode(argument, isRevealCall)) {
+    if (containsNode(argument, isRevealedValue)) {
       return "JSON.stringify() receives a revealed SecretRef. Serialize the wrapper, or a hash of the value, not reveal().";
     }
     if (containsNode(argument, isSecretRefConstruction)) {
@@ -158,20 +216,20 @@ const RULES = [
     return null;
   },
 
-  function logging(node) {
-    if (!isLogCall(node) || !hasRevealedArgument(node)) return null;
+  function logging(node, isRevealedValue) {
+    if (!isLogCall(node) || !hasRevealedArgument(node, isRevealedValue)) return null;
     return `${node.expression.name.text}() receives a revealed SecretRef. Log an identifier or a hash, never the material.`;
   },
 
-  function stringCoercion(node) {
-    if (!isStringCoercionCall(node) || !hasRevealedArgument(node)) return null;
+  function stringCoercion(node, isRevealedValue) {
+    if (!isStringCoercionCall(node) || !hasRevealedArgument(node, isRevealedValue)) return null;
     return 'String() receives a revealed SecretRef. Coerce the wrapper instead — it yields "[REDACTED]".';
   },
 
-  function interpolation(node) {
+  function interpolation(node, isRevealedValue) {
     if (!ts.isTemplateExpression(node)) return null;
     const interpolatesReveal = node.templateSpans.some((span) =>
-      containsNode(span.expression, isRevealCall)
+      containsNode(span.expression, isRevealedValue)
     );
     if (!interpolatesReveal) return null;
     return 'Template literal interpolates a revealed SecretRef. Interpolate the wrapper instead — it yields "[REDACTED]".';
@@ -192,9 +250,20 @@ export function findSecretRefViolations(sourceText, relativePath) {
     relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
 
+  const aliases = collectRevealedAliases(sourceFile);
+  const isRevealedValue = (node) => {
+    if (isRevealCall(node)) return true;
+    if (!ts.isIdentifier(node) || !aliases.has(node.text)) return false;
+    // A same-named property (`obj.v`, `{ v: x }`) is not the variable.
+    const parent = node.parent;
+    if (parent && ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+    if (parent && ts.isPropertyAssignment(parent) && parent.name === node) return false;
+    return true;
+  };
+
   const visit = (node) => {
     for (const rule of RULES) {
-      const message = rule(node);
+      const message = rule(node, isRevealedValue);
       if (message) {
         violations.push(`${relativePath}:${lineOf(sourceFile, node)}: ${message}`);
       }

--- a/scripts/check-secretref-serialization.mjs
+++ b/scripts/check-secretref-serialization.mjs
@@ -1,0 +1,265 @@
+/**
+ * Forbids revealed `SecretRef` material from reaching a serializer, a logger, or
+ * a string.
+ *
+ * `SecretRef<T>` (packages/sdp-helius-rings/src/secrets.ts) wraps viewing keys,
+ * nullifier keys and proof internals. Its `toJSON()`/`toString()` overrides
+ * already return "[REDACTED]", so passing a *wrapped* secret to
+ * `JSON.stringify` or a log call is safe by construction — the plan's original
+ * wording ("forbid JSON.stringify on any value typed SecretRef<*>") targets a
+ * pattern that cannot actually leak.
+ *
+ * The pattern that leaks is `reveal()`. Once unwrapped, the value is an ordinary
+ * string or Uint8Array with no redaction behaviour at all, and the wrapper's
+ * whole purpose is gone. So this check follows the intent rather than the letter
+ * and flags reveal() results flowing into:
+ *
+ *   1. JSON.stringify / JSON.stringify-like serialization
+ *   2. a logger or console call
+ *   3. a template literal or String()
+ *
+ * It also flags `JSON.stringify` applied directly to a `SecretRef` construction,
+ * which is harmless at runtime but always means the author misunderstood the
+ * wrapper.
+ *
+ * `reveal("test")` inside test files is the sanctioned path — `RevealScope`
+ * includes "test" precisely so tests can assert on real values — so test files
+ * are exempt.
+ *
+ * This is a standalone script rather than a lint rule because the repo lints
+ * with Biome, which has no custom-rule authoring mechanism in use here, and the
+ * established convention for bespoke static checks is scripts/check-*.mjs with a
+ * sibling .test.mjs (see check-module-boundaries.mjs, check-env-contract.mjs).
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+/** Methods that write somewhere a human or a log sink can read. */
+const LOG_METHODS = new Set([
+  "log",
+  "info",
+  "warn",
+  "error",
+  "debug",
+  "trace",
+  "fatal",
+  "captureException",
+  "captureMessage",
+]);
+
+const SCAN_ROOTS = ["apps", "packages"];
+
+/** Files that legitimately handle raw secret material. */
+const EXEMPT_SUFFIXES = [
+  "packages/sdp-helius-rings/src/secrets.ts",
+  "scripts/check-secretref-serialization.mjs",
+];
+
+function isTestFile(relativePath) {
+  return (
+    /\.(test|spec)\.(ts|tsx|mts)$/.test(relativePath) || /(^|\/)(test|tests)\//.test(relativePath)
+  );
+}
+
+function isExempt(relativePath) {
+  return EXEMPT_SUFFIXES.some((suffix) => relativePath.endsWith(suffix));
+}
+
+/** True when `node` is a `<something>.reveal(...)` call. */
+function isRevealCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "reveal"
+  );
+}
+
+/** True when `node` is `JSON.stringify(...)`. */
+function isJsonStringifyCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "stringify" &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "JSON"
+  );
+}
+
+/** True when `node` is a `<obj>.info(...)`-style call onto a log-ish method. */
+function isLogCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    LOG_METHODS.has(node.expression.name.text)
+  );
+}
+
+/** True when `node` is `String(...)`. */
+function isStringCoercionCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "String"
+  );
+}
+
+/** True when `node` is `new SecretRef(...)`. */
+function isSecretRefConstruction(node) {
+  return (
+    ts.isNewExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "SecretRef"
+  );
+}
+
+/** Walks `root` (inclusive) looking for any node satisfying `predicate`. */
+function containsNode(root, predicate) {
+  let found = false;
+  const visit = (node) => {
+    if (found) return;
+    if (predicate(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return found;
+}
+
+function lineOf(sourceFile, node) {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+/** True when any argument of a call contains a reveal(). */
+function hasRevealedArgument(node) {
+  return node.arguments.some((argument) => containsNode(argument, isRevealCall));
+}
+
+/**
+ * The rules. Each takes a node and returns the violation message for it, or
+ * null. Kept as separate small functions rather than one branching visitor so
+ * adding a rule does not push the walker past the repo's complexity ceiling.
+ */
+const RULES = [
+  function serialization(node) {
+    if (!isJsonStringifyCall(node)) return null;
+    const [argument] = node.arguments;
+    if (!argument) return null;
+    if (containsNode(argument, isRevealCall)) {
+      return "JSON.stringify() receives a revealed SecretRef. Serialize the wrapper, or a hash of the value, not reveal().";
+    }
+    if (containsNode(argument, isSecretRefConstruction)) {
+      return 'JSON.stringify() receives a SecretRef. It serializes to "[REDACTED]" and carries no information — drop the call.';
+    }
+    return null;
+  },
+
+  function logging(node) {
+    if (!isLogCall(node) || !hasRevealedArgument(node)) return null;
+    return `${node.expression.name.text}() receives a revealed SecretRef. Log an identifier or a hash, never the material.`;
+  },
+
+  function stringCoercion(node) {
+    if (!isStringCoercionCall(node) || !hasRevealedArgument(node)) return null;
+    return 'String() receives a revealed SecretRef. Coerce the wrapper instead — it yields "[REDACTED]".';
+  },
+
+  function interpolation(node) {
+    if (!ts.isTemplateExpression(node)) return null;
+    const interpolatesReveal = node.templateSpans.some((span) =>
+      containsNode(span.expression, isRevealCall)
+    );
+    if (!interpolatesReveal) return null;
+    return 'Template literal interpolates a revealed SecretRef. Interpolate the wrapper instead — it yields "[REDACTED]".';
+  },
+];
+
+/**
+ * Returns violation strings for one file's source text. Exported so the sibling
+ * test can drive it without touching the filesystem.
+ */
+export function findSecretRefViolations(sourceText, relativePath) {
+  const violations = [];
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  const visit = (node) => {
+    for (const rule of RULES) {
+      const message = rule(node);
+      if (message) {
+        violations.push(`${relativePath}:${lineOf(sourceFile, node)}: ${message}`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sourceFile, visit);
+  return violations;
+}
+
+function collectSourceFiles(repositoryRoot) {
+  const files = [];
+
+  for (const root of SCAN_ROOTS) {
+    const absoluteRoot = path.join(repositoryRoot, root);
+    let entries;
+    try {
+      if (!statSync(absoluteRoot).isDirectory()) continue;
+      entries = readdirSync(absoluteRoot, { recursive: true, encoding: "utf8" });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!/\.(ts|tsx|mts)$/.test(entry)) continue;
+      if (/(^|\/)(node_modules|dist|build|\.next|\.turbo)(\/|$)/.test(entry)) continue;
+      if (entry.endsWith(".d.ts")) continue;
+
+      const relativePath = path.posix.join(root, entry.split(path.sep).join("/"));
+      if (isTestFile(relativePath) || isExempt(relativePath)) continue;
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
+export function checkSecretRefSerialization(repositoryRoot) {
+  const violations = [];
+
+  for (const relativePath of collectSourceFiles(repositoryRoot)) {
+    const sourceText = readFileSync(path.join(repositoryRoot, relativePath), "utf8");
+    // Cheap prefilter: parsing every file in the monorepo to find a handful of
+    // reveal() calls is wasted work.
+    if (!sourceText.includes("reveal(") && !sourceText.includes("SecretRef")) continue;
+    violations.push(...findSecretRefViolations(sourceText, relativePath));
+  }
+
+  return violations;
+}
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMainModule) {
+  const repositoryRoot = path.resolve(
+    process.argv[2] ?? path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+  );
+  const violations = checkSecretRefSerialization(repositoryRoot);
+
+  if (violations.length > 0) {
+    console.error("SecretRef serialization violations:\n");
+    console.error(violations.map((violation) => `- ${violation}`).join("\n"));
+    process.exitCode = 1;
+  } else {
+    console.log("SecretRef serialization check passed.");
+  }
+}

--- a/scripts/check-secretref-serialization.test.mjs
+++ b/scripts/check-secretref-serialization.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findSecretRefViolations } from "./check-secretref-serialization.mjs";
+
+test("flags a revealed secret passed to JSON.stringify", () => {
+  const violations = findSecretRefViolations(
+    `const payload = JSON.stringify({ key: keyRef.material.reveal("adapter") });\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /^apps\/sdp-api\/src\/services\/helius-rings\/example\.ts:1: /);
+  assert.match(violations[0], /JSON\.stringify\(\) receives a revealed SecretRef/);
+});
+
+test("flags a revealed secret passed to a logger", () => {
+  const violations = findSecretRefViolations(
+    `getLogger().info({ viewingKey: keys.viewing.reveal("adapter") }, "provisioned");\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /info\(\) receives a revealed SecretRef/);
+});
+
+test("flags a revealed secret interpolated into a template literal", () => {
+  const violations = findSecretRefViolations(
+    `const message = \`viewing key is \${secret.reveal("signer")}\`;\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /Template literal interpolates a revealed SecretRef/);
+});
+
+test("flags a revealed secret coerced with String()", () => {
+  const violations = findSecretRefViolations(
+    `const asText = String(secret.reveal("adapter"));\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /String\(\) receives a revealed SecretRef/);
+});
+
+test("flags stringifying a SecretRef as pointless rather than dangerous", () => {
+  const violations = findSecretRefViolations(
+    `const encoded = JSON.stringify(new SecretRef("hunter2"));\n`,
+    "packages/sdp-helius-rings/src/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /carries no information/);
+});
+
+test("finds a reveal nested deep inside a log argument", () => {
+  const violations = findSecretRefViolations(
+    `logger.error({ op: { detail: { material: ref.material.reveal("signer") } } }, "failed");\n`,
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /error\(\) receives a revealed SecretRef/);
+});
+
+test("reports each offending call once, with its own line", () => {
+  const violations = findSecretRefViolations(
+    [
+      `logger.info({ a: s.reveal("adapter") }, "one");`,
+      `const t = \`\${s.reveal("adapter")}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/example.ts"
+  );
+
+  assert.equal(violations.length, 2);
+  assert.match(violations[0], /:1: /);
+  assert.match(violations[1], /:2: /);
+});
+
+test("allows passing the wrapper itself to a logger or serializer", () => {
+  const violations = findSecretRefViolations(
+    [
+      `getLogger().info({ proof: operation.proof }, "prepared");`,
+      `const body = JSON.stringify({ ref: operation.proof.ref });`,
+      `const shown = \`proof \${operation.proof.ref}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("allows reveal() where it belongs — handed to an adapter or signer", () => {
+  const violations = findSecretRefViolations(
+    [
+      `await gateway.buildOperation({ material: keyRef.material.reveal("adapter") });`,
+      `const signature = await signer.sign(payload, key.reveal("signer"));`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("does not confuse an unrelated reveal() method", () => {
+  const violations = findSecretRefViolations(
+    `logger.info({ state: animation.reveal() }, "toggled");\n`,
+    "apps/sdp-web/src/example.ts"
+  );
+
+  // A false positive here is acceptable and deliberate: the check is
+  // name-based, and `reveal()` is rare enough outside SecretRef that catching
+  // the leak is worth the occasional rename. Documented so the behaviour is a
+  // decision rather than a surprise.
+  assert.equal(violations.length, 1);
+});

--- a/scripts/check-secretref-serialization.test.mjs
+++ b/scripts/check-secretref-serialization.test.mjs
@@ -102,6 +102,62 @@ test("allows reveal() where it belongs — handed to an adapter or signer", () =
   assert.deepEqual(violations, []);
 });
 
+test("flags a revealed secret logged through a variable", () => {
+  const violations = findSecretRefViolations(
+    [
+      `const material = keyRef.material.reveal("adapter");`,
+      `logger.info({ material }, "provisioned");`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /:2: info\(\) receives a revealed SecretRef/);
+});
+
+test("follows an alias chain and reassignment to a sink", () => {
+  const violations = findSecretRefViolations(
+    [
+      `let value = other;`,
+      `value = secret.reveal("signer");`,
+      `const copy = value;`,
+      `const body = JSON.stringify({ copy });`,
+      `const shown = \`key \${copy}\`;`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.equal(violations.length, 2);
+  assert.match(violations[0], /:4: JSON\.stringify\(\) receives a revealed SecretRef/);
+  assert.match(violations[1], /:5: Template literal interpolates a revealed SecretRef/);
+});
+
+test("does not taint values transformed by another call", () => {
+  const violations = findSecretRefViolations(
+    [
+      `const digest = sha256(secret.reveal("adapter"));`,
+      `logger.info({ digest }, "provisioned");`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  // Hashing is the sanctioned way to log; only direct aliases are tracked.
+  assert.deepEqual(violations, []);
+});
+
+test("does not flag a same-named property on another object", () => {
+  const violations = findSecretRefViolations(
+    [
+      `const material = keyRef.material.reveal("adapter");`,
+      `await gateway.buildOperation({ material });`,
+      `logger.info({ kind: row.material }, "stored");`,
+    ].join("\n"),
+    "apps/sdp-api/src/services/helius-rings/example.ts"
+  );
+
+  assert.deepEqual(violations, []);
+});
+
 test("does not confuse an unrelated reveal() method", () => {
   const violations = findSecretRefViolations(
     `logger.info({ state: animation.reveal() }, "toggled");\n`,


### PR DESCRIPTION
Supersedes #1331 (closed as erroneous push); incorporates its review finding (indirect reveal flows).

- Adds `log-redaction.ts` registry (`viewingKey`, `nullifierKey`, `ringsMetadata`, `proof.ref/internal`, `keyRefs[*].material`), wired into pino via `baseLoggerOptions()`
- Adds `scripts/check-secretref-serialization.mjs` CI check: fails the build when a `reveal()` result — direct or via variable alias — reaches `JSON.stringify`, a logger, `String()`, or a template literal; hashed/transformed values and test files exempt
- ~1s repo-wide; wired into the Unit Tests CI job
- 14 checker tests + registry unit tests
