### PR TITLE
refactor(earn): share program envelopes and payout capability via @sdp/types

### DIFF
--- a/apps/sdp-api/src/routes/earn/handlers/program.ts
+++ b/apps/sdp-api/src/routes/earn/handlers/program.ts
@@ -3,12 +3,16 @@ import { notImplemented } from "@sdp/earn/errors";
 import type { EarnPortfolioWalletProvider } from "@sdp/earn/types";
 import type {
   EarnPortfolioAllocationInput,
-  EarnPortfolioDepositsPage,
   EarnPortfolioWalletSnapshot,
   EarnPortfolioWithdrawal,
-  EarnPortfolioWithdrawalPreview,
   EarnPortfolioYield,
+  EarnProgram,
+  EarnProgramDepositsResponse,
+  EarnProgramResponse,
+  EarnProgramWithdrawalPreviewResponse,
   EarnProgramWithdrawalRecord,
+  EarnProgramWithdrawalResponse,
+  ListEarnProgramsResponse,
   ListEarnProgramWithdrawalsResponse,
 } from "@sdp/types";
 import type { EarnProviderId } from "@sdp/types/provider-access";
@@ -54,6 +58,15 @@ import {
 } from "../schemas";
 import { listResponse, pageWindow, parseBody, parseParams, parseQuery } from "./shared";
 
+export type {
+  EarnProgram,
+  EarnProgramDepositsResponse,
+  EarnProgramResponse,
+  EarnProgramWithdrawalPreviewResponse,
+  EarnProgramWithdrawalResponse,
+  ListEarnProgramsResponse,
+} from "@sdp/types";
+
 /**
  * Earn "programs": provider-managed portfolio wallets, N per (organization,
  * environment, provider) since PRO-1670, each pinned to a single vault with
@@ -86,43 +99,6 @@ import { listResponse, pageWindow, parseBody, parseParams, parseQuery } from "./
  * API); the ledger list takes no provider gate at all — the audit trail
  * outlives even credential removal.
  */
-
-// Response envelopes (route-owned until a second surface needs them in @sdp/types).
-export interface EarnProgram {
-  /** SDP's own program id — how every `/programs/:programId` route names it. */
-  id: string;
-  provider: string;
-  label: string | null;
-  createdAt: string;
-  wallet: EarnPortfolioWalletSnapshot;
-  /**
-   * Yield metrics, absent when the provider's yield endpoint fails. Balances
-   * are the load-bearing part of this response, so a yield outage degrades the
-   * headline rate rather than the whole program view.
-   */
-  yield?: EarnPortfolioYield;
-}
-
-export interface EarnProgramResponse {
-  program: EarnProgram;
-}
-
-export interface ListEarnProgramsResponse {
-  programs: EarnProgram[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
-export type EarnProgramDepositsResponse = EarnPortfolioDepositsPage;
-
-export interface EarnProgramWithdrawalPreviewResponse {
-  preview: EarnPortfolioWithdrawalPreview;
-}
-
-export interface EarnProgramWithdrawalResponse {
-  withdrawal: EarnPortfolioWithdrawal;
-}
 
 function mapProgram(
   row: EarnProviderWalletRow,

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -156,9 +156,10 @@ the body `requestId` form, which is the only one that can get through.
   A token Ground never routes to Solana (USDT: Ethereum
   only, per their supported-chains doc — sandbox USDT is Ground's mock Sepolia
   asset) is NOT OFFERED at all: the token select renders only
-  `SOLANA_PAYOUT_TOKENS`, mirroring `GROUND_SOLANA_ROUTED_TOKENS` in the
-  provider client, which also keeps un-routable strategies out of the
-  catalogue at sync time. Preview failures render TRANSLATED copy naming the per-lane
+  `SOLANA_PAYOUT_TOKENS`, read from the shared
+  `EARN_PROGRAM_SOLANA_PAYOUT_TOKENS` registry in `@sdp/types` that the
+  provider client gates on too, which also keeps un-routable strategies out of
+  the catalogue at sync time. Preview failures render TRANSLATED copy naming the per-lane
   reality — never the provider's wire text ("ground request failed with status
   409" explains nothing).
 - `deposit/` — the deposit flow: funding wallet → full strategy catalogue →

--- a/apps/sdp-web/src/app/dashboard/markets/earn/earn-withdraw-modal.tsx
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/earn-withdraw-modal.tsx
@@ -2,6 +2,7 @@
 
 import {
   EARN_PORTFOLIO_TOKENS,
+  EARN_PROGRAM_SOLANA_PAYOUT_TOKENS,
   type EarnPortfolioToken,
   type EarnPortfolioWithdrawal,
   type EarnPortfolioWithdrawalPreview,
@@ -32,14 +33,17 @@ const PREVIEW_DEBOUNCE_MS = 400;
 
 /**
  * Stablecoins Ground pays out on the Solana rail — a GROUND constraint, not an
- * SDP preference, mirrored from `GROUND_SOLANA_ROUTED_TOKENS` in the provider
- * client (packages/sdp-earn/src/providers/ground/client.ts; Ground's
- * supported-chains doc: "Solana = USDC deposits and withdrawals only", USDT
- * rides Ethereum). SDP's surface is Solana-only, so tokens outside this set
+ * SDP preference, read from the shared payout registry in @sdp/types rather
+ * than restated here (Ground's supported-chains doc: "Solana = USDC deposits
+ * and withdrawals only", USDT rides Ethereum). The provider client refuses the
+ * same registry entry before any network call, so the button and the server
+ * cannot disagree. SDP's surface is Solana-only, so tokens outside this set
  * are not offered AT ALL — they can never complete a withdrawal here, and the
  * same constraint already keeps their strategies out of the catalogue.
  */
-const SOLANA_PAYOUT_TOKENS: ReadonlySet<EarnPortfolioToken> = new Set(["usdc"]);
+const SOLANA_PAYOUT_TOKENS: ReadonlySet<EarnPortfolioToken> = new Set(
+  EARN_PROGRAM_SOLANA_PAYOUT_TOKENS.ground
+);
 
 /** The withdraw token choices: only lanes Ground can actually pay out. */
 const WITHDRAW_TOKEN_OPTIONS = EARN_PORTFOLIO_TOKENS.filter((candidate) =>

--- a/packages/sdp-earn/src/providers/ground/client.ts
+++ b/packages/sdp-earn/src/providers/ground/client.ts
@@ -4,6 +4,7 @@ import {
   EARN_PORTFOLIO_POSITION_KINDS,
   EARN_PORTFOLIO_TOKENS,
   EARN_PORTFOLIO_WITHDRAWAL_STATUSES,
+  EARN_PROGRAM_SOLANA_PAYOUT_TOKENS,
   type EarnPortfolioAllocationInput,
   type EarnPortfolioDeposit,
   type EarnPortfolioDepositsPage,
@@ -75,11 +76,12 @@ const GROUND_SOLANA_CHAINS = { sandbox: "solana_devnet", production: "solana" } 
  * the Solana addresses SDP surfaces, so `listStrategies` keeps it out of the
  * catalogue on every cluster, withdrawal preview/create refuse it before any
  * network call (`assertSolanaRoutable` — Ground's own rejection is wire text
- * partners can't act on), and the dashboard's withdraw-token whitelist
- * mirrors this set (apps/sdp-web/src/app/dashboard/markets/earn/
- * earn-withdraw-modal.tsx, `SOLANA_PAYOUT_TOKENS`).
+ * partners can't act on). The shared provider capability also drives the
+ * dashboard's withdraw-token choices.
  */
-const GROUND_SOLANA_ROUTED_TOKENS: ReadonlySet<string> = new Set(["usdc"]);
+const GROUND_SOLANA_ROUTED_TOKENS: ReadonlySet<string> = new Set(
+  EARN_PROGRAM_SOLANA_PAYOUT_TOKENS.ground
+);
 
 /**
  * Fail fast on a token Ground cannot route on Solana rails. Gates on a static

--- a/packages/sdp-types/src/earn.ts
+++ b/packages/sdp-types/src/earn.ts
@@ -6,10 +6,11 @@ import type { SolanaCluster, WellKnownTokenSymbol } from "./well-known-tokens";
  * Earn is a stablecoin deposit facility: organizations browse a catalogue of
  * yield strategies (DeFi protocols or tokenized RWAs, fronted by vault-infra
  * providers), fund a shared portfolio wallet, and withdraw to addresses they
- * control. Positions and balances are always read live from the provider
- * (never persisted); SDP-initiated withdrawals are recorded in a ledger —
- * "Record"-suffixed types are ledger rows, `EarnPortfolio*` types are live
- * provider reads (PRO-1628 / ADR 0002 addendum).
+ * control. Custodial portfolio balances are read live from the provider, while
+ * non-custodial vault ownership and movement records are durable and their
+ * balances are hydrated live. SDP-initiated portfolio withdrawals are recorded
+ * in a ledger — "Record"-suffixed types are ledger rows, `EarnPortfolio*`
+ * types are live provider reads (PRO-1628 / ADR 0002 addendum).
  *
  * Registries follow ADR 0001 (asset profiles): closed unions defined in code,
  * open TEXT columns in Postgres, Zod validation at the app layer — adding a
@@ -159,6 +160,65 @@ export interface EarnStrategy {
   fundable: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Non-custodial vault positions — the custody wallet owns the vault shares and
+ * SDP reads their current value live from the provider on every list request.
+ */
+export interface EarnVaultPosition {
+  id: string;
+  provider: string;
+  providerReference: string;
+  label: string;
+  custodyWalletId: string;
+  tokenMint: string;
+  shareMint: string;
+  createdAt: string;
+  closedAt: string | null;
+  /** Absent when the provider read failed; never coerce an unavailable value to zero. */
+  shares?: string;
+  /** Deposit-token value, absent when the provider cannot hydrate the position. */
+  tokenValue?: string;
+}
+
+export interface EarnVaultPositionsPage {
+  positions: EarnVaultPosition[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+/** JSON body for POST /v1/earn/vault-deposits. Idempotency is header-only. */
+export interface EarnVaultDepositRequest {
+  strategyId: string;
+  custodyWalletId: string;
+  amount: string;
+  minSharesOut?: string;
+}
+
+export const EARN_VAULT_MOVEMENT_STATUSES = [
+  "pending",
+  "submitted",
+  "confirmed",
+  "failed",
+] as const;
+export type EarnVaultMovementStatus = (typeof EARN_VAULT_MOVEMENT_STATUSES)[number];
+
+/** Durable result of a submitted vault deposit (fresh or idempotently replayed). */
+export interface EarnVaultDeposit {
+  positionId: string;
+  movementId: string;
+  status: EarnVaultMovementStatus;
+  signature: string;
+  failureReason: string | null;
+  replayed: boolean;
+  strategy: {
+    id: string;
+    name: string;
+    provider: string;
+    providerReference: string;
+    hostCluster: SolanaCluster;
+  };
 }
 
 /**
@@ -443,6 +503,48 @@ export interface EarnPortfolioLiquidityBalance {
 }
 
 // API response envelopes (mirrors the asset-profiles response naming).
+
+/**
+ * One provider-managed Earn program, hydrated from the provider on every read.
+ * The program id, label, and creation time are SDP-owned; wallet and yield state
+ * remain provider-authoritative and are never replaced with persisted balances.
+ */
+export interface EarnProgram {
+  /** SDP's own program id — how every `/programs/:programId` route names it. */
+  id: string;
+  /** Open provider id because a persisted program can outlive its registry entry. */
+  provider: string;
+  label: string | null;
+  createdAt: string;
+  wallet: EarnPortfolioWalletSnapshot;
+  /**
+   * Absent when the provider's yield lookup fails. Balances remain available,
+   * while consumers render an unavailable rate rather than fabricating 0%.
+   */
+  yield?: EarnPortfolioYield;
+}
+
+export interface EarnProgramResponse {
+  program: EarnProgram;
+}
+
+export interface ListEarnProgramsResponse {
+  programs: EarnProgram[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export type EarnProgramDepositsResponse = EarnPortfolioDepositsPage;
+
+export interface EarnProgramWithdrawalPreviewResponse {
+  preview: EarnPortfolioWithdrawalPreview;
+}
+
+export interface EarnProgramWithdrawalResponse {
+  withdrawal: EarnPortfolioWithdrawal;
+}
+
 export interface EarnStrategyResponse {
   strategy: EarnStrategy;
 }

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -1,5 +1,6 @@
 import type { SdpEnvironment } from "./api-keys";
 import { CUSTODY_PROVIDERS, type CustodyProvider } from "./custody";
+import type { EarnPortfolioToken } from "./earn";
 import {
   normalizeOrganizationTier,
   ORGANIZATION_RPC_PROVIDERS,
@@ -40,6 +41,29 @@ export type RampProviderId = (typeof RAMP_PROVIDERS)[number];
  */
 export const EARN_PROVIDERS = ["veda", "upshift", "perena", "ground", "kamino"] as const;
 export type EarnProviderId = (typeof EARN_PROVIDERS)[number];
+
+/**
+ * Portfolio-withdrawal tokens each provider can pay to a Solana address.
+ *
+ * This is exhaustive and shared because the provider client must reject an
+ * impossible rail before calling upstream while the dashboard must never
+ * offer that same impossible choice. Empty means SDP exposes no program-style
+ * Solana payout capability for the provider.
+ */
+export const EARN_PROGRAM_SOLANA_PAYOUT_TOKENS = {
+  veda: [],
+  upshift: [],
+  perena: [],
+  ground: ["usdc"],
+  kamino: [],
+} as const satisfies Record<EarnProviderId, readonly EarnPortfolioToken[]>;
+
+/** Fail closed for provider ids from open database read models. */
+export function earnProgramSolanaPayoutTokens(provider: string): readonly EarnPortfolioToken[] {
+  return Object.hasOwn(EARN_PROGRAM_SOLANA_PAYOUT_TOKENS, provider)
+    ? EARN_PROGRAM_SOLANA_PAYOUT_TOKENS[provider as EarnProviderId]
+    : [];
+}
 
 /**
  * Whether SDP currently OFFERS a registered Earn provider — the one switch that
@@ -95,9 +119,10 @@ export const EARN_PROVIDER_SURFACING = {
  * - `custodial` — SDP provisions a provider-managed portfolio wallet and the
  *   customer funds THAT address. SDP never signs; it watches the address and the
  *   provider deploys on its own rebalance. Ground.
- * - `vault_direct` — the vault is non-custodial and takes deposits straight from
- *   the customer's own wallet, as an on-chain program instruction. There is no
- *   SDP-side address to fund and no SDP-side signature. Kamino.
+ * - `vault_direct` — the vault is non-custodial and takes an on-chain program
+ *   instruction signed by the organization's selected custody wallet. There is
+ *   no provider deposit address to fund; SDP builds and submits the custody-
+ *   signed transaction. Kamino.
  *
  * **The difference is load-bearing in the UI and is not cosmetic.** A custodial
  * program has a real deposit ADDRESS a customer can send USDC to. A K-Vault does
@@ -152,10 +177,10 @@ export const SURFACED_EARN_PROVIDERS: readonly EarnProviderId[] = EARN_PROVIDERS
  * ── Why production is closed ────────────────────────────────────────────────
  * SDP can currently move money INTO a K-Vault and not back out. There is no
  * vault-withdraw route (the Kamino client withholds the capability because its
- * plan is not yet batched), and the dashboard's Active tab reads custodial
- * `earn_provider_wallets` only, so a vault position does not even appear there.
- * Entitlement will not save us: it is org-scoped, not environment-scoped, so an
- * entitled org would otherwise reach mainnet with real funds.
+ * plan is not yet batched). The dashboard now shows durable vault positions,
+ * but it can only label their SDP withdrawal action unavailable. Entitlement
+ * will not save us: it is org-scoped, not environment-scoped, so an entitled
+ * org would otherwise reach mainnet with real funds and no SDP exit path.
  *
  * Nothing here traps money that is already deposited. The shares sit in the
  * org's OWN custody wallet and Kamino's UI can always redeem them — this closes
@@ -165,9 +190,9 @@ export const SURFACED_EARN_PROVIDERS: readonly EarnProviderId[] = EARN_PROVIDERS
  * refuses on and the dashboard hides the affordance on, and a UI that offered a
  * button the server refuses is the specific failure this replaces.
  *
- * TO OPEN PRODUCTION: land the withdraw path and the Active-tab surface, then
- * add "production" here. It is one line precisely so it cannot be forgotten,
- * and it is not a flag flip precisely because the work is real.
+ * TO OPEN PRODUCTION: land the withdraw path, then add "production" here. It is
+ * one line precisely so it cannot be forgotten, and it is not a flag flip
+ * precisely because the work is real.
  */
 export const VAULT_DIRECT_DEPOSIT_ENVIRONMENTS: readonly SdpEnvironment[] = ["sandbox"];
 


### PR DESCRIPTION
## Summary

- add `EarnVaultPosition`, `EarnVaultPositionsPage`, `EarnVaultDepositRequest`, `EarnVaultDeposit`, and `EARN_VAULT_MOVEMENT_STATUSES` to `@sdp/types`
- move the `EarnProgram*` response envelopes out of `routes/earn/handlers/program.ts` into `@sdp/types`, re-exported from the handler so existing importers are untouched
- add `EARN_PROGRAM_SOLANA_PAYOUT_TOKENS` plus `earnProgramSolanaPayoutTokens()` — one exhaustive, provider-keyed declaration of which tokens each provider can pay to a Solana address

## Why

The envelopes were route-owned "until a second surface needs them". Two now do: the Ground client needs the payout capability to reject an impossible rail before calling upstream, and the dashboard needs the same set so it never offers a choice the server will refuse. Declaring it once removes the duplicated whitelist.

**Purely additive.** No existing type changes shape and no behavior changes, which is why it leads the stack.

## Validation

- 19/19 packages typecheck
- 1,210 web tests, 141 `@sdp/earn`, 164 API earn tests
- biome + module boundaries clean

## Note

Some doc comments in `provider-access.ts` describe the end state of the stack (the dashboard surfacing durable vault positions), which lands in #1397.

## Stack

Split out of #1389 (102 files, +5,939/-8,328). The seven branches together reproduce that branch tree **byte for byte**.

1. **#1391 (this PR)** — share program envelopes + payout capability via `@sdp/types`
2. #1392 — Ground client fails closed, exact APY math
3. #1393 — remove the demo seed
4. #1394 — opt-in upstream headers
5. #1395 — vault deposit/position BFF routes
6. #1396 — retire the prototype, rebuild the Earn program page
7. #1397 — Treasury Solutions

Review in order; each targets the one before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)