### PR TITLE
feat(helius): add the rings dashboard workspace

### DIFF
--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -1,0 +1,72 @@
+{
+  "DashboardHeliusRings": {
+    "title": "Helius Rings",
+    "subtitle": "Shielded wallets and private transfers on Solana devnet.",
+    "devnetBanner": "Devnet only — Helius Rings runs exclusively on Solana devnet. Nothing here touches mainnet funds.",
+    "health": {
+      "title": "Runtime health",
+      "description": "Live status of the Rings upstreams. Actions stay disabled while a component is red.",
+      "component_rpc": "RPC",
+      "component_prover": "Prover",
+      "component_photon": "Photon indexer",
+      "component_gateway": "Gateway",
+      "status_green": "Operational",
+      "status_amber": "Degraded",
+      "status_red": "Unavailable",
+      "pendingIntegration": "The Rings gateway is awaiting external integration. Wallet provisioning and shielded operations will fail honestly until it comes online."
+    },
+    "wallets": {
+      "title": "Private wallets",
+      "description": "Each private wallet is bound to one SDP custody wallet and holds its own shielded identity.",
+      "empty": "No private wallets yet. Create one from a custody wallet below.",
+      "name": "Name",
+      "backingWallet": "Custody wallet",
+      "shieldedAddress": "Shielded address",
+      "shieldedAddressPending": "Not provisioned",
+      "status_pending": "Pending",
+      "status_ready": "Ready",
+      "status_paused": "Paused",
+      "create": "Create private wallet",
+      "createNameLabel": "Wallet name",
+      "createNamePlaceholder": "Treasury",
+      "createWalletLabel": "Custody wallet",
+      "createWalletPlaceholder": "Select a custody wallet",
+      "creating": "Provisioning…",
+      "createPendingNotice": "The wallet was reserved but its shielded identity is awaiting the external gateway integration. It will stay Pending until that lands.",
+      "createFailed": "The wallet could not be created. Check the details and try again.",
+      "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first.",
+      "testOperation": "Prepare test operation",
+      "testOperationHint": "Files a shield operation through policy; it fails at the gateway seam until the integration lands."
+    },
+    "activity": {
+      "title": "Activity",
+      "description": "Every shielded operation, newest first. Failed operations carry their failure code.",
+      "empty": "No operations yet.",
+      "operation": "Operation",
+      "state": "State",
+      "amount": "Amount (base units)",
+      "created": "Created",
+      "opType_shield": "Shield",
+      "opType_transfer_registered": "Send (registered)",
+      "opType_transfer_anonymous": "Send (anonymous)",
+      "opType_withdraw": "Withdraw",
+      "opType_merge": "Merge",
+      "opType_timelock_create": "Timelock",
+      "opType_timelock_settle": "Timelock settle",
+      "opType_zone_create": "Zone create",
+      "state_draft": "Draft",
+      "state_preparing": "Preparing",
+      "state_approval_required": "Approval required",
+      "state_proving": "Proving",
+      "state_ready_to_sign": "Ready to sign",
+      "state_submitted": "Submitted",
+      "state_indexing": "Indexing",
+      "state_completed": "Completed",
+      "state_failed": "Failed"
+    },
+    "errors": {
+      "loadFailed": "Could not load Helius Rings data. Retry shortly.",
+      "gatewayUnavailable": "External integration pending"
+    }
+  }
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/health/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/health/route.ts
@@ -1,0 +1,9 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.health",
+    path: "/v1/helius-rings/health",
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/route.ts
@@ -1,0 +1,13 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ operationId: string }> }
+) {
+  const { operationId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.operation",
+    path: `/v1/helius-rings/operations/${encodeURIComponent(operationId)}`,
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/route.ts
@@ -1,0 +1,17 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.operations",
+    path: "/v1/helius-rings/operations",
+  });
+}
+
+export async function POST(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.operations",
+    path: "/v1/helius-rings/operations",
+  });
+}

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/route.ts
@@ -1,0 +1,17 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.wallets",
+    path: "/v1/helius-rings/wallets",
+  });
+}
+
+export async function POST(request: Request) {
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.wallets",
+    path: "/v1/helius-rings/wallets",
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectItem } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useTranslations } from "@/i18n/provider";
+import {
+  createRingsWallet,
+  fetchRingsHealth,
+  fetchRingsOperations,
+  fetchRingsWallets,
+  prepareRingsTestOperation,
+  type RingsHealth,
+  type RingsHealthStatus,
+  type RingsOperationState,
+  type RingsOperationSummary,
+  type RingsWallet,
+} from "./helius-rings.data";
+
+interface CustodyWalletOption {
+  walletId: string;
+  label: string | null;
+  publicKey: string;
+}
+
+const HEALTH_COMPONENTS = ["rpc", "prover", "photon", "gateway"] as const;
+
+const HEALTH_BADGE: Record<RingsHealthStatus, "success" | "warning" | "danger"> = {
+  green: "success",
+  amber: "warning",
+  red: "danger",
+};
+
+const WALLET_BADGE: Record<RingsWallet["status"], "warning" | "success" | "default"> = {
+  pending: "warning",
+  ready: "success",
+  paused: "default",
+};
+
+const STATE_BADGE: Record<RingsOperationState, "default" | "success" | "warning" | "danger"> = {
+  draft: "default",
+  preparing: "default",
+  approval_required: "warning",
+  proving: "default",
+  ready_to_sign: "default",
+  submitted: "default",
+  indexing: "default",
+  completed: "success",
+  failed: "danger",
+};
+
+export function HeliusRingsWorkspace({
+  custodyWallets,
+}: {
+  custodyWallets: CustodyWalletOption[];
+}) {
+  const t = useTranslations();
+
+  const [health, setHealth] = useState<RingsHealth | null>(null);
+  const [wallets, setWallets] = useState<RingsWallet[]>([]);
+  const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [walletName, setWalletName] = useState("");
+  const [selectedCustodyWallet, setSelectedCustodyWallet] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createNotice, setCreateNotice] = useState<"pending" | "failed" | null>(null);
+
+  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
+
+  const refresh = useCallback(async () => {
+    try {
+      const [healthResult, walletsResult, operationsResult] = await Promise.all([
+        fetchRingsHealth(loadFailedCopy),
+        fetchRingsWallets(loadFailedCopy),
+        fetchRingsOperations(loadFailedCopy),
+      ]);
+      setHealth(healthResult.health);
+      setWallets(walletsResult.wallets);
+      setOperations(operationsResult.operations);
+      setLoadError(null);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : loadFailedCopy);
+    }
+  }, [loadFailedCopy]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const gatewayPending = health !== null && health.gateway !== "green";
+
+  const handleCreate = useCallback(async () => {
+    if (!selectedCustodyWallet || !walletName.trim()) return;
+    setCreating(true);
+    setCreateNotice(null);
+    const result = await createRingsWallet({
+      walletId: selectedCustodyWallet,
+      name: walletName.trim(),
+    });
+    setCreating(false);
+    if (result.pendingIntegration) {
+      setCreateNotice("pending");
+    } else if (result.error) {
+      setCreateNotice("failed");
+    }
+    setWalletName("");
+    await refresh();
+  }, [selectedCustodyWallet, walletName, refresh]);
+
+  const handleTestOperation = useCallback(
+    async (walletId: string) => {
+      await prepareRingsTestOperation({ walletId });
+      await refresh();
+    },
+    [refresh]
+  );
+
+  const custodyLabel = useMemo(() => {
+    const byId = new Map(custodyWallets.map((wallet) => [wallet.walletId, wallet]));
+    return (sdpWalletId: string) => {
+      const wallet = byId.get(sdpWalletId);
+      return wallet?.label ?? sdpWalletId;
+    };
+  }, [custodyWallets]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Callout variant="warning">{t("DashboardHeliusRings.devnetBanner")}</Callout>
+
+      {loadError ? <Callout variant="danger">{loadError}</Callout> : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("DashboardHeliusRings.health.title")}</CardTitle>
+          <CardDescription>{t("DashboardHeliusRings.health.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-4">
+            {HEALTH_COMPONENTS.map((component) => {
+              const status = health?.[component] ?? "red";
+              return (
+                <div key={component} className="flex items-center gap-2">
+                  <span className="text-sm text-secondary">
+                    {t(`DashboardHeliusRings.health.component_${component}`)}
+                  </span>
+                  <Badge variant={HEALTH_BADGE[status]}>
+                    {t(`DashboardHeliusRings.health.status_${status}`)}
+                  </Badge>
+                </div>
+              );
+            })}
+          </div>
+          {gatewayPending ? (
+            <p className="text-sm text-secondary">
+              {t("DashboardHeliusRings.health.pendingIntegration")}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("DashboardHeliusRings.wallets.title")}</CardTitle>
+          <CardDescription>{t("DashboardHeliusRings.wallets.description")}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {wallets.length === 0 ? (
+            <p className="text-sm text-secondary">{t("DashboardHeliusRings.wallets.empty")}</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("DashboardHeliusRings.wallets.name")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.wallets.backingWallet")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.wallets.shieldedAddress")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.state")}</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {wallets.map((wallet) => (
+                  <TableRow key={wallet.id}>
+                    <TableCell>{wallet.name}</TableCell>
+                    <TableCell>{custodyLabel(wallet.sdpWalletId)}</TableCell>
+                    <TableCell>
+                      {wallet.shieldedAddress ??
+                        t("DashboardHeliusRings.wallets.shieldedAddressPending")}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={WALLET_BADGE[wallet.status]}>
+                        {t(`DashboardHeliusRings.wallets.status_${wallet.status}`)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        title={t("DashboardHeliusRings.wallets.testOperationHint")}
+                        onClick={() => void handleTestOperation(wallet.id)}
+                      >
+                        {t("DashboardHeliusRings.wallets.testOperation")}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {createNotice === "pending" ? (
+            <Callout variant="info">
+              {t("DashboardHeliusRings.wallets.createPendingNotice")}
+            </Callout>
+          ) : null}
+          {createNotice === "failed" ? (
+            <Callout variant="danger">{t("DashboardHeliusRings.wallets.createFailed")}</Callout>
+          ) : null}
+
+          {custodyWallets.length === 0 ? (
+            <p className="text-sm text-secondary">
+              {t("DashboardHeliusRings.wallets.noCustodyWallets")}
+            </p>
+          ) : (
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="flex min-w-56 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.wallets.createWalletLabel")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.wallets.createWalletLabel")}
+                  value={selectedCustodyWallet}
+                  onValueChange={setSelectedCustodyWallet}
+                  placeholder={t("DashboardHeliusRings.wallets.createWalletPlaceholder")}
+                >
+                  {custodyWallets.map((wallet) => (
+                    <SelectItem key={wallet.walletId} value={wallet.walletId}>
+                      {wallet.label ?? wallet.walletId}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+              <div className="flex min-w-48 flex-col gap-1.5">
+                <Label htmlFor="rings-wallet-name">
+                  {t("DashboardHeliusRings.wallets.createNameLabel")}
+                </Label>
+                <Input
+                  id="rings-wallet-name"
+                  value={walletName}
+                  placeholder={t("DashboardHeliusRings.wallets.createNamePlaceholder")}
+                  onChange={(event) => setWalletName(event.target.value)}
+                />
+              </div>
+              <Button
+                disabled={creating || !selectedCustodyWallet || !walletName.trim()}
+                onClick={() => void handleCreate()}
+              >
+                {creating
+                  ? t("DashboardHeliusRings.wallets.creating")
+                  : t("DashboardHeliusRings.wallets.create")}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("DashboardHeliusRings.activity.title")}</CardTitle>
+          <CardDescription>{t("DashboardHeliusRings.activity.description")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {operations.length === 0 ? (
+            <p className="text-sm text-secondary">{t("DashboardHeliusRings.activity.empty")}</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("DashboardHeliusRings.activity.operation")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.state")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.amount")}</TableHead>
+                  <TableHead>{t("DashboardHeliusRings.activity.created")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {operations.map((operation) => (
+                  <TableRow key={operation.id}>
+                    <TableCell>
+                      {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={STATE_BADGE[operation.state]}>
+                        {t(`DashboardHeliusRings.activity.state_${operation.state}`)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{operation.amountRaw ?? "—"}</TableCell>
+                    <TableCell>{new Date(operation.createdAt).toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -29,9 +29,21 @@ export type RingsOperationState =
   | "completed"
   | "failed";
 
+/** Mirrors OP_TYPES in @sdp/helius-rings; a literal union so the typed i18n
+ * keys (`activity.opType_*`) resolve. */
+export type RingsOperationOpType =
+  | "shield"
+  | "transfer_registered"
+  | "transfer_anonymous"
+  | "withdraw"
+  | "merge"
+  | "timelock_create"
+  | "timelock_settle"
+  | "zone_create";
+
 export interface RingsOperationSummary {
   id: string;
-  opType: string;
+  opType: RingsOperationOpType;
   state: RingsOperationState;
   assetMint: string | null;
   amountRaw: string | null;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -1,0 +1,125 @@
+/**
+ * Client seam for the Helius Rings workspace. Fetches go through the
+ * /api/dashboard/helius-rings BFF proxies; view-model types mirror the API
+ * DTOs without importing server packages.
+ */
+
+export type RingsHealthStatus = "green" | "amber" | "red";
+export type RingsHealth = Record<"rpc" | "prover" | "photon" | "gateway", RingsHealthStatus>;
+
+export type RingsWalletStatus = "pending" | "ready" | "paused";
+
+export interface RingsWallet {
+  id: string;
+  sdpWalletId: string;
+  name: string;
+  shieldedAddress: string | null;
+  status: RingsWalletStatus;
+  network: "devnet";
+}
+
+export type RingsOperationState =
+  | "draft"
+  | "preparing"
+  | "approval_required"
+  | "proving"
+  | "ready_to_sign"
+  | "submitted"
+  | "indexing"
+  | "completed"
+  | "failed";
+
+export interface RingsOperationSummary {
+  id: string;
+  opType: string;
+  state: RingsOperationState;
+  assetMint: string | null;
+  amountRaw: string | null;
+  createdAt: string;
+}
+
+export interface RingsOperationDetail extends RingsOperationSummary {
+  failure: { code: string; message: string; retryable: boolean } | null;
+}
+
+interface Envelope<T> {
+  data?: T;
+  error?: { message?: string };
+}
+
+async function getJson<T>(path: string, fallbackError: string): Promise<T> {
+  const response = await fetch(path, { cache: "no-store" });
+  const body = (await response.json().catch(() => ({}))) as Envelope<T>;
+  if (!response.ok || !body.data) {
+    throw new Error(body.error?.message ?? fallbackError);
+  }
+  return body.data;
+}
+
+export function fetchRingsHealth(fallbackError: string): Promise<{ health: RingsHealth }> {
+  return getJson("/api/dashboard/helius-rings/health", fallbackError);
+}
+
+export function fetchRingsWallets(fallbackError: string): Promise<{ wallets: RingsWallet[] }> {
+  return getJson("/api/dashboard/helius-rings/wallets", fallbackError);
+}
+
+export function fetchRingsOperations(
+  fallbackError: string
+): Promise<{ operations: RingsOperationSummary[] }> {
+  return getJson("/api/dashboard/helius-rings/operations", fallbackError);
+}
+
+export interface CreateRingsWalletResult {
+  wallet?: RingsWallet;
+  /** Set when the gateway seam refused (503): the wallet stays pending. */
+  pendingIntegration: boolean;
+  error?: string;
+}
+
+export async function createRingsWallet(input: {
+  walletId: string;
+  name: string;
+}): Promise<CreateRingsWalletResult> {
+  const response = await fetch("/api/dashboard/helius-rings/wallets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cache: "no-store",
+  });
+  const body = (await response.json().catch(() => ({}))) as Envelope<{ wallet: RingsWallet }>;
+  if (response.status === 503) {
+    return { pendingIntegration: true };
+  }
+  if (!response.ok || !body.data) {
+    return { pendingIntegration: false, error: body.error?.message };
+  }
+  return { wallet: body.data.wallet, pendingIntegration: false };
+}
+
+export async function prepareRingsTestOperation(input: {
+  walletId: string;
+}): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  const response = await fetch("/api/dashboard/helius-rings/operations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      walletId: input.walletId,
+      opType: "shield",
+      asset: {
+        // Wrapped SOL on devnet; seeded in the rings asset allowlist.
+        mint: "So11111111111111111111111111111111111111112",
+        amountRaw: "1000000",
+      },
+      clientNonce: crypto.randomUUID(),
+    }),
+    cache: "no-store",
+  });
+  const body = (await response.json().catch(() => ({}))) as Envelope<{
+    operation: RingsOperationDetail;
+  }>;
+  if (!response.ok || !body.data) {
+    return { error: body.error?.message };
+  }
+  return { operation: body.data.operation };
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/page.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/page.tsx
@@ -1,15 +1,63 @@
-import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { notFound, redirect } from "next/navigation";
 import { heliusRings } from "@/flags";
+import { getAuthEntryPath } from "@/lib/auth-entry";
+import { createRequestScopedSdpApiClients } from "@/lib/sdp-api";
+import { HeliusRingsWorkspace } from "./helius-rings-workspace";
 
+export const dynamic = "force-dynamic";
+
+interface CustodyWalletOption {
+  walletId: string;
+  label: string | null;
+  publicKey: string;
+}
+
+/**
+ * Helius Rings overview — devnet-only shielded wallet workspace. Live data
+ * flows through the /api/dashboard/helius-rings BFF proxies; the custody
+ * wallet options for the create form are resolved server-side. Degraded
+ * upstreams render honestly: red health, pending wallets, failed operations.
+ */
 export default async function HeliusRingsPage() {
   if (!(await heliusRings())) {
     notFound();
   }
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    redirect(await getAuthEntryPath());
+  }
+  if (!orgId) {
+    redirect("/dashboard");
+  }
+
+  // Best-effort: losing the wallet list costs the reader the create form,
+  // never the health card or the activity table beside it.
+  let custodyWallets: CustodyWalletOption[] = [];
+  try {
+    const { projectClient } = await createRequestScopedSdpApiClients();
+    if (projectClient) {
+      const response = await projectClient.request("/v1/wallets?view=summary", { method: "GET" });
+      if (response.ok) {
+        const body = (await response.json()) as {
+          data?: {
+            wallets?: Array<{ walletId: string; label?: string | null; publicKey: string }>;
+          };
+        };
+        custodyWallets = (body.data?.wallets ?? []).map((wallet) => ({
+          walletId: wallet.walletId,
+          label: wallet.label ?? null,
+          publicKey: wallet.publicKey,
+        }));
+      }
+    }
+  } catch {
+    // The workspace renders its own empty-state copy.
+  }
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16">
-      <h1 className="text-2xl font-semibold tracking-tight text-primary">Helius Rings</h1>
-      <p className="mt-2 text-sm text-secondary">Coming soon.</p>
+    <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
+      <HeliusRingsWorkspace custodyWallets={custodyWallets} />
     </div>
   );
 }

--- a/apps/sdp-web/src/i18n/messages.ts
+++ b/apps/sdp-web/src/i18n/messages.ts
@@ -2,6 +2,9 @@ import type { AppLocale } from "@/i18n/config";
 import dashboardApprovals from "../../messages/en/dashboard-approvals.json";
 import dashboardCustody from "../../messages/en/dashboard-custody.json";
 import dashboardEarn from "../../messages/en/dashboard-earn.json";
+// No localized dashboard-helius-rings.json yet: product branches ship English
+// source only; localized copy lands via the translation bot on the release PR.
+import dashboardHeliusRings from "../../messages/en/dashboard-helius-rings.json";
 import dashboardIssuance from "../../messages/en/dashboard-issuance.json";
 import dashboardPayments from "../../messages/en/dashboard-payments.json";
 import dashboardPolicies from "../../messages/en/dashboard-policies.json";
@@ -49,6 +52,7 @@ const enMessages = {
   ...dashboardApprovals,
   ...dashboardCustody,
   ...dashboardEarn,
+  ...dashboardHeliusRings,
   ...dashboardIssuance,
   ...dashboardPayments,
   ...dashboardPolicies,


### PR DESCRIPTION
- Replaces the "Coming soon" stub with the rings workspace: devnet banner, runtime health board, private wallets card with create form, activity table
- Honest degraded states throughout: health renders red until the live gateway; a 503 on create shows "integration pending" and the wallet stays Pending; failed operations carry their state badge
- Per-wallet "Prepare test operation" action files a shield op through the full prepare-through-policy path — useful for manual verification until the composers (A14+) land
- BFF proxies under `/api/dashboard/helius-rings/*`; custody wallet options resolved server-side (best-effort)
- Copy in `messages/en/dashboard-helius-rings.json` (English-only per the earn precedent); page gated by the existing `helius-rings` flag
- Note: `pnpm check:i18n` failures on earn files are pre-existing, untouched here
