### PR TITLE
feat(helius): verify approvals server-side, cap retry chains, add recovery UI

### DIFF
--- a/apps/sdp-api/src/routes/helius-rings/handlers.ts
+++ b/apps/sdp-api/src/routes/helius-rings/handlers.ts
@@ -20,7 +20,6 @@ import {
 import {
   createRingsWalletSchema,
   createRingsZoneSchema,
-  executeRingsOperationSchema,
   listLimitSchema,
   prepareRingsOperationSchema,
   retryRingsOperationSchema,
@@ -170,28 +169,53 @@ export async function getRingsOperation(c: AppContext) {
   return success(c, { operation });
 }
 
-/** POST /operations/:operationId/execute — advance a waiting operation. */
+/**
+ * POST /operations/:operationId/execute — advance a waiting operation. The
+ * approval verdict is read server-side from the approval request; the request
+ * carries no body worth trusting.
+ */
 export async function executeRingsOperation(c: AppContext) {
-  const parsed = executeRingsOperationSchema.safeParse(await c.req.json().catch(() => ({})));
-  if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
-
   const { tenant } = tenantOf(c);
   const service = getHeliusRingsService(c, tenant);
   const operation = await withRingsErrors(() =>
-    service.executeOperation(requireParam(c, "operationId"), parsed.data)
+    service.executeOperation(requireParam(c, "operationId"))
   );
   return success(c, { operation });
 }
 
-/** POST /operations/:operationId/retry — file a linked retry of a failed op. */
+/**
+ * POST /operations/:operationId/retry — file a linked retry of a failed op.
+ * The retry runs the full prepare-through-policy path, so it re-earns its
+ * policy verdict under the current caller's context.
+ */
 export async function retryRingsOperation(c: AppContext) {
   const parsed = retryRingsOperationSchema.safeParse(await c.req.json());
   if (!parsed.success) throw badRequest(parsed.error.issues[0]?.message ?? "invalid body");
 
-  const { tenant } = tenantOf(c);
+  const { auth, tenant } = tenantOf(c);
+  const failedId = requireParam(c, "operationId");
+  const failed = await getHeliusRingsOperationRepository(c).getOperationById({
+    ...tenant,
+    id: failedId,
+  });
+  if (!failed) throw notFound("rings operation");
+
+  const ringsWallet = await getHeliusRingsWalletRepository(c).getWalletById({
+    ...tenant,
+    id: failed.wallet_id,
+  });
+  const scope = await resolveScope(c);
+  const custodyWallet = ringsWallet
+    ? scope.wallets.find((entry) => entry.walletId === ringsWallet.sdp_wallet_id)
+    : undefined;
+
   const service = getHeliusRingsService(c, tenant);
   const operation = await withRingsErrors(() =>
-    service.retryOperation(requireParam(c, "operationId"), parsed.data.clientNonce)
+    service.retryOperation(failedId, parsed.data.clientNonce, {
+      apiKeyId: auth.apiKeyId,
+      actor: walletOperationActorFromAuth(auth),
+      custodyWalletId: custodyWallet?.id ?? null,
+    })
   );
   return success(c, { operation }, 201);
 }

--- a/apps/sdp-api/src/routes/helius-rings/schemas.ts
+++ b/apps/sdp-api/src/routes/helius-rings/schemas.ts
@@ -30,10 +30,6 @@ export const prepareRingsOperationSchema = z.object({
   clientNonce: z.string().min(1).max(128),
 });
 
-export const executeRingsOperationSchema = z.object({
-  approvalStatus: z.enum(["approved", "rejected", "pending"]).optional(),
-});
-
 export const retryRingsOperationSchema = z.object({
   clientNonce: z.string().min(1).max(128),
 });

--- a/apps/sdp-api/src/services/helius-rings/service.test.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.test.ts
@@ -206,12 +206,14 @@ describe("HeliusRingsService", () => {
   });
 
   describe("executeOperation", () => {
-    it("advances an approved operation and is inert while approval is pending", async () => {
+    it("advances only once the stored approval reads approved", async () => {
+      let approvalStatus: "pending" | "approved" = "pending";
       const svc = liveishService({
         enforcePolicy: policyStub("approval_required", {
           requiresApproval: true,
           approvalRequestId: "apr_1",
         }),
+        getApprovalStatus: async () => approvalStatus,
       });
       const paused = await svc.prepareOperation(
         operationInput({ clientNonce: "nonce-exec" }),
@@ -219,10 +221,13 @@ describe("HeliusRingsService", () => {
       );
       expect(paused.state).toBe("approval_required");
 
-      const stillPaused = await svc.executeOperation(paused.id, { approvalStatus: "pending" });
+      // The verdict comes from the approval request, never the caller: while
+      // it reads pending, execute is inert no matter how often it is called.
+      const stillPaused = await svc.executeOperation(paused.id);
       expect(stillPaused.state).toBe("approval_required");
 
-      const advanced = await svc.executeOperation(paused.id, { approvalStatus: "approved" });
+      approvalStatus = "approved";
+      const advanced = await svc.executeOperation(paused.id);
       expect(advanced.state).toBe("indexing");
     });
 
@@ -232,13 +237,14 @@ describe("HeliusRingsService", () => {
           requiresApproval: true,
           approvalRequestId: "apr_1",
         }),
+        getApprovalStatus: async () => "rejected",
       });
       const paused = await svc.prepareOperation(
         operationInput({ clientNonce: "nonce-reject" }),
         actorContext
       );
 
-      const rejected = await svc.executeOperation(paused.id, { approvalStatus: "rejected" });
+      const rejected = await svc.executeOperation(paused.id);
       expect(rejected.state).toBe("failed");
       expect(rejected.failure).toMatchObject({ code: "approval_rejected", retryable: false });
     });
@@ -277,7 +283,7 @@ describe("HeliusRingsService", () => {
       );
       expect(failed.state).toBe("failed");
 
-      const retry = await svc.retryOperation(failed.id, "nonce-retry-2");
+      const retry = await svc.retryOperation(failed.id, "nonce-retry-2", actorContext);
 
       expect(retry.id).not.toBe(failed.id);
       expect(retry.intentKey).not.toBe(failed.intentKey);
@@ -295,8 +301,32 @@ describe("HeliusRingsService", () => {
         actorContext
       );
 
-      await expect(svc.retryOperation(denied.id, "nonce-noretry-2")).rejects.toMatchObject({
+      await expect(
+        svc.retryOperation(denied.id, "nonce-noretry-2", actorContext)
+      ).rejects.toMatchObject({
         code: "CONFLICT",
+      });
+    });
+
+    it("caps the retry lineage depth", async () => {
+      const svc = service();
+      let current = await svc.prepareOperation(
+        operationInput({ clientNonce: "nonce-depth-0" }),
+        actorContext
+      );
+      expect(current.state).toBe("failed");
+
+      // Depth 1 is the original; four retries reach the cap of five.
+      for (let attempt = 1; attempt < 5; attempt++) {
+        current = await svc.retryOperation(current.id, `nonce-depth-${attempt}`, actorContext);
+        expect(current.state).toBe("failed");
+      }
+
+      await expect(
+        svc.retryOperation(current.id, "nonce-depth-5", actorContext)
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        message: expect.stringContaining("retry limit"),
       });
     });
 
@@ -308,7 +338,7 @@ describe("HeliusRingsService", () => {
       );
       expect(inFlight.state).toBe("indexing");
 
-      await expect(svc.retryOperation(inFlight.id, "again")).rejects.toMatchObject({
+      await expect(svc.retryOperation(inFlight.id, "again", actorContext)).rejects.toMatchObject({
         code: "CONFLICT",
       });
     });

--- a/apps/sdp-api/src/services/helius-rings/service.ts
+++ b/apps/sdp-api/src/services/helius-rings/service.ts
@@ -15,12 +15,13 @@ import {
   type RingsGatewayPort,
 } from "@sdp/helius-rings";
 import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
-import type { WalletOperationActor } from "@sdp/types";
+import type { ApprovalRequestStatus, WalletOperationActor } from "@sdp/types";
 import {
   createHeliusRingsEventRepository,
   createHeliusRingsHealthRepository,
   createHeliusRingsOperationRepository,
   createHeliusRingsWalletRepository,
+  createPolicyRepository,
   type HeliusRingsEventRepository,
   type HeliusRingsHealthRepository,
   type HeliusRingsOperationRepository,
@@ -69,8 +70,16 @@ export interface HeliusRingsServiceDependencies {
   enforcePolicy?: typeof enforceWalletOperationPolicy;
   signOuterTransaction?: typeof signRingsOuterTransaction;
   submitOuterTransaction?: typeof submitRingsOuterTransaction;
+  /** Reads the approval verdict; defaults to the policy repository. */
+  getApprovalStatus?: (approvalRequestId: string) => Promise<ApprovalRequestStatus | null>;
   now?: () => string;
 }
+
+/**
+ * How deep a retry chain may grow. Retrying the same failure past this depth
+ * is churn, not recovery, and the operator should look at the failure code.
+ */
+export const RINGS_MAX_RETRY_DEPTH = 5;
 
 export interface ProvisionPrivateWalletInput {
   sdpWalletId: string;
@@ -104,6 +113,9 @@ export class HeliusRingsService {
   private readonly enforcePolicy: typeof enforceWalletOperationPolicy;
   private readonly signOuterTransaction: typeof signRingsOuterTransaction;
   private readonly submitOuterTransaction: typeof submitRingsOuterTransaction;
+  private readonly getApprovalStatus: (
+    approvalRequestId: string
+  ) => Promise<ApprovalRequestStatus | null>;
   private readonly now: () => string;
 
   constructor(
@@ -125,6 +137,20 @@ export class HeliusRingsService {
     this.signOuterTransaction = dependencies.signOuterTransaction ?? signRingsOuterTransaction;
     this.submitOuterTransaction =
       dependencies.submitOuterTransaction ?? submitRingsOuterTransaction;
+    this.getApprovalStatus =
+      dependencies.getApprovalStatus ??
+      (async (approvalRequestId) => {
+        const scope = createTenantScope({
+          organizationId: tenant.organizationId,
+          projectId: tenant.projectId,
+        });
+        const detail = await createPolicyRepository(env, scope).getApprovalRequestDetail({
+          organizationId: tenant.organizationId,
+          projectId: tenant.projectId,
+          approvalRequestId,
+        });
+        return detail?.approval_status ?? null;
+      });
     this.now = dependencies.now ?? (() => new Date().toISOString());
   }
 
@@ -177,7 +203,8 @@ export class HeliusRingsService {
    */
   async prepareOperation(
     input: PrivateOperationInput,
-    context: PrepareOperationContext
+    context: PrepareOperationContext,
+    retryOfOperationId: string | null = null
   ): Promise<PrivateOperation> {
     const wallet = await this.requireWallet(input.walletId);
     const intentKey = computeIntentKey(input);
@@ -193,6 +220,7 @@ export class HeliusRingsService {
       toAddr: input.to ?? null,
       zoneId: input.zoneId ?? null,
       transferMode: input.transferMode ?? null,
+      retryOfOperationId,
       timelock: input.timelock
         ? { unlockAt: input.timelock.unlockAt, beneficiaryAddr: input.timelock.beneficiary }
         : null,
@@ -201,7 +229,11 @@ export class HeliusRingsService {
       return this.toPrivateOperation(operation);
     }
 
-    await this.events.append({ operationId: operation.id, kind: "operation.created" });
+    await this.events.append({
+      operationId: operation.id,
+      kind: retryOfOperationId ? "operation.retried" : "operation.created",
+      payload: retryOfOperationId ? { retryOfOperationId } : undefined,
+    });
     const preparing = await this.transition(operation.id, "draft", undefined);
     if (!preparing) return this.toPrivateOperation(await this.requireOperation(operation.id));
 
@@ -278,21 +310,29 @@ export class HeliusRingsService {
    * per state: an approval still pending or a signature not yet indexed leaves
    * the row untouched.
    */
-  async executeOperation(
-    operationId: string,
-    options: { approvalStatus?: "approved" | "rejected" | "pending" } = {}
-  ): Promise<PrivateOperation> {
+  async executeOperation(operationId: string): Promise<PrivateOperation> {
     const operation = await this.requireOperation(operationId);
     if (!EXECUTABLE_STATES.has(operation.state)) {
       return this.toPrivateOperation(operation);
     }
 
     if (operation.state === "approval_required") {
-      const status = options.approvalStatus ?? "pending";
-      if (status === "rejected") {
+      // The approval verdict is read from the approval request itself — never
+      // from the caller. Trusting the request body here would let anyone with
+      // write access skip a reviewer.
+      if (!operation.approval_request_id) {
+        const failed = await this.fail(operation.id, "approval_required", {
+          code: "invalid_input",
+          message: "approval_required without an approval request",
+          retryable: false,
+        });
+        return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
+      }
+      const status = await this.getApprovalStatus(operation.approval_request_id);
+      if (status === "rejected" || status === "canceled" || status === "expired") {
         const failed = await this.fail(operation.id, "approval_required", {
           code: "approval_rejected",
-          message: "approval request was rejected",
+          message: `approval request was ${status}`,
           retryable: false,
         });
         return this.toPrivateOperation(failed ?? (await this.requireOperation(operation.id)));
@@ -335,11 +375,16 @@ export class HeliusRingsService {
   }
 
   /**
-   * Files a fresh operation linked to a failed, retryable one. The retry gets
-   * its own intent key (new client nonce), so the original row stays exactly
-   * as it failed — the lineage is audit evidence.
+   * Files a fresh operation linked to a failed, retryable one and runs it
+   * through the same prepare-through-policy path — a retry re-earns its policy
+   * verdict, never inherits one. The original row stays exactly as it failed;
+   * the lineage is audit evidence, capped at RINGS_MAX_RETRY_DEPTH.
    */
-  async retryOperation(operationId: string, clientNonce: string): Promise<PrivateOperation> {
+  async retryOperation(
+    operationId: string,
+    clientNonce: string,
+    context: PrepareOperationContext
+  ): Promise<PrivateOperation> {
     const failed = await this.requireOperation(operationId);
     if (failed.state !== "failed") {
       throw new AppError("CONFLICT", "only a failed operation can be retried");
@@ -347,6 +392,7 @@ export class HeliusRingsService {
     if (!failed.retryable) {
       throw new AppError("CONFLICT", "operation failure is not retryable");
     }
+    await this.assertRetryDepth(failed);
 
     const timelock = failed.timelock_unlock_at
       ? await this.operations.getTimelock({ operationId: failed.id })
@@ -369,31 +415,7 @@ export class HeliusRingsService {
       clientNonce,
     };
 
-    const intentKey = computeIntentKey(input);
-    const { operation, reserved } = await this.operations.reserveIntent({
-      ...this.tenant,
-      walletId: failed.wallet_id,
-      opType: failed.op_type,
-      intentKey,
-      assetMint: failed.asset_mint,
-      amountRaw: failed.amount_raw,
-      fromAddr: failed.from_addr,
-      toAddr: failed.to_addr,
-      zoneId: failed.zone_id,
-      transferMode: failed.transfer_mode,
-      retryOfOperationId: failed.id,
-      timelock: timelock
-        ? { unlockAt: timelock.unlock_at, beneficiaryAddr: timelock.beneficiary_addr }
-        : null,
-    });
-    if (reserved) {
-      await this.events.append({
-        operationId: operation.id,
-        kind: "operation.retried",
-        payload: { retryOfOperationId: failed.id },
-      });
-    }
-    return this.toPrivateOperation(operation);
+    return this.prepareOperation(input, context, failed.id);
   }
 
   async getOperation(operationId: string): Promise<PrivateOperation> {
@@ -559,6 +581,31 @@ export class HeliusRingsService {
       });
     }
     return row;
+  }
+
+  /**
+   * Walks the retry lineage toward the original operation and refuses once the
+   * chain reaches RINGS_MAX_RETRY_DEPTH. The DB's retry_not_self CHECK rules
+   * out a self-loop; the walk is still bounded in case of a longer cycle.
+   */
+  private async assertRetryDepth(operation: HeliusRingsOperationRow): Promise<void> {
+    let depth = 1;
+    let ancestorId = operation.retry_of_operation_id;
+    while (ancestorId && depth < RINGS_MAX_RETRY_DEPTH + 1) {
+      depth += 1;
+      const ancestor = await this.operations.getOperationById({
+        ...this.tenant,
+        id: ancestorId,
+      });
+      ancestorId = ancestor?.retry_of_operation_id ?? null;
+    }
+    // The retry being filed would sit at depth + 1.
+    if (depth + 1 > RINGS_MAX_RETRY_DEPTH) {
+      throw new AppError(
+        "CONFLICT",
+        `retry limit reached (${RINGS_MAX_RETRY_DEPTH}); inspect the failure instead of retrying`
+      );
+    }
   }
 
   private async requireWallet(walletId: string) {

--- a/apps/sdp-web/messages/en/dashboard-helius-rings.json
+++ b/apps/sdp-web/messages/en/dashboard-helius-rings.json
@@ -95,7 +95,8 @@
       "summaryZone": "Zone",
       "summaryUnlockAt": "Unlocks at",
       "summaryBeneficiary": "Beneficiary",
-      "anonymousWarning": "I understand the counterparty is not disclosed on-chain. Anonymous transfers are subject to the same wallet policy and approval rules as any other transfer — they are not lower-risk."
+      "anonymousWarning": "I understand the counterparty is not disclosed on-chain. Anonymous transfers are subject to the same wallet policy and approval rules as any other transfer — they are not lower-risk.",
+      "gatewayRedNotice": "The Rings gateway is unavailable. You can still compose and confirm — the operation will run through policy and record an honest gateway failure."
     },
     "zones": {
       "title": "Zones",
@@ -115,6 +116,13 @@
       "timelineEmpty": "No events recorded.",
       "retryable": "A retry can succeed.",
       "notRetryable": "Not retryable."
+    },
+    "recovery": {
+      "title": "Recovery",
+      "description": "Failed operations. A retry files a fresh operation linked to the original and re-runs policy; retry chains are capped server-side.",
+      "empty": "Nothing to recover.",
+      "retry": "Retry",
+      "retrying": "Retrying…"
     }
   }
 }

--- a/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/retry/route.ts
+++ b/apps/sdp-web/src/app/api/dashboard/helius-rings/operations/[operationId]/retry/route.ts
@@ -1,0 +1,13 @@
+import { proxyToSdpApi } from "@/lib/sdp-api";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ operationId: string }> }
+) {
+  const { operationId } = await params;
+  return proxyToSdpApi({
+    request,
+    traceSource: "route.dashboard.helius-rings.retry",
+    path: `/v1/helius-rings/operations/${encodeURIComponent(operationId)}/retry`,
+  });
+}

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings-workspace.tsx
@@ -31,6 +31,7 @@ import {
 } from "./helius-rings.data";
 import { OperationComposer } from "./operation-composer";
 import { OperationDetailDrawer } from "./operation-detail-drawer";
+import { RecoveryCard } from "./recovery-card";
 import { ZonesCard } from "./zones-card";
 
 interface CustodyWalletOption {
@@ -263,9 +264,16 @@ export function HeliusRingsWorkspace({
         </CardContent>
       </Card>
 
-      <OperationComposer wallets={wallets} zones={zones} onPrepared={refresh} />
+      <OperationComposer
+        wallets={wallets}
+        zones={zones}
+        gatewayRed={gatewayPending}
+        onPrepared={refresh}
+      />
 
       <ZonesCard wallets={wallets} onZonesChanged={setZones} />
+
+      <RecoveryCard operations={operations} onRetried={refresh} />
 
       <Card>
         <CardHeader>

--- a/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/helius-rings.data.ts
@@ -161,6 +161,27 @@ export async function prepareRingsOperation(
   return { operation: body.data.operation };
 }
 
+export async function retryRingsOperation(
+  operationId: string
+): Promise<{ operation?: RingsOperationDetail; error?: string }> {
+  const response = await fetch(
+    `/api/dashboard/helius-rings/operations/${encodeURIComponent(operationId)}/retry`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clientNonce: crypto.randomUUID() }),
+      cache: "no-store",
+    }
+  );
+  const body = (await response.json().catch(() => ({}))) as Envelope<{
+    operation: RingsOperationDetail;
+  }>;
+  if (!response.ok || !body.data) {
+    return { error: body.error?.message };
+  }
+  return { operation: body.data.operation };
+}
+
 export interface RingsZone {
   id: string;
   name: string;

--- a/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/operation-composer.tsx
@@ -131,10 +131,12 @@ function buildSummaryRows(
 export function OperationComposer({
   wallets,
   zones,
+  gatewayRed,
   onPrepared,
 }: {
   wallets: RingsWallet[];
   zones: RingsZone[];
+  gatewayRed: boolean;
   onPrepared: () => Promise<void>;
 }) {
   const t = useTranslations();
@@ -218,6 +220,7 @@ export function OperationComposer({
             isAnonymous={draft.opType === "transfer_anonymous"}
             acknowledged={anonymousAcknowledged}
             onAcknowledge={setAnonymousAcknowledged}
+            gatewayRed={gatewayRed}
             error={error}
             submitting={submitting}
             onBack={() => setStep("compose")}
@@ -384,6 +387,7 @@ function ReviewStep({
   isAnonymous,
   acknowledged,
   onAcknowledge,
+  gatewayRed,
   error,
   submitting,
   onBack,
@@ -393,6 +397,7 @@ function ReviewStep({
   isAnonymous: boolean;
   acknowledged: boolean;
   onAcknowledge: (acknowledged: boolean) => void;
+  gatewayRed: boolean;
   error: string | null;
   submitting: boolean;
   onBack: () => void;
@@ -401,6 +406,9 @@ function ReviewStep({
   const t = useTranslations();
   return (
     <>
+      {gatewayRed ? (
+        <Callout variant="info">{t("DashboardHeliusRings.composer.gatewayRedNotice")}</Callout>
+      ) : null}
       <dl className="flex flex-col gap-2">
         {rows.map(([label, value]) => (
           <div key={label} className="flex items-baseline justify-between gap-4">

--- a/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
+++ b/apps/sdp-web/src/app/dashboard/helius-rings/recovery-card.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useTranslations } from "@/i18n/provider";
+import { type RingsOperationSummary, retryRingsOperation } from "./helius-rings.data";
+
+/**
+ * Failed operations with a retry action. Retryability is enforced server-side
+ * (non-retryable failures and exhausted chains reject); the card just relays
+ * the verdict.
+ */
+export function RecoveryCard({
+  operations,
+  onRetried,
+}: {
+  operations: RingsOperationSummary[];
+  onRetried: () => Promise<void>;
+}) {
+  const t = useTranslations();
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const failed = operations.filter((operation) => operation.state === "failed");
+
+  const handleRetry = useCallback(
+    async (operationId: string) => {
+      setRetryingId(operationId);
+      setError(null);
+      const result = await retryRingsOperation(operationId);
+      setRetryingId(null);
+      if (result.error) {
+        setError(result.error);
+      }
+      await onRetried();
+    },
+    [onRetried]
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("DashboardHeliusRings.recovery.title")}</CardTitle>
+        <CardDescription>{t("DashboardHeliusRings.recovery.description")}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {error ? <Callout variant="danger">{error}</Callout> : null}
+        {failed.length === 0 ? (
+          <p className="text-sm text-secondary">{t("DashboardHeliusRings.recovery.empty")}</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("DashboardHeliusRings.activity.operation")}</TableHead>
+                <TableHead>{t("DashboardHeliusRings.activity.created")}</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {failed.map((operation) => (
+                <TableRow key={operation.id}>
+                  <TableCell>
+                    <span className="flex items-center gap-2">
+                      {t(`DashboardHeliusRings.activity.opType_${operation.opType}`)}
+                      <Badge variant="danger">
+                        {t("DashboardHeliusRings.activity.state_failed")}
+                      </Badge>
+                    </span>
+                  </TableCell>
+                  <TableCell>{new Date(operation.createdAt).toLocaleString()}</TableCell>
+                  <TableCell>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={retryingId === operation.id}
+                      onClick={() => void handleRetry(operation.id)}
+                    >
+                      {retryingId === operation.id
+                        ? t("DashboardHeliusRings.recovery.retrying")
+                        : t("DashboardHeliusRings.recovery.retry")}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
**Server hardening (A21):**
- `executeOperation` now reads the approval verdict from the stored approval request — never from the caller. The previous shape accepted `approvalStatus` in the request body, which would have let anyone with `payments:write` skip a reviewer
- Retries run the full prepare-through-policy path (a retry re-earns its policy verdict, never inherits one) and lineage is capped at 5 — the walk is bounded even against a hypothetical cycle
- New tests: verdict-from-store (pending is inert, approved advances, rejected/canceled/expired fail non-retryably), depth cap

**Recovery UI:**
- Recovery card lists failed operations with a Retry action; retryability and chain limits are enforced server-side and the card relays the verdict
- Composer review step states plainly that operations will record an honest gateway failure while the seam is red
