### PR TITLE
feat(api): dispatch Veda through the vault-direct execution path

### DIFF
--- a/apps/sdp-api/Dockerfile
+++ b/apps/sdp-api/Dockerfile
@@ -27,7 +27,9 @@ WORKDIR /repo
 
 # Lockfile + workspace metadata first so the install layer only invalidates
 # when versions change. Root tsconfig.json is needed for esbuild's "extends".
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.json ./
+# `.npmrc` carries the `${NPM_TOKEN}` auth REFERENCE for the private @vedatech
+# scope — the value arrives separately, as a mounted secret below.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.json .npmrc ./
 COPY apps/sdp-api/package.json ./apps/sdp-api/
 COPY packages/sdp-types/package.json ./packages/sdp-types/
 COPY packages/sdp-env-config/package.json ./packages/sdp-env-config/
@@ -43,6 +45,7 @@ COPY packages/sdp-spc-escrow/package.json ./packages/sdp-spc-escrow/
 COPY packages/sdp-spc-withdraw/package.json ./packages/sdp-spc-withdraw/
 COPY packages/kit-augment/package.json ./packages/kit-augment/
 COPY packages/sdp-kamino/package.json ./packages/sdp-kamino/
+COPY packages/sdp-veda/package.json ./packages/sdp-veda/
 COPY patches ./patches
 
 # The secret is read INSIDE the RUN and never assigned with ENV/ARG, so it lives
@@ -54,9 +57,14 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     if [ -f /run/secrets/npm_token ]; then \
       NPM_TOKEN="$(sed -n 's/^[[:space:]]*NPM_TOKEN=//p' /run/secrets/npm_token | tail -n1)"; \
       [ -n "$NPM_TOKEN" ] || NPM_TOKEN="$(tr -d ' \t\r\n' < /run/secrets/npm_token)"; \
+      if [ -z "$NPM_TOKEN" ]; then \
+        echo "error: the npm_token build secret is empty. It must contain the token, or a NPM_TOKEN=<token> line." >&2; \
+        exit 1; \
+      fi; \
       export NPM_TOKEN; \
     else \
-      echo "warning: no npm_token build secret; @vedatech/svm-sdk will 404. Pass --secret id=npm_token,src=<env file or token file>." >&2; \
+      echo "error: no npm_token build secret. @sdp/veda installs the private @vedatech/svm-sdk; pass --secret id=npm_token,src=<env file or token file>." >&2; \
+      exit 1; \
     fi; \
     pnpm install --frozen-lockfile --filter @sdp/api...
 
@@ -79,6 +87,7 @@ COPY packages/sdp-spc-escrow ./packages/sdp-spc-escrow
 COPY packages/sdp-spc-withdraw ./packages/sdp-spc-withdraw
 COPY packages/kit-augment ./packages/kit-augment
 COPY packages/sdp-kamino ./packages/sdp-kamino
+COPY packages/sdp-veda ./packages/sdp-veda
 
 WORKDIR /repo/apps/sdp-api
 RUN node scripts/build-node.mjs

--- a/apps/sdp-api/Dockerfile.dockerignore
+++ b/apps/sdp-api/Dockerfile.dockerignore
@@ -30,6 +30,7 @@ packages/*
 !packages/sdp-spc-withdraw
 !packages/kit-augment
 !packages/sdp-kamino
+!packages/sdp-veda
 docs
 infra
 scripts

--- a/apps/sdp-api/package.json
+++ b/apps/sdp-api/package.json
@@ -60,6 +60,7 @@
     "@sdp/spc-escrow": "workspace:*",
     "@sdp/spc-withdraw": "workspace:*",
     "@sdp/types": "workspace:*",
+    "@sdp/veda": "workspace:*",
     "@sentry/node": "10.70.0",
     "@solana-program/system": "catalog:",
     "@solana-program/token": "catalog:",

--- a/apps/sdp-api/src/routes/earn.vault.test.ts
+++ b/apps/sdp-api/src/routes/earn.vault.test.ts
@@ -1,6 +1,28 @@
 import { hashString } from "@sdp/payments/hash";
 import type { CachedApiKey } from "@sdp/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Surfacing is real by default here (Kamino is offered, so the happy paths need
+ * no help) and forced ON only for the Veda block below.
+ *
+ * Veda is registered and executable but NOT offered — `EARN_PROVIDER_SURFACING`
+ * keeps it at `false` until deposits are proven end to end in sandbox. That is
+ * business config, not a property of the dispatch this file tests, so the Veda
+ * cases flip this flag rather than editing the map, and the gate keeps its own
+ * test that runs against the real one. Same pattern as `earn-program.test.ts`.
+ */
+const surfacing = vi.hoisted(() => ({ forceOn: false }));
+
+vi.mock("@sdp/types", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@sdp/types")>();
+  return {
+    ...actual,
+    isEarnProviderSurfaced: (provider: string) =>
+      surfacing.forceOn || actual.isEarnProviderSurfaced(provider),
+  };
+});
+
 import { getDb } from "@/db";
 import {
   createPostgresEarnRepository,
@@ -157,7 +179,7 @@ async function seedAuth(): Promise<void> {
         TEST_ORG.slug,
         "enterprise",
         "active",
-        JSON.stringify({ providerOverrides: { earn: { kamino: true } } })
+        JSON.stringify({ providerOverrides: { earn: { kamino: true, veda: true } } })
       ),
     getDb(env)
       .prepare("INSERT INTO users (id, email, email_verified, status) VALUES (?, ?, ?, ?)")
@@ -279,6 +301,7 @@ beforeEach(async () => {
 afterEach(() => {
   env.MARKETS_ENABLED = originalMarketsEnabled;
   env.EARN_ENABLED = originalEarnEnabled;
+  surfacing.forceOn = false;
   vi.restoreAllMocks();
 });
 
@@ -742,6 +765,122 @@ describe("POST /v1/earn/vault-deposits — request validation", () => {
     });
 
     expect(res.status).toBe(403);
+    expect(depositIntoVault).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Veda's dispatch through the provider-neutral deposit route.
+ *
+ * The route names no provider — it resolves a catalogue row, applies the
+ * money-in gates and hands the resolved identity to `depositIntoVault`, which
+ * narrows on capability. So "does Veda work here?" is really "does a second
+ * `vault_direct` provider need any route change?", and the answer these cases
+ * pin is no.
+ */
+describe("POST /v1/earn/vault-deposits — Veda", () => {
+  const VEDA_SHARE_MINT = "9BEcn9aPEmhSPbPQeFGjidRiEKki46fVQDyPpSQXPA2D";
+
+  async function seedVedaStrategy() {
+    return seedStrategy({
+      provider: "veda",
+      name: "Veda USDC vault #7",
+      underlyingSource: undefined,
+      shareMint: VEDA_SHARE_MINT,
+      currentApy: null,
+      riskMetadata: { platformFeeBps: 25, performanceFeeBps: 1000 },
+    });
+  }
+
+  /**
+   * THE GATE THAT IS REAL TODAY, run against the unmocked map: Veda is
+   * registered and executable but not OFFERED, so a deposit is refused before
+   * the provider is ever called. Flipping `EARN_PROVIDER_SURFACING.veda` is its
+   * own change, made only once deposits are proven end to end in sandbox.
+   */
+  it("is refused as not currently offered while it stays un-surfaced", async () => {
+    await seedAuth();
+    const strategy = await seedVedaStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_veda_gate",
+      custodyWalletId: "cwlt_earn_vault_veda_gate",
+      providerWalletId: "privy_earn_vault_veda_gate",
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_veda_gate",
+      amount: "10",
+      minSharesOut: "9.5",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(403);
+    expect(depositIntoVault).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a surfaced Veda row with the catalogue's own asset identity", async () => {
+    surfacing.forceOn = true;
+    await seedAuth();
+    const strategy = await seedVedaStrategy();
+    await seedWallet({
+      configId: "cfg_earn_vault_veda",
+      custodyWalletId: "cwlt_earn_vault_veda",
+      providerWalletId: "privy_earn_vault_veda",
+    });
+    const requestId = crypto.randomUUID();
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_veda",
+      amount: "10",
+      minSharesOut: "9.5",
+      requestId,
+    });
+
+    expect(res.status).toBe(200);
+    expect(depositIntoVault).toHaveBeenCalledTimes(1);
+    expect(depositIntoVault.mock.calls[0]?.[1]).toMatchObject({
+      provider: "veda",
+      providerReference: strategy.provider_reference,
+      // Straight from the catalogue row, and the same values the builder's
+      // `assetIdentity` is later compared against.
+      tokenMint: USDC_MINT,
+      shareMint: VEDA_SHARE_MINT,
+      amount: "10",
+      minSharesOut: "9.5",
+      requestId,
+    });
+  });
+
+  /**
+   * A row whose provider this deployment cannot execute must fail CLOSED at the
+   * provider gate, never reach dispatch. Catalogue rows persist `provider` as
+   * open TEXT, so a newer deploy's id can reach this route.
+   */
+  it("fails closed on a strategy naming a provider this deployment cannot execute", async () => {
+    surfacing.forceOn = true;
+    await seedAuth();
+    const strategy = await seedVedaStrategy();
+    await getDb(env)
+      .prepare("UPDATE earn_strategies SET provider = 'vedanext' WHERE id = ?")
+      .bind(strategy.id)
+      .run();
+    await seedWallet({
+      configId: "cfg_earn_vault_unknown",
+      custodyWalletId: "cwlt_earn_vault_unknown",
+      providerWalletId: "privy_earn_vault_unknown",
+    });
+
+    const res = await postVaultDeposit({
+      strategyId: strategy.id,
+      custodyWalletId: "cwlt_earn_vault_unknown",
+      amount: "10",
+      minSharesOut: "9.5",
+      requestId: crypto.randomUUID(),
+    });
+
+    expect(res.status).toBe(503);
     expect(depositIntoVault).not.toHaveBeenCalled();
   });
 });

--- a/apps/sdp-api/src/services/earn-provider-registry.ts
+++ b/apps/sdp-api/src/services/earn-provider-registry.ts
@@ -6,6 +6,10 @@ import {
 import type { EarnRuntimeContext, EarnVaultProvider } from "@sdp/earn/types";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
 import type { EarnProviderId, SolanaCluster } from "@sdp/types";
+import {
+  assertNotPortfolioProvider as assertVedaNotPortfolioProvider,
+  VedaVaultDirectClient,
+} from "@sdp/veda";
 import type { Env } from "@/types/env";
 import { assertClusterEndpoint, resolveClusterRpcUrl } from "./earn/execution-registry";
 import { createVaultDeadline } from "./earn/vault-deadline";
@@ -15,7 +19,7 @@ import { createVaultDeadline } from "./earn/vault-deadline";
  * singleton provider performs any chain work. The runtime context is
  * request-scoped, so one API process can safely serve both SDP environments.
  */
-async function resolveKaminoRpcUrl(
+async function resolveProvenRpcUrl(
   ctx: EarnRuntimeContext,
   cluster: SolanaCluster
 ): Promise<string> {
@@ -27,23 +31,34 @@ async function resolveKaminoRpcUrl(
   return rpcUrl;
 }
 
-const kamino = new KaminoVaultDirectClient(resolveKaminoRpcUrl, (label, operation) => {
+/** One fresh deadline per operation, since these clients are process singletons. */
+function runVaultOperation<T>(
+  label: string,
+  operation: (assertActive: () => void) => Promise<T>
+): Promise<T> {
   const deadline = createVaultDeadline();
   return deadline.run(label, () => operation(() => deadline.assertActive(label)));
-});
+}
+
+const kamino = new KaminoVaultDirectClient(resolveProvenRpcUrl, runVaultOperation);
 assertNotPortfolioProvider(kamino);
+
+const veda = new VedaVaultDirectClient(resolveProvenRpcUrl, runVaultOperation);
+assertVedaNotPortfolioProvider(veda);
 
 /**
  * API composition root for Earn providers.
  *
- * `@sdp/earn` intentionally owns the lightweight catalogue registry so its
- * cron can list Kamino without loading klend-sdk. The API owns execution, so it
- * replaces only Kamino with the vault-direct superset. Routes must resolve
- * through this registry when they need provider capabilities.
+ * `@sdp/earn` intentionally owns the lightweight catalogue registry so its cron
+ * can list every provider without loading a chain SDK. The API owns execution,
+ * so it replaces the entries that can move money with their vault-direct
+ * supersets and leaves the rest alone. Routes must resolve through this registry
+ * when they need provider capabilities.
  */
 export const EARN_PROVIDER_CLIENTS = {
   ...CATALOGUE_PROVIDER_CLIENTS,
   kamino,
+  veda,
 } as const satisfies Record<EarnProviderId, EarnVaultProvider>;
 
 export function resolveEarnProviderClient(provider: string): EarnVaultProvider {

--- a/apps/sdp-api/src/services/earn/execution-registry.test.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.test.ts
@@ -156,6 +156,56 @@ describe("resolveVaultDirectClient", () => {
     expect(createRpc).not.toHaveBeenCalled();
   });
 
+  it("resolves an executing client for every provider that can move money", () => {
+    const createRpc = vi.spyOn(solanaRpc, "createRpc");
+
+    for (const provider of ["kamino", "veda"]) {
+      const client = resolveVaultDirectClient(executionEnv, provider, createVaultDeadline());
+      expect(client, provider).not.toBeNull();
+      expect(client?.provider, provider).toBe(provider);
+      // The superset, not a replacement: the executing client still catalogues.
+      expect(typeof client?.listStrategies, provider).toBe("function");
+    }
+    expect(createRpc).not.toHaveBeenCalled();
+  });
+
+  /**
+   * This resolver is the ONE sanctioned provider-id branch in the codebase, and
+   * unknown ids must answer null rather than throw: a strategy row written by a
+   * newer deploy would otherwise 500 a read that merely touched it.
+   */
+  it("answers null for anything this deployment cannot execute", () => {
+    for (const provider of ["ground", "upshift", "perena", "not-a-provider", "__proto__", ""]) {
+      expect(
+        resolveVaultDirectClient(executionEnv, provider, createVaultDeadline()),
+        provider
+      ).toBeNull();
+    }
+  });
+
+  /**
+   * SDP has no confirmed Veda deployment, so a deposit fails on THAT rather
+   * than on an RPC — and it fails before any endpoint work, because an
+   * unconfigured deployment is a fact about SDP that should not depend on a
+   * node being reachable.
+   */
+  it("refuses Veda work on the missing deployment, before any RPC", async () => {
+    const createRpc = vi.spyOn(solanaRpc, "createRpc");
+    const client = resolveVaultDirectClient(executionEnv, "veda", createVaultDeadline());
+    if (!client) throw new Error("expected a Veda vault-direct client");
+
+    await expect(
+      client.buildVaultDeposit(runtime, { ...depositInput, minSharesOut: "1" })
+    ).rejects.toMatchObject({ code: "DEPLOYMENT_NOT_CONFIGURED" });
+    await expect(
+      client.readVaultPositions(runtime, {
+        owner: depositInput.owner,
+        providerReferences: [depositInput.providerReference],
+      })
+    ).rejects.toMatchObject({ code: "DEPLOYMENT_NOT_CONFIGURED" });
+    expect(createRpc).not.toHaveBeenCalled();
+  });
+
   it("refuses build and position work before the SDK when genesis is wrong", async () => {
     mockGenesisSend().mockResolvedValue(GENESIS_HASH_BY_CLUSTER["mainnet-beta"]);
     const client = resolveVaultDirectClient(executionEnv, "kamino", createVaultDeadline());

--- a/apps/sdp-api/src/services/earn/execution-registry.ts
+++ b/apps/sdp-api/src/services/earn/execution-registry.ts
@@ -1,6 +1,10 @@
 import { supportsVaultDirect } from "@sdp/earn/capabilities";
 import { providerNotConfigured } from "@sdp/earn/errors";
-import type { EarnVaultDirectProvider, EarnVaultProvider } from "@sdp/earn/types";
+import type {
+  EarnRuntimeContext,
+  EarnVaultDirectProvider,
+  EarnVaultProvider,
+} from "@sdp/earn/types";
 import { assertNotPortfolioProvider, KaminoVaultDirectClient } from "@sdp/kamino";
 import { resolveDefaultSolanaRpcUrl } from "@sdp/rpc";
 import * as solanaRpc from "@sdp/rpc/solana";
@@ -10,6 +14,10 @@ import {
   type SdpEnvironment,
   type SolanaCluster,
 } from "@sdp/types";
+import {
+  assertNotPortfolioProvider as assertVedaNotPortfolioProvider,
+  VedaVaultDirectClient,
+} from "@sdp/veda";
 import type { Env } from "@/types/env";
 import type { VaultDeadline } from "./vault-deadline";
 
@@ -164,19 +172,25 @@ export function resolveEarnExecutionClient(
   provider: string,
   deadline: VaultDeadline
 ): EarnVaultProvider | null {
+  // Construction stays synchronous and I/O-free for every branch. The clients
+  // await this resolver only when a chain method is invoked, so an idempotent
+  // replay can return from durable state during an RPC outage.
+  const provenRpcUrl = async (_ctx: EarnRuntimeContext, cluster: SolanaCluster) => {
+    const rpcUrl = resolveClusterRpcUrl(env, cluster);
+    await assertClusterEndpoint(env, cluster, rpcUrl);
+    return rpcUrl;
+  };
+  const runOperation = <T>(label: string, operation: (assertActive: () => void) => Promise<T>) =>
+    deadline.run(label, () => operation(() => deadline.assertActive(label)));
+
   if (provider === "kamino") {
-    // Construction remains synchronous and I/O-free. The client awaits this
-    // resolver only when a chain method is invoked, so an idempotent replay can
-    // return from durable state during an RPC outage.
-    const client = new KaminoVaultDirectClient(
-      async (_ctx, cluster) => {
-        const rpcUrl = resolveClusterRpcUrl(env, cluster);
-        await assertClusterEndpoint(env, cluster, rpcUrl);
-        return rpcUrl;
-      },
-      (label, operation) => deadline.run(label, () => operation(() => deadline.assertActive(label)))
-    );
+    const client = new KaminoVaultDirectClient(provenRpcUrl, runOperation);
     assertNotPortfolioProvider(client);
+    return client;
+  }
+  if (provider === "veda") {
+    const client = new VedaVaultDirectClient(provenRpcUrl, runOperation);
+    assertVedaNotPortfolioProvider(client);
     return client;
   }
   return null;

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.test.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.test.ts
@@ -1,4 +1,5 @@
 import { SdpKaminoError } from "@sdp/kamino";
+import { SdpVedaError } from "@sdp/veda";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresEarnVaultRepository } from "@/db/repositories/earn-vault.repository";
@@ -328,6 +329,30 @@ describe("depositIntoVault — idempotency", () => {
     expect(broadcastVaultTransaction).toHaveBeenCalledTimes(2);
   });
 
+  /**
+   * Replay is a property of this service, not of a provider, so it is asserted
+   * for the second `vault_direct` provider rather than assumed to carry over —
+   * the fingerprint includes the provider, and the durable movement is what the
+   * retry returns.
+   */
+  it("replays a Veda deposit from durable state without rebuilding it", async () => {
+    const input = depositInput({ provider: "veda", providerReference: VAULT_B });
+
+    const first = await depositIntoVault(env, input);
+    expect(first.replayed).toBe(false);
+
+    buildVaultDeposit.mockClear();
+    const second = await depositIntoVault(env, input);
+
+    expect(second.replayed).toBe(true);
+    expect(second.movement.id).toBe(first.movement.id);
+    expect(second.movement.signature).toBe(first.movement.signature);
+    // The whole point of a durable replay: no chain work, so a retry survives
+    // an RPC outage.
+    expect(buildVaultDeposit).not.toHaveBeenCalled();
+    expect(broadcastVaultTransaction).toHaveBeenCalledTimes(1);
+  });
+
   it("treats a changed minSharesOut as a different request", async () => {
     buildVaultDeposit.mockResolvedValue(plan({ accepted: { amount: "10", minSharesOut: "1" } }));
     await depositIntoVault(env, depositInput({ minSharesOut: "1" }));
@@ -347,6 +372,45 @@ describe("depositIntoVault — validation and custody identity", () => {
     await expect(depositIntoVault(env, depositInput())).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "amount exceeds its mint precision",
+    });
+  });
+
+  /**
+   * Provider-neutral by CODE, not by class. Each of these names something the
+   * request or the vault's current state makes impossible, and the provider's
+   * own sentence explains it better than a status code — while an unrecognised
+   * failure keeps bubbling, because telling a customer their request was wrong
+   * when SDP does not know that would be a guess.
+   */
+  it("maps every refused-build code to a caller 400, across providers", async () => {
+    const refusals = [
+      new SdpKaminoError("INVALID_AMOUNT", "amount exceeds its mint precision"),
+      new SdpVedaError("INVALID_AMOUNT", "minSharesOut is below one share atom"),
+      new SdpVedaError("DEPOSIT_REFUSED", "the vault is at its deposit cap"),
+      new SdpVedaError("COMPLIANCE_APPROVAL_REQUIRED", "this vault requires an approval"),
+    ];
+
+    for (const [index, refusal] of refusals.entries()) {
+      buildVaultDeposit.mockRejectedValueOnce(refusal);
+      await expect(
+        depositIntoVault(
+          env,
+          depositInput({
+            provider: refusal instanceof SdpVedaError ? "veda" : "kamino",
+            requestId: `3333333${index}-3333-4333-8333-333333333333`,
+          })
+        )
+      ).rejects.toMatchObject({ code: "BAD_REQUEST", message: refusal.message });
+    }
+  });
+
+  it("does not dress an unreadable vault up as a caller error", async () => {
+    buildVaultDeposit.mockRejectedValue(
+      new SdpVedaError("VAULT_UNREADABLE", "the configured RPC could not be reached")
+    );
+
+    await expect(depositIntoVault(env, depositInput({ provider: "veda" }))).rejects.toMatchObject({
+      code: "VAULT_UNREADABLE",
     });
   });
 

--- a/apps/sdp-api/src/services/earn/vault-deposit.service.ts
+++ b/apps/sdp-api/src/services/earn/vault-deposit.service.ts
@@ -4,6 +4,7 @@ import { SdpKaminoError } from "@sdp/kamino";
 import { compareDecimalAmounts } from "@sdp/solana/amount";
 import type { SdpEnvironment } from "@sdp/types";
 import type { EarnProviderId } from "@sdp/types/provider-access";
+import { SdpVedaError } from "@sdp/veda";
 import { address } from "@solana/kit";
 import { type AppDb, getDb } from "@/db";
 import {
@@ -135,6 +136,37 @@ function requireAcceptedPlan(
   return { amount, minSharesOut };
 }
 
+/**
+ * Build failures whose reason belongs in front of the CALLER, not in a 500.
+ *
+ * Each names something the request or the vault's current state makes
+ * impossible, and the provider's own sentence explains it better than any
+ * status code:
+ *
+ * - `INVALID_AMOUNT` — the number is unusable at the mint's scale, or below
+ *   what the vault will mint a share for.
+ * - `DEPOSIT_REFUSED` — the vault will not take this right now: paused, at its
+ *   deposit cap, the asset disabled, the wallet short of balance.
+ * - `COMPLIANCE_APPROVAL_REQUIRED` — the vault gates deposits on an approval
+ *   from the provider's compliance service, which SDP does not implement. A
+ *   definite, explainable refusal rather than an internal fault.
+ *
+ * Matched on the shared `code` shape rather than per provider, so a new
+ * vault-direct provider inherits the mapping by using the same vocabulary.
+ * Anything else keeps bubbling: an unrecognised build failure is SDP's problem
+ * to look at, and telling a customer their request was wrong would be a guess.
+ */
+const REFUSED_BUILD_CODES: ReadonlySet<string> = new Set([
+  "INVALID_AMOUNT",
+  "DEPOSIT_REFUSED",
+  "COMPLIANCE_APPROVAL_REQUIRED",
+]);
+
+function refusedBuildMessage(error: unknown): string | null {
+  if (!(error instanceof SdpKaminoError || error instanceof SdpVedaError)) return null;
+  return REFUSED_BUILD_CODES.has(error.code) ? error.message : null;
+}
+
 function appendRequestMemo(
   plan: EarnVaultTransactionPlan,
   requestId: string
@@ -225,9 +257,8 @@ export async function depositIntoVault(
     plan = appendRequestMemo(built, input.requestId);
   } catch (error) {
     getLogger().error({ error }, "vault deposit: build failed before signing");
-    if (error instanceof SdpKaminoError && error.code === "INVALID_AMOUNT") {
-      throw badRequest(error.message);
-    }
+    const refusal = refusedBuildMessage(error);
+    if (refusal) throw badRequest(refusal);
     throw error;
   }
 

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -38,7 +38,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 ## Declared Workspace Graph
 
-- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`
+- `@sdp/api` -> `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`, `@sdp/veda`
 - `@sdp/api-integration` -> `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types`
 - `@sdp/custody` -> `@sdp/types`
 - `@sdp/earn` -> `@sdp/types`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@sdp/types':
         specifier: workspace:*
         version: link:../../packages/sdp-types
+      '@sdp/veda':
+        specifier: workspace:*
+        version: link:../../packages/sdp-veda
       '@sentry/node':
         specifier: 10.70.0
         version: 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))


### PR DESCRIPTION
Wires `@sdp/veda` into the API so a Veda catalogue row can take a deposit through the same route Kamino does. The route itself is unchanged — that is the result, not an accident: `POST /v1/earn/vault-deposits` names no provider, and the only edits needed were the ONE sanctioned provider-id branch and its registry overlay.

`resolveEarnExecutionClient` gains a `veda` case; unknown ids still answer `null` rather than throwing, so a strategy row written by a newer deploy degrades to "cannot execute" instead of 500ing a read that touched it. The shared resolver and deadline runner are lifted out of the Kamino branch rather than copied, and `earn-provider-registry.ts` overlays the executing client the same way, `assertNotPortfolioProvider` included — a client claiming both capabilities would let a portfolio route hand a customer a vault account as a deposit address.

Deposit build failures are now mapped by CODE rather than per error class: `INVALID_AMOUNT`, `DEPOSIT_REFUSED` and `COMPLIANCE_APPROVAL_REQUIRED` become a 400 carrying the provider's own sentence, because each names something the request or the vault's current state makes impossible. Everything else keeps bubbling — telling a customer their request was wrong when SDP does not know that would be a guess, and `VAULT_UNREADABLE` has its own test to pin it.

**Two image-context fixes the Kamino precedent did not need.** `apps/sdp-api/Dockerfile.dockerignore` is an allowlist, so `packages/sdp-veda` had to be re-included or the COPY failed on a directory the build could not see. And the deps stage never copied `.npmrc`, so the mounted secret had nothing to expand into — the install reached the registry with no auth header at all. Both were found by building the image, not by reading it. The stage now FAILS on a missing or empty secret rather than warning: after this change the API cannot be built without one, and a 404 several minutes later explains nothing. Verified end to end — the image builds, `server.js` carries the Veda SDK, and the token appears in neither the image filesystem nor `docker history`. `docker compose build` passes with the token supplied through the compose build secret.

The docs image is deliberately untouched: its own context allowlist excludes `packages/sdp-veda` exactly as it excludes `packages/sdp-kamino`, so `--filter @sdp/api...` there resolves against a workspace without them.

Test coverage follows the layer that owns each property. The route suite gains the surfacing seam (Veda is registered and executable but NOT offered, so the real map refuses it 403) plus dispatch and fail-closed cases; replay lives in the service suite where the movement row is real. `execution-registry.test.ts` pins that Veda refuses on its missing deployment BEFORE any RPC work, since an unconfigured deployment is a fact about SDP that should not depend on a node being reachable.