### PR TITLE
feat(helius): add the shielded operation composers and zone management

### DIFF
--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -34,9 +34,7 @@
       "creating": "Provisioning…",
       "createPendingNotice": "The wallet was reserved but its shielded identity is awaiting the external gateway integration. It will stay Pending until that lands.",
       "createFailed": "The wallet could not be created. Check the details and try again.",
-      "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first.",
-      "testOperation": "Prepare test operation",
-      "testOperationHint": "Files a shield operation through policy; it fails at the gateway seam until the integration lands."
+      "noCustodyWallets": "No custody wallets available. Create a wallet under Wallets first."
     },
     "activity": {
       "title": "Activity",
@@ -67,6 +65,48 @@
     "errors": {
       "loadFailed": "Could not load Helius Rings data. Retry shortly.",
       "gatewayUnavailable": "External integration pending"
+    },
+    "composer": {
+      "title": "New operation",
+      "description": "Compose a shielded operation, review it, then confirm. Until the live gateway lands, operations advance through policy and fail honestly at the integration seam.",
+      "wallet": "Private wallet",
+      "walletPlaceholder": "Select a private wallet",
+      "operation": "Operation",
+      "asset": "Asset",
+      "amount": "Amount (base units)",
+      "baseUnits": "base units",
+      "recipient": "Recipient address",
+      "recipientAnonymous": "Recipient address (undisclosed on-chain)",
+      "recipientPlaceholder": "Solana address",
+      "zone": "Destination zone",
+      "zonePlaceholder": "Optional",
+      "unlockAt": "Unlocks at",
+      "beneficiary": "Beneficiary address",
+      "review": "Review",
+      "back": "Back",
+      "confirm": "Confirm",
+      "preparing": "Preparing…",
+      "newOperation": "New operation",
+      "prepareFailed": "The operation could not be prepared. Check the details and try again.",
+      "summaryWallet": "Wallet",
+      "summaryOperation": "Operation",
+      "summaryAmount": "Amount",
+      "summaryRecipient": "Recipient",
+      "summaryZone": "Zone",
+      "summaryUnlockAt": "Unlocks at",
+      "summaryBeneficiary": "Beneficiary",
+      "anonymousWarning": "I understand the counterparty is not disclosed on-chain. Anonymous transfers are subject to the same wallet policy and approval rules as any other transfer — they are not lower-risk."
+    },
+    "zones": {
+      "title": "Zones",
+      "description": "Named destinations inside a wallet. Zone metadata is SDP-owned and works today; on-chain effects wait on the gateway.",
+      "empty": "No zones yet.",
+      "nameLabel": "Zone name",
+      "namePlaceholder": "Payroll",
+      "kindLabel": "Kind",
+      "kind_treasury": "Treasury",
+      "kind_public": "Public",
+      "create": "Create zone"
     }
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/[walletId]/zones/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/wallets/[walletId]/zones/route.ts
@@ -1,0 +1,22 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function GET(request: Request, { params }: { params: Promise<{ walletId: string }> }) {
+  const { walletId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.zones",
+    path: `/v1/helius-rings/wallets/${encodeURIComponent(walletId)}/zones`,
+  });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ walletId: string }> }
+) {
+  const { walletId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.zones",
+    path: `/v1/helius-rings/wallets/${encodeURIComponent(walletId)}/zones`,
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -22,13 +22,15 @@ import {
   fetchRingsHealth,
   fetchRingsOperations,
   fetchRingsWallets,
-  prepareRingsTestOperation,
   type RingsHealth,
   type RingsHealthStatus,
   type RingsOperationState,
   type RingsOperationSummary,
   type RingsWallet,
+  type RingsZone,
 } from "./helius-rings.data";
+import { OperationComposer } from "./operation-composer";
+import { ZonesCard } from "./zones-card";
 
 interface CustodyWalletOption {
   walletId: string;
@@ -72,6 +74,7 @@ export function HeliusRingsWorkspace({
   const [health, setHealth] = useState<RingsHealth | null>(null);
   const [wallets, setWallets] = useState<RingsWallet[]>([]);
   const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
+  const [zones, setZones] = useState<RingsZone[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [walletName, setWalletName] = useState("");
@@ -120,14 +123,6 @@ export function HeliusRingsWorkspace({
     setWalletName("");
     await refresh();
   }, [selectedCustodyWallet, walletName, refresh]);
-
-  const handleTestOperation = useCallback(
-    async (walletId: string) => {
-      await prepareRingsTestOperation({ walletId });
-      await refresh();
-    },
-    [refresh]
-  );
 
   const custodyLabel = useMemo(() => {
     const byId = new Map(custodyWallets.map((wallet) => [wallet.walletId, wallet]));
@@ -188,7 +183,6 @@ export function HeliusRingsWorkspace({
                   <TableHead>{t("DashboardHeliusRings.wallets.backingWallet")}</TableHead>
                   <TableHead>{t("DashboardHeliusRings.wallets.shieldedAddress")}</TableHead>
                   <TableHead>{t("DashboardHeliusRings.activity.state")}</TableHead>
-                  <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -204,16 +198,6 @@ export function HeliusRingsWorkspace({
                       <Badge variant={WALLET_BADGE[wallet.status]}>
                         {t(`DashboardHeliusRings.wallets.status_${wallet.status}`)}
                       </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        title={t("DashboardHeliusRings.wallets.testOperationHint")}
-                        onClick={() => void handleTestOperation(wallet.id)}
-                      >
-                        {t("DashboardHeliusRings.wallets.testOperation")}
-                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -276,6 +260,10 @@ export function HeliusRingsWorkspace({
           )}
         </CardContent>
       </Card>
+
+      <OperationComposer wallets={wallets} zones={zones} onPrepared={refresh} />
+
+      <ZonesCard wallets={wallets} onZonesChanged={setZones} />
 
       <Card>
         <CardHeader>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -109,22 +109,31 @@ export async function createRingsWallet(input: {
   return { wallet: body.data.wallet, pendingIntegration: false };
 }
 
-export async function prepareRingsTestOperation(input: {
+export type RingsOpType =
+  | "shield"
+  | "transfer_registered"
+  | "transfer_anonymous"
+  | "withdraw"
+  | "merge"
+  | "timelock_create";
+
+export interface PrepareRingsOperationInput {
   walletId: string;
-}): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  opType: RingsOpType;
+  asset?: { mint: string; amountRaw: string };
+  to?: string;
+  zoneId?: string;
+  transferMode?: "registered" | "anonymous";
+  timelock?: { unlockAt: string; beneficiary: string };
+}
+
+export async function prepareRingsOperation(
+  input: PrepareRingsOperationInput
+): Promise<{ operation?: RingsOperationDetail; error?: string }> {
   const response = await fetch("/api/dashboard/helius-rings/operations", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      walletId: input.walletId,
-      opType: "shield",
-      asset: {
-        // Wrapped SOL on devnet; seeded in the rings asset allowlist.
-        mint: "So11111111111111111111111111111111111111112",
-        amountRaw: "1000000",
-      },
-      clientNonce: crypto.randomUUID(),
-    }),
+    body: JSON.stringify({ ...input, clientNonce: crypto.randomUUID() }),
     cache: "no-store",
   });
   const body = (await response.json().catch(() => ({}))) as Envelope<{
@@ -135,3 +144,48 @@ export async function prepareRingsTestOperation(input: {
   }
   return { operation: body.data.operation };
 }
+
+export interface RingsZone {
+  id: string;
+  name: string;
+  kind: "treasury" | "public";
+}
+
+export function fetchRingsZones(
+  walletId: string,
+  fallbackError: string
+): Promise<{ zones: RingsZone[] }> {
+  return getJson(
+    `/api/dashboard/helius-rings/wallets/${encodeURIComponent(walletId)}/zones`,
+    fallbackError
+  );
+}
+
+export async function createRingsZone(input: {
+  walletId: string;
+  name: string;
+  kind: RingsZone["kind"];
+}): Promise<{ zone?: RingsZone; error?: string }> {
+  const response = await fetch(
+    `/api/dashboard/helius-rings/wallets/${encodeURIComponent(input.walletId)}/zones`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: input.name, kind: input.kind }),
+      cache: "no-store",
+    }
+  );
+  const body = (await response.json().catch(() => ({}))) as Envelope<{ zone: RingsZone }>;
+  if (!response.ok || !body.data) {
+    return { error: body.error?.message };
+  }
+  return { zone: body.data.zone };
+}
+
+/** Devnet assets seeded in the rings allowlist. */
+export const RINGS_ALLOWLISTED_ASSETS = [
+  // biome-ignore lint/security/noSecrets: wrapped SOL mint address, not a secret.
+  { mint: "So11111111111111111111111111111111111111112", symbol: "SOL", decimals: 9 },
+  // biome-ignore lint/security/noSecrets: devnet USDC mint address, not a secret.
+  { mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", symbol: "USDC", decimals: 6 },
+] as const;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -184,8 +184,6 @@ export async function createRingsZone(input: {
 
 /** Devnet assets seeded in the rings allowlist. */
 export const RINGS_ALLOWLISTED_ASSETS = [
-  // biome-ignore lint/security/noSecrets: wrapped SOL mint address, not a secret.
   { mint: "So11111111111111111111111111111111111111112", symbol: "SOL", decimals: 9 },
-  // biome-ignore lint/security/noSecrets: devnet USDC mint address, not a secret.
   { mint: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", symbol: "USDC", decimals: 6 },
 ] as const;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -17,6 +17,8 @@ import {
   type RingsZone,
 } from "./helius-rings.data";
 
+type Translate = ReturnType<typeof useTranslations>;
+
 const OP_TYPES: RingsOpType[] = [
   "shield",
   "transfer_registered",
@@ -40,6 +42,87 @@ const NEEDS_RECIPIENT: ReadonlySet<RingsOpType> = new Set([
 
 type Step = "compose" | "review" | "result";
 
+/** Everything the compose form has collected. */
+interface ComposerDraft {
+  walletId: string | null;
+  opType: RingsOpType;
+  assetMint: string;
+  amountRaw: string;
+  recipient: string;
+  zoneId: string | null;
+  unlockAt: string;
+  beneficiary: string;
+}
+
+const EMPTY_DRAFT: ComposerDraft = {
+  walletId: null,
+  opType: "shield",
+  assetMint: RINGS_ALLOWLISTED_ASSETS[0].mint,
+  amountRaw: "",
+  recipient: "",
+  zoneId: null,
+  unlockAt: "",
+  beneficiary: "",
+};
+
+function transferModeFor(opType: RingsOpType): "registered" | "anonymous" | undefined {
+  if (opType === "transfer_registered") return "registered";
+  if (opType === "transfer_anonymous") return "anonymous";
+  return undefined;
+}
+
+function isDraftComplete(draft: ComposerDraft): boolean {
+  if (draft.walletId === null) return false;
+  if (NEEDS_ASSET.has(draft.opType) && !/^\d+$/.test(draft.amountRaw)) return false;
+  if (NEEDS_RECIPIENT.has(draft.opType) && draft.recipient.trim().length === 0) return false;
+  if (
+    draft.opType === "timelock_create" &&
+    (draft.unlockAt.length === 0 || draft.beneficiary.trim().length === 0)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function buildSummaryRows(
+  t: Translate,
+  draft: ComposerDraft,
+  wallets: RingsWallet[],
+  zones: RingsZone[]
+): Array<[string, string]> {
+  const asset = RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === draft.assetMint);
+  const rows: Array<[string, string]> = [
+    [
+      t("DashboardHeliusRings.composer.summaryWallet"),
+      wallets.find((wallet) => wallet.id === draft.walletId)?.name ?? "—",
+    ],
+    [
+      t("DashboardHeliusRings.composer.summaryOperation"),
+      t(`DashboardHeliusRings.activity.opType_${draft.opType}`),
+    ],
+  ];
+  if (NEEDS_ASSET.has(draft.opType)) {
+    rows.push([
+      t("DashboardHeliusRings.composer.summaryAmount"),
+      `${draft.amountRaw} (${asset?.symbol ?? "?"} ${t("DashboardHeliusRings.composer.baseUnits")})`,
+    ]);
+  }
+  if (NEEDS_RECIPIENT.has(draft.opType)) {
+    rows.push([t("DashboardHeliusRings.composer.summaryRecipient"), draft.recipient]);
+  }
+  if (draft.opType === "merge" && draft.zoneId) {
+    rows.push([
+      t("DashboardHeliusRings.composer.summaryZone"),
+      zones.find((zone) => zone.id === draft.zoneId)?.name ?? draft.zoneId,
+    ]);
+  }
+  if (draft.opType === "timelock_create") {
+    rows.push([t("DashboardHeliusRings.composer.summaryUnlockAt"), draft.unlockAt]);
+    rows.push([t("DashboardHeliusRings.composer.summaryBeneficiary"), draft.beneficiary]);
+  }
+  return rows;
+}
+
 /**
  * One composer for every shielded operation kind. A `review` step sits between
  * the form and the POST; anonymous transfers additionally require an explicit
@@ -57,66 +140,46 @@ export function OperationComposer({
   const t = useTranslations();
 
   const [step, setStep] = useState<Step>("compose");
-  const [walletId, setWalletId] = useState<string | null>(null);
-  const [opType, setOpType] = useState<RingsOpType>("shield");
-  const [assetMint, setAssetMint] = useState<string>(RINGS_ALLOWLISTED_ASSETS[0].mint);
-  const [amountRaw, setAmountRaw] = useState("");
-  const [recipient, setRecipient] = useState("");
-  const [zoneId, setZoneId] = useState<string | null>(null);
-  const [unlockAt, setUnlockAt] = useState("");
-  const [beneficiary, setBeneficiary] = useState("");
+  const [draft, setDraft] = useState<ComposerDraft>(EMPTY_DRAFT);
   const [anonymousAcknowledged, setAnonymousAcknowledged] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<RingsOperationDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const needsAsset = NEEDS_ASSET.has(opType);
-  const needsRecipient = NEEDS_RECIPIENT.has(opType);
-  const isTimelock = opType === "timelock_create";
-  const isAnonymous = opType === "transfer_anonymous";
-  const isMerge = opType === "merge";
-
-  const asset = useMemo(
-    () => RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === assetMint),
-    [assetMint]
-  );
-
-  const composeComplete =
-    walletId !== null &&
-    (!needsAsset || /^\d+$/.test(amountRaw)) &&
-    (!needsRecipient || recipient.trim().length > 0) &&
-    (!isTimelock || (unlockAt.length > 0 && beneficiary.trim().length > 0));
+  const patchDraft = useCallback((patch: Partial<ComposerDraft>) => {
+    setDraft((current) => ({ ...current, ...patch }));
+  }, []);
 
   const reset = useCallback(() => {
     setStep("compose");
-    setAmountRaw("");
-    setRecipient("");
-    setUnlockAt("");
-    setBeneficiary("");
-    setZoneId(null);
+    setDraft((current) => ({ ...EMPTY_DRAFT, walletId: current.walletId }));
     setAnonymousAcknowledged(false);
     setResult(null);
     setError(null);
   }, []);
 
   const handleConfirm = useCallback(async () => {
-    if (!walletId) return;
+    if (!draft.walletId) return;
     setSubmitting(true);
     setError(null);
+    const asset = RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === draft.assetMint);
     const prepared = await prepareRingsOperation({
-      walletId,
-      opType,
-      asset: needsAsset && asset ? { mint: asset.mint, amountRaw } : undefined,
-      to: needsRecipient ? recipient.trim() : undefined,
-      zoneId: isMerge && zoneId ? zoneId : undefined,
-      transferMode: isAnonymous
-        ? "anonymous"
-        : opType === "transfer_registered"
-          ? "registered"
+      walletId: draft.walletId,
+      opType: draft.opType,
+      asset:
+        NEEDS_ASSET.has(draft.opType) && asset
+          ? { mint: asset.mint, amountRaw: draft.amountRaw }
           : undefined,
-      timelock: isTimelock
-        ? { unlockAt: new Date(unlockAt).toISOString(), beneficiary: beneficiary.trim() }
-        : undefined,
+      to: NEEDS_RECIPIENT.has(draft.opType) ? draft.recipient.trim() : undefined,
+      zoneId: draft.opType === "merge" && draft.zoneId ? draft.zoneId : undefined,
+      transferMode: transferModeFor(draft.opType),
+      timelock:
+        draft.opType === "timelock_create"
+          ? {
+              unlockAt: new Date(draft.unlockAt).toISOString(),
+              beneficiary: draft.beneficiary.trim(),
+            }
+          : undefined,
     });
     setSubmitting(false);
     if (prepared.error || !prepared.operation) {
@@ -126,61 +189,12 @@ export function OperationComposer({
     setResult(prepared.operation);
     setStep("result");
     await onPrepared();
-  }, [
-    walletId,
-    opType,
-    needsAsset,
-    asset,
-    amountRaw,
-    needsRecipient,
-    recipient,
-    isMerge,
-    zoneId,
-    isAnonymous,
-    isTimelock,
-    unlockAt,
-    beneficiary,
-    onPrepared,
-    t,
-  ]);
+  }, [draft, onPrepared, t]);
 
-  const summaryRows: Array<[string, string]> = [
-    [
-      t("DashboardHeliusRings.composer.summaryWallet"),
-      wallets.find((wallet) => wallet.id === walletId)?.name ?? "—",
-    ],
-    [
-      t("DashboardHeliusRings.composer.summaryOperation"),
-      t(`DashboardHeliusRings.activity.opType_${opType}`),
-    ],
-    ...(needsAsset
-      ? ([
-          [
-            t("DashboardHeliusRings.composer.summaryAmount"),
-            `${amountRaw} (${asset?.symbol ?? "?"} ${t("DashboardHeliusRings.composer.baseUnits")})`,
-          ],
-        ] as Array<[string, string]>)
-      : []),
-    ...(needsRecipient
-      ? ([[t("DashboardHeliusRings.composer.summaryRecipient"), recipient]] as Array<
-          [string, string]
-        >)
-      : []),
-    ...(isMerge && zoneId
-      ? ([
-          [
-            t("DashboardHeliusRings.composer.summaryZone"),
-            zones.find((zone) => zone.id === zoneId)?.name ?? zoneId,
-          ],
-        ] as Array<[string, string]>)
-      : []),
-    ...(isTimelock
-      ? ([
-          [t("DashboardHeliusRings.composer.summaryUnlockAt"), unlockAt],
-          [t("DashboardHeliusRings.composer.summaryBeneficiary"), beneficiary],
-        ] as Array<[string, string]>)
-      : []),
-  ];
+  const summaryRows = useMemo(
+    () => buildSummaryRows(t, draft, wallets, zones),
+    [t, draft, wallets, zones]
+  );
 
   return (
     <Card>
@@ -190,212 +204,263 @@ export function OperationComposer({
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {step === "compose" ? (
-          <>
-            <div className="flex flex-wrap gap-3">
-              <div className="flex min-w-52 flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {t("DashboardHeliusRings.composer.wallet")}
-                </span>
-                <Select
-                  ariaLabel={t("DashboardHeliusRings.composer.wallet")}
-                  value={walletId}
-                  onValueChange={setWalletId}
-                  placeholder={t("DashboardHeliusRings.composer.walletPlaceholder")}
-                >
-                  {wallets.map((wallet) => (
-                    <SelectItem key={wallet.id} value={wallet.id}>
-                      {wallet.name}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </div>
-              <div className="flex min-w-52 flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {t("DashboardHeliusRings.composer.operation")}
-                </span>
-                <Select
-                  ariaLabel={t("DashboardHeliusRings.composer.operation")}
-                  value={opType}
-                  onValueChange={(value) => {
-                    if (value) setOpType(value as RingsOpType);
-                  }}
-                >
-                  {OP_TYPES.map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {t(`DashboardHeliusRings.activity.opType_${type}`)}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </div>
-            </div>
-
-            {needsAsset ? (
-              <div className="flex flex-wrap gap-3">
-                <div className="flex min-w-40 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.asset")}
-                  </span>
-                  <Select
-                    ariaLabel={t("DashboardHeliusRings.composer.asset")}
-                    value={assetMint}
-                    onValueChange={(value) => {
-                      if (value) setAssetMint(value);
-                    }}
-                  >
-                    {RINGS_ALLOWLISTED_ASSETS.map((entry) => (
-                      <SelectItem key={entry.mint} value={entry.mint}>
-                        {entry.symbol}
-                      </SelectItem>
-                    ))}
-                  </Select>
-                </div>
-                <div className="flex min-w-48 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.amount")}
-                  </span>
-                  <Input
-                    inputMode="numeric"
-                    value={amountRaw}
-                    placeholder="1000000"
-                    onChange={(event) => setAmountRaw(event.target.value.replace(/\D/g, ""))}
-                  />
-                </div>
-              </div>
-            ) : null}
-
-            {needsRecipient ? (
-              <div className="flex flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {isAnonymous
-                    ? t("DashboardHeliusRings.composer.recipientAnonymous")
-                    : t("DashboardHeliusRings.composer.recipient")}
-                </span>
-                <Input
-                  value={recipient}
-                  placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
-                  onChange={(event) => setRecipient(event.target.value)}
-                />
-              </div>
-            ) : null}
-
-            {isMerge && zones.length > 0 ? (
-              <div className="flex min-w-52 flex-col gap-1.5">
-                <span className="text-sm font-medium text-primary">
-                  {t("DashboardHeliusRings.composer.zone")}
-                </span>
-                <Select
-                  ariaLabel={t("DashboardHeliusRings.composer.zone")}
-                  value={zoneId}
-                  onValueChange={setZoneId}
-                  placeholder={t("DashboardHeliusRings.composer.zonePlaceholder")}
-                >
-                  {zones.map((zone) => (
-                    <SelectItem key={zone.id} value={zone.id}>
-                      {zone.name}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </div>
-            ) : null}
-
-            {isTimelock ? (
-              <div className="flex flex-wrap gap-3">
-                <div className="flex min-w-52 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.unlockAt")}
-                  </span>
-                  <Input
-                    type="datetime-local"
-                    value={unlockAt}
-                    onChange={(event) => setUnlockAt(event.target.value)}
-                  />
-                </div>
-                <div className="flex min-w-52 flex-col gap-1.5">
-                  <span className="text-sm font-medium text-primary">
-                    {t("DashboardHeliusRings.composer.beneficiary")}
-                  </span>
-                  <Input
-                    value={beneficiary}
-                    placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
-                    onChange={(event) => setBeneficiary(event.target.value)}
-                  />
-                </div>
-              </div>
-            ) : null}
-
-            <div>
-              <Button disabled={!composeComplete} onClick={() => setStep("review")}>
-                {t("DashboardHeliusRings.composer.review")}
-              </Button>
-            </div>
-          </>
+          <ComposeStep
+            draft={draft}
+            wallets={wallets}
+            zones={zones}
+            onPatch={patchDraft}
+            onReview={() => setStep("review")}
+          />
         ) : null}
-
         {step === "review" ? (
-          <>
-            <dl className="flex flex-col gap-2">
-              {summaryRows.map(([label, value]) => (
-                <div key={label} className="flex items-baseline justify-between gap-4">
-                  <dt className="text-sm text-secondary">{label}</dt>
-                  <dd className="text-sm text-primary">{value}</dd>
-                </div>
-              ))}
-            </dl>
-
-            {isAnonymous ? (
-              <Callout variant="warning">
-                <label className="flex items-start gap-2">
-                  <input
-                    type="checkbox"
-                    className="mt-0.5"
-                    checked={anonymousAcknowledged}
-                    onChange={(event) => setAnonymousAcknowledged(event.target.checked)}
-                  />
-                  <span>{t("DashboardHeliusRings.composer.anonymousWarning")}</span>
-                </label>
-              </Callout>
-            ) : null}
-
-            {error ? <Callout variant="danger">{error}</Callout> : null}
-
-            <div className="flex gap-2">
-              <Button variant="secondary" onClick={() => setStep("compose")}>
-                {t("DashboardHeliusRings.composer.back")}
-              </Button>
-              <Button
-                disabled={submitting || (isAnonymous && !anonymousAcknowledged)}
-                onClick={() => void handleConfirm()}
-              >
-                {submitting
-                  ? t("DashboardHeliusRings.composer.preparing")
-                  : t("DashboardHeliusRings.composer.confirm")}
-              </Button>
-            </div>
-          </>
+          <ReviewStep
+            rows={summaryRows}
+            isAnonymous={draft.opType === "transfer_anonymous"}
+            acknowledged={anonymousAcknowledged}
+            onAcknowledge={setAnonymousAcknowledged}
+            error={error}
+            submitting={submitting}
+            onBack={() => setStep("compose")}
+            onConfirm={() => void handleConfirm()}
+          />
         ) : null}
-
-        {step === "result" && result ? (
-          <>
-            <div className="flex items-center gap-2">
-              <Badge variant={result.state === "failed" ? "danger" : "default"}>
-                {t(`DashboardHeliusRings.activity.state_${result.state}`)}
-              </Badge>
-              {result.failure ? (
-                <span className="text-sm text-secondary">
-                  {result.failure.code === "gateway_unavailable"
-                    ? t("DashboardHeliusRings.errors.gatewayUnavailable")
-                    : result.failure.message}
-                </span>
-              ) : null}
-            </div>
-            <div>
-              <Button variant="secondary" onClick={reset}>
-                {t("DashboardHeliusRings.composer.newOperation")}
-              </Button>
-            </div>
-          </>
-        ) : null}
+        {step === "result" && result ? <ResultStep result={result} onReset={reset} /> : null}
       </CardContent>
     </Card>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex min-w-48 flex-col gap-1.5">
+      <span className="text-sm font-medium text-primary">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function ComposeStep({
+  draft,
+  wallets,
+  zones,
+  onPatch,
+  onReview,
+}: {
+  draft: ComposerDraft;
+  wallets: RingsWallet[];
+  zones: RingsZone[];
+  onPatch: (patch: Partial<ComposerDraft>) => void;
+  onReview: () => void;
+}) {
+  const t = useTranslations();
+  const needsAsset = NEEDS_ASSET.has(draft.opType);
+  const needsRecipient = NEEDS_RECIPIENT.has(draft.opType);
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3">
+        <Field label={t("DashboardHeliusRings.composer.wallet")}>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.wallet")}
+            value={draft.walletId}
+            onValueChange={(walletId) => onPatch({ walletId })}
+            placeholder={t("DashboardHeliusRings.composer.walletPlaceholder")}
+          >
+            {wallets.map((wallet) => (
+              <SelectItem key={wallet.id} value={wallet.id}>
+                {wallet.name}
+              </SelectItem>
+            ))}
+          </Select>
+        </Field>
+        <Field label={t("DashboardHeliusRings.composer.operation")}>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.operation")}
+            value={draft.opType}
+            onValueChange={(value) => {
+              if (value) onPatch({ opType: value as RingsOpType });
+            }}
+          >
+            {OP_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {t(`DashboardHeliusRings.activity.opType_${type}`)}
+              </SelectItem>
+            ))}
+          </Select>
+        </Field>
+      </div>
+
+      {needsAsset ? (
+        <div className="flex flex-wrap gap-3">
+          <Field label={t("DashboardHeliusRings.composer.asset")}>
+            <Select
+              ariaLabel={t("DashboardHeliusRings.composer.asset")}
+              value={draft.assetMint}
+              onValueChange={(value) => {
+                if (value) onPatch({ assetMint: value });
+              }}
+            >
+              {RINGS_ALLOWLISTED_ASSETS.map((entry) => (
+                <SelectItem key={entry.mint} value={entry.mint}>
+                  {entry.symbol}
+                </SelectItem>
+              ))}
+            </Select>
+          </Field>
+          <Field label={t("DashboardHeliusRings.composer.amount")}>
+            <Input
+              inputMode="numeric"
+              value={draft.amountRaw}
+              placeholder="1000000"
+              onChange={(event) => onPatch({ amountRaw: event.target.value.replace(/\D/g, "") })}
+            />
+          </Field>
+        </div>
+      ) : null}
+
+      {needsRecipient ? (
+        <Field
+          label={
+            draft.opType === "transfer_anonymous"
+              ? t("DashboardHeliusRings.composer.recipientAnonymous")
+              : t("DashboardHeliusRings.composer.recipient")
+          }
+        >
+          <Input
+            value={draft.recipient}
+            placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+            onChange={(event) => onPatch({ recipient: event.target.value })}
+          />
+        </Field>
+      ) : null}
+
+      {draft.opType === "merge" && zones.length > 0 ? (
+        <Field label={t("DashboardHeliusRings.composer.zone")}>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.zone")}
+            value={draft.zoneId}
+            onValueChange={(zoneId) => onPatch({ zoneId })}
+            placeholder={t("DashboardHeliusRings.composer.zonePlaceholder")}
+          >
+            {zones.map((zone) => (
+              <SelectItem key={zone.id} value={zone.id}>
+                {zone.name}
+              </SelectItem>
+            ))}
+          </Select>
+        </Field>
+      ) : null}
+
+      {draft.opType === "timelock_create" ? (
+        <div className="flex flex-wrap gap-3">
+          <Field label={t("DashboardHeliusRings.composer.unlockAt")}>
+            <Input
+              type="datetime-local"
+              value={draft.unlockAt}
+              onChange={(event) => onPatch({ unlockAt: event.target.value })}
+            />
+          </Field>
+          <Field label={t("DashboardHeliusRings.composer.beneficiary")}>
+            <Input
+              value={draft.beneficiary}
+              placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+              onChange={(event) => onPatch({ beneficiary: event.target.value })}
+            />
+          </Field>
+        </div>
+      ) : null}
+
+      <div>
+        <Button disabled={!isDraftComplete(draft)} onClick={onReview}>
+          {t("DashboardHeliusRings.composer.review")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function ReviewStep({
+  rows,
+  isAnonymous,
+  acknowledged,
+  onAcknowledge,
+  error,
+  submitting,
+  onBack,
+  onConfirm,
+}: {
+  rows: Array<[string, string]>;
+  isAnonymous: boolean;
+  acknowledged: boolean;
+  onAcknowledge: (acknowledged: boolean) => void;
+  error: string | null;
+  submitting: boolean;
+  onBack: () => void;
+  onConfirm: () => void;
+}) {
+  const t = useTranslations();
+  return (
+    <>
+      <dl className="flex flex-col gap-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="flex items-baseline justify-between gap-4">
+            <dt className="text-sm text-secondary">{label}</dt>
+            <dd className="text-sm text-primary">{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {isAnonymous ? (
+        <Callout variant="warning">
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={acknowledged}
+              onChange={(event) => onAcknowledge(event.target.checked)}
+            />
+            <span>{t("DashboardHeliusRings.composer.anonymousWarning")}</span>
+          </label>
+        </Callout>
+      ) : null}
+
+      {error ? <Callout variant="danger">{error}</Callout> : null}
+
+      <div className="flex gap-2">
+        <Button variant="secondary" onClick={onBack}>
+          {t("DashboardHeliusRings.composer.back")}
+        </Button>
+        <Button disabled={submitting || (isAnonymous && !acknowledged)} onClick={onConfirm}>
+          {submitting
+            ? t("DashboardHeliusRings.composer.preparing")
+            : t("DashboardHeliusRings.composer.confirm")}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function ResultStep({ result, onReset }: { result: RingsOperationDetail; onReset: () => void }) {
+  const t = useTranslations();
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Badge variant={result.state === "failed" ? "danger" : "default"}>
+          {t(`DashboardHeliusRings.activity.state_${result.state}`)}
+        </Badge>
+        {result.failure ? (
+          <span className="text-sm text-secondary">
+            {result.failure.code === "gateway_unavailable"
+              ? t("DashboardHeliusRings.errors.gatewayUnavailable")
+              : result.failure.message}
+          </span>
+        ) : null}
+      </div>
+      <div>
+        <Button variant="secondary" onClick={onReset}>
+          {t("DashboardHeliusRings.composer.newOperation")}
+        </Button>
+      </div>
+    </>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectItem } from "@/components/ui/select";
+import { useTranslations } from "@/i18n/provider";
+import {
+  prepareRingsOperation,
+  RINGS_ALLOWLISTED_ASSETS,
+  type RingsOperationDetail,
+  type RingsOpType,
+  type RingsWallet,
+  type RingsZone,
+} from "./helius-rings.data";
+
+const OP_TYPES: RingsOpType[] = [
+  "shield",
+  "transfer_registered",
+  "transfer_anonymous",
+  "withdraw",
+  "merge",
+  "timelock_create",
+];
+
+const NEEDS_ASSET: ReadonlySet<RingsOpType> = new Set([
+  "shield",
+  "transfer_registered",
+  "transfer_anonymous",
+  "withdraw",
+]);
+const NEEDS_RECIPIENT: ReadonlySet<RingsOpType> = new Set([
+  "transfer_registered",
+  "transfer_anonymous",
+  "withdraw",
+]);
+
+type Step = "compose" | "review" | "result";
+
+/**
+ * One composer for every shielded operation kind. A `review` step sits between
+ * the form and the POST; anonymous transfers additionally require an explicit
+ * acknowledgement on that step before Confirm unlocks.
+ */
+export function OperationComposer({
+  wallets,
+  zones,
+  onPrepared,
+}: {
+  wallets: RingsWallet[];
+  zones: RingsZone[];
+  onPrepared: () => Promise<void>;
+}) {
+  const t = useTranslations();
+
+  const [step, setStep] = useState<Step>("compose");
+  const [walletId, setWalletId] = useState<string | null>(null);
+  const [opType, setOpType] = useState<RingsOpType>("shield");
+  const [assetMint, setAssetMint] = useState<string>(RINGS_ALLOWLISTED_ASSETS[0].mint);
+  const [amountRaw, setAmountRaw] = useState("");
+  const [recipient, setRecipient] = useState("");
+  const [zoneId, setZoneId] = useState<string | null>(null);
+  const [unlockAt, setUnlockAt] = useState("");
+  const [beneficiary, setBeneficiary] = useState("");
+  const [anonymousAcknowledged, setAnonymousAcknowledged] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<RingsOperationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const needsAsset = NEEDS_ASSET.has(opType);
+  const needsRecipient = NEEDS_RECIPIENT.has(opType);
+  const isTimelock = opType === "timelock_create";
+  const isAnonymous = opType === "transfer_anonymous";
+  const isMerge = opType === "merge";
+
+  const asset = useMemo(
+    () => RINGS_ALLOWLISTED_ASSETS.find((entry) => entry.mint === assetMint),
+    [assetMint]
+  );
+
+  const composeComplete =
+    walletId !== null &&
+    (!needsAsset || /^\d+$/.test(amountRaw)) &&
+    (!needsRecipient || recipient.trim().length > 0) &&
+    (!isTimelock || (unlockAt.length > 0 && beneficiary.trim().length > 0));
+
+  const reset = useCallback(() => {
+    setStep("compose");
+    setAmountRaw("");
+    setRecipient("");
+    setUnlockAt("");
+    setBeneficiary("");
+    setZoneId(null);
+    setAnonymousAcknowledged(false);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!walletId) return;
+    setSubmitting(true);
+    setError(null);
+    const prepared = await prepareRingsOperation({
+      walletId,
+      opType,
+      asset: needsAsset && asset ? { mint: asset.mint, amountRaw } : undefined,
+      to: needsRecipient ? recipient.trim() : undefined,
+      zoneId: isMerge && zoneId ? zoneId : undefined,
+      transferMode: isAnonymous
+        ? "anonymous"
+        : opType === "transfer_registered"
+          ? "registered"
+          : undefined,
+      timelock: isTimelock
+        ? { unlockAt: new Date(unlockAt).toISOString(), beneficiary: beneficiary.trim() }
+        : undefined,
+    });
+    setSubmitting(false);
+    if (prepared.error || !prepared.operation) {
+      setError(prepared.error ?? t("DashboardHeliusRings.composer.prepareFailed"));
+      return;
+    }
+    setResult(prepared.operation);
+    setStep("result");
+    await onPrepared();
+  }, [
+    walletId,
+    opType,
+    needsAsset,
+    asset,
+    amountRaw,
+    needsRecipient,
+    recipient,
+    isMerge,
+    zoneId,
+    isAnonymous,
+    isTimelock,
+    unlockAt,
+    beneficiary,
+    onPrepared,
+    t,
+  ]);
+
+  const summaryRows: Array<[string, string]> = [
+    [
+      t("DashboardHeliusRings.composer.summaryWallet"),
+      wallets.find((wallet) => wallet.id === walletId)?.name ?? "—",
+    ],
+    [
+      t("DashboardHeliusRings.composer.summaryOperation"),
+      t(`DashboardHeliusRings.activity.opType_${opType}`),
+    ],
+    ...(needsAsset
+      ? ([
+          [
+            t("DashboardHeliusRings.composer.summaryAmount"),
+            `${amountRaw} (${asset?.symbol ?? "?"} ${t("DashboardHeliusRings.composer.baseUnits")})`,
+          ],
+        ] as Array<[string, string]>)
+      : []),
+    ...(needsRecipient
+      ? ([[t("DashboardHeliusRings.composer.summaryRecipient"), recipient]] as Array<
+          [string, string]
+        >)
+      : []),
+    ...(isMerge && zoneId
+      ? ([
+          [
+            t("DashboardHeliusRings.composer.summaryZone"),
+            zones.find((zone) => zone.id === zoneId)?.name ?? zoneId,
+          ],
+        ] as Array<[string, string]>)
+      : []),
+    ...(isTimelock
+      ? ([
+          [t("DashboardHeliusRings.composer.summaryUnlockAt"), unlockAt],
+          [t("DashboardHeliusRings.composer.summaryBeneficiary"), beneficiary],
+        ] as Array<[string, string]>)
+      : []),
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("DashboardHeliusRings.composer.title")}</CardTitle>
+        <CardDescription>{t("DashboardHeliusRings.composer.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {step === "compose" ? (
+          <>
+            <div className="flex flex-wrap gap-3">
+              <div className="flex min-w-52 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.composer.wallet")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.composer.wallet")}
+                  value={walletId}
+                  onValueChange={setWalletId}
+                  placeholder={t("DashboardHeliusRings.composer.walletPlaceholder")}
+                >
+                  {wallets.map((wallet) => (
+                    <SelectItem key={wallet.id} value={wallet.id}>
+                      {wallet.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+              <div className="flex min-w-52 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.composer.operation")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.composer.operation")}
+                  value={opType}
+                  onValueChange={(value) => {
+                    if (value) setOpType(value as RingsOpType);
+                  }}
+                >
+                  {OP_TYPES.map((type) => (
+                    <SelectItem key={type} value={type}>
+                      {t(`DashboardHeliusRings.activity.opType_${type}`)}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+            </div>
+
+            {needsAsset ? (
+              <div className="flex flex-wrap gap-3">
+                <div className="flex min-w-40 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.asset")}
+                  </span>
+                  <Select
+                    ariaLabel={t("DashboardHeliusRings.composer.asset")}
+                    value={assetMint}
+                    onValueChange={(value) => {
+                      if (value) setAssetMint(value);
+                    }}
+                  >
+                    {RINGS_ALLOWLISTED_ASSETS.map((entry) => (
+                      <SelectItem key={entry.mint} value={entry.mint}>
+                        {entry.symbol}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                </div>
+                <div className="flex min-w-48 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.amount")}
+                  </span>
+                  <Input
+                    inputMode="numeric"
+                    value={amountRaw}
+                    placeholder="1000000"
+                    onChange={(event) => setAmountRaw(event.target.value.replace(/\D/g, ""))}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            {needsRecipient ? (
+              <div className="flex flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {isAnonymous
+                    ? t("DashboardHeliusRings.composer.recipientAnonymous")
+                    : t("DashboardHeliusRings.composer.recipient")}
+                </span>
+                <Input
+                  value={recipient}
+                  placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+                  onChange={(event) => setRecipient(event.target.value)}
+                />
+              </div>
+            ) : null}
+
+            {isMerge && zones.length > 0 ? (
+              <div className="flex min-w-52 flex-col gap-1.5">
+                <span className="text-sm font-medium text-primary">
+                  {t("DashboardHeliusRings.composer.zone")}
+                </span>
+                <Select
+                  ariaLabel={t("DashboardHeliusRings.composer.zone")}
+                  value={zoneId}
+                  onValueChange={setZoneId}
+                  placeholder={t("DashboardHeliusRings.composer.zonePlaceholder")}
+                >
+                  {zones.map((zone) => (
+                    <SelectItem key={zone.id} value={zone.id}>
+                      {zone.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </div>
+            ) : null}
+
+            {isTimelock ? (
+              <div className="flex flex-wrap gap-3">
+                <div className="flex min-w-52 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.unlockAt")}
+                  </span>
+                  <Input
+                    type="datetime-local"
+                    value={unlockAt}
+                    onChange={(event) => setUnlockAt(event.target.value)}
+                  />
+                </div>
+                <div className="flex min-w-52 flex-col gap-1.5">
+                  <span className="text-sm font-medium text-primary">
+                    {t("DashboardHeliusRings.composer.beneficiary")}
+                  </span>
+                  <Input
+                    value={beneficiary}
+                    placeholder={t("DashboardHeliusRings.composer.recipientPlaceholder")}
+                    onChange={(event) => setBeneficiary(event.target.value)}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            <div>
+              <Button disabled={!composeComplete} onClick={() => setStep("review")}>
+                {t("DashboardHeliusRings.composer.review")}
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {step === "review" ? (
+          <>
+            <dl className="flex flex-col gap-2">
+              {summaryRows.map(([label, value]) => (
+                <div key={label} className="flex items-baseline justify-between gap-4">
+                  <dt className="text-sm text-secondary">{label}</dt>
+                  <dd className="text-sm text-primary">{value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            {isAnonymous ? (
+              <Callout variant="warning">
+                <label className="flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={anonymousAcknowledged}
+                    onChange={(event) => setAnonymousAcknowledged(event.target.checked)}
+                  />
+                  <span>{t("DashboardHeliusRings.composer.anonymousWarning")}</span>
+                </label>
+              </Callout>
+            ) : null}
+
+            {error ? <Callout variant="danger">{error}</Callout> : null}
+
+            <div className="flex gap-2">
+              <Button variant="secondary" onClick={() => setStep("compose")}>
+                {t("DashboardHeliusRings.composer.back")}
+              </Button>
+              <Button
+                disabled={submitting || (isAnonymous && !anonymousAcknowledged)}
+                onClick={() => void handleConfirm()}
+              >
+                {submitting
+                  ? t("DashboardHeliusRings.composer.preparing")
+                  : t("DashboardHeliusRings.composer.confirm")}
+              </Button>
+            </div>
+          </>
+        ) : null}
+
+        {step === "result" && result ? (
+          <>
+            <div className="flex items-center gap-2">
+              <Badge variant={result.state === "failed" ? "danger" : "default"}>
+                {t(`DashboardHeliusRings.activity.state_${result.state}`)}
+              </Badge>
+              {result.failure ? (
+                <span className="text-sm text-secondary">
+                  {result.failure.code === "gateway_unavailable"
+                    ? t("DashboardHeliusRings.errors.gatewayUnavailable")
+                    : result.failure.message}
+                </span>
+              ) : null}
+            </div>
+            <div>
+              <Button variant="secondary" onClick={reset}>
+                {t("DashboardHeliusRings.composer.newOperation")}
+              </Button>
+            </div>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/zones-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/zones-card.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectItem } from "@/components/ui/select";
+import { useTranslations } from "@/i18n/provider";
+import {
+  createRingsZone,
+  fetchRingsZones,
+  type RingsWallet,
+  type RingsZone,
+} from "./helius-rings.data";
+
+/**
+ * Zone management for one wallet. Zones are SDP-owned metadata, so this card
+ * is fully functional today — no gateway involved.
+ */
+export function ZonesCard({
+  wallets,
+  onZonesChanged,
+}: {
+  wallets: RingsWallet[];
+  onZonesChanged: (zones: RingsZone[]) => void;
+}) {
+  const t = useTranslations();
+
+  const [walletId, setWalletId] = useState<string | null>(wallets[0]?.id ?? null);
+  const [zones, setZones] = useState<RingsZone[]>([]);
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<RingsZone["kind"]>("treasury");
+  const [creating, setCreating] = useState(false);
+
+  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
+
+  const refresh = useCallback(async () => {
+    if (!walletId) {
+      setZones([]);
+      onZonesChanged([]);
+      return;
+    }
+    try {
+      const result = await fetchRingsZones(walletId, loadFailedCopy);
+      setZones(result.zones);
+      onZonesChanged(result.zones);
+    } catch {
+      setZones([]);
+      onZonesChanged([]);
+    }
+  }, [walletId, loadFailedCopy, onZonesChanged]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleCreate = useCallback(async () => {
+    if (!walletId || !name.trim()) return;
+    setCreating(true);
+    await createRingsZone({ walletId, name: name.trim(), kind });
+    setCreating(false);
+    setName("");
+    await refresh();
+  }, [walletId, name, kind, refresh]);
+
+  if (wallets.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("DashboardHeliusRings.zones.title")}</CardTitle>
+        <CardDescription>{t("DashboardHeliusRings.zones.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex min-w-52 flex-col gap-1.5">
+          <span className="text-sm font-medium text-primary">
+            {t("DashboardHeliusRings.composer.wallet")}
+          </span>
+          <Select
+            ariaLabel={t("DashboardHeliusRings.composer.wallet")}
+            value={walletId}
+            onValueChange={setWalletId}
+          >
+            {wallets.map((wallet) => (
+              <SelectItem key={wallet.id} value={wallet.id}>
+                {wallet.name}
+              </SelectItem>
+            ))}
+          </Select>
+        </div>
+
+        {zones.length === 0 ? (
+          <p className="text-sm text-secondary">{t("DashboardHeliusRings.zones.empty")}</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {zones.map((zone) => (
+              <li key={zone.id} className="flex items-center gap-2">
+                <span className="text-sm text-primary">{zone.name}</span>
+                <Badge variant="outline">{t(`DashboardHeliusRings.zones.kind_${zone.kind}`)}</Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex min-w-44 flex-col gap-1.5">
+            <span className="text-sm font-medium text-primary">
+              {t("DashboardHeliusRings.zones.nameLabel")}
+            </span>
+            <Input
+              value={name}
+              placeholder={t("DashboardHeliusRings.zones.namePlaceholder")}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </div>
+          <div className="flex min-w-40 flex-col gap-1.5">
+            <span className="text-sm font-medium text-primary">
+              {t("DashboardHeliusRings.zones.kindLabel")}
+            </span>
+            <Select
+              ariaLabel={t("DashboardHeliusRings.zones.kindLabel")}
+              value={kind}
+              onValueChange={(value) => {
+                if (value) setKind(value as RingsZone["kind"]);
+              }}
+            >
+              <SelectItem value="treasury">
+                {t("DashboardHeliusRings.zones.kind_treasury")}
+              </SelectItem>
+              <SelectItem value="public">{t("DashboardHeliusRings.zones.kind_public")}</SelectItem>
+            </Select>
+          </div>
+          <Button disabled={creating || !name.trim()} onClick={() => void handleCreate()}>
+            {t("DashboardHeliusRings.zones.create")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
- One composer for every shielded op kind: shield, send (registered/anonymous), withdraw, merge, timelock — compose → review → confirm
- Anonymous transfers require an explicit acknowledgement on the review step before Confirm unlocks; copy states they are not lower-risk than registered and policy applies identically
- Zone management card (list + create) is fully functional today — zones are SDP-owned metadata, no gateway involved
- Result step shows the operation's landing state honestly (today: `failed — external integration pending`)
- Replaces the interim per-wallet test button
