### PR TITLE
feat(helius): open operations into a detail drawer with the event timeline

### DIFF
--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -107,6 +107,14 @@
       "kind_treasury": "Treasury",
       "kind_public": "Public",
       "create": "Create zone"
+    },
+    "detail": {
+      "title": "Operation detail",
+      "operationId": "Operation",
+      "timeline": "Timeline",
+      "timelineEmpty": "No events recorded.",
+      "retryable": "A retry can succeed.",
+      "notRetryable": "Not retryable."
     }
   }
 }

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -30,6 +30,7 @@ import {
   type RingsZone,
 } from "./helius-rings.data";
 import { OperationComposer } from "./operation-composer";
+import { OperationDetailDrawer } from "./operation-detail-drawer";
 import { ZonesCard } from "./zones-card";
 
 interface CustodyWalletOption {
@@ -75,6 +76,7 @@ export function HeliusRingsWorkspace({
   const [wallets, setWallets] = useState<RingsWallet[]>([]);
   const [operations, setOperations] = useState<RingsOperationSummary[]>([]);
   const [zones, setZones] = useState<RingsZone[]>([]);
+  const [detailOperationId, setDetailOperationId] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const [walletName, setWalletName] = useState("");
@@ -285,7 +287,11 @@ export function HeliusRingsWorkspace({
               </TableHeader>
               <TableBody>
                 {operations.map((operation) => (
-                  <TableRow key={operation.id}>
+                  <TableRow
+                    key={operation.id}
+                    className="cursor-pointer"
+                    onClick={() => setDetailOperationId(operation.id)}
+                  >
                     <TableCell>
                       {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
                     </TableCell>
@@ -303,6 +309,11 @@ export function HeliusRingsWorkspace({
           )}
         </CardContent>
       </Card>
+
+      <OperationDetailDrawer
+        operationId={detailOperationId}
+        onClose={() => setDetailOperationId(null)}
+      />
     </div>
   );
 }

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -50,8 +50,14 @@ export interface RingsOperationSummary {
   createdAt: string;
 }
 
+export interface RingsOperationEvent {
+  kind: string;
+  createdAt: string;
+}
+
 export interface RingsOperationDetail extends RingsOperationSummary {
   failure: { code: string; message: string; retryable: boolean } | null;
+  events: RingsOperationEvent[];
 }
 
 interface Envelope<T> {
@@ -74,6 +80,16 @@ export function fetchRingsHealth(fallbackError: string): Promise<{ health: Rings
 
 export function fetchRingsWallets(fallbackError: string): Promise<{ wallets: RingsWallet[] }> {
   return getJson("/api/dashboard/helius-rings/wallets", fallbackError);
+}
+
+export function fetchRingsOperationDetail(
+  operationId: string,
+  fallbackError: string
+): Promise<{ operation: RingsOperationDetail }> {
+  return getJson(
+    `/api/dashboard/helius-rings/operations/${encodeURIComponent(operationId)}`,
+    fallbackError
+  );
 }
 
 export function fetchRingsOperations(

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Callout } from "@/components/ui/callout";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
@@ -33,6 +33,19 @@ export function OperationDetailDrawer({
       .then((result) => setDetail(result.operation))
       .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : loadFailedCopy));
   }, [operationId, loadFailedCopy]);
+
+  // Content-derived keys: the timeline is append-only, so kind + timestamp
+  // plus an occurrence counter is stable across re-renders without leaning on
+  // the array index.
+  const keyedEvents = useMemo(() => {
+    const seen = new Map<string, number>();
+    return (detail?.events ?? []).map((event) => {
+      const base = `${event.kind}:${event.createdAt}`;
+      const occurrence = (seen.get(base) ?? 0) + 1;
+      seen.set(base, occurrence);
+      return { ...event, key: `${base}:${occurrence}` };
+    });
+  }, [detail]);
 
   return (
     <Drawer open={operationId !== null} onOpenChange={(open) => !open && onClose()}>
@@ -91,11 +104,8 @@ export function OperationDetailDrawer({
                 </p>
               ) : (
                 <ol className="flex flex-col gap-1.5">
-                  {detail.events.map((event, index) => (
-                    <li
-                      key={`${event.kind}-${index}`}
-                      className="flex items-baseline justify-between gap-4"
-                    >
+                  {keyedEvents.map((event) => (
+                    <li key={event.key} className="flex items-baseline justify-between gap-4">
                       <span className="text-sm text-primary">{event.kind}</span>
                       <span className="text-sm text-secondary">
                         {new Date(event.createdAt).toLocaleTimeString()}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-detail-drawer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Callout } from "@/components/ui/callout";
+import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
+import { useTranslations } from "@/i18n/provider";
+import { fetchRingsOperationDetail, type RingsOperationDetail } from "./helius-rings.data";
+
+/**
+ * Operation detail: identity, failure (code + message, verbatim), and the
+ * event timeline oldest-first. Payloads shown here were redacted at write
+ * time, so nothing sensitive can surface however the operation went.
+ */
+export function OperationDetailDrawer({
+  operationId,
+  onClose,
+}: {
+  operationId: string | null;
+  onClose: () => void;
+}) {
+  const t = useTranslations();
+  const [detail, setDetail] = useState<RingsOperationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadFailedCopy = t("DashboardHeliusRings.errors.loadFailed");
+
+  useEffect(() => {
+    setDetail(null);
+    setError(null);
+    if (!operationId) return;
+    fetchRingsOperationDetail(operationId, loadFailedCopy)
+      .then((result) => setDetail(result.operation))
+      .catch((cause: unknown) => setError(cause instanceof Error ? cause.message : loadFailedCopy));
+  }, [operationId, loadFailedCopy]);
+
+  return (
+    <Drawer open={operationId !== null} onOpenChange={(open) => !open && onClose()}>
+      <DrawerContent className="flex w-full max-w-md flex-col gap-4 p-6">
+        <DrawerTitle>{t("DashboardHeliusRings.detail.title")}</DrawerTitle>
+
+        {error ? <Callout variant="danger">{error}</Callout> : null}
+
+        {detail ? (
+          <>
+            <dl className="flex flex-col gap-2">
+              <DetailRow label={t("DashboardHeliusRings.detail.operationId")} value={detail.id} />
+              <DetailRow
+                label={t("DashboardHeliusRings.activity.operation")}
+                value={t(`DashboardHeliusRings.activity.opType_${detail.opType}`)}
+              />
+              <div className="flex items-baseline justify-between gap-4">
+                <dt className="text-sm text-secondary">
+                  {t("DashboardHeliusRings.activity.state")}
+                </dt>
+                <dd>
+                  <Badge variant={detail.state === "failed" ? "danger" : "default"}>
+                    {t(`DashboardHeliusRings.activity.state_${detail.state}`)}
+                  </Badge>
+                </dd>
+              </div>
+              {detail.amountRaw ? (
+                <DetailRow
+                  label={t("DashboardHeliusRings.activity.amount")}
+                  value={detail.amountRaw}
+                />
+              ) : null}
+              <DetailRow
+                label={t("DashboardHeliusRings.activity.created")}
+                value={new Date(detail.createdAt).toLocaleString()}
+              />
+            </dl>
+
+            {detail.failure ? (
+              <Callout variant="danger">
+                <span className="font-medium">{detail.failure.code}</span> —{" "}
+                {detail.failure.message}
+                {detail.failure.retryable
+                  ? ` ${t("DashboardHeliusRings.detail.retryable")}`
+                  : ` ${t("DashboardHeliusRings.detail.notRetryable")}`}
+              </Callout>
+            ) : null}
+
+            <div className="flex flex-col gap-1.5">
+              <span className="text-sm font-medium text-primary">
+                {t("DashboardHeliusRings.detail.timeline")}
+              </span>
+              {detail.events.length === 0 ? (
+                <p className="text-sm text-secondary">
+                  {t("DashboardHeliusRings.detail.timelineEmpty")}
+                </p>
+              ) : (
+                <ol className="flex flex-col gap-1.5">
+                  {detail.events.map((event, index) => (
+                    <li
+                      key={`${event.kind}-${index}`}
+                      className="flex items-baseline justify-between gap-4"
+                    >
+                      <span className="text-sm text-primary">{event.kind}</span>
+                      <span className="text-sm text-secondary">
+                        {new Date(event.createdAt).toLocaleTimeString()}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          </>
+        ) : null}
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <dt className="text-sm text-secondary">{label}</dt>
+      <dd className="break-all text-right text-sm text-primary">{value}</dd>
+    </div>
+  );
+}


### PR DESCRIPTION
- Activity rows open a right-side drawer: operation identity, state badge, verbatim failure code + message with retryability, and the append-only event timeline (oldest first)
- Timeline payloads were redacted at write time, so the panel cannot surface secret material regardless of what the operation carried
