### PR TITLE
feat(earn): add the unified movement ledger and dual-write into it (PRO-1705)

### DIFF
--- a/apps/sdp-api/scripts/lib/run-postgres-migrations.d.mts
+++ b/apps/sdp-api/scripts/lib/run-postgres-migrations.d.mts
@@ -1,5 +1,8 @@
 export function getPostgresMigrationMode(sql: string): "transactional" | "non-transactional";
 
+/** Comment-stripped, trimmed statements of a migration file, in file order. */
+export function splitSqlStatements(sql: string): string[];
+
 export function applyPostgresMigration(input: {
   client: {
     query(query: string, values?: unknown[]): Promise<{ rows: Array<Record<string, unknown>> }>;

--- a/apps/sdp-api/scripts/lib/run-postgres-migrations.mjs
+++ b/apps/sdp-api/scripts/lib/run-postgres-migrations.mjs
@@ -9,15 +9,29 @@ export function getPostgresMigrationMode(sql) {
   return NON_TRANSACTIONAL_DIRECTIVE.test(sql) ? "non-transactional" : "transactional";
 }
 
-function concurrentIndexName(sql, migrationFile) {
-  const withoutComments = sql
+/**
+ * Split a migration file into its individual statements.
+ *
+ * Comments are stripped first so a `;` inside one cannot split a statement.
+ * Deliberately NOT a general SQL parser: it is correct for the migrations this
+ * repo writes (no dollar-quoted bodies, no semicolons inside string literals),
+ * which is why it lives here — one implementation to audit, used by the runner
+ * and by the tests that execute a migration through the pooled client.
+ *
+ * @param sql - Full text of a migration file.
+ * @returns The statements, comment-free and trimmed, in file order.
+ */
+export function splitSqlStatements(sql) {
+  return sql
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/--.*$/gm, "")
-    .trim();
-  const statements = withoutComments
     .split(";")
     .map((statement) => statement.trim())
     .filter(Boolean);
+}
+
+function concurrentIndexName(sql, migrationFile) {
+  const statements = splitSqlStatements(sql);
   const match = statements[0]?.match(
     /^CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\s+([a-z_][a-z0-9_]*)\b/i
   );

--- a/apps/sdp-api/src/db/migrations/postgres/0062_earn_movements.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0062_earn_movements.sql
@@ -28,13 +28,15 @@
 --
 -- ── Why new tables rather than ALTER/RENAME ────────────────────────────────
 -- Expand/contract, exactly as 0055 did: the legacy tables keep their writers
--- and their data for now, this migration only ADDS. The application dual-writes
--- both shapes in one transaction (0063 backfills history), reads switch in a
--- later release, and the legacy tables are dropped last of all. The point is
--- that every intermediate deploy is rollback-safe — the previously deployed
--- revision keeps working throughout, because nothing it writes was renamed or
--- removed. A rename would have made the rollback of the FIRST deploy break
--- vault deposits outright; the repo also has no RENAME precedent to follow.
+-- and their data for now. The application dual-writes both shapes in one
+-- transaction (0063 backfills history), reads switch in a later release, and
+-- the legacy tables are dropped last of all. The point is that every
+-- intermediate deploy is rollback-safe — the previously deployed revision
+-- keeps working throughout, because nothing it writes was renamed or removed.
+-- The one legacy-schema relaxation below makes a provider wallet's provisioning
+-- project nullable; every old and new writer still supplies one on insert. A
+-- rename would have made the rollback of the FIRST deploy break vault deposits
+-- outright; the repo also has no RENAME precedent to follow.
 --
 -- Conventions inherited from 0055 / 0059:
 -- * provider is open TEXT (ADR 0001/0002 drift rule) — a row can outlive its
@@ -149,6 +151,24 @@ INSERT INTO earn_movement_statuses (execution_model, status, is_terminal) VALUES
     ('vault_direct', 'finalized', TRUE),
     ('vault_direct', 'failed', TRUE)
 ON CONFLICT (execution_model, status) DO NOTHING;
+
+-- A provider wallet is scoped to its organization and environment; project_id
+-- only records which project provisioned it (0049/0056). The original CASCADE
+-- disagreed with that scope: deleting the provisioning project tried to delete
+-- a shared, potentially funded provider account. It also conflicts with the
+-- unified holding below, whose project attribution is deliberately cleared so
+-- its movement history survives. Retain the account and clear only its forensic
+-- project attribution. This is a rollback-safe relaxation: prior revisions
+-- still write a real project, and NULL appears only after a hard deletion.
+ALTER TABLE earn_provider_wallets
+    DROP CONSTRAINT IF EXISTS earn_provider_wallets_project_id_fkey;
+
+ALTER TABLE earn_provider_wallets
+    ALTER COLUMN project_id DROP NOT NULL;
+
+ALTER TABLE earn_provider_wallets
+    ADD CONSTRAINT earn_provider_wallets_project_id_fkey
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL;
 
 -- ───────────────────────────────────────────────────────────────────────────
 -- 2. Holdings: one row per position, whatever its custody model.

--- a/apps/sdp-api/src/db/migrations/postgres/0062_earn_movements.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0062_earn_movements.sql
@@ -1,5 +1,6 @@
 -- Solana Earn: one provider-neutral movement ledger, and one holdings table
--- behind it (PRO-1705, ADR 0002 addendum "One ledger for every movement").
+-- behind it (PRO-1705, ADR 0002 addendum 2026-08-19 "One ledger for every
+-- movement").
 --
 -- ── The problem this closes ────────────────────────────────────────────────
 -- Earn ended up with TWO authoritative movement tables split by EXECUTION
@@ -29,7 +30,7 @@
 -- ── Why new tables rather than ALTER/RENAME ────────────────────────────────
 -- Expand/contract, exactly as 0055 did: the legacy tables keep their writers
 -- and their data for now. The application dual-writes both shapes in one
--- transaction (0063 backfills history), reads switch in a later release, and
+-- transaction (0064 backfills history), reads switch in a later release, and
 -- the legacy tables are dropped last of all. The point is that every
 -- intermediate deploy is rollback-safe — the previously deployed revision
 -- keeps working throughout, because nothing it writes was renamed or removed.
@@ -168,6 +169,36 @@ ALTER TABLE earn_provider_wallets
 
 ALTER TABLE earn_provider_wallets
     ADD CONSTRAINT earn_provider_wallets_project_id_fkey
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL;
+
+-- The same relaxation for 0055's withdrawal history, and for the same reason
+-- twice over.
+--
+-- 1. It is the forensics rule applied consistently: project_id is write-only
+--    provisioning attribution (ADR 0002), and attribution is not a lifetime.
+--    CASCADE made deleting a project DESTROY the withdrawal history of money
+--    that actually left the organization — the one record a purge must not take
+--    with it.
+-- 2. It keeps the two shapes ISOMORPHIC through the expand window, which is
+--    this migration's entire safety argument. `earn_movements.project_id` is
+--    SET NULL; leaving the legacy table on CASCADE would make a hard project
+--    deletion drop the legacy row while the unified row survived. A reused
+--    idempotency key would then insert a fresh legacy row, collide with the
+--    surviving unified row on `idx_earn_movements_custodial_request`, and the
+--    route's unique-violation path — which re-resolves the replay from the
+--    LEGACY table — would find nothing and fail that key permanently.
+--
+-- Rollback-safe, like the wallet relaxation above: every old and new writer
+-- still supplies a real project on insert, and NULL appears only after a hard
+-- deletion.
+ALTER TABLE earn_program_withdrawals
+    DROP CONSTRAINT IF EXISTS earn_program_withdrawals_project_id_fkey;
+
+ALTER TABLE earn_program_withdrawals
+    ALTER COLUMN project_id DROP NOT NULL;
+
+ALTER TABLE earn_program_withdrawals
+    ADD CONSTRAINT earn_program_withdrawals_project_id_fkey
         FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL;
 
 -- ───────────────────────────────────────────────────────────────────────────
@@ -316,6 +347,10 @@ CREATE INDEX IF NOT EXISTS idx_earn_positions_wallet_created
 
 -- Complement the narrow-wallet index above for pages spanning many custody
 -- rows: ORDER BY can stream globally before applying the wallet-array filter.
+-- This also serves the kind-neutral workspace-wide question ("what does this
+-- organization hold"): `custody_wallet_id` is the LAST column, so the leading
+-- (organization_id, environment, created_at DESC, id DESC) prefix answers it
+-- without a second index over exactly that prefix.
 CREATE INDEX IF NOT EXISTS idx_earn_positions_created_wallet
     ON earn_positions(
         organization_id,
@@ -326,12 +361,6 @@ CREATE INDEX IF NOT EXISTS idx_earn_positions_created_wallet
     )
     WHERE activated_at IS NOT NULL AND closed_at IS NULL;
 
--- Workspace-wide holdings list, kind-neutral: the treasury overview asks "what
--- does this organization hold", which no index above answers without also
--- naming wallets.
-CREATE INDEX IF NOT EXISTS idx_earn_positions_workspace_created
-    ON earn_positions(organization_id, environment, created_at DESC, id DESC)
-    WHERE activated_at IS NOT NULL AND closed_at IS NULL;
 
 -- ───────────────────────────────────────────────────────────────────────────
 -- 3. The ledger: every money movement Earn records.
@@ -522,6 +551,24 @@ CREATE TABLE IF NOT EXISTS earn_movements (
     -- Chain commitment time exists exactly for the states that have one. Both
     -- confirmed and finalized carry it: finalization does not erase the earlier
     -- commitment, it supersedes it.
+    --
+    -- This is a BICONDITIONAL, and `EARN_MOVEMENT_TRANSITIONS` is written to
+    -- respect it rather than fight it. Two consequences, both deliberate:
+    --
+    -- * There is no `confirmed -> failed` transition. Recording one would mean
+    --   NULLing `confirmed_at` (and `shares_out` below) — erasing two chain
+    --   facts SDP genuinely observed, and making "failed before landing"
+    --   indistinguishable from "landed, then dropped in a fork". The realistic
+    --   chain path never asks for it: an execution error is reported with the
+    --   FIRST status for a signature, not after a clean one. The remaining
+    --   tail — a confirmed transaction dropped by a fork rollback — stays in
+    --   the reconciliation queue as an open question rather than being declared
+    --   failed on a guess, which is the only answer that keeps the observation.
+    -- * `submitted -> finalized` is legal, and its writer stamps `confirmed_at`
+    --   on the way through. That is not an invented observation: finalized
+    --   strictly implies committed, so the column states a fact the chain
+    --   asserts, and the alternative is a settled row with no record of its own
+    --   commitment.
     CONSTRAINT earn_movements_confirmation_metadata_check
         CHECK (
             execution_model <> 'vault_direct'
@@ -592,7 +639,9 @@ CREATE TABLE IF NOT EXISTS earn_movements (
             )
         ),
     -- Shares are what the chain minted or burned, so they exist only once the
-    -- chain has spoken.
+    -- chain has spoken. Kept to the commitment states for the same reason as
+    -- `confirmed_at` above: no legal transition leaves a movement that observed
+    -- a share count in a status that may not hold one.
     CONSTRAINT earn_movements_shares_out_format_check
         CHECK (
             shares_out IS NULL

--- a/apps/sdp-api/src/db/migrations/postgres/0062_earn_movements.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0062_earn_movements.sql
@@ -1,0 +1,678 @@
+-- Solana Earn: one provider-neutral movement ledger, and one holdings table
+-- behind it (PRO-1705, ADR 0002 addendum "One ledger for every movement").
+--
+-- ── The problem this closes ────────────────────────────────────────────────
+-- Earn ended up with TWO authoritative movement tables split by EXECUTION
+-- MECHANISM rather than by business meaning:
+--
+--   * earn_program_withdrawals (0055) — provider-API portfolio withdrawals.
+--   * earn_vault_movements     (0059) — signed on-chain vault deposits.
+--
+-- Both record the same fact — money moved through Earn — so idempotency,
+-- lifecycle, reconciliation, history and reporting are all duplicated, and no
+-- single query can answer "what moved on this organization". Every new provider
+-- or direction deepened the split: 0061's index comment still anticipates a
+-- third variation (vault withdraw) landing as more columns on 0059.
+--
+-- This table is the answer: ONE row per real-world money movement, both
+-- directions, both execution models, discriminated by `execution_model` rather
+-- than by which table it lives in.
+--
+-- ── On reclaiming the name ─────────────────────────────────────────────────
+-- 0048 had an `earn_movements` and 0055 dropped it unwritten. The NAME is free;
+-- the SHAPE is not. That table was position-scoped with base-unit amounts, a
+-- nullable provider, no environment, no fingerprint, and an FK into the
+-- delist-pruned catalogue. This is a movement-identity-first schema that
+-- happens to reuse the name — see the decisions below, all of which 0048 got
+-- wrong or never had.
+--
+-- ── Why new tables rather than ALTER/RENAME ────────────────────────────────
+-- Expand/contract, exactly as 0055 did: the legacy tables keep their writers
+-- and their data for now, this migration only ADDS. The application dual-writes
+-- both shapes in one transaction (0063 backfills history), reads switch in a
+-- later release, and the legacy tables are dropped last of all. The point is
+-- that every intermediate deploy is rollback-safe — the previously deployed
+-- revision keeps working throughout, because nothing it writes was renamed or
+-- removed. A rename would have made the rollback of the FIRST deploy break
+-- vault deposits outright; the repo also has no RENAME precedent to follow.
+--
+-- Conventions inherited from 0055 / 0059:
+-- * provider is open TEXT (ADR 0001/0002 drift rule) — a row can outlive its
+--   provider's registry entry; allowed values live in code registries.
+-- * Money is decimal strings, never numeric: exact fund amounts must round-trip
+--   without DB coercion. The only NUMERIC column is a block height (a count).
+-- * project_id / created_by / initiated_by_key_id are forensic attribution.
+-- * created_at/updated_at are TEXT ISO via sdp_iso_now().
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1. Vocabulary tables.
+--
+-- Closed, earn-owned vocabularies are LOOKUP TABLES with FK integrity rather
+-- than CHECK (status IN (...)) lists. A CHECK cannot be referenced, cannot
+-- carry attributes, and every new value is a DDL change to a money table; a
+-- lookup row is data, joins for display, and carries `is_terminal` next to the
+-- value it describes.
+--
+-- Natural TEXT primary keys, deliberately: the FK columns stay human-readable
+-- in every row and every query, so no join is needed to know what a movement's
+-- status IS. Native Postgres ENUM types were rejected — values cannot be
+-- renamed or removed, and ALTER TYPE ADD VALUE has transactional restrictions a
+-- lookup row does not.
+--
+-- Rows are seeded here, appended by INSERT in later migrations, and NEVER
+-- deleted once history references them. `@sdp/types` stays the source of truth
+-- for BEHAVIOUR (which transitions are legal, how a status renders); a
+-- conformance test pins these rows to those constants so the two cannot drift.
+--
+-- NOT converted to lookup tables, on purpose:
+-- * provider     — open registry string (ADR 0001/0002); a new provider must
+--                  never require a migration.
+-- * environment  — platform-wide vocabulary spelled as a CHECK on dozens of
+--                  tables; earn diverging alone would be inconsistency, not
+--                  cleanliness.
+-- * denomination — an OPEN set ('usd' or any token mint), not a vocabulary.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS earn_execution_models (
+    id TEXT PRIMARY KEY
+);
+INSERT INTO earn_execution_models (id) VALUES
+    -- Provider-API execution: SDP asks a provider to move money it custodies
+    -- (0055's Ground portfolio withdrawals).
+    ('custodial'),
+    -- On-chain execution: SDP builds, signs and submits the instruction itself
+    -- from a custody wallet (0059's Kamino vault deposits).
+    ('vault_direct')
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS earn_movement_directions (
+    id TEXT PRIMARY KEY
+);
+-- Spelled 'withdrawal' (0048's spelling, and the word every wire contract,
+-- route and dashboard already uses). 0059 wrote 'withdraw' on a column no row
+-- has ever carried — the vault withdraw path does not exist yet — so nothing
+-- is being migrated away from here.
+INSERT INTO earn_movement_directions (id) VALUES
+    ('deposit'),
+    ('withdrawal')
+ON CONFLICT (id) DO NOTHING;
+
+-- Status is scoped BY execution model, because the two lifecycles are genuinely
+-- different and flattening them would lose meaning:
+--
+--   custodial    a provider reports settlement, and can report a PARTIAL one or
+--                park a payout awaiting a customer approval stamp.
+--   vault_direct a chain reports commitment, which is not the same event as
+--                settlement: `confirmed` is an optimistic commitment that a
+--                fork can still drop, `finalized` is irreversible.
+--
+-- So `completed` and `finalized` are NOT synonyms wearing two names — they are
+-- different facts, and the composite primary key is what makes each legal only
+-- for the model that can actually produce it. `earn_movements` FKs the PAIR,
+-- which also makes `execution_model` transitively valid without a second FK.
+CREATE TABLE IF NOT EXISTS earn_movement_statuses (
+    execution_model TEXT NOT NULL,
+    status TEXT NOT NULL,
+    -- Terminal means "this movement never moves on". Stored beside the value so
+    -- SQL (list filters, outbox scans) reads the same terminal set the
+    -- application transition guards enforce, instead of re-spelling it — 0059's
+    -- listDeposits hardcoded ('confirmed','failed') in SQL while the shared
+    -- constant lived in TypeScript, which is exactly the drift this prevents.
+    is_terminal BOOLEAN NOT NULL,
+
+    PRIMARY KEY (execution_model, status),
+    FOREIGN KEY (execution_model) REFERENCES earn_execution_models(id)
+);
+INSERT INTO earn_movement_statuses (execution_model, status, is_terminal) VALUES
+    -- 'requested' is SDP-only intent state: the row exists, the provider has
+    -- not accepted the call yet (0055's vocabulary, unchanged).
+    ('custodial', 'requested', FALSE),
+    ('custodial', 'processing', FALSE),
+    -- Synthesized by the provider client when a payout leg awaits a customer
+    -- approval stamp; a withdrawal waiting on a human must be legible.
+    ('custodial', 'pending_approval', FALSE),
+    ('custodial', 'completed', TRUE),
+    -- Terminal by convention: if a provider ever advances it, the live read
+    -- keeps serving provider truth while the ledger row stays put.
+    ('custodial', 'partially_completed', TRUE),
+    ('custodial', 'failed', TRUE),
+    ('custodial', 'cancelled', TRUE),
+
+    -- 'requested' is 0059's 'pending' under one name for one meaning: a signed
+    -- transaction is durably recorded but is not known to be on the wire. The
+    -- rename is the whole reason both models can share a column honestly.
+    ('vault_direct', 'requested', FALSE),
+    ('vault_direct', 'submitted', FALSE),
+    -- Optimistic chain commitment. NOT terminal, unlike 0059 — a confirmed
+    -- transaction can still be dropped in a fork rollback, and treating it as
+    -- settled is what made "settled" mean two things across SDP.
+    ('vault_direct', 'confirmed', FALSE),
+    ('vault_direct', 'finalized', TRUE),
+    ('vault_direct', 'failed', TRUE)
+ON CONFLICT (execution_model, status) DO NOTHING;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2. Holdings: one row per position, whatever its custody model.
+--
+-- Supersedes earn_vault_positions (0059), generalized so a custodial program is
+-- expressible in the same table. Still emphatically NOT a balance: balances and
+-- share counts are read LIVE on every request (ADR 0002 — for a non-custodial
+-- vault the chain IS the provider, and for a custodial program the provider
+-- is). This records only that a holding exists, so reads know what to hydrate.
+--
+-- Why positions unify but ACCOUNTS do not: earn_provider_wallets models an
+-- ACCOUNT at a provider — the custodial twin of custody_wallets — while this
+-- table models the HOLDING that links an account to an instrument. Folding the
+-- account in here would be the same category error as folding in
+-- custody_wallets. So a custodial position is a link row pointing at its
+-- program wallet, and earn_provider_wallets keeps owning the account.
+--
+-- The instrument for a custodial position is the PORTFOLIO (the program), not
+-- whichever strategy it currently targets — which is what keeps the claim key
+-- immutable across a re-target.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS earn_positions (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    -- Forensic attribution, not ownership. Organization fallback wallets may
+    -- hold one claim for movements initiated by multiple projects.
+    project_id TEXT,
+    environment TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    -- Which execution model this holding is reached by; decides which of the
+    -- two column groups below is populated.
+    kind TEXT NOT NULL,
+
+    -- ─ vault_direct: the custody wallet signs and holds the shares ─
+    custody_wallet_id TEXT,
+    -- The vault's own on-chain address (the catalogue's provider_reference).
+    -- Named for what it IS, because 0059 overloaded `provider_reference` to
+    -- mean the INSTRUMENT here and the MOVEMENT's provider id on the other
+    -- table — two incompatible meanings that could not share a column once the
+    -- tables merged.
+    vault_address TEXT,
+    -- Denormalised from the vault at open time so a position still renders when
+    -- the catalogue row is delisted. Never used to build an instruction — the
+    -- builder always re-reads vault state from chain.
+    share_mint TEXT,
+    token_mint TEXT,
+
+    -- ─ custodial: the provider holds the funds in a program wallet ─
+    provider_wallet_id TEXT,
+
+    label TEXT NOT NULL,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    -- A vault claim is activated only in the transaction that durably records a
+    -- signed transaction that can create the holding; a custodial position is
+    -- active from the moment its program exists.
+    activated_at TEXT,
+    -- Set when the position is fully exited. Kept rather than deleted: the
+    -- movement history references it, and a re-entry reuses the row.
+    closed_at TEXT,
+
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL,
+    -- Deliberately NO cascade on either account FK: an account with holdings
+    -- must not be deletable out from under them (0055/0059's fail-loud rule).
+    FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id),
+    FOREIGN KEY (provider_wallet_id) REFERENCES earn_provider_wallets(id),
+    FOREIGN KEY (created_by) REFERENCES users(id),
+    FOREIGN KEY (kind) REFERENCES earn_execution_models(id),
+
+    CONSTRAINT earn_positions_environment_check
+        CHECK (environment IN ('sandbox', 'production')),
+    -- Exactly one shape per row, both directions asserted: a vault position
+    -- cannot borrow a program wallet and a custodial position cannot claim an
+    -- on-chain vault. This is what lets one table hold both without either
+    -- shape's invariants weakening to "nullable and hope".
+    CONSTRAINT earn_positions_kind_shape_check
+        CHECK (
+            (
+                kind = 'vault_direct'
+                AND custody_wallet_id IS NOT NULL
+                AND vault_address IS NOT NULL
+                AND share_mint IS NOT NULL
+                AND token_mint IS NOT NULL
+                AND provider_wallet_id IS NULL
+            )
+            OR (
+                kind = 'custodial'
+                AND provider_wallet_id IS NOT NULL
+                AND custody_wallet_id IS NULL
+                AND vault_address IS NULL
+                AND share_mint IS NULL
+                AND token_mint IS NULL
+            )
+        ),
+
+    -- FK targets for earn_movements below. Two constraints, because a movement
+    -- asserts two different things: every movement belongs to a holding in its
+    -- own tenancy, and a VAULT movement additionally names its exact claim.
+    CONSTRAINT earn_positions_tenancy_key
+        UNIQUE (id, organization_id, environment, provider),
+    CONSTRAINT earn_positions_movement_identity_key
+        UNIQUE (
+            id,
+            organization_id,
+            environment,
+            provider,
+            vault_address,
+            custody_wallet_id
+        )
+);
+
+-- One vault position per (org, environment, provider, vault, wallet).
+--
+-- Scoped to the ORG and the WALLET — emphatically NOT global on
+-- (provider, vault_address) the way 0056 scopes a custodial wallet. The vault
+-- registry is permissionless and public: two orgs holding "Steakhouse USDC" is
+-- normal, and so is one org holding it from two different wallets. A global
+-- unique here would refuse the second org's deposit outright.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_positions_vault_claim
+    ON earn_positions(organization_id, environment, provider, vault_address, custody_wallet_id)
+    WHERE kind = 'vault_direct';
+
+-- One custodial position per program wallet. Global, matching 0056's global
+-- unique on the wallet itself: a provider-side wallet holds real funds, so
+-- exactly one holding may claim it platform-wide. The org/environment/provider
+-- columns are copied FROM that wallet, so they cannot disagree with it.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_positions_program_claim
+    ON earn_positions(provider_wallet_id)
+    WHERE kind = 'custodial';
+
+-- Wallet-scoped list path: every read supplies the current project's custody
+-- wallet row ids (plus organization fallbacks), pages by (created_at, id), and
+-- excludes provisional claims that never reached the signed boundary.
+CREATE INDEX IF NOT EXISTS idx_earn_positions_wallet_created
+    ON earn_positions(
+        organization_id,
+        environment,
+        custody_wallet_id,
+        created_at DESC,
+        id DESC
+    )
+    WHERE activated_at IS NOT NULL AND closed_at IS NULL;
+
+-- Complement the narrow-wallet index above for pages spanning many custody
+-- rows: ORDER BY can stream globally before applying the wallet-array filter.
+CREATE INDEX IF NOT EXISTS idx_earn_positions_created_wallet
+    ON earn_positions(
+        organization_id,
+        environment,
+        created_at DESC,
+        id DESC,
+        custody_wallet_id
+    )
+    WHERE activated_at IS NOT NULL AND closed_at IS NULL;
+
+-- Workspace-wide holdings list, kind-neutral: the treasury overview asks "what
+-- does this organization hold", which no index above answers without also
+-- naming wallets.
+CREATE INDEX IF NOT EXISTS idx_earn_positions_workspace_created
+    ON earn_positions(organization_id, environment, created_at DESC, id DESC)
+    WHERE activated_at IS NOT NULL AND closed_at IS NULL;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 3. The ledger: every money movement Earn records.
+--
+-- ADR 0002's rule stands — SDP ledgers what SDP INITIATES; SDP reads live what
+-- the provider observes — and this is where everything SDP initiates lands,
+-- whichever way it was executed. Customer-initiated custodial deposits remain
+-- unledgered because SDP has no intent moment for them; nothing here changes
+-- that, and when an observed-deposit feed is built it writes rows HERE.
+--
+-- Exactly one authoritative row per real-world movement. The row id is the
+-- LEGACY row's id for anything migrated or dual-written from 0055/0059, so the
+-- switch of every read is invisible on the wire and the backfill in 0063 is
+-- idempotent against rows the application already mirrored.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS earn_movements (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    -- Initiating project attribution; history survives project deletion.
+    --
+    -- Nullable with ON DELETE SET NULL, following 0059 and deliberately NOT
+    -- 0055, whose cascade meant deleting a project DESTROYED its withdrawal
+    -- history. An audit ledger outlives the project that provisioned the call.
+    project_id TEXT,
+    environment TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    execution_model TEXT NOT NULL,
+    direction TEXT NOT NULL,
+    -- Every movement belongs to exactly one holding, both models alike. This is
+    -- what makes per-position history, the treasury overview and the movement
+    -- feed one table scan instead of a union over mechanism-shaped tables.
+    position_id TEXT NOT NULL,
+
+    status TEXT NOT NULL,
+    failure_reason TEXT,
+    -- Optimistic chain commitment time (vault only). Kept distinct from
+    -- settlement because they are distinct events; see the status vocabulary.
+    confirmed_at TEXT,
+    -- Success-terminal time, one meaning across SDP: finalization for a vault
+    -- movement, provider completion for a custodial one.
+    settled_at TEXT,
+
+    -- ─ Money. Explicit units, never mixed ─
+    --
+    -- The concrete accounting hazard this unification could have introduced is
+    -- USD, mint units and vault shares sharing a column. They do not:
+    --   * every `amount_*`/`fee_*` figure is denominated in `denomination`,
+    --   * share quantities live ONLY in the two share-named columns.
+    -- 'usd' is the legacy custodial denomination (0055's portfolio vocabulary);
+    -- a vault movement is denominated in its token MINT. An open set, so a new
+    -- asset is never a migration.
+    denomination TEXT NOT NULL,
+    amount_requested TEXT NOT NULL,
+    -- What actually moved, once known. The provider (custodial) or the chain
+    -- (vault) is authoritative; NULL until then.
+    amount_settled TEXT,
+    fee_amount TEXT,
+    -- Slippage floor and the shares the chain actually minted or burned, in
+    -- SHARE units — structurally separate from the amount columns above so no
+    -- query can add a share count to a token amount.
+    min_shares_out TEXT,
+    shares_out TEXT,
+    -- 0055's `token`: the payout stablecoin as a provider-neutral lowercase
+    -- symbol ('usdc'|'usdt'). A legacy custodial concept kept for wire
+    -- compatibility, and NOT the asset identity — `denomination` is.
+    payout_token TEXT,
+
+    -- ─ Parties and chain facts ─
+    custody_wallet_id TEXT,
+    vault_address TEXT,
+    -- Chain facts, and the columns a counterparty view filters on: who sent the
+    -- money in, where it went out. NULL wherever SDP never observed one.
+    source_address TEXT,
+    destination_address TEXT,
+
+    -- ─ External correlation ─
+    --
+    -- The provider's id for THIS MOVEMENT (0055's withdrawalRef) — and nothing
+    -- else. A row without one is an unresolved intent: healed by a same-key
+    -- retry or an observation sweep, never by fuzzy matching.
+    provider_reference TEXT,
+    -- Signed outbox payload (vault only), recorded atomically with the movement
+    -- and the position's activation before the bytes can reach the network.
+    -- Enough for a reconciler to query the exact signature and, while its
+    -- blockhash remains valid, rebroadcast the same transaction without
+    -- re-signing.
+    signature TEXT,
+    signed_transaction TEXT,
+    last_valid_block_height NUMERIC,
+
+    -- ─ Idempotency ─
+    --
+    -- request_id keeps its per-model meaning, byte for byte:
+    --   custodial    a DERIVED provider request id (deriveProviderRequestId),
+    --                which the provider ALSO dedupes on.
+    --   vault_direct the caller's raw Idempotency-Key, which is additionally
+    --                published on chain in the deposit's memo.
+    -- Both anchors survive as partial unique indexes below. Neither the
+    -- derivation nor either fingerprint builder changes here: the values are
+    -- persisted in wallet_operations.raw_payload.executionRequest, so altering
+    -- one would 409 every in-flight approved retry across a deploy.
+    request_id TEXT NOT NULL,
+    -- Canonical fingerprint of the request that wrote this row, so a replay
+    -- compares INTENT rather than just the key and a reused key with a
+    -- different payload answers 409 instead of returning the original
+    -- movement's signature. NOT NULL for both models (0055/0059's shared rule):
+    -- a NULL would read as "unclaimed" to resolveIdempotencyReplay and turn the
+    -- replay backstop into an unrecoverable unique violation.
+    idempotency_fingerprint TEXT NOT NULL,
+
+    -- Provider observations, for drift forensics. Explicitly NOT authoritative
+    -- for anything: no read may take a balance, an amount or a status from it.
+    provider_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    -- Who moved the money: a dashboard human, an API key, or both absent for a
+    -- system-initiated observation.
+    created_by TEXT,
+    initiated_by_key_id TEXT,
+
+    created_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+    updated_at TEXT NOT NULL DEFAULT sdp_iso_now(),
+
+    FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL,
+    FOREIGN KEY (custody_wallet_id) REFERENCES custody_wallets(id),
+    FOREIGN KEY (created_by) REFERENCES users(id),
+    FOREIGN KEY (direction) REFERENCES earn_movement_directions(id),
+    -- The (model, status) PAIR, not two independent FKs: this is what makes a
+    -- custodial-only status unrepresentable on a vault movement, and it makes
+    -- `execution_model` transitively valid without a second constraint.
+    FOREIGN KEY (execution_model, status)
+        REFERENCES earn_movement_statuses(execution_model, status),
+
+    -- Tenancy consistency with the parent holding, for EVERY row: a movement
+    -- cannot name a position in another org, environment or provider. 0055 had
+    -- no equivalent — nothing at the DB level stopped a withdrawal row from
+    -- naming a wallet in another organization.
+    FOREIGN KEY (position_id, organization_id, environment, provider)
+        REFERENCES earn_positions(id, organization_id, environment, provider),
+    -- 0059's exact-claim guarantee, carried across undegraded rather than
+    -- weakened to a bare position_id. MATCH SIMPLE (the default) skips the
+    -- constraint while any column is NULL, which is precisely the custodial
+    -- shape — so vault rows are pinned to their exact claim and custodial rows
+    -- are governed by the tenancy FK above.
+    FOREIGN KEY (position_id, organization_id, environment, provider, vault_address, custody_wallet_id)
+        REFERENCES earn_positions(
+            id,
+            organization_id,
+            environment,
+            provider,
+            vault_address,
+            custody_wallet_id
+        ),
+
+    CONSTRAINT earn_movements_environment_check
+        CHECK (environment IN ('sandbox', 'production')),
+    CONSTRAINT earn_movements_provider_data_is_object
+        CHECK (jsonb_typeof(provider_data) = 'object'),
+
+    -- Exactly one shape per row. The vault half is 0059's NOT NULL set, which
+    -- is what makes record-before-broadcast enforceable rather than merely
+    -- intended; the custodial half asserts the absence of every column that
+    -- only signed execution can produce.
+    CONSTRAINT earn_movements_model_shape_check
+        CHECK (
+            (
+                execution_model = 'vault_direct'
+                AND custody_wallet_id IS NOT NULL
+                AND vault_address IS NOT NULL
+                AND signature IS NOT NULL
+                AND signed_transaction IS NOT NULL
+                AND last_valid_block_height IS NOT NULL
+                AND payout_token IS NULL
+                AND fee_amount IS NULL
+            )
+            OR (
+                execution_model = 'custodial'
+                AND custody_wallet_id IS NULL
+                AND vault_address IS NULL
+                AND signature IS NULL
+                AND signed_transaction IS NULL
+                AND last_valid_block_height IS NULL
+                AND min_shares_out IS NULL
+                AND shares_out IS NULL
+            )
+        ),
+
+    -- Chain commitment time exists exactly for the states that have one. Both
+    -- confirmed and finalized carry it: finalization does not erase the earlier
+    -- commitment, it supersedes it.
+    CONSTRAINT earn_movements_confirmation_metadata_check
+        CHECK (
+            execution_model <> 'vault_direct'
+            OR (
+                (status IN ('confirmed', 'finalized'))
+                = (NULLIF(BTRIM(confirmed_at), '') IS NOT NULL)
+            )
+        ),
+    -- Settlement time exists exactly when a vault movement is finalized. The
+    -- custodial side is left unconstrained on purpose: its completed_at is
+    -- written from whatever the provider reports, with no constraint in 0055,
+    -- and adding one here would turn an observation that succeeds today into a
+    -- rolled-back write.
+    CONSTRAINT earn_movements_settlement_metadata_check
+        CHECK (
+            execution_model <> 'vault_direct'
+            OR ((status = 'finalized') = (NULLIF(BTRIM(settled_at), '') IS NOT NULL))
+        ),
+    CONSTRAINT earn_movements_failure_metadata_check
+        CHECK (
+            execution_model <> 'vault_direct'
+            OR ((status = 'failed') = (NULLIF(BTRIM(failure_reason), '') IS NOT NULL))
+        ),
+
+    -- Amount formats. Requested is always SDP-validated before it reaches the
+    -- DB, on both models, so it is checked for both.
+    CONSTRAINT earn_movements_amount_requested_format_check
+        CHECK (
+            LENGTH(amount_requested) BETWEEN 1 AND 128
+            AND amount_requested ~ '^\d+(\.\d+)?$'
+            AND amount_requested ~ '[1-9]'
+        ),
+    -- Settled amounts and fees are PROVIDER-REPORTED on the custodial side, and
+    -- 0055 never constrained them: a provider legitimately answers "0", and a
+    -- JSON number small enough serializes as '1e-7'. Enforcing the vault
+    -- format here would make a currently-successful observation fail, so the
+    -- strict rule applies only where 0059 already proved it safe. Tightening
+    -- the custodial side is a later change, after the real values are surveyed.
+    CONSTRAINT earn_movements_settled_amount_format_check
+        CHECK (
+            amount_settled IS NULL
+            OR LENGTH(amount_settled) BETWEEN 1 AND 128
+        ),
+    CONSTRAINT earn_movements_fee_amount_format_check
+        CHECK (
+            fee_amount IS NULL
+            OR LENGTH(fee_amount) BETWEEN 1 AND 128
+        ),
+    CONSTRAINT earn_movements_vault_amount_format_check
+        CHECK (
+            execution_model <> 'vault_direct'
+            OR (
+                (
+                    amount_settled IS NULL
+                    OR (
+                        amount_settled ~ '^\d+(\.\d+)?$'
+                        AND amount_settled ~ '[1-9]'
+                    )
+                )
+                AND (
+                    min_shares_out IS NULL
+                    OR (
+                        LENGTH(min_shares_out) BETWEEN 1 AND 128
+                        AND min_shares_out ~ '^\d+(\.\d+)?$'
+                        AND min_shares_out ~ '[1-9]'
+                    )
+                )
+            )
+        ),
+    -- Shares are what the chain minted or burned, so they exist only once the
+    -- chain has spoken.
+    CONSTRAINT earn_movements_shares_out_format_check
+        CHECK (
+            shares_out IS NULL
+            OR (
+                status IN ('confirmed', 'finalized')
+                AND LENGTH(shares_out) BETWEEN 1 AND 128
+                AND shares_out ~ '^\d+(\.\d+)?$'
+                AND shares_out ~ '[1-9]'
+            )
+        ),
+    CONSTRAINT earn_movements_denomination_check
+        CHECK (LENGTH(BTRIM(denomination)) BETWEEN 1 AND 128),
+    CONSTRAINT earn_movements_last_valid_block_height_check
+        CHECK (
+            last_valid_block_height IS NULL
+            OR (
+                last_valid_block_height = TRUNC(last_valid_block_height)
+                AND last_valid_block_height BETWEEN 0 AND 18446744073709551615
+            )
+        )
+);
+
+-- ── Idempotency anchors: BOTH legacy scopes, unchanged ────────────────────
+--
+-- Flattening these to one anchor would break whichever side lost, so each
+-- survives as a partial unique index over its own model's rows.
+--
+-- Custodial: keyed on the POSITION, which is 0055's wallet scope expressed in
+-- the new shape — a custodial position is 1:1 with its program wallet. Sibling
+-- projects in one environment share the wallet and derive the SAME request id
+-- for the same caller key, so a narrower (org, project) anchor would let the
+-- second project miss the replay row, insert a duplicate intent, and strand it
+-- on the provider_reference unique below.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_movements_custodial_request
+    ON earn_movements(position_id, request_id)
+    WHERE execution_model = 'custodial';
+
+-- Vault: ORG-scoped, not position-scoped, on purpose (0059) — a retry that
+-- resolves to a DIFFERENT position (the caller corrected the vault) is a
+-- different request and must not silently reuse the key.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_movements_vault_request
+    ON earn_movements(organization_id, request_id)
+    WHERE execution_model = 'vault_direct';
+
+-- Settlement correlation for poll/sweep/webhook observation writes. Global
+-- (not tenant-scoped) like 0055's, so a system-scope lookup needs no
+-- org/project; callers assert organization_id after the fetch.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_movements_provider_reference
+    ON earn_movements(provider, provider_reference)
+    WHERE provider_reference IS NOT NULL;
+
+-- Chain correlation for the confirmation sweep.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_earn_movements_signature
+    ON earn_movements(signature)
+    WHERE signature IS NOT NULL;
+
+-- ── Read paths ────────────────────────────────────────────────────────────
+--
+-- Movements are a low-write, high-question table: the treasury overview, the
+-- B2B2X counterparty views, per-position drill-downs and the reconciler all
+-- ask different questions of the same rows, so each gets its index. id joins
+-- created_at as the deterministic pagination tiebreaker throughout (the lesson
+-- of payment_transfers 0028-0031 and 0048).
+
+-- "Everything that moved in this workspace", newest first.
+CREATE INDEX IF NOT EXISTS idx_earn_movements_workspace_created
+    ON earn_movements(organization_id, environment, created_at DESC, id DESC);
+
+-- "All deposits" / "all withdrawals" for the same workspace.
+CREATE INDEX IF NOT EXISTS idx_earn_movements_direction_created
+    ON earn_movements(organization_id, environment, direction, created_at DESC, id DESC);
+
+-- One holding's history — the drill-down behind every position row.
+CREATE INDEX IF NOT EXISTS idx_earn_movements_position_created
+    ON earn_movements(position_id, created_at DESC, id DESC);
+
+-- Counterparty lookups: "every deposit that came from this address", "every
+-- payout that went to this one". Partial because most rows carry neither.
+CREATE INDEX IF NOT EXISTS idx_earn_movements_source_address
+    ON earn_movements(organization_id, environment, source_address, created_at DESC, id DESC)
+    WHERE source_address IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_earn_movements_destination_address
+    ON earn_movements(organization_id, environment, destination_address, created_at DESC, id DESC)
+    WHERE destination_address IS NOT NULL;
+
+-- Hot existence probe for active-list defence and failed-attempt cleanup: does
+-- this position still have live evidence? Includes `finalized`, which the
+-- 0059 predicate could not name.
+CREATE INDEX IF NOT EXISTS idx_earn_movements_position_live_evidence
+    ON earn_movements(position_id)
+    WHERE status IN ('requested', 'submitted', 'confirmed', 'finalized');
+
+-- The reconciliation sweep's work queue: every signed row without an
+-- IRREVERSIBLE outcome. `confirmed` belongs in it now — the sweep's job did not
+-- end at commitment once finalization became the terminal state — and so does
+-- `requested`, because a broadcast timeout or crash leaves a row unsubmitted
+-- WITH a signature, which is precisely the ambiguous case reconciliation is
+-- for.
+CREATE INDEX IF NOT EXISTS idx_earn_movements_unsettled
+    ON earn_movements(created_at ASC, id ASC)
+    WHERE execution_model = 'vault_direct'
+      AND status IN ('requested', 'submitted', 'confirmed');

--- a/apps/sdp-api/src/db/migrations/postgres/0063_earn_movement_projections.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0063_earn_movement_projections.sql
@@ -1,0 +1,203 @@
+-- Solana Earn: how a legacy row becomes a unified row — defined ONCE, in the
+-- database, for both consumers (PRO-1705).
+--
+-- ── Why these are views and not SQL repeated in two places ─────────────────
+-- The unification has two writers of the same projection:
+--
+--   * the BULK backfill (0064), which projects all existing history, and
+--   * the application's DUAL-WRITE, which projects one row at a time as it is
+--     written, so the new tables stay current until reads switch.
+--
+-- Spelled twice, those two would drift — and the parts that would drift are
+-- exactly the parts that matter: which legacy status maps to which unified one,
+-- which join supplies the denomination, whether a settled amount is recorded
+-- yet. A silent disagreement between "history" and "new rows" in a money ledger
+-- is the worst outcome this migration could produce.
+--
+-- So each projection is a VIEW. The backfill selects from it unfiltered; the
+-- application selects from it by id. Neither can hold an opinion the other does
+-- not, because there is only one expression to hold an opinion in.
+--
+-- ── These are transitional by design ──────────────────────────────────────
+-- Every view reads a table the contract phase drops, so all four are dropped in
+-- that same migration, alongside `earn_program_withdrawals` and
+-- `earn_vault_movements`. They exist for exactly as long as two shapes do.
+--
+-- Column NAMES are still spelled at each INSERT (Postgres has no way to say
+-- "insert these columns positionally and safely"), but the expressions — the
+-- part with the judgement in it — live here alone.
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1. Vault holdings (0059) → earn_positions.
+--
+-- `provider_reference` becomes `vault_address`: on 0059's positions that column
+-- meant the INSTRUMENT, while on 0059's movements the same name meant the
+-- provider's id for the movement. One name per meaning is what lets the merged
+-- tables carry both.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW earn_projected_position_from_vault_position AS
+SELECT
+    legacy.id                  AS id,
+    legacy.organization_id     AS organization_id,
+    legacy.project_id          AS project_id,
+    legacy.environment         AS environment,
+    legacy.provider            AS provider,
+    'vault_direct'::TEXT       AS kind,
+    legacy.custody_wallet_id   AS custody_wallet_id,
+    legacy.provider_reference  AS vault_address,
+    legacy.share_mint          AS share_mint,
+    legacy.token_mint          AS token_mint,
+    legacy.label               AS label,
+    legacy.created_by          AS created_by,
+    legacy.created_at          AS created_at,
+    legacy.updated_at          AS updated_at,
+    legacy.activated_at        AS activated_at,
+    legacy.closed_at           AS closed_at
+FROM earn_vault_positions legacy;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2. Program wallets (0049/0056) → earn_positions.
+--
+-- A custodial position is a LINK row: the ACCOUNT stays in
+-- earn_provider_wallets, which remains its source of truth, and every column
+-- here is copied from it so the two cannot disagree.
+--
+-- `activated_at` is the wallet's own creation time — a custodial holding is
+-- live from the moment its program exists, unlike a vault claim, which is only
+-- activated by a durably recorded signed transaction.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW earn_projected_position_from_provider_wallet AS
+SELECT
+    wallet.id                                            AS provider_wallet_id,
+    wallet.organization_id                               AS organization_id,
+    wallet.project_id                                    AS project_id,
+    wallet.environment                                   AS environment,
+    wallet.provider                                      AS provider,
+    'custodial'::TEXT                                    AS kind,
+    -- earn_provider_wallets.label is nullable; earn_positions.label is not. The
+    -- provider wallet ref is the honest fallback — it is what the provider
+    -- console shows for an unlabelled program.
+    COALESCE(wallet.label, wallet.provider_wallet_ref)    AS label,
+    wallet.created_by                                    AS created_by,
+    wallet.created_at                                    AS created_at,
+    wallet.updated_at                                    AS updated_at,
+    wallet.created_at                                    AS activated_at
+FROM earn_provider_wallets wallet;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 3. Withdrawal history (0055) → earn_movements.
+--
+-- * environment comes from the WALLET — 0055 has no environment column at all,
+--   it was always derived through the program wallet.
+-- * denomination is 'usd' because portfolio withdrawals are USD-denominated
+--   (0055's vocabulary). `token` becomes `payout_token`: it names the payout
+--   stablecoin, which is not the unit the amounts are in.
+-- * status needs no mapping — 0055's vocabulary IS the custodial vocabulary.
+-- * settled_at takes completed_at: provider completion is what "settled" means
+--   on this side.
+--
+-- The join to earn_positions is INNER on purpose. A withdrawal whose program has
+-- no position row must fail loudly rather than project a movement with no
+-- holding: the position mint runs first, in the same migration and on the same
+-- code path, so a miss is a bug and not a state to tolerate.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW earn_projected_movement_from_withdrawal AS
+SELECT
+    withdrawal.id                       AS id,
+    withdrawal.organization_id          AS organization_id,
+    withdrawal.project_id               AS project_id,
+    wallet.environment                  AS environment,
+    withdrawal.provider                 AS provider,
+    'custodial'::TEXT                   AS execution_model,
+    'withdrawal'::TEXT                  AS direction,
+    position.id                         AS position_id,
+    withdrawal.status                   AS status,
+    withdrawal.failure_reason           AS failure_reason,
+    withdrawal.completed_at             AS settled_at,
+    'usd'::TEXT                         AS denomination,
+    withdrawal.amount_requested_usd     AS amount_requested,
+    withdrawal.amount_paid_usd          AS amount_settled,
+    withdrawal.fee_usd                  AS fee_amount,
+    withdrawal.token                    AS payout_token,
+    withdrawal.destination_address       AS destination_address,
+    withdrawal.provider_reference       AS provider_reference,
+    withdrawal.request_id               AS request_id,
+    withdrawal.idempotency_fingerprint  AS idempotency_fingerprint,
+    withdrawal.provider_data            AS provider_data,
+    withdrawal.created_by               AS created_by,
+    withdrawal.initiated_by_key_id      AS initiated_by_key_id,
+    withdrawal.created_at               AS created_at,
+    withdrawal.updated_at               AS updated_at
+FROM earn_program_withdrawals withdrawal
+INNER JOIN earn_provider_wallets wallet
+    ON wallet.id = withdrawal.wallet_id
+INNER JOIN earn_positions position
+    ON position.provider_wallet_id = wallet.id
+   AND position.kind = 'custodial';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 4. Vault movement history (0059) → earn_movements.
+--
+-- * status maps 'pending' → 'requested': the same meaning (a signed transaction
+--   is durably recorded but is not known to be on the wire) under the one word
+--   both execution models can share.
+-- * denomination is the position's token_mint. A vault movement is denominated
+--   in mint units, never USD — this is the join that keeps USD, mint units and
+--   share counts from ever meeting in one column.
+-- * amount_requested takes the caller's text and amount_settled the canonical
+--   plan amount, and only once the chain has spoken. 0059 stored both and
+--   DB-enforced them numerically equal, so collapsing them loses nothing while
+--   each column now states WHICH of the two facts it holds. Same for the
+--   slippage floor: the ENCODED value is the one that constrained the chain.
+-- * settled_at stays NULL even for a confirmed row. Confirmation is not
+--   finalization, and back-dating a settlement SDP never observed would be a
+--   fabricated accounting fact; the finalization sweep sets it honestly.
+-- * provider_reference stays NULL. A vault movement has no provider-side
+--   movement id — the vault is the INSTRUMENT and lives in vault_address.
+-- * source_address is the signing custody wallet and the vault is the
+--   destination, so one movement feed can answer "where did this money come
+--   from and where did it go" without branching on execution model.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW earn_projected_movement_from_vault_movement AS
+SELECT
+    legacy.id                       AS id,
+    legacy.organization_id          AS organization_id,
+    legacy.project_id               AS project_id,
+    legacy.environment              AS environment,
+    legacy.provider                 AS provider,
+    'vault_direct'::TEXT            AS execution_model,
+    CASE legacy.direction
+        WHEN 'withdraw' THEN 'withdrawal'
+        ELSE legacy.direction
+    END                             AS direction,
+    position.id                     AS position_id,
+    CASE legacy.status
+        WHEN 'pending' THEN 'requested'
+        ELSE legacy.status
+    END                             AS status,
+    legacy.failure_reason           AS failure_reason,
+    legacy.confirmed_at             AS confirmed_at,
+    position.token_mint             AS denomination,
+    legacy.requested_amount         AS amount_requested,
+    CASE WHEN legacy.status = 'confirmed' THEN legacy.amount END AS amount_settled,
+    legacy.min_shares_out           AS min_shares_out,
+    legacy.shares                   AS shares_out,
+    legacy.custody_wallet_id        AS custody_wallet_id,
+    legacy.provider_reference       AS vault_address,
+    wallet.public_key               AS source_address,
+    legacy.provider_reference       AS destination_address,
+    legacy.signature                AS signature,
+    legacy.signed_transaction       AS signed_transaction,
+    legacy.last_valid_block_height  AS last_valid_block_height,
+    legacy.request_id               AS request_id,
+    legacy.idempotency_fingerprint  AS idempotency_fingerprint,
+    legacy.created_by               AS created_by,
+    legacy.initiated_by_key_id      AS initiated_by_key_id,
+    legacy.created_at               AS created_at,
+    legacy.updated_at               AS updated_at
+FROM earn_vault_movements legacy
+INNER JOIN earn_positions position
+    ON position.id = legacy.position_id
+   AND position.kind = 'vault_direct'
+INNER JOIN custody_wallets wallet
+    ON wallet.id = legacy.custody_wallet_id;

--- a/apps/sdp-api/src/db/migrations/postgres/0064_earn_movements_backfill.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0064_earn_movements_backfill.sql
@@ -5,13 +5,34 @@
 -- mapping itself lives THERE, shared with the application's dual-write, so this
 -- file only decides WHICH rows to project and how to avoid duplicating them.
 --
--- ── Idempotent by construction, and re-run on purpose ──────────────────────
+-- ── Idempotent by construction — and precisely what that does NOT cover ────
 -- Everything is `INSERT ... SELECT ... ON CONFLICT DO NOTHING` keyed on the
--- LEGACY row's own id, so this converges rather than duplicating. That matters
--- because it is deliberately run again in a later release: migrations apply
--- BEFORE the new revision serves traffic, so rows the outgoing revision writes
--- during the rollout window land in neither this pass nor the dual-write. The
--- same property makes it safe after a rollback that briefly wrote only legacy.
+-- LEGACY row's own id, so re-running this can never duplicate a movement.
+--
+-- `DO NOTHING` converges INSERTS, not ADVANCES, and the difference is
+-- load bearing. Migrations apply BEFORE the new revision serves traffic, so
+-- there is a window in which the OUTGOING revision still writes the legacy
+-- tables alone; the same window reopens for a rollback that briefly restores a
+-- legacy-only writer. Two different things happen in it:
+--
+--   * a row INSERTED in the window is missing here entirely, and a later pass
+--     of this projection inserts it — `DO NOTHING` is enough; and
+--   * a row ADVANCED in the window (mirrored at `requested`, then moved to
+--     `completed` or `confirmed` by the legacy-only writer) already exists under
+--     its own id, so `DO NOTHING` leaves the STALE projection in place. The
+--     runtime mirror does not rescue it either: the custodial appliers early
+--     return on a terminal status, and the vault reconciliation queue selects
+--     only ('pending', 'submitted'), so nothing ever touches that row again.
+--
+-- Closing the second case needs an UPSERT, not this statement, and the release
+-- that switches reads ships exactly that — the same projection with
+-- `ON CONFLICT ... DO UPDATE`, guarded so a unified-only `finalized` row is
+-- never regressed by a legacy row that cannot express it. That pass is where
+-- the convergence guarantee lives; this one establishes the history.
+--
+-- This file is NOT edited to become that pass: the runner ledgers a migration
+-- by filename, so editing an applied migration to run again would rewrite
+-- applied history. It re-states the projection under a new number instead.
 --
 -- ── Ids are preserved, never regenerated ──────────────────────────────────
 -- A projected movement keeps the legacy row's id, and a projected vault holding

--- a/apps/sdp-api/src/db/migrations/postgres/0064_earn_movements_backfill.sql
+++ b/apps/sdp-api/src/db/migrations/postgres/0064_earn_movements_backfill.sql
@@ -1,0 +1,120 @@
+-- Solana Earn: project existing holdings and movement history into the unified
+-- ledger (PRO-1705).
+--
+-- Every statement here applies one of 0063's projection views in bulk. The
+-- mapping itself lives THERE, shared with the application's dual-write, so this
+-- file only decides WHICH rows to project and how to avoid duplicating them.
+--
+-- ── Idempotent by construction, and re-run on purpose ──────────────────────
+-- Everything is `INSERT ... SELECT ... ON CONFLICT DO NOTHING` keyed on the
+-- LEGACY row's own id, so this converges rather than duplicating. That matters
+-- because it is deliberately run again in a later release: migrations apply
+-- BEFORE the new revision serves traffic, so rows the outgoing revision writes
+-- during the rollout window land in neither this pass nor the dual-write. The
+-- same property makes it safe after a rollback that briefly wrote only legacy.
+--
+-- ── Ids are preserved, never regenerated ──────────────────────────────────
+-- A projected movement keeps the legacy row's id, and a projected vault holding
+-- keeps `earn_vault_positions.id`. Three things follow, all load bearing:
+-- `ON CONFLICT (id)` dedupes against rows the application already mirrored,
+-- every GET-by-id and stored reference keeps working when reads switch, and
+-- `earn_vault_movements.position_id` needs no translation.
+--
+-- Timestamps are copied, never re-stamped: `created_at` is when the money moved,
+-- and a backfill must not claim the movement happened today.
+--
+-- ── If this migration fails ───────────────────────────────────────────────
+-- 0062's amount format check is the only plausible failure, and it means a
+-- legacy row holds an `amount_requested_usd` the app-layer schema should have
+-- made impossible (non-decimal, or zero). That is a real data finding, not a
+-- migration bug: inspect the row rather than loosening the constraint.
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1. Holdings first — both movement projections join a position.
+--
+-- The custodial mint is the one projection that generates an id rather than
+-- preserving one, because a program wallet never had a position row to carry an
+-- id from. `provider_wallet_id` is the natural key that makes it repeatable.
+-- ───────────────────────────────────────────────────────────────────────────
+INSERT INTO earn_positions (
+    id, organization_id, project_id, environment, provider, kind,
+    provider_wallet_id, label, created_by, created_at, updated_at, activated_at
+)
+SELECT
+    'earn_position_' || gen_random_uuid(),
+    projected.organization_id,
+    projected.project_id,
+    projected.environment,
+    projected.provider,
+    projected.kind,
+    projected.provider_wallet_id,
+    projected.label,
+    projected.created_by,
+    projected.created_at,
+    projected.updated_at,
+    projected.activated_at
+FROM earn_projected_position_from_provider_wallet projected
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM earn_positions existing
+    WHERE existing.provider_wallet_id = projected.provider_wallet_id
+      AND existing.kind = 'custodial'
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO earn_positions (
+    id, organization_id, project_id, environment, provider, kind,
+    custody_wallet_id, vault_address, share_mint, token_mint,
+    label, created_by, created_at, updated_at, activated_at, closed_at
+)
+SELECT
+    id, organization_id, project_id, environment, provider, kind,
+    custody_wallet_id, vault_address, share_mint, token_mint,
+    label, created_by, created_at, updated_at, activated_at, closed_at
+FROM earn_projected_position_from_vault_position
+ON CONFLICT (id) DO NOTHING;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2. Movement history.
+-- ───────────────────────────────────────────────────────────────────────────
+INSERT INTO earn_movements (
+    id, organization_id, project_id, environment, provider,
+    execution_model, direction, position_id, status,
+    failure_reason, settled_at,
+    denomination, amount_requested, amount_settled, fee_amount, payout_token,
+    destination_address, provider_reference,
+    request_id, idempotency_fingerprint, provider_data,
+    created_by, initiated_by_key_id, created_at, updated_at
+)
+SELECT
+    id, organization_id, project_id, environment, provider,
+    execution_model, direction, position_id, status,
+    failure_reason, settled_at,
+    denomination, amount_requested, amount_settled, fee_amount, payout_token,
+    destination_address, provider_reference,
+    request_id, idempotency_fingerprint, provider_data,
+    created_by, initiated_by_key_id, created_at, updated_at
+FROM earn_projected_movement_from_withdrawal
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO earn_movements (
+    id, organization_id, project_id, environment, provider,
+    execution_model, direction, position_id, status,
+    failure_reason, confirmed_at,
+    denomination, amount_requested, amount_settled, min_shares_out, shares_out,
+    custody_wallet_id, vault_address, source_address, destination_address,
+    signature, signed_transaction, last_valid_block_height,
+    request_id, idempotency_fingerprint,
+    created_by, initiated_by_key_id, created_at, updated_at
+)
+SELECT
+    id, organization_id, project_id, environment, provider,
+    execution_model, direction, position_id, status,
+    failure_reason, confirmed_at,
+    denomination, amount_requested, amount_settled, min_shares_out, shares_out,
+    custody_wallet_id, vault_address, source_address, destination_address,
+    signature, signed_transaction, last_valid_block_height,
+    request_id, idempotency_fingerprint,
+    created_by, initiated_by_key_id, created_at, updated_at
+FROM earn_projected_movement_from_vault_movement
+ON CONFLICT (id) DO NOTHING;

--- a/apps/sdp-api/src/db/repositories/CLAUDE.md
+++ b/apps/sdp-api/src/db/repositories/CLAUDE.md
@@ -1,0 +1,35 @@
+# Repositories — rules that bind every writer here
+
+This directory holds the SQL. The invariants that constrain it are documented
+next to the routes that consume it, which means they are easy to miss from
+here — this file exists to point at the ones that will break money movement if
+you don't know them.
+
+## Earn: two movement shapes exist right now, and every writer must feed both
+
+Earn is mid-migration (PRO-1705, migrations `0062`-`0064`) from two movement
+tables split by execution mechanism to one unified ledger.
+
+**If you add or change a writer of `earn_program_withdrawals`,
+`earn_vault_movements` or `earn_vault_positions`, it MUST mirror into
+`earn_movements` / `earn_positions` in the SAME transaction.** Call the
+projection functions in `earn-movements.repository.ts`; never hand-write an
+insert into the unified tables. The mapping lives in SQL views created by `0063`
+and is shared with the bulk backfill, so history and new rows cannot disagree.
+
+Two traps worth stating outright:
+
+- `INSERT ... SELECT` from a projection view that yields nothing inserts zero
+  rows and **succeeds**. A money movement can be dropped with no error, so the
+  projections assert the row is projectable before writing. Do not "simplify"
+  that check away, and do not substitute the mirror's own row count for it —
+  zero rows is also the legitimate answer when the finalization guard declines.
+- Every movement needs a holding, so project the HOLDING before the movement on
+  every path, including replays and non-terminal transitions.
+
+The full rule set, including what `finalized` protects and why the vault
+transition guard still speaks the legacy vocabulary, is in
+[`../../routes/earn/CLAUDE.md`](../../routes/earn/CLAUDE.md). Architecture and
+the migration inventory are in
+[`packages/sdp-earn/README.md`](../../../../../packages/sdp-earn/README.md);
+invariants are in ADR 0002 (`docs/decisions/0002-earn-provider-pluggability.md`).

--- a/apps/sdp-api/src/db/repositories/earn-movements.backfill.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.backfill.test.ts
@@ -1,0 +1,377 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { type AppDb, getDb } from "@/db";
+import { env } from "@/test/helpers/env";
+import type { EarnMovementRow, EarnPositionRow } from "./earn-movements.repository";
+
+/**
+ * The backfill half of the movement unification (PRO-1705, migration 0064).
+ *
+ * The dual-write suite proves NEW writes reach the ledger. This proves EXISTING
+ * history does — legacy rows written long before the unified tables existed, and
+ * rows an outgoing revision writes during a rollout window, which reach neither
+ * the first backfill pass nor the mirror. Those are swept up by re-running this
+ * exact migration in a later release, so "idempotent" is a shipped requirement
+ * and not a nicety.
+ *
+ * It runs the REAL migration file rather than a copy of its statements: a test
+ * against a transcription would pass while the shipped artifact was broken.
+ */
+
+const BACKFILL_SQL = path.join(
+  __dirname,
+  "../migrations/postgres/0064_earn_movements_backfill.sql"
+);
+
+const ORG = "org_earn_bf";
+const USER = "usr_earn_bf";
+const PROJECT = "prj_earn_bf";
+const CONFIG = "cc_earn_bf";
+const WALLET = "cw_earn_bf";
+const WALLET_PUBKEY = "BackfillDepositorPublicKey11111111111111111";
+const TOKEN_MINT = "BackfillTokenMint111111111111111111111111111";
+const VAULT = "BackfillVaultAddress1111111111111111111111";
+
+/**
+ * Split the migration into statements so it can run through the pooled client,
+ * which binds parameters and therefore speaks the extended protocol (one
+ * statement per round trip). Safe for this file specifically: it is plain
+ * INSERTs with `--` comments, no dollar-quoting and no semicolons inside
+ * literals.
+ */
+function backfillStatements(): string[] {
+  return readFileSync(BACKFILL_SQL, "utf8")
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n")
+    .split(";")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+}
+
+async function runBackfill(db: AppDb): Promise<void> {
+  for (const statement of backfillStatements()) {
+    await db.prepare(statement).run();
+  }
+}
+
+describe("Earn movement backfill (migration 0064)", () => {
+  beforeEach(async () => {
+    const db = getDb(env);
+    for (const table of [
+      "earn_movements",
+      "earn_positions",
+      "earn_vault_movements",
+      "earn_vault_positions",
+      "earn_program_withdrawals",
+      "earn_provider_wallets",
+    ]) {
+      await db.prepare(`DELETE FROM ${table} WHERE organization_id = ?`).bind(ORG).run();
+    }
+    await db.prepare("DELETE FROM custody_wallets WHERE id = ?").bind(WALLET).run();
+    await db.prepare("DELETE FROM custody_configs WHERE id = ?").bind(CONFIG).run();
+    await db.prepare("DELETE FROM projects WHERE id = ?").bind(PROJECT).run();
+    await db.prepare("DELETE FROM organizations WHERE id = ?").bind(ORG).run();
+    await db.prepare("DELETE FROM users WHERE id = ?").bind(USER).run();
+
+    await db
+      .prepare(
+        `INSERT INTO users (id, email, email_verified, status)
+         VALUES (?, 'earn-backfill@example.com', 1, 'active')`
+      )
+      .bind(USER)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO organizations (id, name, slug, tier, status)
+         VALUES (?, 'Earn Backfill', 'earn-backfill', 'individual', 'active')`
+      )
+      .bind(ORG)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES (?, ?, 'Backfill', 'earn-backfill', 'sandbox', 'active', ?)`
+      )
+      .bind(PROJECT, ORG, USER)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted)
+         VALUES (?, ?, NULL, 'local', 'encrypted')`
+      )
+      .bind(CONFIG, ORG)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, label)
+         VALUES (?, ?, 'earn-bf-wallet', ?, 'Backfill wallet')`
+      )
+      .bind(WALLET, CONFIG, WALLET_PUBKEY)
+      .run();
+  });
+
+  /**
+   * Write the legacy world DIRECTLY, bypassing the repositories, so the rows look
+   * exactly like history predating the unified tables: no mirror, no holdings.
+   */
+  async function seedLegacyHistory(db: AppDb): Promise<void> {
+    await db
+      .prepare(
+        `INSERT INTO earn_provider_wallets
+           (id, organization_id, project_id, environment, provider, provider_wallet_ref,
+            label, created_by, created_at, updated_at)
+         VALUES
+           ('epw_bf_labelled', ?, ?, 'production', 'ground', 'gw-bf-1', 'Treasury', ?,
+            '2026-01-02T03:04:05.000Z', '2026-01-02T03:04:05.000Z'),
+           ('epw_bf_unlabelled', ?, ?, 'sandbox', 'ground', 'gw-bf-2', NULL, ?,
+            '2026-01-03T03:04:05.000Z', '2026-01-03T03:04:05.000Z')`
+      )
+      .bind(ORG, PROJECT, USER, ORG, PROJECT, USER)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO earn_program_withdrawals
+           (id, organization_id, project_id, wallet_id, provider, status,
+            amount_requested_usd, amount_paid_usd, fee_usd, token, destination_address,
+            failure_reason, request_id, idempotency_fingerprint, provider_reference,
+            provider_data, created_by, initiated_by_key_id, created_at, updated_at, completed_at)
+         VALUES
+           ('earn_program_withdrawal_bf_done', ?, ?, 'epw_bf_labelled', 'ground', 'completed',
+            '1000.50', '995.25', '5.25', 'usdc', 'BackfillDest1',
+            NULL, 'bf-req-1', 'bf-fp-1', 'gw-withdrawal-bf-1',
+            '{"lastObservation":{"status":"completed"}}', ?, 'key_bf',
+            '2026-02-01T00:00:00.000Z', '2026-02-01T01:00:00.000Z', '2026-02-01T01:00:00.000Z'),
+           ('earn_program_withdrawal_bf_intent', ?, ?, 'epw_bf_unlabelled', 'ground', 'requested',
+            '250', NULL, NULL, 'usdt', 'BackfillDest2',
+            NULL, 'bf-req-2', 'bf-fp-2', NULL, '{}', NULL, NULL,
+            '2026-02-02T00:00:00.000Z', '2026-02-02T00:00:00.000Z', NULL)`
+      )
+      .bind(ORG, PROJECT, USER, ORG, PROJECT)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO earn_vault_positions
+           (id, organization_id, project_id, environment, provider, provider_reference,
+            custody_wallet_id, share_mint, token_mint, label, created_by,
+            created_at, updated_at, activated_at, closed_at)
+         VALUES ('earn_vault_position_bf', ?, ?, 'sandbox', 'kamino', ?, ?,
+            'BackfillShareMint', ?, 'USDC vault', ?,
+            '2026-03-01T00:00:00.000Z', '2026-03-01T00:00:00.000Z',
+            '2026-03-01T00:00:00.000Z', NULL)`
+      )
+      .bind(ORG, PROJECT, VAULT, WALLET, TOKEN_MINT, USER)
+      .run();
+
+    await db
+      .prepare(
+        `INSERT INTO earn_vault_movements
+           (id, organization_id, project_id, environment, position_id, provider,
+            provider_reference, custody_wallet_id, direction, status,
+            requested_amount, amount, requested_min_shares_out, min_shares_out, shares,
+            signature, signed_transaction, last_valid_block_height, failure_reason,
+            request_id, idempotency_fingerprint, created_by, initiated_by_key_id,
+            created_at, updated_at, confirmed_at)
+         VALUES
+           ('earn_vault_movement_bf_pending', ?, ?, 'sandbox', 'earn_vault_position_bf', 'kamino',
+            ?, ?, 'deposit', 'pending', '100', '100.000000', '99', '99.000000', NULL,
+            'BfSig1', 'BfBytes1', 123456, NULL, 'bf-v-1', 'bf-vfp-1', ?, NULL,
+            '2026-03-02T00:00:00.000Z', '2026-03-02T00:00:00.000Z', NULL),
+           ('earn_vault_movement_bf_confirmed', ?, ?, 'sandbox', 'earn_vault_position_bf', 'kamino',
+            ?, ?, 'deposit', 'confirmed', '300', '300.000000', NULL, NULL, '299.5',
+            'BfSig2', 'BfBytes2', 123458, NULL, 'bf-v-2', 'bf-vfp-2', ?, NULL,
+            '2026-03-04T00:00:00.000Z', '2026-03-04T00:00:00.000Z', '2026-03-04T00:05:00.000Z')`
+      )
+      .bind(ORG, PROJECT, VAULT, WALLET, USER, ORG, PROJECT, VAULT, WALLET, USER)
+      .run();
+  }
+
+  async function ledger(db: AppDb): Promise<EarnMovementRow[]> {
+    const result = await db
+      .prepare(
+        `SELECT * FROM earn_movements WHERE organization_id = ? ORDER BY created_at ASC, id ASC`
+      )
+      .bind(ORG)
+      .all<EarnMovementRow>();
+    return result.results ?? [];
+  }
+
+  async function holdings(db: AppDb): Promise<EarnPositionRow[]> {
+    const result = await db
+      .prepare(
+        `SELECT * FROM earn_positions WHERE organization_id = ? ORDER BY kind ASC, created_at ASC`
+      )
+      .bind(ORG)
+      .all<EarnPositionRow>();
+    return result.results ?? [];
+  }
+
+  it("projects every legacy holding and movement, preserving ids, amounts and timestamps", async () => {
+    const db = getDb(env);
+    await seedLegacyHistory(db);
+    await runBackfill(db);
+
+    const positions = await holdings(db);
+    expect(positions).toHaveLength(3);
+    const custodial = positions.filter((row) => row.kind === "custodial");
+    expect(custodial).toHaveLength(2);
+    expect(custodial.map((row) => row.provider_wallet_id).sort()).toEqual([
+      "epw_bf_labelled",
+      "epw_bf_unlabelled",
+    ]);
+    // Environment travels from the wallet, and each program keeps its own.
+    expect(custodial.find((row) => row.provider_wallet_id === "epw_bf_labelled")?.environment).toBe(
+      "production"
+    );
+    expect(
+      custodial.find((row) => row.provider_wallet_id === "epw_bf_unlabelled")?.environment
+    ).toBe("sandbox");
+    // An unlabelled program falls back to its provider wallet ref.
+    expect(custodial.find((row) => row.provider_wallet_id === "epw_bf_unlabelled")?.label).toBe(
+      "gw-bf-2"
+    );
+
+    const vaultPosition = positions.find((row) => row.kind === "vault_direct");
+    expect(vaultPosition).toMatchObject({
+      // The legacy id is carried, so movement.position_id needs no translation.
+      id: "earn_vault_position_bf",
+      vault_address: VAULT,
+      token_mint: TOKEN_MINT,
+      provider_wallet_id: null,
+    });
+
+    const rows = await ledger(db);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((row) => row.id)).toEqual([
+      "earn_program_withdrawal_bf_done",
+      "earn_program_withdrawal_bf_intent",
+      "earn_vault_movement_bf_pending",
+      "earn_vault_movement_bf_confirmed",
+    ]);
+
+    const completed = rows[0];
+    expect(completed).toMatchObject({
+      execution_model: "custodial",
+      direction: "withdrawal",
+      status: "completed",
+      environment: "production",
+      denomination: "usd",
+      // Byte-identical, not re-formatted: an audit ledger stores what was said.
+      amount_requested: "1000.50",
+      amount_settled: "995.25",
+      fee_amount: "5.25",
+      payout_token: "usdc",
+      provider_reference: "gw-withdrawal-bf-1",
+      settled_at: "2026-02-01T01:00:00.000Z",
+      // The migration must not claim the movement happened today.
+      created_at: "2026-02-01T00:00:00.000Z",
+    });
+    expect(completed.position_id).toBe(
+      custodial.find((row) => row.provider_wallet_id === "epw_bf_labelled")?.id
+    );
+
+    const pending = rows[2];
+    expect(pending).toMatchObject({
+      execution_model: "vault_direct",
+      // 'pending' becomes 'requested': one word, one meaning, both models.
+      status: "requested",
+      denomination: TOKEN_MINT,
+      amount_requested: "100",
+      amount_settled: null,
+      min_shares_out: "99.000000",
+      source_address: WALLET_PUBKEY,
+      destination_address: VAULT,
+      vault_address: VAULT,
+      provider_reference: null,
+      created_at: "2026-03-02T00:00:00.000Z",
+    });
+
+    const confirmed = rows[3];
+    expect(confirmed).toMatchObject({
+      status: "confirmed",
+      amount_settled: "300.000000",
+      shares_out: "299.5",
+      confirmed_at: "2026-03-04T00:05:00.000Z",
+      // Confirmation is not finalization; the sweep sets settlement honestly
+      // rather than the backfill inventing a date SDP never observed.
+      settled_at: null,
+    });
+  });
+
+  it("changes nothing when re-run, which is how the rollout-window gap is closed", async () => {
+    const db = getDb(env);
+    await seedLegacyHistory(db);
+    await runBackfill(db);
+
+    const firstPositions = await holdings(db);
+    const firstLedger = await ledger(db);
+
+    await runBackfill(db);
+    await runBackfill(db);
+
+    // Same rows, same ids, same everything — including the minted custodial
+    // holdings, whose ids are generated rather than carried and so are the one
+    // thing a careless re-run would duplicate.
+    expect(await holdings(db)).toEqual(firstPositions);
+    expect(await ledger(db)).toEqual(firstLedger);
+  });
+
+  it("sweeps up a legacy row written after the first pass, leaving mirrored rows alone", async () => {
+    const db = getDb(env);
+    await seedLegacyHistory(db);
+    await runBackfill(db);
+    const before = await ledger(db);
+
+    // Exactly the rollout window: the outgoing revision writes legacy only.
+    await db
+      .prepare(
+        `INSERT INTO earn_vault_movements
+           (id, organization_id, project_id, environment, position_id, provider,
+            provider_reference, custody_wallet_id, direction, status,
+            requested_amount, amount, signature, signed_transaction,
+            last_valid_block_height, request_id, idempotency_fingerprint,
+            created_at, updated_at)
+         VALUES ('earn_vault_movement_bf_late', ?, ?, 'sandbox', 'earn_vault_position_bf',
+            'kamino', ?, ?, 'deposit', 'submitted', '42', '42.000000',
+            'BfSigLate', 'BfBytesLate', 999999, 'bf-v-late', 'bf-vfp-late',
+            '2026-03-10T00:00:00.000Z', '2026-03-10T00:00:00.000Z')`
+      )
+      .bind(ORG, PROJECT, VAULT, WALLET)
+      .run();
+
+    await runBackfill(db);
+
+    const after = await ledger(db);
+    expect(after).toHaveLength(before.length + 1);
+    expect(after.find((row) => row.id === "earn_vault_movement_bf_late")).toMatchObject({
+      status: "submitted",
+      amount_requested: "42",
+      denomination: TOKEN_MINT,
+    });
+    // Rows that were already correct are untouched by the sweep.
+    for (const row of before) {
+      expect(after.find((candidate) => candidate.id === row.id)).toEqual(row);
+    }
+  });
+
+  it("does not resurrect a ledger row whose legacy row was hard-deleted", async () => {
+    const db = getDb(env);
+    await seedLegacyHistory(db);
+    await runBackfill(db);
+
+    await db
+      .prepare("DELETE FROM earn_vault_movements WHERE id = ?")
+      .bind("earn_vault_movement_bf_pending")
+      .run();
+    await runBackfill(db);
+
+    // The backfill projects what legacy holds; it is not a resurrection tool, and
+    // the ledger row it already wrote stays as the durable record.
+    const rows = await ledger(db);
+    expect(rows.map((row) => row.id)).toContain("earn_vault_movement_bf_pending");
+    expect(rows).toHaveLength(4);
+  });
+});

--- a/apps/sdp-api/src/db/repositories/earn-movements.backfill.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.backfill.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { type AppDb, getDb } from "@/db";
 import { env } from "@/test/helpers/env";
+import { splitSqlStatements } from "../../../scripts/lib/run-postgres-migrations.mjs";
 import type { EarnMovementRow, EarnPositionRow } from "./earn-movements.repository";
 
 /**
@@ -36,18 +37,12 @@ const VAULT = "BackfillVaultAddress1111111111111111111111";
 /**
  * Split the migration into statements so it can run through the pooled client,
  * which binds parameters and therefore speaks the extended protocol (one
- * statement per round trip). Safe for this file specifically: it is plain
- * INSERTs with `--` comments, no dollar-quoting and no semicolons inside
- * literals.
+ * statement per round trip). Uses the migration runner's own splitter rather
+ * than a local one, so this test cannot disagree with the shipped tool about
+ * where a statement ends.
  */
 function backfillStatements(): string[] {
-  return readFileSync(BACKFILL_SQL, "utf8")
-    .split("\n")
-    .filter((line) => !line.trimStart().startsWith("--"))
-    .join("\n")
-    .split(";")
-    .map((statement) => statement.trim())
-    .filter((statement) => statement.length > 0);
+  return splitSqlStatements(readFileSync(BACKFILL_SQL, "utf8"));
 }
 
 async function runBackfill(db: AppDb): Promise<void> {

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
@@ -608,6 +608,60 @@ describe("Unified earn movement ledger (postgres)", () => {
       });
     });
 
+    it("preserves a shared program and cross-project history when its provisioning project is deleted", async () => {
+      const db = getDb(env);
+      const wallet = await linkProgram();
+      const primary = await createWithdrawal({
+        walletId: wallet.id,
+        requestId: "wd-project-delete-primary",
+        idempotencyFingerprint: "wd-project-delete-primary-fingerprint",
+      });
+      const sibling = await createWithdrawal({
+        walletId: wallet.id,
+        projectId: PROJECT_SIBLING,
+        requestId: "wd-project-delete-sibling",
+        idempotencyFingerprint: "wd-project-delete-sibling-fingerprint",
+      });
+      if (!primary || !sibling) throw new Error("withdrawal not created");
+      const [positionBefore] = await positions();
+
+      await db.prepare("DELETE FROM projects WHERE id = ?").bind(PROJECT).run();
+
+      // The program is organization-scoped. Deleting the project that first
+      // provisioned it clears only forensic attribution, so sibling projects do
+      // not lose the funded provider account or its global ownership anchor.
+      await expect(
+        earnRepo.getProviderWalletById({
+          organizationId: ORG,
+          environment: "sandbox",
+          walletId: wallet.id,
+        })
+      ).resolves.toMatchObject({ id: wallet.id, project_id: null });
+
+      const [positionAfter] = await positions();
+      expect(positionAfter).toMatchObject({
+        id: positionBefore.id,
+        project_id: null,
+        provider_wallet_id: wallet.id,
+      });
+
+      const unified = await movements();
+      expect(unified).toHaveLength(2);
+      expect(unified.find((row) => row.id === primary.id)?.project_id).toBeNull();
+      expect(unified.find((row) => row.id === sibling.id)?.project_id).toBe(PROJECT_SIBLING);
+
+      // The split legacy table still follows its old project-owned cascade;
+      // the unified ledger is the durable history that deliberately survives.
+      const legacy = await db
+        .prepare(
+          `SELECT id, project_id FROM earn_program_withdrawals
+           WHERE wallet_id = ? ORDER BY id`
+        )
+        .bind(wallet.id)
+        .all<{ id: string; project_id: string }>();
+      expect(legacy.results).toEqual([{ id: sibling.id, project_id: PROJECT_SIBLING }]);
+    });
+
     it("mirrors a provider observation, including a zero fee and a scientific-notation amount", async () => {
       const wallet = await linkProgram();
       const withdrawal = await createWithdrawal({ walletId: wallet.id });

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
@@ -1,0 +1,879 @@
+import {
+  EARN_EXECUTION_MODELS,
+  EARN_MOVEMENT_DIRECTIONS,
+  EARN_MOVEMENT_STATUSES,
+  EARN_MOVEMENT_TRANSITIONS,
+  EARN_TERMINAL_MOVEMENT_STATUSES,
+} from "@sdp/types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "@/db";
+import { env } from "@/test/helpers/env";
+import type { EarnRepository } from "./earn.repository";
+import { createPostgresEarnRepository } from "./earn.repository.postgres";
+import type { EarnMovementRow, EarnPositionRow } from "./earn-movements.repository";
+import {
+  type CreateSignedEarnVaultDepositIntentInput,
+  createPostgresEarnVaultRepository,
+  type EarnVaultRepository,
+} from "./earn-vault.repository";
+
+/**
+ * The unified movement ledger (PRO-1705).
+ *
+ * Two jobs here. First, prove the DUAL-WRITE: every legacy write lands in the
+ * unified shape, in the same transaction, projected correctly — because until
+ * reads switch, a mirror that silently misses a row is a money movement that
+ * vanishes from history. Second, prove the ACCOUNTING invariants that motivated
+ * the unification, above all that USD, mint units and vault shares cannot be
+ * confused once both execution models share a table.
+ */
+
+const ORG = "org_earn_mv";
+const ORG_OTHER = "org_earn_mv_other";
+const USER = "usr_earn_mv";
+const PROJECT = "prj_earn_mv";
+const PROJECT_SIBLING = "prj_earn_mv_sibling";
+const WALLET = "cw_earn_mv";
+const CONFIG = "cc_earn_mv";
+const TOKEN_MINT = "TokenMint1111111111111111111111111111111111";
+const SHARE_MINT = "ShareMint1111111111111111111111111111111111";
+const VAULT = "VaultAddress11111111111111111111111111111111";
+const WALLET_PUBKEY = "DepositorPublicKey11111111111111111111111111";
+
+describe("Unified earn movement ledger (postgres)", () => {
+  let vaultRepo: EarnVaultRepository;
+  let earnRepo: EarnRepository;
+  let sequence = 0;
+
+  async function movements(): Promise<EarnMovementRow[]> {
+    const result = await getDb(env)
+      .prepare(
+        `SELECT * FROM earn_movements WHERE organization_id IN (?, ?)
+         ORDER BY created_at ASC, id ASC`
+      )
+      .bind(ORG, ORG_OTHER)
+      .all<EarnMovementRow>();
+    return result.results ?? [];
+  }
+
+  async function positions(): Promise<EarnPositionRow[]> {
+    const result = await getDb(env)
+      .prepare(
+        `SELECT * FROM earn_positions WHERE organization_id IN (?, ?)
+         ORDER BY kind ASC, created_at ASC, id ASC`
+      )
+      .bind(ORG, ORG_OTHER)
+      .all<EarnPositionRow>();
+    return result.results ?? [];
+  }
+
+  async function onlyMovement(): Promise<EarnMovementRow> {
+    const rows = await movements();
+    expect(rows).toHaveLength(1);
+    return rows[0];
+  }
+
+  beforeEach(async () => {
+    const db = getDb(env);
+
+    for (const table of [
+      "earn_movements",
+      "earn_positions",
+      "earn_vault_movements",
+      "earn_vault_positions",
+      "earn_program_withdrawals",
+      "earn_provider_wallets",
+    ]) {
+      await db
+        .prepare(`DELETE FROM ${table} WHERE organization_id IN (?, ?)`)
+        .bind(ORG, ORG_OTHER)
+        .run();
+    }
+    await db.prepare("DELETE FROM custody_wallets WHERE id = ?").bind(WALLET).run();
+    await db.prepare("DELETE FROM custody_configs WHERE id = ?").bind(CONFIG).run();
+    await db
+      .prepare("DELETE FROM projects WHERE id IN (?, ?)")
+      .bind(PROJECT, PROJECT_SIBLING)
+      .run();
+    await db.prepare("DELETE FROM organizations WHERE id IN (?, ?)").bind(ORG, ORG_OTHER).run();
+    await db.prepare("DELETE FROM users WHERE id = ?").bind(USER).run();
+
+    await db
+      .prepare(
+        `INSERT INTO users (id, email, email_verified, status)
+         VALUES (?, 'earn-movements@example.com', 1, 'active')`
+      )
+      .bind(USER)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO organizations (id, name, slug, tier, status) VALUES
+           (?, 'Earn Movements', 'earn-movements', 'individual', 'active'),
+           (?, 'Earn Movements Other', 'earn-movements-other', 'individual', 'active')`
+      )
+      .bind(ORG, ORG_OTHER)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+         VALUES
+           (?, ?, 'Primary', 'earn-mv-primary', 'sandbox', 'active', ?),
+           (?, ?, 'Sibling', 'earn-mv-sibling', 'sandbox', 'active', ?)`
+      )
+      .bind(PROJECT, ORG, USER, PROJECT_SIBLING, ORG, USER)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted)
+         VALUES (?, ?, NULL, 'local', 'encrypted')`
+      )
+      .bind(CONFIG, ORG)
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, label)
+         VALUES (?, ?, 'earn-mv-wallet', ?, 'Earn movements wallet')`
+      )
+      .bind(WALLET, CONFIG, WALLET_PUBKEY)
+      .run();
+
+    vaultRepo = createPostgresEarnVaultRepository(db);
+    earnRepo = createPostgresEarnRepository(db);
+    sequence = 0;
+  });
+
+  function intent(
+    overrides: Partial<CreateSignedEarnVaultDepositIntentInput> = {}
+  ): CreateSignedEarnVaultDepositIntentInput {
+    sequence += 1;
+    return {
+      organizationId: ORG,
+      projectId: PROJECT,
+      environment: "sandbox",
+      provider: "kamino",
+      providerReference: VAULT,
+      custodyWalletId: WALLET,
+      shareMint: SHARE_MINT,
+      tokenMint: TOKEN_MINT,
+      label: "USDC vault",
+      requestedAmount: "100",
+      acceptedAmount: "100.000000",
+      requestedMinSharesOut: "99",
+      acceptedMinSharesOut: "99.000000",
+      signature: `earn-mv-signature-${sequence}`,
+      signedTransaction: `earn-mv-transaction-${sequence}`,
+      lastValidBlockHeight: "123456",
+      requestId: `earn-mv-request-${sequence}`,
+      idempotencyFingerprint: `earn-mv-fingerprint-${sequence}`,
+      createdBy: USER,
+      initiatedByKeyId: null,
+      ...overrides,
+    };
+  }
+
+  async function linkProgram(walletRef = "gw-ref-1", label: string | null = "Treasury program") {
+    const wallet = await earnRepo.insertProviderWallet({
+      organizationId: ORG,
+      projectId: PROJECT,
+      environment: "sandbox",
+      // Open provider string: nothing in the ledger is Ground-specific, so the
+      // pluggability proof uses a provider that is not the live one.
+      provider: "veda" as never,
+      providerWalletRef: walletRef,
+      label,
+      createdBy: USER,
+    });
+    if (!wallet) throw new Error("failed to link program wallet");
+    return wallet;
+  }
+
+  async function createWithdrawal(
+    overrides: { walletId: string; projectId?: string } & Partial<{
+      amountRequestedUsd: string;
+      requestId: string;
+      idempotencyFingerprint: string;
+    }>
+  ) {
+    return earnRepo.createProgramWithdrawal({
+      organizationId: ORG,
+      projectId: overrides.projectId ?? PROJECT,
+      walletId: overrides.walletId,
+      provider: "veda" as never,
+      amountRequestedUsd: overrides.amountRequestedUsd ?? "250.50",
+      token: "usdc",
+      destinationAddress: "DestinationAddress111111111111111111111111",
+      requestId: overrides.requestId ?? "wd-request-1",
+      idempotencyFingerprint: overrides.idempotencyFingerprint ?? "wd-fingerprint-1",
+      providerData: {},
+      createdBy: USER,
+      initiatedByKeyId: null,
+    });
+  }
+
+  describe("vocabulary conformance", () => {
+    it("seeds exactly the execution models, directions and statuses @sdp/types declares", async () => {
+      const db = getDb(env);
+
+      const models = await db
+        .prepare("SELECT id FROM earn_execution_models ORDER BY id")
+        .all<{ id: string }>();
+      expect((models.results ?? []).map((row) => row.id)).toEqual(
+        [...EARN_EXECUTION_MODELS].sort()
+      );
+
+      const directions = await db
+        .prepare("SELECT id FROM earn_movement_directions ORDER BY id")
+        .all<{ id: string }>();
+      expect((directions.results ?? []).map((row) => row.id)).toEqual(
+        [...EARN_MOVEMENT_DIRECTIONS].sort()
+      );
+
+      const statuses = await db
+        .prepare(
+          "SELECT execution_model, status, is_terminal FROM earn_movement_statuses ORDER BY execution_model, status"
+        )
+        .all<{ execution_model: string; status: string; is_terminal: boolean }>();
+
+      // Set equality in BOTH directions: a status seeded but not declared is as
+      // much a drift as one declared but not seeded.
+      const expected = EARN_EXECUTION_MODELS.flatMap((model) =>
+        EARN_MOVEMENT_STATUSES[model].map((status) => ({
+          execution_model: model,
+          status,
+          is_terminal: (EARN_TERMINAL_MOVEMENT_STATUSES[model] as readonly string[]).includes(
+            status
+          ),
+        }))
+      ).sort((left, right) =>
+        `${left.execution_model}${left.status}`.localeCompare(
+          `${right.execution_model}${right.status}`
+        )
+      );
+      expect(statuses.results ?? []).toEqual(expected);
+    });
+
+    it("declares no transition into or out of a status the database does not know", async () => {
+      const db = getDb(env);
+      const rows = await db
+        .prepare("SELECT execution_model, status FROM earn_movement_statuses")
+        .all<{ execution_model: string; status: string }>();
+      const known = new Set(
+        (rows.results ?? []).map((row) => `${row.execution_model}:${row.status}`)
+      );
+
+      for (const model of EARN_EXECUTION_MODELS) {
+        const matrix: Record<string, readonly string[]> = EARN_MOVEMENT_TRANSITIONS[model];
+        for (const [target, sources] of Object.entries(matrix)) {
+          expect(known).toContain(`${model}:${target}`);
+          for (const source of sources) expect(known).toContain(`${model}:${source}`);
+        }
+      }
+    });
+
+    it("never lists a terminal status as a transition source", () => {
+      for (const model of EARN_EXECUTION_MODELS) {
+        const terminal = EARN_TERMINAL_MOVEMENT_STATUSES[model] as readonly string[];
+        const matrix: Record<string, readonly string[]> = EARN_MOVEMENT_TRANSITIONS[model];
+        for (const sources of Object.values(matrix)) {
+          for (const source of sources) expect(terminal).not.toContain(source);
+        }
+      }
+    });
+  });
+
+  describe("vault deposits mirror into the ledger", () => {
+    it("projects the holding and the movement, with mint-denominated amounts", async () => {
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+
+      const [position] = await positions();
+      expect(position).toMatchObject({
+        id: created.position.id,
+        kind: "vault_direct",
+        organization_id: ORG,
+        project_id: PROJECT,
+        environment: "sandbox",
+        provider: "kamino",
+        custody_wallet_id: WALLET,
+        vault_address: VAULT,
+        token_mint: TOKEN_MINT,
+        share_mint: SHARE_MINT,
+        provider_wallet_id: null,
+      });
+      expect(position.activated_at).not.toBeNull();
+
+      const movement = await onlyMovement();
+      expect(movement).toMatchObject({
+        // The legacy id is preserved, which is what keeps every stored reference
+        // and GET-by-id working when reads switch.
+        id: created.movement.id,
+        position_id: created.position.id,
+        execution_model: "vault_direct",
+        direction: "deposit",
+        // 0059's 'pending' under the one word both models share.
+        status: "requested",
+        denomination: TOKEN_MINT,
+        amount_requested: "100",
+        amount_settled: null,
+        min_shares_out: "99.000000",
+        shares_out: null,
+        custody_wallet_id: WALLET,
+        vault_address: VAULT,
+        source_address: WALLET_PUBKEY,
+        destination_address: VAULT,
+        // A vault movement has no provider-side movement id; the vault is the
+        // instrument and lives in vault_address.
+        provider_reference: null,
+        signature: created.movement.signature,
+        request_id: created.movement.request_id,
+        idempotency_fingerprint: created.movement.idempotency_fingerprint,
+        // Never a custodial column.
+        payout_token: null,
+        fee_amount: null,
+      });
+      expect(movement.created_at).toBe(created.movement.created_at);
+      expect(movement.last_valid_block_height).toBe("123456");
+    });
+
+    it("advances the mirror through submitted, confirmed and finalization-ready state", async () => {
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "submitted",
+      });
+      expect((await onlyMovement()).status).toBe("submitted");
+
+      const confirmedAt = "2026-08-19T12:00:00.000Z";
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending", "submitted"],
+        toStatus: "confirmed",
+        confirmedAt,
+        shares: "99.5",
+      });
+
+      const confirmed = await onlyMovement();
+      expect(confirmed).toMatchObject({
+        status: "confirmed",
+        confirmed_at: confirmedAt,
+        shares_out: "99.5",
+        // Only once the chain has spoken does a settled amount exist.
+        amount_settled: "100.000000",
+        // Confirmation is not settlement: the finalization sweep sets this.
+        settled_at: null,
+      });
+    });
+
+    it("mirrors a failure and the holding de-activation it triggers", async () => {
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending", "submitted"],
+        toStatus: "failed",
+        failureReason: "Transaction blockhash expired before confirmation",
+      });
+
+      const movement = await onlyMovement();
+      expect(movement).toMatchObject({
+        status: "failed",
+        failure_reason: "Transaction blockhash expired before confirmation",
+        confirmed_at: null,
+        settled_at: null,
+      });
+      // The only movement failed, so the holding loses its activation — and the
+      // mirror has to reflect that, not just the movement's own state.
+      const [position] = await positions();
+      expect(position.activated_at).toBeNull();
+    });
+
+    it("leaves the mirror untouched when a guarded transition loses its race", async () => {
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending", "submitted"],
+        toStatus: "confirmed",
+        confirmedAt: "2026-08-19T12:00:00.000Z",
+      });
+
+      const lost = await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "submitted",
+      });
+
+      expect(lost).toBeNull();
+      // A lost CAS wrote nothing legacy-side, so it must write nothing here: a
+      // mirror that "helpfully" re-projected would regress a terminal state.
+      expect((await onlyMovement()).status).toBe("confirmed");
+    });
+
+    it("records many deposits against one holding, and re-entry after a close", async () => {
+      const db = getDb(env);
+      const first = await vaultRepo.createSignedDepositIntent(intent());
+      const second = await vaultRepo.createSignedDepositIntent(
+        // Requested and accepted must stay numerically equal (0059 enforces it).
+        intent({ requestedAmount: "250", acceptedAmount: "250.000000" })
+      );
+
+      // Topping up the same vault from the same wallet is one HOLDING with many
+      // movements — the grain the whole design turns on.
+      expect(second.position.id).toBe(first.position.id);
+      expect(await positions()).toHaveLength(1);
+      const rows = await movements();
+      expect(rows).toHaveLength(2);
+      expect(rows.map((row) => row.position_id)).toEqual([first.position.id, first.position.id]);
+      expect(rows.map((row) => row.amount_requested)).toEqual(["100", "250"]);
+
+      // A closed holding that is re-entered reuses its row, and the mirror has to
+      // follow the reopening rather than leave a stale closed_at behind.
+      await db
+        .prepare("UPDATE earn_vault_positions SET closed_at = sdp_iso_now() WHERE id = ?")
+        .bind(first.position.id)
+        .run();
+      await vaultRepo.advanceMovement({
+        movementId: second.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending", "submitted"],
+        toStatus: "confirmed",
+        confirmedAt: "2026-08-19T12:00:00.000Z",
+      });
+
+      const [reopened] = await positions();
+      expect(reopened.closed_at).toBeNull();
+      expect(reopened.activated_at).not.toBeNull();
+    });
+
+    it("gives two organizations holding the same vault separate holdings and ledgers", async () => {
+      const db = getDb(env);
+      // 0059's founding constraint: a public vault is not claimable by whoever
+      // deposits first. The unified holdings table must not quietly reintroduce a
+      // global unique that would refuse the second organization.
+      await db
+        .prepare(
+          `INSERT INTO projects (id, organization_id, name, slug, environment, status, created_by)
+           VALUES ('prj_earn_mv_other', ?, 'Other', 'earn-mv-other', 'sandbox', 'active', ?)`
+        )
+        .bind(ORG_OTHER, USER)
+        .run();
+      await db
+        .prepare(
+          `INSERT INTO custody_configs (id, organization_id, project_id, provider, config_encrypted)
+           VALUES ('cc_earn_mv_other', ?, NULL, 'local', 'encrypted')`
+        )
+        .bind(ORG_OTHER)
+        .run();
+      await db
+        .prepare(
+          `INSERT INTO custody_wallets (id, custody_config_id, wallet_id, public_key, label)
+           VALUES ('cw_earn_mv_other', 'cc_earn_mv_other', 'other-wallet', 'OtherPubkey1111', 'Other')`
+        )
+        .run();
+
+      const mine = await vaultRepo.createSignedDepositIntent(intent());
+      const theirs = await vaultRepo.createSignedDepositIntent(
+        intent({
+          organizationId: ORG_OTHER,
+          projectId: "prj_earn_mv_other",
+          custodyWalletId: "cw_earn_mv_other",
+        })
+      );
+
+      expect(theirs.position.id).not.toBe(mine.position.id);
+      const rows = await positions();
+      expect(rows).toHaveLength(2);
+      // Same instrument, two holdings, one per organization.
+      expect(rows.every((row) => row.vault_address === VAULT)).toBe(true);
+      expect(rows.map((row) => row.organization_id).sort()).toEqual([ORG, ORG_OTHER].sort());
+
+      const ledgerRows = await movements();
+      expect(ledgerRows).toHaveLength(2);
+      expect(ledgerRows.find((row) => row.organization_id === ORG_OTHER)?.position_id).toBe(
+        theirs.position.id
+      );
+
+      await db
+        .prepare("DELETE FROM earn_movements WHERE organization_id = ?")
+        .bind(ORG_OTHER)
+        .run();
+      await db
+        .prepare("DELETE FROM earn_positions WHERE organization_id = ?")
+        .bind(ORG_OTHER)
+        .run();
+      await db
+        .prepare("DELETE FROM earn_vault_movements WHERE organization_id = ?")
+        .bind(ORG_OTHER)
+        .run();
+      await db
+        .prepare("DELETE FROM earn_vault_positions WHERE organization_id = ?")
+        .bind(ORG_OTHER)
+        .run();
+      await db.prepare("DELETE FROM custody_wallets WHERE id = 'cw_earn_mv_other'").run();
+      await db.prepare("DELETE FROM custody_configs WHERE id = 'cc_earn_mv_other'").run();
+      await db.prepare("DELETE FROM projects WHERE id = 'prj_earn_mv_other'").run();
+    });
+
+    it("keeps exactly one ledger row for an idempotent replay", async () => {
+      const first = await vaultRepo.createSignedDepositIntent(intent({ requestId: "same-key" }));
+      const replay = await vaultRepo.createSignedDepositIntent(
+        intent({
+          requestId: "same-key",
+          idempotencyFingerprint: first.movement.idempotency_fingerprint,
+          signature: "a-different-signature-never-broadcast",
+        })
+      );
+
+      expect(replay.replayed).toBe(true);
+      expect(replay.movement.id).toBe(first.movement.id);
+      const rows = await movements();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].signature).toBe(first.movement.signature);
+    });
+
+    it("writes no ledger row when a divergent replay rolls the whole claim back", async () => {
+      const first = await vaultRepo.createSignedDepositIntent(intent({ requestId: "shared-key" }));
+
+      await expect(
+        vaultRepo.createSignedDepositIntent(
+          intent({ requestId: "shared-key", idempotencyFingerprint: "a-different-fingerprint" })
+        )
+      ).rejects.toThrow(/Idempotency key already used/);
+
+      // The rollback must take the mirror with it — an orphan ledger row for a
+      // movement that never existed is exactly the divergence this design bans.
+      const rows = await movements();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(first.movement.id);
+    });
+  });
+
+  describe("custodial withdrawals mirror into the ledger", () => {
+    it("mints exactly one custodial holding per program wallet, and labels an unlabelled one", async () => {
+      const labelled = await linkProgram("gw-ref-1", "Treasury program");
+      const unlabelled = await linkProgram("gw-ref-2", null);
+
+      const rows = await positions();
+      expect(rows).toHaveLength(2);
+      expect(rows.map((row) => row.provider_wallet_id).sort()).toEqual(
+        [labelled.id, unlabelled.id].sort()
+      );
+      for (const row of rows) {
+        expect(row).toMatchObject({
+          kind: "custodial",
+          custody_wallet_id: null,
+          vault_address: null,
+          token_mint: null,
+          share_mint: null,
+        });
+        // A custodial holding is live from the moment its program exists.
+        expect(row.activated_at).not.toBeNull();
+      }
+      expect(rows.find((row) => row.provider_wallet_id === unlabelled.id)?.label).toBe("gw-ref-2");
+    });
+
+    it("projects a withdrawal intent as a USD-denominated movement on the program's holding", async () => {
+      const wallet = await linkProgram();
+      const withdrawal = await createWithdrawal({ walletId: wallet.id });
+      const [position] = await positions();
+
+      const movement = await onlyMovement();
+      expect(movement).toMatchObject({
+        id: withdrawal?.id,
+        position_id: position.id,
+        execution_model: "custodial",
+        direction: "withdrawal",
+        status: "requested",
+        // USD, not a mint — and the payout stablecoin is a separate column so the
+        // two can never be read as the same fact.
+        denomination: "usd",
+        payout_token: "usdc",
+        amount_requested: "250.50",
+        amount_settled: null,
+        fee_amount: null,
+        // environment is derived from the wallet: 0055 has no such column.
+        environment: "sandbox",
+        provider_reference: null,
+        // Never a vault column.
+        custody_wallet_id: null,
+        vault_address: null,
+        signature: null,
+        min_shares_out: null,
+        shares_out: null,
+      });
+    });
+
+    it("mirrors a provider observation, including a zero fee and a scientific-notation amount", async () => {
+      const wallet = await linkProgram();
+      const withdrawal = await createWithdrawal({ walletId: wallet.id });
+      if (!withdrawal) throw new Error("withdrawal not created");
+
+      await earnRepo.updateProgramWithdrawalStatusGuarded({
+        selector: { withdrawalId: withdrawal.id },
+        organizationId: ORG,
+        fromStatuses: ["requested"],
+        toStatus: "completed",
+        providerReference: "wd-provider-ref-1",
+        // Values a provider legitimately reports and 0055 never constrained. The
+        // ledger must accept them verbatim rather than fail the money write.
+        amountPaidUsd: "1e-7",
+        feeUsd: "0",
+        completedAt: "2026-08-19T13:00:00.000Z",
+        providerData: { lastObservation: { status: "completed" } },
+      });
+
+      const movement = await onlyMovement();
+      expect(movement).toMatchObject({
+        status: "completed",
+        provider_reference: "wd-provider-ref-1",
+        amount_settled: "1e-7",
+        fee_amount: "0",
+        settled_at: "2026-08-19T13:00:00.000Z",
+      });
+      expect(movement.provider_data).toMatchObject({
+        lastObservation: { status: "completed" },
+      });
+    });
+
+    it("leaves the mirror at its terminal state when an observation loses the guard", async () => {
+      const wallet = await linkProgram();
+      const withdrawal = await createWithdrawal({ walletId: wallet.id });
+      if (!withdrawal) throw new Error("withdrawal not created");
+
+      await earnRepo.updateProgramWithdrawalStatusGuarded({
+        selector: { withdrawalId: withdrawal.id },
+        organizationId: ORG,
+        fromStatuses: ["requested"],
+        toStatus: "completed",
+        completedAt: "2026-08-19T13:00:00.000Z",
+      });
+      const regressed = await earnRepo.updateProgramWithdrawalStatusGuarded({
+        selector: { withdrawalId: withdrawal.id },
+        organizationId: ORG,
+        fromStatuses: ["requested", "processing"],
+        toStatus: "processing",
+      });
+
+      expect(regressed).toBeNull();
+      expect((await onlyMovement()).status).toBe("completed");
+    });
+
+    it("refuses to project a withdrawal whose program has no holding", async () => {
+      const db = getDb(env);
+      const wallet = await linkProgram();
+      // Simulate the one state the ledger cannot represent: a program wallet with
+      // no holding. The projection joins INNER precisely so this fails loudly
+      // instead of dropping a money movement on the floor.
+      await db
+        .prepare("DELETE FROM earn_positions WHERE provider_wallet_id = ?")
+        .bind(wallet.id)
+        .run();
+
+      await expect(createWithdrawal({ walletId: wallet.id })).rejects.toThrow();
+      expect(await movements()).toHaveLength(0);
+      // The legacy write rolled back with the mirror, so neither shape holds it.
+      const legacy = await db
+        .prepare("SELECT COUNT(*)::int AS total FROM earn_program_withdrawals WHERE wallet_id = ?")
+        .bind(wallet.id)
+        .first<{ total: number }>();
+      expect(legacy?.total).toBe(0);
+    });
+  });
+
+  describe("accounting invariants across execution models", () => {
+    it("keeps USD, mint units and share counts in separate, self-describing columns", async () => {
+      const wallet = await linkProgram();
+      await createWithdrawal({ walletId: wallet.id, amountRequestedUsd: "250.50" });
+      await vaultRepo.createSignedDepositIntent(intent({ requestedAmount: "100" }));
+
+      const rows = await movements();
+      expect(rows).toHaveLength(2);
+
+      const custodial = rows.find((row) => row.execution_model === "custodial");
+      const vault = rows.find((row) => row.execution_model === "vault_direct");
+
+      // The same numeric column holds two different assets, and each row states
+      // which — the concrete hazard the unification could have introduced.
+      expect(custodial?.denomination).toBe("usd");
+      expect(vault?.denomination).toBe(TOKEN_MINT);
+      expect(custodial?.denomination).not.toBe(vault?.denomination);
+
+      // Share quantities exist only in share-named columns, on neither model's
+      // amount columns.
+      expect(custodial?.min_shares_out).toBeNull();
+      expect(custodial?.shares_out).toBeNull();
+      expect(vault?.min_shares_out).toBe("99.000000");
+
+      // A USD payout symbol never appears on a mint-denominated movement.
+      expect(custodial?.payout_token).toBe("usdc");
+      expect(vault?.payout_token).toBeNull();
+    });
+
+    it("preserves decimal spelling byte for byte, never normalizing an amount", async () => {
+      const wallet = await linkProgram();
+      // Trailing zeroes and a bare integer are different SPELLINGS of the same
+      // value. An audit ledger stores what was said, so no coercion may happen.
+      await createWithdrawal({ walletId: wallet.id, amountRequestedUsd: "1000.500000" });
+      await vaultRepo.createSignedDepositIntent(
+        intent({ requestedAmount: "100", acceptedAmount: "100.000000" })
+      );
+
+      const rows = await movements();
+      const custodial = rows.find((row) => row.execution_model === "custodial");
+      const vault = rows.find((row) => row.execution_model === "vault_direct");
+      expect(custodial?.amount_requested).toBe("1000.500000");
+      expect(vault?.amount_requested).toBe("100");
+    });
+
+    it("serves one chronological history across both execution models", async () => {
+      const wallet = await linkProgram();
+      await createWithdrawal({ walletId: wallet.id });
+      await vaultRepo.createSignedDepositIntent(intent());
+
+      const rows = await getDb(env)
+        .prepare(
+          `SELECT execution_model, direction FROM earn_movements
+           WHERE organization_id = ? AND environment = ?
+           ORDER BY created_at DESC, id DESC`
+        )
+        .bind(ORG, "sandbox")
+        .all<{ execution_model: string; direction: string }>();
+
+      // One query, no union, both mechanisms — the read PRO-1669 promised and
+      // neither legacy table could serve alone.
+      expect((rows.results ?? []).map((row) => `${row.execution_model}:${row.direction}`)).toEqual(
+        expect.arrayContaining(["custodial:withdrawal", "vault_direct:deposit"])
+      );
+      expect(rows.results).toHaveLength(2);
+    });
+  });
+
+  describe("idempotency anchors", () => {
+    it("scopes the custodial anchor to the holding and the vault anchor to the organization", async () => {
+      const db = getDb(env);
+      const wallet = await linkProgram();
+
+      // The SAME caller key on both models is two different requests, and each
+      // anchor is a partial index over its own model's rows — so they coexist.
+      await createWithdrawal({ walletId: wallet.id, requestId: "shared-request-id" });
+      await vaultRepo.createSignedDepositIntent(intent({ requestId: "shared-request-id" }));
+      expect(await movements()).toHaveLength(2);
+
+      // Custodial: position-scoped, which is 0055's wallet scope in the new
+      // shape — a sibling project sharing the program hits the same anchor.
+      await expect(
+        createWithdrawal({
+          walletId: wallet.id,
+          projectId: PROJECT_SIBLING,
+          requestId: "shared-request-id",
+          idempotencyFingerprint: "a-different-fingerprint",
+        })
+      ).rejects.toThrow();
+
+      // Vault: org-scoped, so a retry resolving to a different position is still
+      // a key reuse and must not silently open a second movement.
+      const duplicate = await db
+        .prepare(
+          `INSERT INTO earn_movements (
+             id, organization_id, environment, provider, execution_model, direction,
+             position_id, status, denomination, amount_requested,
+             custody_wallet_id, vault_address, signature, signed_transaction,
+             last_valid_block_height, request_id, idempotency_fingerprint
+           )
+           SELECT 'earn_movement_duplicate', organization_id, environment, provider,
+                  execution_model, direction, position_id, status, denomination,
+                  amount_requested, custody_wallet_id, vault_address,
+                  'another-signature', signed_transaction, last_valid_block_height,
+                  request_id, idempotency_fingerprint
+           FROM earn_movements WHERE execution_model = 'vault_direct' AND organization_id = ?`
+        )
+        .bind(ORG)
+        .run()
+        .then(
+          () => "inserted",
+          () => "rejected"
+        );
+      expect(duplicate).toBe("rejected");
+    });
+  });
+
+  describe("self-healing", () => {
+    it("repairs a legacy row an earlier revision wrote without mirroring", async () => {
+      const db = getDb(env);
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+
+      // Simulate a row written by a revision that predates the mirror (or one
+      // written during a rollback window): legacy has it, the ledger does not.
+      await db.prepare("DELETE FROM earn_movements WHERE id = ?").bind(created.movement.id).run();
+      expect(await movements()).toHaveLength(0);
+
+      // The next legacy write re-projects the whole row, so the gap closes
+      // without a backfill pass.
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "submitted",
+      });
+
+      const healed = await onlyMovement();
+      expect(healed).toMatchObject({
+        id: created.movement.id,
+        status: "submitted",
+        denomination: TOKEN_MINT,
+        source_address: WALLET_PUBKEY,
+      });
+      // Recovered rows keep their original timestamps, not the repair time.
+      expect(healed.created_at).toBe(created.movement.created_at);
+    });
+
+    it("never regresses a finalized ledger row from a legacy write", async () => {
+      const db = getDb(env);
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending", "submitted"],
+        toStatus: "confirmed",
+        confirmedAt: "2026-08-19T12:00:00.000Z",
+      });
+
+      // `finalized` is the one state no legacy table can express, so a legacy row
+      // can never be the authority on a movement that already reached it.
+      await db
+        .prepare(
+          `UPDATE earn_movements
+             SET status = 'finalized', settled_at = '2026-08-19T12:30:00.000Z'
+           WHERE id = ?`
+        )
+        .bind(created.movement.id)
+        .run();
+
+      // A legacy transition that would otherwise re-project 'confirmed' — which
+      // would both regress the status and null out settled_at, violating 0062's
+      // settlement biconditional and failing the legacy write itself.
+      await db
+        .prepare(
+          "UPDATE earn_vault_movements SET status = 'submitted', confirmed_at = NULL WHERE id = ?"
+        )
+        .bind(created.movement.id)
+        .run();
+      await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending", "submitted"],
+        toStatus: "confirmed",
+        confirmedAt: "2026-08-19T14:00:00.000Z",
+      });
+
+      const movement = await onlyMovement();
+      expect(movement.status).toBe("finalized");
+      expect(movement.settled_at).toBe("2026-08-19T12:30:00.000Z");
+    });
+  });
+});

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import {
   EARN_EXECUTION_MODELS,
   EARN_MOVEMENT_DIRECTIONS,
@@ -11,6 +13,11 @@ import { env } from "@/test/helpers/env";
 import type { EarnRepository } from "./earn.repository";
 import { createPostgresEarnRepository } from "./earn.repository.postgres";
 import type { EarnMovementRow, EarnPositionRow } from "./earn-movements.repository";
+import {
+  EARN_POSITION_ID_PREFIX,
+  EARN_PROJECTION_SPECS,
+  generateEarnPositionId,
+} from "./earn-movements.repository";
 import {
   type CreateSignedEarnVaultDepositIntentInput,
   createPostgresEarnVaultRepository,
@@ -176,9 +183,10 @@ describe("Unified earn movement ledger (postgres)", () => {
       organizationId: ORG,
       projectId: PROJECT,
       environment: "sandbox",
-      // Open provider string: nothing in the ledger is Ground-specific, so the
-      // pluggability proof uses a provider that is not the live one.
-      provider: "veda" as never,
+      // Nothing in the ledger is Ground-specific, so the pluggability proof uses
+      // a registered provider that is not the live one. A real `EarnProviderId`,
+      // so the union check the typed id exists for still applies.
+      provider: "veda",
       providerWalletRef: walletRef,
       label,
       createdBy: USER,
@@ -198,7 +206,7 @@ describe("Unified earn movement ledger (postgres)", () => {
       organizationId: ORG,
       projectId: overrides.projectId ?? PROJECT,
       walletId: overrides.walletId,
-      provider: "veda" as never,
+      provider: "veda",
       amountRequestedUsd: overrides.amountRequestedUsd ?? "250.50",
       token: "usdc",
       destinationAddress: "DestinationAddress111111111111111111111111",
@@ -278,6 +286,50 @@ describe("Unified earn movement ledger (postgres)", () => {
           for (const source of sources) expect(terminal).not.toContain(source);
         }
       }
+    });
+
+    it("declares no vault transition migration 0062's CHECK constraints forbid", () => {
+      // The matrix and the schema have to agree, not merely be internally
+      // consistent. `confirmed_at` and `shares_out` are tied to the commitment
+      // states, so a transition OUT of 'confirmed' into a state that may not hold
+      // them could only be written by erasing an observation SDP actually made.
+      for (const [target, sources] of Object.entries(EARN_MOVEMENT_TRANSITIONS.vault_direct)) {
+        if (target === "finalized") continue;
+        expect(sources).not.toContain("confirmed");
+      }
+    });
+  });
+
+  describe("projection column drift", () => {
+    // The failure this prevents is silent: a column added to a 0063 view but
+    // missed in one clause that carries it is written on the first mirror and
+    // never refreshed afterwards, with every other test still green. Generating
+    // the clauses from one array closes the three-clause direction; this closes
+    // the array-vs-view direction.
+    it.each(Object.entries(EARN_PROJECTION_SPECS))(
+      "projects every column %s's view produces",
+      async (_name, spec) => {
+        const result = await getDb(env)
+          .prepare(
+            `SELECT column_name FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ?`
+          )
+          .bind(spec.view)
+          .all<{ column_name: string }>();
+        const viewColumns = (result.results ?? []).map((row) => row.column_name).sort();
+        expect(viewColumns).toEqual([...spec.columns].sort());
+      }
+    );
+
+    it("mints holding ids under the same prefix the backfill migration writes", () => {
+      const backfill = readFileSync(
+        path.join(__dirname, "../migrations/postgres/0064_earn_movements_backfill.sql"),
+        "utf8"
+      );
+      expect(generateEarnPositionId()).toMatch(new RegExp(`^${EARN_POSITION_ID_PREFIX}`));
+      // 0064 mints in SQL and cannot import the constant, so the literal is
+      // pinned here instead.
+      expect(backfill).toContain(`'${EARN_POSITION_ID_PREFIX}' || gen_random_uuid()`);
     });
   });
 
@@ -650,16 +702,27 @@ describe("Unified earn movement ledger (postgres)", () => {
       expect(unified.find((row) => row.id === primary.id)?.project_id).toBeNull();
       expect(unified.find((row) => row.id === sibling.id)?.project_id).toBe(PROJECT_SIBLING);
 
-      // The split legacy table still follows its old project-owned cascade;
-      // the unified ledger is the durable history that deliberately survives.
+      // 0062 relaxes 0055's CASCADE to SET NULL, so the legacy table keeps the
+      // history too and the two shapes stay ISOMORPHIC through the expand
+      // window. That is not cosmetic: a divergence here would let a reused
+      // idempotency key insert a fresh legacy row, collide with the surviving
+      // unified row on the custodial anchor, and fail that key permanently —
+      // because the route re-resolves the replay from the LEGACY table.
       const legacy = await db
         .prepare(
           `SELECT id, project_id FROM earn_program_withdrawals
            WHERE wallet_id = ? ORDER BY id`
         )
         .bind(wallet.id)
-        .all<{ id: string; project_id: string }>();
-      expect(legacy.results).toEqual([{ id: sibling.id, project_id: PROJECT_SIBLING }]);
+        .all<{ id: string; project_id: string | null }>();
+      expect(
+        [...(legacy.results ?? [])].sort((left, right) => left.id.localeCompare(right.id))
+      ).toEqual(
+        [
+          { id: primary.id, project_id: null },
+          { id: sibling.id, project_id: PROJECT_SIBLING },
+        ].sort((left, right) => left.id.localeCompare(right.id))
+      );
     });
 
     it("mirrors a provider observation, including a zero fee and a scientific-notation amount", async () => {
@@ -717,25 +780,76 @@ describe("Unified earn movement ledger (postgres)", () => {
       expect((await onlyMovement()).status).toBe("completed");
     });
 
-    it("refuses to project a withdrawal whose program has no holding", async () => {
+    it("opens a missing holding rather than failing a withdrawal against it", async () => {
       const db = getDb(env);
       const wallet = await linkProgram();
-      // Simulate the one state the ledger cannot represent: a program wallet with
-      // no holding. The projection joins INNER precisely so this fails loudly
-      // instead of dropping a money movement on the floor.
+      // The state a program reaches when it was linked by a revision that
+      // predates the ledger, or during a rollout or rollback window: the wallet
+      // exists and has no holding. Failing here would take the program's whole
+      // withdrawal endpoint down permanently, so the projection opens one.
+      await db
+        .prepare("DELETE FROM earn_positions WHERE provider_wallet_id = ?")
+        .bind(wallet.id)
+        .run();
+      expect(await positions()).toHaveLength(0);
+
+      const withdrawal = await createWithdrawal({ walletId: wallet.id });
+      if (!withdrawal) throw new Error("withdrawal not created");
+
+      const [healed] = await positions();
+      expect(healed).toMatchObject({
+        kind: "custodial",
+        provider_wallet_id: wallet.id,
+        organization_id: ORG,
+      });
+      expect(await onlyMovement()).toMatchObject({
+        id: withdrawal.id,
+        execution_model: "custodial",
+        position_id: healed.id,
+        status: "requested",
+      });
+    });
+
+    it("keeps the provider_reference stamp when the holding was missing at observation", async () => {
+      const db = getDb(env);
+      const wallet = await linkProgram();
+      const withdrawal = await createWithdrawal({ walletId: wallet.id });
+      if (!withdrawal) throw new Error("withdrawal not created");
+
+      // Lose the holding AFTER the intent, so the observation write is the first
+      // thing to notice. This is the dangerous case: the mirror shares its
+      // transaction with the legacy write, so a throw here would roll back the
+      // provider_reference stamp for a withdrawal the provider has already PAID —
+      // and a movement with no reference is the one row no later observation can
+      // find again.
+      await db.prepare("DELETE FROM earn_movements WHERE id = ?").bind(withdrawal.id).run();
       await db
         .prepare("DELETE FROM earn_positions WHERE provider_wallet_id = ?")
         .bind(wallet.id)
         .run();
 
-      await expect(createWithdrawal({ walletId: wallet.id })).rejects.toThrow();
-      expect(await movements()).toHaveLength(0);
-      // The legacy write rolled back with the mirror, so neither shape holds it.
+      const observed = await earnRepo.updateProgramWithdrawalStatusGuarded({
+        selector: { withdrawalId: withdrawal.id },
+        organizationId: ORG,
+        fromStatuses: ["requested"],
+        toStatus: "completed",
+        providerReference: "wd-paid-ref",
+        amountPaidUsd: "250.50",
+        completedAt: "2026-08-19T14:00:00.000Z",
+      });
+
+      expect(observed?.provider_reference).toBe("wd-paid-ref");
       const legacy = await db
-        .prepare("SELECT COUNT(*)::int AS total FROM earn_program_withdrawals WHERE wallet_id = ?")
-        .bind(wallet.id)
-        .first<{ total: number }>();
-      expect(legacy?.total).toBe(0);
+        .prepare("SELECT provider_reference FROM earn_program_withdrawals WHERE id = ?")
+        .bind(withdrawal.id)
+        .first<{ provider_reference: string | null }>();
+      expect(legacy?.provider_reference).toBe("wd-paid-ref");
+      expect(await onlyMovement()).toMatchObject({
+        id: withdrawal.id,
+        status: "completed",
+        provider_reference: "wd-paid-ref",
+        amount_settled: "250.50",
+      });
     });
   });
 
@@ -884,6 +998,56 @@ describe("Unified earn movement ledger (postgres)", () => {
       });
       // Recovered rows keep their original timestamps, not the repair time.
       expect(healed.created_at).toBe(created.movement.created_at);
+    });
+
+    it("repairs an unmirrored holding on a non-terminal transition, not only a terminal one", async () => {
+      const db = getDb(env);
+      const created = await vaultRepo.createSignedDepositIntent(intent());
+
+      // A movement whose HOLDING never reached the ledger. The movement
+      // projection INNER JOINs earn_positions, so before this was fixed the
+      // non-terminal branch threw and rolled the legacy status write back with
+      // it — leaving reconciliation to re-broadcast the same signed bytes every
+      // tick until blockhash expiry forced it down the terminal path.
+      await db.prepare("DELETE FROM earn_movements WHERE id = ?").bind(created.movement.id).run();
+      await db.prepare("DELETE FROM earn_positions WHERE id = ?").bind(created.position.id).run();
+      expect(await positions()).toHaveLength(0);
+
+      const advanced = await vaultRepo.advanceMovement({
+        movementId: created.movement.id,
+        organizationId: ORG,
+        fromStatuses: ["pending"],
+        toStatus: "submitted",
+      });
+
+      expect(advanced?.status).toBe("submitted");
+      const [holding] = await positions();
+      expect(holding).toMatchObject({ id: created.position.id, kind: "vault_direct" });
+      expect(await onlyMovement()).toMatchObject({
+        id: created.movement.id,
+        status: "submitted",
+        position_id: created.position.id,
+      });
+    });
+
+    it("repairs an unmirrored row on an idempotent replay", async () => {
+      const db = getDb(env);
+      const input = intent();
+      const created = await vaultRepo.createSignedDepositIntent(input);
+
+      // A replay writes no legacy row, so it used to project nothing — meaning a
+      // caller retrying the one request that touches an unmirrored movement got
+      // a 200 while the ledger still had no record of it.
+      await db.prepare("DELETE FROM earn_movements WHERE id = ?").bind(created.movement.id).run();
+      await db.prepare("DELETE FROM earn_positions WHERE id = ?").bind(created.position.id).run();
+
+      const replay = await vaultRepo.createSignedDepositIntent(input);
+      expect(replay.replayed).toBe(true);
+      expect(await positions()).toHaveLength(1);
+      expect(await onlyMovement()).toMatchObject({
+        id: created.movement.id,
+        position_id: created.position.id,
+      });
     });
 
     it("never regresses a finalized ledger row from a legacy write", async () => {

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -28,6 +28,13 @@ import type { AppDb } from "@/db";
  * the next write that touches it, and the bulk backfill in 0064 is the same
  * projection applied to everything at once.
  *
+ * That repair rule covers HOLDINGS as well as movements, and deliberately: a
+ * movement whose holding is missing cannot be projected at all, so every write
+ * path projects the holding first, and the custodial path opens one if none
+ * exists. A missing holding must never be able to fail a money write — on the
+ * observation path the mirror shares its transaction with the legacy write, so
+ * throwing would roll back the record of a payout the provider already made.
+ *
  * ── The projections live in SQL, not here ─────────────────────────────────
  * Every mapping decision — which legacy status becomes which unified one, which
  * join supplies the denomination, whether a settled amount is known yet — is a
@@ -38,9 +45,18 @@ import type { AppDb } from "@/db";
  * database decides what it becomes.
  */
 
+/**
+ * Prefix of a minted holding id.
+ *
+ * Exported because migration 0064 mints the same ids in SQL and cannot import
+ * this: a conformance test asserts the literal in that file matches this
+ * constant, so the two mints cannot come to disagree on the id shape.
+ */
+export const EARN_POSITION_ID_PREFIX = "earn_position_";
+
 /** Ids are minted only for custodial holdings — see `mintEarnPositionForProviderWallet`. */
 export function generateEarnPositionId(): string {
-  return `earn_position_${crypto.randomUUID()}`;
+  return `${EARN_POSITION_ID_PREFIX}${crypto.randomUUID()}`;
 }
 
 export interface EarnPositionRow {
@@ -122,7 +138,7 @@ export interface EarnMovementRow {
 const NOT_ALREADY_FINALIZED = `WHERE earn_movements.status <> 'finalized'`;
 
 /**
- * Assert that a legacy row actually projects, BEFORE trying to mirror it.
+ * Does this legacy row actually project?
  *
  * `INSERT ... SELECT ... FROM <view> WHERE id = ?` inserts zero rows and
  * SUCCEEDS when the view yields nothing — so an unprojectable row would be
@@ -135,6 +151,20 @@ const NOT_ALREADY_FINALIZED = `WHERE earn_movements.status <> 'finalized'`;
  * zero rows is also the legitimate answer when the finalization guard above
  * declines an update.
  */
+async function isProjectable(
+  db: AppDb,
+  view: string,
+  keyColumn: string,
+  key: string
+): Promise<boolean> {
+  const projected = await db
+    .prepare(`SELECT 1 AS projectable FROM ${view} WHERE ${keyColumn} = ?`)
+    .bind(key)
+    .first<{ projectable: number }>();
+  return Boolean(projected);
+}
+
+/** `isProjectable`, as the precondition it guards. */
 async function requireProjectableRow(
   db: AppDb,
   view: string,
@@ -142,13 +172,149 @@ async function requireProjectableRow(
   key: string,
   remedy: string
 ): Promise<void> {
-  const projected = await db
-    .prepare(`SELECT 1 AS projectable FROM ${view} WHERE ${keyColumn} = ?`)
-    .bind(key)
-    .first<{ projectable: number }>();
-  if (!projected) {
+  if (!(await isProjectable(db, view, keyColumn, key))) {
     throw new Error(`Earn ledger cannot project ${keyColumn}=${key} through ${view}: ${remedy}`);
   }
+}
+
+/**
+ * One projection, described once.
+ *
+ * The column list is the part of a projection that drifts SILENTLY: a column
+ * added to a view but missed in one of the three clauses that carry it (the
+ * INSERT list, the SELECT list, the `DO UPDATE SET` assignments) is written on
+ * the first mirror and then never refreshed on any later transition, with every
+ * test still green. So the three clauses are GENERATED from this array rather
+ * than maintained beside each other, which makes that particular disagreement
+ * unrepresentable — and `columns` is pinned against the view's own output
+ * columns by a conformance test, which closes the remaining direction.
+ */
+interface EarnProjectionSpec {
+  /** The unified table the projection writes. */
+  table: string;
+  /** 0063's view — the single definition of what a legacy row becomes. */
+  view: string;
+  /** Every column carried, in one order, used by all three clauses. */
+  columns: readonly string[];
+}
+
+/**
+ * The id-preserving projections, keyed by the legacy row they mirror.
+ *
+ * Exported for the conformance test only. `earn_projected_position_from_provider_wallet`
+ * is deliberately absent: it MINTS an id rather than preserving one and is keyed
+ * on `provider_wallet_id`, so it is not an `ON CONFLICT (id)` upsert.
+ */
+export const EARN_PROJECTION_SPECS = {
+  vaultMovement: {
+    table: "earn_movements",
+    view: "earn_projected_movement_from_vault_movement",
+    columns: [
+      "id",
+      "organization_id",
+      "project_id",
+      "environment",
+      "provider",
+      "execution_model",
+      "direction",
+      "position_id",
+      "status",
+      "failure_reason",
+      "confirmed_at",
+      "denomination",
+      "amount_requested",
+      "amount_settled",
+      "min_shares_out",
+      "shares_out",
+      "custody_wallet_id",
+      "vault_address",
+      "source_address",
+      "destination_address",
+      "signature",
+      "signed_transaction",
+      "last_valid_block_height",
+      "request_id",
+      "idempotency_fingerprint",
+      "created_by",
+      "initiated_by_key_id",
+      "created_at",
+      "updated_at",
+    ],
+  },
+  withdrawal: {
+    table: "earn_movements",
+    view: "earn_projected_movement_from_withdrawal",
+    columns: [
+      "id",
+      "organization_id",
+      "project_id",
+      "environment",
+      "provider",
+      "execution_model",
+      "direction",
+      "position_id",
+      "status",
+      "failure_reason",
+      "settled_at",
+      "denomination",
+      "amount_requested",
+      "amount_settled",
+      "fee_amount",
+      "payout_token",
+      "destination_address",
+      "provider_reference",
+      "request_id",
+      "idempotency_fingerprint",
+      "provider_data",
+      "created_by",
+      "initiated_by_key_id",
+      "created_at",
+      "updated_at",
+    ],
+  },
+  vaultPosition: {
+    table: "earn_positions",
+    view: "earn_projected_position_from_vault_position",
+    columns: [
+      "id",
+      "organization_id",
+      "project_id",
+      "environment",
+      "provider",
+      "kind",
+      "custody_wallet_id",
+      "vault_address",
+      "share_mint",
+      "token_mint",
+      "label",
+      "created_by",
+      "created_at",
+      "updated_at",
+      "activated_at",
+      "closed_at",
+    ],
+  },
+} as const satisfies Record<string, EarnProjectionSpec>;
+
+/**
+ * `INSERT ... SELECT ... FROM <view> WHERE id = ? ON CONFLICT (id) DO UPDATE`,
+ * with all three column clauses generated from `spec.columns`.
+ *
+ * Re-projects the WHOLE row rather than patching what changed, because the
+ * invariant is "a unified row IS the projection of its legacy row". `id` is
+ * excluded from the assignments: it is the conflict key and is by definition
+ * already equal.
+ */
+function projectByIdSql(spec: EarnProjectionSpec, guard = ""): string {
+  const columns = spec.columns.join(", ");
+  const assignments = spec.columns
+    .filter((column) => column !== "id")
+    .map((column) => `${column} = EXCLUDED.${column}`)
+    .join(", ");
+  return `INSERT INTO ${spec.table} (${columns})
+     SELECT ${columns} FROM ${spec.view} WHERE id = ?
+     ON CONFLICT (id) DO UPDATE SET ${assignments}
+     ${guard}`;
 }
 
 /**
@@ -165,65 +331,13 @@ export async function projectEarnMovementFromVaultMovement(
 ): Promise<void> {
   await requireProjectableRow(
     db,
-    "earn_projected_movement_from_vault_movement",
+    EARN_PROJECTION_SPECS.vaultMovement.view,
     "id",
     movementId,
     "its vault holding is missing from earn_positions"
   );
   await db
-    .prepare(
-      `INSERT INTO earn_movements (
-         id, organization_id, project_id, environment, provider,
-         execution_model, direction, position_id, status,
-         failure_reason, confirmed_at,
-         denomination, amount_requested, amount_settled, min_shares_out, shares_out,
-         custody_wallet_id, vault_address, source_address, destination_address,
-         signature, signed_transaction, last_valid_block_height,
-         request_id, idempotency_fingerprint,
-         created_by, initiated_by_key_id, created_at, updated_at
-       )
-       SELECT
-         id, organization_id, project_id, environment, provider,
-         execution_model, direction, position_id, status,
-         failure_reason, confirmed_at,
-         denomination, amount_requested, amount_settled, min_shares_out, shares_out,
-         custody_wallet_id, vault_address, source_address, destination_address,
-         signature, signed_transaction, last_valid_block_height,
-         request_id, idempotency_fingerprint,
-         created_by, initiated_by_key_id, created_at, updated_at
-       FROM earn_projected_movement_from_vault_movement
-       WHERE id = ?
-       ON CONFLICT (id) DO UPDATE SET
-         organization_id = EXCLUDED.organization_id,
-         project_id = EXCLUDED.project_id,
-         environment = EXCLUDED.environment,
-         provider = EXCLUDED.provider,
-         execution_model = EXCLUDED.execution_model,
-         direction = EXCLUDED.direction,
-         position_id = EXCLUDED.position_id,
-         status = EXCLUDED.status,
-         failure_reason = EXCLUDED.failure_reason,
-         confirmed_at = EXCLUDED.confirmed_at,
-         denomination = EXCLUDED.denomination,
-         amount_requested = EXCLUDED.amount_requested,
-         amount_settled = EXCLUDED.amount_settled,
-         min_shares_out = EXCLUDED.min_shares_out,
-         shares_out = EXCLUDED.shares_out,
-         custody_wallet_id = EXCLUDED.custody_wallet_id,
-         vault_address = EXCLUDED.vault_address,
-         source_address = EXCLUDED.source_address,
-         destination_address = EXCLUDED.destination_address,
-         signature = EXCLUDED.signature,
-         signed_transaction = EXCLUDED.signed_transaction,
-         last_valid_block_height = EXCLUDED.last_valid_block_height,
-         request_id = EXCLUDED.request_id,
-         idempotency_fingerprint = EXCLUDED.idempotency_fingerprint,
-         created_by = EXCLUDED.created_by,
-         initiated_by_key_id = EXCLUDED.initiated_by_key_id,
-         created_at = EXCLUDED.created_at,
-         updated_at = EXCLUDED.updated_at
-       ${NOT_ALREADY_FINALIZED}`
-    )
+    .prepare(projectByIdSql(EARN_PROJECTION_SPECS.vaultMovement, NOT_ALREADY_FINALIZED))
     .bind(movementId)
     .run();
 }
@@ -232,72 +346,59 @@ export async function projectEarnMovementFromVaultMovement(
  * Mirror one withdrawal intent/observation (`earn_program_withdrawals`) into the
  * ledger. Call inside the same transaction as the legacy write.
  *
- * Requires the program's custodial holding to exist — 0064 mints one for every
- * existing program wallet and `mintEarnPositionForProviderWallet` covers new
- * ones, so a missing holding fails loudly here rather than silently skipping a
- * money movement.
+ * Needs the program's custodial holding, and OPENS one if the ledger has none.
+ * 0064 mints a holding for every program wallet that already exists and
+ * `insertProviderWallet` mints one for each new link, so healing here is the
+ * path for a program those two could not reach — see the comment below for why
+ * failing instead was not survivable.
  */
 export async function projectEarnMovementFromWithdrawal(
   db: AppDb,
   withdrawalId: string
 ): Promise<void> {
-  await requireProjectableRow(
-    db,
-    "earn_projected_movement_from_withdrawal",
-    "id",
-    withdrawalId,
-    "its program wallet has no custodial holding in earn_positions"
-  );
-  await db
-    .prepare(
-      `INSERT INTO earn_movements (
-         id, organization_id, project_id, environment, provider,
-         execution_model, direction, position_id, status,
-         failure_reason, settled_at,
-         denomination, amount_requested, amount_settled, fee_amount, payout_token,
-         destination_address, provider_reference,
-         request_id, idempotency_fingerprint, provider_data,
-         created_by, initiated_by_key_id, created_at, updated_at
-       )
-       SELECT
-         id, organization_id, project_id, environment, provider,
-         execution_model, direction, position_id, status,
-         failure_reason, settled_at,
-         denomination, amount_requested, amount_settled, fee_amount, payout_token,
-         destination_address, provider_reference,
-         request_id, idempotency_fingerprint, provider_data,
-         created_by, initiated_by_key_id, created_at, updated_at
-       FROM earn_projected_movement_from_withdrawal
-       WHERE id = ?
-       ON CONFLICT (id) DO UPDATE SET
-         organization_id = EXCLUDED.organization_id,
-         project_id = EXCLUDED.project_id,
-         environment = EXCLUDED.environment,
-         provider = EXCLUDED.provider,
-         execution_model = EXCLUDED.execution_model,
-         direction = EXCLUDED.direction,
-         position_id = EXCLUDED.position_id,
-         status = EXCLUDED.status,
-         failure_reason = EXCLUDED.failure_reason,
-         settled_at = EXCLUDED.settled_at,
-         denomination = EXCLUDED.denomination,
-         amount_requested = EXCLUDED.amount_requested,
-         amount_settled = EXCLUDED.amount_settled,
-         fee_amount = EXCLUDED.fee_amount,
-         payout_token = EXCLUDED.payout_token,
-         destination_address = EXCLUDED.destination_address,
-         provider_reference = EXCLUDED.provider_reference,
-         request_id = EXCLUDED.request_id,
-         idempotency_fingerprint = EXCLUDED.idempotency_fingerprint,
-         provider_data = EXCLUDED.provider_data,
-         created_by = EXCLUDED.created_by,
-         initiated_by_key_id = EXCLUDED.initiated_by_key_id,
-         created_at = EXCLUDED.created_at,
-         updated_at = EXCLUDED.updated_at
-       ${NOT_ALREADY_FINALIZED}`
-    )
+  const spec = EARN_PROJECTION_SPECS.withdrawal;
+  if (!(await isProjectable(db, spec.view, "id", withdrawalId))) {
+    // The program has no custodial holding yet. Opening one here — rather than
+    // failing — is what keeps `insertProviderWallet` from being a PRIVILEGED
+    // creator whose absence breaks money movement: a program linked by a
+    // revision that predates the ledger, or during a rollout or rollback
+    // window, otherwise had no holding permanently, and every withdrawal
+    // against it would fail closed for good.
+    //
+    // That failure was not merely an outage. On the observation path the mirror
+    // shares its transaction with the status write, so a throw here rolled back
+    // the `provider_reference` stamp for a withdrawal the provider had already
+    // PAID — and a movement with no reference is the one row nothing can heal,
+    // because every observation lookup resolves through it. Healing is the same
+    // "repaired by the next write that touches it" rule the rest of this module
+    // follows, applied to the holding instead of the movement.
+    await healCustodialHoldingForWithdrawal(db, withdrawalId);
+    await requireProjectableRow(
+      db,
+      spec.view,
+      "id",
+      withdrawalId,
+      "its program wallet has no custodial holding in earn_positions and one could not be opened"
+    );
+  }
+  await db.prepare(projectByIdSql(spec, NOT_ALREADY_FINALIZED)).bind(withdrawalId).run();
+}
+
+/**
+ * Open the custodial holding for the program a withdrawal was made through.
+ *
+ * Resolves the program wallet from the withdrawal rather than taking it as an
+ * argument, so every caller of the projection heals identically and none has to
+ * know the rule. A withdrawal row that does not exist is left to the projection
+ * assertion to report — this is a repair, not a validation.
+ */
+async function healCustodialHoldingForWithdrawal(db: AppDb, withdrawalId: string): Promise<void> {
+  const owner = await db
+    .prepare(`SELECT wallet_id FROM earn_program_withdrawals WHERE id = ?`)
     .bind(withdrawalId)
-    .run();
+    .first<{ wallet_id: string }>();
+  if (!owner) return;
+  await mintEarnPositionForProviderWallet(db, owner.wallet_id);
 }
 
 /**
@@ -312,43 +413,62 @@ export async function projectEarnPositionFromVaultPosition(
 ): Promise<void> {
   await requireProjectableRow(
     db,
-    "earn_projected_position_from_vault_position",
+    EARN_PROJECTION_SPECS.vaultPosition.view,
     "id",
     positionId,
     "no such row in earn_vault_positions"
   );
-  await db
-    .prepare(
-      `INSERT INTO earn_positions (
-         id, organization_id, project_id, environment, provider, kind,
-         custody_wallet_id, vault_address, share_mint, token_mint,
-         label, created_by, created_at, updated_at, activated_at, closed_at
-       )
-       SELECT
-         id, organization_id, project_id, environment, provider, kind,
-         custody_wallet_id, vault_address, share_mint, token_mint,
-         label, created_by, created_at, updated_at, activated_at, closed_at
-       FROM earn_projected_position_from_vault_position
-       WHERE id = ?
-       ON CONFLICT (id) DO UPDATE SET
-         organization_id = EXCLUDED.organization_id,
-         project_id = EXCLUDED.project_id,
-         environment = EXCLUDED.environment,
-         provider = EXCLUDED.provider,
-         kind = EXCLUDED.kind,
-         custody_wallet_id = EXCLUDED.custody_wallet_id,
-         vault_address = EXCLUDED.vault_address,
-         share_mint = EXCLUDED.share_mint,
-         token_mint = EXCLUDED.token_mint,
-         label = EXCLUDED.label,
-         created_by = EXCLUDED.created_by,
-         created_at = EXCLUDED.created_at,
-         updated_at = EXCLUDED.updated_at,
-         activated_at = EXCLUDED.activated_at,
-         closed_at = EXCLUDED.closed_at`
-    )
+  await db.prepare(projectByIdSql(EARN_PROJECTION_SPECS.vaultPosition)).bind(positionId).run();
+}
+
+/**
+ * Repair a vault movement the ledger is missing, without rewriting one it has.
+ *
+ * For the REPLAY paths, whose job is repair rather than refresh: a replay wrote
+ * no legacy row, so there is by definition nothing new to project — but it may
+ * be the first write path to touch a movement an older revision recorded
+ * without mirroring. Probing first keeps a replay from taking a row lock on the
+ * very row its concurrent twin is writing, which is the ordinary shape of a
+ * raced idempotent deposit.
+ */
+export async function ensureEarnMovementFromVaultMovement(
+  db: AppDb,
+  movementId: string
+): Promise<void> {
+  const mirrored = await db
+    .prepare(`SELECT 1 AS mirrored FROM earn_movements WHERE id = ?`)
+    .bind(movementId)
+    .first<{ mirrored: number }>();
+  if (mirrored) return;
+  await projectEarnMovementFromVaultMovement(db, movementId);
+}
+
+/**
+ * Make sure a vault movement's holding is in the ledger, WITHOUT rewriting it.
+ *
+ * The distinction from `projectEarnPositionFromVaultPosition` is about locks,
+ * not tidiness. A movement transition that changes no holding state has nothing
+ * to refresh, so re-projecting would take a row lock on the holding for no
+ * reason — and two concurrent flows against the SAME holding (the ordinary
+ * shape of a raced idempotent deposit: one request advancing to `submitted`
+ * while its twin resolves the replay) would then deadlock against each other.
+ * A probe takes no row lock, so the common case does not contend at all, and
+ * the repair still happens on the one path that needs it.
+ *
+ * Use this wherever a holding must merely EXIST; use the projection itself
+ * wherever the holding's own state may have changed — activation and closure,
+ * which only a terminal transition performs.
+ */
+export async function ensureEarnPositionFromVaultPosition(
+  db: AppDb,
+  positionId: string
+): Promise<void> {
+  const held = await db
+    .prepare(`SELECT 1 AS held FROM earn_positions WHERE id = ?`)
     .bind(positionId)
-    .run();
+    .first<{ held: number }>();
+  if (held) return;
+  await projectEarnPositionFromVaultPosition(db, positionId);
 }
 
 /**
@@ -359,29 +479,30 @@ export async function projectEarnPositionFromVaultPosition(
  * the wallet, so linking is idempotent and an existing holding — including one
  * 0064 already minted — is left exactly as it is.
  */
+export const EARN_CUSTODIAL_MINT_COLUMNS = [
+  "organization_id",
+  "project_id",
+  "environment",
+  "provider",
+  "kind",
+  "provider_wallet_id",
+  "label",
+  "created_by",
+  "created_at",
+  "updated_at",
+  "activated_at",
+] as const;
+
 export async function mintEarnPositionForProviderWallet(
   db: AppDb,
   providerWalletId: string
 ): Promise<void> {
+  const copied = EARN_CUSTODIAL_MINT_COLUMNS.join(", ");
+  const selected = EARN_CUSTODIAL_MINT_COLUMNS.map((column) => `projected.${column}`).join(", ");
   await db
     .prepare(
-      `INSERT INTO earn_positions (
-         id, organization_id, project_id, environment, provider, kind,
-         provider_wallet_id, label, created_by, created_at, updated_at, activated_at
-       )
-       SELECT
-         ?,
-         projected.organization_id,
-         projected.project_id,
-         projected.environment,
-         projected.provider,
-         projected.kind,
-         projected.provider_wallet_id,
-         projected.label,
-         projected.created_by,
-         projected.created_at,
-         projected.updated_at,
-         projected.activated_at
+      `INSERT INTO earn_positions (id, ${copied})
+       SELECT ?, ${selected}
        FROM earn_projected_position_from_provider_wallet projected
        WHERE projected.provider_wallet_id = ?
          AND NOT EXISTS (

--- a/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-movements.repository.ts
@@ -1,0 +1,414 @@
+import type {
+  EarnExecutionModel,
+  EarnMovementDirection,
+  EarnMovementStatus,
+  SdpEnvironment,
+} from "@sdp/types";
+import type { AppDb } from "@/db";
+
+/**
+ * The unified Earn movement ledger (PRO-1705, migrations 0062-0064).
+ *
+ * `earn_movements` is the single authoritative record of every Earn money
+ * movement — both directions, both execution models — and `earn_positions` is
+ * the single holdings table behind it. This module owns writing them.
+ *
+ * ── What this module is, during the transition ────────────────────────────
+ * The legacy tables (`earn_program_withdrawals`, `earn_vault_movements`,
+ * `earn_vault_positions`) are still the authoritative writers and readers. This
+ * module MIRRORS each of their writes into the unified shape, in the SAME
+ * transaction, so the new tables are continuously current before any read
+ * switches to them. The invariant is exactly:
+ *
+ *     a unified row IS the projection of its legacy row
+ *
+ * which is why every function here re-projects the whole row rather than
+ * patching the columns that happened to change. A row that a previous revision
+ * wrote without mirroring (a rollback window, an older deploy) is repaired by
+ * the next write that touches it, and the bulk backfill in 0064 is the same
+ * projection applied to everything at once.
+ *
+ * ── The projections live in SQL, not here ─────────────────────────────────
+ * Every mapping decision — which legacy status becomes which unified one, which
+ * join supplies the denomination, whether a settled amount is known yet — is a
+ * view created in migration 0063 and shared with the bulk backfill. That is
+ * deliberate: a projection spelled once in SQL and once in TypeScript would
+ * drift, and "history" disagreeing with "new rows" is the worst failure this
+ * migration could produce. These functions choose WHICH row to project; the
+ * database decides what it becomes.
+ */
+
+/** Ids are minted only for custodial holdings — see `mintEarnPositionForProviderWallet`. */
+export function generateEarnPositionId(): string {
+  return `earn_position_${crypto.randomUUID()}`;
+}
+
+export interface EarnPositionRow {
+  id: string;
+  organization_id: string;
+  project_id: string | null;
+  environment: SdpEnvironment;
+  provider: string;
+  kind: EarnExecutionModel;
+  /** vault_direct only. */
+  custody_wallet_id: string | null;
+  /** vault_direct only — the vault's on-chain address. */
+  vault_address: string | null;
+  share_mint: string | null;
+  token_mint: string | null;
+  /** custodial only — the program wallet this holding is reached through. */
+  provider_wallet_id: string | null;
+  label: string;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  activated_at: string | null;
+  closed_at: string | null;
+}
+
+export interface EarnMovementRow {
+  id: string;
+  organization_id: string;
+  project_id: string | null;
+  environment: SdpEnvironment;
+  provider: string;
+  execution_model: EarnExecutionModel;
+  direction: EarnMovementDirection;
+  position_id: string;
+  status: EarnMovementStatus;
+  failure_reason: string | null;
+  /** Optimistic chain commitment (vault only); not settlement. */
+  confirmed_at: string | null;
+  /** Success-terminal: finalization (vault) or provider completion (custodial). */
+  settled_at: string | null;
+  /** `usd`, or the token mint — the unit every amount below is denominated in. */
+  denomination: string;
+  amount_requested: string;
+  amount_settled: string | null;
+  fee_amount: string | null;
+  /** Share units, never comparable to the amount columns. */
+  min_shares_out: string | null;
+  shares_out: string | null;
+  /** Legacy custodial payout stablecoin symbol; NOT the asset identity. */
+  payout_token: string | null;
+  custody_wallet_id: string | null;
+  vault_address: string | null;
+  source_address: string | null;
+  destination_address: string | null;
+  /** The provider's id for THIS movement; null while an intent is unresolved. */
+  provider_reference: string | null;
+  signature: string | null;
+  signed_transaction: string | null;
+  /** NUMERIC in Postgres, read back as a string so uint64 round-trips exactly. */
+  last_valid_block_height: string | null;
+  request_id: string;
+  idempotency_fingerprint: string;
+  provider_data: Record<string, unknown>;
+  created_by: string | null;
+  initiated_by_key_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Columns a re-projection must not clobber.
+ *
+ * `finalized` is the one status the unified ledger can hold that no legacy table
+ * can express, so a legacy row can never be the authority on a row that already
+ * reached it. Without this guard a later legacy write would not merely regress
+ * the status — it would re-project `settled_at` as NULL and violate 0062's
+ * settlement biconditional, failing the legacy write itself.
+ */
+const NOT_ALREADY_FINALIZED = `WHERE earn_movements.status <> 'finalized'`;
+
+/**
+ * Assert that a legacy row actually projects, BEFORE trying to mirror it.
+ *
+ * `INSERT ... SELECT ... FROM <view> WHERE id = ?` inserts zero rows and
+ * SUCCEEDS when the view yields nothing — so an unprojectable row would be
+ * silently dropped from the ledger rather than failing. For a money movement
+ * that is the worst possible outcome, and it is reachable: the movement views
+ * join INNER to a holding, so a program wallet or vault claim without one
+ * produces exactly that empty result.
+ *
+ * The row count of the mirror itself cannot stand in for this check, because
+ * zero rows is also the legitimate answer when the finalization guard above
+ * declines an update.
+ */
+async function requireProjectableRow(
+  db: AppDb,
+  view: string,
+  keyColumn: string,
+  key: string,
+  remedy: string
+): Promise<void> {
+  const projected = await db
+    .prepare(`SELECT 1 AS projectable FROM ${view} WHERE ${keyColumn} = ?`)
+    .bind(key)
+    .first<{ projectable: number }>();
+  if (!projected) {
+    throw new Error(`Earn ledger cannot project ${keyColumn}=${key} through ${view}: ${remedy}`);
+  }
+}
+
+/**
+ * Mirror one signed vault movement (`earn_vault_movements`) into the ledger.
+ *
+ * Call inside the same transaction as the legacy write. The projected row keeps
+ * the legacy id, so this is an upsert rather than an insert: the deposit path
+ * projects a fresh `requested` row, and every later guarded transition
+ * re-projects the same id with its new state.
+ */
+export async function projectEarnMovementFromVaultMovement(
+  db: AppDb,
+  movementId: string
+): Promise<void> {
+  await requireProjectableRow(
+    db,
+    "earn_projected_movement_from_vault_movement",
+    "id",
+    movementId,
+    "its vault holding is missing from earn_positions"
+  );
+  await db
+    .prepare(
+      `INSERT INTO earn_movements (
+         id, organization_id, project_id, environment, provider,
+         execution_model, direction, position_id, status,
+         failure_reason, confirmed_at,
+         denomination, amount_requested, amount_settled, min_shares_out, shares_out,
+         custody_wallet_id, vault_address, source_address, destination_address,
+         signature, signed_transaction, last_valid_block_height,
+         request_id, idempotency_fingerprint,
+         created_by, initiated_by_key_id, created_at, updated_at
+       )
+       SELECT
+         id, organization_id, project_id, environment, provider,
+         execution_model, direction, position_id, status,
+         failure_reason, confirmed_at,
+         denomination, amount_requested, amount_settled, min_shares_out, shares_out,
+         custody_wallet_id, vault_address, source_address, destination_address,
+         signature, signed_transaction, last_valid_block_height,
+         request_id, idempotency_fingerprint,
+         created_by, initiated_by_key_id, created_at, updated_at
+       FROM earn_projected_movement_from_vault_movement
+       WHERE id = ?
+       ON CONFLICT (id) DO UPDATE SET
+         organization_id = EXCLUDED.organization_id,
+         project_id = EXCLUDED.project_id,
+         environment = EXCLUDED.environment,
+         provider = EXCLUDED.provider,
+         execution_model = EXCLUDED.execution_model,
+         direction = EXCLUDED.direction,
+         position_id = EXCLUDED.position_id,
+         status = EXCLUDED.status,
+         failure_reason = EXCLUDED.failure_reason,
+         confirmed_at = EXCLUDED.confirmed_at,
+         denomination = EXCLUDED.denomination,
+         amount_requested = EXCLUDED.amount_requested,
+         amount_settled = EXCLUDED.amount_settled,
+         min_shares_out = EXCLUDED.min_shares_out,
+         shares_out = EXCLUDED.shares_out,
+         custody_wallet_id = EXCLUDED.custody_wallet_id,
+         vault_address = EXCLUDED.vault_address,
+         source_address = EXCLUDED.source_address,
+         destination_address = EXCLUDED.destination_address,
+         signature = EXCLUDED.signature,
+         signed_transaction = EXCLUDED.signed_transaction,
+         last_valid_block_height = EXCLUDED.last_valid_block_height,
+         request_id = EXCLUDED.request_id,
+         idempotency_fingerprint = EXCLUDED.idempotency_fingerprint,
+         created_by = EXCLUDED.created_by,
+         initiated_by_key_id = EXCLUDED.initiated_by_key_id,
+         created_at = EXCLUDED.created_at,
+         updated_at = EXCLUDED.updated_at
+       ${NOT_ALREADY_FINALIZED}`
+    )
+    .bind(movementId)
+    .run();
+}
+
+/**
+ * Mirror one withdrawal intent/observation (`earn_program_withdrawals`) into the
+ * ledger. Call inside the same transaction as the legacy write.
+ *
+ * Requires the program's custodial holding to exist — 0064 mints one for every
+ * existing program wallet and `mintEarnPositionForProviderWallet` covers new
+ * ones, so a missing holding fails loudly here rather than silently skipping a
+ * money movement.
+ */
+export async function projectEarnMovementFromWithdrawal(
+  db: AppDb,
+  withdrawalId: string
+): Promise<void> {
+  await requireProjectableRow(
+    db,
+    "earn_projected_movement_from_withdrawal",
+    "id",
+    withdrawalId,
+    "its program wallet has no custodial holding in earn_positions"
+  );
+  await db
+    .prepare(
+      `INSERT INTO earn_movements (
+         id, organization_id, project_id, environment, provider,
+         execution_model, direction, position_id, status,
+         failure_reason, settled_at,
+         denomination, amount_requested, amount_settled, fee_amount, payout_token,
+         destination_address, provider_reference,
+         request_id, idempotency_fingerprint, provider_data,
+         created_by, initiated_by_key_id, created_at, updated_at
+       )
+       SELECT
+         id, organization_id, project_id, environment, provider,
+         execution_model, direction, position_id, status,
+         failure_reason, settled_at,
+         denomination, amount_requested, amount_settled, fee_amount, payout_token,
+         destination_address, provider_reference,
+         request_id, idempotency_fingerprint, provider_data,
+         created_by, initiated_by_key_id, created_at, updated_at
+       FROM earn_projected_movement_from_withdrawal
+       WHERE id = ?
+       ON CONFLICT (id) DO UPDATE SET
+         organization_id = EXCLUDED.organization_id,
+         project_id = EXCLUDED.project_id,
+         environment = EXCLUDED.environment,
+         provider = EXCLUDED.provider,
+         execution_model = EXCLUDED.execution_model,
+         direction = EXCLUDED.direction,
+         position_id = EXCLUDED.position_id,
+         status = EXCLUDED.status,
+         failure_reason = EXCLUDED.failure_reason,
+         settled_at = EXCLUDED.settled_at,
+         denomination = EXCLUDED.denomination,
+         amount_requested = EXCLUDED.amount_requested,
+         amount_settled = EXCLUDED.amount_settled,
+         fee_amount = EXCLUDED.fee_amount,
+         payout_token = EXCLUDED.payout_token,
+         destination_address = EXCLUDED.destination_address,
+         provider_reference = EXCLUDED.provider_reference,
+         request_id = EXCLUDED.request_id,
+         idempotency_fingerprint = EXCLUDED.idempotency_fingerprint,
+         provider_data = EXCLUDED.provider_data,
+         created_by = EXCLUDED.created_by,
+         initiated_by_key_id = EXCLUDED.initiated_by_key_id,
+         created_at = EXCLUDED.created_at,
+         updated_at = EXCLUDED.updated_at
+       ${NOT_ALREADY_FINALIZED}`
+    )
+    .bind(withdrawalId)
+    .run();
+}
+
+/**
+ * Mirror one vault holding (`earn_vault_positions`) into `earn_positions`.
+ *
+ * Must run before the movement that references it: the ledger's tenancy and
+ * exact-claim foreign keys both point at this row.
+ */
+export async function projectEarnPositionFromVaultPosition(
+  db: AppDb,
+  positionId: string
+): Promise<void> {
+  await requireProjectableRow(
+    db,
+    "earn_projected_position_from_vault_position",
+    "id",
+    positionId,
+    "no such row in earn_vault_positions"
+  );
+  await db
+    .prepare(
+      `INSERT INTO earn_positions (
+         id, organization_id, project_id, environment, provider, kind,
+         custody_wallet_id, vault_address, share_mint, token_mint,
+         label, created_by, created_at, updated_at, activated_at, closed_at
+       )
+       SELECT
+         id, organization_id, project_id, environment, provider, kind,
+         custody_wallet_id, vault_address, share_mint, token_mint,
+         label, created_by, created_at, updated_at, activated_at, closed_at
+       FROM earn_projected_position_from_vault_position
+       WHERE id = ?
+       ON CONFLICT (id) DO UPDATE SET
+         organization_id = EXCLUDED.organization_id,
+         project_id = EXCLUDED.project_id,
+         environment = EXCLUDED.environment,
+         provider = EXCLUDED.provider,
+         kind = EXCLUDED.kind,
+         custody_wallet_id = EXCLUDED.custody_wallet_id,
+         vault_address = EXCLUDED.vault_address,
+         share_mint = EXCLUDED.share_mint,
+         token_mint = EXCLUDED.token_mint,
+         label = EXCLUDED.label,
+         created_by = EXCLUDED.created_by,
+         created_at = EXCLUDED.created_at,
+         updated_at = EXCLUDED.updated_at,
+         activated_at = EXCLUDED.activated_at,
+         closed_at = EXCLUDED.closed_at`
+    )
+    .bind(positionId)
+    .run();
+}
+
+/**
+ * Create the custodial holding for a newly linked program wallet.
+ *
+ * The only projection that mints an id instead of preserving one: a program
+ * wallet never had a holding row to carry an id from. Insert-only and guarded on
+ * the wallet, so linking is idempotent and an existing holding — including one
+ * 0064 already minted — is left exactly as it is.
+ */
+export async function mintEarnPositionForProviderWallet(
+  db: AppDb,
+  providerWalletId: string
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO earn_positions (
+         id, organization_id, project_id, environment, provider, kind,
+         provider_wallet_id, label, created_by, created_at, updated_at, activated_at
+       )
+       SELECT
+         ?,
+         projected.organization_id,
+         projected.project_id,
+         projected.environment,
+         projected.provider,
+         projected.kind,
+         projected.provider_wallet_id,
+         projected.label,
+         projected.created_by,
+         projected.created_at,
+         projected.updated_at,
+         projected.activated_at
+       FROM earn_projected_position_from_provider_wallet projected
+       WHERE projected.provider_wallet_id = ?
+         AND NOT EXISTS (
+           SELECT 1
+           FROM earn_positions existing
+           WHERE existing.provider_wallet_id = projected.provider_wallet_id
+             AND existing.kind = 'custodial'
+         )
+       ON CONFLICT DO NOTHING`
+    )
+    .bind(generateEarnPositionId(), providerWalletId)
+    .run();
+
+  // The invariant is the POST-condition, not the insert: after this call the
+  // program has a custodial holding, whether this call minted it or found one.
+  // Asserting it here is what stops a program from existing that the ledger
+  // cannot record a withdrawal against — a zero-row insert is silent otherwise.
+  const held = await db
+    .prepare(
+      `SELECT 1 AS held FROM earn_positions
+       WHERE provider_wallet_id = ? AND kind = 'custodial'`
+    )
+    .bind(providerWalletId)
+    .first<{ held: number }>();
+  if (!held) {
+    throw new Error(
+      `Earn ledger could not open a custodial holding for program wallet ${providerWalletId}`
+    );
+  }
+}

--- a/apps/sdp-api/src/db/repositories/earn-vault.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn-vault.repository.test.ts
@@ -23,6 +23,17 @@ describe("EarnVaultRepository (postgres)", () => {
   beforeEach(async () => {
     const db = getDb(env);
 
+    // The unified ledger the repository mirrors into (PRO-1705) is cleared
+    // first: its rows reference both the legacy holdings and the custody wallets
+    // deleted below.
+    await db
+      .prepare("DELETE FROM earn_movements WHERE organization_id IN (?, ?)")
+      .bind(ORG_A, ORG_B)
+      .run();
+    await db
+      .prepare("DELETE FROM earn_positions WHERE organization_id IN (?, ?)")
+      .bind(ORG_A, ORG_B)
+      .run();
     await db
       .prepare("DELETE FROM earn_vault_movements WHERE organization_id IN (?, ?)")
       .bind(ORG_A, ORG_B)

--- a/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
@@ -1,8 +1,20 @@
 import type { SdpEnvironment } from "@sdp/types";
 import { type AppDb, asTransactionalClient } from "@/db";
 import { conflict } from "@/lib/errors";
+import {
+  projectEarnMovementFromVaultMovement,
+  projectEarnPositionFromVaultPosition,
+} from "./earn-movements.repository";
 
-/** Persistence for signed, non-custodial Earn vault movements and holdings. */
+/**
+ * Persistence for signed, non-custodial Earn vault movements and holdings.
+ *
+ * Still the authoritative writer, and additionally MIRRORS every write into the
+ * unified `earn_movements`/`earn_positions` ledger in the same transaction
+ * (PRO-1705, migrations 0062-0064). Reads switch to the unified tables in a
+ * later release; until then the mirror is what keeps them current, and one
+ * Postgres transaction is what makes the two shapes unable to diverge.
+ */
 
 export function generateEarnVaultPositionId(): string {
   return `earn_vault_position_${crypto.randomUUID()}`;
@@ -432,6 +444,9 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
         }
 
         const claimed = await claimPosition(transaction, input);
+        // Mirror the holding before the movement: the ledger's tenancy and
+        // exact-claim foreign keys both point at it.
+        await projectEarnPositionFromVaultPosition(transaction, claimed.id);
         const inserted = await insertMovement(transaction, input, claimed.id);
         if (!inserted) {
           // A concurrent request committed after the preflight. A divergent
@@ -449,6 +464,8 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
             replayed: true,
           };
         }
+
+        await projectEarnMovementFromVaultMovement(transaction, inserted.id);
 
         return {
           position: claimed,
@@ -607,7 +624,19 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
           .bind(...values, input.movementId, input.organizationId, ...input.fromStatuses)
           .first<EarnVaultMovementRow>();
 
-      if (input.toStatus !== "failed" && input.toStatus !== "confirmed") return advance(db);
+      // Every transition now runs in a transaction, including the non-terminal
+      // ones that used to be a bare UPDATE: the ledger mirror has to commit with
+      // the transition it describes, or a crash between them would leave the two
+      // shapes disagreeing about a money movement's state.
+      if (input.toStatus !== "failed" && input.toStatus !== "confirmed") {
+        return db.transaction(async (executor) => {
+          const transaction = asTransactionalClient(executor);
+          const movement = await advance(transaction);
+          if (!movement) return null;
+          await projectEarnMovementFromVaultMovement(transaction, movement.id);
+          return movement;
+        });
+      }
 
       return db.transaction(async (executor) => {
         const transaction = asTransactionalClient(executor);
@@ -654,6 +683,10 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
             .bind(movement.position_id)
             .run();
         }
+        // A terminal transition can activate or de-activate the holding, so the
+        // holding is re-projected too — not just the movement.
+        await projectEarnPositionFromVaultPosition(transaction, movement.position_id);
+        await projectEarnMovementFromVaultMovement(transaction, movement.id);
         return movement;
       });
     },

--- a/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn-vault.repository.ts
@@ -2,6 +2,8 @@ import type { SdpEnvironment } from "@sdp/types";
 import { type AppDb, asTransactionalClient } from "@/db";
 import { conflict } from "@/lib/errors";
 import {
+  ensureEarnMovementFromVaultMovement,
+  ensureEarnPositionFromVaultPosition,
   projectEarnMovementFromVaultMovement,
   projectEarnPositionFromVaultPosition,
 } from "./earn-movements.repository";
@@ -436,11 +438,15 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
         );
         if (prior) {
           assertMovementIsOwnReplay(prior, input);
-          return {
-            position: await requireMovementPosition(transaction, prior),
-            movement: prior,
-            replayed: true,
-          };
+          const position = await requireMovementPosition(transaction, prior);
+          // A replay writes no legacy row, but it is still the path a caller
+          // retrying an unmirrored row takes — so repair rather than answer 200
+          // while the ledger is still missing the movement. `ensure`, because a
+          // replay changes nothing about the holding and this runs concurrently
+          // with the winning request's own writes.
+          await ensureEarnPositionFromVaultPosition(transaction, position.id);
+          await ensureEarnMovementFromVaultMovement(transaction, prior.id);
+          return { position, movement: prior, replayed: true };
         }
 
         const claimed = await claimPosition(transaction, input);
@@ -458,11 +464,13 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
           );
           if (!winner) throw new Error("Failed to resolve concurrent earn vault movement");
           assertMovementIsOwnReplay(winner, input);
-          return {
-            position: await requireMovementPosition(transaction, winner),
-            movement: winner,
-            replayed: true,
-          };
+          const winnerPosition = await requireMovementPosition(transaction, winner);
+          // Same repair as the sequential replay above: the winner projected its
+          // own row, but this loser may be the first write to touch a holding
+          // that predates the ledger.
+          await ensureEarnPositionFromVaultPosition(transaction, winnerPosition.id);
+          await ensureEarnMovementFromVaultMovement(transaction, winner.id);
+          return { position: winnerPosition, movement: winner, replayed: true };
         }
 
         await projectEarnMovementFromVaultMovement(transaction, inserted.id);
@@ -633,6 +641,15 @@ export function createPostgresEarnVaultRepository(db: AppDb): EarnVaultRepositor
           const transaction = asTransactionalClient(executor);
           const movement = await advance(transaction);
           if (!movement) return null;
+          // The holding first, as in the terminal branch below. The movement
+          // projection INNER JOINs earn_positions, so a movement whose holding
+          // was never mirrored — one written by a revision that predates the
+          // ledger, or during a rollout window — would otherwise fail here and
+          // roll the legacy status write back with it. `ensure` rather than
+          // re-project: a non-terminal transition changes no holding state, so
+          // there is nothing to refresh, and taking a row lock on the holding
+          // here would deadlock against a concurrent flow on the same one.
+          await ensureEarnPositionFromVaultPosition(transaction, movement.position_id);
           await projectEarnMovementFromVaultMovement(transaction, movement.id);
           return movement;
         });

--- a/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
@@ -81,7 +81,7 @@ function mapProviderWalletRow(row: Record<string, unknown>): EarnProviderWalletR
   return {
     id: row.id as string,
     organization_id: row.organization_id as string,
-    project_id: row.project_id as string,
+    project_id: row.project_id as string | null,
     environment: row.environment as SdpEnvironment,
     provider: row.provider as string,
     provider_wallet_ref: row.provider_wallet_ref as string,

--- a/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.postgres.ts
@@ -10,7 +10,7 @@ import type {
   SolanaCluster,
 } from "@sdp/types";
 import { CLUSTER_BY_SDP_ENVIRONMENT } from "@sdp/types";
-import type { AppDb } from "@/db";
+import { type AppDb, asTransactionalClient } from "@/db";
 import type {
   CreateEarnProgramWithdrawalInput,
   DeleteUnlistedEarnStrategiesInput,
@@ -34,6 +34,10 @@ import {
   generateEarnProviderWalletId,
   generateEarnStrategyId,
 } from "./earn.repository";
+import {
+  mintEarnPositionForProviderWallet,
+  projectEarnMovementFromWithdrawal,
+} from "./earn-movements.repository";
 
 /**
  * `host_cluster` is NULLABLE in the schema on purpose (migration 0057 is the
@@ -409,27 +413,36 @@ export function createPostgresEarnRepository(db: AppDb): EarnRepository {
     async insertProviderWallet(input: InsertEarnProviderWalletInput) {
       const id = generateEarnProviderWalletId();
 
-      const row = await db
-        .prepare(
-          `INSERT INTO earn_provider_wallets (
+      // Linking a program also opens its custodial HOLDING in the unified
+      // ledger, atomically. Without it the program's first withdrawal would have
+      // no position to belong to, and the ledger requires every movement to have
+      // one (PRO-1705). 0064 does the same for programs that already exist.
+      return db.transaction(async (executor) => {
+        const transaction = asTransactionalClient(executor);
+        const row = await transaction
+          .prepare(
+            `INSERT INTO earn_provider_wallets (
              id, organization_id, project_id, environment,
              provider, provider_wallet_ref, label, created_by
            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
            RETURNING *`
-        )
-        .bind(
-          id,
-          input.organizationId,
-          input.projectId,
-          input.environment,
-          input.provider,
-          input.providerWalletRef,
-          input.label,
-          input.createdBy
-        )
-        .first<Record<string, unknown>>();
+          )
+          .bind(
+            id,
+            input.organizationId,
+            input.projectId,
+            input.environment,
+            input.provider,
+            input.providerWalletRef,
+            input.label,
+            input.createdBy
+          )
+          .first<Record<string, unknown>>();
+        if (!row) return null;
 
-      return row ? mapProviderWalletRow(row) : null;
+        await mintEarnPositionForProviderWallet(transaction, id);
+        return mapProviderWalletRow(row);
+      });
     },
 
     async createProgramWithdrawal(input: CreateEarnProgramWithdrawalInput) {
@@ -437,34 +450,39 @@ export function createPostgresEarnRepository(db: AppDb): EarnRepository {
 
       // Status comes from the DB default ('requested'): an intent row exists
       // before the provider call is accepted, never in any other state.
-      const row = await db
-        .prepare(
-          `INSERT INTO earn_program_withdrawals (
+      return db.transaction(async (executor) => {
+        const transaction = asTransactionalClient(executor);
+        const row = await transaction
+          .prepare(
+            `INSERT INTO earn_program_withdrawals (
              id, organization_id, project_id, wallet_id, provider,
              amount_requested_usd, token, destination_address,
              request_id, idempotency_fingerprint, provider_data,
              created_by, initiated_by_key_id
            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?)
            RETURNING *`
-        )
-        .bind(
-          id,
-          input.organizationId,
-          input.projectId,
-          input.walletId,
-          input.provider,
-          input.amountRequestedUsd,
-          input.token,
-          input.destinationAddress,
-          input.requestId,
-          input.idempotencyFingerprint,
-          JSON.stringify(input.providerData ?? {}),
-          input.createdBy,
-          input.initiatedByKeyId
-        )
-        .first<Record<string, unknown>>();
+          )
+          .bind(
+            id,
+            input.organizationId,
+            input.projectId,
+            input.walletId,
+            input.provider,
+            input.amountRequestedUsd,
+            input.token,
+            input.destinationAddress,
+            input.requestId,
+            input.idempotencyFingerprint,
+            JSON.stringify(input.providerData ?? {}),
+            input.createdBy,
+            input.initiatedByKeyId
+          )
+          .first<Record<string, unknown>>();
+        if (!row) return null;
 
-      return row ? mapProgramWithdrawalRow(row) : null;
+        await projectEarnMovementFromWithdrawal(transaction, id);
+        return mapProgramWithdrawalRow(row);
+      });
     },
 
     async getProgramWithdrawalByRequestId(params) {
@@ -535,17 +553,24 @@ export function createPostgresEarnRepository(db: AppDb): EarnRepository {
         conditionValues.push(input.selector.provider, input.selector.providerReference);
       }
 
-      const row = await db
-        .prepare(
-          `UPDATE earn_program_withdrawals
+      return db.transaction(async (executor) => {
+        const transaction = asTransactionalClient(executor);
+        const row = await transaction
+          .prepare(
+            `UPDATE earn_program_withdrawals
              SET ${assignments.join(", ")}
            WHERE ${conditions.join(" AND ")}
            RETURNING *`
-        )
-        .bind(...assignmentValues, ...conditionValues)
-        .first<Record<string, unknown>>();
+          )
+          .bind(...assignmentValues, ...conditionValues)
+          .first<Record<string, unknown>>();
+        // A lost CAS wrote nothing, so there is nothing to mirror: the winner
+        // already projected the state it moved the row to.
+        if (!row) return null;
 
-      return row ? mapProgramWithdrawalRow(row) : null;
+        await projectEarnMovementFromWithdrawal(transaction, row.id as string);
+        return mapProgramWithdrawalRow(row);
+      });
     },
 
     async listProgramWithdrawals(

--- a/apps/sdp-api/src/db/repositories/earn.repository.test.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.test.ts
@@ -44,6 +44,10 @@ describe("EarnRepository (postgres)", () => {
 
   beforeEach(async () => {
     const db = getDb(env);
+    // The unified ledger the repository mirrors into (PRO-1705) references both
+    // the withdrawal's holding and the program wallet, so it is cleared first.
+    await db.prepare("DELETE FROM earn_movements").run();
+    await db.prepare("DELETE FROM earn_positions").run();
     await db.prepare("DELETE FROM earn_program_withdrawals").run();
     await db.prepare("DELETE FROM earn_strategies").run();
     await db.prepare("DELETE FROM earn_provider_wallets").run();

--- a/apps/sdp-api/src/db/repositories/earn.repository.ts
+++ b/apps/sdp-api/src/db/repositories/earn.repository.ts
@@ -67,11 +67,13 @@ export interface EarnStrategyRow {
  *
  * project_id records the provisioning project only — it is not part of the
  * program's scope, and every project in an environment reaches every program.
+ * It becomes null if that provisioning project is hard-deleted; the funded,
+ * organization-scoped provider account survives.
  */
 export interface EarnProviderWalletRow {
   id: string;
   organization_id: string;
-  project_id: string;
+  project_id: string | null;
   environment: SdpEnvironment;
   /** Open TEXT, same drift rule as EarnStrategyRow.provider. */
   provider: string;

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -31,14 +31,32 @@ knowing before touching it:
 - The projections assert their row is projectable BEFORE writing. `INSERT ...
   SELECT` from a view that yields nothing inserts zero rows and SUCCEEDS, which
   would silently drop a money movement.
-- Every movement needs a holding. A custodial one is minted when the program
-  wallet is linked (`insertProviderWallet`); without it a withdrawal cannot
-  project and the write fails loudly rather than going unrecorded.
+- Every movement needs a holding, so every write path projects the holding
+  BEFORE the movement. A custodial holding is minted when the program wallet is
+  linked (`insertProviderWallet`) and by `0064` for programs that already exist;
+  if a program somehow has none, the withdrawal projection OPENS one rather than
+  failing. That is not politeness: on the observation path the mirror shares its
+  transaction with the legacy write, so throwing would roll back the
+  `provider_reference` stamp for a payout the provider had already made, and a
+  movement with no reference is the one row nothing can heal.
 - `finalized` is the one status no legacy table can express, so a legacy write
   never regresses a unified row that already reached it.
 - The vocabulary tables `earn_execution_models`, `earn_movement_directions` and
   `earn_movement_statuses` are seeded reference data, pinned to `@sdp/types` by a
   conformance test. Never truncate them in a test fixture.
+- `EARN_MOVEMENT_TRANSITIONS` in `@sdp/types` is the one declaration of which
+  transitions are legal. The custodial half is enforced today
+  (`earn-withdrawal-ledger.service.ts` derives its CAS source statuses from it);
+  the vault half has no enforcer until reads switch, because the live guard still
+  guards the LEGACY table in migration 0059's vocabulary. It is written to agree
+  with `0062`'s CHECK constraints — in particular there is no
+  `confirmed → failed`, because recording one could only succeed by erasing a
+  `confirmed_at` SDP actually observed.
+- `0064` establishes history; it does NOT converge rows that a legacy-only writer
+  ADVANCED during a rollout or rollback window (`ON CONFLICT DO NOTHING` leaves
+  the stale projection). The read-switch release re-states the projection as an
+  upsert to sweep those. Read `0064`'s header before assuming the backfill is
+  self-correcting.
 
 ## Route map — with each route's single source of truth
 

--- a/apps/sdp-api/src/routes/earn/CLAUDE.md
+++ b/apps/sdp-api/src/routes/earn/CLAUDE.md
@@ -5,6 +5,41 @@ the fail-closed registry and check capabilities — no `if (provider === "ground
 anywhere. See `packages/sdp-earn/README.md` for architecture; ADR 0002 for
 invariants (the 2026-08-11 addendum owns the ledger-vs-live rules below).
 
+## In flight: the unified movement ledger (PRO-1705)
+
+Earn is mid-migration from two movement tables split by execution mechanism to
+ONE. Migrations `0062`-`0064` add `earn_movements` (every money movement, both
+directions, both execution models) and `earn_positions` (every holding, vault
+and custodial), and backfill all existing history into them.
+
+**Nothing reads the new tables yet.** `earn_program_withdrawals`,
+`earn_vault_movements` and `earn_vault_positions` remain authoritative for every
+route below; the unified tables are kept current by a dual-write so the read
+switch is a later, separate release.
+
+**The rule while both shapes exist — if you add or change a writer of any legacy
+earn table, it MUST mirror into the unified ledger in the SAME transaction.**
+Call the projection functions in
+`db/repositories/earn-movements.repository.ts`; do not hand-write an insert. The
+mapping itself lives in SQL views created by `0063` and is shared with the bulk
+backfill, precisely so history and new rows cannot disagree. Details worth
+knowing before touching it:
+
+- A projection is an upsert keyed on the LEGACY row's id — the unified row keeps
+  it — so every guarded transition simply re-projects the whole row, and a row an
+  older revision wrote without mirroring is repaired by the next write to it.
+- The projections assert their row is projectable BEFORE writing. `INSERT ...
+  SELECT` from a view that yields nothing inserts zero rows and SUCCEEDS, which
+  would silently drop a money movement.
+- Every movement needs a holding. A custodial one is minted when the program
+  wallet is linked (`insertProviderWallet`); without it a withdrawal cannot
+  project and the write fails loudly rather than going unrecorded.
+- `finalized` is the one status no legacy table can express, so a legacy write
+  never regresses a unified row that already reached it.
+- The vocabulary tables `earn_execution_models`, `earn_movement_directions` and
+  `earn_movement_statuses` are seeded reference data, pinned to `@sdp/types` by a
+  conformance test. Never truncate them in a test fixture.
+
 ## Route map — with each route's single source of truth
 
 Every route reads exactly ONE source for the STATE it reports (DB or live

--- a/apps/sdp-api/src/services/earn-withdrawal-ledger.service.ts
+++ b/apps/sdp-api/src/services/earn-withdrawal-ledger.service.ts
@@ -3,7 +3,7 @@ import type {
   EarnPortfolioWithdrawalStatus,
   EarnProgramWithdrawalRecordStatus,
 } from "@sdp/types";
-import { EARN_TERMINAL_WITHDRAWAL_STATUSES } from "@sdp/types";
+import { EARN_MOVEMENT_TRANSITIONS, isTerminalEarnMovementStatus } from "@sdp/types";
 import type { EarnProgramWithdrawalRow, EarnRepository } from "@/db/repositories";
 import { getLogger } from "@/runtime/logger";
 
@@ -31,20 +31,22 @@ import { getLogger } from "@/runtime/logger";
  * guard closes the read-then-write race (braces), mirroring the two-layer
  * shape of applyRampSettlementEvent.
  */
-const ALLOWED_EARN_WITHDRAWAL_SOURCE_STATUSES = {
-  processing: ["requested", "processing", "pending_approval"],
-  pending_approval: ["requested", "processing", "pending_approval"],
-  completed: ["requested", "processing", "pending_approval"],
-  partially_completed: ["requested", "processing", "pending_approval"],
-  failed: ["requested", "processing", "pending_approval"],
-  cancelled: ["requested", "processing", "pending_approval"],
-} as const satisfies Record<
-  EarnPortfolioWithdrawalStatus,
-  readonly EarnProgramWithdrawalRecordStatus[]
->;
+/**
+ * The custodial half of `EARN_MOVEMENT_TRANSITIONS`, which is the single
+ * declaration of this matrix (PRO-1705). It was spelled here as well until the
+ * unified vocabulary existed; two copies of a money-movement transition table
+ * is exactly the drift the unification exists to remove, so this now narrows
+ * the shared constant to the statuses a PROVIDER can report rather than
+ * restating it.
+ */
+const ALLOWED_EARN_WITHDRAWAL_SOURCE_STATUSES =
+  EARN_MOVEMENT_TRANSITIONS.custodial satisfies Record<
+    EarnPortfolioWithdrawalStatus,
+    readonly EarnProgramWithdrawalRecordStatus[]
+  >;
 
 export function isTerminalEarnWithdrawalStatus(status: EarnProgramWithdrawalRecordStatus): boolean {
-  return (EARN_TERMINAL_WITHDRAWAL_STATUSES as readonly string[]).includes(status);
+  return isTerminalEarnMovementStatus("custodial", status);
 }
 
 /**

--- a/apps/sdp-api/src/test/mocks/db.ts
+++ b/apps/sdp-api/src/test/mocks/db.ts
@@ -13,7 +13,16 @@ import {
 } from "@/services/audit.service";
 import type { Env } from "@/types/env";
 
+// FK-dependency ordered: dependents before the rows they point at.
+//
+// The Earn vocabulary tables (earn_execution_models, earn_movement_directions,
+// earn_movement_statuses) are deliberately ABSENT. They are seeded reference data
+// from migration 0062, not tenant state — truncating them would make every
+// subsequent movement insert fail its status foreign key. Nothing here is
+// referenced BY them, so CASCADE cannot reach them either.
 const POSTGRES_TEST_TABLES = [
+  "earn_movements",
+  "earn_positions",
   "earn_vault_movements",
   "earn_vault_positions",
   "sponsorship_budget_policy_revisions",

--- a/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
+++ b/apps/sdp-web/src/app/dashboard/markets/earn/CLAUDE.md
@@ -265,7 +265,13 @@ Terminal for a vault movement is `confirmed | failed`
 (`EARN_TERMINAL_VAULT_MOVEMENT_STATUSES`) — note `pending` is NOT terminal: it
 reads like a failure and is not one, it means SDP could not establish that the
 transaction reached the network, which is the one case where the customer's
-money is genuinely in the air. An unreadable poll returns `undefined` and keeps
+money is genuinely in the air. **Keep using
+`EARN_TERMINAL_VAULT_MOVEMENT_STATUSES` here, not the similarly named
+`EARN_TERMINAL_MOVEMENT_STATUSES.vault_direct`** (PRO-1705): that one is the
+unified ledger's vocabulary, where `confirmed` is NOT terminal because
+`finalized` exists after it. This poll reads the legacy wire field, so switching
+to the unified set would make it wait for a `finalized` nothing writes yet and
+never stop. An unreadable poll returns `undefined` and keeps
 polling; a read that failed says nothing about whether the deposit landed.
 
 Two tiers, deliberately at different clocks, exactly as the withdrawal side

--- a/docs/decisions/0002-earn-provider-pluggability.md
+++ b/docs/decisions/0002-earn-provider-pluggability.md
@@ -584,3 +584,124 @@ both — but they still guard Ground, production Kamino, rows already stored und
 the old behaviour, and the next genuinely single-cluster provider. The
 simplification here is to the mental model ("catalogued but not fundable" was a
 Kamino-shaped special case), not to the safety machinery.
+
+## Addendum (2026-08-19) — One ledger for every movement (PRO-1705)
+
+The 2026-08-11 "ledger vs live" addendum above stands in full; this settles
+*how many* ledgers implement it. Earn had grown **two authoritative movement
+tables split by execution mechanism rather than by business meaning**:
+
+- `earn_program_withdrawals` (`0055`) — provider-API portfolio withdrawals.
+- `earn_vault_movements` (`0059`) — signed, on-chain vault deposits.
+
+Both record the same fact — money moved through Earn — so idempotency,
+lifecycle, reconciliation, history and reporting existed twice in two shapes,
+and no single query could answer "what moved on this organization". Every new
+provider or direction deepened it: `0061`'s own index comment anticipated a
+third variation landing as more columns on `0059`.
+
+### Decision
+
+**One row per real-world money movement, discriminated by `execution_model`
+rather than by which table it lives in** (`earn_movements`, migration `0062`),
+and **one holdings table behind it** (`earn_positions`) so every movement
+belongs to exactly one holding — a vault claim or a custodial program alike.
+`earn_provider_wallets` keeps owning the *account*; a custodial position is the
+link row.
+
+This supersedes the earlier plan of record in two places, deliberately:
+
+- `0059`'s "extend `earn_vault_movements` for vault withdraw" — that is the
+  third mechanism-shaped variation, and it is not built.
+- The 2026-08-11 addendum's "PRO-1634 redesigns a movements ledger *if* the
+  execution era arrives". It arrived: the Kamino `vault_direct` pivot made SDP
+  a signer, so a movements ledger is no longer speculative and the name
+  `earn_movements` is reclaimed — with a movement-identity-first shape, not
+  `0048`'s position-scoped one.
+
+### Invariants this establishes
+
+- **Accounting units never share a column.** Every amount is denominated in an
+  explicit `denomination` (`usd` for custodial, the token MINT for vault), and
+  share quantities live only in share-named columns. Unifying USD, mint units
+  and vault share counts into one `amount` was the concrete accounting hazard
+  here, and it is closed by construction rather than by convention.
+- **Closed vocabularies are lookup tables with FK integrity**, not
+  `CHECK (status IN (...))` lists. The composite `(execution_model, status)`
+  foreign key makes a custodial status unrepresentable on a vault movement and
+  makes `execution_model` transitively valid without a second constraint.
+  `@sdp/types` remains the source of truth for BEHAVIOUR (which statuses are
+  terminal, which transitions are legal); a conformance test pins the seeded
+  rows to it, so a migration and a constant can only move together.
+- **The transition matrix must agree with the schema, not merely with itself.**
+  `EARN_MOVEMENT_TRANSITIONS` declares no `confirmed → failed` for a vault
+  movement, because `0062` ties `confirmed_at`/`shares_out` to the commitment
+  states and recording that transition could only succeed by erasing an
+  observation SDP genuinely made. A confirmed transaction dropped by a fork
+  stays in the reconciliation queue as an open question rather than being
+  declared failed on a guess.
+- **`confirmed` is not settlement.** A vault movement's chain commitment can
+  still be dropped by a fork; `finalized` is the irreversible state and the only
+  one that stamps `settled_at`. Treating `confirmed` as terminal (`0059`'s
+  vocabulary) is what made "settled" mean two things across SDP.
+- **Both legacy idempotency anchors survive**, scoped as they were — custodial
+  position-scoped (≡ `0055`'s wallet scope, since a custodial position is 1:1
+  with its program wallet), vault org-scoped (`0059`). Flattening them to one
+  anchor would have broken whichever side lost. No fingerprint builder or
+  request-id derivation changes: those values are persisted in
+  `wallet_operations.raw_payload.executionRequest`, so altering one would 409
+  every in-flight approved retry across a deploy.
+- **Project attribution is not a lifetime.** `project_id` is nullable with
+  `ON DELETE SET NULL` on the unified tables *and*, as of this change, on
+  `earn_provider_wallets` and `earn_program_withdrawals`. `0055`'s CASCADE meant
+  deleting a project destroyed the withdrawal history of money that had actually
+  left the organization. Keeping the two shapes isomorphic here also removes a
+  trap: a divergence would let a reused idempotency key insert a legacy row that
+  collides with a surviving unified row and fail that key permanently.
+
+### Migration shape, and the rule while both shapes exist
+
+Expand → backfill → switch → contract, exactly as `0055` did, because every
+intermediate deploy must be rollback-safe: the previously deployed revision
+keeps working throughout, since nothing it writes was renamed or removed. A
+rename would have made the *first* rollback break vault deposits outright.
+
+- `0062` adds the tables and vocabularies; `0063` defines each projection as a
+  **VIEW**; `0064` backfills all existing holdings and history.
+- Each projection is a view precisely because it has two consumers — the bulk
+  backfill and the application's dual-write. Spelled twice they would drift, and
+  the parts that drift are the dangerous ones (which status maps to which, which
+  join supplies the denomination). "History" disagreeing with "new rows" in a
+  money ledger is the worst outcome available, so it is made structurally
+  impossible rather than test-guarded. All four views are dropped with the
+  legacy tables.
+- **The rule, for as long as two shapes exist: any writer of a legacy earn
+  movement table MUST mirror into the unified ledger in the SAME transaction.**
+  One Postgres, one transaction — divergence is unrepresentable and there is no
+  reconciliation problem to monitor. It is documented where the writers live
+  (`db/repositories/CLAUDE.md`) and where the routes are
+  (`routes/earn/CLAUDE.md`).
+- **A missing holding must never fail a money write.** Every write path projects
+  the holding before the movement, and the custodial projection opens one if the
+  ledger has none. On the observation path the mirror shares its transaction
+  with the legacy write, so throwing there would roll back the
+  `provider_reference` stamp for a payout the provider had already made — and a
+  movement with no reference is the one row no observation can heal.
+- **The backfill establishes history; it does not converge advances.**
+  `ON CONFLICT DO NOTHING` cannot refresh a row a legacy-only writer advanced
+  during a rollout or rollback window, so the read-switch release re-states the
+  projection as a guarded upsert to sweep that window. Before the contract
+  phase stops dual-writing, a read-only parity check (row counts plus a per-row
+  projection diff) runs in the deployed environments, expecting zero
+  differences.
+
+### What did NOT change
+
+Reads. `earn_program_withdrawals`, `earn_vault_movements` and
+`earn_vault_positions` stay authoritative for every route until a later,
+separate release switches them — so this addendum changes where movements are
+*recorded*, not yet where any surface *reads* them. ADR 0002's rule that SDP
+ledgers what SDP initiates, and reads live what the provider observes, is
+untouched: customer-initiated custodial deposits remain unledgered because SDP
+has no intent moment for them, and when an observed-deposit feed is built it
+writes rows here.

--- a/packages/sdp-earn/README.md
+++ b/packages/sdp-earn/README.md
@@ -303,7 +303,7 @@ apps/sdp-api/src/
                                    the programs family (list/create/re-target,
                                    live provider reads + the withdrawal
                                    ledger); strategies is the catalogue family.
-  db/migrations/postgres/0048–0056 earn_strategies (0048);
+  db/migrations/postgres/0048–0064 earn_strategies (0048);
                                    earn_provider_wallets (0049, the program
                                    link); earn_program_withdrawals (0055, the
                                    withdrawal ledger — 0055 also dropped the
@@ -311,7 +311,19 @@ apps/sdp-api/src/
                                    tables, PRO-1628); 0056 lifted the
                                    one-program-per-org cap and moved uniqueness
                                    onto (provider, provider_wallet_ref),
-                                   PRO-1670.
+                                   PRO-1670; earn_vault_positions +
+                                   earn_vault_movements (0059, the non-custodial
+                                   claim index and its signed-movement ledger);
+                                   earn_movements + earn_positions (0062-0064,
+                                   PRO-1705 — the ONE provider-neutral movement
+                                   ledger and ONE holdings table that supersede
+                                   the two mechanism-split tables above).
+                                   0062-0064 are the expand/backfill half: the
+                                   legacy tables still own every read, and
+                                   writes are mirrored into the unified shape in
+                                   the same transaction until reads switch. See
+                                   routes/earn/CLAUDE.md for the rule that
+                                   binds any new writer.
   services/earn-withdrawal-ledger.service.ts
                                    Withdrawal-ledger status machine + appliers
                                    (Hono-free; poll path today, sweep/webhooks

--- a/packages/sdp-types/src/earn.ts
+++ b/packages/sdp-types/src/earn.ts
@@ -618,3 +618,119 @@ export interface ListEarnProgramWithdrawalsResponse {
   page: number;
   pageSize: number;
 }
+
+/**
+ * The unified movement ledger (PRO-1705, migration 0062).
+ *
+ * One vocabulary for every Earn money movement, whichever way it was executed.
+ * Earn previously split its movements across two tables by EXECUTION MECHANISM
+ * — provider-API withdrawals in one, signed on-chain deposits in the other — so
+ * every status, terminal set and transition rule existed twice, in two
+ * different shapes, in two different packages.
+ *
+ * This is the single source of truth for movement BEHAVIOUR: which statuses
+ * exist, which are terminal, and which transitions are legal. The database
+ * mirrors the first two as rows in `earn_movement_statuses` (so SQL can read
+ * the terminal set instead of re-spelling it), and a conformance test asserts
+ * the rows equal these constants — a migration and a change here can only move
+ * together. Transitions stay here alone: a table cannot enforce them without
+ * triggers, and the guards need them at compile time.
+ */
+export const EARN_EXECUTION_MODELS = ["custodial", "vault_direct"] as const;
+export type EarnExecutionModel = (typeof EARN_EXECUTION_MODELS)[number];
+
+/**
+ * Spelled `withdrawal`, matching every wire contract, route and dashboard label
+ * that already exists. (Migration 0059 wrote `withdraw` on a column no row has
+ * ever carried, because the vault withdraw path does not exist yet.)
+ */
+export const EARN_MOVEMENT_DIRECTIONS = ["deposit", "withdrawal"] as const;
+export type EarnMovementDirection = (typeof EARN_MOVEMENT_DIRECTIONS)[number];
+
+/**
+ * Statuses per execution model, because the two lifecycles are genuinely
+ * different rather than one lifecycle wearing two vocabularies:
+ *
+ * * `custodial` — a provider reports settlement, and can report a PARTIAL one
+ *   or park a payout awaiting a customer approval stamp. This is 0055's
+ *   vocabulary unchanged.
+ * * `vault_direct` — a chain reports commitment, which is not settlement.
+ *   `confirmed` is an optimistic commitment a fork can still drop; `finalized`
+ *   is irreversible. `requested` is 0059's `pending` renamed, so that one word
+ *   means one thing on both models: a signed transaction is durably recorded
+ *   but is not known to be on the wire.
+ *
+ * So `completed` and `finalized` are not synonyms — they are different facts,
+ * and keeping them keyed by model is what lets one column hold both honestly.
+ */
+export const EARN_MOVEMENT_STATUSES = {
+  custodial: EARN_PROGRAM_WITHDRAWAL_RECORD_STATUSES,
+  vault_direct: ["requested", "submitted", "confirmed", "finalized", "failed"],
+} as const satisfies Record<EarnExecutionModel, readonly string[]>;
+
+export type EarnCustodialMovementStatus = (typeof EARN_MOVEMENT_STATUSES)["custodial"][number];
+export type EarnVaultDirectMovementStatus = (typeof EARN_MOVEMENT_STATUSES)["vault_direct"][number];
+export type EarnMovementStatus = EarnCustodialMovementStatus | EarnVaultDirectMovementStatus;
+
+/** Statuses a movement never moves on from, per model. */
+export const EARN_TERMINAL_MOVEMENT_STATUSES = {
+  custodial: EARN_TERMINAL_WITHDRAWAL_STATUSES,
+  // `confirmed` is deliberately absent, unlike 0059's terminal set: the sweep's
+  // job does not end at chain commitment now that finalization is a state.
+  vault_direct: ["finalized", "failed"],
+} as const satisfies {
+  [Model in EarnExecutionModel]: readonly (typeof EARN_MOVEMENT_STATUSES)[Model][number][];
+};
+
+export function isTerminalEarnMovementStatus(
+  executionModel: EarnExecutionModel,
+  status: string
+): boolean {
+  return (EARN_TERMINAL_MOVEMENT_STATUSES[executionModel] as readonly string[]).includes(status);
+}
+
+/**
+ * Legal transitions, keyed by TARGET status to the statuses it may be reached
+ * from — the shape both legacy guards already used.
+ *
+ * Two properties make terminal-state regression unrepresentable rather than
+ * merely discouraged: terminal statuses appear in NO source list, and neither
+ * model's insert state (`requested`) is a target at all. Repositories apply
+ * these as a database-level compare-and-swap (`status IN (...)` in the same
+ * statement as the write), so a concurrent writer that already advanced a row
+ * makes the loser match zero rows instead of overwriting it.
+ *
+ * `custodial` self-transitions are intentional: a same-status observation still
+ * refreshes amounts, fees and provider_data, and `processing → processing` is
+ * the common poll case. `pending_approval ↔ processing` is a legitimate
+ * park/unpark cycle.
+ *
+ * `vault_direct` allows `submitted → finalized` directly, because a sweep whose
+ * first observation is already finalized must be able to record the truth
+ * rather than invent an intermediate commitment it never saw. It has no
+ * self-transitions: there is no in-place observation refresh on a signed
+ * movement, only advancement.
+ */
+export const EARN_MOVEMENT_TRANSITIONS = {
+  custodial: {
+    processing: ["requested", "processing", "pending_approval"],
+    pending_approval: ["requested", "processing", "pending_approval"],
+    completed: ["requested", "processing", "pending_approval"],
+    partially_completed: ["requested", "processing", "pending_approval"],
+    failed: ["requested", "processing", "pending_approval"],
+    cancelled: ["requested", "processing", "pending_approval"],
+  },
+  vault_direct: {
+    submitted: ["requested"],
+    confirmed: ["requested", "submitted"],
+    finalized: ["submitted", "confirmed"],
+    failed: ["requested", "submitted", "confirmed"],
+  },
+} as const satisfies {
+  [Model in EarnExecutionModel]: Partial<
+    Record<
+      (typeof EARN_MOVEMENT_STATUSES)[Model][number],
+      readonly (typeof EARN_MOVEMENT_STATUSES)[Model][number][]
+    >
+  >;
+};

--- a/packages/sdp-types/src/earn.ts
+++ b/packages/sdp-types/src/earn.ts
@@ -204,7 +204,20 @@ export const EARN_VAULT_MOVEMENT_STATUSES = [
 ] as const;
 export type EarnVaultMovementStatus = (typeof EARN_VAULT_MOVEMENT_STATUSES)[number];
 
-/** Statuses a vault movement never moves on from. */
+/**
+ * Statuses a vault movement never moves on from — in migration 0059's LEGACY
+ * vocabulary, which is what `earn_vault_movements` and every existing wire
+ * contract still speak.
+ *
+ * **Do not reach for this in new code.** The unified ledger's answer is
+ * `EARN_TERMINAL_MOVEMENT_STATUSES.vault_direct`, and the two deliberately
+ * disagree: `confirmed` is terminal HERE because 0059 had no state after chain
+ * commitment, and is NOT terminal there because `finalized` now exists and a
+ * confirmed transaction can still be dropped by a fork. Treating `confirmed` as
+ * settled is exactly the conflation the unification exists to end, so this set
+ * is correct only for a consumer reading the legacy table or a legacy wire
+ * field. Both names are retired together when the legacy tables are dropped.
+ */
 export const EARN_TERMINAL_VAULT_MOVEMENT_STATUSES = ["confirmed", "failed"] as const;
 export type EarnTerminalVaultMovementStatus =
   (typeof EARN_TERMINAL_VAULT_MOVEMENT_STATUSES)[number];
@@ -672,7 +685,14 @@ export type EarnCustodialMovementStatus = (typeof EARN_MOVEMENT_STATUSES)["custo
 export type EarnVaultDirectMovementStatus = (typeof EARN_MOVEMENT_STATUSES)["vault_direct"][number];
 export type EarnMovementStatus = EarnCustodialMovementStatus | EarnVaultDirectMovementStatus;
 
-/** Statuses a movement never moves on from, per model. */
+/**
+ * Statuses a movement never moves on from, per model — the UNIFIED ledger's
+ * answer, and the one new code should use.
+ *
+ * Not to be confused with `EARN_TERMINAL_VAULT_MOVEMENT_STATUSES` above, which
+ * is the legacy `earn_vault_movements` vocabulary and calls `confirmed`
+ * terminal. See that constant's note for why the disagreement is intentional.
+ */
 export const EARN_TERMINAL_MOVEMENT_STATUSES = {
   custodial: EARN_TERMINAL_WITHDRAWAL_STATUSES,
   // `confirmed` is deliberately absent, unlike 0059's terminal set: the sweep's
@@ -710,6 +730,22 @@ export function isTerminalEarnMovementStatus(
  * rather than invent an intermediate commitment it never saw. It has no
  * self-transitions: there is no in-place observation refresh on a signed
  * movement, only advancement.
+ *
+ * ── Who enforces this, and when ───────────────────────────────────────────
+ * The custodial half is enforced NOW: `earn-withdrawal-ledger.service.ts`
+ * derives its compare-and-swap source statuses from it, so there is no second
+ * copy to drift from. The vault half has no enforcer in this release — the
+ * live guard (`assertValidMovementTransition` in `earn-vault.repository.ts`)
+ * still speaks migration 0059's legacy vocabulary (`pending`, and `confirmed`
+ * as terminal) because it guards the LEGACY table, which is still the
+ * authoritative writer here. It is replaced by a guard reading this matrix in
+ * the release that switches reads to the unified ledger; until then the
+ * vault half describes the ledger's intended lifecycle, and the conformance
+ * test in `earn-movements.repository.test.ts` pins it against
+ * `earn_movement_statuses`.
+ *
+ * The matrix is written to be consistent with migration 0062's CHECK
+ * constraints, not merely with itself — see the `vault_direct` notes below.
  */
 export const EARN_MOVEMENT_TRANSITIONS = {
   custodial: {
@@ -722,9 +758,29 @@ export const EARN_MOVEMENT_TRANSITIONS = {
   },
   vault_direct: {
     submitted: ["requested"],
+    // From `requested` too, not only `submitted`: a broadcast whose response was
+    // lost leaves a movement unsubmitted WITH a signature, and the chain is then
+    // the only authority on it. Refusing the transition would strand exactly the
+    // rows reconciliation exists for.
     confirmed: ["requested", "submitted"],
-    finalized: ["submitted", "confirmed"],
-    failed: ["requested", "submitted", "confirmed"],
+    // Reachable from ANY pre-terminal state, for the same reason: the sweep may
+    // learn of finalization as its first observation of a movement, and a
+    // transaction the chain calls finalized was demonstrably submitted and
+    // committed whether or not SDP recorded those moments separately. The writer
+    // stamps `confirmed_at` on the way through, so the row is never a settled one
+    // with no record of its own commitment.
+    finalized: ["requested", "submitted", "confirmed"],
+    // NOT from `confirmed`, deliberately. Migration 0062 ties `confirmed_at` and
+    // `shares_out` to the commitment states, so failing a confirmed movement
+    // could only succeed by erasing observations SDP genuinely made — and it
+    // would make "failed before landing" indistinguishable from "landed, then
+    // dropped in a fork". The realistic chain path never asks for it: an
+    // execution error is reported with the FIRST status for a signature, not
+    // after a clean one. The remaining tail, a confirmed transaction dropped by
+    // a fork rollback, is an open question rather than something handled here:
+    // such a row stops being observable and is left in the reconciliation queue
+    // rather than declared failed on a guess.
+    failed: ["requested", "submitted"],
   },
 } as const satisfies {
   [Model in EarnExecutionModel]: Partial<

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -135,13 +135,20 @@ export const EARN_PROVIDER_SURFACING = {
  * mirrors — and must agree with — the server-side `supportsPortfolioWallets`
  * capability, which the dashboard cannot see; a drift test in apps/sdp-api
  * asserts the two never disagree.
- */
-/**
- * One vocabulary, not two that happen to match: a provider's deposit style IS
- * the execution model every movement through it is executed by, so this is
- * `EARN_EXECUTION_MODELS` under the name that reads correctly when the subject
- * is a provider rather than a movement (PRO-1705). The ledger's
- * `execution_model` column and this const can therefore never drift apart.
+ *
+ * ── One vocabulary, not two that happen to match (PRO-1705) ───────────────
+ * A provider's deposit style IS the execution model every movement through it
+ * is executed by, so this is `EARN_EXECUTION_MODELS` under the name that reads
+ * correctly when the subject is a provider rather than a movement. The ledger's
+ * `execution_model` column and this const therefore cannot drift apart.
+ *
+ * The aliasing is deliberate but not free: `EarnDepositStyle` and
+ * `EarnExecutionModel` are now the SAME type, so the compiler no longer
+ * distinguishes "how money reaches this provider" from "how this movement was
+ * executed". That is sound precisely because they are one fact — but if a
+ * provider ever gains a deposit style that is not an execution model (a second
+ * way in to the same on-chain vault, say), this must become its own tuple again
+ * rather than gaining a member here.
  */
 export const EARN_DEPOSIT_STYLES = EARN_EXECUTION_MODELS;
 export type EarnDepositStyle = (typeof EARN_DEPOSIT_STYLES)[number];

--- a/packages/sdp-types/src/provider-access.ts
+++ b/packages/sdp-types/src/provider-access.ts
@@ -1,6 +1,6 @@
 import type { SdpEnvironment } from "./api-keys";
 import { CUSTODY_PROVIDERS, type CustodyProvider } from "./custody";
-import type { EarnPortfolioToken } from "./earn";
+import { EARN_EXECUTION_MODELS, type EarnPortfolioToken } from "./earn";
 import {
   normalizeOrganizationTier,
   ORGANIZATION_RPC_PROVIDERS,
@@ -136,7 +136,14 @@ export const EARN_PROVIDER_SURFACING = {
  * capability, which the dashboard cannot see; a drift test in apps/sdp-api
  * asserts the two never disagree.
  */
-export const EARN_DEPOSIT_STYLES = ["custodial", "vault_direct"] as const;
+/**
+ * One vocabulary, not two that happen to match: a provider's deposit style IS
+ * the execution model every movement through it is executed by, so this is
+ * `EARN_EXECUTION_MODELS` under the name that reads correctly when the subject
+ * is a provider rather than a movement (PRO-1705). The ledger's
+ * `execution_model` column and this const can therefore never drift apart.
+ */
+export const EARN_DEPOSIT_STYLES = EARN_EXECUTION_MODELS;
 export type EarnDepositStyle = (typeof EARN_DEPOSIT_STYLES)[number];
 
 export const EARN_PROVIDER_DEPOSIT_STYLE = {


### PR DESCRIPTION
**PR 1 of 4** for [PRO-1705](https://linear.app/solana-fndn/issue/PRO-1705). Adds the unified Earn movement ledger and dual-writes into it. **Nothing reads it yet.**

`#1408` → #1409 read switch → #1410 retire legacy writers → #1411 drop tables

## Why

Earn has two authoritative movement tables split by *execution mechanism* rather than business meaning:

| Table | Records |
|---|---|
| `earn_program_withdrawals` (0055) | provider-API portfolio withdrawals |
| `earn_vault_movements` (0059) | signed on-chain vault deposits |

Same fact recorded twice, so idempotency, lifecycle, reconciliation and history all exist twice, and no single query answers "what moved on this org".

## What

The expand-only half of expand → backfill → switch → contract. Nothing is renamed or removed.

| Migration | Adds |
|---|---|
| `0062` | `earn_movements`, `earn_positions`, 3 seeded vocabulary tables |
| `0063` | 4 projection views: how a legacy row becomes a unified row |
| `0064` | Backfill of existing holdings and movement history |

Legacy tables keep every reader and stay authoritative. Their writes mirror into the unified shape **in the same transaction**, so divergence is unrepresentable and there's no reconciliation job to monitor.

**Full rationale is in the migration headers** (0062 especially) and the ADR 0002 addendum: new tables vs rename, why each projection is a view, denomination discipline, the two idempotency anchors, and why `confirmed → failed` is absent.

## Reviewer notes

- **No reads change.** Zero unused read surface in this PR.
- **0064 establishes history; it does not converge advances.** A row a legacy-only writer advanced during a rollout window stays stale. `0065` in #1409 is the guarded upsert that sweeps it.
- **`project_id` relaxed to `ON DELETE SET NULL`** on the legacy tables too, so both shapes stay isomorphic through the expand window. Changes one existing assertion.
- **A missing holding never fails a money write.** The custodial path opens one rather than throwing, because the mirror shares its transaction with the legacy write.
- **Nothing manual, any environment.** Migrations run as a Cloud Run job with `--wait` before the service updates.

## Verification

`sdp-api` **265/265 files, 3360 tests** · `@sdp/earn` 152/152 · typecheck, biome and module boundaries clean · 30 new tests · 15 deliberate constraint violations rejected against real Postgres.

CI: the two Kora integration failures are pre-existing on `main`.
