### PR TITLE
feat(helius): add rings repositories

### DIFF
--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -19,6 +19,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.json ./
 COPY apps/sdp-api/package.json ./apps/sdp-api/
 COPY packages/sdp-types/package.json ./packages/sdp-types/
 COPY packages/sdp-env-config/package.json ./packages/sdp-env-config/
+COPY packages/sdp-helius-rings/package.json ./packages/sdp-helius-rings/
 COPY packages/sdp-earn/package.json ./packages/sdp-earn/
 COPY packages/sdp-payments/package.json ./packages/sdp-payments/
 COPY packages/sdp-rpc/package.json ./packages/sdp-rpc/
@@ -43,6 +44,7 @@ COPY --from=deps /repo /repo
 COPY apps/sdp-api ./apps/sdp-api
 COPY packages/sdp-types ./packages/sdp-types
 COPY packages/sdp-env-config ./packages/sdp-env-config
+COPY packages/sdp-helius-rings ./packages/sdp-helius-rings
 COPY packages/sdp-earn ./packages/sdp-earn
 COPY packages/sdp-payments ./packages/sdp-payments
 COPY packages/sdp-rpc ./packages/sdp-rpc

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -19,6 +19,7 @@ packages/*
 !packages/sdp-types
 !packages/sdp-env-config
 !packages/sdp-earn
+!packages/sdp-helius-rings
 !packages/sdp-rpc
 !packages/sdp-custody
 !packages/sdp-solana

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -50,6 +50,7 @@
     "@sdp/custody": "workspace:*",
     "@sdp/earn": "workspace:*",
     "@sdp/env-config": "workspace:*",
+    "@sdp/helius-rings": "workspace:*",
     "@sdp/issuance": "workspace:*",
     "@sdp/kamino": "workspace:*",
     "@sdp/payments": "workspace:*",

--- a/apps/sdp-api/src/db/repositories/helius-rings-event.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-event.repository.postgres.ts
@@ -1,0 +1,59 @@
+import type { AppDb } from "@/db";
+import {
+  type AppendHeliusRingsEventInput,
+  DEFAULT_RINGS_EVENT_LIST_LIMIT,
+  generateHeliusRingsEventId,
+  type HeliusRingsEventRepository,
+  type HeliusRingsEventRow,
+  type ListHeliusRingsEventsInput,
+  redactHeliusRingsEventPayload,
+} from "./helius-rings-event.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsEventRow {
+  return {
+    id: row.id as string,
+    operation_id: row.operation_id as string,
+    kind: row.kind as string,
+    payload: (row.payload ?? null) as Record<string, unknown> | null,
+    created_at: row.created_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsEventRepository(db: AppDb): HeliusRingsEventRepository {
+  return {
+    async append(input: AppendHeliusRingsEventInput) {
+      const id = generateHeliusRingsEventId();
+      // Redact before the value ever reaches the driver, so nothing sensitive
+      // exists in a query log or a statement parameter either.
+      const payload =
+        input.payload === undefined || input.payload === null
+          ? null
+          : JSON.stringify(redactHeliusRingsEventPayload(input.payload));
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_events (id, operation_id, kind, payload)
+           VALUES (?, ?, ?, ?::jsonb)
+           RETURNING *`
+        )
+        .bind(id, input.operationId, input.kind, payload)
+        .first<Record<string, unknown>>();
+      if (!row) {
+        throw new Error("helius rings event append returned no row");
+      }
+      return mapRow(row);
+    },
+
+    async listByOperation(input: ListHeliusRingsEventsInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_events
+            WHERE operation_id = ?
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?`
+        )
+        .bind(input.operationId, input.limit ?? DEFAULT_RINGS_EVENT_LIST_LIMIT)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-event.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-event.repository.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { REDACTION_CENSOR } from "@/runtime/log-redaction";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type { HeliusRingsEventRepository } from "./helius-rings-event.repository";
+import {
+  mapHeliusRingsEventRow,
+  redactHeliusRingsEventPayload,
+} from "./helius-rings-event.repository";
+import { createPostgresHeliusRingsEventRepository } from "./helius-rings-event.repository.postgres";
+import type { HeliusRingsOperationRepository } from "./helius-rings-operation.repository";
+import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hre_repo_test";
+const scope = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+describe("redactHeliusRingsEventPayload", () => {
+  it("censors rings key material wherever it appears", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      viewingKey: "vk-secret",
+      nullifierKey: "nk-secret",
+      ringsMetadata: { anything: "opaque" },
+      amountRaw: "1000",
+    });
+
+    expect(redacted).toEqual({
+      viewingKey: REDACTION_CENSOR,
+      nullifierKey: REDACTION_CENSOR,
+      ringsMetadata: REDACTION_CENSOR,
+      amountRaw: "1000",
+    });
+  });
+
+  it("censors at arbitrary depth, unlike the one-level pino registry", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      a: { b: { c: { viewingKey: "vk-secret", label: "keep" } } },
+    });
+
+    expect(redacted).toEqual({
+      a: { b: { c: { viewingKey: REDACTION_CENSOR, label: "keep" } } },
+    });
+  });
+
+  it("censors through arrays", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      keyRefs: [{ material: "sealed", kind: "viewing" }],
+    });
+
+    expect(redacted).toEqual({
+      keyRefs: [{ material: REDACTION_CENSOR, kind: "viewing" }],
+    });
+  });
+
+  it("censors proof internals but keeps the rest of the proof readable", () => {
+    const redacted = redactHeliusRingsEventPayload({
+      proof: { ref: "opaque-handle", internal: "witness", source: "simulated" },
+      // `ref` outside a proof parent is an ordinary reference, not a secret.
+      ref: "operation-ref",
+    });
+
+    expect(redacted).toEqual({
+      proof: { ref: REDACTION_CENSOR, internal: REDACTION_CENSOR, source: "simulated" },
+      ref: "operation-ref",
+    });
+  });
+
+  it("breaks cycles rather than throwing", () => {
+    const payload: Record<string, unknown> = { kind: "loop" };
+    payload.self = payload;
+
+    // A malformed payload must not fail the state transition trying to record
+    // itself.
+    expect(redactHeliusRingsEventPayload(payload)).toEqual({
+      kind: "loop",
+      self: "[Circular]",
+    });
+  });
+
+  it("passes primitives through untouched", () => {
+    expect(redactHeliusRingsEventPayload("plain")).toBe("plain");
+    expect(redactHeliusRingsEventPayload(null)).toBeNull();
+    expect(redactHeliusRingsEventPayload(7)).toBe(7);
+  });
+});
+
+describe("HeliusRingsEventRepository (postgres)", () => {
+  let repo: HeliusRingsEventRepository;
+  let operationRepo: HeliusRingsOperationRepository;
+  let operationId: string;
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const wallet = await createPostgresHeliusRingsWalletRepository(db).createWallet({
+      ...scope,
+      sdpWalletId: "wal_hre_repo_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+
+    operationRepo = createPostgresHeliusRingsOperationRepository(db);
+    const { operation } = await operationRepo.reserveIntent({
+      ...scope,
+      walletId: wallet.id,
+      opType: "shield",
+      intentKey: "sha256:event-test",
+    });
+    operationId = operation.id;
+
+    repo = createPostgresHeliusRingsEventRepository(db);
+  });
+
+  it("appends an event with its payload", async () => {
+    const event = await repo.append({
+      operationId,
+      kind: "state.transitioned",
+      payload: { from: "draft", to: "preparing" },
+    });
+
+    expect(event).toMatchObject({
+      operation_id: operationId,
+      kind: "state.transitioned",
+      payload: { from: "draft", to: "preparing" },
+    });
+  });
+
+  it("redacts key material before it reaches the table", async () => {
+    await repo.append({
+      operationId,
+      kind: "wallet.provisioned",
+      payload: { viewingKey: "vk-secret", shieldedAddress: "shielded-1" },
+    });
+
+    const [stored] = await repo.listByOperation({ operationId });
+    expect(stored.payload).toEqual({
+      viewingKey: REDACTION_CENSOR,
+      shieldedAddress: "shielded-1",
+    });
+
+    // Belt and braces: the literal secret is nowhere in the column.
+    const raw = await getDb(env)
+      .prepare("SELECT payload::text AS payload FROM helius_rings_events WHERE operation_id = ?")
+      .bind(operationId)
+      .first<{ payload: string }>();
+    expect(raw?.payload).not.toContain("vk-secret");
+  });
+
+  it("accepts an event with no payload", async () => {
+    const event = await repo.append({ operationId, kind: "operation.created" });
+
+    expect(event.payload).toBeNull();
+  });
+
+  it("lists the timeline oldest first", async () => {
+    await repo.append({ operationId, kind: "first" });
+    await repo.append({ operationId, kind: "second" });
+    await repo.append({ operationId, kind: "third" });
+    const db = getDb(env);
+    await db
+      .prepare("UPDATE helius_rings_events SET created_at = ? WHERE kind = ?")
+      .bind("2026-01-01T00:00:00.000Z", "first")
+      .run();
+    await db
+      .prepare("UPDATE helius_rings_events SET created_at = ? WHERE kind = ?")
+      .bind("2026-02-01T00:00:00.000Z", "second")
+      .run();
+    await db
+      .prepare("UPDATE helius_rings_events SET created_at = ? WHERE kind = ?")
+      .bind("2026-03-01T00:00:00.000Z", "third")
+      .run();
+
+    const events = await repo.listByOperation({ operationId });
+    expect(events.map((event) => event.kind)).toEqual(["first", "second", "third"]);
+  });
+
+  it("honours the list limit", async () => {
+    await repo.append({ operationId, kind: "first" });
+    await repo.append({ operationId, kind: "second" });
+
+    expect(await repo.listByOperation({ operationId, limit: 1 })).toHaveLength(1);
+  });
+
+  it("maps a row onto the domain event", async () => {
+    const event = await repo.append({ operationId, kind: "state.transitioned", payload: null });
+
+    expect(mapHeliusRingsEventRow(event)).toEqual({
+      kind: "state.transitioned",
+      createdAt: event.created_at,
+      payload: undefined,
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-event.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-event.repository.ts
@@ -1,0 +1,114 @@
+import type { OperationEvent } from "@sdp/helius-rings";
+import { REDACTED_LEAF_FIELDS, REDACTION_CENSOR } from "@/runtime/log-redaction";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsEventId(): string {
+  return `hre_${crypto.randomUUID()}`;
+}
+
+/** Upper bound on an unpaginated timeline read. */
+export const DEFAULT_RINGS_EVENT_LIST_LIMIT = 200;
+
+export interface HeliusRingsEventRow {
+  id: string;
+  operation_id: string;
+  /**
+   * Free-form. Event kinds are additive documentation of what happened, and the
+   * DB deliberately carries no CHECK on them — gating each new kind behind a
+   * migration is how you end up with someone logging it somewhere worse.
+   */
+  kind: string;
+  payload: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface AppendHeliusRingsEventInput {
+  operationId: string;
+  kind: string;
+  /** Redacted by `append` before it is written. */
+  payload?: Record<string, unknown> | null;
+}
+
+export interface ListHeliusRingsEventsInput {
+  operationId: string;
+  limit?: number;
+}
+
+export interface HeliusRingsEventRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsEventRepository {
+  /**
+   * Appends one timeline entry. The payload is redacted on the way in, so the
+   * table cannot accumulate secret material even if a caller passes something it
+   * should not have.
+   */
+  append(input: AppendHeliusRingsEventInput): Promise<HeliusRingsEventRow>;
+  listByOperation(input: ListHeliusRingsEventsInput): Promise<HeliusRingsEventRow[]>;
+}
+
+/**
+ * Keys censored wherever they appear in an event payload.
+ *
+ * The Rings key domain comes from the log redaction registry rather than being
+ * retyped here — two copies of a security-critical list is how one of them goes
+ * stale. `material` is added because that is the key ref field name, and
+ * `ciphertext` because a sealed blob is still not timeline material.
+ */
+const CENSORED_KEYS = new Set<string>([...REDACTED_LEAF_FIELDS, "material", "ciphertext"]);
+
+/** Keys censored only under a `proof` parent, where they mean proof internals. */
+const CENSORED_PROOF_KEYS = new Set(["ref", "internal"]);
+
+function shouldCensor(key: string, parentKey: string | null): boolean {
+  return CENSORED_KEYS.has(key) || (parentKey === "proof" && CENSORED_PROOF_KEYS.has(key));
+}
+
+/**
+ * Deep-copies a payload, replacing sensitive values with the censor.
+ *
+ * Unlike the pino registry — which is bounded to one nesting level by
+ * fast-redact — this walks to arbitrary depth, because an event payload is
+ * written once and then read back forever, so the cost is paid on write rather
+ * than on every log line. Cycles are broken with a seen-set rather than
+ * throwing, since a malformed payload should not fail the state transition that
+ * is trying to record itself.
+ */
+export function redactHeliusRingsEventPayload(value: unknown, seen = new WeakSet()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactHeliusRingsEventPayload(entry, seen));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (shouldCensor(key, null)) {
+      result[key] = REDACTION_CENSOR;
+      continue;
+    }
+    if (key === "proof" && entry !== null && typeof entry === "object" && !Array.isArray(entry)) {
+      const proof: Record<string, unknown> = {};
+      for (const [proofKey, proofEntry] of Object.entries(entry as Record<string, unknown>)) {
+        proof[proofKey] = shouldCensor(proofKey, "proof")
+          ? REDACTION_CENSOR
+          : redactHeliusRingsEventPayload(proofEntry, seen);
+      }
+      result[key] = proof;
+      continue;
+    }
+    result[key] = redactHeliusRingsEventPayload(entry, seen);
+  }
+  return result;
+}
+
+export function mapHeliusRingsEventRow(row: HeliusRingsEventRow): OperationEvent {
+  return {
+    kind: row.kind,
+    createdAt: row.created_at,
+    payload: row.payload ?? undefined,
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-health.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-health.repository.postgres.ts
@@ -1,0 +1,58 @@
+import type { AppDb } from "@/db";
+import type {
+  HeliusRingsHealthRepository,
+  HeliusRingsRuntimeHealthRow,
+  RecordHeliusRingsHealthInput,
+} from "./helius-rings-health.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsRuntimeHealthRow {
+  return {
+    project_id: row.project_id as string,
+    component: row.component as HeliusRingsRuntimeHealthRow["component"],
+    status: row.status as HeliusRingsRuntimeHealthRow["status"],
+    observed_at: row.observed_at as string,
+    detail: (row.detail ?? null) as Record<string, string> | null,
+  };
+}
+
+export function createPostgresHeliusRingsHealthRepository(db: AppDb): HeliusRingsHealthRepository {
+  return {
+    async recordHealth(input: RecordHeliusRingsHealthInput) {
+      const detail =
+        input.detail === undefined || input.detail === null ? null : JSON.stringify(input.detail);
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_runtime_health (project_id, component, status, observed_at, detail)
+           VALUES (?, ?, ?, sdp_iso_now(), ?::jsonb)
+           ON CONFLICT (project_id, component)
+           -- Overwrite in place: this table is a status board, not a history.
+           -- observed_at moves even when the status is unchanged, because "still
+           -- green as of a minute ago" and "green, last checked on Tuesday" are
+           -- different answers for the operator staring at the diagnostics page.
+           DO UPDATE SET
+             status = EXCLUDED.status,
+             observed_at = EXCLUDED.observed_at,
+             detail = EXCLUDED.detail
+           RETURNING *`
+        )
+        .bind(input.projectId, input.component, input.status, detail)
+        .first<Record<string, unknown>>();
+      if (!row) {
+        throw new Error("helius rings recordHealth returned no row");
+      }
+      return mapRow(row);
+    },
+
+    async listHealthByProject(input: { projectId: string }) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_runtime_health
+            WHERE project_id = ?
+            ORDER BY component ASC`
+        )
+        .bind(input.projectId)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-health.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-health.repository.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type {
+  HeliusRingsHealthRepository,
+  HeliusRingsRuntimeHealthRow,
+} from "./helius-rings-health.repository";
+import { mapHeliusRingsHealthRows } from "./helius-rings-health.repository";
+import { createPostgresHeliusRingsHealthRepository } from "./helius-rings-health.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hrh_repo_test";
+
+function row(overrides: Partial<HeliusRingsRuntimeHealthRow> = {}): HeliusRingsRuntimeHealthRow {
+  return {
+    project_id: TEST_PROJECT_ID,
+    component: "rpc",
+    status: "green",
+    observed_at: "2026-08-17T00:00:00.000Z",
+    detail: null,
+    ...overrides,
+  };
+}
+
+describe("mapHeliusRingsHealthRows", () => {
+  it("reads an unobserved component as red, not green", () => {
+    // Never having checked an upstream is not evidence that it is healthy, and
+    // the action gate keys off this value.
+    expect(mapHeliusRingsHealthRows([])).toEqual({
+      rpc: "red",
+      prover: "red",
+      photon: "red",
+      gateway: "red",
+    });
+  });
+
+  it("reports each observed component's stored status", () => {
+    const health = mapHeliusRingsHealthRows([
+      row({ component: "rpc", status: "green" }),
+      row({ component: "prover", status: "amber" }),
+      row({ component: "photon", status: "red" }),
+    ]);
+
+    expect(health).toEqual({
+      rpc: "green",
+      prover: "amber",
+      photon: "red",
+      gateway: "red",
+    });
+  });
+
+  it("prefixes detail keys with their component so they cannot collide", () => {
+    const health = mapHeliusRingsHealthRows([
+      row({ component: "rpc", detail: { reason: "slow" } }),
+      row({ component: "prover", detail: { reason: "queue depth" } }),
+    ]);
+
+    expect(health.detail).toEqual({
+      "rpc.reason": "slow",
+      "prover.reason": "queue depth",
+    });
+  });
+
+  it("omits detail entirely when no row carries any", () => {
+    expect(mapHeliusRingsHealthRows([row()])).not.toHaveProperty("detail");
+  });
+});
+
+describe("HeliusRingsHealthRepository (postgres)", () => {
+  let repo: HeliusRingsHealthRepository;
+
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    repo = createPostgresHeliusRingsHealthRepository(db);
+  });
+
+  it("records an observation with its detail", async () => {
+    const recorded = await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "prover",
+      status: "amber",
+      detail: { reason: "queue depth 40" },
+    });
+
+    expect(recorded).toMatchObject({
+      component: "prover",
+      status: "amber",
+      detail: { reason: "queue depth 40" },
+    });
+    expect(recorded.observed_at).toBeTruthy();
+  });
+
+  it("overwrites in place rather than appending a history", async () => {
+    await repo.recordHealth({ projectId: TEST_PROJECT_ID, component: "rpc", status: "red" });
+    const updated = await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "rpc",
+      status: "green",
+    });
+
+    expect(updated.status).toBe("green");
+    const rows = await repo.listHealthByProject({ projectId: TEST_PROJECT_ID });
+    expect(rows).toHaveLength(1);
+  });
+
+  it("clears stale detail when a later observation carries none", async () => {
+    await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "rpc",
+      status: "red",
+      detail: { reason: "timeout" },
+    });
+    const recovered = await repo.recordHealth({
+      projectId: TEST_PROJECT_ID,
+      component: "rpc",
+      status: "green",
+    });
+
+    // A green row still carrying the old failure text misreports a healthy
+    // upstream as broken.
+    expect(recovered.detail).toBeNull();
+  });
+
+  it("keeps components independent", async () => {
+    await repo.recordHealth({ projectId: TEST_PROJECT_ID, component: "rpc", status: "green" });
+    await repo.recordHealth({ projectId: TEST_PROJECT_ID, component: "photon", status: "amber" });
+
+    const health = mapHeliusRingsHealthRows(
+      await repo.listHealthByProject({ projectId: TEST_PROJECT_ID })
+    );
+    expect(health).toMatchObject({ rpc: "green", photon: "amber", prover: "red", gateway: "red" });
+  });
+
+  it("rejects a component outside the known set", async () => {
+    await expect(
+      repo.recordHealth({
+        projectId: TEST_PROJECT_ID,
+        // Deliberately outside RUNTIME_HEALTH_COMPONENTS: the DB CHECK is the
+        // backstop for a component added in code but not in a migration.
+        component: "sidecar" as never,
+        status: "green",
+      })
+    ).rejects.toMatchObject({ message: expect.stringContaining("component_check") });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-health.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-health.repository.ts
@@ -1,0 +1,57 @@
+import type { RuntimeHealth, RuntimeHealthComponent, RuntimeHealthStatus } from "@sdp/helius-rings";
+import { RUNTIME_HEALTH_COMPONENTS } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+/**
+ * One row per (project, component). Overwritten in place rather than appended:
+ * this is the status board the diagnostics page and the red-state action gate
+ * read, not a history. Durable history lives in the event feed.
+ */
+export interface HeliusRingsRuntimeHealthRow {
+  project_id: string;
+  component: RuntimeHealthComponent;
+  status: RuntimeHealthStatus;
+  observed_at: string;
+  detail: Record<string, string> | null;
+}
+
+export interface RecordHeliusRingsHealthInput {
+  projectId: string;
+  component: RuntimeHealthComponent;
+  status: RuntimeHealthStatus;
+  detail?: Record<string, string> | null;
+}
+
+export interface HeliusRingsHealthRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsHealthRepository {
+  /** Upserts the latest observation for one component. */
+  recordHealth(input: RecordHeliusRingsHealthInput): Promise<HeliusRingsRuntimeHealthRow>;
+  listHealthByProject(input: { projectId: string }): Promise<HeliusRingsRuntimeHealthRow[]>;
+}
+
+/**
+ * Collapses the stored rows into the domain's component-to-status map.
+ *
+ * A component with no row yet reads as `red`, not `green`: never having observed
+ * an upstream is not evidence that it is healthy, and the action gate keys off
+ * this value.
+ */
+export function mapHeliusRingsHealthRows(rows: HeliusRingsRuntimeHealthRow[]): RuntimeHealth {
+  const byComponent = new Map(rows.map((row) => [row.component, row]));
+  const detail: Record<string, string> = {};
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row.detail ?? {})) {
+      detail[`${row.component}.${key}`] = value;
+    }
+  }
+
+  const health = {} as Record<RuntimeHealthComponent, RuntimeHealthStatus>;
+  for (const component of RUNTIME_HEALTH_COMPONENTS) {
+    health[component] = byComponent.get(component)?.status ?? "red";
+  }
+
+  return Object.keys(detail).length > 0 ? { ...health, detail } : { ...health };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.postgres.ts
@@ -1,0 +1,65 @@
+import type { KeyKind } from "@sdp/helius-rings";
+import type { AppDb } from "@/db";
+import {
+  type CreateHeliusRingsKeyRefInput,
+  generateHeliusRingsKeyRefId,
+  type HeliusRingsKeyRefRepository,
+  type HeliusRingsKeyRefRow,
+} from "./helius-rings-key-ref.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsKeyRefRow {
+  return {
+    id: row.id as string,
+    wallet_id: row.wallet_id as string,
+    kind: row.kind as HeliusRingsKeyRefRow["kind"],
+    ciphertext: row.ciphertext as string,
+    key_version: row.key_version as string,
+    material_tag: row.material_tag as HeliusRingsKeyRefRow["material_tag"],
+    created_at: row.created_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsKeyRefRepository(db: AppDb): HeliusRingsKeyRefRepository {
+  return {
+    async createKeyRef(input: CreateHeliusRingsKeyRefInput) {
+      const id = generateHeliusRingsKeyRefId();
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_key_refs (
+             id,
+             wallet_id,
+             kind,
+             ciphertext,
+             key_version,
+             material_tag
+           ) VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT (wallet_id, kind)
+           -- Self-assignment returns the blob already sealed. Note it assigns
+           -- created_at to itself rather than the incoming ciphertext: a replay
+           -- must not overwrite sealed material, because the first blob is the
+           -- one the shielded identity was derived from.
+           DO UPDATE SET created_at = helius_rings_key_refs.created_at
+           RETURNING *`
+        )
+        .bind(id, input.walletId, input.kind, input.ciphertext, input.keyVersion, input.materialTag)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getKeyRef(input: { walletId: string; kind: KeyKind }) {
+      const row = await db
+        .prepare(`SELECT * FROM helius_rings_key_refs WHERE wallet_id = ? AND kind = ?`)
+        .bind(input.walletId, input.kind)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listKeyRefsByWallet(input: { walletId: string }) {
+      const result = await db
+        .prepare(`SELECT * FROM helius_rings_key_refs WHERE wallet_id = ? ORDER BY kind ASC`)
+        .bind(input.walletId)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type { HeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository";
+import { createPostgresHeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository.postgres";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+import type { HeliusRingsZoneRepository } from "./helius-rings-zone.repository";
+import { mapHeliusRingsZoneRow } from "./helius-rings-zone.repository";
+import { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hrk_repo_test";
+const scope = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+let keyRefRepo: HeliusRingsKeyRefRepository;
+let zoneRepo: HeliusRingsZoneRepository;
+let walletId: string;
+let otherWalletId: string;
+
+describe("HeliusRingsKeyRefRepository / HeliusRingsZoneRepository (postgres)", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const walletRepo = createPostgresHeliusRingsWalletRepository(db);
+    const wallet = await walletRepo.createWallet({
+      ...scope,
+      sdpWalletId: "wal_hrk_repo_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    const other = await walletRepo.createWallet({
+      ...scope,
+      sdpWalletId: "wal_hrk_repo_other",
+      name: "Operations",
+      materialTag: "simulated",
+    });
+    if (!wallet || !other) throw new Error("wallet fixtures were not created");
+    walletId = wallet.id;
+    otherWalletId = other.id;
+
+    keyRefRepo = createPostgresHeliusRingsKeyRefRepository(db);
+    zoneRepo = createPostgresHeliusRingsZoneRepository(db);
+  });
+
+  describe("key refs", () => {
+    it("stores a sealed blob without interpreting it", async () => {
+      const keyRef = await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-blob",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+
+      expect(keyRef).toMatchObject({
+        wallet_id: walletId,
+        kind: "viewing",
+        ciphertext: "sealed-blob",
+        key_version: "v1",
+      });
+    });
+
+    it("does not re-seal on a replay, because the first blob owns the identity", async () => {
+      const first = await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-first",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+      const replay = await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-second",
+        keyVersion: "v2",
+        materialTag: "simulated",
+      });
+
+      expect(replay?.id).toBe(first?.id);
+      // Overwriting would strand the blob the shielded identity was derived
+      // from and make the wallet unreachable.
+      expect(replay?.ciphertext).toBe("sealed-first");
+      expect(replay?.key_version).toBe("v1");
+    });
+
+    it("keeps one blob per kind per wallet", async () => {
+      await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-viewing",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+      await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "nullifier",
+        ciphertext: "sealed-nullifier",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+
+      const listed = await keyRefRepo.listKeyRefsByWallet({ walletId });
+      expect(listed.map((keyRef) => keyRef.kind)).toEqual(["nullifier", "viewing"]);
+      expect(await keyRefRepo.getKeyRef({ walletId, kind: "viewing" })).toMatchObject({
+        ciphertext: "sealed-viewing",
+      });
+    });
+
+    it("does not leak another wallet's blobs", async () => {
+      await keyRefRepo.createKeyRef({
+        walletId,
+        kind: "viewing",
+        ciphertext: "sealed-viewing",
+        keyVersion: "v1",
+        materialTag: "simulated",
+      });
+
+      expect(await keyRefRepo.getKeyRef({ walletId: otherWalletId, kind: "viewing" })).toBeNull();
+      expect(await keyRefRepo.listKeyRefsByWallet({ walletId: otherWalletId })).toEqual([]);
+    });
+  });
+
+  describe("zones", () => {
+    it("creates a zone", async () => {
+      const zone = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+
+      expect(zone).toMatchObject({ wallet_id: walletId, name: "Payroll", kind: "treasury" });
+    });
+
+    it("returns the existing zone on a replay without moving its kind", async () => {
+      const first = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      const replay = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "public" });
+
+      expect(replay?.id).toBe(first?.id);
+      // Changing the kind under a live operation would move its destination.
+      expect(replay?.kind).toBe("treasury");
+      expect(await zoneRepo.listZonesByWallet({ walletId })).toHaveLength(1);
+    });
+
+    it("lets two wallets each hold a zone of the same name", async () => {
+      await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      const other = await zoneRepo.createZone({
+        walletId: otherWalletId,
+        name: "Payroll",
+        kind: "treasury",
+      });
+
+      expect(other?.wallet_id).toBe(otherWalletId);
+    });
+
+    it("scopes a zone read to its wallet", async () => {
+      const zone = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      if (!zone) throw new Error("zone was not created");
+
+      expect(await zoneRepo.getZoneById({ id: zone.id, walletId: otherWalletId })).toBeNull();
+      expect(await zoneRepo.getZoneById({ id: zone.id, walletId })).toMatchObject({ id: zone.id });
+    });
+
+    it("maps a row onto the domain zone", async () => {
+      const zone = await zoneRepo.createZone({ walletId, name: "Payroll", kind: "treasury" });
+      if (!zone) throw new Error("zone was not created");
+
+      expect(mapHeliusRingsZoneRow(zone)).toEqual({
+        id: zone.id,
+        name: "Payroll",
+        kind: "treasury",
+      });
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-key-ref.repository.ts
@@ -1,0 +1,46 @@
+import type { KeyKind, MaterialTag } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsKeyRefId(): string {
+  return `hrk_${crypto.randomUUID()}`;
+}
+
+/**
+ * A sealed key blob as stored. `ciphertext` is whatever custody-cipher produced
+ * and is never interpreted here — ciphertext in, ciphertext out. This repository
+ * must never call `SecretRef.reveal`, and there is deliberately no method that
+ * decrypts.
+ */
+export interface HeliusRingsKeyRefRow {
+  id: string;
+  wallet_id: string;
+  kind: KeyKind;
+  ciphertext: string;
+  /** Cipher key generation that sealed this blob, for rotation. */
+  key_version: string;
+  material_tag: MaterialTag;
+  created_at: string;
+}
+
+export interface CreateHeliusRingsKeyRefInput {
+  walletId: string;
+  kind: KeyKind;
+  ciphertext: string;
+  keyVersion: string;
+  materialTag: MaterialTag;
+}
+
+export interface HeliusRingsKeyRefRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsKeyRefRepository {
+  /**
+   * Stores one key blob. A wallet holds at most one key per kind, so a replay of
+   * provisioning returns the blob already sealed rather than writing a second
+   * one — re-sealing would strand the first and make the identity unreachable.
+   */
+  createKeyRef(input: CreateHeliusRingsKeyRefInput): Promise<HeliusRingsKeyRefRow | null>;
+  getKeyRef(input: { walletId: string; kind: KeyKind }): Promise<HeliusRingsKeyRefRow | null>;
+  listKeyRefsByWallet(input: { walletId: string }): Promise<HeliusRingsKeyRefRow[]>;
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.postgres.ts
@@ -1,0 +1,361 @@
+import type { AppDb } from "@/db";
+import {
+  DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT,
+  DEFAULT_RINGS_OPERATION_LIST_LIMIT,
+  type FailHeliusRingsOperationInput,
+  generateHeliusRingsOperationId,
+  type HeliusRingsOperationRepository,
+  type HeliusRingsOperationRow,
+  type HeliusRingsTimelockRow,
+  type ListHeliusRingsInFlightOperationsInput,
+  type ListHeliusRingsOperationsByProjectInput,
+  type ListHeliusRingsOperationsByWalletInput,
+  type ReleaseHeliusRingsTimelockInput,
+  type ReserveHeliusRingsIntentInput,
+  type TransitionHeliusRingsOperationInput,
+} from "./helius-rings-operation.repository";
+import type { HeliusRingsProjectScope } from "./helius-rings-wallet.repository";
+
+/** The states the resume sweep considers live, matching the partial index. */
+const IN_FLIGHT_STATES = [
+  "preparing",
+  "approval_required",
+  "proving",
+  "ready_to_sign",
+  "submitted",
+  "indexing",
+] as const;
+
+function mapRow(row: Record<string, unknown>): HeliusRingsOperationRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    wallet_id: row.wallet_id as string,
+    op_type: row.op_type as HeliusRingsOperationRow["op_type"],
+    state: row.state as HeliusRingsOperationRow["state"],
+    asset_mint: (row.asset_mint ?? null) as string | null,
+    amount_raw: (row.amount_raw ?? null) as string | null,
+    from_addr: (row.from_addr ?? null) as string | null,
+    to_addr: (row.to_addr ?? null) as string | null,
+    zone_id: (row.zone_id ?? null) as string | null,
+    transfer_mode: (row.transfer_mode ?? null) as HeliusRingsOperationRow["transfer_mode"],
+    intent_key: row.intent_key as string,
+    approval_request_id: (row.approval_request_id ?? null) as string | null,
+    policy_evaluation_id: (row.policy_evaluation_id ?? null) as string | null,
+    proof_source: (row.proof_source ?? null) as HeliusRingsOperationRow["proof_source"],
+    proof_ref: (row.proof_ref ?? null) as string | null,
+    outer_tx_signature: (row.outer_tx_signature ?? null) as string | null,
+    photon_indexed_at: (row.photon_indexed_at ?? null) as string | null,
+    failure_code: (row.failure_code ?? null) as HeliusRingsOperationRow["failure_code"],
+    failure_message: (row.failure_message ?? null) as string | null,
+    retryable: (row.retryable ?? null) as boolean | null,
+    retry_of_operation_id: (row.retry_of_operation_id ?? null) as string | null,
+    timelock_unlock_at: (row.timelock_unlock_at ?? null) as string | null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
+function mapTimelockRow(row: Record<string, unknown>): HeliusRingsTimelockRow {
+  return {
+    operation_id: row.operation_id as string,
+    unlock_at: row.unlock_at as string,
+    released_at: (row.released_at ?? null) as string | null,
+    beneficiary_addr: row.beneficiary_addr as string,
+  };
+}
+
+export function createPostgresHeliusRingsOperationRepository(
+  db: AppDb
+): HeliusRingsOperationRepository {
+  return {
+    async reserveIntent(input: ReserveHeliusRingsIntentInput) {
+      const id = generateHeliusRingsOperationId();
+
+      return db.transaction(async (tx) => {
+        const row = await tx
+          .prepare(
+            `INSERT INTO helius_rings_operations (
+               id,
+               organization_id,
+               project_id,
+               wallet_id,
+               op_type,
+               intent_key,
+               asset_mint,
+               amount_raw,
+               from_addr,
+               to_addr,
+               zone_id,
+               transfer_mode,
+               retry_of_operation_id,
+               timelock_unlock_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT (intent_key)
+             -- Self-assignment rather than DO NOTHING: DO NOTHING returns zero
+             -- rows on a replay, which is indistinguishable from a failed
+             -- insert. Assigning updated_at to itself makes RETURNING emit the
+             -- row that is already there without altering it.
+             DO UPDATE SET updated_at = helius_rings_operations.updated_at
+             RETURNING *`
+          )
+          .bind(
+            id,
+            input.organizationId,
+            input.projectId,
+            input.walletId,
+            input.opType,
+            input.intentKey,
+            input.assetMint ?? null,
+            input.amountRaw ?? null,
+            input.fromAddr ?? null,
+            input.toAddr ?? null,
+            input.zoneId ?? null,
+            input.transferMode ?? null,
+            input.retryOfOperationId ?? null,
+            input.timelock?.unlockAt ?? null
+          )
+          .first<Record<string, unknown>>();
+
+        if (!row) {
+          // The upsert always returns a row; a null here means the statement
+          // matched nothing at all, which is not a state this table can reach.
+          throw new Error("helius rings reserveIntent returned no row");
+        }
+
+        const operation = mapRow(row);
+        // The id we generated only survives if this call is the one that
+        // inserted. On a replay the row carries the original id, which is a
+        // cheaper and clearer signal than inspecting xmax.
+        const reserved = operation.id === id;
+
+        if (reserved && input.timelock) {
+          await tx
+            .prepare(
+              `INSERT INTO helius_rings_timelocks (operation_id, unlock_at, beneficiary_addr)
+               VALUES (?, ?, ?)
+               ON CONFLICT (operation_id) DO NOTHING`
+            )
+            .bind(operation.id, input.timelock.unlockAt, input.timelock.beneficiaryAddr)
+            .run();
+        }
+
+        return { operation, reserved };
+      });
+    },
+
+    async getOperationById(input: HeliusRingsProjectScope & { id: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(input.id, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getOperationByIntentKey(input: HeliusRingsProjectScope & { intentKey: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE intent_key = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(input.intentKey, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listOperationsByWallet(input: ListHeliusRingsOperationsByWalletInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE wallet_id = ? AND organization_id = ? AND project_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?`
+        )
+        .bind(
+          input.walletId,
+          input.organizationId,
+          input.projectId,
+          input.limit ?? DEFAULT_RINGS_OPERATION_LIST_LIMIT
+        )
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async listOperationsByProject(input: ListHeliusRingsOperationsByProjectInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE organization_id = ? AND project_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?`
+        )
+        .bind(
+          input.organizationId,
+          input.projectId,
+          input.limit ?? DEFAULT_RINGS_OPERATION_LIST_LIMIT
+        )
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async transitionState(input: TransitionHeliusRingsOperationInput) {
+      return db.transaction(async (tx) => {
+        // Lock first. Two workers resuming the same operation would otherwise
+        // both read `submitted`, both write `indexing`, and both go on to do the
+        // follow-up work once each.
+        const locked = await tx
+          .prepare(
+            `SELECT state FROM helius_rings_operations
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+              FOR UPDATE`
+          )
+          .bind(input.id, input.organizationId, input.projectId)
+          .first<{ state: string }>();
+
+        if (!locked || locked.state !== input.expectedState) return null;
+
+        const patch = input.patch ?? {};
+        const assignments: string[] = ["state = ?", "updated_at = sdp_iso_now()"];
+        const values: unknown[] = [input.nextState];
+
+        // Only columns the caller named are written, so a later step cannot
+        // blank the approval id an earlier one recorded.
+        if (patch.approvalRequestId !== undefined) {
+          assignments.push("approval_request_id = ?");
+          values.push(patch.approvalRequestId);
+        }
+        if (patch.policyEvaluationId !== undefined) {
+          assignments.push("policy_evaluation_id = ?");
+          values.push(patch.policyEvaluationId);
+        }
+        if (patch.proofSource !== undefined) {
+          assignments.push("proof_source = ?");
+          values.push(patch.proofSource);
+        }
+        if (patch.proofRef !== undefined) {
+          assignments.push("proof_ref = ?");
+          values.push(patch.proofRef);
+        }
+        if (patch.outerTxSignature !== undefined) {
+          assignments.push("outer_tx_signature = ?");
+          values.push(patch.outerTxSignature);
+        }
+        if (patch.photonIndexedAt !== undefined) {
+          assignments.push("photon_indexed_at = ?");
+          values.push(patch.photonIndexedAt);
+        }
+
+        const row = await tx
+          .prepare(
+            `UPDATE helius_rings_operations
+                SET ${assignments.join(", ")}
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+            RETURNING *`
+          )
+          .bind(...values, input.id, input.organizationId, input.projectId)
+          .first<Record<string, unknown>>();
+
+        return row ? mapRow(row) : null;
+      });
+    },
+
+    async failOperation(input: FailHeliusRingsOperationInput) {
+      return db.transaction(async (tx) => {
+        const locked = await tx
+          .prepare(
+            `SELECT state FROM helius_rings_operations
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+              FOR UPDATE`
+          )
+          .bind(input.id, input.organizationId, input.projectId)
+          .first<{ state: string }>();
+
+        if (!locked || locked.state !== input.expectedState) return null;
+
+        // The failure triple moves together because the DB CHECK requires it:
+        // a `failed` row without a code is unactionable in the recovery UI.
+        const row = await tx
+          .prepare(
+            `UPDATE helius_rings_operations
+                SET state = 'failed',
+                    failure_code = ?,
+                    failure_message = ?,
+                    retryable = ?,
+                    updated_at = sdp_iso_now()
+              WHERE id = ? AND organization_id = ? AND project_id = ?
+            RETURNING *`
+          )
+          .bind(
+            input.code,
+            input.message,
+            input.retryable,
+            input.id,
+            input.organizationId,
+            input.projectId
+          )
+          .first<Record<string, unknown>>();
+
+        return row ? mapRow(row) : null;
+      });
+    },
+
+    async listInFlightOperations(input: ListHeliusRingsInFlightOperationsInput) {
+      const placeholders = IN_FLIGHT_STATES.map(() => "?").join(", ");
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_operations
+            WHERE state IN (${placeholders})
+              AND updated_at < ?
+            ORDER BY updated_at ASC, id ASC
+            LIMIT ?`
+        )
+        .bind(
+          ...IN_FLIGHT_STATES,
+          input.staleBefore,
+          input.limit ?? DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT
+        )
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async getTimelock(input: { operationId: string }) {
+      const row = await db
+        .prepare(`SELECT * FROM helius_rings_timelocks WHERE operation_id = ?`)
+        .bind(input.operationId)
+        .first<Record<string, unknown>>();
+      return row ? mapTimelockRow(row) : null;
+    },
+
+    async listReleasableTimelocks(input: { asOf: string; limit?: number }) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_timelocks
+            WHERE released_at IS NULL AND unlock_at <= ?
+            ORDER BY unlock_at ASC, operation_id ASC
+            LIMIT ?`
+        )
+        .bind(input.asOf, input.limit ?? DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapTimelockRow);
+    },
+
+    async releaseTimelock(input: ReleaseHeliusRingsTimelockInput) {
+      // `released_at IS NULL` is the whole guard: it makes the release
+      // single-shot, so two sweeps racing produce one payout and one null.
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_timelocks
+              SET released_at = ?
+            WHERE operation_id = ? AND released_at IS NULL
+          RETURNING *`
+        )
+        .bind(input.releasedAt, input.operationId)
+        .first<Record<string, unknown>>();
+      return row ? mapTimelockRow(row) : null;
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
@@ -10,6 +10,7 @@ import type {
 import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
 import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
 import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+import { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
 
 const TEST_PROJECT_ID = "prj_hro_repo_test";
 const OTHER_PROJECT_ID = "prj_hro_repo_other";
@@ -313,6 +314,29 @@ describe("HeliusRingsOperationRepository (postgres)", () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("zone destinations", () => {
+    it("rejects a zone owned by another wallet", async () => {
+      const other = await walletRepo.createWallet({
+        ...scope,
+        sdpWalletId: "wal_hro_zone_other",
+        name: "Operations",
+        materialTag: "simulated",
+      });
+      if (!other) throw new Error("wallet fixture was not created");
+      const zone = await createPostgresHeliusRingsZoneRepository(getDb(env)).createZone({
+        walletId: other.id,
+        name: "Payroll",
+        kind: "treasury",
+      });
+      if (!zone) throw new Error("zone fixture was not created");
+
+      // The composite (zone_id, wallet_id) FK refuses the cross-wallet reference.
+      await expect(
+        repo.reserveIntent(shieldIntent({ intentKey: "sha256:cross-zone", zoneId: zone.id }))
+      ).rejects.toMatchObject({ message: expect.stringContaining("zone") });
     });
   });
 

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.test.ts
@@ -1,0 +1,458 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type {
+  HeliusRingsOperationRepository,
+  ReserveHeliusRingsIntentInput,
+} from "./helius-rings-operation.repository";
+import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hro_repo_test";
+const OTHER_PROJECT_ID = "prj_hro_repo_other";
+
+let repo: HeliusRingsOperationRepository;
+let walletRepo: HeliusRingsWalletRepository;
+let walletId: string;
+
+const scope = {
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT_ID,
+};
+
+function shieldIntent(
+  overrides: Partial<ReserveHeliusRingsIntentInput> = {}
+): ReserveHeliusRingsIntentInput {
+  return {
+    ...scope,
+    walletId,
+    opType: "shield",
+    intentKey: "sha256:shield-1",
+    assetMint: "So11111111111111111111111111111111111111112",
+    amountRaw: "1000000",
+    ...overrides,
+  };
+}
+
+/** Pins created_at so ordering assertions do not depend on clock resolution. */
+async function setCreatedAt(id: string, createdAt: string): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE helius_rings_operations SET created_at = ? WHERE id = ?")
+    .bind(createdAt, id)
+    .run();
+}
+
+/** Pins updated_at so the sweep's staleness window is deterministic. */
+async function setUpdatedAt(id: string, updatedAt: string): Promise<void> {
+  await getDb(env)
+    .prepare("UPDATE helius_rings_operations SET updated_at = ? WHERE id = ?")
+    .bind(updatedAt, id)
+    .run();
+}
+
+describe("HeliusRingsOperationRepository (postgres)", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    for (const projectId of [TEST_PROJECT_ID, OTHER_PROJECT_ID]) {
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, TEST_ORG.id, projectId, TEST_USER.id)
+        .run();
+    }
+
+    walletRepo = createPostgresHeliusRingsWalletRepository(db);
+    repo = createPostgresHeliusRingsOperationRepository(db);
+
+    const wallet = await walletRepo.createWallet({
+      ...scope,
+      sdpWalletId: "wal_hro_repo_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+    walletId = wallet.id;
+  });
+
+  describe("reserveIntent", () => {
+    it("inserts a draft operation and reports it as reserved", async () => {
+      const result = await repo.reserveIntent(shieldIntent());
+
+      expect(result.reserved).toBe(true);
+      expect(result.operation).toMatchObject({
+        wallet_id: walletId,
+        op_type: "shield",
+        state: "draft",
+        intent_key: "sha256:shield-1",
+        amount_raw: "1000000",
+        failure_code: null,
+      });
+    });
+
+    it("returns the existing operation on a replay instead of opening a second one", async () => {
+      const first = await repo.reserveIntent(shieldIntent());
+      // Same intent key, different everything else: a replay must be decided by
+      // the key alone, or a retried request with a jittered payload would slip
+      // through and move funds twice.
+      const replay = await repo.reserveIntent(
+        shieldIntent({ amountRaw: "999", toAddr: "somewhere-else" })
+      );
+
+      expect(replay.reserved).toBe(false);
+      expect(replay.operation.id).toBe(first.operation.id);
+      expect(replay.operation.amount_raw).toBe("1000000");
+      expect(replay.operation.to_addr).toBeNull();
+
+      const all = await repo.listOperationsByWallet({ ...scope, walletId });
+      expect(all).toHaveLength(1);
+    });
+
+    it("does not let a replay overwrite work the first attempt already recorded", async () => {
+      const first = await repo.reserveIntent(shieldIntent());
+      await repo.transitionState({
+        ...scope,
+        id: first.operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+        patch: { policyEvaluationId: "pev_1" },
+      });
+
+      const replay = await repo.reserveIntent(shieldIntent());
+
+      expect(replay.operation.state).toBe("preparing");
+      expect(replay.operation.policy_evaluation_id).toBe("pev_1");
+    });
+
+    it("keeps distinct intent keys as distinct operations", async () => {
+      await repo.reserveIntent(shieldIntent({ intentKey: "sha256:shield-1" }));
+      const second = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:shield-2" }));
+
+      expect(second.reserved).toBe(true);
+      const all = await repo.listOperationsByWallet({ ...scope, walletId });
+      expect(all).toHaveLength(2);
+    });
+
+    it("writes the escrow row and the denormalized unlock time for a timelock", async () => {
+      const result = await repo.reserveIntent(
+        shieldIntent({
+          opType: "timelock_create",
+          intentKey: "sha256:timelock-1",
+          timelock: { unlockAt: "2026-12-01T00:00:00.000Z", beneficiaryAddr: "beneficiary-1" },
+        })
+      );
+
+      expect(result.operation.timelock_unlock_at).toBe("2026-12-01T00:00:00.000Z");
+      const timelock = await repo.getTimelock({ operationId: result.operation.id });
+      expect(timelock).toMatchObject({
+        unlock_at: "2026-12-01T00:00:00.000Z",
+        beneficiary_addr: "beneficiary-1",
+        released_at: null,
+      });
+    });
+
+    it("pins transfer_mode to the op type", async () => {
+      const result = await repo.reserveIntent(
+        shieldIntent({
+          opType: "transfer_anonymous",
+          intentKey: "sha256:transfer-1",
+          transferMode: "anonymous",
+          toAddr: "recipient-1",
+        })
+      );
+
+      expect(result.operation.transfer_mode).toBe("anonymous");
+
+      // The DB refuses the pairing that would misreport disclosure.
+      await expect(
+        repo.reserveIntent(
+          shieldIntent({
+            opType: "transfer_anonymous",
+            intentKey: "sha256:transfer-2",
+            transferMode: "registered",
+          })
+        )
+      ).rejects.toMatchObject({ message: expect.stringContaining("transfer_mode") });
+    });
+  });
+
+  describe("transitionState", () => {
+    it("advances when the expected state still holds", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      const moved = await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      expect(moved?.state).toBe("preparing");
+    });
+
+    it("refuses and leaves the row alone when the expectation is stale", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+      await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      // The second worker still believes the operation is a draft.
+      const loser = await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      expect(loser).toBeNull();
+      const current = await repo.getOperationById({ ...scope, id: operation.id });
+      expect(current?.state).toBe("preparing");
+    });
+
+    it("writes only the patched columns and preserves the rest", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "approval_required",
+        patch: { approvalRequestId: "apr_1", policyEvaluationId: "pev_1" },
+      });
+      const later = await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "approval_required",
+        nextState: "proving",
+        patch: { proofSource: "simulated" },
+      });
+
+      expect(later).toMatchObject({
+        state: "proving",
+        approval_request_id: "apr_1",
+        policy_evaluation_id: "pev_1",
+        proof_source: "simulated",
+      });
+    });
+
+    it("will not transition an operation belonging to another project", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      const crossTenant = await repo.transitionState({
+        organizationId: TEST_ORG.id,
+        projectId: OTHER_PROJECT_ID,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      expect(crossTenant).toBeNull();
+    });
+  });
+
+  describe("failOperation", () => {
+    it("records the whole failure triple", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+      await repo.transitionState({
+        ...scope,
+        id: operation.id,
+        expectedState: "draft",
+        nextState: "preparing",
+      });
+
+      const failed = await repo.failOperation({
+        ...scope,
+        id: operation.id,
+        expectedState: "preparing",
+        code: "gateway_unavailable",
+        message: "rings gateway is not implemented",
+        retryable: true,
+      });
+
+      expect(failed).toMatchObject({
+        state: "failed",
+        failure_code: "gateway_unavailable",
+        failure_message: "rings gateway is not implemented",
+        retryable: true,
+      });
+    });
+
+    it("refuses when the expected state is stale", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      const result = await repo.failOperation({
+        ...scope,
+        id: operation.id,
+        expectedState: "submitted",
+        code: "submit_failed",
+        message: "nope",
+        retryable: false,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("retry lineage", () => {
+    it("links a retry to the operation it replaces", async () => {
+      const first = await repo.reserveIntent(shieldIntent());
+      const retry = await repo.reserveIntent(
+        shieldIntent({ intentKey: "sha256:shield-retry", retryOfOperationId: first.operation.id })
+      );
+
+      expect(retry.operation.retry_of_operation_id).toBe(first.operation.id);
+    });
+  });
+
+  describe("reads", () => {
+    it("scopes lookups to the tenant that owns the operation", async () => {
+      const { operation } = await repo.reserveIntent(shieldIntent());
+
+      expect(
+        await repo.getOperationById({
+          organizationId: TEST_ORG.id,
+          projectId: OTHER_PROJECT_ID,
+          id: operation.id,
+        })
+      ).toBeNull();
+      expect(
+        await repo.getOperationByIntentKey({
+          organizationId: TEST_ORG.id,
+          projectId: OTHER_PROJECT_ID,
+          intentKey: "sha256:shield-1",
+        })
+      ).toBeNull();
+      expect(
+        await repo.getOperationByIntentKey({ ...scope, intentKey: "sha256:shield-1" })
+      ).toMatchObject({ id: operation.id });
+    });
+
+    it("lists newest first", async () => {
+      const older = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:older" }));
+      const newer = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:newer" }));
+      await setCreatedAt(older.operation.id, "2026-01-01T00:00:00.000Z");
+      await setCreatedAt(newer.operation.id, "2026-02-01T00:00:00.000Z");
+
+      const listed = await repo.listOperationsByProject(scope);
+      expect(listed.map((row) => row.id)).toEqual([newer.operation.id, older.operation.id]);
+    });
+
+    it("honours the list limit", async () => {
+      await repo.reserveIntent(shieldIntent({ intentKey: "sha256:a" }));
+      await repo.reserveIntent(shieldIntent({ intentKey: "sha256:b" }));
+
+      expect(await repo.listOperationsByWallet({ ...scope, walletId, limit: 1 })).toHaveLength(1);
+    });
+  });
+
+  describe("listInFlightOperations", () => {
+    it("returns only non-terminal operations older than the staleness cutoff", async () => {
+      const inFlight = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:in-flight" }));
+      const draft = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:draft" }));
+      const done = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:done" }));
+      const fresh = await repo.reserveIntent(shieldIntent({ intentKey: "sha256:fresh" }));
+
+      for (const id of [inFlight.operation.id, done.operation.id, fresh.operation.id]) {
+        await repo.transitionState({
+          ...scope,
+          id,
+          expectedState: "draft",
+          nextState: "submitted",
+        });
+      }
+      await repo.transitionState({
+        ...scope,
+        id: done.operation.id,
+        expectedState: "submitted",
+        nextState: "completed",
+      });
+
+      await setUpdatedAt(inFlight.operation.id, "2026-01-01T00:00:00.000Z");
+      await setUpdatedAt(draft.operation.id, "2026-01-01T00:00:00.000Z");
+      await setUpdatedAt(done.operation.id, "2026-01-01T00:00:00.000Z");
+
+      const swept = await repo.listInFlightOperations({ staleBefore: "2026-06-01T00:00:00.000Z" });
+
+      // `draft` is excluded because nothing is in flight yet, `completed`
+      // because it is terminal, and the fresh row because it was just touched.
+      expect(swept.map((row) => row.id)).toEqual([inFlight.operation.id]);
+    });
+  });
+
+  describe("timelocks", () => {
+    async function reserveTimelock(key: string, unlockAt: string): Promise<string> {
+      const result = await repo.reserveIntent(
+        shieldIntent({
+          opType: "timelock_create",
+          intentKey: key,
+          timelock: { unlockAt, beneficiaryAddr: "beneficiary-1" },
+        })
+      );
+      return result.operation.id;
+    }
+
+    it("lists only escrows whose unlock time has passed and that are still held", async () => {
+      const due = await reserveTimelock("sha256:due", "2026-01-01T00:00:00.000Z");
+      const notDue = await reserveTimelock("sha256:not-due", "2027-01-01T00:00:00.000Z");
+      const released = await reserveTimelock("sha256:released", "2026-01-01T00:00:00.000Z");
+      await repo.releaseTimelock({
+        operationId: released,
+        releasedAt: "2026-02-01T00:00:00.000Z",
+      });
+
+      const releasable = await repo.listReleasableTimelocks({ asOf: "2026-06-01T00:00:00.000Z" });
+
+      expect(releasable.map((row) => row.operation_id)).toEqual([due]);
+      expect(releasable.map((row) => row.operation_id)).not.toContain(notDue);
+    });
+
+    it("releases once, so a double sweep cannot pay a beneficiary twice", async () => {
+      const operationId = await reserveTimelock("sha256:once", "2026-01-01T00:00:00.000Z");
+
+      const first = await repo.releaseTimelock({
+        operationId,
+        releasedAt: "2026-02-01T00:00:00.000Z",
+      });
+      const second = await repo.releaseTimelock({
+        operationId,
+        releasedAt: "2026-03-01T00:00:00.000Z",
+      });
+
+      expect(first?.released_at).toBe("2026-02-01T00:00:00.000Z");
+      expect(second).toBeNull();
+      const stored = await repo.getTimelock({ operationId });
+      expect(stored?.released_at).toBe("2026-02-01T00:00:00.000Z");
+    });
+
+    it("refuses a release dated before the unlock time", async () => {
+      const operationId = await reserveTimelock("sha256:early", "2026-06-01T00:00:00.000Z");
+
+      await expect(
+        repo.releaseTimelock({ operationId, releasedAt: "2026-01-01T00:00:00.000Z" })
+      ).rejects.toMatchObject({ message: expect.stringContaining("released_after_unlock") });
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-operation.repository.ts
@@ -1,0 +1,210 @@
+import type {
+  FailureCode,
+  OperationState,
+  OpType,
+  PrivateOperationSummary,
+  TransferMode,
+} from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+import type { HeliusRingsProjectScope } from "./helius-rings-wallet.repository";
+
+export function generateHeliusRingsOperationId(): string {
+  return `hro_${crypto.randomUUID()}`;
+}
+
+/** Upper bound on an unpaginated activity read. */
+export const DEFAULT_RINGS_OPERATION_LIST_LIMIT = 50;
+
+/** Upper bound on one pass of the resume sweep. */
+export const DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT = 100;
+
+export interface HeliusRingsOperationRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  wallet_id: string;
+  op_type: OpType;
+  state: OperationState;
+  asset_mint: string | null;
+  amount_raw: string | null;
+  from_addr: string | null;
+  to_addr: string | null;
+  zone_id: string | null;
+  transfer_mode: TransferMode | null;
+  intent_key: string;
+  approval_request_id: string | null;
+  policy_evaluation_id: string | null;
+  proof_source: "simulated" | "live" | null;
+  proof_ref: string | null;
+  outer_tx_signature: string | null;
+  photon_indexed_at: string | null;
+  failure_code: FailureCode | null;
+  failure_message: string | null;
+  retryable: boolean | null;
+  retry_of_operation_id: string | null;
+  /** Denormalized from `helius_rings_timelocks`; that table stays the authority. */
+  timelock_unlock_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HeliusRingsTimelockRow {
+  operation_id: string;
+  unlock_at: string;
+  released_at: string | null;
+  beneficiary_addr: string;
+}
+
+export interface HeliusRingsTimelockInput {
+  unlockAt: string;
+  beneficiaryAddr: string;
+}
+
+/**
+ * The intent as the caller described it. `intentKey` is computed upstream — the
+ * repository takes it as given rather than deriving it, so the hashing rule
+ * lives in one place (the service) instead of being duplicated behind a column.
+ */
+export interface ReserveHeliusRingsIntentInput extends HeliusRingsProjectScope {
+  walletId: string;
+  opType: OpType;
+  intentKey: string;
+  assetMint?: string | null;
+  amountRaw?: string | null;
+  fromAddr?: string | null;
+  toAddr?: string | null;
+  zoneId?: string | null;
+  transferMode?: TransferMode | null;
+  retryOfOperationId?: string | null;
+  /** Required for `timelock_create`; writes the escrow row and the denormalized column. */
+  timelock?: HeliusRingsTimelockInput | null;
+}
+
+export interface ReserveHeliusRingsIntentResult {
+  operation: HeliusRingsOperationRow;
+  /**
+   * False when the intent key was already taken and `operation` is the row that
+   * was there. Callers use this to skip re-doing side effects on a replay — the
+   * whole point of the idempotency contract.
+   */
+  reserved: boolean;
+}
+
+/**
+ * Optional columns a transition may set on its way through. Each is written only
+ * when present, so a transition never blanks a field an earlier step recorded.
+ */
+export interface HeliusRingsOperationTransitionPatch {
+  approvalRequestId?: string | null;
+  policyEvaluationId?: string | null;
+  proofSource?: "simulated" | "live" | null;
+  proofRef?: string | null;
+  outerTxSignature?: string | null;
+  photonIndexedAt?: string | null;
+}
+
+export interface TransitionHeliusRingsOperationInput extends HeliusRingsProjectScope {
+  id: string;
+  /** Compare-and-swap guard; the update is skipped unless the locked row still reads this. */
+  expectedState: OperationState;
+  nextState: OperationState;
+  patch?: HeliusRingsOperationTransitionPatch;
+}
+
+export interface FailHeliusRingsOperationInput extends HeliusRingsProjectScope {
+  id: string;
+  expectedState: OperationState;
+  code: FailureCode;
+  message: string;
+  retryable: boolean;
+}
+
+export interface ListHeliusRingsOperationsByWalletInput extends HeliusRingsProjectScope {
+  walletId: string;
+  limit?: number;
+}
+
+export interface ListHeliusRingsOperationsByProjectInput extends HeliusRingsProjectScope {
+  limit?: number;
+}
+
+export interface ListHeliusRingsInFlightOperationsInput {
+  /** Only operations untouched since this ISO-8601 instant, so a fresh write is not swept mid-flight. */
+  staleBefore: string;
+  limit?: number;
+}
+
+export interface ReleaseHeliusRingsTimelockInput {
+  operationId: string;
+  releasedAt: string;
+}
+
+export interface HeliusRingsOperationRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsOperationRepository {
+  /**
+   * The idempotency entry point. Inserts the operation, or returns the one the
+   * intent key already names — a retried request must never open a second
+   * shielded operation, because the caller has no way to tell the duplicate
+   * apart afterwards and both would move funds.
+   */
+  reserveIntent(input: ReserveHeliusRingsIntentInput): Promise<ReserveHeliusRingsIntentResult>;
+  getOperationById(
+    input: HeliusRingsProjectScope & { id: string }
+  ): Promise<HeliusRingsOperationRow | null>;
+  getOperationByIntentKey(
+    input: HeliusRingsProjectScope & { intentKey: string }
+  ): Promise<HeliusRingsOperationRow | null>;
+  listOperationsByWallet(
+    input: ListHeliusRingsOperationsByWalletInput
+  ): Promise<HeliusRingsOperationRow[]>;
+  listOperationsByProject(
+    input: ListHeliusRingsOperationsByProjectInput
+  ): Promise<HeliusRingsOperationRow[]>;
+  /**
+   * Advances one operation under `SELECT ... FOR UPDATE`. Returns null when the
+   * guard loses — either the row moved on already or it is not in this tenant —
+   * leaving the row untouched.
+   */
+  transitionState(
+    input: TransitionHeliusRingsOperationInput
+  ): Promise<HeliusRingsOperationRow | null>;
+  /** Terminal failure. Writes the full failure triple the DB CHECK requires. */
+  failOperation(input: FailHeliusRingsOperationInput): Promise<HeliusRingsOperationRow | null>;
+  /** Resume sweep feed: non-terminal operations, oldest touched first. */
+  listInFlightOperations(
+    input: ListHeliusRingsInFlightOperationsInput
+  ): Promise<HeliusRingsOperationRow[]>;
+  getTimelock(input: { operationId: string }): Promise<HeliusRingsTimelockRow | null>;
+  /** Escrows whose unlock time has passed and that are still held. */
+  listReleasableTimelocks(input: {
+    asOf: string;
+    limit?: number;
+  }): Promise<HeliusRingsTimelockRow[]>;
+  /**
+   * Marks one escrow released. Returns null if it was already released, so a
+   * double sweep cannot pay a beneficiary twice.
+   */
+  releaseTimelock(input: ReleaseHeliusRingsTimelockInput): Promise<HeliusRingsTimelockRow | null>;
+}
+
+/**
+ * Row to the list-shaped domain projection. The activity table renders this;
+ * the full `PrivateOperation` needs the event feed joined in, which the service
+ * assembles.
+ */
+export function mapHeliusRingsOperationSummaryRow(
+  row: HeliusRingsOperationRow
+): PrivateOperationSummary {
+  return {
+    id: row.id,
+    opType: row.op_type,
+    state: row.state,
+    assetMint: row.asset_mint ?? null,
+    amountRaw: row.amount_raw ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.postgres.ts
@@ -1,0 +1,152 @@
+import type { AppDb } from "@/db";
+import {
+  type CreateHeliusRingsWalletInput,
+  DEFAULT_RINGS_WALLET_LIST_LIMIT,
+  generateHeliusRingsWalletId,
+  type HeliusRingsProjectScope,
+  type HeliusRingsWalletRepository,
+  type HeliusRingsWalletRow,
+  type ListHeliusRingsWalletsInput,
+  type MarkHeliusRingsWalletProvisionedInput,
+  type UpdateHeliusRingsWalletStatusInput,
+  type UpdateHeliusRingsWalletSyncCursorInput,
+} from "./helius-rings-wallet.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsWalletRow {
+  return {
+    id: row.id as string,
+    organization_id: row.organization_id as string,
+    project_id: row.project_id as string,
+    sdp_wallet_id: row.sdp_wallet_id as string,
+    name: row.name as string,
+    network: row.network as string,
+    status: row.status as HeliusRingsWalletRow["status"],
+    shielded_address: (row.shielded_address ?? null) as string | null,
+    sync_cursor: (row.sync_cursor ?? null) as string | null,
+    material_tag: row.material_tag as HeliusRingsWalletRow["material_tag"],
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsWalletRepository(db: AppDb): HeliusRingsWalletRepository {
+  return {
+    async createWallet(input: CreateHeliusRingsWalletInput) {
+      const id = generateHeliusRingsWalletId();
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_wallets (
+             id,
+             organization_id,
+             project_id,
+             sdp_wallet_id,
+             name,
+             material_tag
+           ) VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT (project_id, sdp_wallet_id)
+           -- Self-assignment so RETURNING * emits the row that already exists.
+           -- DO NOTHING would return zero rows and make a retried provision
+           -- look like a failure.
+           DO UPDATE SET updated_at = helius_rings_wallets.updated_at
+           RETURNING *`
+        )
+        .bind(
+          id,
+          input.organizationId,
+          input.projectId,
+          input.sdpWalletId,
+          input.name,
+          input.materialTag
+        )
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getWalletById(scope: HeliusRingsProjectScope & { id: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_wallets
+            WHERE id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(scope.id, scope.organizationId, scope.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getWalletBySdpWalletId(scope: HeliusRingsProjectScope & { sdpWalletId: string }) {
+      const row = await db
+        .prepare(
+          `SELECT * FROM helius_rings_wallets
+            WHERE sdp_wallet_id = ? AND organization_id = ? AND project_id = ?`
+        )
+        .bind(scope.sdpWalletId, scope.organizationId, scope.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listWallets(input: ListHeliusRingsWalletsInput) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_wallets
+            WHERE organization_id = ? AND project_id = ?
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?`
+        )
+        .bind(input.organizationId, input.projectId, input.limit ?? DEFAULT_RINGS_WALLET_LIST_LIMIT)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+
+    async markProvisioned(input: MarkHeliusRingsWalletProvisionedInput) {
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_wallets
+              SET status = 'ready',
+                  shielded_address = ?,
+                  material_tag = ?,
+                  updated_at = sdp_iso_now()
+            WHERE id = ?
+              AND organization_id = ?
+              AND project_id = ?
+              AND status = ?
+          RETURNING *`
+        )
+        .bind(
+          input.shieldedAddress,
+          input.materialTag,
+          input.id,
+          input.organizationId,
+          input.projectId,
+          input.expectedStatus
+        )
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async updateStatus(input: UpdateHeliusRingsWalletStatusInput) {
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_wallets
+              SET status = ?, updated_at = sdp_iso_now()
+            WHERE id = ? AND organization_id = ? AND project_id = ?
+          RETURNING *`
+        )
+        .bind(input.status, input.id, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async updateSyncCursor(input: UpdateHeliusRingsWalletSyncCursorInput) {
+      const row = await db
+        .prepare(
+          `UPDATE helius_rings_wallets
+              SET sync_cursor = ?, updated_at = sdp_iso_now()
+            WHERE id = ? AND organization_id = ? AND project_id = ?
+          RETURNING *`
+        )
+        .bind(input.syncCursor, input.id, input.organizationId, input.projectId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
+import { mapHeliusRingsWalletRow } from "./helius-rings-wallet.repository";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+
+const TEST_PROJECT_ID = "prj_hrw_repo_test";
+const OTHER_PROJECT_ID = "prj_hrw_repo_other";
+
+const scope = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+let repo: HeliusRingsWalletRepository;
+
+async function createWallet(sdpWalletId: string, name = "Treasury") {
+  const wallet = await repo.createWallet({ ...scope, sdpWalletId, name, materialTag: "simulated" });
+  if (!wallet) throw new Error("wallet fixture was not created");
+  return wallet;
+}
+
+describe("HeliusRingsWalletRepository (postgres)", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+
+    for (const projectId of [TEST_PROJECT_ID, OTHER_PROJECT_ID]) {
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+        )
+        .bind(projectId, TEST_ORG.id, projectId, TEST_USER.id)
+        .run();
+    }
+
+    repo = createPostgresHeliusRingsWalletRepository(db);
+  });
+
+  it("creates a wallet pending with no shielded address", async () => {
+    const wallet = await createWallet("wal_1");
+
+    expect(wallet).toMatchObject({
+      status: "pending",
+      network: "devnet",
+      shielded_address: null,
+      sync_cursor: null,
+      material_tag: "simulated",
+    });
+  });
+
+  it("returns the existing wallet when provisioning is retried", async () => {
+    const first = await createWallet("wal_1", "Treasury");
+    // A second shielded identity over one custody wallet would split its
+    // balance across two identities that cannot see each other.
+    const replay = await createWallet("wal_1", "Renamed");
+
+    expect(replay.id).toBe(first.id);
+    expect(replay.name).toBe("Treasury");
+    expect(await repo.listWallets(scope)).toHaveLength(1);
+  });
+
+  it("allows the same sdp wallet id under a different project", async () => {
+    await createWallet("wal_shared");
+    const other = await repo.createWallet({
+      organizationId: TEST_ORG.id,
+      projectId: OTHER_PROJECT_ID,
+      sdpWalletId: "wal_shared",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+
+    expect(other?.project_id).toBe(OTHER_PROJECT_ID);
+  });
+
+  describe("markProvisioned", () => {
+    it("attaches the shielded address and flips the wallet ready", async () => {
+      const wallet = await createWallet("wal_1");
+
+      const provisioned = await repo.markProvisioned({
+        ...scope,
+        id: wallet.id,
+        shieldedAddress: "shielded-1",
+        materialTag: "live",
+        expectedStatus: "pending",
+      });
+
+      expect(provisioned).toMatchObject({
+        status: "ready",
+        shielded_address: "shielded-1",
+        material_tag: "live",
+      });
+    });
+
+    it("loses the compare-and-swap against a paused wallet", async () => {
+      const wallet = await createWallet("wal_1");
+      await repo.updateStatus({ ...scope, id: wallet.id, status: "paused" });
+
+      // A late provisioning callback must not resurrect a wallet an operator
+      // deliberately paused.
+      const late = await repo.markProvisioned({
+        ...scope,
+        id: wallet.id,
+        shieldedAddress: "shielded-1",
+        materialTag: "live",
+        expectedStatus: "pending",
+      });
+
+      expect(late).toBeNull();
+      const current = await repo.getWalletById({ ...scope, id: wallet.id });
+      expect(current).toMatchObject({ status: "paused", shielded_address: null });
+    });
+  });
+
+  it("advances the sync cursor", async () => {
+    const wallet = await createWallet("wal_1");
+
+    const updated = await repo.updateSyncCursor({ ...scope, id: wallet.id, syncCursor: "slot:42" });
+
+    expect(updated?.sync_cursor).toBe("slot:42");
+  });
+
+  it("scopes reads and writes to the owning tenant", async () => {
+    const wallet = await createWallet("wal_1");
+    const crossTenant = {
+      organizationId: TEST_ORG.id,
+      projectId: OTHER_PROJECT_ID,
+    };
+
+    expect(await repo.getWalletById({ ...crossTenant, id: wallet.id })).toBeNull();
+    expect(await repo.getWalletBySdpWalletId({ ...crossTenant, sdpWalletId: "wal_1" })).toBeNull();
+    expect(await repo.updateStatus({ ...crossTenant, id: wallet.id, status: "paused" })).toBeNull();
+    expect(await repo.getWalletBySdpWalletId({ ...scope, sdpWalletId: "wal_1" })).toMatchObject({
+      id: wallet.id,
+    });
+  });
+
+  it("honours the list limit", async () => {
+    await createWallet("wal_1");
+    await createWallet("wal_2");
+
+    expect(await repo.listWallets({ ...scope, limit: 1 })).toHaveLength(1);
+  });
+
+  describe("mapHeliusRingsWalletRow", () => {
+    it("projects the row onto the domain wallet without tenant columns", async () => {
+      const wallet = await createWallet("wal_1");
+      const provisioned = await repo.markProvisioned({
+        ...scope,
+        id: wallet.id,
+        shieldedAddress: "shielded-1",
+        materialTag: "live",
+        expectedStatus: "pending",
+      });
+      if (!provisioned) throw new Error("wallet was not provisioned");
+
+      expect(mapHeliusRingsWalletRow(provisioned)).toEqual({
+        id: wallet.id,
+        sdpWalletId: "wal_1",
+        name: "Treasury",
+        shieldedAddress: "shielded-1",
+        status: "ready",
+        network: "devnet",
+        syncCursor: null,
+        materialTag: "live",
+      });
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-wallet.repository.ts
@@ -1,0 +1,115 @@
+import type { MaterialTag, PrivateWallet, WalletStatus } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsWalletId(): string {
+  return `hrw_${crypto.randomUUID()}`;
+}
+
+/** Upper bound on an unpaginated wallet list. */
+export const DEFAULT_RINGS_WALLET_LIST_LIMIT = 100;
+
+export interface HeliusRingsWalletRow {
+  id: string;
+  organization_id: string;
+  project_id: string;
+  sdp_wallet_id: string;
+  name: string;
+  /** Always 'devnet' for this scope; the DB CHECK enforces it. */
+  network: string;
+  status: WalletStatus;
+  /** Null until the gateway provisions the shielded identity. */
+  shielded_address: string | null;
+  /** Photon sync cursor; null before the first successful sync. */
+  sync_cursor: string | null;
+  material_tag: MaterialTag;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HeliusRingsProjectScope {
+  organizationId: string;
+  projectId: string;
+}
+
+/**
+ * Wallets are always inserted as `pending` with no shielded address — those
+ * arrive from the gateway via `markProvisioned`.
+ */
+export interface CreateHeliusRingsWalletInput extends HeliusRingsProjectScope {
+  sdpWalletId: string;
+  name: string;
+  materialTag: MaterialTag;
+}
+
+export interface MarkHeliusRingsWalletProvisionedInput extends HeliusRingsProjectScope {
+  id: string;
+  shieldedAddress: string;
+  materialTag: MaterialTag;
+  /**
+   * Compare-and-swap guard: only applies while the wallet is still in this
+   * status, so a late provisioning callback cannot resurrect a paused wallet.
+   */
+  expectedStatus: WalletStatus;
+}
+
+export interface UpdateHeliusRingsWalletStatusInput extends HeliusRingsProjectScope {
+  id: string;
+  status: WalletStatus;
+}
+
+export interface UpdateHeliusRingsWalletSyncCursorInput extends HeliusRingsProjectScope {
+  id: string;
+  syncCursor: string;
+}
+
+export interface ListHeliusRingsWalletsInput extends HeliusRingsProjectScope {
+  limit?: number;
+}
+
+export interface HeliusRingsWalletRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsWalletRepository {
+  /**
+   * Reserves the one wallet allowed per (project, sdpWalletId). On a replay it
+   * returns the wallet already there rather than a second one, so provisioning
+   * is safe to retry.
+   */
+  createWallet(input: CreateHeliusRingsWalletInput): Promise<HeliusRingsWalletRow | null>;
+  getWalletById(
+    scope: HeliusRingsProjectScope & { id: string }
+  ): Promise<HeliusRingsWalletRow | null>;
+  getWalletBySdpWalletId(
+    scope: HeliusRingsProjectScope & { sdpWalletId: string }
+  ): Promise<HeliusRingsWalletRow | null>;
+  listWallets(input: ListHeliusRingsWalletsInput): Promise<HeliusRingsWalletRow[]>;
+  /** Returns null when the CAS guard loses, leaving the row untouched. */
+  markProvisioned(
+    input: MarkHeliusRingsWalletProvisionedInput
+  ): Promise<HeliusRingsWalletRow | null>;
+  updateStatus(input: UpdateHeliusRingsWalletStatusInput): Promise<HeliusRingsWalletRow | null>;
+  updateSyncCursor(
+    input: UpdateHeliusRingsWalletSyncCursorInput
+  ): Promise<HeliusRingsWalletRow | null>;
+}
+
+/**
+ * Row to domain object. `organization_id`/`project_id` are dropped: the domain
+ * `PrivateWallet` is what the API returns, and the caller already knows the
+ * scope it queried by.
+ */
+export function mapHeliusRingsWalletRow(row: HeliusRingsWalletRow): PrivateWallet {
+  return {
+    id: row.id,
+    sdpWalletId: row.sdp_wallet_id,
+    name: row.name,
+    shieldedAddress: row.shielded_address ?? null,
+    status: row.status,
+    // The DB CHECK pins this column to 'devnet', which is what makes the cast
+    // to the domain literal honest rather than hopeful.
+    network: "devnet",
+    syncCursor: row.sync_cursor ?? null,
+    materialTag: row.material_tag,
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.postgres.ts
@@ -1,0 +1,59 @@
+import type { AppDb } from "@/db";
+import {
+  type CreateHeliusRingsZoneInput,
+  generateHeliusRingsZoneId,
+  type HeliusRingsZoneRepository,
+  type HeliusRingsZoneRow,
+} from "./helius-rings-zone.repository";
+
+function mapRow(row: Record<string, unknown>): HeliusRingsZoneRow {
+  return {
+    id: row.id as string,
+    wallet_id: row.wallet_id as string,
+    name: row.name as string,
+    kind: row.kind as HeliusRingsZoneRow["kind"],
+    created_at: row.created_at as string,
+  };
+}
+
+export function createPostgresHeliusRingsZoneRepository(db: AppDb): HeliusRingsZoneRepository {
+  return {
+    async createZone(input: CreateHeliusRingsZoneInput) {
+      const id = generateHeliusRingsZoneId();
+      const row = await db
+        .prepare(
+          `INSERT INTO helius_rings_zones (id, wallet_id, name, kind)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT (wallet_id, name)
+           -- Self-assignment so a replayed zone_create returns the existing zone
+           -- rather than zero rows. The kind is not overwritten: renaming a
+           -- zone's kind under a live operation would move its destination.
+           DO UPDATE SET created_at = helius_rings_zones.created_at
+           RETURNING *`
+        )
+        .bind(id, input.walletId, input.name, input.kind)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async getZoneById(input: { id: string; walletId: string }) {
+      const row = await db
+        .prepare(`SELECT * FROM helius_rings_zones WHERE id = ? AND wallet_id = ?`)
+        .bind(input.id, input.walletId)
+        .first<Record<string, unknown>>();
+      return row ? mapRow(row) : null;
+    },
+
+    async listZonesByWallet(input: { walletId: string }) {
+      const result = await db
+        .prepare(
+          `SELECT * FROM helius_rings_zones
+            WHERE wallet_id = ?
+            ORDER BY created_at DESC, id DESC`
+        )
+        .bind(input.walletId)
+        .all<Record<string, unknown>>();
+      return result.results.map(mapRow);
+    },
+  };
+}

--- a/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.ts
+++ b/apps/sdp-api/src/db/repositories/helius-rings-zone.repository.ts
@@ -1,0 +1,35 @@
+import type { Zone, ZoneKind } from "@sdp/helius-rings";
+import type { RepositoryDbClient } from "./base";
+
+export function generateHeliusRingsZoneId(): string {
+  return `hrz_${crypto.randomUUID()}`;
+}
+
+export interface HeliusRingsZoneRow {
+  id: string;
+  wallet_id: string;
+  name: string;
+  kind: ZoneKind;
+  created_at: string;
+}
+
+export interface CreateHeliusRingsZoneInput {
+  walletId: string;
+  name: string;
+  kind: ZoneKind;
+}
+
+export interface HeliusRingsZoneRepositoryContext {
+  db: RepositoryDbClient;
+}
+
+export interface HeliusRingsZoneRepository {
+  /** Zone names are unique per wallet; a replay returns the existing zone. */
+  createZone(input: CreateHeliusRingsZoneInput): Promise<HeliusRingsZoneRow | null>;
+  getZoneById(input: { id: string; walletId: string }): Promise<HeliusRingsZoneRow | null>;
+  listZonesByWallet(input: { walletId: string }): Promise<HeliusRingsZoneRow[]>;
+}
+
+export function mapHeliusRingsZoneRow(row: HeliusRingsZoneRow): Zone {
+  return { id: row.id, name: row.name, kind: row.kind };
+}

--- a/apps/sdp-api/src/db/repositories/index.ts
+++ b/apps/sdp-api/src/db/repositories/index.ts
@@ -60,6 +60,87 @@ export type {
 export { generateEarnProgramWithdrawalId, generateEarnStrategyId } from "./earn.repository";
 export { createPostgresEarnRepository } from "./earn.repository.postgres";
 export type {
+  AppendHeliusRingsEventInput,
+  HeliusRingsEventRepository,
+  HeliusRingsEventRepositoryContext,
+  HeliusRingsEventRow,
+  ListHeliusRingsEventsInput,
+} from "./helius-rings-event.repository";
+export {
+  DEFAULT_RINGS_EVENT_LIST_LIMIT,
+  generateHeliusRingsEventId,
+  mapHeliusRingsEventRow,
+  redactHeliusRingsEventPayload,
+} from "./helius-rings-event.repository";
+export { createPostgresHeliusRingsEventRepository } from "./helius-rings-event.repository.postgres";
+export type {
+  HeliusRingsHealthRepository,
+  HeliusRingsHealthRepositoryContext,
+  HeliusRingsRuntimeHealthRow,
+  RecordHeliusRingsHealthInput,
+} from "./helius-rings-health.repository";
+export { mapHeliusRingsHealthRows } from "./helius-rings-health.repository";
+export { createPostgresHeliusRingsHealthRepository } from "./helius-rings-health.repository.postgres";
+export type {
+  CreateHeliusRingsKeyRefInput,
+  HeliusRingsKeyRefRepository,
+  HeliusRingsKeyRefRepositoryContext,
+  HeliusRingsKeyRefRow,
+} from "./helius-rings-key-ref.repository";
+export { generateHeliusRingsKeyRefId } from "./helius-rings-key-ref.repository";
+export { createPostgresHeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository.postgres";
+export type {
+  FailHeliusRingsOperationInput,
+  HeliusRingsOperationRepository,
+  HeliusRingsOperationRepositoryContext,
+  HeliusRingsOperationRow,
+  HeliusRingsOperationTransitionPatch,
+  HeliusRingsTimelockInput,
+  HeliusRingsTimelockRow,
+  ListHeliusRingsInFlightOperationsInput,
+  ListHeliusRingsOperationsByProjectInput,
+  ListHeliusRingsOperationsByWalletInput,
+  ReleaseHeliusRingsTimelockInput,
+  ReserveHeliusRingsIntentInput,
+  ReserveHeliusRingsIntentResult,
+  TransitionHeliusRingsOperationInput,
+} from "./helius-rings-operation.repository";
+export {
+  DEFAULT_RINGS_IN_FLIGHT_SWEEP_LIMIT,
+  DEFAULT_RINGS_OPERATION_LIST_LIMIT,
+  generateHeliusRingsOperationId,
+  mapHeliusRingsOperationSummaryRow,
+} from "./helius-rings-operation.repository";
+export { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+export type {
+  CreateHeliusRingsWalletInput,
+  HeliusRingsProjectScope,
+  HeliusRingsWalletRepository,
+  HeliusRingsWalletRepositoryContext,
+  HeliusRingsWalletRow,
+  ListHeliusRingsWalletsInput,
+  MarkHeliusRingsWalletProvisionedInput,
+  UpdateHeliusRingsWalletStatusInput,
+  UpdateHeliusRingsWalletSyncCursorInput,
+} from "./helius-rings-wallet.repository";
+export {
+  DEFAULT_RINGS_WALLET_LIST_LIMIT,
+  generateHeliusRingsWalletId,
+  mapHeliusRingsWalletRow,
+} from "./helius-rings-wallet.repository";
+export { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+export type {
+  CreateHeliusRingsZoneInput,
+  HeliusRingsZoneRepository,
+  HeliusRingsZoneRepositoryContext,
+  HeliusRingsZoneRow,
+} from "./helius-rings-zone.repository";
+export {
+  generateHeliusRingsZoneId,
+  mapHeliusRingsZoneRow,
+} from "./helius-rings-zone.repository";
+export { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
+export type {
   KycWalletRow,
   KycWalletsRepository,
   SetKycStatusByCounterpartyInput,
@@ -336,6 +417,12 @@ export {
   createCounterpartiesRepository,
   createCounterpartyAccountsRepository,
   createEarnRepository,
+  createHeliusRingsEventRepository,
+  createHeliusRingsHealthRepository,
+  createHeliusRingsKeyRefRepository,
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+  createHeliusRingsZoneRepository,
   createKycWalletsRepository,
   createNotificationsRepository,
   createPaymentRecurringPaymentsRepository,

--- a/apps/sdp-api/src/db/repositories/repository-factory.ts
+++ b/apps/sdp-api/src/db/repositories/repository-factory.ts
@@ -13,6 +13,18 @@ import type { CounterpartyAccountsRepository } from "./counterparty-account.repo
 import { createPostgresCounterpartyAccountsRepository } from "./counterparty-account.repository.postgres";
 import type { EarnRepository } from "./earn.repository";
 import { createPostgresEarnRepository } from "./earn.repository.postgres";
+import type { HeliusRingsEventRepository } from "./helius-rings-event.repository";
+import { createPostgresHeliusRingsEventRepository } from "./helius-rings-event.repository.postgres";
+import type { HeliusRingsHealthRepository } from "./helius-rings-health.repository";
+import { createPostgresHeliusRingsHealthRepository } from "./helius-rings-health.repository.postgres";
+import type { HeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository";
+import { createPostgresHeliusRingsKeyRefRepository } from "./helius-rings-key-ref.repository.postgres";
+import type { HeliusRingsOperationRepository } from "./helius-rings-operation.repository";
+import { createPostgresHeliusRingsOperationRepository } from "./helius-rings-operation.repository.postgres";
+import type { HeliusRingsWalletRepository } from "./helius-rings-wallet.repository";
+import { createPostgresHeliusRingsWalletRepository } from "./helius-rings-wallet.repository.postgres";
+import type { HeliusRingsZoneRepository } from "./helius-rings-zone.repository";
+import { createPostgresHeliusRingsZoneRepository } from "./helius-rings-zone.repository.postgres";
 import type { KycWalletsRepository } from "./kyc-wallet.repository";
 import { createPostgresKycWalletsRepository } from "./kyc-wallet.repository.postgres";
 import type { NotificationsRepository } from "./notification.repository";
@@ -216,6 +228,30 @@ export function createNotificationsRepository(env: Env): NotificationsRepository
 
 export function createEarnRepository(env: Env): EarnRepository {
   return createPostgresEarnRepository(getDb(env));
+}
+
+export function createHeliusRingsWalletRepository(env: Env): HeliusRingsWalletRepository {
+  return createPostgresHeliusRingsWalletRepository(getDb(env));
+}
+
+export function createHeliusRingsOperationRepository(env: Env): HeliusRingsOperationRepository {
+  return createPostgresHeliusRingsOperationRepository(getDb(env));
+}
+
+export function createHeliusRingsKeyRefRepository(env: Env): HeliusRingsKeyRefRepository {
+  return createPostgresHeliusRingsKeyRefRepository(getDb(env));
+}
+
+export function createHeliusRingsZoneRepository(env: Env): HeliusRingsZoneRepository {
+  return createPostgresHeliusRingsZoneRepository(getDb(env));
+}
+
+export function createHeliusRingsEventRepository(env: Env): HeliusRingsEventRepository {
+  return createPostgresHeliusRingsEventRepository(getDb(env));
+}
+
+export function createHeliusRingsHealthRepository(env: Env): HeliusRingsHealthRepository {
+  return createPostgresHeliusRingsHealthRepository(getDb(env));
 }
 
 export function createPrivateChannelInstanceRepository(env: Env): PrivateChannelInstanceRepository {

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -69,6 +69,16 @@ const POSTGRES_TEST_TABLES = [
   "private_channel_deposits",
   "private_channels",
   "private_channel_instances",
+  "helius_rings_events",
+  "helius_rings_timelocks",
+  "helius_rings_operations",
+  "helius_rings_zones",
+  "helius_rings_key_refs",
+  "helius_rings_wallets",
+  "helius_rings_runtime_health",
+  // helius_rings_asset_allowlist is deliberately absent: it is platform
+  // reference data seeded by migration 0057, not per-test state. Truncating it
+  // would empty it for the rest of the run, and nothing re-seeds it.
   "magic_links",
   "sessions",
   "project_members",

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -14,7 +14,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 | Module | Purpose | Allowed workspace dependencies |
 | --- | --- | --- |
-| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
+| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
 | `@sdp/api-integration` | Maintainer integration harness for API endpoint and provider coverage. | `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types` |
 | `@sdp/custody` | Custody provider abstractions and keychain adapters. | `@sdp/types` |
 | `@sdp/earn` | Earn domain services, yield strategies, and vault-infra providers. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
@@ -36,7 +36,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 ## Declared Workspace Graph
 
-- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
+- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/helius-rings`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
 - `@sdp/api-integration` -> `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types`
 - `@sdp/custody` -> `@sdp/types`
 - `@sdp/earn` -> `@sdp/types`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@sdp/env-config':
         specifier: workspace:*
         version: link:../../packages/sdp-env-config
+      '@sdp/helius-rings':
+        specifier: workspace:*
+        version: link:../../packages/sdp-helius-rings
       '@sdp/issuance':
         specifier: workspace:*
         version: link:../../packages/sdp-issuance

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -23,6 +23,7 @@ const MODULE_METADATA = [
       "@sdp/custody",
       "@sdp/earn",
       "@sdp/env-config",
+      "@sdp/helius-rings",
       "@sdp/issuance",
       "@sdp/kamino",
       "@sdp/payments",


### PR DESCRIPTION
- 6 repositories (interface + Postgres impl): wallet, operation+timelocks, key-ref, zone, event, health; factory getters + barrel exports
- `reserveIntent`: `ON CONFLICT (intent_key) DO UPDATE SET updated_at = itself RETURNING *` — a replay returns the existing row; the `reserved` flag tells callers whether to run side effects
- State transitions CAS-guarded under `SELECT … FOR UPDATE`; sparse patches never blank earlier columns
- Event payloads redacted on write (shares the registry from the parent PR); key-ref repo never decrypts; timelock release is single-shot
- 60 repository tests against the real testcontainer schema

Notes for review: size is dominated by tests (~900 lines) and mechanical row mapping. The 3-line `pnpm-lock.yaml` change (workspace link) was hand-applied — the registry currently fails `pnpm install --lockfile-only` with `ERR_PNPM_MISSING_TIME` — and verified with `pnpm install --frozen-lockfile`.
