### PR TITLE
feat(helius): add the rings service orchestrating the operation lifecycle

### DIFF
--- a/apps/sdp-api/src/services/helius-rings/index.ts
+++ b/apps/sdp-api/src/services/helius-rings/index.ts
@@ -1,0 +1,19 @@
+export { RingsAdapterError } from "./adapter-error";
+export {
+  buildRingsWalletOperationInput,
+  RINGS_ENVELOPE_KINDS,
+  type RingsEnvelopeKind,
+  ringsEnvelopeKind,
+} from "./policy-envelope";
+export { submitRingsOuterTransaction } from "./rpc-adapter";
+export {
+  computeIntentKey,
+  createHeliusRingsService,
+  type HeliusRingsActor,
+  HeliusRingsService,
+  type HeliusRingsServiceDependencies,
+  type HeliusRingsTenant,
+  type PrepareOperationContext,
+  type ProvisionPrivateWalletInput,
+} from "./service";
+export { signRingsOuterTransaction } from "./signer-adapter";

--- a/apps/sdp-api/src/services/helius-rings/service.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.test.ts
@@ -1,0 +1,367 @@
+import type { PrivateOperationInput } from "@sdp/helius-rings";
+import { InMemoryRingsGateway } from "@sdp/helius-rings/testing";
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
+import type { PolicyDecision } from "@sdp/types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { createHeliusRingsWalletRepository } from "@/db/repositories";
+import { AppError } from "@/lib/errors";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { RingsAdapterError } from "./adapter-error";
+import {
+  computeIntentKey,
+  createHeliusRingsService,
+  type HeliusRingsServiceDependencies,
+} from "./service";
+
+const TEST_PROJECT_ID = "prj_hrs_service_test";
+const tenant = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+let walletId: string;
+
+function policyStub(
+  decision: PolicyDecision,
+  overrides: { requiresApproval?: boolean; approvalRequestId?: string | null } = {}
+): HeliusRingsServiceDependencies["enforcePolicy"] {
+  return async () =>
+    ({
+      operation: { id: "wop_1" },
+      evaluation: {
+        id: "pev_1",
+        decision,
+        reason: decision === "deny" ? "denied by wallet policy" : null,
+        requiresApproval: overrides.requiresApproval ?? false,
+        approvalRequestId: overrides.approvalRequestId ?? null,
+      },
+    }) as unknown as WalletOperationPolicyEnforcement;
+}
+
+function operationInput(overrides: Partial<PrivateOperationInput> = {}): PrivateOperationInput {
+  return {
+    walletId,
+    opType: "shield",
+    asset: { mint: "So11111111111111111111111111111111111111112", amountRaw: "1000000" },
+    clientNonce: "nonce-1",
+    ...overrides,
+  };
+}
+
+const actorContext = { apiKeyId: "key_1", actor: null, custodyWalletId: "cw_1" };
+
+function service(deps: HeliusRingsServiceDependencies = {}) {
+  return createHeliusRingsService(env, tenant, {
+    enforcePolicy: policyStub("allow"),
+    ...deps,
+  });
+}
+
+/** A service whose gateway succeeds and whose sign/submit adapters are stubbed. */
+function liveishService(deps: HeliusRingsServiceDependencies = {}) {
+  return service({
+    gateway: new InMemoryRingsGateway(),
+    signOuterTransaction: async () => "c2lnbmVk",
+    submitOuterTransaction: async () => "sig_outer_1",
+    ...deps,
+  });
+}
+
+describe("HeliusRingsService", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const wallet = await createHeliusRingsWalletRepository(env).createWallet({
+      ...tenant,
+      sdpWalletId: "wal_hrs_service_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+    walletId = wallet.id;
+  });
+
+  describe("devnet guard", () => {
+    it("refuses to construct outside devnet", () => {
+      expect(() =>
+        createHeliusRingsService({ ...env, SOLANA_NETWORK: "mainnet-beta" }, tenant)
+      ).toThrow(AppError);
+    });
+  });
+
+  describe("provisionPrivateWallet", () => {
+    it("provisions through the gateway and marks the wallet ready", async () => {
+      const wallet = await service({ gateway: new InMemoryRingsGateway() }).provisionPrivateWallet({
+        sdpWalletId: "wal_prov_1",
+        sdpAddress: "addr1",
+        name: "Ops",
+      });
+
+      expect(wallet.status).toBe("ready");
+      expect(wallet.shieldedAddress).toMatch(/^rings1/);
+    });
+
+    it("leaves the wallet pending when the gateway is not implemented", async () => {
+      const result = await service()
+        .provisionPrivateWallet({ sdpWalletId: "wal_prov_2", sdpAddress: "addr2", name: "Ops" })
+        .then(
+          () => null,
+          (error: unknown) => error
+        );
+
+      // The route maps this to a 503; the wizard renders the pending state.
+      expect(result).toMatchObject({ code: "gateway_unavailable" });
+      const rows = await createHeliusRingsWalletRepository(env).getWalletBySdpWalletId({
+        ...tenant,
+        sdpWalletId: "wal_prov_2",
+      });
+      expect(rows?.status).toBe("pending");
+    });
+  });
+
+  describe("prepareOperation", () => {
+    it("is idempotent: the same client nonce returns the same operation", async () => {
+      const svc = service();
+      const first = await svc.prepareOperation(operationInput(), actorContext);
+      const replay = await svc.prepareOperation(operationInput(), actorContext);
+
+      expect(replay.id).toBe(first.id);
+      expect(replay.intentKey).toBe(computeIntentKey(operationInput()));
+    });
+
+    it("ends in failed:policy_denied when the policy denies", async () => {
+      const operation = await service({ enforcePolicy: policyStub("deny") }).prepareOperation(
+        operationInput({ clientNonce: "nonce-deny" }),
+        actorContext
+      );
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "policy_denied", retryable: false });
+    });
+
+    it("pauses at approval_required and records the approval request", async () => {
+      const operation = await service({
+        enforcePolicy: policyStub("approval_required", {
+          requiresApproval: true,
+          approvalRequestId: "apr_1",
+        }),
+      }).prepareOperation(operationInput({ clientNonce: "nonce-approval" }), actorContext);
+
+      expect(operation.state).toBe("approval_required");
+      expect(operation.approvalRequestId).toBe("apr_1");
+      expect(operation.policyEvaluationId).toBe("pev_1");
+    });
+
+    it("fails honestly at the port when the gateway is not implemented", async () => {
+      const operation = await service().prepareOperation(
+        operationInput({ clientNonce: "nonce-notimpl" }),
+        actorContext
+      );
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "gateway_unavailable", retryable: true });
+    });
+
+    it("drives an allowed operation through sign and submit to indexing", async () => {
+      const operation = await liveishService().prepareOperation(
+        operationInput({ clientNonce: "nonce-live" }),
+        actorContext
+      );
+
+      expect(operation.state).toBe("indexing");
+      expect(operation.outerTxSignature).toBe("sig_outer_1");
+    });
+
+    it("takes the signer's fail edge when custody signing fails", async () => {
+      const operation = await liveishService({
+        signOuterTransaction: async () => {
+          throw new RingsAdapterError("signer_failed", "signer down", { retryable: true });
+        },
+      }).prepareOperation(operationInput({ clientNonce: "nonce-signer" }), actorContext);
+
+      expect(operation.state).toBe("failed");
+      expect(operation.failure).toMatchObject({ code: "signer_failed", retryable: true });
+    });
+  });
+
+  describe("executeOperation", () => {
+    it("advances an approved operation and is inert while approval is pending", async () => {
+      const svc = liveishService({
+        enforcePolicy: policyStub("approval_required", {
+          requiresApproval: true,
+          approvalRequestId: "apr_1",
+        }),
+      });
+      const paused = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-exec" }),
+        actorContext
+      );
+      expect(paused.state).toBe("approval_required");
+
+      const stillPaused = await svc.executeOperation(paused.id, { approvalStatus: "pending" });
+      expect(stillPaused.state).toBe("approval_required");
+
+      const advanced = await svc.executeOperation(paused.id, { approvalStatus: "approved" });
+      expect(advanced.state).toBe("indexing");
+    });
+
+    it("fails a rejected approval as non-retryable", async () => {
+      const svc = liveishService({
+        enforcePolicy: policyStub("approval_required", {
+          requiresApproval: true,
+          approvalRequestId: "apr_1",
+        }),
+      });
+      const paused = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-reject" }),
+        actorContext
+      );
+
+      const rejected = await svc.executeOperation(paused.id, { approvalStatus: "rejected" });
+      expect(rejected.state).toBe("failed");
+      expect(rejected.failure).toMatchObject({ code: "approval_rejected", retryable: false });
+    });
+
+    it("polls indexing idempotently and completes on the Photon hit", async () => {
+      let now = "2026-08-18T00:00:00.000Z";
+      const gateway = new InMemoryRingsGateway({ now: () => now, indexingDelayMs: 1000 });
+      const svc = liveishService({ gateway });
+      const operation = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-index" }),
+        actorContext
+      );
+      expect(operation.state).toBe("indexing");
+
+      gateway.recordSubmission("sig_outer_1");
+      // Photon has not indexed yet: repeated polls change nothing.
+      expect((await svc.executeOperation(operation.id)).state).toBe("indexing");
+      expect((await svc.executeOperation(operation.id)).state).toBe("indexing");
+
+      now = "2026-08-18T00:00:02.000Z";
+      const completed = await svc.executeOperation(operation.id);
+      expect(completed.state).toBe("completed");
+      expect(completed.photonIndexedAt).toBe(now);
+
+      // Executing a terminal operation is a no-op.
+      expect((await svc.executeOperation(operation.id)).state).toBe("completed");
+    });
+  });
+
+  describe("retryOperation", () => {
+    it("files a linked retry and leaves the failed original untouched", async () => {
+      const svc = service();
+      const failed = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-retry" }),
+        actorContext
+      );
+      expect(failed.state).toBe("failed");
+
+      const retry = await svc.retryOperation(failed.id, "nonce-retry-2");
+
+      expect(retry.id).not.toBe(failed.id);
+      expect(retry.intentKey).not.toBe(failed.intentKey);
+      const original = await svc.getOperation(failed.id);
+      expect(original.state).toBe("failed");
+
+      const detail = await svc.getOperationWithEvents(retry.id);
+      expect(detail.events.map((event) => event.kind)).toContain("operation.retried");
+    });
+
+    it("refuses to retry a non-retryable failure", async () => {
+      const svc = service({ enforcePolicy: policyStub("deny") });
+      const denied = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-noretry" }),
+        actorContext
+      );
+
+      await expect(svc.retryOperation(denied.id, "nonce-noretry-2")).rejects.toMatchObject({
+        code: "CONFLICT",
+      });
+    });
+
+    it("refuses to retry an operation that has not failed", async () => {
+      const svc = liveishService();
+      const inFlight = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-inflight" }),
+        actorContext
+      );
+      expect(inFlight.state).toBe("indexing");
+
+      await expect(svc.retryOperation(inFlight.id, "again")).rejects.toMatchObject({
+        code: "CONFLICT",
+      });
+    });
+  });
+
+  describe("probeHealth", () => {
+    it("records gateway red when the port is not implemented", async () => {
+      const health = await service().probeHealth();
+
+      expect(health.gateway).toBe("red");
+      // Unobserved components read red, not green.
+      expect(health.prover).toBe("red");
+    });
+
+    it("records the gateway's component statuses when reachable", async () => {
+      const health = await service({
+        gateway: new InMemoryRingsGateway({
+          health: { rpc: "green", prover: "amber", photon: "green", gateway: "green" },
+        }),
+      }).probeHealth();
+
+      expect(health).toMatchObject({ rpc: "green", prover: "amber", gateway: "green" });
+    });
+  });
+
+  describe("event feed", () => {
+    it("records the full lifecycle on the timeline", async () => {
+      const svc = liveishService();
+      const operation = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-events" }),
+        actorContext
+      );
+
+      const detail = await svc.getOperationWithEvents(operation.id);
+      const kinds = detail.events.map((event) => event.kind);
+      expect(kinds).toContain("operation.created");
+      expect(kinds).toContain("policy.evaluated");
+      expect(kinds).toContain("proof.received");
+      expect(kinds).toContain("transaction.submitted");
+    });
+  });
+});
+
+describe("computeIntentKey", () => {
+  it("is deterministic and nonce-sensitive", () => {
+    const base: PrivateOperationInput = {
+      walletId: "hrw_1",
+      opType: "shield",
+      clientNonce: "n1",
+    };
+
+    expect(computeIntentKey(base)).toBe(computeIntentKey({ ...base }));
+    expect(computeIntentKey(base)).not.toBe(computeIntentKey({ ...base, clientNonce: "n2" }));
+    expect(computeIntentKey(base)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -1,0 +1,647 @@
+import { createHash } from "node:crypto";
+import type {
+  OperationEvent,
+  OperationState,
+  PrivateOperation,
+  PrivateOperationInput,
+  PrivateWallet,
+  RuntimeHealth,
+  TransitionGuard,
+} from "@sdp/helius-rings";
+import {
+  HeliusRingsError,
+  NotImplementedRingsGateway,
+  nextState,
+  type RingsGatewayPort,
+} from "@sdp/helius-rings";
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
+import type { WalletOperationActor } from "@sdp/types";
+import {
+  createHeliusRingsEventRepository,
+  createHeliusRingsHealthRepository,
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+  type HeliusRingsEventRepository,
+  type HeliusRingsHealthRepository,
+  type HeliusRingsOperationRepository,
+  type HeliusRingsOperationRow,
+  type HeliusRingsWalletRepository,
+  mapHeliusRingsEventRow,
+  mapHeliusRingsHealthRows,
+  mapHeliusRingsWalletRow,
+} from "@/db/repositories";
+import { AppError } from "@/lib/errors";
+import { createTenantScope } from "@/lib/tenant-scope";
+import { enforceWalletOperationPolicy } from "@/services/policy/enforcement.service";
+import type { Env } from "@/types/env";
+import { RingsAdapterError } from "./adapter-error";
+import { buildRingsWalletOperationInput } from "./policy-envelope";
+import { submitRingsOuterTransaction } from "./rpc-adapter";
+import { signRingsOuterTransaction } from "./signer-adapter";
+
+/**
+ * Orchestrates every Rings action: provisioning, prepare-through-policy,
+ * execution, retry lineage. State transitions run through the persisted state
+ * machine with compare-and-swap guards, and every hop is recorded on the
+ * operation's event feed.
+ *
+ * Until Track B lands the live gateway, any path that reaches the port ends in
+ * `failed:gateway_unavailable` (retryable) — the UI reports the pending
+ * integration honestly instead of simulating it.
+ */
+
+export interface HeliusRingsTenant {
+  organizationId: string;
+  projectId: string;
+}
+
+export interface HeliusRingsActor {
+  apiKeyId: string | null;
+  actor: WalletOperationActor | null;
+}
+
+export interface HeliusRingsServiceDependencies {
+  gateway?: RingsGatewayPort;
+  wallets?: HeliusRingsWalletRepository;
+  operations?: HeliusRingsOperationRepository;
+  events?: HeliusRingsEventRepository;
+  health?: HeliusRingsHealthRepository;
+  enforcePolicy?: typeof enforceWalletOperationPolicy;
+  signOuterTransaction?: typeof signRingsOuterTransaction;
+  submitOuterTransaction?: typeof submitRingsOuterTransaction;
+  now?: () => string;
+}
+
+export interface ProvisionPrivateWalletInput {
+  sdpWalletId: string;
+  /** The custody wallet's public address, handed to the gateway. */
+  sdpAddress: string;
+  name: string;
+}
+
+export interface PrepareOperationContext extends HeliusRingsActor {
+  /** The SDP custody wallet id backing the rings wallet, for the policy envelope. */
+  custodyWalletId: string | null;
+}
+
+/** States `executeOperation` acts on; the rest return unchanged. */
+const EXECUTABLE_STATES: ReadonlySet<OperationState> = new Set(["approval_required", "indexing"]);
+
+export function createHeliusRingsService(
+  env: Env,
+  tenant: HeliusRingsTenant,
+  dependencies: HeliusRingsServiceDependencies = {}
+): HeliusRingsService {
+  return new HeliusRingsService(env, tenant, dependencies);
+}
+
+export class HeliusRingsService {
+  private readonly gateway: RingsGatewayPort;
+  private readonly wallets: HeliusRingsWalletRepository;
+  private readonly operations: HeliusRingsOperationRepository;
+  private readonly events: HeliusRingsEventRepository;
+  private readonly health: HeliusRingsHealthRepository;
+  private readonly enforcePolicy: typeof enforceWalletOperationPolicy;
+  private readonly signOuterTransaction: typeof signRingsOuterTransaction;
+  private readonly submitOuterTransaction: typeof submitRingsOuterTransaction;
+  private readonly now: () => string;
+
+  constructor(
+    private readonly env: Env,
+    private readonly tenant: HeliusRingsTenant,
+    dependencies: HeliusRingsServiceDependencies = {}
+  ) {
+    // The schema's network CHECK is the second half of this guard. Going to
+    // mainnet is a deliberate migration, not a config flip.
+    if ((env.SOLANA_NETWORK ?? "devnet") !== "devnet") {
+      throw new AppError("SERVICE_UNAVAILABLE", "Helius Rings is devnet-only");
+    }
+    this.gateway = dependencies.gateway ?? new NotImplementedRingsGateway();
+    this.wallets = dependencies.wallets ?? createHeliusRingsWalletRepository(env);
+    this.operations = dependencies.operations ?? createHeliusRingsOperationRepository(env);
+    this.events = dependencies.events ?? createHeliusRingsEventRepository(env);
+    this.health = dependencies.health ?? createHeliusRingsHealthRepository(env);
+    this.enforcePolicy = dependencies.enforcePolicy ?? enforceWalletOperationPolicy;
+    this.signOuterTransaction = dependencies.signOuterTransaction ?? signRingsOuterTransaction;
+    this.submitOuterTransaction =
+      dependencies.submitOuterTransaction ?? submitRingsOuterTransaction;
+    this.now = dependencies.now ?? (() => new Date().toISOString());
+  }
+
+  /**
+   * Creates (or returns) the rings wallet bound to one custody wallet, then
+   * asks the gateway for a shielded identity. Until Track B lands, the port
+   * throws and the wallet stays `pending` — the wizard renders that state.
+   *
+   * Key material is deliberately not persisted here: sealing it through
+   * custody-cipher into `helius_rings_key_refs` is the key-authority work
+   * (Track B4), and holding it unsealed anywhere is not an option.
+   */
+  async provisionPrivateWallet(input: ProvisionPrivateWalletInput): Promise<PrivateWallet> {
+    const wallet = await this.wallets.createWallet({
+      ...this.tenant,
+      sdpWalletId: input.sdpWalletId,
+      name: input.name,
+      materialTag: "simulated",
+    });
+    if (!wallet) {
+      throw new AppError("INTERNAL_ERROR", "rings wallet reservation returned no row");
+    }
+    if (wallet.status !== "pending") {
+      return mapHeliusRingsWalletRow(wallet);
+    }
+
+    const identity = await this.gateway.provisionIdentity({
+      walletId: wallet.id,
+      sdpAddress: input.sdpAddress,
+    });
+
+    const materialTag = identity.keyRefs.every((keyRef) => keyRef.materialTag === "live")
+      ? "live"
+      : "simulated";
+    const provisioned = await this.wallets.markProvisioned({
+      ...this.tenant,
+      id: wallet.id,
+      shieldedAddress: identity.shieldedAddress,
+      materialTag,
+      expectedStatus: "pending",
+    });
+    // A lost CAS means an operator paused the wallet mid-provision; honour it.
+    return mapHeliusRingsWalletRow(provisioned ?? (await this.requireWallet(wallet.id)));
+  }
+
+  /**
+   * Reserves the intent, then advances draft → preparing → policy. Idempotent:
+   * a replayed request returns the operation already reserved, at whatever
+   * state it has reached, without re-running policy.
+   */
+  async prepareOperation(
+    input: PrivateOperationInput,
+    context: PrepareOperationContext
+  ): Promise<PrivateOperation> {
+    const wallet = await this.requireWallet(input.walletId);
+    const intentKey = computeIntentKey(input);
+
+    const { operation, reserved } = await this.operations.reserveIntent({
+      ...this.tenant,
+      walletId: wallet.id,
+      opType: input.opType,
+      intentKey,
+      assetMint: input.asset?.mint ?? null,
+      amountRaw: input.asset?.amountRaw ?? null,
+      fromAddr: input.from ?? null,
+      toAddr: input.to ?? null,
+      zoneId: input.zoneId ?? null,
+      transferMode: input.transferMode ?? null,
+      timelock: input.timelock
+        ? { unlockAt: input.timelock.unlockAt, beneficiaryAddr: input.timelock.beneficiary }
+        : null,
+    });
+    if (!reserved) {
+      return this.toPrivateOperation(operation);
+    }
+
+    await this.events.append({ operationId: operation.id, kind: "operation.created" });
+    const preparing = await this.transition(operation.id, "draft", undefined);
+    if (!preparing) return this.toPrivateOperation(await this.requireOperation(operation.id));
+
+    let enforcement: WalletOperationPolicyEnforcement;
+    try {
+      enforcement = await this.enforcePolicy(
+        this.env,
+        createTenantScope({
+          organizationId: this.tenant.organizationId,
+          projectId: this.tenant.projectId,
+        }),
+        buildRingsWalletOperationInput({
+          organizationId: this.tenant.organizationId,
+          projectId: this.tenant.projectId,
+          custodyWalletId: context.custodyWalletId,
+          sdpWalletId: wallet.sdp_wallet_id,
+          apiKeyId: context.apiKeyId,
+          actor: context.actor,
+          operation: input,
+          operationId: operation.id,
+          intentKey,
+        })
+      );
+    } catch (error) {
+      const failed = await this.fail(operation.id, "preparing", {
+        code: "invalid_input",
+        message: error instanceof Error ? error.message : "policy evaluation failed",
+        retryable: true,
+      });
+      return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+    }
+
+    const { evaluation } = enforcement;
+    await this.events.append({
+      operationId: operation.id,
+      kind: "policy.evaluated",
+      payload: { decision: evaluation.decision, policyEvaluationId: evaluation.id },
+    });
+
+    if (evaluation.decision === "deny") {
+      const failed = await this.fail(operation.id, "preparing", {
+        code: "policy_denied",
+        message: evaluation.reason ?? "denied by wallet policy",
+        retryable: false,
+      });
+      return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+    }
+
+    // The machine has no preparing → proving shortcut: an allowed operation
+    // passes through approval_required with the `approved` guard immediately
+    // satisfied, so the row's history reads the same either way.
+    const paused = await this.transition(operation.id, "preparing", "policy_ok", {
+      policyEvaluationId: evaluation.id,
+      approvalRequestId: evaluation.approvalRequestId,
+    });
+    if (!paused) return this.toPrivateOperation(await this.requireOperation(operation.id));
+
+    if (evaluation.requiresApproval) {
+      await this.events.append({
+        operationId: operation.id,
+        kind: "approval.requested",
+        payload: { approvalRequestId: evaluation.approvalRequestId },
+      });
+      return this.toPrivateOperation(paused);
+    }
+
+    const proving = await this.transition(operation.id, "approval_required", "approved");
+    if (!proving) return this.toPrivateOperation(await this.requireOperation(operation.id));
+    return this.toPrivateOperation(await this.runPipeline(proving));
+  }
+
+  /**
+   * Advances an operation that is waiting on an external condition. Idempotent
+   * per state: an approval still pending or a signature not yet indexed leaves
+   * the row untouched.
+   */
+  async executeOperation(
+    operationId: string,
+    options: { approvalStatus?: "approved" | "rejected" | "pending" } = {}
+  ): Promise<PrivateOperation> {
+    const operation = await this.requireOperation(operationId);
+    if (!EXECUTABLE_STATES.has(operation.state)) {
+      return this.toPrivateOperation(operation);
+    }
+
+    if (operation.state === "approval_required") {
+      const status = options.approvalStatus ?? "pending";
+      if (status === "rejected") {
+        const failed = await this.fail(operation.id, "approval_required", {
+          code: "approval_rejected",
+          message: "approval request was rejected",
+          retryable: false,
+        });
+        return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+      }
+      if (status !== "approved") {
+        return this.toPrivateOperation(operation);
+      }
+      await this.events.append({ operationId: operation.id, kind: "approval.granted" });
+      const proving = await this.transition(operation.id, "approval_required", "approved");
+      if (!proving) return this.toPrivateOperation(await this.requireOperation(operation.id));
+      return this.toPrivateOperation(await this.runPipeline(proving));
+    }
+
+    // indexing: poll Photon through the port.
+    if (!operation.outer_tx_signature) {
+      const failed = await this.fail(operation.id, "indexing", {
+        code: "invalid_input",
+        message: "indexing without a submitted signature",
+        retryable: false,
+      });
+      return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+    }
+    try {
+      const indexed = await this.gateway.verifyIndexed(operation.outer_tx_signature);
+      if (!indexed) return this.toPrivateOperation(operation);
+      const completed = await this.transition(operation.id, "indexing", "indexed", {
+        photonIndexedAt: indexed.indexedAt,
+      });
+      if (completed) {
+        await this.events.append({
+          operationId: operation.id,
+          kind: "operation.completed",
+          payload: { photonRef: indexed.photonRef },
+        });
+      }
+      return this.toPrivateOperation(completed ?? (await this.requireOperation(operation.id)));
+    } catch (error) {
+      return this.toPrivateOperation(await this.failFromPortError(operation, error));
+    }
+  }
+
+  /**
+   * Files a fresh operation linked to a failed, retryable one. The retry gets
+   * its own intent key (new client nonce), so the original row stays exactly
+   * as it failed — the lineage is audit evidence.
+   */
+  async retryOperation(operationId: string, clientNonce: string): Promise<PrivateOperation> {
+    const failed = await this.requireOperation(operationId);
+    if (failed.state !== "failed") {
+      throw new AppError("CONFLICT", "only a failed operation can be retried");
+    }
+    if (!failed.retryable) {
+      throw new AppError("CONFLICT", "operation failure is not retryable");
+    }
+
+    const timelock = failed.timelock_unlock_at
+      ? await this.operations.getTimelock({ operationId: failed.id })
+      : null;
+
+    const input: PrivateOperationInput = {
+      walletId: failed.wallet_id,
+      opType: failed.op_type,
+      asset:
+        failed.asset_mint && failed.amount_raw
+          ? { mint: failed.asset_mint, amountRaw: failed.amount_raw }
+          : undefined,
+      from: failed.from_addr ?? undefined,
+      to: failed.to_addr ?? undefined,
+      zoneId: failed.zone_id ?? undefined,
+      transferMode: failed.transfer_mode ?? undefined,
+      timelock: timelock
+        ? { unlockAt: timelock.unlock_at, beneficiary: timelock.beneficiary_addr }
+        : undefined,
+      clientNonce,
+    };
+
+    const intentKey = computeIntentKey(input);
+    const { operation, reserved } = await this.operations.reserveIntent({
+      ...this.tenant,
+      walletId: failed.wallet_id,
+      opType: failed.op_type,
+      intentKey,
+      assetMint: failed.asset_mint,
+      amountRaw: failed.amount_raw,
+      fromAddr: failed.from_addr,
+      toAddr: failed.to_addr,
+      zoneId: failed.zone_id,
+      transferMode: failed.transfer_mode,
+      retryOfOperationId: failed.id,
+      timelock: timelock
+        ? { unlockAt: timelock.unlock_at, beneficiaryAddr: timelock.beneficiary_addr }
+        : null,
+    });
+    if (reserved) {
+      await this.events.append({
+        operationId: operation.id,
+        kind: "operation.retried",
+        payload: { retryOfOperationId: failed.id },
+      });
+    }
+    return this.toPrivateOperation(operation);
+  }
+
+  async getOperation(operationId: string): Promise<PrivateOperation> {
+    return this.toPrivateOperation(await this.requireOperation(operationId));
+  }
+
+  /**
+   * Probes the gateway and records the observation per component. A gateway
+   * that cannot be reached records itself red — never having observed an
+   * upstream is not evidence that it is healthy.
+   */
+  async probeHealth(): Promise<RuntimeHealth> {
+    try {
+      const health = await this.gateway.probeHealth();
+      for (const component of ["rpc", "prover", "photon", "gateway"] as const) {
+        await this.health.recordHealth({
+          projectId: this.tenant.projectId,
+          component,
+          status: health[component],
+        });
+      }
+    } catch (error) {
+      await this.health.recordHealth({
+        projectId: this.tenant.projectId,
+        component: "gateway",
+        status: "red",
+        detail: {
+          reason: error instanceof HeliusRingsError ? error.message : "gateway probe failed",
+        },
+      });
+    }
+    return mapHeliusRingsHealthRows(
+      await this.health.listHealthByProject({ projectId: this.tenant.projectId })
+    );
+  }
+
+  /**
+   * Drives an operation from `proving` as far as the port allows:
+   * build → proof → sign → submit → indexing. The first port failure takes the
+   * state's fail edge; adapter failures carry their own codes.
+   */
+  private async runPipeline(operation: HeliusRingsOperationRow): Promise<HeliusRingsOperationRow> {
+    let current = operation;
+
+    // proving: build the outer tx and request the proof.
+    try {
+      const built = await this.gateway.buildOperation({
+        // The port receives the domain view; key refs arrive with Track B4.
+        operation: this.toPrivateOperation(current),
+        keyRefs: [],
+      });
+      const proof = await this.gateway.requestProof({
+        operationId: current.id,
+        ringsMetadata: built.ringsMetadata,
+      });
+      const ready = await this.transition(current.id, "proving", "proof_received", {
+        proofSource: proof.source,
+        proofRef: proof.ref.reveal("adapter"),
+      });
+      if (!ready) return this.requireOperation(current.id);
+      current = ready;
+
+      await this.events.append({
+        operationId: current.id,
+        kind: "proof.received",
+        payload: { source: proof.source },
+      });
+
+      // ready_to_sign → submitted: sign with custody, then broadcast.
+      const signed = await this.signOuterTransaction({
+        env: this.env,
+        organizationId: this.tenant.organizationId,
+        projectId: this.tenant.projectId,
+        unsignedTxBase64: built.outerUnsignedTxBase64,
+      });
+      const signature = await this.submitOuterTransaction({
+        env: this.env,
+        signedTxBase64: signed,
+      });
+
+      const submitted = await this.transition(current.id, "ready_to_sign", "signed", {
+        outerTxSignature: signature,
+      });
+      if (!submitted) return this.requireOperation(current.id);
+      current = submitted;
+      await this.events.append({
+        operationId: current.id,
+        kind: "transaction.submitted",
+        payload: { signature },
+      });
+
+      const indexing = await this.transition(current.id, "submitted", "submitted");
+      return indexing ?? (await this.requireOperation(current.id));
+    } catch (error) {
+      return this.failFromPortError(current, error);
+    }
+  }
+
+  /** Maps a port or adapter failure onto the operation's fail edge. */
+  private async failFromPortError(
+    operation: HeliusRingsOperationRow,
+    error: unknown
+  ): Promise<HeliusRingsOperationRow> {
+    const failure =
+      error instanceof RingsAdapterError
+        ? { code: error.failureCode, message: error.message, retryable: error.retryable }
+        : error instanceof HeliusRingsError && error.code === "gateway_unavailable"
+          ? { code: "gateway_unavailable" as const, message: error.message, retryable: true }
+          : {
+              code: "gateway_unavailable" as const,
+              message: error instanceof Error ? error.message : "rings gateway failed",
+              retryable: true,
+            };
+
+    const failed = await this.fail(operation.id, operation.state, failure);
+    return failed ?? (await this.requireOperation(operation.id));
+  }
+
+  private async transition(
+    operationId: string,
+    expectedState: OperationState,
+    guard: TransitionGuard | undefined,
+    patch?: Parameters<HeliusRingsOperationRepository["transitionState"]>[0]["patch"]
+  ): Promise<HeliusRingsOperationRow | null> {
+    const to = nextState(expectedState, guard);
+    if (!to) return null;
+    const row = await this.operations.transitionState({
+      ...this.tenant,
+      id: operationId,
+      expectedState,
+      nextState: to,
+      patch,
+    });
+    if (row) {
+      await this.events.append({
+        operationId,
+        kind: "state.transitioned",
+        payload: { from: expectedState, to },
+      });
+    }
+    return row;
+  }
+
+  private async fail(
+    operationId: string,
+    expectedState: OperationState,
+    failure: { code: HeliusRingsOperationRow["failure_code"]; message: string; retryable: boolean }
+  ): Promise<HeliusRingsOperationRow | null> {
+    if (!failure.code) return null;
+    const row = await this.operations.failOperation({
+      ...this.tenant,
+      id: operationId,
+      expectedState,
+      code: failure.code,
+      message: failure.message,
+      retryable: failure.retryable,
+    });
+    if (row) {
+      await this.events.append({
+        operationId,
+        kind: "operation.failed",
+        payload: { code: failure.code, retryable: failure.retryable },
+      });
+    }
+    return row;
+  }
+
+  private async requireWallet(walletId: string) {
+    const wallet = await this.wallets.getWalletById({ ...this.tenant, id: walletId });
+    if (!wallet) throw new AppError("NOT_FOUND", "rings wallet not found");
+    return wallet;
+  }
+
+  private async requireOperation(operationId: string): Promise<HeliusRingsOperationRow> {
+    const operation = await this.operations.getOperationById({
+      ...this.tenant,
+      id: operationId,
+    });
+    if (!operation) throw new AppError("NOT_FOUND", "rings operation not found");
+    return operation;
+  }
+
+  private toPrivateOperation(
+    row: HeliusRingsOperationRow,
+    events: OperationEvent[] = []
+  ): PrivateOperation {
+    return {
+      id: row.id,
+      walletId: row.wallet_id,
+      opType: row.op_type,
+      state: row.state,
+      approvalRequestId: row.approval_request_id,
+      policyEvaluationId: row.policy_evaluation_id,
+      proof: null,
+      outerTxSignature: row.outer_tx_signature,
+      photonIndexedAt: row.photon_indexed_at,
+      failure:
+        row.failure_code && row.failure_message !== null && row.retryable !== null
+          ? { code: row.failure_code, message: row.failure_message, retryable: row.retryable }
+          : null,
+      input: {
+        walletId: row.wallet_id,
+        opType: row.op_type,
+        asset:
+          row.asset_mint && row.amount_raw
+            ? { mint: row.asset_mint, amountRaw: row.amount_raw }
+            : undefined,
+        from: row.from_addr ?? undefined,
+        to: row.to_addr ?? undefined,
+        zoneId: row.zone_id ?? undefined,
+        transferMode: row.transfer_mode ?? undefined,
+        timelock: undefined,
+        // Consumed by the intent key at reservation; not retained.
+        clientNonce: "",
+      },
+      intentKey: row.intent_key,
+      events,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  /** The operation with its event feed joined in, for the detail panel. */
+  async getOperationWithEvents(operationId: string): Promise<PrivateOperation> {
+    const row = await this.requireOperation(operationId);
+    const events = await this.events.listByOperation({ operationId: row.id });
+    return this.toPrivateOperation(row, events.map(mapHeliusRingsEventRow));
+  }
+}
+
+/**
+ * The idempotency contract: one deterministic key per (wallet, op, canonical
+ * input, client nonce). Field order is pinned here — object spread order is
+ * not part of the contract.
+ */
+export function computeIntentKey(input: PrivateOperationInput): string {
+  const canonical = JSON.stringify({
+    walletId: input.walletId,
+    opType: input.opType,
+    asset: input.asset ? { mint: input.asset.mint, amountRaw: input.asset.amountRaw } : null,
+    from: input.from ?? null,
+    to: input.to ?? null,
+    zoneId: input.zoneId ?? null,
+    transferMode: input.transferMode ?? null,
+    timelock: input.timelock
+      ? { unlockAt: input.timelock.unlockAt, beneficiary: input.timelock.beneficiary }
+      : null,
+    clientNonce: input.clientNonce,
+  });
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}


### PR DESCRIPTION
- `HeliusRingsService`: the path every rings action travels — provisioning, prepare-through-policy, execution, retry lineage
- Devnet guard at construction (`SOLANA_NETWORK !== "devnet"` refuses); the schema's network CHECK is the other half
- `prepareOperation`: idempotent intent reservation (sha256 intent key) → draft→preparing → policy envelope → deny ends `failed:policy_denied` (non-retryable), approval pauses at `approval_required`, allow runs the pipeline
- Pipeline: gateway build+proof → custody sign → RPC submit → `indexing`, each hop CAS-guarded and recorded on the event feed; adapter failures take their own fail edges
- `executeOperation`: advances an approved operation; polls `verifyIndexed` idempotently until the Photon hit completes it
- `retryOperation`: failed+retryable only; new intent key, `retry_of_operation_id` lineage, original row untouched
- With the production `NotImplementedRingsGateway`, every port call ends in `failed:gateway_unavailable` (retryable) — nothing is simulated
- 19 DB-backed tests covering both gateway variants; key material is deliberately not persisted (that is the key-authority work, Track B4)
