### PR TITLE
feat(helius): expose rings over the API behind the feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ ASSET_PROFILES_ENABLED=true
 # reconcilers, and the dashboard workspace. Requires
 # SPC_CREDENTIAL_ENCRYPTION_KEY below when enabled.
 PRIVATE_CHANNELS_ENABLED=false
+# Helius Rings (opt-in, devnet-only). Gates the shielded-wallet API routes
+# and the dashboard workspace.
+HELIUS_RINGS_ENABLED=false
 SDP_FLAG_ASSET_PROFILES=true
 PRIVY_BYOK_ENABLED=false
 SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED=false

--- a/apps/sdp-api/src/app.ts
+++ b/apps/sdp-api/src/app.ts
@@ -35,6 +35,7 @@ import wallets from "@/routes/custody";
 import docs from "@/routes/docs";
 import earn from "@/routes/earn";
 import health from "@/routes/health";
+import heliusRings from "@/routes/helius-rings";
 import internalCustody from "@/routes/internal-custody";
 import issuance from "@/routes/issuance";
 import llms from "@/routes/llms";
@@ -362,6 +363,7 @@ export function createApp(deps: AppDeps): Hono<{ Bindings: Env }> {
   v1.route("/places", places);
   v1.route("/policies", policies);
   v1.route("/private-channels", privateChannels);
+  v1.route("/helius-rings", heliusRings);
   v1.route("/compliance", compliance);
 
   const registeredPluginNames = new Set<string>();

--- a/apps/sdp-api/src/lib/feature-flags.ts
+++ b/apps/sdp-api/src/lib/feature-flags.ts
@@ -31,6 +31,10 @@ export function isPrivateChannelsEnabled(env: Pick<Env, "PRIVATE_CHANNELS_ENABLE
   return isTruthyFlag(env.PRIVATE_CHANNELS_ENABLED);
 }
 
+export function isHeliusRingsEnabled(env: Pick<Env, "HELIUS_RINGS_ENABLED">): boolean {
+  return isTruthyFlag(env.HELIUS_RINGS_ENABLED);
+}
+
 export function isPrivyByokEnabled(env: Pick<Env, "PRIVY_BYOK_ENABLED">): boolean {
   return isTruthyFlag(env.PRIVY_BYOK_ENABLED);
 }

--- a/apps/sdp-api/src/routes/helius-rings.test.ts
+++ b/apps/sdp-api/src/routes/helius-rings.test.ts
@@ -1,0 +1,283 @@
+import { hashString } from "@sdp/payments/hash";
+import type { CachedApiKey } from "@sdp/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { createHeliusRingsWalletRepository } from "@/db/repositories";
+import app from "@/index";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { clearKVStores, seedCachedApiKey } from "@/test/mocks/kv";
+
+const TEST_ORG = { id: "org_hr_route", name: "Rings Route Org", slug: "rings-route-org" };
+const TEST_PROJECT = { id: "prj_hr_route", slug: "rings-route-project" };
+const TEST_USER = { id: "usr_hr_route", email: "rings-route@example.com" };
+const TEST_API_KEY = { id: "key_hr_route", raw: "sk_test_helius_rings", prefix: "sk_test_hr" };
+
+const TEST_CACHED_API_KEY: CachedApiKey = {
+  id: TEST_API_KEY.id,
+  organizationId: TEST_ORG.id,
+  projectId: TEST_PROJECT.id,
+  role: "api_admin",
+  permissions: ["*"],
+  environment: "sandbox",
+  rateLimitTier: "standard",
+  allowedIps: null,
+  signingWalletId: null,
+  status: "active",
+  expiresAt: null,
+};
+
+let originalFlag: string | undefined;
+let ringsWalletId: string;
+
+async function seedAuth(): Promise<void> {
+  const keyHash = await hashString(TEST_API_KEY.raw, env.API_KEY_PEPPER);
+  await seedCachedApiKey(env, keyHash, TEST_CACHED_API_KEY);
+  const db = getDb(env);
+  await db.batch([
+    db
+      .prepare("INSERT INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, ?, ?)")
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug, "enterprise", "active"),
+    db
+      .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
+      .bind(TEST_USER.id, TEST_USER.email, 1, "active"),
+    db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_PROJECT.id,
+        TEST_ORG.id,
+        "Rings Route Project",
+        TEST_PROJECT.slug,
+        "sandbox",
+        "active",
+        TEST_USER.id
+      ),
+    db
+      .prepare(
+        `INSERT INTO api_keys
+           (id, organization_id, project_id, created_by, name, key_prefix, key_hash, role, permissions, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        TEST_API_KEY.id,
+        TEST_ORG.id,
+        TEST_PROJECT.id,
+        TEST_USER.id,
+        "Rings Route Key",
+        TEST_API_KEY.prefix,
+        keyHash,
+        "api_admin",
+        JSON.stringify(["*"]),
+        "active"
+      ),
+  ]);
+
+  // Policy enforcement requires the operation's wallet to be an active
+  // custody wallet owned by the tenant.
+  await db.batch([
+    db
+      .prepare(
+        `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted, status)
+         VALUES ('cfg_hr_route', ?, ?, 'privy', 'test-encrypted', 'active')`
+      )
+      .bind(TEST_ORG.id, TEST_PROJECT.id),
+    db
+      .prepare(
+        `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, status)
+         VALUES ('cw_hr_route', 'cfg_hr_route', 'wal_hr_route', 'HrRouteTestPublicKey111111111111111111111111', 'active')`
+      )
+      .bind(),
+  ]);
+
+  const wallet = await createHeliusRingsWalletRepository(env).createWallet({
+    organizationId: TEST_ORG.id,
+    projectId: TEST_PROJECT.id,
+    sdpWalletId: "wal_hr_route",
+    name: "Treasury",
+    materialTag: "simulated",
+  });
+  if (!wallet) throw new Error("rings wallet fixture was not created");
+  ringsWalletId = wallet.id;
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${TEST_API_KEY.raw}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function post(path: string, body: unknown) {
+  return app.request(
+    path,
+    { method: "POST", headers: authHeaders(), body: JSON.stringify(body) },
+    env
+  );
+}
+
+describe("Helius Rings routes", () => {
+  beforeEach(async () => {
+    originalFlag = env.HELIUS_RINGS_ENABLED;
+    env.HELIUS_RINGS_ENABLED = "true";
+    await seedTestDatabase(env);
+    await seedAuth();
+  });
+
+  afterEach(async () => {
+    env.HELIUS_RINGS_ENABLED = originalFlag;
+    await clearKVStores(env);
+  });
+
+  it("returns 403 when the feature flag is off", async () => {
+    env.HELIUS_RINGS_ENABLED = undefined;
+    const res = await app.request("/v1/helius-rings/wallets", { headers: authHeaders() }, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("GET /health reports the unimplemented gateway red", async () => {
+    const res = await app.request("/v1/helius-rings/health", { headers: authHeaders() }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { health: Record<string, string> } };
+    expect(body.data.health.gateway).toBe("red");
+  });
+
+  it("GET /wallets lists the project's rings wallets", async () => {
+    const res = await app.request("/v1/helius-rings/wallets", { headers: authHeaders() }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { wallets: Array<{ id: string; status: string }> } };
+    expect(body.data.wallets).toHaveLength(1);
+    expect(body.data.wallets[0]).toMatchObject({ id: ringsWalletId, status: "pending" });
+  });
+
+  it("POST /wallets 404s for an unknown custody wallet", async () => {
+    const res = await post("/v1/helius-rings/wallets", { walletId: "wal_missing", name: "Ops" });
+    expect(res.status).toBe(404);
+  });
+
+  it("zone create and list round-trips, idempotently", async () => {
+    const created = await post(`/v1/helius-rings/wallets/${ringsWalletId}/zones`, {
+      name: "Payroll",
+      kind: "treasury",
+    });
+    expect(created.status).toBe(201);
+    const replay = await post(`/v1/helius-rings/wallets/${ringsWalletId}/zones`, {
+      name: "Payroll",
+      kind: "treasury",
+    });
+    expect(replay.status).toBe(201);
+
+    const listed = await app.request(
+      `/v1/helius-rings/wallets/${ringsWalletId}/zones`,
+      { headers: authHeaders() },
+      env
+    );
+    const body = (await listed.json()) as { data: { zones: Array<{ name: string }> } };
+    expect(body.data.zones).toHaveLength(1);
+    expect(body.data.zones[0]?.name).toBe("Payroll");
+  });
+
+  it("prepares an operation through real policy and fails honestly at the port", async () => {
+    const res = await post("/v1/helius-rings/operations", {
+      walletId: ringsWalletId,
+      opType: "shield",
+      asset: { mint: "So11111111111111111111111111111111111111112", amountRaw: "1000000" },
+      clientNonce: "route-nonce-1",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      data: {
+        operation: {
+          id: string;
+          state: string;
+          failure: { code: string; message: string } | null;
+        };
+      };
+    };
+
+    // Default policy is implicit allow, so the operation advances until the
+    // port call — which the NotImplemented gateway refuses.
+    expect(body.data.operation.state).toBe("failed");
+    expect(body.data.operation.failure, body.data.operation.failure?.message).toMatchObject({
+      code: "gateway_unavailable",
+    });
+  });
+
+  it("replays a prepare idempotently and serves detail with the timeline", async () => {
+    const input = {
+      walletId: ringsWalletId,
+      opType: "shield",
+      clientNonce: "route-nonce-2",
+    };
+    const first = (await (await post("/v1/helius-rings/operations", input)).json()) as {
+      data: { operation: { id: string } };
+    };
+    const replay = (await (await post("/v1/helius-rings/operations", input)).json()) as {
+      data: { operation: { id: string } };
+    };
+    expect(replay.data.operation.id).toBe(first.data.operation.id);
+
+    const detail = await app.request(
+      `/v1/helius-rings/operations/${first.data.operation.id}`,
+      { headers: authHeaders() },
+      env
+    );
+    expect(detail.status).toBe(200);
+    const detailBody = (await detail.json()) as {
+      data: { operation: { events: Array<{ kind: string }> } };
+    };
+    const kinds = detailBody.data.operation.events.map((event) => event.kind);
+    expect(kinds).toContain("operation.created");
+    expect(kinds).toContain("operation.failed");
+  });
+
+  it("retries a failed operation with lineage and lists the activity feed", async () => {
+    const failed = (await (
+      await post("/v1/helius-rings/operations", {
+        walletId: ringsWalletId,
+        opType: "shield",
+        clientNonce: "route-nonce-3",
+      })
+    ).json()) as { data: { operation: { id: string } } };
+
+    const retried = await post(`/v1/helius-rings/operations/${failed.data.operation.id}/retry`, {
+      clientNonce: "route-nonce-3-retry",
+    });
+    expect(retried.status).toBe(201);
+    const retryBody = (await retried.json()) as { data: { operation: { id: string } } };
+    expect(retryBody.data.operation.id).not.toBe(failed.data.operation.id);
+
+    const list = await app.request("/v1/helius-rings/operations", { headers: authHeaders() }, env);
+    const listBody = (await list.json()) as { data: { operations: Array<{ id: string }> } };
+    expect(listBody.data.operations.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("execute is a no-op on a terminal operation", async () => {
+    const failed = (await (
+      await post("/v1/helius-rings/operations", {
+        walletId: ringsWalletId,
+        opType: "shield",
+        clientNonce: "route-nonce-4",
+      })
+    ).json()) as { data: { operation: { id: string; state: string } } };
+
+    const executed = await post(
+      `/v1/helius-rings/operations/${failed.data.operation.id}/execute`,
+      {}
+    );
+    expect(executed.status).toBe(200);
+    const body = (await executed.json()) as { data: { operation: { state: string } } };
+    expect(body.data.operation.state).toBe("failed");
+  });
+
+  it("rejects an invalid operation body", async () => {
+    const res = await post("/v1/helius-rings/operations", {
+      walletId: ringsWalletId,
+      opType: "not-a-real-op",
+      clientNonce: "route-nonce-5",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/sdp-api/src/routes/helius-rings/context.ts
+++ b/apps/sdp-api/src/routes/helius-rings/context.ts
@@ -1,0 +1,61 @@
+import { HeliusRingsError } from "@sdp/helius-rings";
+import type { Context } from "hono";
+import {
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+  createHeliusRingsZoneRepository,
+} from "@/db/repositories";
+import { AppError, type ErrorCode } from "@/lib/errors";
+import { createHeliusRingsService } from "@/services/helius-rings";
+import type { Env } from "@/types/env";
+
+/** Hono request context bound to the app `Env`. */
+export type AppContext = Context<{ Bindings: Env }>;
+
+export function getHeliusRingsService(
+  c: AppContext,
+  tenant: { organizationId: string; projectId: string }
+) {
+  return createHeliusRingsService(c.env, tenant);
+}
+
+export function getHeliusRingsWalletRepository(c: AppContext) {
+  return createHeliusRingsWalletRepository(c.env);
+}
+
+export function getHeliusRingsOperationRepository(c: AppContext) {
+  return createHeliusRingsOperationRepository(c.env);
+}
+
+export function getHeliusRingsZoneRepository(c: AppContext) {
+  return createHeliusRingsZoneRepository(c.env);
+}
+
+const RINGS_ERROR_CODES: Record<HeliusRingsError["code"], ErrorCode> = {
+  invalid_input: "BAD_REQUEST",
+  not_found: "NOT_FOUND",
+  conflict: "CONFLICT",
+  // 503 with the seam-marker message: the wizard renders "external
+  // integration pending" from exactly this response.
+  gateway_unavailable: "SERVICE_UNAVAILABLE",
+  config_error: "SERVICE_UNAVAILABLE",
+};
+
+/** Path param, typed as present — the router only matches when it is. */
+export function requireParam(c: AppContext, name: string): string {
+  const value = c.req.param(name);
+  if (!value) throw new AppError("BAD_REQUEST", `missing ${name}`);
+  return value;
+}
+
+/** Runs a handler body, translating domain errors to API errors. */
+export async function withRingsErrors<T>(work: () => Promise<T>): Promise<T> {
+  try {
+    return await work();
+  } catch (error) {
+    if (error instanceof HeliusRingsError) {
+      throw new AppError(RINGS_ERROR_CODES[error.code], error.message);
+    }
+    throw error;
+  }
+}

--- a/apps/sdp-api/src/routes/helius-rings/handlers.ts
+++ b/apps/sdp-api/src/routes/helius-rings/handlers.ts
@@ -1,0 +1,197 @@
+import {
+  mapHeliusRingsOperationSummaryRow,
+  mapHeliusRingsWalletRow,
+  mapHeliusRingsZoneRow,
+} from "@/db/repositories";
+import { getAuth, requireProjectId } from "@/lib/auth";
+import { badRequest, notFound } from "@/lib/errors";
+import { success } from "@/lib/response";
+import { resolveScope, resolveWallet } from "@/routes/payments/wallets";
+import { walletOperationActorFromAuth } from "@/services/policy/enforcement.service";
+import {
+  type AppContext,
+  getHeliusRingsOperationRepository,
+  getHeliusRingsService,
+  getHeliusRingsWalletRepository,
+  getHeliusRingsZoneRepository,
+  requireParam,
+  withRingsErrors,
+} from "./context";
+import {
+  createRingsWalletSchema,
+  createRingsZoneSchema,
+  executeRingsOperationSchema,
+  listLimitSchema,
+  prepareRingsOperationSchema,
+  retryRingsOperationSchema,
+} from "./schemas";
+
+function tenantOf(c: AppContext) {
+  const auth = getAuth(c);
+  return {
+    auth,
+    tenant: { organizationId: auth.organizationId, projectId: requireProjectId(c) },
+  };
+}
+
+// --- health -----------------------------------------------------------------
+
+/** GET /health — probe the gateway and return the per-component status board. */
+export async function getRingsHealth(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  return success(c, { health: await service.probeHealth() });
+}
+
+// --- wallets ----------------------------------------------------------------
+
+/**
+ * POST /wallets — bind a rings wallet to an SDP custody wallet and provision
+ * its shielded identity. Until the live gateway lands this responds 503 with a
+ * seam-marker message and the wallet stays `pending` — the wizard renders that.
+ */
+export async function createRingsWallet(c: AppContext) {
+  const parsed = createRingsWalletSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const scope = await resolveScope(c);
+  const custodyWallet = resolveWallet(scope.wallets, parsed.data.walletId);
+
+  const service = getHeliusRingsService(c, tenant);
+  const wallet = await withRingsErrors(() =>
+    service.provisionPrivateWallet({
+      sdpWalletId: custodyWallet.walletId,
+      sdpAddress: custodyWallet.publicKey,
+      name: parsed.data.name,
+    })
+  );
+  return success(c, { wallet }, 201);
+}
+
+/** GET /wallets — the project's rings wallets, newest first. */
+export async function listRingsWallets(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const limit = listLimitSchema.parse(c.req.query("limit"));
+  const rows = await getHeliusRingsWalletRepository(c).listWallets({ ...tenant, limit });
+  return success(c, { wallets: rows.map(mapHeliusRingsWalletRow) });
+}
+
+/** GET /wallets/:walletId */
+export async function getRingsWallet(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const row = await getHeliusRingsWalletRepository(c).getWalletById({
+    ...tenant,
+    id: requireParam(c, "walletId"),
+  });
+  if (!row) throw notFound("rings wallet");
+  return success(c, { wallet: mapHeliusRingsWalletRow(row) });
+}
+
+// --- zones ------------------------------------------------------------------
+
+/** GET /wallets/:walletId/zones — SDP-owned metadata; fully functional today. */
+export async function listRingsZones(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const walletId = requireParam(c, "walletId");
+  const wallet = await getHeliusRingsWalletRepository(c).getWalletById({ ...tenant, id: walletId });
+  if (!wallet) throw notFound("rings wallet");
+  const zones = await getHeliusRingsZoneRepository(c).listZonesByWallet({ walletId });
+  return success(c, { zones: zones.map(mapHeliusRingsZoneRow) });
+}
+
+/** POST /wallets/:walletId/zones — idempotent per (wallet, name). */
+export async function createRingsZone(c: AppContext) {
+  const parsed = createRingsZoneSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const walletId = requireParam(c, "walletId");
+  const wallet = await getHeliusRingsWalletRepository(c).getWalletById({ ...tenant, id: walletId });
+  if (!wallet) throw notFound("rings wallet");
+
+  const zone = await getHeliusRingsZoneRepository(c).createZone({
+    walletId,
+    name: parsed.data.name,
+    kind: parsed.data.kind,
+  });
+  if (!zone) throw badRequest("zone could not be created");
+  return success(c, { zone: mapHeliusRingsZoneRow(zone) }, 201);
+}
+
+// --- operations ---------------------------------------------------------------
+
+/** POST /operations — reserve the intent and advance through policy. */
+export async function prepareRingsOperation(c: AppContext) {
+  const parsed = prepareRingsOperationSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { auth, tenant } = tenantOf(c);
+  const ringsWallet = await getHeliusRingsWalletRepository(c).getWalletById({
+    ...tenant,
+    id: parsed.data.walletId,
+  });
+  if (!ringsWallet) throw notFound("rings wallet");
+
+  // The policy envelope wants the custody wallet backing the rings wallet;
+  // absence is tolerated (the envelope's wallet id still scopes the policy).
+  const scope = await resolveScope(c);
+  const custodyWallet = scope.wallets.find((entry) => entry.walletId === ringsWallet.sdp_wallet_id);
+
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.prepareOperation(parsed.data, {
+      apiKeyId: auth.apiKeyId,
+      actor: walletOperationActorFromAuth(auth),
+      custodyWalletId: custodyWallet?.id ?? null,
+    })
+  );
+  return success(c, { operation }, 201);
+}
+
+/** GET /operations — the project's activity feed, newest first. */
+export async function listRingsOperations(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const limit = listLimitSchema.parse(c.req.query("limit"));
+  const rows = await getHeliusRingsOperationRepository(c).listOperationsByProject({
+    ...tenant,
+    limit,
+  });
+  return success(c, { operations: rows.map(mapHeliusRingsOperationSummaryRow) });
+}
+
+/** GET /operations/:operationId — full detail with the event timeline. */
+export async function getRingsOperation(c: AppContext) {
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.getOperationWithEvents(requireParam(c, "operationId"))
+  );
+  return success(c, { operation });
+}
+
+/** POST /operations/:operationId/execute — advance a waiting operation. */
+export async function executeRingsOperation(c: AppContext) {
+  const parsed = executeRingsOperationSchema.safeParse(await c.req.json().catch(() => ({})));
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.executeOperation(requireParam(c, "operationId"), parsed.data)
+  );
+  return success(c, { operation });
+}
+
+/** POST /operations/:operationId/retry — file a linked retry of a failed op. */
+export async function retryRingsOperation(c: AppContext) {
+  const parsed = retryRingsOperationSchema.safeParse(await c.req.json());
+  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
+
+  const { tenant } = tenantOf(c);
+  const service = getHeliusRingsService(c, tenant);
+  const operation = await withRingsErrors(() =>
+    service.retryOperation(requireParam(c, "operationId"), parsed.data.clientNonce)
+  );
+  return success(c, { operation }, 201);
+}

--- a/apps/sdp-api/src/routes/helius-rings/index.ts
+++ b/apps/sdp-api/src/routes/helius-rings/index.ts
@@ -1,0 +1,61 @@
+import { type Context, Hono, type Next } from "hono";
+import { AppError } from "@/lib/errors";
+import { isHeliusRingsEnabled } from "@/lib/feature-flags";
+import { requirePermissions, unifiedAuthMiddleware } from "@/middleware/auth";
+import { projectContextMiddleware } from "@/middleware/project-context";
+import type { Env } from "@/types/env";
+import {
+  createRingsWallet,
+  createRingsZone,
+  executeRingsOperation,
+  getRingsHealth,
+  getRingsOperation,
+  getRingsWallet,
+  listRingsOperations,
+  listRingsWallets,
+  listRingsZones,
+  prepareRingsOperation,
+  retryRingsOperation,
+} from "./handlers";
+
+const heliusRings = new Hono<{ Bindings: Env }>();
+
+/**
+ * Router-wide gate: 403 unless the feature flag is on. The flag stays off in
+ * every deployed environment until Track B lands the live gateway; the
+ * devnet-only guard inside HeliusRingsService is the second lock.
+ */
+async function requireHeliusRingsFeature(c: Context<{ Bindings: Env }>, next: Next) {
+  if (!isHeliusRingsEnabled(c.env)) {
+    throw new AppError("FORBIDDEN", "Helius Rings is not enabled for this environment.");
+  }
+  await next();
+}
+
+heliusRings.use("*", requireHeliusRingsFeature);
+heliusRings.use("*", unifiedAuthMiddleware({ allowClerk: true, allowSession: true }));
+heliusRings.use("*", projectContextMiddleware());
+
+heliusRings.get("/health", requirePermissions("payments:read"), getRingsHealth);
+
+heliusRings.get("/wallets", requirePermissions("payments:read"), listRingsWallets);
+heliusRings.post("/wallets", requirePermissions("payments:write"), createRingsWallet);
+heliusRings.get("/wallets/:walletId", requirePermissions("payments:read"), getRingsWallet);
+heliusRings.get("/wallets/:walletId/zones", requirePermissions("payments:read"), listRingsZones);
+heliusRings.post("/wallets/:walletId/zones", requirePermissions("payments:write"), createRingsZone);
+
+heliusRings.get("/operations", requirePermissions("payments:read"), listRingsOperations);
+heliusRings.post("/operations", requirePermissions("payments:write"), prepareRingsOperation);
+heliusRings.get("/operations/:operationId", requirePermissions("payments:read"), getRingsOperation);
+heliusRings.post(
+  "/operations/:operationId/execute",
+  requirePermissions("payments:write"),
+  executeRingsOperation
+);
+heliusRings.post(
+  "/operations/:operationId/retry",
+  requirePermissions("payments:write"),
+  retryRingsOperation
+);
+
+export default heliusRings;

--- a/apps/sdp-api/src/routes/helius-rings/schemas.ts
+++ b/apps/sdp-api/src/routes/helius-rings/schemas.ts
@@ -1,0 +1,46 @@
+import { OP_TYPES, TRANSFER_MODES, ZONE_KINDS } from "@sdp/helius-rings";
+import { z } from "zod";
+
+export const createRingsWalletSchema = z.object({
+  /** SDP custody wallet id (`walletId` from GET /v1/wallets). */
+  walletId: z.string().min(1),
+  name: z.string().min(1).max(120),
+});
+
+export const prepareRingsOperationSchema = z.object({
+  walletId: z.string().min(1),
+  opType: z.enum(OP_TYPES),
+  asset: z
+    .object({
+      mint: z.string().min(1),
+      amountRaw: z.string().regex(/^\d+$/, "amountRaw must be a base-unit integer string"),
+    })
+    .optional(),
+  from: z.string().min(1).optional(),
+  to: z.string().min(1).optional(),
+  zoneId: z.string().min(1).optional(),
+  transferMode: z.enum(TRANSFER_MODES).optional(),
+  timelock: z
+    .object({
+      unlockAt: z.string().datetime(),
+      beneficiary: z.string().min(1),
+    })
+    .optional(),
+  /** Caller-supplied; contributes to the intent key so retries are explicit. */
+  clientNonce: z.string().min(1).max(128),
+});
+
+export const executeRingsOperationSchema = z.object({
+  approvalStatus: z.enum(["approved", "rejected", "pending"]).optional(),
+});
+
+export const retryRingsOperationSchema = z.object({
+  clientNonce: z.string().min(1).max(128),
+});
+
+export const createRingsZoneSchema = z.object({
+  name: z.string().min(1).max(120),
+  kind: z.enum(ZONE_KINDS),
+});
+
+export const listLimitSchema = z.coerce.number().int().min(1).max(200).optional();

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -223,6 +223,9 @@ export interface Env {
   // Private Channels (SPC) feature gate — API routes + deposit/withdrawal cron.
   PRIVATE_CHANNELS_ENABLED?: string;
 
+  // Helius Rings feature gate — devnet-only shielded wallet API routes.
+  HELIUS_RINGS_ENABLED?: string;
+
   // Compliance providers
   RANGE_API_KEY?: string;
   RANGE_API_BASE_URL?: string;

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -69,6 +69,11 @@ SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED=false
 # dashboard workspace. Set SPC_CREDENTIAL_ENCRYPTION_KEY above when enabling.
 PRIVATE_CHANNELS_ENABLED=false
 
+# Helius Rings is opt-in and devnet-only. Gates the shielded-wallet API
+# routes and the dashboard workspace; production wiring stays off until the
+# live gateway integration lands.
+HELIUS_RINGS_ENABLED=false
+
 # Authentication (Clerk) — required.
 # See apps/sdp-api/docs/self-hosting/clerk-setup.md for full walkthrough.
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -721,6 +721,18 @@ export const FIELDS: EnvField[] = [
     help: "Gates Private Channels API routes and deposit/withdrawal reconcilers.",
   },
   {
+    key: "HELIUS_RINGS_ENABLED",
+    section: "advanced",
+    kind: "select",
+    label: "Helius Rings enabled",
+    defaultValue: "false",
+    options: [
+      { value: "false", label: "Disabled" },
+      { value: "true", label: "Enabled" },
+    ],
+    help: "Gates the devnet-only Helius Rings shielded wallet API routes.",
+  },
+  {
     key: "SPC_CREDENTIAL_ENCRYPTION_KEY",
     section: "secrets",
     kind: "secret",


### PR DESCRIPTION
- `/v1/helius-rings` routes behind `HELIUS_RINGS_ENABLED` (router-wide 403 gate mirroring private-channels; the service's devnet guard is the second lock)
- Health board, wallet provisioning (503 seam-marker response until the live gateway — the wizard renders it as "integration pending"), zone CRUD, operation lifecycle: prepare / list / detail-with-timeline / execute / retry
- Prepare runs through **real** policy enforcement — route test proves an implicit-allow policy advances the op to the port and ends `failed:gateway_unavailable`, and that enforcement refuses a wallet the tenant doesn't own
- `HeliusRingsError` → `AppError` mapping (`gateway_unavailable`/`config_error` → 503)
- Flag declared in env.d.ts, env-config fields, both `.env.example`s; 10 route tests
