### PR TITLE
chore(deps): override jayson>uuid to 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "brace-expansion": "5.0.9",
       "esbuild": "0.28.1",
       "fast-uri": "3.1.5",
+      "jayson>uuid": "11.1.1",
       "js-yaml": "4.3.0",
       "postcss>nanoid": "3.3.18",
       "postcss": "^8.5.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,7 @@ overrides:
   brace-expansion: 5.0.9
   esbuild: 0.28.1
   fast-uri: 3.1.5
+  jayson>uuid: 11.1.1
   js-yaml: 4.3.0
   postcss>nanoid: 3.3.18
   postcss: ^8.5.22
@@ -9051,13 +9052,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -16576,7 +16576,7 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -18848,9 +18848,9 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@14.0.1: {}
+  uuid@11.1.1: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.1: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
- Resolves Dependabot alert #62 (uuid <11.1.1 missing buffer bounds check in v3/v5/v6)
- uuid@8.3.2 came in via @solana/web3.js -> jayson@4.3.0, which pins ^8.3.2 with no upstream fix
- Scoped pnpm override `jayson>uuid: 11.1.1`; jayson only uses the v4 named export, verified generateId works against uuid 11