### PR TITLE
feat(helius): poll rings indexing on a cron, dormant until the live adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ PRIVATE_CHANNELS_ENABLED=false
 # Helius Rings (opt-in, devnet-only). Gates the shielded-wallet API routes
 # and the dashboard workspace.
 HELIUS_RINGS_ENABLED=false
+# Rings gateway selector; only "http" activates the live adapter (Track B).
+HELIUS_RINGS_ADAPTER=none
 SDP_FLAG_ASSET_PROFILES=true
 PRIVY_BYOK_ENABLED=false
 SELF_HOSTED_STORED_CONNECTION_SETUP_ENABLED=false

--- a/apps/sdp-api/src/cron/rings-indexing.ts
+++ b/apps/sdp-api/src/cron/rings-indexing.ts
@@ -1,0 +1,35 @@
+/**
+ * Rings indexing-poll entrypoint.
+ *
+ * Mirrors `pending-deposits`: wraps `pollRingsIndexing` with a Sentry cron
+ * monitor when observability is supplied and hands the promise to the
+ * BackgroundRunner. The job itself early-returns unless the rings flag is on
+ * and HELIUS_RINGS_ADAPTER is "http" (the Track B live-gateway selector), so
+ * scheduling it everywhere is free.
+ */
+
+import type { BackgroundRunner } from "@/runtime/background";
+import type { Observability } from "@/runtime/observability";
+import { pollRingsIndexing } from "@/services/jobs/poll-rings-indexing";
+import type { Env } from "@/types/env";
+
+export const RINGS_INDEXING_MONITOR = "sdp-api-poll-rings-indexing";
+export const RINGS_INDEXING_CRON = "* * * * *";
+
+export interface RingsIndexingPollDeps {
+  env: Env;
+  bg: BackgroundRunner;
+  observability?: Observability;
+}
+
+export function runRingsIndexingPoll(deps: RingsIndexingPollDeps): void {
+  const work = () => pollRingsIndexing(deps.env);
+
+  const promise = deps.observability
+    ? deps.observability.withMonitor(RINGS_INDEXING_MONITOR, work, {
+        schedule: { type: "crontab", value: RINGS_INDEXING_CRON },
+      })
+    : Promise.resolve().then(work);
+
+  deps.bg.run(promise);
+}

--- a/apps/sdp-api/src/cron/runner.node.test.ts
+++ b/apps/sdp-api/src/cron/runner.node.test.ts
@@ -17,6 +17,7 @@ import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
 } from "./recurring-payments";
+import { RINGS_INDEXING_CRON, runRingsIndexingPoll } from "./rings-indexing";
 import { startCron } from "./runner";
 import { runWorkflowExecutions, WORKFLOW_EXECUTIONS_CRON } from "./workflow-executions";
 import {
@@ -88,6 +89,15 @@ vi.mock("./workflow-executions", () => ({
   runWorkflowExecutions: vi.fn(),
 }));
 
+// The rings poll pulls the rings service and through it the Solana signer stack;
+// mocked like the other wrappers. Registered unconditionally (the job itself
+// early-returns unless the rings flag and the http adapter are set), so it is
+// part of every schedule count below.
+vi.mock("./rings-indexing", () => ({
+  RINGS_INDEXING_CRON: "* * * * *",
+  runRingsIndexingPoll: vi.fn(),
+}));
+
 // Pulls in the credential secret store (and through it the custody cipher); mocked for
 // the same reason as the wrappers above.
 vi.mock("./workflow-secret-retirements", () => ({
@@ -116,6 +126,7 @@ describe("startCron", () => {
     vi.mocked(runEarnVaultMovementsReconciliation).mockReset();
     vi.mocked(runPendingTransfersReconciliation).mockReset();
     vi.mocked(runRecurringPaymentsCollection).mockReset();
+    vi.mocked(runRingsIndexingPoll).mockReset();
     vi.mocked(runWorkflowExecutions).mockReset();
     vi.mocked(runWorkflowSecretRetirements).mockReset();
   });
@@ -144,12 +155,13 @@ describe("startCron", () => {
 
   it("schedules a task with PENDING_TRANSFERS_CRON when DISABLE_CRON is unset", () => {
     startCron({ env: {} as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(5);
+    expect(scheduleMock).toHaveBeenCalledTimes(6);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
     expect(scheduleMock.mock.calls[2][0]).toBe(WORKFLOW_EXECUTIONS_CRON);
-    expect(scheduleMock.mock.calls[3][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
-    expect(scheduleMock.mock.calls[4][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
+    expect(scheduleMock.mock.calls[3][0]).toBe(RINGS_INDEXING_CRON);
+    expect(scheduleMock.mock.calls[4][0]).toBe(WORKFLOW_SECRET_RETIREMENTS_CRON);
+    expect(scheduleMock.mock.calls[5][0]).toBe(EARN_VAULT_MOVEMENTS_CRON);
   });
 
   it("schedules workflow executions by default, and its tick runs the engine", () => {
@@ -168,7 +180,7 @@ describe("startCron", () => {
   it("omits workflow executions when asset profiles is off", () => {
     startCron({ env: SELF_HOSTED_NO_PROFILES, bg: makeBg() });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(4);
+    expect(scheduleMock).toHaveBeenCalledTimes(5);
     for (const call of scheduleMock.mock.calls) {
       (call[1] as () => void)();
     }
@@ -208,7 +220,7 @@ describe("startCron", () => {
       env: { K_SERVICE: "sdp-api", DISABLE_CRON: "false" } as Env,
       bg: makeBg(),
     });
-    expect(scheduleMock).toHaveBeenCalledTimes(5);
+    expect(scheduleMock).toHaveBeenCalledTimes(6);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
   });
@@ -216,7 +228,7 @@ describe("startCron", () => {
   it("does not schedule recurring collection unless collection is enabled", () => {
     startCron({ env: {} as Env, bg: makeBg() });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(5);
+    expect(scheduleMock).toHaveBeenCalledTimes(6);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
     expect(runRecurringPaymentsCollection).not.toHaveBeenCalled();
@@ -228,7 +240,7 @@ describe("startCron", () => {
       bg: makeBg(),
     });
 
-    expect(scheduleMock).toHaveBeenCalledTimes(6);
+    expect(scheduleMock).toHaveBeenCalledTimes(7);
     expect(scheduleMock.mock.calls[0][0]).toBe(APPROVED_WALLET_OPERATIONS_CRON);
     expect(scheduleMock.mock.calls[1][0]).toBe(PENDING_TRANSFERS_CRON);
     expect(scheduleMock.mock.calls[2][0]).toBe(RECURRING_PAYMENTS_COLLECTION_CRON);
@@ -240,8 +252,8 @@ describe("startCron", () => {
     startCron({ env, bg });
 
     // approved-operation recovery + transfers + workflow executions + deposits +
-    // withdrawals (recurring stays off).
-    expect(scheduleMock).toHaveBeenCalledTimes(7);
+    // withdrawals + rings poll (recurring stays off).
+    expect(scheduleMock).toHaveBeenCalledTimes(8);
 
     // Fire every scheduled tick; the two private-channels reconcilers must run.
     for (const call of scheduleMock.mock.calls) {
@@ -262,7 +274,7 @@ describe("startCron", () => {
   it("schedules when DISABLE_CRON is set to a recognised falsy value ('false' / '0')", () => {
     startCron({ env: { DISABLE_CRON: "false" } as Env, bg: makeBg() });
     startCron({ env: { DISABLE_CRON: "0" } as Env, bg: makeBg() });
-    expect(scheduleMock).toHaveBeenCalledTimes(10);
+    expect(scheduleMock).toHaveBeenCalledTimes(12);
   });
 
   it("throws on an unrecognised DISABLE_CRON value to surface env typos", () => {
@@ -358,7 +370,7 @@ describe("startCron", () => {
     const handle = startCron({ env: {} as Env, bg: makeBg() });
     expect(handle).not.toBeNull();
     await handle?.stop();
-    expect(stopMock).toHaveBeenCalledTimes(5);
+    expect(stopMock).toHaveBeenCalledTimes(6);
   });
 
   it("returned handle.stop() stops every scheduled task", async () => {
@@ -368,6 +380,16 @@ describe("startCron", () => {
     });
     expect(handle).not.toBeNull();
     await handle?.stop();
-    expect(stopMock).toHaveBeenCalledTimes(6);
+    expect(stopMock).toHaveBeenCalledTimes(7);
+  });
+
+  it("tick invokes the rings indexing poll with the supplied deps", () => {
+    const bg = makeBg();
+    const env = {} as Env;
+    const observability = makeObservability();
+    startCron({ env, bg, observability });
+    const tick = scheduleMock.mock.calls[3][1] as () => void;
+    tick();
+    expect(runRingsIndexingPoll).toHaveBeenCalledWith({ env, bg, observability });
   });
 });

--- a/apps/sdp-api/src/cron/runner.ts
+++ b/apps/sdp-api/src/cron/runner.ts
@@ -39,6 +39,7 @@ import {
   RECURRING_PAYMENTS_COLLECTION_CRON,
   runRecurringPaymentsCollection,
 } from "./recurring-payments";
+import { RINGS_INDEXING_CRON, runRingsIndexingPoll } from "./rings-indexing";
 import { runWorkflowExecutions, WORKFLOW_EXECUTIONS_CRON } from "./workflow-executions";
 import {
   runWorkflowSecretRetirements,
@@ -172,6 +173,21 @@ export function startCron(deps: CronDeps): CronHandle | null {
       })
     );
   }
+
+  // Cheap to schedule unconditionally: the job early-returns unless the rings
+  // flag is on and the live gateway adapter is selected.
+  tasks.push(
+    schedule(RINGS_INDEXING_CRON, () => {
+      if (stopping) {
+        return;
+      }
+      runRingsIndexingPoll({
+        env: deps.env,
+        bg: deps.bg,
+        observability: deps.observability,
+      });
+    })
+  );
 
   if (isEarnEnabled(deps.env)) {
     tasks.push(

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.test.ts
@@ -1,0 +1,140 @@
+import { InMemoryRingsGateway } from "@sdp/helius-rings/testing";
+import type { WalletOperationPolicyEnforcement } from "@sdp/policy";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import {
+  createHeliusRingsOperationRepository,
+  createHeliusRingsWalletRepository,
+} from "@/db/repositories";
+import { createHeliusRingsService } from "@/services/helius-rings";
+import { TEST_ORG, TEST_USER } from "@/test/fixtures/organizations";
+import { env } from "@/test/helpers/env";
+import { seedTestDatabase } from "@/test/mocks/db";
+import { pollRingsIndexing, RINGS_INDEXING_TIMEOUT_MS } from "./poll-rings-indexing";
+
+const TEST_PROJECT_ID = "prj_hr_job_test";
+const tenant = { organizationId: TEST_ORG.id, projectId: TEST_PROJECT_ID };
+
+const allowPolicy = async () =>
+  ({
+    operation: { id: "wop_1" },
+    evaluation: {
+      id: "pev_1",
+      decision: "allow",
+      reason: null,
+      requiresApproval: false,
+      approvalRequestId: null,
+    },
+  }) as unknown as WalletOperationPolicyEnforcement;
+
+let walletId: string;
+let jobEnv: typeof env;
+
+function serviceWith(gateway: InMemoryRingsGateway) {
+  return createHeliusRingsService(env, tenant, {
+    gateway,
+    enforcePolicy: allowPolicy,
+    signOuterTransaction: async () => "c2lnbmVk",
+    submitOuterTransaction: async () => "sig_job_1",
+  });
+}
+
+describe("pollRingsIndexing", () => {
+  beforeEach(async () => {
+    await seedTestDatabase(env);
+    jobEnv = { ...env, HELIUS_RINGS_ENABLED: "true", HELIUS_RINGS_ADAPTER: "http" };
+    const db = getDb(env);
+
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO organizations (id, name, slug, tier, status) VALUES (?, ?, ?, 'individual', 'active')"
+      )
+      .bind(TEST_ORG.id, TEST_ORG.name, TEST_ORG.slug)
+      .run();
+    await db
+      .prepare(
+        "INSERT OR REPLACE INTO users (id, email, email_verified, status) VALUES (?, ?, 1, 'active')"
+      )
+      .bind(TEST_USER.id, TEST_USER.email)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Test Project', ?, 'sandbox', 'active', ?)`
+      )
+      .bind(TEST_PROJECT_ID, TEST_ORG.id, TEST_PROJECT_ID, TEST_USER.id)
+      .run();
+
+    const wallet = await createHeliusRingsWalletRepository(env).createWallet({
+      ...tenant,
+      sdpWalletId: "wal_hr_job_test",
+      name: "Treasury",
+      materialTag: "simulated",
+    });
+    if (!wallet) throw new Error("wallet fixture was not created");
+    walletId = wallet.id;
+  });
+
+  it("stays dormant unless the flag and the http adapter are both set", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 0 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-dormant" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+    gateway.recordSubmission("sig_job_1");
+
+    await pollRingsIndexing(
+      { ...env, HELIUS_RINGS_ENABLED: "true" },
+      { createService: () => serviceWith(gateway) }
+    );
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("indexing");
+  });
+
+  it("completes an indexing operation once Photon reports it", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 0 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-complete" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+    gateway.recordSubmission("sig_job_1");
+
+    await pollRingsIndexing(jobEnv, { createService: () => serviceWith(gateway) });
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("completed");
+  });
+
+  it("times out an operation stuck in indexing past the budget", async () => {
+    const gateway = new InMemoryRingsGateway({ indexingDelayMs: 60 * 60 * 1000 });
+    const operation = await serviceWith(gateway).prepareOperation(
+      { walletId, opType: "shield", clientNonce: "job-timeout" },
+      { apiKeyId: null, actor: null, custodyWalletId: null }
+    );
+    expect(operation.state).toBe("indexing");
+
+    // Sweep from a clock beyond the budget: the poll fails it rather than
+    // leaving it in limbo.
+    await pollRingsIndexing(jobEnv, {
+      createService: () => serviceWith(gateway),
+      now: () => new Date(Date.now() + RINGS_INDEXING_TIMEOUT_MS + 60_000),
+    });
+
+    const row = await createHeliusRingsOperationRepository(env).getOperationById({
+      ...tenant,
+      id: operation.id,
+    });
+    expect(row?.state).toBe("failed");
+    expect(row?.failure_code).toBe("indexing_timeout");
+    expect(row?.retryable).toBe(true);
+  });
+});

--- a/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
+++ b/apps/sdp-api/src/services/jobs/poll-rings-indexing.ts
@@ -1,0 +1,101 @@
+/**
+ * Background job: poll Photon for rings operations stuck in `indexing`.
+ *
+ * Each tick sweeps in-flight operations:
+ *  1. `indexing` → `executeOperation` polls `verifyIndexed` through the port;
+ *     a hit completes the operation, a miss leaves it untouched (idempotent).
+ *  2. `indexing` older than the timeout budget → `failed:indexing_timeout`
+ *     (retryable) — the sweep never leaves an operation in limbo forever.
+ *
+ * Ships dormant: the job early-returns unless the feature flag is on AND
+ * HELIUS_RINGS_ADAPTER is "http" — the live gateway selector Track B flips.
+ * Until then no operation can reach `indexing` in production anyway (the
+ * NotImplemented gateway fails the pipeline at `proving`).
+ */
+
+import {
+  createHeliusRingsOperationRepository,
+  type HeliusRingsOperationRow,
+} from "@/db/repositories";
+import { isHeliusRingsEnabled } from "@/lib/feature-flags";
+import { getLogger } from "@/runtime/logger";
+import { createHeliusRingsService, type HeliusRingsService } from "@/services/helius-rings";
+import type { Env } from "@/types/env";
+
+/** An operation may sit in `indexing` this long before it times out. */
+export const RINGS_INDEXING_TIMEOUT_MS = 30 * 60 * 1000;
+
+const MAX_PER_RUN = 100;
+
+export interface PollRingsIndexingDependencies {
+  /** Test seam: service per tenant; production builds the real one. */
+  createService?: (tenant: { organizationId: string; projectId: string }) => HeliusRingsService;
+  now?: () => Date;
+}
+
+export function isRingsIndexingPollEnabled(
+  env: Pick<Env, "HELIUS_RINGS_ENABLED" | "HELIUS_RINGS_ADAPTER">
+): boolean {
+  return isHeliusRingsEnabled(env) && env.HELIUS_RINGS_ADAPTER === "http";
+}
+
+export async function pollRingsIndexing(
+  env: Env,
+  dependencies: PollRingsIndexingDependencies = {}
+): Promise<void> {
+  if (!isRingsIndexingPollEnabled(env)) {
+    return;
+  }
+
+  const now = dependencies.now ?? (() => new Date());
+  const createService =
+    dependencies.createService ??
+    ((tenant: { organizationId: string; projectId: string }) =>
+      createHeliusRingsService(env, tenant));
+
+  const repository = createHeliusRingsOperationRepository(env);
+  // Everything in flight as of this tick; the poll itself decides per state.
+  const inFlight = await repository.listInFlightOperations({
+    staleBefore: now().toISOString(),
+    limit: MAX_PER_RUN,
+  });
+
+  const logger = getLogger();
+  const timeoutCutoff = now().getTime() - RINGS_INDEXING_TIMEOUT_MS;
+
+  for (const operation of inFlight) {
+    if (operation.state !== "indexing") continue;
+    try {
+      if (Date.parse(operation.updated_at) < timeoutCutoff) {
+        await failIndexingTimeout(repository, operation);
+        continue;
+      }
+      const service = createService({
+        organizationId: operation.organization_id,
+        projectId: operation.project_id,
+      });
+      await service.executeOperation(operation.id);
+    } catch (error) {
+      // One stuck operation must not starve the rest of the sweep.
+      logger.warn(
+        { operationId: operation.id, err: error },
+        "rings indexing poll failed for operation"
+      );
+    }
+  }
+}
+
+async function failIndexingTimeout(
+  repository: ReturnType<typeof createHeliusRingsOperationRepository>,
+  operation: HeliusRingsOperationRow
+): Promise<void> {
+  await repository.failOperation({
+    organizationId: operation.organization_id,
+    projectId: operation.project_id,
+    id: operation.id,
+    expectedState: "indexing",
+    code: "indexing_timeout",
+    message: "Photon did not index the transaction within the budget",
+    retryable: true,
+  });
+}

--- a/apps/sdp-api/src/types/env.d.ts
+++ b/apps/sdp-api/src/types/env.d.ts
@@ -226,6 +226,10 @@ export interface Env {
   // Helius Rings feature gate — devnet-only shielded wallet API routes.
   HELIUS_RINGS_ENABLED?: string;
 
+  // Rings gateway selector. Only "http" activates the live adapter and the
+  // indexing-poll job; anything else keeps NotImplementedRingsGateway.
+  HELIUS_RINGS_ADAPTER?: string;
+
   // Compliance providers
   RANGE_API_KEY?: string;
   RANGE_API_BASE_URL?: string;

--- a/infra/self-hosted/.env.example
+++ b/infra/self-hosted/.env.example
@@ -73,6 +73,8 @@ PRIVATE_CHANNELS_ENABLED=false
 # routes and the dashboard workspace; production wiring stays off until the
 # live gateway integration lands.
 HELIUS_RINGS_ENABLED=false
+# Rings gateway selector; only "http" activates the live adapter (Track B).
+HELIUS_RINGS_ADAPTER=none
 
 # Authentication (Clerk) — required.
 # See apps/sdp-api/docs/self-hosting/clerk-setup.md for full walkthrough.

--- a/packages/sdp-env-config/src/fields.ts
+++ b/packages/sdp-env-config/src/fields.ts
@@ -733,6 +733,18 @@ export const FIELDS: EnvField[] = [
     help: "Gates the devnet-only Helius Rings shielded wallet API routes.",
   },
   {
+    key: "HELIUS_RINGS_ADAPTER",
+    section: "advanced",
+    kind: "select",
+    label: "Helius Rings gateway adapter",
+    defaultValue: "none",
+    options: [
+      { value: "none", label: "Not implemented (default)" },
+      { value: "http", label: "Live HTTP gateway" },
+    ],
+    help: 'Only "http" activates the live Rings gateway and the indexing-poll job.',
+  },
+  {
     key: "SPC_CREDENTIAL_ENCRYPTION_KEY",
     section: "secrets",
     kind: "secret",


### PR DESCRIPTION
- `poll-rings-indexing` cron (every minute): operations in `indexing` poll `verifyIndexed` through the port — a hit completes them; operations stuck past 30 minutes fail as `indexing_timeout` (retryable), so nothing sits in limbo forever
- Ships inert: early-returns unless `HELIUS_RINGS_ENABLED=true` **and** `HELIUS_RINGS_ADAPTER=http` — the live-gateway selector Track B flips. Until then no production operation can reach `indexing` anyway
- `HELIUS_RINGS_ADAPTER` declared across env.d.ts, env-config fields, and both `.env.example`s
- 3 DB-backed job tests: dormant without the selector, completes on a Photon hit, times out past the budget
