### PR TITLE
feat(earn): read Veda's vault shelf on chain, SDK-free

### DIFF
--- a/packages/sdp-earn/src/providers/kamino/devnet.ts
+++ b/packages/sdp-earn/src/providers/kamino/devnet.ts
@@ -1,6 +1,12 @@
 import { KAMINO_DEVNET_KVAULT_PROGRAM_ID } from "@sdp/types/kamino-programs";
-import { internalError, providerNotConfigured } from "../../errors";
-import { providerFetchJson } from "../../fetch";
+import { internalError } from "../../errors";
+import {
+  assertRpcServesCluster,
+  fromBase64,
+  type RpcProgramAccount,
+  solanaRpcCall,
+  toBase58,
+} from "../../solana-rpc";
 
 /**
  * Kamino's DEVNET K-Vault shelf, read on-chain.
@@ -69,94 +75,12 @@ const OFFSET_SHARES_MINT = 184;
 const OFFSET_NAME = 58_528;
 const NAME_LENGTH = 40;
 
-const RPC_TIMEOUT_MS = 20_000;
-
-/**
- * Solana devnet's genesis hash — the chain's own identity, checked before any
- * vault is read.
- *
- * This exists because `EarnRuntimeContext.environment` is a PER-PROJECT
- * attribute while `ctx.env` is the PROCESS environment, and `syncEarnCatalogue`
- * walks both environments inside one process with one env object. A production
- * deployment therefore reaches this code with `SOLANA_RPC_URL` pointing at
- * MAINNET while syncing the sandbox environment. Without this check the devnet
- * program id would be queried against mainnet, return zero accounts, and hand
- * back a confident empty shelf — which is also the one shape that makes the
- * sync skip its delist pass, so sandbox would silently freeze on whatever it
- * last held.
- *
- * It also makes `hostCluster: "devnet"` a measurement rather than a derivation.
- * Migration 0057's whole point is that the environment must never be assumed to
- * imply the cluster; asserting the chain we actually read is how this path
- * honours that rather than quietly re-introducing the assumption.
- */
-// biome-ignore lint/security/noSecrets: Solana devnet's public genesis hash
-const DEVNET_GENESIS_HASH = "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG";
-
 export interface KaminoDevnetVault {
   /** Vault account address — the catalogue's `providerReference`. */
   address: string;
   name: string;
   tokenMint: string;
   sharesMint: string;
-}
-
-interface RpcAccount {
-  pubkey: string;
-  account: { data: [string, string] };
-}
-
-interface JsonRpcRequest {
-  jsonrpc: "2.0";
-  id: number;
-  method: string;
-  params: unknown[];
-}
-
-interface RpcResponse<T> {
-  result?: T;
-  error?: { message?: string };
-}
-
-// biome-ignore lint/security/noSecrets: the bitcoin/Solana base58 alphabet
-const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
-/**
- * Encode 32 raw bytes as base58. Hand-rolled because pulling `@solana/*` into
- * this package for one function would give it its first non-`@sdp` dependency.
- */
-function toBase58(bytes: Uint8Array): string {
-  let value = 0n;
-  for (const byte of bytes) {
-    value = (value << 8n) + BigInt(byte);
-  }
-
-  let encoded = "";
-  while (value > 0n) {
-    const remainder = Number(value % 58n);
-    value /= 58n;
-    encoded = BASE58_ALPHABET[remainder] + encoded;
-  }
-
-  // Leading zero bytes are significant and carry no value in the integer above:
-  // each encodes as '1'. Dropping them yields a shorter string that decodes to
-  // a DIFFERENT address, which would silently mis-key a vault.
-  for (const byte of bytes) {
-    if (byte !== 0) break;
-    encoded = `1${encoded}`;
-  }
-
-  return encoded === "" ? "1" : encoded;
-}
-
-/** `atob` rather than `Buffer`, so this stays runtime-agnostic. */
-function fromBase64(data: string): Uint8Array {
-  const binary = atob(data);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
 }
 
 /**
@@ -215,52 +139,29 @@ export function decodeVaultState(address: string, data: Uint8Array): KaminoDevne
  * the same reason: the catalogue sync DELETES rows a provider no longer lists,
  * so a partial read would not degrade gracefully — it would delist the vaults
  * whose page went unread. An RPC failure throws and the sync skips its pass.
+ *
+ * The genesis proof, the JSON-RPC transport and the base58/base64 helpers are
+ * shared with every other on-chain catalogue read (../../solana-rpc.ts); only
+ * the layout knowledge below is Kamino's.
  */
-async function rpcCall<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
-  const response = await providerFetchJson<RpcResponse<T>, JsonRpcRequest>("kamino", rpcUrl, {
-    method: "POST",
-    body: { jsonrpc: "2.0", id: 1, method, params },
-    timeoutMs: RPC_TIMEOUT_MS,
-  });
-
-  // JSON-RPC reports failure inside a 200 body, so the HTTP layer above cannot
-  // see it. Without this an errored read looks like an empty shelf — the exact
-  // shape that would delist every Kamino row.
-  if (response.error) {
-    throw internalError(
-      `Kamino devnet ${method} failed: ${response.error.message ?? "unknown RPC error"}`
-    );
-  }
-  if (response.result === undefined) {
-    throw internalError(`Kamino devnet ${method} returned no result`);
-  }
-  return response.result;
-}
-
 export async function listKaminoDevnetVaults(rpcUrl: string): Promise<KaminoDevnetVault[]> {
-  if (rpcUrl.trim() === "") {
-    throw providerNotConfigured("Kamino devnet catalogue needs a Solana RPC URL");
-  }
+  await assertRpcServesCluster("kamino", rpcUrl, "devnet");
 
-  const genesisHash = await rpcCall<string>(rpcUrl, "getGenesisHash", []);
-  if (genesisHash !== DEVNET_GENESIS_HASH) {
-    throw providerNotConfigured(
-      `Kamino devnet catalogue requires a devnet RPC; ${rpcUrl} reports genesis ${genesisHash}`
-    );
-  }
-
-  // `providerFetchJson` serializes the body and sets the JSON headers itself,
-  // so the request object goes in as a value rather than pre-stringified.
-  const accounts = await rpcCall<RpcAccount[]>(rpcUrl, "getProgramAccounts", [
-    KAMINO_DEVNET_KVAULT_PROGRAM_ID,
-    {
-      encoding: "base64",
-      // Server-side size filter: the program also owns smaller bookkeeping
-      // accounts, and shipping only vault states keeps this read at a few
-      // hundred KB instead of the whole program's account set.
-      filters: [{ dataSize: VAULT_STATE_SIZE }],
-    },
-  ]);
+  const accounts = await solanaRpcCall<RpcProgramAccount[]>(
+    "kamino",
+    rpcUrl,
+    "getProgramAccounts",
+    [
+      KAMINO_DEVNET_KVAULT_PROGRAM_ID,
+      {
+        encoding: "base64",
+        // Server-side size filter: the program also owns smaller bookkeeping
+        // accounts, and shipping only vault states keeps this read at a few
+        // hundred KB instead of the whole program's account set.
+        filters: [{ dataSize: VAULT_STATE_SIZE }],
+      },
+    ]
+  );
 
   if (!Array.isArray(accounts)) {
     throw internalError("Kamino devnet vault read returned no result array");

--- a/packages/sdp-earn/src/providers/veda/client.test.ts
+++ b/packages/sdp-earn/src/providers/veda/client.test.ts
@@ -1,16 +1,38 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
-import { wellKnownMint } from "@sdp/types";
+import { afterEach, describe, it, mock } from "node:test";
+import { GENESIS_HASH_BY_CLUSTER, wellKnownMint } from "@sdp/types";
 import {
   isVedaDeployed,
   VEDA_DEPLOYMENTS,
   VEDA_DEPOSIT_TOKEN_SYMBOLS,
+  type VedaDeployment,
   vedaDeployment,
   vedaDepositMints,
 } from "@sdp/types/veda-programs";
+import { toBase58 } from "../../solana-rpc";
 import { isStrategyWithinDeclaredSupport } from "../../support";
 import type { ProviderStrategySnapshot } from "../../types";
 import { VedaEarnClient } from "./client";
+import {
+  decodeAssetData,
+  decodeBoringVault,
+  VEDA_ASSET_DATA_DISCRIMINATOR,
+  VEDA_ASSET_DATA_LAYOUT,
+  VEDA_BORING_VAULT_DISCRIMINATOR,
+  VEDA_BORING_VAULT_LAYOUT,
+  VEDA_BORING_VAULT_SIZE,
+  VEDA_UNSET_AUTHORITY,
+} from "./vault-state";
+
+/**
+ * Canonical no-network harness (see src/fetch.test.ts): `globalThis.fetch` is
+ * stubbed per test and restored in `afterEach`. Nothing here reaches an RPC.
+ *
+ * Note what is absent and is the point of this provider: no API key in any
+ * context. Veda is read entirely on chain, so the only thing that can be
+ * misconfigured is the DEPLOYMENT — which is what `PROVIDER_NOT_CONFIGURED`
+ * reports here.
+ */
 
 const client = new VedaEarnClient();
 
@@ -19,10 +41,173 @@ const USDC_MAINNET = wellKnownMint("USDC", "mainnet-beta") as string;
 const USDT_MAINNET = wellKnownMint("USDT", "mainnet-beta") as string;
 const SOL_MINT = "So11111111111111111111111111111111111111112";
 
+/**
+ * Fixture addresses are ENCODED from bytes rather than written by hand: a
+ * hand-typed base58 string is easy to make invalid (no `0`, `O`, `I` or `l`)
+ * and easy to make longer than 32 bytes, and either mistake fails inside the
+ * fixture builder rather than in the code under test.
+ */
+function fixtureAddress(seed: number): string {
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i += 1) bytes[i] = ((seed * 31 + i * 7) % 251) + 1;
+  return toBase58(bytes);
+}
+
+const VAULT_ADDRESS = fixtureAddress(1);
+const SHARE_MINT = fixtureAddress(2);
+const NAMED_AUTHORITY = fixtureAddress(3);
+/** A mint the well-known token catalogue does not know. */
+const UNKNOWN_MINT = fixtureAddress(4);
+
+const DEPLOYMENT: VedaDeployment = {
+  vaultProgramAddress: fixtureAddress(5),
+  queueProgramAddress: fixtureAddress(6),
+  hookProgramAddress: fixtureAddress(7),
+  vaultStateAddresses: [VAULT_ADDRESS],
+};
+
+// --- fixture encoders, written through the exported layout ------------------
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/** base58 → 32 bytes, so a fixture can state addresses the way the chain does. */
+function decodeBase58(value: string): Uint8Array {
+  let n = 0n;
+  for (const char of value) {
+    const index = BASE58_ALPHABET.indexOf(char);
+    assert.ok(index >= 0, `invalid base58 character ${char}`);
+    n = n * 58n + BigInt(index);
+  }
+  const bytes: number[] = [];
+  while (n > 0n) {
+    bytes.unshift(Number(n & 0xffn));
+    n >>= 8n;
+  }
+  for (const char of value) {
+    if (char !== "1") break;
+    bytes.unshift(0);
+  }
+  while (bytes.length < 32) bytes.unshift(0);
+  return Uint8Array.from(bytes);
+}
+
+function writeUintLe(data: Uint8Array, offset: number, value: bigint, length: number): void {
+  let remaining = value < 0n ? (1n << BigInt(length * 8)) + value : value;
+  for (let i = 0; i < length; i += 1) {
+    data[offset + i] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+}
+
+interface VaultFixture {
+  vaultId?: bigint;
+  shareMint?: string;
+  baseAsset?: string;
+  shareDecimals?: number;
+  withdrawAuthority?: string;
+  lockDurationSeconds?: bigint;
+  platformFeeBps?: number;
+  performanceFeeBps?: number;
+}
+
+function encodeBoringVault(fixture: VaultFixture = {}): Uint8Array {
+  const { offsets } = VEDA_BORING_VAULT_LAYOUT;
+  const data = new Uint8Array(VEDA_BORING_VAULT_SIZE);
+  data.set(VEDA_BORING_VAULT_DISCRIMINATOR, 0);
+  writeUintLe(data, offsets["config.vaultId"], fixture.vaultId ?? 7n, 8);
+  data.set(decodeBase58(fixture.shareMint ?? SHARE_MINT), offsets["config.shareMint"]);
+  data.set(decodeBase58(fixture.baseAsset ?? USDC_DEVNET), offsets["teller.baseAsset"]);
+  data[offsets["teller.decimals"]] = fixture.shareDecimals ?? 6;
+  data.set(
+    decodeBase58(fixture.withdrawAuthority ?? VEDA_UNSET_AUTHORITY),
+    offsets["teller.withdrawAuthority"]
+  );
+  writeUintLe(data, offsets["config.lockDurationSeconds"], fixture.lockDurationSeconds ?? 0n, 8);
+  writeUintLe(data, offsets["teller.platformFeeBps"], BigInt(fixture.platformFeeBps ?? 25), 2);
+  writeUintLe(
+    data,
+    offsets["teller.performanceFeeBps"],
+    BigInt(fixture.performanceFeeBps ?? 1000),
+    2
+  );
+  return data;
+}
+
+function encodeAssetData(
+  mint: string,
+  options: { vaultId?: bigint; allowDeposits?: boolean; allowWithdrawals?: boolean } = {}
+): Uint8Array {
+  const { offsets, size } = VEDA_ASSET_DATA_LAYOUT;
+  // Longer than the read prefix, matching the real account's variable tail.
+  const data = new Uint8Array(size + 64);
+  data.set(VEDA_ASSET_DATA_DISCRIMINATOR, 0);
+  writeUintLe(data, offsets.vaultId, options.vaultId ?? 7n, 8);
+  data.set(decodeBase58(mint), offsets.assetMint);
+  data[offsets.allowDeposits] = options.allowDeposits === false ? 0 : 1;
+  data[offsets.allowWithdrawals] = options.allowWithdrawals === false ? 0 : 1;
+  return data;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+// --- RPC stub ---------------------------------------------------------------
+
+interface RpcStub {
+  genesis?: string;
+  /** `null` marks a configured vault whose account does not exist. */
+  accounts?: (Uint8Array | null)[];
+  assets?: { pubkey: string; data: Uint8Array }[];
+  /** Force a JSON-RPC error body on this method. */
+  errorOn?: string;
+}
+
+function stubRpc(stub: RpcStub) {
+  const calls: { method: string; params: unknown[] }[] = [];
+  mock.method(globalThis, "fetch", async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(String(init.body)) as { method: string; params: unknown[] };
+    calls.push({ method: body.method, params: body.params });
+
+    if (stub.errorOn === body.method) {
+      return new Response(JSON.stringify({ error: { message: "node behind" } }), { status: 200 });
+    }
+
+    const result = (() => {
+      if (body.method === "getGenesisHash") {
+        return stub.genesis ?? GENESIS_HASH_BY_CLUSTER.devnet;
+      }
+      if (body.method === "getMultipleAccounts") {
+        return {
+          value: (stub.accounts ?? []).map((data) =>
+            data === null ? null : { data: [toBase64(data), "base64"] }
+          ),
+        };
+      }
+      if (body.method === "getProgramAccounts") {
+        return (stub.assets ?? []).map((asset) => ({
+          pubkey: asset.pubkey,
+          account: { data: [toBase64(asset.data), "base64"] },
+        }));
+      }
+      throw new Error(`unexpected RPC method ${body.method}`);
+    })();
+
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), { status: 200 });
+  });
+  return calls;
+}
+
+const RPC_URL = "https://rpc.test.invalid";
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
 function snapshot(overrides: Partial<ProviderStrategySnapshot>): ProviderStrategySnapshot {
   return {
-    providerReference: "vault-state-address",
-    name: "Veda USDC",
+    providerReference: VAULT_ADDRESS,
+    name: "Veda USDC vault #7",
     sourceKind: "defi",
     depositMints: [USDC_DEVNET],
     apyType: "variable",
@@ -69,35 +254,15 @@ describe("VedaEarnClient.declaredSupport", () => {
       );
     }
   });
-
-  /**
-   * `isStrategyWithinDeclaredSupport` requires EVERY mint to be in the
-   * envelope, so a vault that also accepts something SDP does not front is
-   * refused whole rather than admitted on its USDC leg. Pinned because the
-   * catalogue read has to screen the mint list itself, not hand a mixed list up.
-   */
-  it("refuses a mixed mint list rather than admitting its supported half", () => {
-    assert.equal(
-      isStrategyWithinDeclaredSupport(
-        client.declaredSupport,
-        snapshot({ depositMints: [USDC_DEVNET, SOL_MINT] })
-      ),
-      false
-    );
-  });
-
-  it("still throws NOT_IMPLEMENTED for listStrategies until the catalogue read lands", async () => {
-    await assert.rejects(client.listStrategies({ env: {}, environment: "sandbox" }), /veda/);
-  });
 });
 
 describe("the Veda deployment registry", () => {
   /**
    * The load-bearing state of this stack, asserted rather than assumed: SDP has
-   * no confirmed Veda deployment, so every cluster reads as undeployed and
-   * every downstream path fails closed. When Veda confirms addresses, this test
-   * is the one that changes — deliberately, and with the confirmation in the
-   * pull request that changes it.
+   * no confirmed Veda deployment, so every cluster reads as undeployed and the
+   * catalogue fails closed. When Veda confirms addresses this test is the one
+   * that changes — deliberately, and with the confirmation in the pull request
+   * that changes it.
    */
   it("reports no confirmed deployment on any cluster", () => {
     assert.equal(vedaDeployment("devnet"), null);
@@ -114,5 +279,288 @@ describe("the Veda deployment registry", () => {
     assert.deepEqual(vedaDepositMints("devnet"), [USDC_DEVNET]);
     assert.deepEqual(vedaDepositMints("mainnet-beta"), [USDC_MAINNET]);
     assert.notEqual(USDC_DEVNET, USDC_MAINNET);
+  });
+});
+
+describe("decodeBoringVault", () => {
+  it("reads the fields the catalogue needs", () => {
+    const decoded = decodeBoringVault(VAULT_ADDRESS, encodeBoringVault());
+    assert.deepEqual(decoded, {
+      address: VAULT_ADDRESS,
+      vaultId: 7n,
+      shareMint: SHARE_MINT,
+      baseAsset: USDC_DEVNET,
+      shareDecimals: 6,
+      accountingPaused: false,
+      tellerPaused: false,
+      withdrawAuthority: VEDA_UNSET_AUTHORITY,
+      lockDurationSeconds: 0n,
+      platformFeeBps: 25,
+      performanceFeeBps: 1000,
+      complianceMode: false,
+    });
+  });
+
+  /**
+   * The layout is derived from Veda's published IDL field order, and 512 bytes
+   * is what that order sums to. Pinned as a number so a mistake in the table —
+   * a missing field, a wrong width — fails here rather than by shifting every
+   * offset after it and reading a plausible wrong mint.
+   */
+  it("expects a 512-byte account", () => {
+    assert.equal(VEDA_BORING_VAULT_SIZE, 512);
+    assert.equal(decodeBoringVault(VAULT_ADDRESS, new Uint8Array(511)), null);
+    assert.equal(decodeBoringVault(VAULT_ADDRESS, new Uint8Array(513)), null);
+  });
+
+  it("refuses an account that is not a BoringVault", () => {
+    const wrongDiscriminator = encodeBoringVault();
+    wrongDiscriminator[0] = 0;
+    assert.equal(decodeBoringVault(VAULT_ADDRESS, wrongDiscriminator), null);
+  });
+
+  /**
+   * An all-zero pubkey is the system program, never a mint — the signature of
+   * reading the wrong offset, and the one corruption a size check cannot see.
+   */
+  it("refuses a vault whose share or base mint decodes to the unset pubkey", () => {
+    const noShare = encodeBoringVault({ shareMint: VEDA_UNSET_AUTHORITY });
+    assert.equal(decodeBoringVault(VAULT_ADDRESS, noShare), null);
+    const noBase = encodeBoringVault({ baseAsset: VEDA_UNSET_AUTHORITY });
+    assert.equal(decodeBoringVault(VAULT_ADDRESS, noBase), null);
+  });
+
+  it("refuses an impossible share decimal count", () => {
+    assert.equal(decodeBoringVault(VAULT_ADDRESS, encodeBoringVault({ shareDecimals: 40 })), null);
+  });
+});
+
+describe("decodeAssetData", () => {
+  it("reads the mint and both permission flags", () => {
+    assert.deepEqual(decodeAssetData(encodeAssetData(USDC_DEVNET)), {
+      vaultId: 7n,
+      assetMint: USDC_DEVNET,
+      allowDeposits: true,
+      allowWithdrawals: true,
+    });
+    assert.deepEqual(decodeAssetData(encodeAssetData(USDC_DEVNET, { allowDeposits: false })), {
+      vaultId: 7n,
+      assetMint: USDC_DEVNET,
+      allowDeposits: false,
+      allowWithdrawals: true,
+    });
+  });
+
+  it("refuses a truncated or foreign account", () => {
+    assert.equal(decodeAssetData(new Uint8Array(8)), null);
+    const foreign = encodeAssetData(USDC_DEVNET);
+    foreign[0] = 0;
+    assert.equal(decodeAssetData(foreign), null);
+  });
+});
+
+describe("VedaEarnClient.listStrategies", () => {
+  it("fails closed when SDP has no confirmed deployment for the cluster", async () => {
+    for (const environment of ["sandbox", "production"] as const) {
+      await assert.rejects(
+        client.listStrategies({ env: { SOLANA_RPC_URL: RPC_URL }, environment }),
+        {
+          code: "PROVIDER_NOT_CONFIGURED",
+        }
+      );
+    }
+  });
+
+  it("maps a vault to a snapshot", async () => {
+    stubRpc({
+      accounts: [encodeBoringVault()],
+      assets: [{ pubkey: "asset-1", data: encodeAssetData(USDC_DEVNET) }],
+    });
+
+    const snapshots = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+
+    assert.deepEqual(snapshots, [
+      {
+        providerReference: VAULT_ADDRESS,
+        name: "Veda USDC vault #7",
+        sourceKind: "defi",
+        depositMints: [USDC_DEVNET],
+        shareMint: SHARE_MINT,
+        hostCluster: "devnet",
+        apyType: "variable",
+        liquidityTerm: "instant",
+        riskMetadata: { platformFeeBps: 25, performanceFeeBps: 1000 },
+      },
+    ]);
+  });
+
+  it("reports no rate rather than a fabricated one", async () => {
+    stubRpc({
+      accounts: [encodeBoringVault()],
+      assets: [{ pubkey: "asset-1", data: encodeAssetData(USDC_DEVNET) }],
+    });
+    const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+    assert.equal(only?.currentApy, undefined);
+  });
+
+  it("carries no curator, which SDP has no on-chain basis to attribute", async () => {
+    stubRpc({
+      accounts: [encodeBoringVault()],
+      assets: [{ pubkey: "asset-1", data: encodeAssetData(USDC_DEVNET) }],
+    });
+    const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+    assert.equal(only?.riskMetadata?.curator, undefined);
+  });
+
+  it("falls back to the vault id when the base asset is not a known token", async () => {
+    stubRpc({
+      accounts: [encodeBoringVault({ baseAsset: UNKNOWN_MINT, vaultId: 12n })],
+      assets: [{ pubkey: "asset-1", data: encodeAssetData(USDC_DEVNET, { vaultId: 12n }) }],
+    });
+    const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+    assert.equal(only?.name, "Veda vault #12");
+  });
+
+  /** The fixture helper has to round-trip, or every assertion above is vacuous. */
+  it("uses fixture addresses that survive an encode/decode round trip", () => {
+    assert.equal(toBase58(decodeBase58(VAULT_ADDRESS)), VAULT_ADDRESS);
+    assert.equal(decodeBase58(VAULT_ADDRESS).length, 32);
+  });
+
+  it("screens deposit mints against both the vault's flags and the declared envelope", async () => {
+    stubRpc({
+      accounts: [encodeBoringVault()],
+      assets: [
+        { pubkey: "asset-1", data: encodeAssetData(USDC_DEVNET) },
+        // Enabled on the vault, outside SDP's envelope.
+        { pubkey: "asset-2", data: encodeAssetData(SOL_MINT) },
+        // In SDP's envelope on mainnet, but deposits disabled here.
+        { pubkey: "asset-3", data: encodeAssetData(USDC_MAINNET, { allowDeposits: false }) },
+      ],
+    });
+
+    const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+    assert.deepEqual(only?.depositMints, [USDC_DEVNET]);
+  });
+
+  it("omits a vault with no deposit asset SDP fronts", async () => {
+    stubRpc({
+      accounts: [encodeBoringVault()],
+      assets: [{ pubkey: "asset-1", data: encodeAssetData(SOL_MINT) }],
+    });
+    assert.deepEqual(await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT), []);
+  });
+
+  describe("liquidity", () => {
+    const withAssets = (vault: Uint8Array) =>
+      stubRpc({ accounts: [vault], assets: [{ pubkey: "a", data: encodeAssetData(USDC_DEVNET) }] });
+
+    it("is instant only when redemption is permissionless and shares are unlocked", async () => {
+      withAssets(encodeBoringVault());
+      const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+      assert.equal(only?.liquidityTerm, "instant");
+      assert.equal(only?.redemptionDelayDays, undefined);
+    });
+
+    it("is delayed when a named authority must sign the redemption", async () => {
+      withAssets(encodeBoringVault({ withdrawAuthority: NAMED_AUTHORITY }));
+      const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+      assert.equal(only?.liquidityTerm, "delayed");
+    });
+
+    it("is delayed with a day count, rounded up, when shares are locked", async () => {
+      // 36 hours: a day and a half, which is two days before a holder can exit.
+      withAssets(encodeBoringVault({ lockDurationSeconds: 129_600n }));
+      const [only] = await client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT);
+      assert.equal(only?.liquidityTerm, "delayed");
+      assert.equal(only?.redemptionDelayDays, 2);
+    });
+  });
+
+  describe("the shelf read is all-or-nothing", () => {
+    /**
+     * The catalogue sync DELETES rows a provider no longer lists, so a partial
+     * read does not degrade — it delists whatever went unread. Every case here
+     * must throw rather than return a short shelf.
+     */
+    it("throws when the RPC serves a different cluster", async () => {
+      stubRpc({ genesis: GENESIS_HASH_BY_CLUSTER["mainnet-beta"] });
+      await assert.rejects(client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT), {
+        code: "PROVIDER_NOT_CONFIGURED",
+      });
+    });
+
+    it("proves the cluster BEFORE reading any account", async () => {
+      const calls = stubRpc({ genesis: GENESIS_HASH_BY_CLUSTER["mainnet-beta"] });
+      await assert.rejects(client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT));
+      assert.deepEqual(
+        calls.map((call) => call.method),
+        ["getGenesisHash"]
+      );
+    });
+
+    it("throws when a configured vault account does not exist", async () => {
+      stubRpc({ accounts: [null] });
+      await assert.rejects(
+        client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT),
+        /does not exist/
+      );
+    });
+
+    it("throws when a configured vault does not decode", async () => {
+      const corrupted = encodeBoringVault();
+      corrupted[0] = 0;
+      stubRpc({ accounts: [corrupted] });
+      await assert.rejects(
+        client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT),
+        /layout has changed/
+      );
+    });
+
+    it("throws when the account read returns a short list", async () => {
+      stubRpc({ accounts: [] });
+      await assert.rejects(
+        client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT),
+        /configured vaults/
+      );
+    });
+
+    /**
+     * JSON-RPC reports failure inside a 200 body, so without this the HTTP
+     * layer sees success and the read looks like an empty shelf.
+     */
+    it("throws on a JSON-RPC error body", async () => {
+      stubRpc({ errorOn: "getMultipleAccounts", accounts: [encodeBoringVault()] });
+      await assert.rejects(
+        client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT),
+        /node behind/
+      );
+    });
+
+    it("throws when an asset account does not decode", async () => {
+      const corrupted = encodeAssetData(USDC_DEVNET);
+      corrupted[0] = 0;
+      stubRpc({ accounts: [encodeBoringVault()], assets: [{ pubkey: "a", data: corrupted }] });
+      await assert.rejects(
+        client._listVaultStrategies(RPC_URL, "devnet", DEPLOYMENT),
+        /did not decode/
+      );
+    });
+
+    it("needs an RPC URL", async () => {
+      await assert.rejects(client._listVaultStrategies("", "devnet", DEPLOYMENT), {
+        code: "PROVIDER_NOT_CONFIGURED",
+      });
+    });
+  });
+
+  it("reads no accounts at all when the deployment lists no vaults", async () => {
+    const calls = stubRpc({});
+    const snapshots = await client._listVaultStrategies(RPC_URL, "devnet", {
+      ...DEPLOYMENT,
+      vaultStateAddresses: [],
+    });
+    assert.deepEqual(snapshots, []);
+    assert.deepEqual(calls, []);
   });
 });

--- a/packages/sdp-earn/src/providers/veda/client.ts
+++ b/packages/sdp-earn/src/providers/veda/client.ts
@@ -1,12 +1,107 @@
-import { VEDA_DEPOSIT_TOKEN_SYMBOLS } from "@sdp/types/veda-programs";
-import type { EarnDeclaredStrategySupport } from "../../types";
+import {
+  CLUSTER_BY_SDP_ENVIRONMENT,
+  type SolanaCluster,
+  WELL_KNOWN_TOKEN_BY_MINT,
+} from "@sdp/types";
+import {
+  VEDA_DEPOSIT_TOKEN_SYMBOLS,
+  type VedaDeployment,
+  vedaDeployment,
+} from "@sdp/types/veda-programs";
+import { providerNotConfigured } from "../../errors";
+import type {
+  EarnDeclaredStrategySupport,
+  EarnRuntimeContext,
+  ProviderStrategySnapshot,
+} from "../../types";
 import { StubEarnClient } from "../stub";
+import { readVedaVaults, VEDA_UNSET_AUTHORITY, type VedaVault } from "./vault-state";
 
 /**
  * Veda vault-infra client — the catalogue half. `@sdp/veda` extends this class
  * with the vault-direct capability (deposit building and position reads); this
  * package stays SDK-free so the hourly catalogue cron never loads a chain SDK.
+ *
+ * Everything here is read from the chain and nothing from a Veda API, because
+ * there is no Veda API: the SDK is a client for the programs, so the catalogue
+ * and the builder read the same accounts by different routes.
  */
+
+const SECONDS_PER_DAY = 86_400;
+
+/** Symbols SDP fronts, as a set, for the mint screen below. */
+const DECLARED_SYMBOLS = new Set<string>(VEDA_DEPOSIT_TOKEN_SYMBOLS);
+
+/**
+ * Deposit mints this vault actually takes, intersected with what SDP declares.
+ *
+ * Both halves are needed and neither is redundant. The vault's own
+ * `AssetData.allow_deposits` is the only truth about what it will accept;
+ * `declaredSupport` is SDP's ceiling. Screening here rather than leaving it to
+ * `isStrategyWithinDeclaredSupport` is the same choice the Kamino devnet path
+ * makes: the sync warn-logs every out-of-envelope snapshot, and a vault
+ * configured for assets SDP never claimed to front is not provider drift worth
+ * a warning every hour.
+ */
+function depositMints(entry: VedaVault): string[] {
+  return entry.assets
+    .filter((asset) => asset.allowDeposits)
+    .map((asset) => asset.assetMint)
+    .filter((mint) => {
+      const token = WELL_KNOWN_TOKEN_BY_MINT.get(mint);
+      return token !== undefined && DECLARED_SYMBOLS.has(token.symbol);
+    })
+    .sort();
+}
+
+/**
+ * A display name for a vault that has none.
+ *
+ * `BoringVault` carries no name field, so unlike Kamino there is no
+ * attacker-controlled string to quote — and nothing to parse a claim out of
+ * either. The name is composed from two facts the account establishes: the
+ * base asset's symbol and the vault id. A vault whose base asset is not in the
+ * well-known catalogue still gets a stable, unambiguous name from its id.
+ */
+export function vedaVaultName(baseAsset: string, vaultId: bigint): string {
+  const symbol = WELL_KNOWN_TOKEN_BY_MINT.get(baseAsset)?.symbol;
+  return symbol ? `Veda ${symbol} vault #${vaultId}` : `Veda vault #${vaultId}`;
+}
+
+/**
+ * How quickly a holder can get out, from what the vault configures.
+ *
+ * Two independent constraints, and BOTH have to be clear for `instant`:
+ *
+ * - `teller.withdraw_authority` — unset means redemption is permissionless,
+ *   which is exactly the comparison Veda's own SDK makes to decide whether an
+ *   instant withdrawal exists. A named authority means someone else has to
+ *   sign, so the holder cannot leave on their own schedule.
+ * - `config.lock_duration_seconds` — shares are locked for this long after a
+ *   deposit, so a non-zero lock delays the exit no matter what the authority
+ *   says.
+ *
+ * Reporting `instant` for a vault with either constraint would be the field
+ * lying in the direction that costs a customer money, so both fail to `delayed`.
+ */
+export function vedaLiquidity(entry: VedaVault): {
+  liquidityTerm: "instant" | "delayed";
+  redemptionDelayDays?: number;
+} {
+  const lockSeconds = entry.vault.lockDurationSeconds;
+  const permissionless = entry.vault.withdrawAuthority === VEDA_UNSET_AUTHORITY;
+  if (permissionless && lockSeconds <= 0n) return { liquidityTerm: "instant" };
+  if (lockSeconds <= 0n) return { liquidityTerm: "delayed" };
+  return {
+    liquidityTerm: "delayed",
+    // Rounded UP: a lock that ends part-way through a day is not over until
+    // that day is. Rounding down would advertise an exit a holder cannot take.
+    redemptionDelayDays: Number(
+      (lockSeconds + BigInt(SECONDS_PER_DAY) - 1n) / BigInt(SECONDS_PER_DAY)
+    ),
+  };
+}
+
 export class VedaEarnClient extends StubEarnClient {
   readonly provider = "veda" as const;
 
@@ -35,4 +130,92 @@ export class VedaEarnClient extends StubEarnClient {
     sourceKinds: ["defi"],
     depositTokens: VEDA_DEPOSIT_TOKEN_SYMBOLS,
   };
+
+  /**
+   * Veda's shelf for this environment's cluster, read on chain.
+   *
+   * Two properties are worth stating plainly:
+   *
+   * - **The shelf is an ALLOWLIST, never a census.** Veda deploys a vault per
+   *   customer under one program, so enumerating the program's accounts would
+   *   put other integrators' vaults on SDP's shelf. The addresses come from
+   *   `@sdp/types/veda-programs`, which only carries what Veda confirmed — and
+   *   that is also what makes this provider's `sourceKind` defensible, since
+   *   every row traces to an address Veda named rather than to anything a
+   *   stranger could create.
+   * - **The cluster is MEASURED before anything is read.** `readVedaVaults`
+   *   proves the RPC's genesis hash matches, so `hostCluster` below is an
+   *   observation. This matters more for Veda than for most providers: its
+   *   integration material implies devnet and mainnet may share addresses, and
+   *   if they do, the genesis proof is the only thing standing between reading
+   *   one and reporting the other.
+   *
+   * No credential check: there is nothing to configure but the deployment, and
+   * a missing deployment is what `PROVIDER_NOT_CONFIGURED` reports here.
+   */
+  async listStrategies(ctx: EarnRuntimeContext): Promise<ProviderStrategySnapshot[]> {
+    const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
+    const deployment = vedaDeployment(cluster);
+    if (!deployment) {
+      // Not a soft empty shelf: an empty return is the one shape that makes the
+      // sync skip its delist pass, so it would freeze an existing catalogue
+      // rather than report that SDP cannot reach Veda here.
+      throw providerNotConfigured(
+        `Veda has no confirmed ${cluster} deployment. Add its program and vault-state addresses to @sdp/types/veda-programs once Veda confirms them.`
+      );
+    }
+
+    return this._listVaultStrategies(ctx.env.SOLANA_RPC_URL ?? "", cluster, deployment);
+  }
+
+  /**
+   * The read and the mapping, with the deployment already resolved.
+   *
+   * Split out so tests can exercise the mapping against a deployment SDP does
+   * not yet have — `VEDA_DEPLOYMENTS` is empty until Veda confirms addresses,
+   * and the mapping is the half that must already be right when they do. Same
+   * shape as Kamino's `_listDevnetStrategies`.
+   */
+  async _listVaultStrategies(
+    rpcUrl: string,
+    cluster: SolanaCluster,
+    deployment: VedaDeployment
+  ): Promise<ProviderStrategySnapshot[]> {
+    const entries = await readVedaVaults(rpcUrl, cluster, deployment);
+
+    const snapshots: ProviderStrategySnapshot[] = [];
+    for (const entry of entries) {
+      const mints = depositMints(entry);
+      // A vault with no deposit asset SDP fronts is not an error and not a row:
+      // it is a vault this deployment has nothing to offer for.
+      if (mints.length === 0) continue;
+
+      snapshots.push({
+        providerReference: entry.vault.address,
+        name: vedaVaultName(entry.vault.baseAsset, entry.vault.vaultId),
+        // The one classification the vault's own mechanics establish. Never
+        // `rwa` — see `declaredSupport` above.
+        sourceKind: "defi",
+        depositMints: mints,
+        shareMint: entry.vault.shareMint,
+        // Measured by `readVedaVaults`, never derived from `ctx.environment`.
+        hostCluster: cluster,
+        // The share price moves with the strategies the vault holds; nothing
+        // about it is fixed. `currentApy` is deliberately absent — one reading
+        // of an exchange rate is not a rate of return, and the dashboard
+        // renders a missing rate as "—" rather than a fabricated number.
+        apyType: "variable",
+        ...vedaLiquidity(entry),
+        // Protocol-reported figures only, read from the vault's own state.
+        // No `curator`: nothing Veda publishes on-chain attributes one, and an
+        // attribution is SDP vouching rather than quoting.
+        riskMetadata: {
+          platformFeeBps: entry.vault.platformFeeBps,
+          performanceFeeBps: entry.vault.performanceFeeBps,
+        },
+      });
+    }
+
+    return snapshots;
+  }
 }

--- a/packages/sdp-earn/src/providers/veda/vault-state.ts
+++ b/packages/sdp-earn/src/providers/veda/vault-state.ts
@@ -1,0 +1,382 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { VedaDeployment } from "@sdp/types/veda-programs";
+import { internalError } from "../../errors";
+import {
+  assertRpcServesCluster,
+  bytesEqual,
+  fromBase64,
+  type RpcAccount,
+  type RpcProgramAccount,
+  readIntLe,
+  readUintLe,
+  solanaRpcCall,
+  toBase58,
+  u64ToLeBytes,
+} from "../../solana-rpc";
+
+/**
+ * Veda's `boring_vault_svm` account layouts, decoded straight off the chain.
+ *
+ * ── Why this reads bytes rather than calling the SDK ────────────────────────
+ * `@vedatech/svm-sdk` can read all of this, and `@sdp/veda` uses it to. But that
+ * SDK is built against `@solana/kit` 7 and this package's only dependency is
+ * `@sdp/types`, because it runs inside the HOURLY catalogue cron in both
+ * environments. Same rule that keeps klend-sdk out of the Kamino catalogue path.
+ *
+ * ── Why the layout is a TABLE, not a list of magic offsets ──────────────────
+ * Unlike Kamino — whose offsets had to be located by matching live values
+ * against an independent API — Veda publishes Anchor IDLs, and
+ * `@vedatech/svm-sdk` ships them with a `programs.lock.json` recording the
+ * commit and a SHA-256 of each. So every offset here is DERIVED from the
+ * published field order, and stating that order explicitly is what makes it
+ * checkable: `@sdp/veda` (which has the IDL) owns a test that recomputes this
+ * table from `idl/boring_vault_svm.json` and fails if Veda's ABI moves.
+ *
+ * Borsh, so there is no padding: each field's offset is the sum of the sizes
+ * before it, and the total is the account's exact byte length.
+ */
+
+const PUBKEY = 32;
+const BOOL = 1;
+const U8 = 1;
+const U16 = 2;
+const U32 = 4;
+const U64 = 8;
+const I64 = 8;
+const U128 = 16;
+
+/**
+ * `BoringVault`, field by field, in IDL order. The nested `VaultState`,
+ * `TellerState` and `VestingState` structs are flattened because Borsh lays
+ * them out inline.
+ */
+const BORING_VAULT_FIELDS = [
+  ["discriminator", 8],
+  // --- config: VaultState ---
+  ["config.vaultId", U64],
+  ["config.authority", PUBKEY],
+  ["config.pendingAuthority", PUBKEY],
+  ["config.accountingPaused", BOOL],
+  ["config.tellerPaused", BOOL],
+  ["config.managePaused", BOOL],
+  ["config.shareMint", PUBKEY],
+  ["config.depositSubAccount", U8],
+  ["config.withdrawSubAccount", U8],
+  ["config.shareMover", PUBKEY],
+  ["config.complianceMode", BOOL],
+  ["config.complianceAuthority", PUBKEY],
+  ["config.lockDurationSeconds", I64],
+  // --- teller: TellerState ---
+  ["teller.baseAsset", PUBKEY],
+  ["teller.decimals", U8],
+  ["teller.exchangeRate", U64],
+  ["teller.exchangeRateHighWaterMark", U64],
+  ["teller.platformFeesOwedInBaseAsset", U64],
+  ["teller.performanceFeesOwedInBaseAsset", U64],
+  ["teller.totalSharesLastUpdate", U64],
+  ["teller.supplyLastUpdateTimestamp", U64],
+  ["teller.platformPayoutAddress", PUBKEY],
+  ["teller.performancePayoutAddress", PUBKEY],
+  // biome-ignore lint/security/noSecrets: an IDL field name, not a credential
+  ["teller.allowedExchangeRateChangeUpperBound", U16],
+  // biome-ignore lint/security/noSecrets: an IDL field name, not a credential
+  ["teller.allowedExchangeRateChangeLowerBound", U16],
+  // biome-ignore lint/security/noSecrets: an IDL field name, not a credential
+  ["teller.minimumUpdateDelayInSeconds", U32],
+  ["teller.platformFeeBps", U16],
+  ["teller.performanceFeeBps", U16],
+  ["teller.withdrawAuthority", PUBKEY],
+  ["teller.maxDeviationYieldBps", U16],
+  ["teller.maxDeviationLossBps", U16],
+  ["teller.vestingState.lastVirtualSharePrice", U128],
+  ["teller.vestingState.vestingGains", U64],
+  ["teller.vestingState.lastVestingUpdate", U64],
+  ["teller.vestingState.startVestingTime", U64],
+  ["teller.vestingState.endVestingTime", U64],
+  ["teller.vestingState.cumulativeSupply", U128],
+  ["teller.vestingState.vestingPeriodStart", U64],
+  ["teller.lastStrategistUpdateTimestamp", U64],
+  ["teller.stateLastUpdateTimestamp", U64],
+  ["teller.depositCap", U64],
+  ["teller.minimumVestDuration", U64],
+  ["teller.maximumVestDuration", U64],
+  ["teller.platformFeeRemainder", U64],
+  ["teller.performanceFeeRemainder", U64],
+  // --- accrualMode: VaultAccrualMode (fieldless enum, one byte) ---
+  ["accrualMode", U8],
+] as const;
+
+/**
+ * `AssetData`, up to the last field SDP reads.
+ *
+ * Truncated on purpose: the tail carries an `OracleSource` enum whose variants
+ * differ in size, so the account has no fixed length and cannot be size-checked.
+ * Everything SDP needs sits before it.
+ */
+const ASSET_DATA_FIELDS = [
+  ["discriminator", 8],
+  ["vaultId", U64],
+  ["assetMint", PUBKEY],
+  ["allowDeposits", BOOL],
+  ["allowWithdrawals", BOOL],
+  ["sharePremiumBps", U16],
+  // biome-ignore lint/security/noSecrets: an IDL field name, not a credential
+  ["isPeggedToBaseAsset", BOOL],
+  ["inversePriceFeed", BOOL],
+] as const;
+
+function layout<const T extends readonly (readonly [string, number])[]>(
+  fields: T
+): { offsets: Record<T[number][0], number>; size: number } {
+  const offsets = {} as Record<T[number][0], number>;
+  let offset = 0;
+  for (const [name, size] of fields) {
+    offsets[name as T[number][0]] = offset;
+    offset += size;
+  }
+  return { offsets, size: offset };
+}
+
+/**
+ * The derived layouts, EXPORTED rather than private.
+ *
+ * Two callers need them and both are checks rather than conveniences: this
+ * package's own decoder tests write fixture bytes at exact offsets, and
+ * `@sdp/veda` — the package that actually holds the IDL — recomputes these
+ * tables from `idl/boring_vault_svm.json` and fails if they disagree. A
+ * hand-maintained offset table that nothing can contradict is how a silent ABI
+ * change becomes a silently wrong share mint.
+ */
+export const VEDA_BORING_VAULT_LAYOUT = layout(BORING_VAULT_FIELDS);
+export const VEDA_ASSET_DATA_LAYOUT = layout(ASSET_DATA_FIELDS);
+
+const VAULT = VEDA_BORING_VAULT_LAYOUT;
+const ASSET = VEDA_ASSET_DATA_LAYOUT;
+
+/** Exact `BoringVault` account length — 512 bytes, derived from the table above. */
+export const VEDA_BORING_VAULT_SIZE = VAULT.size;
+/** Bytes of `AssetData` SDP reads; the account itself is longer and variable. */
+export const VEDA_ASSET_DATA_MIN_SIZE = ASSET.size;
+
+/** Anchor account discriminators, from the published IDL. */
+export const VEDA_BORING_VAULT_DISCRIMINATOR = [35, 84, 44, 89, 150, 55, 236, 25] as const;
+export const VEDA_ASSET_DATA_DISCRIMINATOR = [91, 115, 36, 105, 141, 93, 1, 135] as const;
+
+/**
+ * The default pubkey (all zero bytes), which Veda uses as "unset".
+ *
+ * On `teller.withdraw_authority` it means redemption is PERMISSIONLESS — the
+ * SDK's own `resolveWithdrawalOptions` reads exactly this comparison to decide
+ * whether instant withdrawal is available. Any other value is a named authority
+ * that must sign, so SDP cannot promise an instant exit.
+ */
+export const VEDA_UNSET_AUTHORITY = "11111111111111111111111111111111";
+
+/** What the catalogue reads out of one Veda vault account. */
+export interface VedaVaultAccount {
+  /** Vault-state address — the catalogue's `providerReference`. */
+  address: string;
+  vaultId: bigint;
+  shareMint: string;
+  /** The accounting asset the vault's exchange rate is denominated in. */
+  baseAsset: string;
+  shareDecimals: number;
+  accountingPaused: boolean;
+  tellerPaused: boolean;
+  /** Named authority that must sign a redemption, or the unset pubkey. */
+  withdrawAuthority: string;
+  /** Seconds a deposit's shares stay locked. Zero means no lock. */
+  lockDurationSeconds: bigint;
+  platformFeeBps: number;
+  performanceFeeBps: number;
+  complianceMode: boolean;
+}
+
+/** One asset the vault is configured for. */
+export interface VedaAssetAccount {
+  vaultId: bigint;
+  assetMint: string;
+  allowDeposits: boolean;
+  allowWithdrawals: boolean;
+}
+
+function pubkeyAt(data: Uint8Array, offset: number): string {
+  return toBase58(data.subarray(offset, offset + PUBKEY));
+}
+
+/**
+ * Decode a `BoringVault`, or `null` when the account is not one.
+ *
+ * Fail-closed, exactly like the Kamino decoder: the size and discriminator
+ * together mean a program upgrade that changed the layout drops the row rather
+ * than producing a plausible-looking one. Losing a vault from the shelf is a
+ * visible gap; publishing a row whose share mint is read from the wrong offset
+ * is a deposit aimed at the wrong token.
+ */
+export function decodeBoringVault(address: string, data: Uint8Array): VedaVaultAccount | null {
+  if (data.length !== VEDA_BORING_VAULT_SIZE) return null;
+  if (!bytesEqual(data, 0, [...VEDA_BORING_VAULT_DISCRIMINATOR])) return null;
+
+  const shareMint = pubkeyAt(data, VAULT.offsets["config.shareMint"]);
+  const baseAsset = pubkeyAt(data, VAULT.offsets["teller.baseAsset"]);
+  // An all-zero pubkey is the system program, never a mint — the signature of
+  // reading the wrong offset, and the one case the size check cannot catch.
+  if (shareMint === VEDA_UNSET_AUTHORITY || baseAsset === VEDA_UNSET_AUTHORITY) return null;
+
+  const shareDecimals = Number(readUintLe(data, VAULT.offsets["teller.decimals"], U8));
+  // Token decimals are bounded at 9 on Solana; anything larger means the
+  // decode is wrong, not that Veda invented a 200-decimal share.
+  if (shareDecimals > 9) return null;
+
+  return {
+    address,
+    vaultId: readUintLe(data, VAULT.offsets["config.vaultId"], U64),
+    shareMint,
+    baseAsset,
+    shareDecimals,
+    accountingPaused: data[VAULT.offsets["config.accountingPaused"]] === 1,
+    tellerPaused: data[VAULT.offsets["config.tellerPaused"]] === 1,
+    withdrawAuthority: pubkeyAt(data, VAULT.offsets["teller.withdrawAuthority"]),
+    lockDurationSeconds: readIntLe(data, VAULT.offsets["config.lockDurationSeconds"], I64),
+    platformFeeBps: Number(readUintLe(data, VAULT.offsets["teller.platformFeeBps"], U16)),
+    performanceFeeBps: Number(readUintLe(data, VAULT.offsets["teller.performanceFeeBps"], U16)),
+    complianceMode: data[VAULT.offsets["config.complianceMode"]] === 1,
+  };
+}
+
+/** Decode an `AssetData`, or `null` when the account is not one. */
+export function decodeAssetData(data: Uint8Array): VedaAssetAccount | null {
+  if (data.length < VEDA_ASSET_DATA_MIN_SIZE) return null;
+  if (!bytesEqual(data, 0, [...VEDA_ASSET_DATA_DISCRIMINATOR])) return null;
+
+  const assetMint = pubkeyAt(data, ASSET.offsets.assetMint);
+  if (assetMint === VEDA_UNSET_AUTHORITY) return null;
+
+  return {
+    vaultId: readUintLe(data, ASSET.offsets.vaultId, U64),
+    assetMint,
+    allowDeposits: data[ASSET.offsets.allowDeposits] === 1,
+    allowWithdrawals: data[ASSET.offsets.allowWithdrawals] === 1,
+  };
+}
+
+/** One catalogued vault with the assets it is configured for. */
+export interface VedaVault {
+  vault: VedaVaultAccount;
+  assets: readonly VedaAssetAccount[];
+}
+
+function accountData(account: RpcAccount | RpcProgramAccount["account"]): Uint8Array | null {
+  const encoded = account?.data?.[0];
+  return typeof encoded === "string" ? fromBase64(encoded) : null;
+}
+
+/**
+ * Every vault SDP catalogues for Veda on `cluster`, with its asset
+ * configuration.
+ *
+ * **ALL-OR-NOTHING**, and this is the load-bearing property. The catalogue sync
+ * DELETES rows a provider no longer lists, so a partial read does not degrade
+ * gracefully — it delists whatever went unread. Every failure below throws:
+ * an unreachable RPC, a genesis mismatch, a configured vault whose account is
+ * missing, and an account that does not decode. The sync then skips its pass
+ * and the catalogue keeps what it had.
+ *
+ * That is the opposite of the per-row tolerance the Kamino devnet path uses,
+ * and deliberately so: Kamino reads a permissionless census where an odd
+ * account is expected, while every address here is one SDP was given. A vault
+ * on that list failing to decode is a fact about the deployment, not noise.
+ */
+export async function readVedaVaults(
+  rpcUrl: string,
+  cluster: SolanaCluster,
+  deployment: VedaDeployment
+): Promise<VedaVault[]> {
+  const addresses = deployment.vaultStateAddresses;
+  if (addresses.length === 0) return [];
+
+  await assertRpcServesCluster("veda", rpcUrl, cluster);
+
+  const response = await solanaRpcCall<{ value?: RpcAccount[] }>(
+    "veda",
+    rpcUrl,
+    "getMultipleAccounts",
+    [addresses, { encoding: "base64" }]
+  );
+  const accounts = response?.value;
+  if (!Array.isArray(accounts) || accounts.length !== addresses.length) {
+    throw internalError(
+      `Veda vault read returned ${Array.isArray(accounts) ? accounts.length : "no"} accounts for ${addresses.length} configured vaults`
+    );
+  }
+
+  const vaults: VedaVaultAccount[] = [];
+  for (const [index, address] of addresses.entries()) {
+    const data = accountData(accounts[index] ?? null);
+    if (data === null) {
+      throw internalError(
+        `Veda vault ${address} does not exist on ${cluster}. Check the configured deployment addresses in @sdp/types/veda-programs.`
+      );
+    }
+    const decoded = decodeBoringVault(address, data);
+    if (decoded === null) {
+      throw internalError(
+        `Veda vault ${address} on ${cluster} is not a boring_vault_svm account, or its layout has changed.`
+      );
+    }
+    vaults.push(decoded);
+  }
+
+  // One asset read per vault rather than one census across the program: Veda
+  // deploys vaults per customer, so the program's account set includes other
+  // integrators'. Filtering server-side by vault id keeps this read proportional
+  // to SDP's own shelf and never materializes anyone else's configuration.
+  const assetsByVault = await Promise.all(
+    vaults.map((vault) => readVedaVaultAssets(rpcUrl, deployment, vault.vaultId))
+  );
+
+  return vaults.map((vault, index) => ({ vault, assets: assetsByVault[index] ?? [] }));
+}
+
+async function readVedaVaultAssets(
+  rpcUrl: string,
+  deployment: VedaDeployment,
+  vaultId: bigint
+): Promise<VedaAssetAccount[]> {
+  const accounts = await solanaRpcCall<RpcProgramAccount[]>("veda", rpcUrl, "getProgramAccounts", [
+    deployment.vaultProgramAddress,
+    {
+      encoding: "base64",
+      // No `dataSize` filter: `AssetData` ends in an `OracleSource` enum whose
+      // variants differ in length, so the account has no single size. The
+      // discriminator plus the vault id is already an exact match.
+      filters: [
+        { memcmp: { offset: 0, bytes: toBase58(Uint8Array.from(VEDA_ASSET_DATA_DISCRIMINATOR)) } },
+        { memcmp: { offset: ASSET.offsets.vaultId, bytes: toBase58(u64ToLeBytes(vaultId)) } },
+      ],
+    },
+  ]);
+
+  if (!Array.isArray(accounts)) {
+    throw internalError(`Veda asset read for vault ${vaultId} returned no result array`);
+  }
+
+  const assets: VedaAssetAccount[] = [];
+  for (const account of accounts) {
+    const data = accountData(account.account ?? null);
+    if (data === null) continue;
+    const decoded = decodeAssetData(data);
+    // The filters already asserted the discriminator and the vault id, so a
+    // failure here means the layout moved. Throwing keeps the deposit mints a
+    // vault reports from silently shrinking to a subset.
+    if (decoded === null) {
+      throw internalError(
+        `Veda asset account ${account.pubkey} did not decode; the boring_vault_svm layout may have changed.`
+      );
+    }
+    if (decoded.vaultId !== vaultId) continue;
+    assets.push(decoded);
+  }
+
+  return assets;
+}

--- a/packages/sdp-earn/src/solana-rpc.ts
+++ b/packages/sdp-earn/src/solana-rpc.ts
@@ -1,0 +1,193 @@
+import { GENESIS_HASH_BY_CLUSTER, type SolanaCluster } from "@sdp/types";
+import type { EarnProviderId } from "@sdp/types/provider-access";
+import { internalError, providerNotConfigured } from "./errors";
+import { providerFetchJson } from "./fetch";
+
+/**
+ * Raw Solana JSON-RPC for CATALOGUE reads, shared by every provider whose shelf
+ * lives on chain (Kamino's devnet vaults, Veda's).
+ *
+ * ── Why this package speaks JSON-RPC at all ─────────────────────────────────
+ * `@sdp/earn` runs inside the hourly catalogue cron and its only dependency is
+ * `@sdp/types`. A chain SDK here would be loaded on every pass in both
+ * environments to read a handful of accounts, which is why the execution
+ * packages (`@sdp/kamino`, `@sdp/veda`) exist as separate consumers. The cost of
+ * that rule is this file: base58, base64 and one RPC helper, hand-rolled.
+ *
+ * Everything goes through `providerFetchJson`, so timeouts and the error
+ * taxonomy are the package's rather than bespoke per provider.
+ */
+
+/** Default deadline for a catalogue RPC read, inherited from the Kamino path. */
+export const CATALOGUE_RPC_TIMEOUT_MS = 20_000;
+
+// biome-ignore lint/security/noSecrets: the bitcoin/Solana base58 alphabet
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/**
+ * Encode bytes as base58 — addresses read out of account data, and the
+ * discriminator bytes a `memcmp` filter compares against.
+ *
+ * Hand-rolled because importing `@solana/*` for one function would give this
+ * package its first non-`@sdp` dependency.
+ */
+export function toBase58(bytes: Uint8Array): string {
+  let value = 0n;
+  for (const byte of bytes) {
+    value = (value << 8n) + BigInt(byte);
+  }
+
+  let encoded = "";
+  while (value > 0n) {
+    const remainder = Number(value % 58n);
+    value /= 58n;
+    encoded = BASE58_ALPHABET[remainder] + encoded;
+  }
+
+  // Leading zero bytes are significant and carry no value in the integer above:
+  // each encodes as '1'. Dropping them yields a shorter string that decodes to
+  // a DIFFERENT address, which would silently mis-key a vault.
+  for (const byte of bytes) {
+    if (byte !== 0) break;
+    encoded = `1${encoded}`;
+  }
+
+  return encoded === "" ? "1" : encoded;
+}
+
+/** `atob` rather than `Buffer`, so this stays runtime-agnostic. */
+export function fromBase64(data: string): Uint8Array {
+  const binary = atob(data);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/** Little-endian u64 as raw bytes — the wire form of an Anchor `u64` filter. */
+export function u64ToLeBytes(value: bigint): Uint8Array {
+  const bytes = new Uint8Array(8);
+  let remaining = value;
+  for (let i = 0; i < 8; i += 1) {
+    bytes[i] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return bytes;
+}
+
+/** Read a little-endian unsigned integer of `length` bytes at `offset`. */
+export function readUintLe(data: Uint8Array, offset: number, length: number): bigint {
+  let value = 0n;
+  for (let i = length - 1; i >= 0; i -= 1) {
+    value = (value << 8n) + BigInt(data[offset + i] as number);
+  }
+  return value;
+}
+
+/** Read a little-endian SIGNED integer of `length` bytes at `offset`. */
+export function readIntLe(data: Uint8Array, offset: number, length: number): bigint {
+  const unsigned = readUintLe(data, offset, length);
+  const bound = 1n << BigInt(length * 8);
+  return unsigned >= bound >> 1n ? unsigned - bound : unsigned;
+}
+
+/** True when every byte in `[offset, offset + length)` matches `expected`. */
+export function bytesEqual(data: Uint8Array, offset: number, expected: readonly number[]): boolean {
+  if (data.length < offset + expected.length) return false;
+  return expected.every((byte, index) => data[offset + index] === byte);
+}
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params: unknown[];
+}
+
+interface JsonRpcResponse<T> {
+  result?: T;
+  error?: { message?: string };
+}
+
+/** One `{ pubkey, account }` entry as `getProgramAccounts` returns it. */
+export interface RpcProgramAccount {
+  pubkey: string;
+  account?: { data?: [string, string] } | null;
+}
+
+/** One entry of `getMultipleAccounts` — `null` when the account does not exist. */
+export type RpcAccount = { data?: [string, string] } | null;
+
+/**
+ * One JSON-RPC call, with the failure mode that matters here handled.
+ *
+ * JSON-RPC reports failure INSIDE a 200 body, so the HTTP layer above cannot
+ * see it. Left unchecked, an errored read looks like an empty shelf — and the
+ * catalogue sync DELETES rows a provider no longer lists, so "empty" is the one
+ * shape that quietly delists a provider's whole catalogue. Both branches below
+ * throw for that reason.
+ */
+export async function solanaRpcCall<T>(
+  provider: EarnProviderId,
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+  timeoutMs = CATALOGUE_RPC_TIMEOUT_MS
+): Promise<T> {
+  const response = await providerFetchJson<JsonRpcResponse<T>, JsonRpcRequest>(provider, rpcUrl, {
+    method: "POST",
+    // `providerFetchJson` serializes the body and sets the JSON headers itself,
+    // so the request object goes in as a value rather than pre-stringified.
+    body: { jsonrpc: "2.0", id: 1, method, params },
+    timeoutMs,
+  });
+
+  if (response.error) {
+    throw internalError(
+      `${provider} ${method} failed: ${response.error.message ?? "unknown RPC error"}`
+    );
+  }
+  if (response.result === undefined) {
+    throw internalError(`${provider} ${method} returned no result`);
+  }
+  return response.result;
+}
+
+/**
+ * MEASURE the cluster before reading anything from it.
+ *
+ * `EarnRuntimeContext.environment` is a PER-PROJECT attribute while `ctx.env` is
+ * the PROCESS environment, and `syncEarnCatalogue` walks both environments
+ * inside one process with one env object. A production deployment therefore
+ * reaches this code with `SOLANA_RPC_URL` pointing at MAINNET while syncing the
+ * sandbox environment. Without this check a devnet program id would be queried
+ * against mainnet, return zero accounts, and hand back a confident empty
+ * shelf — which is also the shape that makes the sync skip its delist pass, so
+ * sandbox would silently freeze on whatever it last held.
+ *
+ * It is also what makes a snapshot's `hostCluster` a MEASUREMENT rather than a
+ * derivation. Migration 0057's whole point is that the environment must never be
+ * assumed to imply the cluster; asserting the chain actually read is how a
+ * provider honours that instead of quietly re-introducing the assumption. For a
+ * provider whose devnet and mainnet deployments may share addresses — Veda's
+ * might — it is the ONLY thing standing between the two.
+ */
+export async function assertRpcServesCluster(
+  provider: EarnProviderId,
+  rpcUrl: string,
+  cluster: SolanaCluster,
+  timeoutMs = CATALOGUE_RPC_TIMEOUT_MS
+): Promise<void> {
+  if (rpcUrl.trim() === "") {
+    throw providerNotConfigured(`${provider} catalogue needs a Solana RPC URL for ${cluster}`);
+  }
+
+  const observed = await solanaRpcCall<string>(provider, rpcUrl, "getGenesisHash", [], timeoutMs);
+  const expected = GENESIS_HASH_BY_CLUSTER[cluster];
+  if (observed !== expected) {
+    throw providerNotConfigured(
+      `${provider} catalogue requires a ${cluster} RPC; the configured endpoint reports genesis ${observed}, not ${expected}`
+    );
+  }
+}


### PR DESCRIPTION
`listStrategies` for Veda, plus the account decoding it needs. `@sdp/earn` runs the hourly catalogue cron in both environments and its only dependency is `@sdp/types`, so this reads bytes over JSON-RPC rather than loading `@vedatech/svm-sdk` — the same rule that keeps klend-sdk out of the Kamino catalogue path.

**The shelf is an ALLOWLIST, never a census.** Veda deploys a vault per customer under one program, so enumerating the program's accounts would put other integrators' vaults on SDP's shelf. Addresses come from `@sdp/types/veda-programs`, which carries only what Veda confirmed — which is also what makes `sourceKind: "defi"` defensible here, since every row traces to an address Veda named rather than to anything a stranger could create.

**The layout is a table, not magic offsets.** Kamino's offsets had to be located by matching live values against an independent API; Veda publishes Anchor IDLs, so every offset is derived from the published field order and the account's exact 512-byte length falls out of it. Stating the order explicitly is what makes it checkable — `@sdp/veda`, which holds the IDL, will recompute the table from it and fail if Veda's ABI moves.

**The read is all-or-nothing.** The sync DELETES rows a provider no longer lists, so a partial read does not degrade — it delists whatever went unread. An unreachable RPC, a genesis mismatch, a configured vault whose account is missing, an account that does not decode, and a JSON-RPC error inside a 200 body all throw. That is stricter than the Kamino devnet path's per-row tolerance, and deliberately so: Kamino reads a permissionless census where an odd account is expected, while every address here is one SDP was given.

**The cluster is measured, not derived.** Veda's integration material implies devnet and mainnet may share program addresses. If they do, the genesis-hash proof is the ONLY thing between reading one chain and reporting the other, so `hostCluster` is stamped from the chain actually read and the proof happens before a single account is fetched.

Mapping decisions worth naming:

- **No `currentApy`.** One reading of an exchange rate is not a rate of return. The dashboard renders a missing rate as "—", which is honest; `EarnLiveMetricsProvider` is therefore not implemented — it would return nothing on every five-minute pass forever.
- **No `curator`.** Nothing Veda publishes on-chain attributes one, and an attribution is SDP vouching rather than quoting.
- **`liquidityTerm` needs BOTH constraints clear.** `instant` only when `withdraw_authority` is unset (the comparison Veda's own SDK makes) AND `lock_duration_seconds` is zero. A lock reports `delayed` with a day count rounded UP, because a lock ending part-way through a day is not over until that day is.
- **The name is composed**, since `BoringVault` carries no name field — from the base asset's symbol and the vault id, both facts the account establishes, falling back to the id alone for an unknown asset.

The base58/base64 helpers, the JSON-RPC transport and the genesis proof move to `src/solana-rpc.ts` and are now shared with the Kamino devnet reader, which had private copies of the first two.