### PR TITLE
feat(helius): map rings operations onto the wallet policy envelope

### DIFF
--- a/apps/sdp-api/src/services/helius-rings/policy-envelope.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/policy-envelope.test.ts
@@ -1,0 +1,163 @@
+import { OP_TYPES } from "@sdp/helius-rings";
+import { evaluateCandidatePolicies } from "@sdp/policy";
+import type { EffectiveWalletPolicy, PolicyCandidate, PolicyRule } from "@sdp/types";
+import { describe, expect, it } from "vitest";
+import {
+  buildRingsWalletOperationInput,
+  RINGS_ENVELOPE_KINDS,
+  ringsEnvelopeKind,
+} from "./policy-envelope";
+
+function ringsCandidate(opType: (typeof OP_TYPES)[number]): PolicyCandidate {
+  return {
+    organizationId: "org_1",
+    projectId: "prj_1",
+    custodyWalletId: "cw_1",
+    walletId: "wal_1",
+    apiKeyId: null,
+    actor: null,
+    source: "api",
+    operationFamily: "transfer",
+    operationType: ringsEnvelopeKind(opType),
+    asset: null,
+    amount: null,
+    destination: null,
+    context: {},
+    providerExtensions: {},
+  };
+}
+
+function activeWalletPolicy(rules: PolicyRule[]): EffectiveWalletPolicy {
+  const now = "2026-08-17T00:00:00.000Z";
+  return {
+    source: "customer_profile",
+    profile: {
+      id: "wcp_1",
+      organizationId: "org_1",
+      projectId: "prj_1",
+      custodyWalletId: "cw_1",
+      name: "Wallet controls",
+      status: "active",
+      activeRevisionId: "wcpr_1",
+      createdBy: "usr_1",
+      createdAt: now,
+      updatedAt: now,
+      activatedAt: now,
+      archivedAt: null,
+    },
+    revision: {
+      id: "wcpr_1",
+      profileId: "wcp_1",
+      revisionNumber: 1,
+      rules,
+      defaultAction: "allow",
+      commitMessage: null,
+      createdBy: "usr_1",
+      createdAt: now,
+      activatedAt: now,
+    },
+    defaultAction: "allow",
+  };
+}
+
+describe("ringsEnvelopeKind", () => {
+  it("covers every op type with a rings_ prefix", () => {
+    expect(RINGS_ENVELOPE_KINDS).toEqual(OP_TYPES.map((opType) => `rings_${opType}`));
+  });
+});
+
+describe("rings operations under wallet policy", () => {
+  it("a policy denying transfers denies every rings op type — no bypass", () => {
+    const denyTransfers = activeWalletPolicy([
+      { kind: "operation_family", family: "transfer", action: "deny" },
+    ]);
+
+    for (const opType of OP_TYPES) {
+      const evaluation = evaluateCandidatePolicies({
+        candidate: ringsCandidate(opType),
+        legs: [],
+        walletPolicy: denyTransfers,
+        apiKeyPolicy: null,
+      });
+      expect(evaluation.decision, `rings_${opType} escaped the transfer deny`).toBe("deny");
+    }
+  });
+
+  it("a rule can target one rings op type without touching the rest", () => {
+    const approveAnonymous = activeWalletPolicy([
+      {
+        kind: "operation_type",
+        operationType: "rings_transfer_anonymous",
+        action: "approval_required",
+      },
+    ]);
+
+    expect(
+      evaluateCandidatePolicies({
+        candidate: ringsCandidate("transfer_anonymous"),
+        legs: [],
+        walletPolicy: approveAnonymous,
+        apiKeyPolicy: null,
+      }).decision
+    ).toBe("approval_required");
+    expect(
+      evaluateCandidatePolicies({
+        candidate: ringsCandidate("shield"),
+        legs: [],
+        walletPolicy: approveAnonymous,
+        apiKeyPolicy: null,
+      }).decision
+    ).toBe("allow");
+  });
+});
+
+describe("buildRingsWalletOperationInput", () => {
+  const base = {
+    organizationId: "org_1",
+    projectId: "prj_1",
+    custodyWalletId: "cw_1",
+    sdpWalletId: "wal_1",
+    apiKeyId: "key_1",
+    actor: null,
+    operationId: "hro_1",
+    intentKey: "sha256:abc",
+  };
+
+  it("maps a transfer onto the transfer family with a rings operation type", () => {
+    const input = buildRingsWalletOperationInput({
+      ...base,
+      operation: {
+        walletId: "hrw_1",
+        opType: "transfer_anonymous",
+        asset: { mint: "mint_1", amountRaw: "1000" },
+        to: "recipient",
+        transferMode: "anonymous",
+        clientNonce: "n1",
+      },
+    });
+
+    expect(input).toMatchObject({
+      operationFamily: "transfer",
+      operationType: "rings_transfer_anonymous",
+      asset: "mint_1",
+      amount: "1000",
+      destination: "recipient",
+      idempotencyKey: "sha256:abc",
+      source: "api",
+    });
+    expect(input.context).toMatchObject({ transferMode: "anonymous", ringsOperationId: "hro_1" });
+  });
+
+  it("marks a system-originated operation as system-sourced", () => {
+    const input = buildRingsWalletOperationInput({
+      ...base,
+      apiKeyId: null,
+      actor: null,
+      operation: { walletId: "hrw_1", opType: "shield", clientNonce: "n1" },
+    });
+
+    expect(input.source).toBe("system");
+    expect(input.asset).toBeNull();
+    expect(input.destination).toBeNull();
+  });
+});

--- a/apps/sdp-api/src/services/helius-rings/policy-envelope.ts
+++ b/apps/sdp-api/src/services/helius-rings/policy-envelope.ts
@@ -1,0 +1,70 @@
+import type { OpType, PrivateOperationInput } from "@sdp/helius-rings";
+import { OP_TYPES } from "@sdp/helius-rings";
+import type { CreateWalletOperationInput } from "@sdp/policy";
+import type { WalletOperationActor } from "@sdp/types";
+
+/**
+ * Maps a Rings operation onto the wallet-operation policy machinery. Every
+ * Rings op evaluates as `operationFamily: "transfer"` with a `rings_*`
+ * operation type: a policy that gates transfers on a wallet therefore gates
+ * every Rings op rooted in it, so Rings can never be an approval bypass.
+ * Finer-grained rules target the individual `rings_*` types.
+ */
+
+export type RingsEnvelopeKind = `rings_${OpType}`;
+
+export const RINGS_ENVELOPE_KINDS = OP_TYPES.map((opType): RingsEnvelopeKind => `rings_${opType}`);
+
+export function ringsEnvelopeKind(opType: OpType): RingsEnvelopeKind {
+  return `rings_${opType}`;
+}
+
+export interface BuildRingsWalletOperationInput {
+  organizationId: string;
+  projectId: string;
+  /** The SDP custody wallet the Rings wallet is bound to. */
+  custodyWalletId: string | null;
+  sdpWalletId: string;
+  apiKeyId: string | null;
+  actor: WalletOperationActor | null;
+  operation: PrivateOperationInput;
+  /** The reserved operation id, kept with the raw payload for audit. */
+  operationId: string;
+  intentKey: string;
+}
+
+export function buildRingsWalletOperationInput(
+  input: BuildRingsWalletOperationInput
+): CreateWalletOperationInput {
+  const { operation } = input;
+  return {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    custodyWalletId: input.custodyWalletId,
+    walletId: input.sdpWalletId,
+    apiKeyId: input.apiKeyId,
+    actor: input.actor,
+    source: input.apiKeyId === null && input.actor === null ? "system" : "api",
+    operationFamily: "transfer",
+    operationType: ringsEnvelopeKind(operation.opType),
+    asset: operation.asset?.mint ?? null,
+    amount: operation.asset?.amountRaw ?? null,
+    destination: operation.to ?? null,
+    legs: [],
+    context: {
+      ringsOperationId: input.operationId,
+      ringsWalletId: operation.walletId,
+      // Anonymous transfers are not lower-risk than registered ones — the
+      // counterparty is undisclosed, so reviewers see the mode explicitly.
+      transferMode: operation.transferMode ?? null,
+      zoneId: operation.zoneId ?? null,
+    },
+    providerExtensions: {},
+    rawPayload: {
+      opType: operation.opType,
+      intentKey: input.intentKey,
+      timelock: operation.timelock ?? null,
+    },
+    idempotencyKey: input.intentKey,
+  };
+}

--- a/packages/sdp-types/src/policy.ts
+++ b/packages/sdp-types/src/policy.ts
@@ -16,6 +16,18 @@ export const WALLET_OPERATION_TYPES = [
   "recurring_payment_collection",
   "recurring_payment_create",
   "recurring_payment_update",
+  // Helius Rings shielded operations. Mirror OP_TYPES in
+  // packages/sdp-helius-rings/src/constants.ts; the template type
+  // `rings_${OpType}` in the rings policy envelope fails to compile if the
+  // two lists drift.
+  "rings_shield",
+  "rings_transfer_registered",
+  "rings_transfer_anonymous",
+  "rings_withdraw",
+  "rings_merge",
+  "rings_timelock_create",
+  "rings_timelock_settle",
+  "rings_zone_create",
 ] as const;
 
 export type WalletOperationType = (typeof WALLET_OPERATION_TYPES)[number];


### PR DESCRIPTION
- Maps rings operations onto the wallet-operation policy machinery: every rings op evaluates as `operationFamily: "transfer"` with a `rings_*` operation type
- A policy gating transfers on a wallet therefore gates every rings op rooted in it — rings cannot be an approval bypass; verified by test across all op types
- Finer-grained rules can target individual `rings_*` types (e.g. `approval_required` on `rings_transfer_anonymous` only)
- `buildRingsWalletOperationInput` produces the `CreateWalletOperationInput` for the existing enforcement service; intent key doubles as the idempotency key
- No changes to `@sdp/policy` or `@sdp/types` — `operationType` is already an open string
