### PR TITLE
feat(helius): add rings gateway port and the not-implemented seam

### DIFF
--- a/packages/sdp-helius-rings/package.json
+++ b/packages/sdp-helius-rings/package.json
@@ -8,6 +8,11 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/index.ts",
+      "import": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
     }
   },
   "scripts": {

--- a/packages/sdp-helius-rings/src/index.ts
+++ b/packages/sdp-helius-rings/src/index.ts
@@ -11,6 +11,18 @@ export {
   ZONE_KINDS,
 } from "./constants";
 export { HeliusRingsError, type HeliusRingsErrorCode } from "./errors";
+export { NotImplementedRingsGateway } from "./not-implemented-gateway";
+export type {
+  BuildOperationInput,
+  BuildOperationResult,
+  ProvisionIdentityInput,
+  ProvisionIdentityResult,
+  RequestProofInput,
+  RingsGatewayPort,
+  SyncPhotonInput,
+  SyncPhotonResult,
+  VerifyIndexedResult,
+} from "./port";
 export { type RevealScope, SecretRef } from "./secrets";
 export {
   type FailEdge,

--- a/packages/sdp-helius-rings/src/not-implemented-gateway.test.ts
+++ b/packages/sdp-helius-rings/src/not-implemented-gateway.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { HeliusRingsError } from "./errors";
+import { NotImplementedRingsGateway } from "./not-implemented-gateway";
+import type { RingsGatewayPort } from "./port";
+
+describe("NotImplementedRingsGateway", () => {
+  const gateway: RingsGatewayPort = new NotImplementedRingsGateway();
+
+  const calls: Array<[string, () => Promise<unknown>]> = [
+    ["probeHealth", () => gateway.probeHealth()],
+    [
+      "provisionIdentity",
+      () => gateway.provisionIdentity({ walletId: "hrw_1", sdpAddress: "addr" }),
+    ],
+    ["syncPhoton", () => gateway.syncPhoton({ walletId: "hrw_1", cursor: null })],
+    ["buildOperation", () => gateway.buildOperation({ operation: {} as never, keyRefs: [] })],
+    [
+      "requestProof",
+      () => gateway.requestProof({ operationId: "hro_1", ringsMetadata: {} as never }),
+    ],
+    ["verifyIndexed", () => gateway.verifyIndexed("sig")],
+  ];
+
+  it.each(calls)("%s throws gateway_unavailable naming the seam", async (method, call) => {
+    const error = await call().then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(HeliusRingsError);
+    expect((error as HeliusRingsError).code).toBe("gateway_unavailable");
+    expect((error as HeliusRingsError).message).toContain(method);
+  });
+});

--- a/packages/sdp-helius-rings/src/not-implemented-gateway.ts
+++ b/packages/sdp-helius-rings/src/not-implemented-gateway.ts
@@ -1,0 +1,42 @@
+import { HeliusRingsError } from "./errors";
+import type { RingsGatewayPort } from "./port";
+
+/**
+ * The production gateway until Track B lands the live HTTP adapter. Every
+ * method throws `gateway_unavailable` naming its seam, so an operation that
+ * reaches the port ends in `failed:gateway_unavailable` (retryable) and the UI
+ * reports the integration honestly instead of simulating it.
+ */
+
+function notImplemented(method: string): never {
+  throw new HeliusRingsError(
+    "gateway_unavailable",
+    `${method} awaiting Zolana sidecar integration`
+  );
+}
+
+export class NotImplementedRingsGateway implements RingsGatewayPort {
+  async probeHealth(): Promise<never> {
+    return notImplemented("probeHealth");
+  }
+
+  async provisionIdentity(): Promise<never> {
+    return notImplemented("provisionIdentity");
+  }
+
+  async syncPhoton(): Promise<never> {
+    return notImplemented("syncPhoton");
+  }
+
+  async buildOperation(): Promise<never> {
+    return notImplemented("buildOperation");
+  }
+
+  async requestProof(): Promise<never> {
+    return notImplemented("requestProof");
+  }
+
+  async verifyIndexed(): Promise<never> {
+    return notImplemented("verifyIndexed");
+  }
+}

--- a/packages/sdp-helius-rings/src/port.ts
+++ b/packages/sdp-helius-rings/src/port.ts
@@ -1,0 +1,64 @@
+import type { SecretRef } from "./secrets";
+import type { KeyRef, PrivateOperation, ProofArtifact, RuntimeHealth } from "./types";
+
+/**
+ * The only seam between SDP and the Rings upstreams (Zolana sidecar, Photon,
+ * prover, key authority). Track A ships NotImplementedRingsGateway behind it;
+ * Track B replaces that with the live HTTP adapter. Nothing else in the
+ * codebase may talk to those upstreams directly.
+ */
+
+export interface ProvisionIdentityInput {
+  walletId: string;
+  sdpAddress: string;
+}
+
+export interface ProvisionIdentityResult {
+  shieldedAddress: string;
+  keyRefs: KeyRef[];
+}
+
+export interface SyncPhotonInput {
+  walletId: string;
+  /** Null on the first sync. */
+  cursor: string | null;
+}
+
+export interface SyncPhotonResult {
+  cursor: string;
+  balances: Array<{ mint: string; amountRaw: string; decimals: number; symbol: string }>;
+  /** Outer tx signatures Photon has indexed since the previous cursor. */
+  indexedOperationSignatures: string[];
+}
+
+export interface BuildOperationInput {
+  operation: PrivateOperation;
+  keyRefs: KeyRef[];
+}
+
+export interface BuildOperationResult {
+  outerUnsignedTxBase64: string;
+  requiredSigners: string[];
+  /** Opaque gateway state carried into requestProof; never logged or persisted raw. */
+  ringsMetadata: SecretRef<Record<string, unknown>>;
+}
+
+export interface RequestProofInput {
+  operationId: string;
+  ringsMetadata: SecretRef<Record<string, unknown>>;
+}
+
+export interface VerifyIndexedResult {
+  indexedAt: string;
+  photonRef: string;
+}
+
+export interface RingsGatewayPort {
+  probeHealth(): Promise<RuntimeHealth>;
+  provisionIdentity(input: ProvisionIdentityInput): Promise<ProvisionIdentityResult>;
+  syncPhoton(input: SyncPhotonInput): Promise<SyncPhotonResult>;
+  buildOperation(input: BuildOperationInput): Promise<BuildOperationResult>;
+  requestProof(input: RequestProofInput): Promise<ProofArtifact>;
+  /** Null while Photon has not indexed the signature yet. */
+  verifyIndexed(signature: string): Promise<VerifyIndexedResult | null>;
+}

--- a/packages/sdp-helius-rings/src/testing/in-memory-gateway.test.ts
+++ b/packages/sdp-helius-rings/src/testing/in-memory-gateway.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { PrivateOperation } from "../types";
+import { InMemoryRingsGateway } from "./in-memory-gateway";
+
+const OPERATION = {
+  walletId: "hrw_1",
+  opType: "shield",
+  intentKey: "sha256:abc",
+} as PrivateOperation;
+
+describe("InMemoryRingsGateway", () => {
+  it("is deterministic: same inputs produce identical outputs", async () => {
+    const a = new InMemoryRingsGateway({ now: () => "2026-08-17T00:00:00.000Z" });
+    const b = new InMemoryRingsGateway({ now: () => "2026-08-17T00:00:00.000Z" });
+
+    const [identityA, identityB] = await Promise.all([
+      a.provisionIdentity({ walletId: "hrw_1", sdpAddress: "addr" }),
+      b.provisionIdentity({ walletId: "hrw_1", sdpAddress: "addr" }),
+    ]);
+    expect(identityA.shieldedAddress).toBe(identityB.shieldedAddress);
+    expect(identityA.keyRefs[0].material.reveal("test")).toEqual(
+      identityB.keyRefs[0].material.reveal("test")
+    );
+
+    const [builtA, builtB] = await Promise.all([
+      a.buildOperation({ operation: OPERATION, keyRefs: [] }),
+      b.buildOperation({ operation: OPERATION, keyRefs: [] }),
+    ]);
+    expect(builtA.outerUnsignedTxBase64).toBe(builtB.outerUnsignedTxBase64);
+  });
+
+  it("returns all-green health by default and honours an override", async () => {
+    expect(await new InMemoryRingsGateway().probeHealth()).toEqual({
+      rpc: "green",
+      prover: "green",
+      photon: "green",
+      gateway: "green",
+    });
+
+    const degraded = new InMemoryRingsGateway({
+      health: { rpc: "green", prover: "red", photon: "amber", gateway: "green" },
+    });
+    expect((await degraded.probeHealth()).prover).toBe("red");
+  });
+
+  it("provisions exactly a viewing and a nullifier key, both simulated", async () => {
+    const identity = await new InMemoryRingsGateway().provisionIdentity({
+      walletId: "hrw_1",
+      sdpAddress: "addr",
+    });
+
+    expect(identity.keyRefs.map((keyRef) => keyRef.kind)).toEqual(["viewing", "nullifier"]);
+    expect(identity.keyRefs.every((keyRef) => keyRef.materialTag === "simulated")).toBe(true);
+    // The wrapper must be real — the downstream chain handles SecretRef before
+    // the live adapter exists.
+    expect(JSON.stringify(identity.keyRefs[0].material)).toBe('"[REDACTED]"');
+  });
+
+  it("advances a monotonic sync cursor per wallet", async () => {
+    const gateway = new InMemoryRingsGateway();
+
+    expect((await gateway.syncPhoton({ walletId: "hrw_1", cursor: null })).cursor).toBe("slot:1");
+    expect((await gateway.syncPhoton({ walletId: "hrw_1", cursor: "slot:1" })).cursor).toBe(
+      "slot:2"
+    );
+    expect((await gateway.syncPhoton({ walletId: "hrw_2", cursor: null })).cursor).toBe("slot:1");
+  });
+
+  it("always marks proofs simulated", async () => {
+    const proof = await new InMemoryRingsGateway({
+      now: () => "2026-08-17T00:00:00.000Z",
+    }).requestProof({ operationId: "hro_1", ringsMetadata: {} as never });
+
+    expect(proof.source).toBe("simulated");
+    expect(proof.createdAt).toBe("2026-08-17T00:00:00.000Z");
+  });
+
+  it("reports indexed only after the delay elapses on the injected clock", async () => {
+    let now = "2026-08-17T00:00:00.000Z";
+    const gateway = new InMemoryRingsGateway({ now: () => now, indexingDelayMs: 1000 });
+
+    expect(await gateway.verifyIndexed("sig")).toBeNull();
+
+    gateway.recordSubmission("sig");
+    expect(await gateway.verifyIndexed("sig")).toBeNull();
+
+    now = "2026-08-17T00:00:01.000Z";
+    expect(await gateway.verifyIndexed("sig")).toMatchObject({ indexedAt: now });
+  });
+
+  it("lets a test inject a signable unsigned tx", async () => {
+    const gateway = new InMemoryRingsGateway({ buildUnsignedTx: () => "c2lnbmFibGU=" });
+
+    const built = await gateway.buildOperation({ operation: OPERATION, keyRefs: [] });
+    expect(built.outerUnsignedTxBase64).toBe("c2lnbmFibGU=");
+  });
+});

--- a/packages/sdp-helius-rings/src/testing/in-memory-gateway.ts
+++ b/packages/sdp-helius-rings/src/testing/in-memory-gateway.ts
@@ -1,0 +1,167 @@
+import type {
+  BuildOperationInput,
+  BuildOperationResult,
+  ProvisionIdentityInput,
+  ProvisionIdentityResult,
+  RequestProofInput,
+  RingsGatewayPort,
+  SyncPhotonInput,
+  SyncPhotonResult,
+  VerifyIndexedResult,
+} from "../port";
+import { SecretRef } from "../secrets";
+import type { ProofArtifact, RuntimeHealth } from "../types";
+
+/**
+ * Test-only implementation of RingsGatewayPort. Never shipped: it lives under
+ * src/testing/, is exported only via the `@sdp/helius-rings/testing` subpath,
+ * and is not selectable by environment. Production uses
+ * NotImplementedRingsGateway until Track B lands the live adapter.
+ *
+ * Deterministic by construction — outputs derive from a hash of the inputs,
+ * and time comes from the injected clock — so the same test always sees the
+ * same values.
+ */
+
+export interface InMemoryRingsGatewayOptions {
+  /** Injected clock; defaults to the real one. */
+  now?: () => string;
+  /** Health returned by probeHealth; defaults to all green. */
+  health?: RuntimeHealth;
+  /** How long after submission verifyIndexed starts reporting indexed. */
+  indexingDelayMs?: number;
+  /** Override for tests that need a signable unsigned tx (A8/A9). */
+  buildUnsignedTx?: (input: BuildOperationInput) => string;
+}
+
+const ALL_GREEN: RuntimeHealth = {
+  rpc: "green",
+  prover: "green",
+  photon: "green",
+  gateway: "green",
+};
+
+/** FNV-1a, hex-encoded — deterministic bytes without a crypto dependency. */
+function hashHex(seed: string, bytes: number): string {
+  let hash = 0x811c9dc5;
+  let out = "";
+  for (let round = 0; out.length < bytes * 2; round++) {
+    const input = `${seed}:${round}`;
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    out += hash.toString(16).padStart(8, "0");
+  }
+  return out.slice(0, bytes * 2);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// biome-ignore lint/security/noSecrets: character alphabet, not a secret.
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/** Dependency-free base64 so the package needs neither Buffer nor btoa types. */
+function bytesToBase64(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const [a, b, c] = [bytes[i], bytes[i + 1], bytes[i + 2]];
+    out += BASE64_ALPHABET[a >> 2];
+    out += BASE64_ALPHABET[((a & 3) << 4) | ((b ?? 0) >> 4)];
+    out += b === undefined ? "=" : BASE64_ALPHABET[((b & 15) << 2) | ((c ?? 0) >> 6)];
+    out += c === undefined ? "=" : BASE64_ALPHABET[c & 63];
+  }
+  return out;
+}
+
+export class InMemoryRingsGateway implements RingsGatewayPort {
+  private readonly now: () => string;
+  private readonly health: RuntimeHealth;
+  private readonly indexingDelayMs: number;
+  private readonly buildUnsignedTx?: (input: BuildOperationInput) => string;
+  private readonly syncCounters = new Map<string, number>();
+  private readonly submittedAt = new Map<string, number>();
+
+  constructor(options: InMemoryRingsGatewayOptions = {}) {
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.health = options.health ?? ALL_GREEN;
+    this.indexingDelayMs = options.indexingDelayMs ?? 0;
+    this.buildUnsignedTx = options.buildUnsignedTx;
+  }
+
+  async probeHealth(): Promise<RuntimeHealth> {
+    return { ...this.health };
+  }
+
+  async provisionIdentity(input: ProvisionIdentityInput): Promise<ProvisionIdentityResult> {
+    const seed = `${input.walletId}:${input.sdpAddress}`;
+    return {
+      shieldedAddress: `rings1${hashHex(`${seed}:address`, 16)}`,
+      keyRefs: (["viewing", "nullifier"] as const).map((kind) => ({
+        kind,
+        material: new SecretRef(hexToBytes(hashHex(`${seed}:${kind}`, 32))),
+        materialTag: "simulated",
+        keyVersion: "v1",
+      })),
+    };
+  }
+
+  async syncPhoton(input: SyncPhotonInput): Promise<SyncPhotonResult> {
+    const next = (this.syncCounters.get(input.walletId) ?? 0) + 1;
+    this.syncCounters.set(input.walletId, next);
+    return {
+      cursor: `slot:${next}`,
+      balances: [
+        {
+          // biome-ignore lint/security/noSecrets: wrapped SOL mint address, not a secret.
+          mint: "So11111111111111111111111111111111111111112",
+          amountRaw: String(1_000_000_000 * next),
+          decimals: 9,
+          symbol: "SOL",
+        },
+      ],
+      indexedOperationSignatures: [],
+    };
+  }
+
+  async buildOperation(input: BuildOperationInput): Promise<BuildOperationResult> {
+    const seed = `${input.operation.walletId}:${input.operation.opType}:${input.operation.intentKey}`;
+    const outerUnsignedTxBase64 =
+      this.buildUnsignedTx?.(input) ?? bytesToBase64(hexToBytes(hashHex(`${seed}:tx`, 64)));
+    return {
+      outerUnsignedTxBase64,
+      requiredSigners: [input.operation.walletId],
+      ringsMetadata: new SecretRef({ seed: hashHex(`${seed}:metadata`, 16) }),
+    };
+  }
+
+  async requestProof(input: RequestProofInput): Promise<ProofArtifact> {
+    return {
+      source: "simulated",
+      ref: new SecretRef(hashHex(`${input.operationId}:proof`, 32)),
+      createdAt: this.now(),
+    };
+  }
+
+  /** Tests call this to start the indexing clock for a signature. */
+  recordSubmission(signature: string): void {
+    this.submittedAt.set(signature, Date.parse(this.now()));
+  }
+
+  async verifyIndexed(signature: string): Promise<VerifyIndexedResult | null> {
+    const submitted = this.submittedAt.get(signature);
+    if (submitted === undefined) return null;
+    const elapsed = Date.parse(this.now()) - submitted;
+    if (elapsed < this.indexingDelayMs) return null;
+    return {
+      indexedAt: this.now(),
+      photonRef: `photon:${hashHex(signature, 8)}`,
+    };
+  }
+}

--- a/packages/sdp-helius-rings/src/testing/index.ts
+++ b/packages/sdp-helius-rings/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { InMemoryRingsGateway, type InMemoryRingsGatewayOptions } from "./in-memory-gateway";


### PR DESCRIPTION
- Adds `RingsGatewayPort` — the single seam to Zolana/Photon/prover; Track B's B3 implements it as the live HTTP adapter
- Production wiring gets `NotImplementedRingsGateway`: every method throws `gateway_unavailable` naming its seam, so operations end in `failed:gateway_unavailable` and the UI reports the pending integration honestly
- `InMemoryRingsGateway` (deterministic, injectable clock) is test-only: exported via the `@sdp/helius-rings/testing` subpath, never from the package root, never env-selectable — no mocks ship to production
- 13 tests: seam errors per method, determinism, health override, simulated-proof tagging, indexing-delay clock semantics
