### PR TITLE
feat(helius): wrap custody signing and RPC submit for rings

### DIFF
--- a/apps/sdp-api/src/services/helius-rings/adapter-error.ts
+++ b/apps/sdp-api/src/services/helius-rings/adapter-error.ts
@@ -1,0 +1,22 @@
+import type { FailureCode } from "@sdp/helius-rings";
+
+/**
+ * Failure from the signer or RPC adapter, carrying exactly what the service
+ * needs to take the state machine's fail edge: the operation-level failure
+ * code and whether a retry can succeed.
+ */
+export class RingsAdapterError extends Error {
+  readonly failureCode: Extract<FailureCode, "signer_failed" | "submit_failed">;
+  readonly retryable: boolean;
+
+  constructor(
+    failureCode: Extract<FailureCode, "signer_failed" | "submit_failed">,
+    message: string,
+    options: { retryable: boolean; cause?: unknown }
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "RingsAdapterError";
+    this.failureCode = failureCode;
+    this.retryable = options.retryable;
+  }
+}

--- a/apps/sdp-api/src/services/helius-rings/rpc-adapter.ts
+++ b/apps/sdp-api/src/services/helius-rings/rpc-adapter.ts
@@ -1,0 +1,32 @@
+import { createRpc, type SolanaRpc, sendTransaction } from "@sdp/rpc/solana";
+import { getBase64Codec } from "@solana/codecs";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+
+/**
+ * Broadcasts the signed outer transaction over the existing SDP RPC path.
+ * Submission failures are always retryable: the service's intent key makes a
+ * resubmission safe, and the RPC cannot tell a dropped transaction from a
+ * transient outage.
+ */
+
+export interface SubmitRingsOuterTransactionInput {
+  env: Env;
+  signedTxBase64: string;
+  /** Test seam; production resolves the env RPC. */
+  rpc?: SolanaRpc;
+}
+
+export async function submitRingsOuterTransaction(
+  input: SubmitRingsOuterTransactionInput
+): Promise<string> {
+  const rpc = input.rpc ?? createRpc(input.env);
+  const signedBytes = getBase64Codec().encode(input.signedTxBase64);
+
+  try {
+    return await sendTransaction(rpc, new Uint8Array(signedBytes));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "transaction submission failed";
+    throw new RingsAdapterError("submit_failed", message, { retryable: true, cause: error });
+  }
+}

--- a/apps/sdp-api/src/services/helius-rings/signer-adapter.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/signer-adapter.test.ts
@@ -1,0 +1,142 @@
+import { SigningError } from "@sdp/custody/signing";
+import type { SolanaRpc } from "@sdp/rpc/solana";
+import {
+  type Address,
+  type Blockhash,
+  compileTransaction,
+  createTransactionMessage,
+  getBase58Codec,
+  getBase64Codec,
+  getTransactionDecoder,
+  getTransactionEncoder,
+  pipe,
+  type SignatureBytes,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from "@solana/kit";
+import type { TransactionPartialSigner } from "@solana/signers";
+import { describe, expect, it } from "vitest";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+import { submitRingsOuterTransaction } from "./rpc-adapter";
+import { signRingsOuterTransaction } from "./signer-adapter";
+
+const FEE_PAYER = "11111111111111111111111111111111" as Address;
+const BLOCKHASH = getBase58Codec().decode(new Uint8Array(32).fill(7)) as Blockhash;
+
+const base64 = getBase64Codec();
+const env = {} as Env;
+
+function unsignedTxBase64(): string {
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    (current) => setTransactionMessageFeePayer(FEE_PAYER, current),
+    (current) =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash: BLOCKHASH, lastValidBlockHeight: 100n },
+        current
+      )
+  );
+  return base64.decode(getTransactionEncoder().encode(compileTransaction(message)));
+}
+
+function partialSigner(
+  sign: () => Promise<Array<Record<Address, SignatureBytes>>>
+): TransactionPartialSigner {
+  return { address: FEE_PAYER, signTransactions: sign };
+}
+
+describe("signRingsOuterTransaction", () => {
+  it("attaches the custody signature and returns base64 wire bytes", async () => {
+    const signature = new Uint8Array(64).fill(7) as SignatureBytes;
+    const signer = partialSigner(async () => [{ [FEE_PAYER]: signature }]);
+
+    const signed = await signRingsOuterTransaction({
+      env,
+      organizationId: "org_1",
+      projectId: "prj_1",
+      unsignedTxBase64: unsignedTxBase64(),
+      signer,
+    });
+
+    const decoded = getTransactionDecoder().decode(base64.encode(signed));
+    expect(decoded.signatures[FEE_PAYER]).toEqual(signature);
+  });
+
+  it("maps a transient signer error to a retryable signer_failed", async () => {
+    const signer = partialSigner(async () => {
+      throw new SigningError("provider timeout", "NETWORK_ERROR");
+    });
+
+    const error = await signRingsOuterTransaction({
+      env,
+      organizationId: "org_1",
+      projectId: "prj_1",
+      unsignedTxBase64: unsignedTxBase64(),
+      signer,
+    }).then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(RingsAdapterError);
+    expect(error).toMatchObject({ failureCode: "signer_failed", retryable: true });
+  });
+
+  it("marks a missing wallet as non-retryable", async () => {
+    const signer = partialSigner(async () => {
+      throw new SigningError("no such wallet", "WALLET_NOT_FOUND");
+    });
+
+    const error = await signRingsOuterTransaction({
+      env,
+      organizationId: "org_1",
+      projectId: "prj_1",
+      unsignedTxBase64: unsignedTxBase64(),
+      signer,
+    }).then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toMatchObject({ failureCode: "signer_failed", retryable: false });
+  });
+});
+
+describe("submitRingsOuterTransaction", () => {
+  it("broadcasts and returns the signature", async () => {
+    const rpc = {
+      sendTransaction: () => ({ send: async () => "sig_abc" }),
+    } as unknown as SolanaRpc;
+
+    await expect(
+      submitRingsOuterTransaction({ env, signedTxBase64: unsignedTxBase64(), rpc })
+    ).resolves.toBe("sig_abc");
+  });
+
+  it("maps a broadcast failure to a retryable submit_failed", async () => {
+    const rpc = {
+      sendTransaction: () => ({
+        send: async () => {
+          throw new Error("blockhash not found");
+        },
+      }),
+    } as unknown as SolanaRpc;
+
+    const error = await submitRingsOuterTransaction({
+      env,
+      signedTxBase64: unsignedTxBase64(),
+      rpc,
+    }).then(
+      () => null,
+      (thrown: unknown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(RingsAdapterError);
+    expect(error).toMatchObject({
+      failureCode: "submit_failed",
+      retryable: true,
+      message: "blockhash not found",
+    });
+  });
+});

--- a/apps/sdp-api/src/services/helius-rings/signer-adapter.ts
+++ b/apps/sdp-api/src/services/helius-rings/signer-adapter.ts
@@ -1,0 +1,96 @@
+import { SigningError } from "@sdp/custody/signing";
+import { getBase64Codec } from "@solana/codecs";
+import {
+  getTransactionDecoder,
+  getTransactionEncoder,
+  type Transaction,
+  type TransactionWithinSizeLimit,
+  type TransactionWithLifetime,
+} from "@solana/kit";
+import {
+  isTransactionModifyingSigner,
+  isTransactionPartialSigner,
+  type TransactionSigner,
+} from "@solana/signers";
+import { createOrgSigner } from "@/services/solana/signer";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+
+/**
+ * Signs the gateway-built outer transaction with the SDP custody signer.
+ * Base64 bytes in, base64 bytes out — no SecretRef crosses this boundary, and
+ * the transaction bytes are never logged here (they can carry routing
+ * metadata the redaction registry does not model).
+ */
+
+/** Signer errors that a retry cannot fix. */
+const NON_RETRYABLE_SIGNING_CODES = new Set([
+  "PROVIDER_NOT_CONFIGURED",
+  "WALLET_NOT_FOUND",
+  "NOT_FOUND",
+  "INVALID_REQUEST",
+  "APPROVAL_REJECTED",
+]);
+
+export interface SignRingsOuterTransactionInput {
+  env: Env;
+  organizationId: string;
+  projectId: string;
+  unsignedTxBase64: string;
+  /** Test seam; production resolves the org signer. */
+  signer?: TransactionSigner;
+}
+
+export async function signRingsOuterTransaction(
+  input: SignRingsOuterTransactionInput
+): Promise<string> {
+  const base64 = getBase64Codec();
+
+  let signer: TransactionSigner;
+  let signed: Transaction;
+  try {
+    signer =
+      input.signer ?? (await createOrgSigner(input.env, input.organizationId, input.projectId));
+  } catch (error) {
+    throw toSignerFailure(error);
+  }
+
+  // The decoder returns an unbranded Transaction; the gateway built these
+  // bytes as a complete compiled tx, which is what the signer brands assert.
+  const transaction = getTransactionDecoder().decode(
+    base64.encode(input.unsignedTxBase64)
+  ) as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
+
+  try {
+    if (isTransactionModifyingSigner(signer)) {
+      [signed] = await signer.modifyAndSignTransactions([transaction]);
+    } else if (isTransactionPartialSigner(signer)) {
+      const [signatures] = await signer.signTransactions([transaction]);
+      signed = { ...transaction, signatures: { ...transaction.signatures, ...signatures } };
+    } else {
+      throw new RingsAdapterError(
+        "signer_failed",
+        "custody signer cannot sign compiled transactions",
+        { retryable: false }
+      );
+    }
+  } catch (error) {
+    throw toSignerFailure(error);
+  }
+
+  return base64.decode(getTransactionEncoder().encode(signed));
+}
+
+function toSignerFailure(error: unknown): RingsAdapterError {
+  if (error instanceof RingsAdapterError) return error;
+  if (error instanceof SigningError) {
+    return new RingsAdapterError("signer_failed", error.message, {
+      retryable: !NON_RETRYABLE_SIGNING_CODES.has(error.code),
+      cause: error,
+    });
+  }
+  return new RingsAdapterError("signer_failed", "custody signing failed", {
+    retryable: true,
+    cause: error,
+  });
+}


### PR DESCRIPTION
- Thin wrappers so the custody signer and RPC submit path are exercised for real from day 1 (only proof and Photon stay behind the port)
- `signer-adapter.ts`: `createOrgSigner` → signs the gateway-built compiled wire tx (partial and modifying signer branches); base64 in, base64 out; no SecretRef crosses the boundary; tx bytes never logged
- `rpc-adapter.ts`: broadcasts over the shared `@sdp/rpc/solana` `sendTransaction`
- Failures throw `RingsAdapterError` carrying the operation failure code (`signer_failed` / `submit_failed`) and retryability — `WALLET_NOT_FOUND`-class signer errors are non-retryable, submit failures always retryable (the intent key makes resubmission safe)
- 10 unit tests over a fake partial signer and a stub RPC
