### PR TITLE
feat(veda): add @sdp/veda, the SDK wrapper that builds Veda deposits

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - name: Check Kamino dependency boundary
         run: node scripts/check-kamino-dependency-boundary.mjs
+      # `@sdp/veda` must remain the ONLY owner of the private @vedatech/svm-sdk:
+      # the fork-safe install degrades by deselecting exactly that one project,
+      # and a second owner would break every credential-less build.
+      - name: Check Veda dependency boundary
+        run: node scripts/check-veda-dependency-boundary.mjs
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high

--- a/biome.json
+++ b/biome.json
@@ -179,7 +179,8 @@
       "!**/packages/sdp-spc-escrow/src/generated",
       "!**/packages/sdp-spc-withdraw/src/generated",
       "!**/packages/sdp-spc-escrow/idl",
-      "!**/packages/sdp-spc-withdraw/idl"
+      "!**/packages/sdp-spc-withdraw/idl",
+      "!**/packages/sdp-veda/idl"
     ]
   },
   "vcs": {

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -14,7 +14,7 @@ This map is generated from the module-boundary check. It records the permitted w
 
 | Module | Purpose | Allowed workspace dependencies |
 | --- | --- | --- |
-| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types` |
+| `@sdp/api` | Node.js API and application composition root. | `@sdp/custody`, `@sdp/earn`, `@sdp/env-config`, `@sdp/issuance`, `@sdp/kamino`, `@sdp/payments`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/solana`, `@sdp/spc-escrow`, `@sdp/spc-withdraw`, `@sdp/types`, `@sdp/veda` |
 | `@sdp/api-integration` | Maintainer integration harness for API endpoint and provider coverage. | `@sdp/api`, `@sdp/private-channels`, `@sdp/rpc`, `@sdp/spc-escrow`, `@sdp/types` |
 | `@sdp/custody` | Custody provider abstractions and keychain adapters. | `@sdp/types` |
 | `@sdp/earn` | Earn domain services, yield strategies, and vault-infra providers. | `@sdp/payments`, `@sdp/rpc`, `@sdp/solana`, `@sdp/types` |
@@ -32,6 +32,7 @@ This map is generated from the module-boundary check. It records the permitted w
 | `@sdp/spc-escrow` | Generated @solana/kit client for the Private Channels escrow program. | `@sdp/kit-augment` |
 | `@sdp/spc-withdraw` | Generated @solana/kit client for the Private Channels withdraw program. | `@sdp/kit-augment` |
 | `@sdp/types` | Shared runtime types, constants, and product contracts. | None |
+| `@sdp/veda` | Kit-native Veda SVM vault deposit plans and position reads over the private @vedatech/svm-sdk. | `@sdp/earn`, `@sdp/solana`, `@sdp/types` |
 | `sdp-docs` | Public documentation site and generated API reference. | `@sdp/env-config`, `@sdp/types` |
 | `sdp-web` | Dashboard application. | `@sdp/issuance`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/solana`, `@sdp/types` |
 
@@ -55,5 +56,6 @@ This map is generated from the module-boundary check. It records the permitted w
 - `@sdp/spc-escrow` -> `@sdp/kit-augment`
 - `@sdp/spc-withdraw` -> `@sdp/kit-augment`
 - `@sdp/types` -> None
+- `@sdp/veda` -> `@sdp/earn`, `@sdp/solana`, `@sdp/types`
 - `sdp-docs` -> `@sdp/env-config`, `@sdp/types`
 - `sdp-web` -> `@sdp/issuance`, `@sdp/policy`, `@sdp/private-channels`, `@sdp/solana`, `@sdp/types`

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:module-boundaries": "node scripts/check-module-boundaries.mjs",
     "check:pinned-dependencies": "node scripts/check-pinned-dependency-versions.mjs",
     "check:kamino-dependency-boundary": "node scripts/check-kamino-dependency-boundary.mjs",
+    "check:veda-dependency-boundary": "node scripts/check-veda-dependency-boundary.mjs",
     "check:well-known-mints": "pnpm --filter @sdp/api exec tsx ../../scripts/check-well-known-mints.mjs",
     "check:api-playground": "pnpm -C apps/sdp-api playground:check",
     "generate:api-playground": "pnpm -C apps/sdp-api playground:generate",

--- a/packages/sdp-earn/package.json
+++ b/packages/sdp-earn/package.json
@@ -29,6 +29,11 @@
       "import": "./src/support.ts",
       "default": "./src/support.ts"
     },
+    "./providers/veda/vault-state": {
+      "types": "./src/providers/veda/vault-state.ts",
+      "import": "./src/providers/veda/vault-state.ts",
+      "default": "./src/providers/veda/vault-state.ts"
+    },
     "./types": {
       "types": "./src/types.ts",
       "import": "./src/types.ts",

--- a/packages/sdp-earn/src/providers/veda/client.ts
+++ b/packages/sdp-earn/src/providers/veda/client.ts
@@ -4,6 +4,7 @@ import {
   WELL_KNOWN_TOKEN_BY_MINT,
 } from "@sdp/types";
 import {
+  isVedaDepositMint,
   VEDA_DEPOSIT_TOKEN_SYMBOLS,
   type VedaDeployment,
   vedaDeployment,
@@ -29,9 +30,6 @@ import { readVedaVaults, VEDA_UNSET_AUTHORITY, type VedaVault } from "./vault-st
 
 const SECONDS_PER_DAY = 86_400;
 
-/** Symbols SDP fronts, as a set, for the mint screen below. */
-const DECLARED_SYMBOLS = new Set<string>(VEDA_DEPOSIT_TOKEN_SYMBOLS);
-
 /**
  * Deposit mints this vault actually takes, intersected with what SDP declares.
  *
@@ -47,10 +45,7 @@ function depositMints(entry: VedaVault): string[] {
   return entry.assets
     .filter((asset) => asset.allowDeposits)
     .map((asset) => asset.assetMint)
-    .filter((mint) => {
-      const token = WELL_KNOWN_TOKEN_BY_MINT.get(mint);
-      return token !== undefined && DECLARED_SYMBOLS.has(token.symbol);
-    })
+    .filter(isVedaDepositMint)
     .sort();
 }
 

--- a/packages/sdp-types/src/veda-programs.ts
+++ b/packages/sdp-types/src/veda-programs.ts
@@ -1,5 +1,5 @@
 import type { EarnDepositTokenSymbol } from "./earn";
-import { type SolanaCluster, wellKnownMint } from "./well-known-tokens";
+import { type SolanaCluster, WELL_KNOWN_TOKEN_BY_MINT, wellKnownMint } from "./well-known-tokens";
 
 /**
  * Veda's on-chain deployment, per cluster.
@@ -148,5 +148,27 @@ export function isVedaDeployed(cluster: SolanaCluster): boolean {
 export function vedaDepositMints(cluster: SolanaCluster): readonly string[] {
   return VEDA_DEPOSIT_TOKEN_SYMBOLS.map((symbol) => wellKnownMint(symbol, cluster)).filter(
     (mint): mint is string => mint !== undefined
+  );
+}
+
+/**
+ * Whether SDP fronts this mint for Veda — the admission rule, in ONE place.
+ *
+ * Two very different code paths ask it and they must never disagree: the
+ * catalogue read in `@sdp/earn` decides which of a vault's enabled assets
+ * become a row's `depositMints`, and the builder in `@sdp/veda` decides which
+ * asset a deposit instruction spends. A row admitted under one rule and spent
+ * under another is how a deposit ends up moving a token the ledger did not
+ * record, which is exactly what `EarnVaultAssetIdentity` exists to catch — and
+ * a check that fires is still a customer-visible failure, so the two sides
+ * share this predicate rather than each restating it.
+ *
+ * Fails closed on an unknown mint: a mint the well-known catalogue does not
+ * carry has no symbol to compare, so it is not something SDP fronts.
+ */
+export function isVedaDepositMint(mint: string): boolean {
+  const token = WELL_KNOWN_TOKEN_BY_MINT.get(mint);
+  return (
+    token !== undefined && (VEDA_DEPOSIT_TOKEN_SYMBOLS as readonly string[]).includes(token.symbol)
   );
 }

--- a/packages/sdp-veda/CLAUDE.md
+++ b/packages/sdp-veda/CLAUDE.md
@@ -1,0 +1,211 @@
+# @sdp/veda — agent notes
+
+Kit-native deposit **instruction building** for Veda's SVM vaults, plus the live
+position read. It builds unsigned plans and reads chain state; it never signs,
+never submits, never touches a database, and holds no runtime credential —
+Veda's vaults are reached entirely on chain. Signing and submission belong to
+the API, which owns custody.
+
+Read `packages/sdp-earn/CLAUDE.md` for the catalogue side (what a Veda vault row
+IS) and ADR 0002 for the pluggability invariants. `packages/sdp-kamino` is the
+precedent this package mirrors, and the differences from it are the interesting
+part of this file.
+
+## THE BLOCKER: SDP does not know Veda's addresses
+
+`VEDA_DEPLOYMENTS` in `@sdp/types/veda-programs` is `null` for both clusters, so
+**every chain call in this package fails closed with `DEPLOYMENT_NOT_CONFIGURED`
+and nothing here has ever run against a live vault.** That is deliberate, not an
+oversight:
+
+- The `address` baked into each Anchor IDL inside `@vedatech/svm-sdk`
+  (`5J76xGGXn5op…`, `Cchro8d7bN5X…`, `FSZPGBfPWb6f…`) — MEASURED 2026-08-19 with
+  `getAccountInfo` against both public RPCs: **none of the three exists on
+  either cluster.** They are the source repository's `declare_id!` defaults.
+- Veda's integration document names three different addresses, and SDP has only
+  truncated prefixes of them.
+
+The SDK is built for this: `createVedaClient` takes every program address at
+runtime and, per its README, "does not include default addresses or infer one
+program from another". The addresses are deployment CONFIGURATION Veda supplies.
+
+**Filling them in is a pure data change** in `@sdp/types/veda-programs`. Before
+doing it, get Veda to confirm, per cluster: the three program addresses, the
+vault-state address(es) SDP should catalogue, and whether devnet and mainnet
+really share addresses (the document implies they do). Then run
+`src/sdk.smoke.test.ts`, which is the only thing in this repository that can
+prove the integration end to end — see "Tests" below.
+
+## The kit-version firewall
+
+`@vedatech/svm-sdk` is built against `@solana/kit` **7.0.0**; this repo pins
+**6.8.0**, and pnpm nests the SDK's own copy (the tree now carries four kit
+majors — 2.3.0 via klend-sdk, 5.5.1, 6.8.0, 7.0.0). `src/sdk.ts` is the only
+module that may import it. Everything crossing this package's surface is
+`@solana/kit` 6.8, `@sdp/types`, or a **decimal string**.
+
+Every cast at that seam is a structural re-label, not a coercion: kit's
+`Instruction` is a plain object with `programAddress`, a numeric `AccountRole`
+and `Uint8Array` data in both majors, and the client converts to base64 strings
+and numbers before anything leaves.
+
+`sdk-construction.test.ts` greps this package's own source for the rule, because
+it is invisible to the type checker.
+
+## It is also a PRIVATE-registry firewall, and that is load-bearing
+
+`@vedatech/svm-sdk` is the only package here that needs a credential to install.
+`.github/scripts/pnpm-install.sh` degrades a credential-less install — a forked
+pull request, or a repository whose `NPM_TOKEN` is not provisioned — by
+deselecting exactly ONE workspace project: `@sdp/veda`. That works only while
+this package is the SDK's sole owner, which `scripts/check-veda-dependency-boundary.mjs`
+enforces. A second owner would turn every external contribution red on a
+dependency it never touched.
+
+## Money in requires a way out
+
+`assertVedaVaultUsable` runs `validateDeployment()` **and**
+`validateCompatibility({ requireQueue: true })` before any deposit is built.
+Requiring the withdrawal queue on the DEPOSIT path looks like the wrong
+capability to demand until you read it as ADR 0002's exit-safety rule: the queue
+is Veda's durable exit, and SDP will not open a position in a vault whose exit
+infrastructure is not configured and wired to that vault.
+
+It gates only the way IN. The catalogue read, position reads and any future exit
+path never call it, so it can never trap funds — only decline to create them.
+
+Verdicts are cached per (cluster, endpoint, vault) for ten minutes.
+**Failures are never cached**: an incompatible or unreachable deployment is
+re-checked, not remembered.
+
+## The withdraw capability is WITHHELD
+
+`VedaVaultDirectClient` implements `buildVaultDeposit` and `readVaultPositions`
+and deliberately not `buildVaultWithdrawal`, so `supportsVaultWithdraw` answers
+false. Veda offers two independent exits — an instant redemption and a
+request → fulfil → cancel queue — and neither has an SDP route: there is no
+`POST /vault-withdrawals`, and the queue's lifecycle does not fit the
+`pending|submitted|confirmed|failed` movement model the deposit path uses.
+
+Nothing is fund-trapped by that: the shares sit in the organization's own
+custody wallet and Veda's own surfaces can redeem them. Implementing the method
+is the LAST step of the withdrawal work, not the first (`client.test.ts` pins
+this).
+
+## Slippage protection is never invented
+
+`minSharesOut` is **required** on this client, unlike Kamino's, where it is
+optional. Veda's SDK refuses an implicit tolerance — `buildDeposit` throws
+`SLIPPAGE_PROTECTION_REQUIRED` without either a floor or a bps tolerance — and
+SDP passes that refusal through rather than papering over it with a default.
+`slippageBps` appears nowhere in this package, and a source test asserts it.
+
+Note the API only requires a floor in PRODUCTION; for Veda it is required in
+every environment, which is why the refusal is a typed `INVALID_AMOUNT` raised
+before any chain work.
+
+## Amounts are checked against the MINT, not just parsed
+
+The SDK takes atomic `bigint`s, so SDP owns the decimal→atoms conversion and the
+only two options are refuse or round. `amounts.ts` (deliberately outside the
+firewall, so it is unit-testable without loading the SDK) refuses any value
+finer than its mint can represent and returns the canonical form the instruction
+actually encodes — surfaced as `VedaInstructionPlan.accepted`, which is what the
+ledger persists.
+
+Two bugs hide under rounding: a deposit of `1.0000009` on a six-decimal mint
+would be RECORDED as 1.0000009 while 1.000000 moved, and a `minSharesOut` below
+one atom would become `0` — a floor that reads as protection everywhere and
+imposes none on chain.
+
+The deposit mint's decimals are read from the MINT ACCOUNT (`mint.ts`), not from
+`WELL_KNOWN_TOKEN_BY_MINT`: the number that decides how many atoms a decimal
+becomes has to be the mint's own.
+
+## The deposit asset is resolved, and ambiguity is REFUSED
+
+`EarnVaultDepositInput` carries no mint — the catalogue row does, and the API
+compares the built plan's `assetIdentity` against it — so the builder must
+arrive at the same asset the catalogue admitted. It does that by applying the
+same predicate (`isVedaDepositMint`, in `@sdp/types` precisely so both sides
+share one copy) to the same source: the vault's own enabled assets.
+
+If more than one matches, the build FAILS. While SDP declares one deposit symbol
+there can be at most one, and "pick the first" is the kind of silent choice that
+spends the wrong token. Widening `VEDA_DEPOSIT_TOKEN_SYMBOLS` therefore means
+carrying a mint on the deposit contract first.
+
+## `owner` is the rent payer, not the fee payer
+
+Veda's `buildDeposit` creates the owner's share account and the vault's asset
+account idempotently, with the owner as `payer` — embedded in the instruction
+accounts as writable+signer. That is ATA rent, a real spend separate from the
+transaction fee, which SDP's Kora path sets at compile time and signs
+post-compile. No sponsor address is accepted here for that reason.
+
+## Positions are read in base units, and the valuation may be absent
+
+`getUserPosition` returns an exact atomic `bigint` for the share balance —
+never a JSON `uiAmount`, which loses value above 2^53 base units.
+
+`tokenValue` comes from `previewWithdraw`, so the figure is the vault's own
+accounting including its oracle and any withdraw premium, rather than
+arithmetic this package invents on top of a raw exchange rate. That makes it a
+REDEEMABLE value, which is the conservative one to show a holder. The valuation
+is allowed to fail INDEPENDENTLY of the share read: a stale oracle or a disabled
+withdrawal asset makes the VALUE unknown without making the HOLDING unknown, and
+the caller renders "—" rather than a fabricated number.
+
+An empty reference list reads every vault SDP has CONFIGURED. Veda's SDK
+publishes no vault discovery and there is nothing to discover: unlike Kamino's
+permissionless registry, a Veda vault reaches SDP only by being named in
+`VEDA_DEPLOYMENTS`.
+
+## Compliance approvals are not implemented
+
+A Veda vault may run in compliance mode, where a deposit needs an Ed25519-signed
+approval from Veda's compliance service placed immediately before the deposit
+instruction. v1 does not implement that flow: the SDK's
+`COMPLIANCE_APPROVAL_REQUIRED` maps to this package's error of the same name and
+the build fails. Implementing it is a deliberate later decision — it needs a
+credentialed call to a Veda service, which would also make this the first Veda
+surface that is not purely on-chain.
+
+The Ed25519 program is nonetheless in the cluster allowlist, so a future
+approval-carrying plan is not rejected by the guard for the wrong reason.
+
+## RPC reads are bounded
+
+`rpc.ts` applies a 30-second deadline at the transport boundary shared with the
+SDK, so vault, asset, oracle, mint and position reads cannot hold an API worker
+forever. A deposit build fans out over several of those. The API additionally
+injects its own absolute vault deadline through the client's operation runner.
+
+## Tests
+
+`vitest run`, and **offline by default** — the repo rule is that package tests
+touch no network.
+
+`idl-layout.test.ts` earns its place: it recomputes `@sdp/earn`'s hand-written
+`BoringVault` offset table from the committed IDL's own field order, and checks
+the committed IDLs against the SDK's shipped copies AND their recorded SHA-256s.
+`@sdp/earn` cannot do this itself — it may not depend on the SDK — so a silent
+Veda ABI change would otherwise become a silently wrong share mint on a
+customer's row. If Veda changes the ABI, this fails on the next `pnpm install`.
+
+`sdk.smoke.test.ts` is the exception to the offline rule: env-gated, skipped
+when unset, so CI never runs it. It takes its deployment from the environment
+because `VEDA_DEPLOYMENTS` is empty, and it is the only thing that can prove the
+integration works.
+
+```bash
+VEDA_SMOKE_RPC_URL=https://api.devnet.solana.com \
+VEDA_SMOKE_VAULT_PROGRAM=<address> VEDA_SMOKE_QUEUE_PROGRAM=<address> \
+VEDA_SMOKE_HOOK_PROGRAM=<address> VEDA_SMOKE_VAULT=<vault-state address> \
+VEDA_SMOKE_OWNER=<wallet address> \
+pnpm --filter @sdp/veda test
+```
+
+DEVNET only. Veda's own checklist requires their separate approval for any
+value-moving mainnet test, and `VAULT_DIRECT_DEPOSIT_ENVIRONMENTS` is
+sandbox-only for the same reason.

--- a/packages/sdp-veda/idl/boring_onchain_queue.json
+++ b/packages/sdp-veda/idl/boring_onchain_queue.json
@@ -1,0 +1,3011 @@
+{
+  "address": "Cchro8d7bN5Xfk77z9hJKxREJwSAjpz5K2seK4iNN396",
+  "metadata": {
+    "name": "boring_onchain_queue",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "accept_authority",
+      "docs": [
+        "Completes a queue authority handshake. Only the staged pending authority may call",
+        "this, promoting itself to the queue authority.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID"
+      ],
+      "discriminator": [
+        107,
+        86,
+        198,
+        91,
+        33,
+        12,
+        107,
+        160
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "queue_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "accept_program_authority",
+      "docs": [
+        "Completes the ProgramAuthority handshake. Only the pending authority may call this,",
+        "promoting itself to the program authority.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts"
+      ],
+      "discriminator": [
+        224,
+        193,
+        101,
+        195,
+        243,
+        34,
+        10,
+        108
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cancel_withdraw",
+      "docs": [
+        "Cancels a withdraw request and returns shares to user",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `request_id` - The request ID to cancel",
+        "",
+        "# Errors",
+        "* `RequestDeadlineNotPassed` - If request deadline hasn't passed yet",
+        "* `InvalidShareMint` - If share mint doesn't match queue state"
+      ],
+      "discriminator": [
+        112,
+        53,
+        226,
+        58,
+        158,
+        30,
+        37,
+        168
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The vault's share mint"
+          ]
+        },
+        {
+          "name": "withdraw_request",
+          "writable": true
+        },
+        {
+          "name": "queue_state"
+        },
+        {
+          "name": "queue"
+        },
+        {
+          "name": "user_shares",
+          "docs": [
+            "The user's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "queue_shares",
+          "docs": [
+            "The queue's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "queue"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "_request_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "deploy",
+      "docs": [
+        "Deploys a new queue for a vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - The deployment arguments containing vault configuration"
+      ],
+      "discriminator": [
+        67,
+        36,
+        143,
+        118,
+        36,
+        164,
+        92,
+        217
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "queue_state",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "DeployArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fulfill_withdraw",
+      "docs": [
+        "Fulfills a withdraw request by transferring assets to user",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `request_id` - The request ID to fulfill",
+        "* `cpi_digest_ix_data` - instruction data passed into the withdraw CPI",
+        "",
+        "# Errors",
+        "* `RequestNotMature` - If maturity period hasn't passed",
+        "* `RequestDeadlinePassed` - If request has expired",
+        "* `InvalidWithdrawMint` - If withdraw mint doesn't match request",
+        "* `QueuePaused` - If queue is paused",
+        "* `InvalidTokenProgram` - If token program doesn't match mint"
+      ],
+      "discriminator": [
+        158,
+        10,
+        86,
+        153,
+        67,
+        210,
+        223,
+        6
+      ],
+      "accounts": [
+        {
+          "name": "solver",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user"
+        },
+        {
+          "name": "withdraw_request",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The vault's share mint"
+          ],
+          "writable": true
+        },
+        {
+          "name": "queue_state"
+        },
+        {
+          "name": "withdraw_mint"
+        },
+        {
+          "name": "user_ata",
+          "docs": [
+            "Users's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "queue_ata",
+          "docs": [
+            "Queues's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_ata",
+          "docs": [
+            "Vault's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "queue",
+          "writable": true
+        },
+        {
+          "name": "queue_shares",
+          "docs": [
+            "The queue's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "queue"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "boring_vault_program",
+          "docs": [
+            "The Boring Vault program"
+          ],
+          "address": "5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc"
+        },
+        {
+          "name": "boring_vault_state",
+          "docs": [
+            "The vault state account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "boring_vault"
+        },
+        {
+          "name": "vault_asset_data",
+          "docs": [
+            "The vault's asset data for the withdraw mint"
+          ]
+        },
+        {
+          "name": "price_feed",
+          "docs": [
+            "Price feed for the withdraw asset"
+          ]
+        },
+        {
+          "name": "allowed_user",
+          "docs": [
+            "The queue's `AllowedUser` in the vault program, forwarded to the vault withdraw CPI. The",
+            "queue is the withdraw signer; in compliance mode it must be an enabled allowed user."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "queue"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "boring_vault_program"
+            }
+          }
+        },
+        {
+          "name": "user_allowed_user",
+          "docs": [
+            "The recipient's (`withdraw_request.user`) `AllowedUser` in the vault program.",
+            "Required only when the vault is in compliance mode, `None` otherwise."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "boring_vault_program"
+            }
+          }
+        },
+        {
+          "name": "cpi_digest",
+          "docs": [
+            "The vault's `CpiDigest` for the withdraw sidecar. Required when the withdraw asset",
+            "has a non-default `withdraw_cpi_digest`, `None` otherwise."
+          ],
+          "optional": true
+        },
+        {
+          "name": "ix_program_id",
+          "docs": [
+            "Target program of the withdraw sidecar CPI. Required when the withdraw asset",
+            "has a non-default `withdraw_cpi_digest`, `None` otherwise."
+          ],
+          "optional": true
+        },
+        {
+          "name": "target_program_data",
+          "docs": [
+            "ProgramData of the sidecar target program. Required when the vault's withdraw `CpiDigest`",
+            "is bound to the target program's deployed code, `None` otherwise."
+          ],
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "_request_id",
+          "type": "u64"
+        },
+        {
+          "name": "cpi_digest_ix_data",
+          "type": {
+            "option": "bytes"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "docs": [
+        "Initializes the program configuration",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `authority` - The authority address to set"
+      ],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "program_data",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  172,
+                  150,
+                  21,
+                  90,
+                  40,
+                  12,
+                  53,
+                  232,
+                  96,
+                  195,
+                  223,
+                  103,
+                  241,
+                  81,
+                  30,
+                  161,
+                  100,
+                  139,
+                  252,
+                  240,
+                  8,
+                  215,
+                  126,
+                  229,
+                  216,
+                  218,
+                  58,
+                  17,
+                  228,
+                  135,
+                  7,
+                  21
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "pause",
+      "docs": [
+        "Pauses the queue, preventing new withdraw requests",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID"
+      ],
+      "discriminator": [
+        211,
+        22,
+        221,
+        251,
+        74,
+        121,
+        193,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "queue_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "request_withdraw",
+      "docs": [
+        "Requests a withdrawal from the queue",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - The withdraw request arguments containing:",
+        "- vault_id: The vault to withdraw from",
+        "- share_amount: Amount of shares to withdraw",
+        "- discount: Discount rate in BPS",
+        "- seconds_to_deadline: Time until request expires",
+        "",
+        "# Errors",
+        "* `InvalidShareMint` - If share mint doesn't match queue state",
+        "* `InvalidDiscount` - If discount is outside allowed range",
+        "* `InvalidShareAmount` - If share amount is below minimum",
+        "* `InvalidSecondsToDeadline` - If deadline is too short"
+      ],
+      "discriminator": [
+        137,
+        95,
+        187,
+        96,
+        250,
+        138,
+        31,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "queue_state"
+        },
+        {
+          "name": "withdraw_mint"
+        },
+        {
+          "name": "withdraw_asset_data"
+        },
+        {
+          "name": "user_withdraw_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  111,
+                  114,
+                  105,
+                  110,
+                  103,
+                  45,
+                  113,
+                  117,
+                  101,
+                  117,
+                  101,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114,
+                  45,
+                  119,
+                  105,
+                  116,
+                  104,
+                  100,
+                  114,
+                  97,
+                  119,
+                  45,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "withdraw_request",
+          "writable": true
+        },
+        {
+          "name": "queue"
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The vault's share mint"
+          ]
+        },
+        {
+          "name": "user_shares",
+          "docs": [
+            "The user's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "queue_shares",
+          "docs": [
+            "The queue's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "queue"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "boring_vault_program",
+          "docs": [
+            "The Boring Vault program"
+          ],
+          "address": "5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc"
+        },
+        {
+          "name": "boring_vault_state",
+          "docs": [
+            "The vault state account.",
+            "Mutable: for VestingYield vaults the `vest_to_exchange_rate` CPI persists pending gains",
+            "into this account before the rate is read.",
+            "Constrained to the vault PDA for `args.vault_id` and to this queue's share mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "queue_permission",
+          "docs": [
+            "The queue PDA's permission in the vault. Required for VestingYield vaults so the queue can",
+            "sign the `vest_to_exchange_rate` CPI."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "queue"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "boring_vault_program"
+            }
+          }
+        },
+        {
+          "name": "vault_asset_data",
+          "docs": [
+            "The vault's asset data for the withdraw mint, used to price the quote."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "withdraw_mint"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "boring_vault_program"
+            }
+          }
+        },
+        {
+          "name": "price_feed",
+          "docs": [
+            "Price feed for the withdraw asset."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "RequestWithdrawArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_solve_authority",
+      "docs": [
+        "Sets the solve authority for the queue",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_solve_authority` - The new solve authority address"
+      ],
+      "discriminator": [
+        46,
+        173,
+        39,
+        53,
+        34,
+        224,
+        54,
+        195
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "queue_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_solve_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "setup_user_withdraw_state",
+      "docs": [
+        "Initializes a user's withdraw state",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts"
+      ],
+      "discriminator": [
+        105,
+        154,
+        55,
+        232,
+        156,
+        127,
+        164,
+        235
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user_withdraw_state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  111,
+                  114,
+                  105,
+                  110,
+                  103,
+                  45,
+                  113,
+                  117,
+                  101,
+                  117,
+                  101,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114,
+                  45,
+                  119,
+                  105,
+                  116,
+                  104,
+                  100,
+                  114,
+                  97,
+                  119,
+                  45,
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "transfer_authority",
+      "docs": [
+        "Stages a new authority for a queue. Only the current queue authority may call this.",
+        "The transfer only takes effect once `pending_authority` calls `accept_authority`,",
+        "so a typo'd or unusable key cannot lock the queue out.",
+        "",
+        "Passing `Pubkey::default()` revokes a staged transfer.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `pending_authority` - The proposed next queue authority or the default pubkey",
+        "",
+        "# Errors",
+        "* `SelfTransferNotAllowed` - If `pending_authority` is the current authority"
+      ],
+      "discriminator": [
+        48,
+        169,
+        76,
+        72,
+        229,
+        180,
+        55,
+        161
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "queue_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "pending_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "transfer_program_authority",
+      "docs": [
+        "Stages a new ProgramConfig authority. Only the current program authority may call this.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `pending_authority` - The proposed next program authority"
+      ],
+      "discriminator": [
+        133,
+        0,
+        66,
+        166,
+        130,
+        239,
+        5,
+        130
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "pending_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "unpause",
+      "docs": [
+        "Unpauses the queue, allowing new withdraw requests",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID"
+      ],
+      "discriminator": [
+        169,
+        144,
+        4,
+        38,
+        10,
+        141,
+        188,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "queue_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_withdraw_asset_data",
+      "docs": [
+        "Updates withdraw asset configuration",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - The configuration parameters to update",
+        "",
+        "# Errors",
+        "* `MaximumDeadlineExceeded` - If minimum_seconds_to_deadline exceeds MAXIMUM_DEADLINE (90 days)",
+        "* `MaximumMaturityExceeded` - If seconds_to_maturity exceeds MAXIMUM_MATURITY (90 days)",
+        "* `InvalidDiscount` - If maximum_discount is less than minimum_discount",
+        "* `MaximumDiscountExceeded` - If maximum_discount exceeds MAXIMUM_DISCOUNT (10%)"
+      ],
+      "discriminator": [
+        101,
+        194,
+        137,
+        82,
+        34,
+        107,
+        239,
+        117
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "queue_state"
+        },
+        {
+          "name": "withdraw_mint"
+        },
+        {
+          "name": "withdraw_asset_data",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "UpdateWithdrawAssetArgs"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ProgramConfig",
+      "discriminator": [
+        196,
+        210,
+        90,
+        231,
+        144,
+        149,
+        140,
+        63
+      ]
+    },
+    {
+      "name": "QueueState",
+      "discriminator": [
+        18,
+        227,
+        150,
+        65,
+        218,
+        214,
+        72,
+        191
+      ]
+    },
+    {
+      "name": "UserWithdrawState",
+      "discriminator": [
+        203,
+        226,
+        117,
+        250,
+        185,
+        251,
+        209,
+        162
+      ]
+    },
+    {
+      "name": "WithdrawAssetData",
+      "discriminator": [
+        222,
+        123,
+        55,
+        75,
+        117,
+        35,
+        221,
+        77
+      ]
+    },
+    {
+      "name": "WithdrawRequest",
+      "discriminator": [
+        186,
+        239,
+        174,
+        191,
+        189,
+        13,
+        47,
+        196
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "AuthorityUpdated",
+      "discriminator": [
+        133,
+        207,
+        24,
+        122,
+        14,
+        234,
+        91,
+        34
+      ]
+    },
+    {
+      "name": "PendingAuthoritySet",
+      "discriminator": [
+        112,
+        115,
+        80,
+        37,
+        41,
+        177,
+        221,
+        81
+      ]
+    },
+    {
+      "name": "ProgramAuthorityUpdated",
+      "discriminator": [
+        172,
+        190,
+        142,
+        146,
+        101,
+        19,
+        87,
+        104
+      ]
+    },
+    {
+      "name": "ProgramPendingAuthoritySet",
+      "discriminator": [
+        105,
+        16,
+        11,
+        186,
+        226,
+        198,
+        238,
+        130
+      ]
+    },
+    {
+      "name": "QueueDeployed",
+      "discriminator": [
+        157,
+        189,
+        181,
+        240,
+        186,
+        76,
+        142,
+        85
+      ]
+    },
+    {
+      "name": "QueuePaused",
+      "discriminator": [
+        89,
+        197,
+        162,
+        223,
+        106,
+        67,
+        169,
+        133
+      ]
+    },
+    {
+      "name": "QueueUnpaused",
+      "discriminator": [
+        202,
+        71,
+        194,
+        196,
+        102,
+        197,
+        246,
+        253
+      ]
+    },
+    {
+      "name": "SolveAuthorityUpdated",
+      "discriminator": [
+        123,
+        46,
+        70,
+        180,
+        163,
+        106,
+        254,
+        144
+      ]
+    },
+    {
+      "name": "WithdrawAssetDataUpdated",
+      "discriminator": [
+        116,
+        54,
+        182,
+        49,
+        228,
+        133,
+        174,
+        168
+      ]
+    },
+    {
+      "name": "WithdrawCancelled",
+      "discriminator": [
+        162,
+        153,
+        181,
+        47,
+        154,
+        132,
+        183,
+        117
+      ]
+    },
+    {
+      "name": "WithdrawFulfilled",
+      "discriminator": [
+        71,
+        21,
+        145,
+        222,
+        215,
+        28,
+        31,
+        50
+      ]
+    },
+    {
+      "name": "WithdrawRequested",
+      "discriminator": [
+        114,
+        16,
+        240,
+        206,
+        93,
+        128,
+        151,
+        39
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "NotAuthorized",
+      "msg": "Not authorized"
+    },
+    {
+      "code": 6001,
+      "name": "QueuePaused",
+      "msg": "Queue paused"
+    },
+    {
+      "code": 6002,
+      "name": "WithdrawsNotAllowedForAsset",
+      "msg": "Withdraws not allowed for asset"
+    },
+    {
+      "code": 6003,
+      "name": "UnsupportedWithdrawSidecar",
+      "msg": "Withdraw sidecar CPI not supported by queue"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidDiscount",
+      "msg": "Invalid discount"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidShareAmount",
+      "msg": "Invalid share amount"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidSecondsToDeadline",
+      "msg": "Invalid seconds to deadline"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidBoringVaultProgram",
+      "msg": "Invalid boring vault program"
+    },
+    {
+      "code": 6008,
+      "name": "RequestNotMature",
+      "msg": "Request not mature"
+    },
+    {
+      "code": 6009,
+      "name": "RequestDeadlinePassed",
+      "msg": "Request deadline passed"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidWithdrawMint",
+      "msg": "Invalid withdraw mint"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidTokenProgram",
+      "msg": "Invalid token program"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidShareMint",
+      "msg": "Invalid share mint"
+    },
+    {
+      "code": 6013,
+      "name": "DecimalConversionFailed",
+      "msg": "Decimal conversion failed"
+    },
+    {
+      "code": 6014,
+      "name": "RequestDeadlineNotPassed",
+      "msg": "Request deadline not passed"
+    },
+    {
+      "code": 6015,
+      "name": "MaximumMaturityExceeded",
+      "msg": "Maximum maturity exceeded"
+    },
+    {
+      "code": 6016,
+      "name": "MaximumDeadlineExceeded",
+      "msg": "Maximum deadline exceeded"
+    },
+    {
+      "code": 6017,
+      "name": "MaximumDiscountExceeded",
+      "msg": "Maximum discount exceeded"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidAssociatedTokenAccount",
+      "msg": "Invalid associated token account"
+    },
+    {
+      "code": 6019,
+      "name": "MathError",
+      "msg": "Math error"
+    },
+    {
+      "code": 6020,
+      "name": "ComplianceAccountRequired",
+      "msg": "Compliance account required"
+    },
+    {
+      "code": 6021,
+      "name": "UserNotAllowed",
+      "msg": "User is not an allowed (compliant) user"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidPendingAuthority",
+      "msg": "Invalid pending authority"
+    },
+    {
+      "code": 6023,
+      "name": "SelfTransferNotAllowed",
+      "msg": "Self transfer not allowed"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority"
+    },
+    {
+      "code": 6025,
+      "name": "IncompatibleWithdrawAuthority",
+      "msg": "Vault withdraw authority is not compatible with this queue"
+    },
+    {
+      "code": 6026,
+      "name": "MissingQueuePermission",
+      "msg": "Queue permission account required for VestingYield vaults"
+    }
+  ],
+  "types": [
+    {
+      "name": "AllowedUser",
+      "docs": [
+        "PDA account that stores an allowed user",
+        "Seeds: [\"allowed-user\", vault, user]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this account's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "docs": [
+              "The user wallet used in this account's PDA derivation."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          },
+          {
+            "name": "last_deposit_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this account's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "docs": [
+              "The asset mint used in this account's PDA derivation."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "allow_deposits",
+            "type": "bool"
+          },
+          {
+            "name": "allow_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "share_premium_bps",
+            "type": "u16"
+          },
+          {
+            "name": "is_pegged_to_base_asset",
+            "type": "bool"
+          },
+          {
+            "name": "inverse_price_feed",
+            "type": "bool"
+          },
+          {
+            "name": "oracle_source",
+            "docs": [
+              "Oracle implementation with encapsulated parameters and addresses"
+            ],
+            "type": {
+              "defined": {
+                "name": "OracleSource"
+              }
+            }
+          },
+          {
+            "name": "deposit_cpi_digest",
+            "type": "pubkey"
+          },
+          {
+            "name": "withdraw_cpi_digest",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorityUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BoringVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "VaultState"
+              }
+            }
+          },
+          {
+            "name": "teller",
+            "type": {
+              "defined": {
+                "name": "TellerState"
+              }
+            }
+          },
+          {
+            "name": "accrual_mode",
+            "type": {
+              "defined": {
+                "name": "VaultAccrualMode"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DeployArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "boring_vault_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "share_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "solve_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleSource",
+      "docs": [
+        "Enumerates the supported on-chain oracle adapters with their addresses and parameters."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SwitchboardV2",
+            "fields": [
+              {
+                "name": "feed_address",
+                "type": "pubkey"
+              },
+              {
+                "name": "min_samples",
+                "type": "u32"
+              },
+              {
+                "name": "max_staleness_slots",
+                "type": "u32"
+              }
+            ]
+          },
+          {
+            "name": "PythV2",
+            "fields": [
+              {
+                "name": "feed_address",
+                "docs": [
+                  "The canonical price feed account address"
+                ],
+                "type": "pubkey"
+              },
+              {
+                "name": "feed_id",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "max_conf_width_bps",
+                "docs": [
+                  "Maximum allowed confidence as basis points of price (e.g., 500 = 5%)"
+                ],
+                "type": "u16"
+              },
+              {
+                "name": "min_verification_level",
+                "docs": [
+                  "Required Pyth verification level, encoded as a signature-count threshold:",
+                  "- `0` => only `Full` verification is accepted (default, most secure).",
+                  "- `>= 2` => accepts `Partial { num_signatures }` updates whose",
+                  "`num_signatures` is at least this value (`Full` always qualifies too).",
+                  "- `1` is rejected by an operational guard: partial verification must",
+                  "use at least 2 signatures."
+                ],
+                "type": "u8"
+              },
+              {
+                "name": "max_staleness_seconds",
+                "type": "u32"
+              }
+            ]
+          },
+          {
+            "name": "PythV2Pro",
+            "fields": [
+              {
+                "name": "feed_address",
+                "docs": [
+                  "The canonical price feed account address"
+                ],
+                "type": "pubkey"
+              },
+              {
+                "name": "feed_id",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "max_conf_width_bps",
+                "docs": [
+                  "Maximum allowed confidence as basis points of price (e.g., 500 = 5%)"
+                ],
+                "type": "u16"
+              },
+              {
+                "name": "min_verification_level",
+                "docs": [
+                  "Required Pyth verification level. Same encoding as [`PythV2`]."
+                ],
+                "type": "u8"
+              },
+              {
+                "name": "max_staleness_seconds",
+                "type": "u32"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PendingAuthoritySet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "docs": [
+        "PDA account that stores permissions for",
+        "a given key on a given vault.",
+        "Seeds: [b\"permission\", vault, user]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this permission's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "The key that is granted these permissions"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "can_pause",
+            "docs": [
+              "Flag for whether this key can pause a vault or not"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "can_update_exchange_rate",
+            "docs": [
+              "Flag for whether this key has the Exchange Rate Updater role"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "strategist_group",
+            "docs": [
+              "Bit masking that designates a unique grouping for strategist actions available corresponding with CPI Digest.",
+              "0 [default] = no strategist permission"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramAuthorityUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramPendingAuthoritySet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "QueueDeployed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "queue_state",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "boring_vault_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "share_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "solve_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "QueuePaused",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "QueueState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_authority",
+            "docs": [
+              "Staged next `authority`, promoted by `accept_authority`. `Pubkey::default()` when",
+              "no transfer is in flight."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "boring_vault_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "share_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "solve_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "paused",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "QueueUnpaused",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RequestWithdrawArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "share_amount",
+            "type": "u64"
+          },
+          {
+            "name": "discount",
+            "type": "u16"
+          },
+          {
+            "name": "seconds_to_deadline",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SolveAuthorityUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "new_solve_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TellerState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_asset",
+            "docs": [
+              "Immutable after deployment"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "decimals",
+            "docs": [
+              "The share mint's decimals (set to the base mint's decimals during deployment).",
+              "Immutable after deployment"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          },
+          {
+            "name": "exchange_rate_high_water_mark",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fees_owed_in_base_asset",
+            "docs": [
+              "Platform fees accrued and awaiting claim, in base-asset atoms."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "performance_fees_owed_in_base_asset",
+            "docs": [
+              "Performance fees accrued and awaiting claim, in base-asset atoms."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_shares_last_update",
+            "type": "u64"
+          },
+          {
+            "name": "supply_last_update_timestamp",
+            "docs": [
+              "TWAS / cumulative-supply clock (EVM: `supplyObservation.lastUpdateTimestamp`).",
+              "Advanced on every cumulative-supply sync (deposit/withdraw/vest/post_loss)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "platform_payout_address",
+            "docs": [
+              "Recipient of claimed platform fees."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "performance_payout_address",
+            "docs": [
+              "Recipient of claimed performance fees."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "allowed_exchange_rate_change_upper_bound",
+            "type": "u16"
+          },
+          {
+            "name": "allowed_exchange_rate_change_lower_bound",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_update_delay_in_seconds",
+            "type": "u32"
+          },
+          {
+            "name": "platform_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "performance_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "withdraw_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_deviation_yield_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_deviation_loss_bps",
+            "type": "u16"
+          },
+          {
+            "name": "vesting_state",
+            "type": {
+              "defined": {
+                "name": "VestingState"
+              }
+            }
+          },
+          {
+            "name": "last_strategist_update_timestamp",
+            "docs": [
+              "Admin/strategist cooldown clock (EVM: `lastStrategistUpdateTimestamp`).",
+              "The last time vest_yield or post_loss was called; gates their minimum-update-delay."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "state_last_update_timestamp",
+            "docs": [
+              "Platform/performance fee proration anchor (EVM: `accountantState.lastUpdateTimestamp`).",
+              "Advanced inside `accrue_platform_fee` on every fee accrual",
+              "(deposit/withdraw/vest/rate update)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_cap",
+            "docs": [
+              "Maximum total share supply allowed via deposits (denominated in shares).",
+              "`u64::MAX` disables the cap."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minimum_vest_duration",
+            "docs": [
+              "Minimum allowed `vest_yield` streaming duration in seconds"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maximum_vest_duration",
+            "docs": [
+              "Maximum allowed `vest_yield` streaming duration in seconds"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_remainder",
+            "docs": [
+              "Sub-atom platform fee carry: the part of the accrued platform fee that did not bridge a",
+              "whole base-asset atom, scaled by `FEE_REMAINDER_SCALE`. Always `< FEE_REMAINDER_SCALE`."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "performance_fee_remainder",
+            "docs": [
+              "Sub-atom performance fee carry. Same contract as `platform_fee_remainder`."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateWithdrawAssetArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "allow_withdraws",
+            "type": "bool"
+          },
+          {
+            "name": "seconds_to_maturity",
+            "type": "u32"
+          },
+          {
+            "name": "minimum_seconds_to_deadline",
+            "type": "u32"
+          },
+          {
+            "name": "minimum_discount",
+            "type": "u16"
+          },
+          {
+            "name": "maximum_discount",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_shares",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserWithdrawState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_nonce",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultAccrualMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ExchangeRateStep"
+          },
+          {
+            "name": "VestingYield"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "Immutable after deployment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "accounting_paused",
+            "docs": [
+              "Halts accounting operations and anything related: deposit, withdraw, exchange-rate updates,",
+              "vesting, safe rate reads, claim fees, and share mint/burn."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "teller_paused",
+            "docs": [
+              "Halts deposits and withdrawals"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "manage_paused",
+            "docs": [
+              "Halts manage instruction"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "share_mint",
+            "docs": [
+              "Immutable after deployment"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "deposit_sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "withdraw_sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "share_mover",
+            "type": "pubkey"
+          },
+          {
+            "name": "compliance_mode",
+            "type": "bool"
+          },
+          {
+            "name": "compliance_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_duration_seconds",
+            "docs": [
+              "Share-lock duration in seconds. Must be the source of truth and driver over the",
+              "lock_duration_seconds field on the transfer HookConfig"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VestingState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_virtual_share_price",
+            "docs": [
+              "High-precision, dimensionless virtual share price: the raw ratio",
+              "`total_assets_atomic / total_shares_atomic` scaled by RAY.",
+              "Gains are added here per-share as they vest; the human-readable",
+              "exchange_rate (= lastSharePrice in EVM) is derived as",
+              "`last_virtual_share_price * 10^decimals / RAY`."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "vesting_gains",
+            "docs": [
+              "Total unvested gains in base-asset units (not per-share).",
+              "Set to the full yield_amount on each vest_yield call (= overwrite, not +=)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_vesting_update",
+            "docs": [
+              "The last time a yield update was posted"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "start_vesting_time",
+            "docs": [
+              "The start time for the yield streaming period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "end_vesting_time",
+            "docs": [
+              "The end time for the yield streaming period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_supply",
+            "docs": [
+              "Accumulated supply * time for TWAS calculation"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "vesting_period_start",
+            "docs": [
+              "Start of the current TWAS window, reset by vest_yield"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawAssetData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used in this account's PDA derivation."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "docs": [
+              "The withdrawal mint used in this account's PDA derivation."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "allow_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "seconds_to_maturity",
+            "type": "u32"
+          },
+          {
+            "name": "minimum_seconds_to_deadline",
+            "type": "u32"
+          },
+          {
+            "name": "minimum_discount",
+            "type": "u16"
+          },
+          {
+            "name": "maximum_discount",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_shares",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawAssetDataUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "queue_state",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "allow_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "seconds_to_maturity",
+            "type": "u32"
+          },
+          {
+            "name": "minimum_seconds_to_deadline",
+            "type": "u32"
+          },
+          {
+            "name": "minimum_discount",
+            "type": "u16"
+          },
+          {
+            "name": "maximum_discount",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_shares",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawCancelled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "queue_state",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "shares_returned",
+            "type": "u64"
+          },
+          {
+            "name": "cancelled_at",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawFulfilled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "queue_state",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "solver",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "shares_burned",
+            "type": "u64"
+          },
+          {
+            "name": "assets_paid",
+            "type": "u64"
+          },
+          {
+            "name": "vault_assets_out",
+            "type": "u64"
+          },
+          {
+            "name": "excess_returned",
+            "type": "u64"
+          },
+          {
+            "name": "fulfilled_at",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawRequest",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset_out",
+            "type": "pubkey"
+          },
+          {
+            "name": "share_amount",
+            "type": "u64"
+          },
+          {
+            "name": "asset_amount",
+            "type": "u64"
+          },
+          {
+            "name": "creation_time",
+            "type": "u64"
+          },
+          {
+            "name": "seconds_to_maturity",
+            "type": "u32"
+          },
+          {
+            "name": "seconds_to_deadline",
+            "type": "u32"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawRequested",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "queue_state",
+            "type": "pubkey"
+          },
+          {
+            "name": "request",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "shares",
+            "type": "u64"
+          },
+          {
+            "name": "assets",
+            "type": "u64"
+          },
+          {
+            "name": "creation_time",
+            "type": "u64"
+          },
+          {
+            "name": "maturity_time",
+            "type": "u64"
+          },
+          {
+            "name": "deadline",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/sdp-veda/idl/boring_vault_svm.json
+++ b/packages/sdp-veda/idl/boring_vault_svm.json
@@ -1,0 +1,7939 @@
+{
+  "address": "5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc",
+  "metadata": {
+    "name": "boring_vault_svm",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "accept_authority",
+      "docs": [
+        "Accepts authority from a pending authority",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault id"
+      ],
+      "discriminator": [
+        107,
+        86,
+        198,
+        91,
+        33,
+        12,
+        107,
+        160
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "accept_program_authority",
+      "docs": [
+        "Completes the program-authority handshake. Only the pending authority may call this,",
+        "promoting itself to the program authority.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the pending program authority"
+      ],
+      "discriminator": [
+        224,
+        193,
+        101,
+        195,
+        243,
+        34,
+        10,
+        108
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "add_permission",
+      "docs": [
+        "Adds a new permission entry for a wallet on a vault",
+        "",
+        "Creates a PDA account storing permission flags (can_pause, can_update_exchange_rate,",
+        "strategist_group) for the given wallet, scoped to the vault.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Permission arguments including:",
+        "* `wallet` - The public key to grant permissions to",
+        "* `can_pause` - Whether this wallet can pause the vault",
+        "* `can_update_exchange_rate` - Whether this wallet can update the exchange rate",
+        "* `strategist_group` - Bitmask for strategist action grouping (0 = no strategist permission)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        144,
+        66,
+        124,
+        76,
+        232,
+        97,
+        99,
+        77
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "permission",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "arg",
+                "path": "args.wallet"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "PermissionArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "burn_shares",
+      "discriminator": [
+        98,
+        168,
+        88,
+        31,
+        217,
+        221,
+        191,
+        214
+      ],
+      "accounts": [
+        {
+          "name": "source",
+          "signer": true
+        },
+        {
+          "name": "share_mover",
+          "signer": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "share_mint",
+          "writable": true
+        },
+        {
+          "name": "source_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "source"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_performance_fees_in_base",
+      "docs": [
+        "Claims accumulated performance fees in base asset, transferring them to the performance payout",
+        "address.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `sub_account` - The sub-account to claim from",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::InvalidTokenProgram` - If token program doesn't match mint"
+      ],
+      "discriminator": [
+        28,
+        1,
+        134,
+        121,
+        146,
+        168,
+        201,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "base_mint"
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "boring_vault"
+        },
+        {
+          "name": "payout_ata",
+          "docs": [
+            "Payout's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_ata",
+          "docs": [
+            "Vault's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "sub_account",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "claim_platform_fees_in_base",
+      "docs": [
+        "Claims accumulated platform fees in base asset, transferring them to the platform payout",
+        "address.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `sub_account` - The sub-account to claim from",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::InvalidTokenProgram` - If token program doesn't match mint"
+      ],
+      "discriminator": [
+        79,
+        178,
+        227,
+        212,
+        204,
+        130,
+        250,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "base_mint"
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "boring_vault"
+        },
+        {
+          "name": "payout_ata",
+          "docs": [
+            "Payout's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_ata",
+          "docs": [
+            "Vault's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "sub_account",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "close_compliance_approval",
+      "docs": [
+        "Permissionlessly closes an expired ComplianceApproval PDA, returning its",
+        "rent to the user the approval belongs to.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault` - The vault state pubkey the approval was issued for (PDA seed)",
+        "* `expiration` - The expiration timestamp of the approval (PDA seed)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::ComplianceApprovalNotExpired` - If the approval has not yet reached its expiration timestamp"
+      ],
+      "discriminator": [
+        211,
+        142,
+        81,
+        229,
+        144,
+        118,
+        121,
+        110
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "docs": [
+            "Anyone may crank the close of an expired approval."
+          ],
+          "signer": true
+        },
+        {
+          "name": "user",
+          "writable": true
+        },
+        {
+          "name": "compliance_approval",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  109,
+                  112,
+                  108,
+                  105,
+                  97,
+                  110,
+                  99,
+                  101,
+                  45,
+                  97,
+                  112,
+                  112,
+                  114,
+                  111,
+                  118,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "vault"
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              },
+              {
+                "kind": "arg",
+                "path": "expiration"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault",
+          "type": "pubkey"
+        },
+        {
+          "name": "expiration",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "close_cpi_digest",
+      "docs": [
+        "Closes a CPI digest account, returning its rent to the signer.",
+        "",
+        "NOTE: Its on the caller to remove the deposit/withdraw_cpi_digest on any AssetData.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID (PDA seed)",
+        "* `digest` - The 32-byte digest identifying the CPI digest PDA (PDA seed)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority and does not hold the can_pause permission"
+      ],
+      "discriminator": [
+        222,
+        229,
+        29,
+        88,
+        144,
+        101,
+        61,
+        79
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "permission",
+          "docs": [
+            "Required, only when the signer is not the vault authority, to prove the signer holds the",
+            "`can_pause` permission on this vault"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "cpi_digest",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "digest",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "configure_exchange_rate_update_bounds",
+      "docs": [
+        "Configures the exchange rate update bounds",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `args` - Configuration arguments including:",
+        "* `upper_bound` - Maximum allowed increase in exchange rate (in bps)",
+        "* `lower_bound` - Maximum allowed decrease in exchange rate (in bps)",
+        "* `minimum_update_delay` - Minimum time between updates",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidAllowedExchangeRateChangeUpperBound` - If upper bound is invalid",
+        "* `BoringErrorCode::InvalidAllowedExchangeRateChangeLowerBound` - If lower bound is invalid"
+      ],
+      "discriminator": [
+        255,
+        144,
+        53,
+        50,
+        163,
+        209,
+        159,
+        102
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "ConfigureExchangeRateUpdateBoundsArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "deploy",
+      "docs": [
+        "Deploys a new vault instance",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Deployment arguments including:",
+        "* `authority` - The vault authority who can manage vault settings",
+        "* `base_asset` - The base asset mint address for the vault",
+        "* `exchange_rate` - Initial exchange rate between base asset and shares",
+        "* `strategist` - Address of the strategist who can execute vault strategies",
+        "* `payout_address` - Address where fees will be sent",
+        "* `decimals` - Decimals for the share token mint",
+        "* `allowed_exchange_rate_change_upper_bound` - Maximum allowed increase in exchange rate (in bps)",
+        "* `allowed_exchange_rate_change_lower_bound` - Maximum allowed decrease in exchange rate (in bps)",
+        "* `minimum_update_delay_in_seconds` - Minimum time between exchange rate updates",
+        "* `platform_fee_bps` - Platform fee in basis points",
+        "* `performance_fee_bps` - Performance fee in basis points",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::InvalidPayoutAddress` - If payout address is zero address",
+        "* `BoringErrorCode::InvalidAllowedExchangeRateChangeUpperBound` - If upper bound is invalid",
+        "* `BoringErrorCode::InvalidAllowedExchangeRateChangeLowerBound` - If lower bound is invalid",
+        "* `BoringErrorCode::InvalidPlatformFeeBps` - If platform fee exceeds maximum",
+        "* `BoringErrorCode::InvalidPerformanceFeeBps` - If performance fee exceeds maximum"
+      ],
+      "discriminator": [
+        67,
+        36,
+        143,
+        118,
+        36,
+        164,
+        92,
+        217
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The mint of the share token."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "base_asset"
+        },
+        {
+          "name": "transfer_hook_program",
+          "docs": [
+            "share mint is created with the transfer hook extension enabled for every",
+            "deployment (compliance and non-compliance), so share locking is always available."
+          ],
+          "address": "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9"
+        },
+        {
+          "name": "hook_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "transfer_hook_program"
+            }
+          }
+        },
+        {
+          "name": "extra_account_metas",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  116,
+                  114,
+                  97,
+                  45,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116,
+                  45,
+                  109,
+                  101,
+                  116,
+                  97,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "transfer_hook_program"
+            }
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "DeployArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "deposit",
+      "docs": [
+        "Deposits tokens into the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Deposit arguments including:",
+        "* `deposit_amount` - Amount of tokens to deposit",
+        "* `min_mint_amount` - Minimum amount of shares to mint",
+        "",
+        "# Returns",
+        "* `u64` - Amount of shares minted",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::TellerPaused` - If the teller is paused",
+        "* `BoringErrorCode::AssetNotAllowed` - If deposits are not allowed",
+        "* `BoringErrorCode::InvalidTokenProgram` - If token program doesn't match mint"
+      ],
+      "discriminator": [
+        242,
+        35,
+        198,
+        137,
+        82,
+        225,
+        242,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "boring_vault"
+        },
+        {
+          "name": "deposit_mint"
+        },
+        {
+          "name": "asset_data",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "deposit_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_ata",
+          "docs": [
+            "User's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_ata",
+          "docs": [
+            "Vault's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The vault's share mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_shares",
+          "docs": [
+            "The user's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "price_feed"
+        },
+        {
+          "name": "allowed_user",
+          "docs": [
+            "The depositor's AllowedUser PDA. Always required and initialized on first deposit, even",
+            "when compliance mode is off and no share lock is active. That way a share lock enabled",
+            "after the deposit can never block the depositor's transfers for lack of this account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "compliance_approval",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "instructions_sysvar",
+          "optional": true,
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "cpi_digest",
+          "optional": true
+        },
+        {
+          "name": "ix_program_id",
+          "optional": true
+        },
+        {
+          "name": "target_program_data",
+          "docs": [
+            "Required only when the deposit cpi digest is bound to the target program's deployed code."
+          ],
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "DepositArgs"
+            }
+          }
+        }
+      ],
+      "returns": "u64"
+    },
+    {
+      "name": "deposit_sol",
+      "docs": [
+        "Deposits SOL into the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Deposit arguments including:",
+        "* `deposit_amount` - Amount of SOL to deposit",
+        "* `min_mint_amount` - Minimum amount of shares to mint",
+        "",
+        "# Returns",
+        "* `u64` - Amount of shares minted",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::TellerPaused` - If the teller is paused",
+        "* `BoringErrorCode::AssetNotAllowed` - If deposits are not allowed",
+        "* `BoringErrorCode::SlippageExceeded` - If min share amount is not met"
+      ],
+      "discriminator": [
+        108,
+        81,
+        78,
+        117,
+        125,
+        155,
+        56,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "boring_vault",
+          "writable": true
+        },
+        {
+          "name": "asset_data",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The vault's share mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_shares",
+          "docs": [
+            "The user's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "price_feed"
+        },
+        {
+          "name": "allowed_user",
+          "docs": [
+            "The depositor's AllowedUser PDA. Always required and initialized on first deposit, even",
+            "when compliance mode is off and no share lock is active. That way a share lock enabled",
+            "after the deposit can never block the depositor's transfers for lack of this account."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "compliance_approval",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "instructions_sysvar",
+          "optional": true,
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "cpi_digest",
+          "optional": true
+        },
+        {
+          "name": "ix_program_id",
+          "optional": true
+        },
+        {
+          "name": "target_program_data",
+          "docs": [
+            "Required only when the deposit cpi digest is bound to the target program's deployed code."
+          ],
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "DepositArgs"
+            }
+          }
+        }
+      ],
+      "returns": "u64"
+    },
+    {
+      "name": "enable_allowed_user",
+      "docs": [
+        "Creates and enables an `AllowedUser` for an arbitrary address, callable only",
+        "by the compliance authority. Intended for participants that cannot make a",
+        "compliant deposit themselves — notably the Boring Queue PDA.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `user` - The address to enable as an allowed user",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::InvalidComplianceAuthority` - If signer is not the compliance authority"
+      ],
+      "discriminator": [
+        46,
+        158,
+        252,
+        168,
+        180,
+        243,
+        118,
+        35
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Separated from `compliance_authority` so the authority never needs to carry a SOL balance"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "compliance_authority",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "allowed_user",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "arg",
+                "path": "user"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "user",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initialize",
+      "docs": [
+        "Initializes the program config with the given authority",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `authority` - The pubkey of the authority who can deploy vaults",
+        "",
+        "# Returns",
+        "* `Result<()>` - Result indicating success or failure"
+      ],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "program_data",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  63,
+                  208,
+                  133,
+                  144,
+                  37,
+                  230,
+                  219,
+                  109,
+                  35,
+                  98,
+                  197,
+                  125,
+                  171,
+                  66,
+                  209,
+                  86,
+                  6,
+                  59,
+                  48,
+                  18,
+                  215,
+                  19,
+                  203,
+                  79,
+                  160,
+                  166,
+                  180,
+                  218,
+                  13,
+                  62,
+                  57,
+                  127
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initialize_cpi_digest",
+      "docs": [
+        "Initializes the CPI digest for managing vault assets",
+        "",
+        "Note: This function does not check that the provided digest",
+        "actually corresponds to the given operators and expected size",
+        "but in the case that it doesn't this digest is just unusable.",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - The CPI digest initialize arguments"
+      ],
+      "discriminator": [
+        137,
+        9,
+        120,
+        93,
+        182,
+        194,
+        100,
+        147
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "cpi_digest",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "CpiDigestArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "manage",
+      "docs": [
+        "Executes a management operation on the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Management arguments including CPI call details",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::InvalidCpiDigest` - If CPI digest is invalid"
+      ],
+      "discriminator": [
+        168,
+        141,
+        131,
+        54,
+        79,
+        150,
+        88,
+        36
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "permission",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "boring_vault",
+          "writable": true
+        },
+        {
+          "name": "cpi_digest"
+        },
+        {
+          "name": "ix_program_id"
+        },
+        {
+          "name": "target_program_data",
+          "docs": [
+            "Required only when the cpi digest is bound to the target program's deployed code."
+          ],
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "ManageArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "mint_shares",
+      "discriminator": [
+        24,
+        196,
+        132,
+        0,
+        183,
+        158,
+        216,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "share_mover",
+          "signer": true
+        },
+        {
+          "name": "vault"
+        },
+        {
+          "name": "share_mint",
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "arg",
+                "path": "recipient"
+              },
+              {
+                "kind": "account",
+                "path": "token_program"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "_recipient",
+          "type": "pubkey"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "pause_accounting",
+      "docs": [
+        "Pauses accounting (rate updates, vesting, safe rate reads, manage, fees, share mint/burn).",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority and does not have can_pause permission"
+      ],
+      "discriminator": [
+        105,
+        98,
+        189,
+        136,
+        208,
+        192,
+        60,
+        23
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "pause_all",
+      "docs": [
+        "Convenience: pauses all three flags (teller, accounting, manage) in one instruction.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority and does not have can_pause permission"
+      ],
+      "discriminator": [
+        166,
+        26,
+        112,
+        43,
+        126,
+        10,
+        31,
+        83
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "pause_manage",
+      "docs": [
+        "Pauses the `manage` instruction only (strategy execution); everything else keeps running.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority and does not have can_pause permission"
+      ],
+      "discriminator": [
+        239,
+        38,
+        207,
+        149,
+        220,
+        223,
+        226,
+        149
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "pause_teller",
+      "docs": [
+        "Pauses the teller, preventing deposits and withdrawals (accounting keeps running).",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority and does not have can_pause permission"
+      ],
+      "discriminator": [
+        133,
+        141,
+        102,
+        138,
+        217,
+        29,
+        231,
+        235
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "post_loss",
+      "docs": [
+        "Posts a loss to the vault, reducing the exchange rate",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `loss_amount` - The amount of loss to post",
+        "",
+        "# Returns",
+        "* `Result<()>` - Result indicating success or failure",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the exchange rate provider"
+      ],
+      "discriminator": [
+        155,
+        145,
+        140,
+        177,
+        23,
+        241,
+        151,
+        179
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "loss_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "remove_cpi_digest_from_asset",
+      "docs": [
+        "Removes (clears to the default pubkey) an asset's deposit and/or withdraw CPI digest.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID (PDA seed)",
+        "* `remove_deposit` - When true, resets `asset_data.deposit_cpi_digest` to the default pubkey",
+        "* `remove_withdraw` - When true, resets `asset_data.withdraw_cpi_digest` to the default pubkey",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority and does not hold the can_pause permission"
+      ],
+      "discriminator": [
+        65,
+        39,
+        255,
+        1,
+        43,
+        31,
+        127,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "permission",
+          "docs": [
+            "Required, only when the signer is not the vault authority, to prove the signer holds the",
+            "`can_pause` permission on this vault"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset",
+          "docs": [
+            "UpdateAssetData."
+          ]
+        },
+        {
+          "name": "asset_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "asset"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "remove_deposit",
+          "type": "bool"
+        },
+        {
+          "name": "remove_withdraw",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "remove_permission",
+      "docs": [
+        "Removes an existing permission entry for a wallet on a vault",
+        "",
+        "Closes the permission PDA account and returns the rent to the payer.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `wallet` - The public key whose permissions are being revoked",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        122,
+        51,
+        186,
+        238,
+        78,
+        104,
+        205,
+        204
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "arg",
+                "path": "wallet"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "wallet",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "reset_high_water_mark",
+      "docs": [
+        "Collects any fees owed up to now at the unchanged rate, then re-anchors the",
+        "high water mark to the current exchange rate.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::ExchangeRateAboveHighWaterMark` - If the exchange rate is",
+        "above the high water mark"
+      ],
+      "discriminator": [
+        250,
+        189,
+        10,
+        2,
+        115,
+        60,
+        220,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "revoke_user_compliance",
+      "docs": [
+        "Revokes user compliance by setting AllowedUsed.enabled = false.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::InvalidComplianceAuthority` - If signer is not the compliance authority"
+      ],
+      "discriminator": [
+        160,
+        73,
+        208,
+        137,
+        18,
+        107,
+        164,
+        195
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Separated from `compliance_authority` so the authority never needs to carry a SOL balance"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "compliance_authority",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "user"
+        },
+        {
+          "name": "allowed_user",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "user"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_compliance",
+      "docs": [
+        "Enables compliance mode on the vault and sets the compliance authority",
+        "",
+        "Once enabled, compliance mode cannot be disabled. The compliance authority",
+        "is responsible for managing the allowlist of permitted users.",
+        "",
+        "This instruction is idempotent and used to change the compliance_authority.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `compliance_authority` - The pubkey of the authority who can manage user compliance",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidComplianceAuthority` - If compliance authority is the zero address"
+      ],
+      "discriminator": [
+        46,
+        128,
+        120,
+        26,
+        105,
+        175,
+        165,
+        6
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hook_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "transfer_hook_program"
+            }
+          }
+        },
+        {
+          "name": "transfer_hook_program",
+          "address": "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9"
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "compliance_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_deposit_cap",
+      "docs": [
+        "Sets the deposit cap (maximum total share supply reachable via deposits).",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `cap` - Maximum total share supply; `u64::MAX` disables the cap",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        30,
+        43,
+        219,
+        90,
+        254,
+        4,
+        85,
+        236
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "cap",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_deposit_cpi_digest",
+      "docs": [
+        "Sets the allowed CPI digest for deposits",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `cpi_digest` - The allowed CPI digest pubkey (Pubkey::default() to clear)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidCpiDigest` - If the digest account is missing, does not match",
+        "`cpi_digest`, or belongs to another vault",
+        "* `BoringErrorCode::CpiAmountNotBound` - If the digest does not bind its CPI amount"
+      ],
+      "discriminator": [
+        249,
+        28,
+        240,
+        198,
+        32,
+        181,
+        119,
+        144
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "asset"
+        },
+        {
+          "name": "asset_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "asset"
+              }
+            ]
+          }
+        },
+        {
+          "name": "cpi_digest",
+          "docs": [
+            "The digest being attached Required unless the `cpi_digest` argument is the default pubkey."
+          ],
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "cpi_digest",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_deposit_sub_account",
+      "docs": [
+        "Sets the deposit sub-account for the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_sub_account` - The new sub-account number",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        135,
+        238,
+        218,
+        4,
+        120,
+        77,
+        207,
+        156
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_sub_account",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_deviation_bounds",
+      "docs": [
+        "Sets the maximum deviation bounds for yield and loss",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `max_deviation_yield_bps` - Maximum allowed daily yield deviation in basis points",
+        "* `max_deviation_loss_bps` - Maximum allowed loss before auto-pause in basis points",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        80,
+        200,
+        219,
+        195,
+        180,
+        97,
+        19,
+        144
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "max_deviation_yield_bps",
+          "type": "u16"
+        },
+        {
+          "name": "max_deviation_loss_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "set_fees",
+      "docs": [
+        "Sets the platform and performance fees for the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `platform_fee_bps` - Platform fee in basis points",
+        "* `performance_fee_bps` - Performance fee in basis points",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidPlatformFeeBps` - If platform fee exceeds maximum",
+        "* `BoringErrorCode::InvalidPerformanceFeeBps` - If performance fee exceeds maximum"
+      ],
+      "discriminator": [
+        137,
+        178,
+        49,
+        58,
+        0,
+        245,
+        242,
+        190
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "platform_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "performance_fee_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "set_lock_duration",
+      "docs": [
+        "Sets the vault's share-lock duration and syncs it into the transfer hook's",
+        "HookConfig. This is the only path that may change the hook's `lock_duration_seconds`.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `lock_duration_seconds` - New share-lock duration (`0` disables the lock)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `HookErrorCode::InvalidLockDuration` - If the duration is negative or exceeds the max"
+      ],
+      "discriminator": [
+        197,
+        198,
+        131,
+        75,
+        25,
+        116,
+        20,
+        111
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hook_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "account",
+              "path": "transfer_hook_program"
+            }
+          }
+        },
+        {
+          "name": "transfer_hook_program",
+          "address": "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9"
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "lock_duration_seconds",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "set_payout",
+      "docs": [
+        "Sets the payout address for the given fee type (platform or performance).",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `fee_type` - Which fee recipient to update (platform or performance)",
+        "* `new_payout` - The new payout address",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidPayoutAddress` - If payout address is zero address"
+      ],
+      "discriminator": [
+        55,
+        43,
+        132,
+        51,
+        227,
+        169,
+        242,
+        195
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "fee_type",
+          "type": {
+            "defined": {
+              "name": "FeeType"
+            }
+          }
+        },
+        {
+          "name": "new_payout",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_share_mover",
+      "discriminator": [
+        163,
+        123,
+        165,
+        217,
+        30,
+        254,
+        10,
+        116
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "share_mover",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_withdraw_authority",
+      "docs": [
+        "Sets the withdraw authority for the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_authority` - The new withdraw authority address",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        199,
+        146,
+        140,
+        67,
+        1,
+        90,
+        8,
+        222
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_withdraw_cpi_digest",
+      "docs": [
+        "Sets the allowed CPI digest for withdrawals",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `cpi_digest` - The allowed CPI digest pubkey (Pubkey::default() to clear)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidCpiDigest` - If the digest account is missing, does not match",
+        "`cpi_digest`, or belongs to another vault",
+        "* `BoringErrorCode::CpiAmountNotBound` - If the digest does not bind its CPI amount"
+      ],
+      "discriminator": [
+        248,
+        94,
+        48,
+        173,
+        249,
+        117,
+        237,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "asset"
+        },
+        {
+          "name": "asset_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "asset"
+              }
+            ]
+          }
+        },
+        {
+          "name": "cpi_digest",
+          "docs": [
+            "The digest being attached Required unless the `cpi_digest` argument is the default pubkey."
+          ],
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "cpi_digest",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "set_withdraw_sub_account",
+      "docs": [
+        "Sets the withdraw sub-account for the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_sub_account` - The new sub-account number",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        152,
+        197,
+        103,
+        249,
+        56,
+        180,
+        0,
+        172
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_sub_account",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "transfer_authority",
+      "docs": [
+        "Stages a new vault authority. The transfer only takes effect once",
+        "`pending_authority` calls `accept_authority`.",
+        "",
+        "Passing `Pubkey::default()` revokes a staged transfer",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault id",
+        "* `pending_authority` - The new pending authority or the default pubkey",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::SelfTransferNotAllowed` - If `pending_authority` is the current authority"
+      ],
+      "discriminator": [
+        48,
+        169,
+        76,
+        72,
+        229,
+        180,
+        55,
+        161
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "pending_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "transfer_program_authority",
+      "docs": [
+        "Stages a new program-level authority. Only the current program authority may call this.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `pending_authority` - The proposed next program authority",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the current program authority",
+        "* `BoringErrorCode::InvalidPendingAuthority` - If `pending_authority` is the default pubkey",
+        "* `BoringErrorCode::SelfTransferNotAllowed` - If `pending_authority` is the current authority"
+      ],
+      "discriminator": [
+        133,
+        0,
+        66,
+        166,
+        130,
+        239,
+        5,
+        130
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "pending_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "unpause_accounting",
+      "docs": [
+        "Unpauses accounting, re-enabling rate updates, vesting, safe rate reads, manage, fees, and",
+        "share mint/burn.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        114,
+        197,
+        251,
+        101,
+        205,
+        94,
+        21,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "unpause_all",
+      "docs": [
+        "Convenience: unpauses all three flags (teller, accounting, manage) in one instruction.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        63,
+        150,
+        39,
+        10,
+        86,
+        213,
+        114,
+        7
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "unpause_manage",
+      "docs": [
+        "Unpauses the `manage` instruction, re-enabling strategy execution.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        62,
+        139,
+        43,
+        66,
+        251,
+        120,
+        50,
+        70
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "unpause_teller",
+      "docs": [
+        "Unpauses the teller, allowing deposits and withdrawals.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        132,
+        156,
+        244,
+        207,
+        43,
+        144,
+        95,
+        68
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_asset_data",
+      "docs": [
+        "Updates the asset data configuration for a given asset",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - The asset data update arguments including:",
+        "* `vault_id` - The vault ID",
+        "* `asset_data` - The new asset data configuration",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidPriceFeed` - If price feed is invalid for non-pegged asset"
+      ],
+      "discriminator": [
+        73,
+        69,
+        104,
+        229,
+        48,
+        169,
+        98,
+        67
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "asset",
+          "docs": [
+            "would only prevent deposits with that asset, which is not a security risk since the asset mint",
+            "account would not exist."
+          ]
+        },
+        {
+          "name": "asset_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "asset"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "UpdateAssetDataArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_cpi_digest_strategist_group",
+      "docs": [
+        "Updates the strategist group mask for an existing CPI digest.",
+        "Only the vault authority may call this instruction."
+      ],
+      "discriminator": [
+        188,
+        49,
+        63,
+        113,
+        219,
+        210,
+        207,
+        152
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "cpi_digest",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "digest",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "strategist_group",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "update_exchange_rate",
+      "docs": [
+        "Updates the exchange rate for the vault",
+        "",
+        "`new_exchange_rate` is the **gross** rate: total vault assets / shares, including assets",
+        "still earmarked for unclaimed platform and performance fees. The program accrues the fees",
+        "owed for the elapsed interval and then stores the rate net of the full outstanding fee",
+        "liability, so the caller must not pre-deduct fees from the reported rate.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_exchange_rate` - The new exchange rate",
+        "",
+        "# Returns",
+        "* `Result<()>` - Result indicating success or failure"
+      ],
+      "discriminator": [
+        69,
+        102,
+        48,
+        181,
+        8,
+        41,
+        8,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_exchange_rate",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_maximum_vest_duration",
+      "docs": [
+        "Updates the vault's maximum `vest_yield` streaming duration in seconds.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_maximum_vest_duration` - New maximum vesting duration in seconds",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidVestDuration` - If less than the minimum vest duration"
+      ],
+      "discriminator": [
+        160,
+        94,
+        98,
+        33,
+        182,
+        253,
+        213,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_maximum_vest_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_minimum_vest_duration",
+      "docs": [
+        "Updates the vault's minimum `vest_yield` streaming duration in seconds.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_minimum_vest_duration` - New minimum vesting duration in seconds",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority",
+        "* `BoringErrorCode::InvalidVestDuration` - If zero or greater than the maximum vest duration"
+      ],
+      "discriminator": [
+        83,
+        100,
+        228,
+        77,
+        220,
+        212,
+        102,
+        99
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_minimum_vest_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_permission",
+      "docs": [
+        "Updates the permission flags for an existing wallet on a vault",
+        "",
+        "Modifies the can_pause, can_update_exchange_rate, and strategist_group",
+        "fields on an already-initialized permission PDA account.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Permission arguments including:",
+        "* `wallet` - The public key whose permissions are being updated",
+        "* `can_pause` - New value for whether this wallet can pause the vault",
+        "* `can_update_exchange_rate` - New value for whether this wallet can update the exchange rate",
+        "* `strategist_group` - New bitmask for strategist action grouping (0 = no strategist permission)",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        1,
+        120,
+        111,
+        126,
+        237,
+        61,
+        41,
+        61
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state"
+        },
+        {
+          "name": "permission",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "arg",
+                "path": "args.wallet"
+              }
+            ]
+          }
+        },
+        {
+          "name": "signer_permission",
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "PermissionArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_vault_accrue_mode",
+      "docs": [
+        "Updates the vault's accrual mode",
+        "",
+        "When switching from `VestingYield` to `ExchangeRateStep`, the vesting state",
+        "is reset to default values (clearing the TWAS accumulator and all vesting fields).",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "* `new_mode` - The new accrual mode to set",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If signer is not the vault authority"
+      ],
+      "discriminator": [
+        88,
+        80,
+        119,
+        185,
+        140,
+        87,
+        238,
+        126
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "new_mode",
+          "type": {
+            "defined": {
+              "name": "VaultAccrualMode"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "vest_to_exchange_rate",
+      "docs": [
+        "Flushes pending vested yield into the exchange rate and collects fees,",
+        "without posting any new yield. VestingYield accrual mode only.",
+        "",
+        "Restricted to signers holding the `can_update_exchange_rate` permission",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::NotAuthorized` - If the signer lacks `can_update_exchange_rate`",
+        "* `BoringErrorCode::AccountingPaused` - If accounting is paused",
+        "* `BoringErrorCode::InvalidAccrualMode` - If vault is not in VestingYield mode"
+      ],
+      "discriminator": [
+        95,
+        109,
+        71,
+        8,
+        164,
+        20,
+        100,
+        158
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "docs": [
+            "Must hold the `can_update_exchange_rate` permission"
+          ],
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "vest_yield",
+      "docs": [
+        "Vests accumulated yield in VestingYield accrual mode",
+        "",
+        "Updates the exchange rate based on the time-weighted vesting schedule.",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `vault_id` - The vault ID",
+        "",
+        "# Returns",
+        "* `Result<()>` - Result indicating success or failure"
+      ],
+      "discriminator": [
+        114,
+        143,
+        25,
+        249,
+        175,
+        119,
+        54,
+        46
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "permission",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "yield_amount",
+          "type": "u64"
+        },
+        {
+          "name": "duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "view_cpi_digest",
+      "docs": [
+        "Views the CPI digest for a management operation",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Management arguments to generate digest for",
+        "",
+        "# Returns",
+        "* `[u8; 32]` - The CPI digest"
+      ],
+      "discriminator": [
+        243,
+        10,
+        27,
+        160,
+        175,
+        112,
+        119,
+        60
+      ],
+      "accounts": [
+        {
+          "name": "ix_program_id"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "ViewCpiDigestArgs"
+            }
+          }
+        }
+      ],
+      "returns": {
+        "array": [
+          "u8",
+          32
+        ]
+      }
+    },
+    {
+      "name": "withdraw",
+      "docs": [
+        "Withdraws assets from the vault",
+        "",
+        "# Arguments",
+        "* `ctx` - The context of accounts",
+        "* `args` - Withdraw arguments including:",
+        "* `share_amount` - Amount of shares to burn",
+        "* `min_asset_amount` - Minimum amount of assets to receive",
+        "",
+        "# Returns",
+        "* `u64` - Amount of assets withdrawn",
+        "",
+        "# Errors",
+        "* `BoringErrorCode::TellerPaused` - If the teller is paused",
+        "* `BoringErrorCode::AssetNotAllowed` - If withdrawals are not allowed",
+        "* `BoringErrorCode::InvalidTokenProgram` - If token program doesn't match mint"
+      ],
+      "discriminator": [
+        183,
+        18,
+        70,
+        156,
+        148,
+        109,
+        161,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "boring_vault_state",
+          "writable": true
+        },
+        {
+          "name": "boring_vault"
+        },
+        {
+          "name": "withdraw_mint"
+        },
+        {
+          "name": "asset_data",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  45,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "withdraw_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_ata",
+          "docs": [
+            "User's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_ata",
+          "docs": [
+            "Vault's Token associated token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "share_mint",
+          "docs": [
+            "The vault's share mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "user_shares",
+          "docs": [
+            "The user's share token 2022 account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "signer"
+              },
+              {
+                "kind": "account",
+                "path": "token_program_2022"
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "price_feed"
+        },
+        {
+          "name": "allowed_user",
+          "docs": [
+            "The signer's AllowedUser PDA. It only needs to exist when the vault is in compliance mode",
+            "(then it must be enabled) or when the signer is a depositor under an active share lock. A",
+            "holder who never deposited (e.g. someone who received shares by transfer, or the queue PDA",
+            "escrowing shares) has no AllowedUser."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  108,
+                  108,
+                  111,
+                  119,
+                  101,
+                  100,
+                  45,
+                  117,
+                  115,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "boring_vault_state"
+              },
+              {
+                "kind": "account",
+                "path": "signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "cpi_digest",
+          "optional": true
+        },
+        {
+          "name": "ix_program_id",
+          "optional": true
+        },
+        {
+          "name": "target_program_data",
+          "docs": [
+            "Required only when the withdraw cpi digest is bound to the target program's deployed code."
+          ],
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "returns": "u64"
+    }
+  ],
+  "accounts": [
+    {
+      "name": "AllowedUser",
+      "discriminator": [
+        10,
+        226,
+        218,
+        96,
+        35,
+        89,
+        70,
+        2
+      ]
+    },
+    {
+      "name": "AssetData",
+      "discriminator": [
+        91,
+        115,
+        36,
+        105,
+        141,
+        93,
+        1,
+        135
+      ]
+    },
+    {
+      "name": "BoringVault",
+      "discriminator": [
+        35,
+        84,
+        44,
+        89,
+        150,
+        55,
+        236,
+        25
+      ]
+    },
+    {
+      "name": "ComplianceApproval",
+      "discriminator": [
+        118,
+        34,
+        10,
+        203,
+        224,
+        67,
+        195,
+        128
+      ]
+    },
+    {
+      "name": "CpiDigest",
+      "discriminator": [
+        23,
+        4,
+        189,
+        185,
+        96,
+        27,
+        98,
+        226
+      ]
+    },
+    {
+      "name": "Permission",
+      "discriminator": [
+        224,
+        83,
+        28,
+        79,
+        10,
+        253,
+        161,
+        28
+      ]
+    },
+    {
+      "name": "ProgramConfig",
+      "discriminator": [
+        196,
+        210,
+        90,
+        231,
+        144,
+        149,
+        140,
+        63
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "AccrualModeUpdated",
+      "discriminator": [
+        127,
+        156,
+        237,
+        46,
+        43,
+        240,
+        147,
+        7
+      ]
+    },
+    {
+      "name": "AllowedUserEnabled",
+      "discriminator": [
+        3,
+        65,
+        194,
+        42,
+        188,
+        100,
+        85,
+        92
+      ]
+    },
+    {
+      "name": "AllowedUserRevoked",
+      "discriminator": [
+        255,
+        91,
+        255,
+        203,
+        203,
+        9,
+        97,
+        24
+      ]
+    },
+    {
+      "name": "AssetDataUpdated",
+      "discriminator": [
+        167,
+        131,
+        88,
+        11,
+        100,
+        79,
+        127,
+        223
+      ]
+    },
+    {
+      "name": "AuthorityUpdated",
+      "discriminator": [
+        133,
+        207,
+        24,
+        122,
+        14,
+        234,
+        91,
+        34
+      ]
+    },
+    {
+      "name": "ComplianceApprovalClosed",
+      "discriminator": [
+        191,
+        34,
+        98,
+        26,
+        233,
+        62,
+        193,
+        46
+      ]
+    },
+    {
+      "name": "ComplianceModeEnabled",
+      "discriminator": [
+        123,
+        58,
+        140,
+        220,
+        192,
+        2,
+        20,
+        118
+      ]
+    },
+    {
+      "name": "CpiDigestClosed",
+      "discriminator": [
+        64,
+        62,
+        166,
+        115,
+        206,
+        188,
+        170,
+        148
+      ]
+    },
+    {
+      "name": "CpiDigestInitialized",
+      "discriminator": [
+        202,
+        86,
+        44,
+        191,
+        36,
+        255,
+        70,
+        40
+      ]
+    },
+    {
+      "name": "CpiDigestRemovedFromAsset",
+      "discriminator": [
+        85,
+        210,
+        212,
+        61,
+        47,
+        203,
+        178,
+        33
+      ]
+    },
+    {
+      "name": "CpiDigestStrategistGroupUpdated",
+      "discriminator": [
+        233,
+        95,
+        43,
+        118,
+        246,
+        7,
+        214,
+        124
+      ]
+    },
+    {
+      "name": "DepositCapUpdated",
+      "discriminator": [
+        243,
+        162,
+        252,
+        12,
+        177,
+        96,
+        193,
+        101
+      ]
+    },
+    {
+      "name": "DepositCompleted",
+      "discriminator": [
+        87,
+        191,
+        139,
+        46,
+        172,
+        192,
+        191,
+        52
+      ]
+    },
+    {
+      "name": "DepositCpiDigestUpdated",
+      "discriminator": [
+        186,
+        40,
+        135,
+        36,
+        103,
+        38,
+        164,
+        223
+      ]
+    },
+    {
+      "name": "DepositSubAccountUpdated",
+      "discriminator": [
+        239,
+        206,
+        188,
+        208,
+        7,
+        110,
+        130,
+        73
+      ]
+    },
+    {
+      "name": "DeviationBoundsUpdated",
+      "discriminator": [
+        120,
+        48,
+        112,
+        31,
+        150,
+        105,
+        184,
+        65
+      ]
+    },
+    {
+      "name": "ExchangeRateBoundsUpdated",
+      "discriminator": [
+        60,
+        26,
+        156,
+        51,
+        56,
+        76,
+        109,
+        126
+      ]
+    },
+    {
+      "name": "ExchangeRateDeviationExceeded",
+      "discriminator": [
+        230,
+        203,
+        144,
+        136,
+        116,
+        166,
+        34,
+        111
+      ]
+    },
+    {
+      "name": "ExchangeRateUpdated",
+      "discriminator": [
+        14,
+        26,
+        168,
+        130,
+        145,
+        75,
+        117,
+        55
+      ]
+    },
+    {
+      "name": "FeesAccrued",
+      "discriminator": [
+        1,
+        151,
+        46,
+        93,
+        244,
+        90,
+        12,
+        191
+      ]
+    },
+    {
+      "name": "FeesClaimed",
+      "discriminator": [
+        22,
+        104,
+        110,
+        222,
+        38,
+        157,
+        14,
+        62
+      ]
+    },
+    {
+      "name": "FeesUpdated",
+      "discriminator": [
+        65,
+        34,
+        234,
+        59,
+        248,
+        242,
+        101,
+        118
+      ]
+    },
+    {
+      "name": "HighWaterMarkReset",
+      "discriminator": [
+        59,
+        167,
+        231,
+        103,
+        188,
+        104,
+        164,
+        68
+      ]
+    },
+    {
+      "name": "LockDurationUpdated",
+      "discriminator": [
+        169,
+        53,
+        234,
+        3,
+        38,
+        151,
+        87,
+        223
+      ]
+    },
+    {
+      "name": "LossDeviationExceeded",
+      "discriminator": [
+        14,
+        83,
+        34,
+        20,
+        146,
+        102,
+        36,
+        116
+      ]
+    },
+    {
+      "name": "LossPosted",
+      "discriminator": [
+        176,
+        210,
+        131,
+        254,
+        200,
+        120,
+        222,
+        77
+      ]
+    },
+    {
+      "name": "ManageExecuted",
+      "discriminator": [
+        240,
+        115,
+        120,
+        142,
+        204,
+        152,
+        135,
+        187
+      ]
+    },
+    {
+      "name": "MaximumVestDurationUpdated",
+      "discriminator": [
+        86,
+        33,
+        139,
+        157,
+        112,
+        84,
+        107,
+        144
+      ]
+    },
+    {
+      "name": "MinimumVestDurationUpdated",
+      "discriminator": [
+        135,
+        190,
+        8,
+        228,
+        221,
+        73,
+        163,
+        179
+      ]
+    },
+    {
+      "name": "PauseStateChanged",
+      "discriminator": [
+        224,
+        2,
+        23,
+        9,
+        225,
+        156,
+        4,
+        72
+      ]
+    },
+    {
+      "name": "PayoutAddressUpdated",
+      "discriminator": [
+        114,
+        216,
+        128,
+        252,
+        155,
+        247,
+        226,
+        115
+      ]
+    },
+    {
+      "name": "PendingAuthoritySet",
+      "discriminator": [
+        112,
+        115,
+        80,
+        37,
+        41,
+        177,
+        221,
+        81
+      ]
+    },
+    {
+      "name": "PermissionAdded",
+      "discriminator": [
+        141,
+        113,
+        225,
+        148,
+        130,
+        49,
+        73,
+        159
+      ]
+    },
+    {
+      "name": "PermissionRemoved",
+      "discriminator": [
+        29,
+        113,
+        171,
+        136,
+        201,
+        210,
+        145,
+        239
+      ]
+    },
+    {
+      "name": "PermissionUpdated",
+      "discriminator": [
+        82,
+        173,
+        224,
+        81,
+        165,
+        91,
+        56,
+        31
+      ]
+    },
+    {
+      "name": "ProgramAuthorityUpdated",
+      "discriminator": [
+        172,
+        190,
+        142,
+        146,
+        101,
+        19,
+        87,
+        104
+      ]
+    },
+    {
+      "name": "ProgramPendingAuthoritySet",
+      "discriminator": [
+        105,
+        16,
+        11,
+        186,
+        226,
+        198,
+        238,
+        130
+      ]
+    },
+    {
+      "name": "VaultDeployed",
+      "discriminator": [
+        37,
+        249,
+        235,
+        135,
+        97,
+        76,
+        53,
+        71
+      ]
+    },
+    {
+      "name": "WithdrawAuthorityUpdated",
+      "discriminator": [
+        75,
+        204,
+        202,
+        229,
+        238,
+        168,
+        40,
+        7
+      ]
+    },
+    {
+      "name": "WithdrawCompleted",
+      "discriminator": [
+        180,
+        77,
+        152,
+        99,
+        248,
+        179,
+        163,
+        44
+      ]
+    },
+    {
+      "name": "WithdrawCpiDigestUpdated",
+      "discriminator": [
+        148,
+        119,
+        194,
+        187,
+        3,
+        12,
+        50,
+        67
+      ]
+    },
+    {
+      "name": "WithdrawSubAccountUpdated",
+      "discriminator": [
+        112,
+        109,
+        134,
+        167,
+        150,
+        100,
+        65,
+        123
+      ]
+    },
+    {
+      "name": "YieldDeviationExceeded",
+      "discriminator": [
+        46,
+        48,
+        22,
+        113,
+        61,
+        73,
+        139,
+        216
+      ]
+    },
+    {
+      "name": "YieldVested",
+      "discriminator": [
+        175,
+        17,
+        143,
+        235,
+        135,
+        204,
+        125,
+        157
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "SlippageExceeded",
+      "msg": "Slippage tolerance exceeded"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidShareMint",
+      "msg": "Invalid share mint"
+    },
+    {
+      "code": 6002,
+      "name": "AssetNotAllowed",
+      "msg": "Asset not allowed"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidAssociatedTokenAccount",
+      "msg": "Invalid associated token account"
+    },
+    {
+      "code": 6004,
+      "name": "VaultPaused",
+      "msg": "Vault paused"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidPriceFeed",
+      "msg": "Invalid price feed"
+    },
+    {
+      "code": 6006,
+      "name": "NotAuthorized",
+      "msg": "Not authorized"
+    },
+    {
+      "code": 6007,
+      "name": "MathError",
+      "msg": "Math error"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidCpiDigest",
+      "msg": "Invalid CPI digest"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidTokenProgram",
+      "msg": "Invalid token program"
+    },
+    {
+      "code": 6010,
+      "name": "TransferFeeMintNotSupported",
+      "msg": "Transfer-fee mints are not supported"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidPayoutAddress",
+      "msg": "Invalid payout address"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidAllowedExchangeRateChangeUpperBound",
+      "msg": "Invalid allowed exchange rate change upper bound"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidAllowedExchangeRateChangeLowerBound",
+      "msg": "Invalid allowed exchange rate change lower bound"
+    },
+    {
+      "code": 6015,
+      "name": "InvalidPlatformFeeBps",
+      "msg": "Invalid platform fee bps"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidPerformanceFeeBps",
+      "msg": "Invalid performance fee bps"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidBaseAsset",
+      "msg": "Invalid base asset"
+    },
+    {
+      "code": 6018,
+      "name": "DecimalConversionFailed",
+      "msg": "Decimal conversion failed"
+    },
+    {
+      "code": 6019,
+      "name": "MaximumSharePremiumExceeded",
+      "msg": "Maximum share premium exceeded"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidAmount",
+      "msg": "Invalid amount"
+    },
+    {
+      "code": 6021,
+      "name": "InsufficientBalance",
+      "msg": "Insufficient balance"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidShareMover",
+      "msg": "Invalid share mover"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidVault",
+      "msg": "Invalid vault"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidAccrualMode",
+      "msg": "Invalid accrual mode"
+    },
+    {
+      "code": 6025,
+      "name": "MinimumUpdateDelayNotMet",
+      "msg": "Minimum update delay not met"
+    },
+    {
+      "code": 6026,
+      "name": "MaxDeviationYieldExceeded",
+      "msg": "Max deviation yield exceeded"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidOperatorIndex",
+      "msg": "Operator index is not valid"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidStrategistGroup",
+      "msg": "Strategist group must be greater than 0"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidComplianceAuthority",
+      "msg": "Invalid compliance authority"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidTransferHookProgram",
+      "msg": "Invalid transfer hook program"
+    },
+    {
+      "code": 6031,
+      "name": "Ed25519InstructionNotFound",
+      "msg": "Ed25519 instruction not found"
+    },
+    {
+      "code": 6032,
+      "name": "InvalidEd25519Instruction",
+      "msg": "Invalid ed25519 instruction"
+    },
+    {
+      "code": 6033,
+      "name": "InvalidComplianceSignature",
+      "msg": "Invalid compliance signature"
+    },
+    {
+      "code": 6034,
+      "name": "InvalidComplianceMessage",
+      "msg": "Invalid compliance message"
+    },
+    {
+      "code": 6035,
+      "name": "ComplianceMessageExpired",
+      "msg": "Compliance message expired"
+    },
+    {
+      "code": 6036,
+      "name": "ComplianceAccountRequired",
+      "msg": "Compliance account required"
+    },
+    {
+      "code": 6037,
+      "name": "ComplianceMessageRequired",
+      "msg": "Compliance message required"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidPendingAuthority",
+      "msg": "Invalid pending authority"
+    },
+    {
+      "code": 6039,
+      "name": "SelfTransferNotAllowed",
+      "msg": "Cannot transfer authority to self"
+    },
+    {
+      "code": 6040,
+      "name": "ZeroExchangeRate",
+      "msg": "Exchange rate cannot be zero"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidSubAccount",
+      "msg": "Invalid sub account"
+    },
+    {
+      "code": 6042,
+      "name": "ZeroShares",
+      "msg": "Deposit too small, zero shares minted"
+    },
+    {
+      "code": 6043,
+      "name": "DecimalsMismatch",
+      "msg": "Share decimals must equal base asset decimals"
+    },
+    {
+      "code": 6044,
+      "name": "UserNotAllowed",
+      "msg": "User is not allowed"
+    },
+    {
+      "code": 6045,
+      "name": "StaleUpdateTimestamp",
+      "msg": "Cumulative state must be updated before vesting"
+    },
+    {
+      "code": 6046,
+      "name": "VestingPeriodTooShort",
+      "msg": "Vesting period is below the minimum required duration"
+    },
+    {
+      "code": 6047,
+      "name": "VestingPeriodTooLong",
+      "msg": "Vesting period exceeds the maximum allowed duration"
+    },
+    {
+      "code": 6048,
+      "name": "ZeroYieldAmount",
+      "msg": "Yield amount cannot be zero"
+    },
+    {
+      "code": 6049,
+      "name": "InstantDepositNotAllowed",
+      "msg": "Instant deposit not allowed for this vault"
+    },
+    {
+      "code": 6050,
+      "name": "DepositExceedsCap",
+      "msg": "Deposit would exceed the vault's deposit cap"
+    },
+    {
+      "code": 6051,
+      "name": "AllowedUserRequired",
+      "msg": "AllowedUser account is required"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidLockDuration",
+      "msg": "Lock duration must be >= 0 and <= MAX_LOCK_DURATION_SECONDS"
+    },
+    {
+      "code": 6053,
+      "name": "ShareLockInEffect",
+      "msg": "Share lock still in effect"
+    },
+    {
+      "code": 6054,
+      "name": "ExchangeRateAboveHighWaterMark",
+      "msg": "Exchange rate is above the high water mark"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidVestDuration",
+      "msg": "Invalid vest duration bounds (0 < minimum <= maximum)"
+    },
+    {
+      "code": 6056,
+      "name": "ComplianceApprovalNotExpired",
+      "msg": "Compliance approval has not expired yet"
+    },
+    {
+      "code": 6057,
+      "name": "VirtualSharePriceNotSeeded",
+      "msg": "Virtual share price was not seeded for a VestingYield vault"
+    },
+    {
+      "code": 6058,
+      "name": "TellerPaused",
+      "msg": "Teller paused"
+    },
+    {
+      "code": 6059,
+      "name": "AccountingPaused",
+      "msg": "Accounting paused"
+    },
+    {
+      "code": 6060,
+      "name": "ManagePaused",
+      "msg": "Manage paused"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidVerificationLevel",
+      "msg": "Invalid verification level: partial verification must use at least 2 signatures"
+    },
+    {
+      "code": 6062,
+      "name": "InvalidProgramData",
+      "msg": "Target program data account is missing or does not match the CPI digest binding"
+    },
+    {
+      "code": 6063,
+      "name": "ProgramUpgraded",
+      "msg": "Target program was upgraded after the CPI digest was created"
+    },
+    {
+      "code": 6064,
+      "name": "CpiAmountMismatch",
+      "msg": "CPI instruction data amount does not match the amount moved by the deposit/withdraw"
+    },
+    {
+      "code": 6065,
+      "name": "CpiAmountNotBound",
+      "msg": "Deposit/withdraw CPI digests must bind their amount to the deposited/withdrawn amount"
+    },
+    {
+      "code": 6066,
+      "name": "CpiAmountBindingNotSupported",
+      "msg": "Amount-bound CPI digests can only be executed by deposit and withdraw"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccrualModeUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "previous_mode",
+            "type": {
+              "defined": {
+                "name": "VaultAccrualMode"
+              }
+            }
+          },
+          {
+            "name": "accrual_mode",
+            "type": {
+              "defined": {
+                "name": "VaultAccrualMode"
+              }
+            }
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllowedUser",
+      "docs": [
+        "PDA account that stores an allowed user",
+        "Seeds: [\"allowed-user\", vault, user]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this account's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "docs": [
+              "The user wallet used in this account's PDA derivation."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          },
+          {
+            "name": "last_deposit_timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllowedUserEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          },
+          {
+            "name": "via_compliance_approval",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AllowedUserRevoked",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this account's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "docs": [
+              "The asset mint used in this account's PDA derivation."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "allow_deposits",
+            "type": "bool"
+          },
+          {
+            "name": "allow_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "share_premium_bps",
+            "type": "u16"
+          },
+          {
+            "name": "is_pegged_to_base_asset",
+            "type": "bool"
+          },
+          {
+            "name": "inverse_price_feed",
+            "type": "bool"
+          },
+          {
+            "name": "oracle_source",
+            "docs": [
+              "Oracle implementation with encapsulated parameters and addresses"
+            ],
+            "type": {
+              "defined": {
+                "name": "OracleSource"
+              }
+            }
+          },
+          {
+            "name": "deposit_cpi_digest",
+            "type": "pubkey"
+          },
+          {
+            "name": "withdraw_cpi_digest",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetDataConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allow_deposits",
+            "type": "bool"
+          },
+          {
+            "name": "allow_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "share_premium_bps",
+            "type": "u16"
+          },
+          {
+            "name": "is_pegged_to_base_asset",
+            "type": "bool"
+          },
+          {
+            "name": "inverse_price_feed",
+            "type": "bool"
+          },
+          {
+            "name": "oracle_source",
+            "docs": [
+              "Oracle implementation with encapsulated parameters and addresses"
+            ],
+            "type": {
+              "defined": {
+                "name": "OracleSource"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetDataUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "allow_deposits",
+            "type": "bool"
+          },
+          {
+            "name": "allow_withdrawals",
+            "type": "bool"
+          },
+          {
+            "name": "share_premium_bps",
+            "type": "u16"
+          },
+          {
+            "name": "is_pegged_to_base_asset",
+            "type": "bool"
+          },
+          {
+            "name": "inverse_price_feed",
+            "type": "bool"
+          },
+          {
+            "name": "oracle_source",
+            "type": {
+              "defined": {
+                "name": "OracleSource"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorityUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BoringVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "VaultState"
+              }
+            }
+          },
+          {
+            "name": "teller",
+            "type": {
+              "defined": {
+                "name": "TellerState"
+              }
+            }
+          },
+          {
+            "name": "accrual_mode",
+            "type": {
+              "defined": {
+                "name": "VaultAccrualMode"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ComplianceApproval",
+      "docs": [
+        "PDA account that records a consumed compliance approval, enforcing single use",
+        "of a signed ComplianceMessage so revoked users cannot replay an old approval.",
+        "Seeds: [\"compliance-approval\", vault, user, expiration]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this approval's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "user",
+            "docs": [
+              "The user included in this approval's PDA derivation."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "expiration",
+            "docs": [
+              "The expiration included in this approval's PDA derivation."
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "used",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ComplianceApprovalClosed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "expiration",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ComplianceMessage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "expiration",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ComplianceModeEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "compliance_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigureExchangeRateUpdateBoundsArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "upper_bound",
+            "type": "u16"
+          },
+          {
+            "name": "lower_bound",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_update_delay",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CpiDigest",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used in this account's PDA derivation."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "digest",
+            "docs": [
+              "The digest hash used in this account's PDA derivation."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "operators",
+            "type": {
+              "defined": {
+                "name": "Operators"
+              }
+            }
+          },
+          {
+            "name": "strategist_group",
+            "docs": [
+              "Bit mask designating which strategist groups can execute this digest.",
+              "Validated against Permission.strategist_group via bitwise AND."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "program_data",
+            "docs": [
+              "Optional binding to the target program's deployed code. When set to anything other",
+              "than the default pubkey, every CPI must pass this ProgramData account and it must",
+              "still be at `deployment_slot`, so any upgrade invalidates the digest."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "deployment_slot",
+            "docs": [
+              "The deployment slot approved for `program_data`. Ignored when unbound."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CpiDigestArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "cpi_digest",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "operators",
+            "type": {
+              "defined": {
+                "name": "Operators"
+              }
+            }
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "program_data",
+            "type": "pubkey"
+          },
+          {
+            "name": "deployment_slot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CpiDigestClosed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "digest",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CpiDigestInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "cpi_digest",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CpiDigestRemovedFromAsset",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset",
+            "type": "pubkey"
+          },
+          {
+            "name": "removed_deposit",
+            "type": "bool"
+          },
+          {
+            "name": "removed_withdraw",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CpiDigestStrategistGroupUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "digest",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "previous_strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DeployArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          },
+          {
+            "name": "platform_payout_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "performance_payout_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "allowed_exchange_rate_change_upper_bound",
+            "type": "u16"
+          },
+          {
+            "name": "allowed_exchange_rate_change_lower_bound",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_update_delay_in_seconds",
+            "type": "u32"
+          },
+          {
+            "name": "platform_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "performance_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "withdraw_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_deviation_yield_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_deviation_loss_bps",
+            "type": "u16"
+          },
+          {
+            "name": "accrual_mode",
+            "docs": [
+              "Accrual mode the vault launches in"
+            ],
+            "type": {
+              "defined": {
+                "name": "VaultAccrualMode"
+              }
+            }
+          },
+          {
+            "name": "compliance_mode",
+            "type": "bool"
+          },
+          {
+            "name": "compliance_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_duration_seconds",
+            "docs": [
+              "Share-lock duration in seconds. `0` disables"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount",
+            "type": "u64"
+          },
+          {
+            "name": "min_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "compliance_message",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "ComplianceMessage"
+                }
+              }
+            }
+          },
+          {
+            "name": "cpi_digest_ix_data",
+            "type": {
+              "option": "bytes"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositCapUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "deposit_cap",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositCompleted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "assets_in",
+            "type": "u64"
+          },
+          {
+            "name": "shares_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositCpiDigestUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "cpi_digest",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositSubAccountUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DeviationBoundsUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "max_deviation_yield_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_deviation_loss_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExchangeRateBoundsUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "upper_bound",
+            "type": "u16"
+          },
+          {
+            "name": "lower_bound",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_update_delay_in_seconds",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExchangeRateDeviationExceeded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "old_exchange_rate",
+            "type": "u64"
+          },
+          {
+            "name": "new_exchange_rate",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExchangeRateUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeType",
+      "docs": [
+        "Which fee bucket a `FeesClaimed` event refers to."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Platform"
+          },
+          {
+            "name": "Performance"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeesAccrued",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fees",
+            "type": "u64"
+          },
+          {
+            "name": "performance_fees",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeesClaimed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "payout",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_type",
+            "type": {
+              "defined": {
+                "name": "FeeType"
+              }
+            }
+          },
+          {
+            "name": "assets_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeesUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "performance_fee_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HighWaterMarkReset",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockDurationUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "lock_duration_seconds",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LossDeviationExceeded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "loss_bps",
+            "type": "u64"
+          },
+          {
+            "name": "max_deviation_loss_bps",
+            "type": "u16"
+          },
+          {
+            "name": "exchange_rate_before",
+            "type": "u64"
+          },
+          {
+            "name": "exchange_rate_after",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LossPosted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "loss_amount",
+            "type": "u64"
+          },
+          {
+            "name": "vesting_loss",
+            "type": "u64"
+          },
+          {
+            "name": "principal_loss",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ManageArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "ix_data",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ManageExecuted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "strategist",
+            "type": "pubkey"
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "digest",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "target_program",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MaximumVestDurationUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "maximum_vest_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MinimumVestDurationUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_vest_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Noop"
+          },
+          {
+            "name": "IngestInstruction",
+            "fields": [
+              "u32",
+              "u8"
+            ]
+          },
+          {
+            "name": "IngestAccount",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "IngestInstructionDataSize"
+          },
+          {
+            "name": "ExpectAssetAmount",
+            "fields": [
+              "u32"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operators",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operators",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "Operator"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleSource",
+      "docs": [
+        "Enumerates the supported on-chain oracle adapters with their addresses and parameters."
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SwitchboardV2",
+            "fields": [
+              {
+                "name": "feed_address",
+                "type": "pubkey"
+              },
+              {
+                "name": "min_samples",
+                "type": "u32"
+              },
+              {
+                "name": "max_staleness_slots",
+                "type": "u32"
+              }
+            ]
+          },
+          {
+            "name": "PythV2",
+            "fields": [
+              {
+                "name": "feed_address",
+                "docs": [
+                  "The canonical price feed account address"
+                ],
+                "type": "pubkey"
+              },
+              {
+                "name": "feed_id",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "max_conf_width_bps",
+                "docs": [
+                  "Maximum allowed confidence as basis points of price (e.g., 500 = 5%)"
+                ],
+                "type": "u16"
+              },
+              {
+                "name": "min_verification_level",
+                "docs": [
+                  "Required Pyth verification level, encoded as a signature-count threshold:",
+                  "- `0` => only `Full` verification is accepted (default, most secure).",
+                  "- `>= 2` => accepts `Partial { num_signatures }` updates whose",
+                  "`num_signatures` is at least this value (`Full` always qualifies too).",
+                  "- `1` is rejected by an operational guard: partial verification must",
+                  "use at least 2 signatures."
+                ],
+                "type": "u8"
+              },
+              {
+                "name": "max_staleness_seconds",
+                "type": "u32"
+              }
+            ]
+          },
+          {
+            "name": "PythV2Pro",
+            "fields": [
+              {
+                "name": "feed_address",
+                "docs": [
+                  "The canonical price feed account address"
+                ],
+                "type": "pubkey"
+              },
+              {
+                "name": "feed_id",
+                "type": {
+                  "array": [
+                    "u8",
+                    32
+                  ]
+                }
+              },
+              {
+                "name": "max_conf_width_bps",
+                "docs": [
+                  "Maximum allowed confidence as basis points of price (e.g., 500 = 5%)"
+                ],
+                "type": "u16"
+              },
+              {
+                "name": "min_verification_level",
+                "docs": [
+                  "Required Pyth verification level. Same encoding as [`PythV2`]."
+                ],
+                "type": "u8"
+              },
+              {
+                "name": "max_staleness_seconds",
+                "type": "u32"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PauseStateChanged",
+      "docs": [
+        "Emitted whenever any pause flag changes (pause/unpause instructions and auto-pause)."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "teller_paused",
+            "type": "bool"
+          },
+          {
+            "name": "accounting_paused",
+            "type": "bool"
+          },
+          {
+            "name": "manage_paused",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PayoutAddressUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "fee_type",
+            "type": {
+              "defined": {
+                "name": "FeeType"
+              }
+            }
+          },
+          {
+            "name": "payout_address",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PendingAuthoritySet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "docs": [
+        "PDA account that stores permissions for",
+        "a given key on a given vault.",
+        "Seeds: [b\"permission\", vault, user]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "The vault ID used to derive this permission's parent vault."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "The key that is granted these permissions"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "can_pause",
+            "docs": [
+              "Flag for whether this key can pause a vault or not"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "can_update_exchange_rate",
+            "docs": [
+              "Flag for whether this key has the Exchange Rate Updater role"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "strategist_group",
+            "docs": [
+              "Bit masking that designates a unique grouping for strategist actions available corresponding with CPI Digest.",
+              "0 [default] = no strategist permission"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissionAdded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "can_pause",
+            "type": "bool"
+          },
+          {
+            "name": "can_update_exchange_rate",
+            "type": "bool"
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissionArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "can_pause",
+            "type": "bool"
+          },
+          {
+            "name": "can_update_exchange_rate",
+            "type": "bool"
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissionRemoved",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "can_pause",
+            "type": "bool"
+          },
+          {
+            "name": "can_update_exchange_rate",
+            "type": "bool"
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PermissionUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "previous_can_pause",
+            "type": "bool"
+          },
+          {
+            "name": "can_pause",
+            "type": "bool"
+          },
+          {
+            "name": "previous_can_update_exchange_rate",
+            "type": "bool"
+          },
+          {
+            "name": "can_update_exchange_rate",
+            "type": "bool"
+          },
+          {
+            "name": "previous_strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "strategist_group",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramAuthorityUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_count",
+            "type": "u64"
+          },
+          {
+            "name": "pending_authority",
+            "docs": [
+              "`Pubkey::default()` means no transfer is pending."
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProgramPendingAuthoritySet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TellerState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_asset",
+            "docs": [
+              "Immutable after deployment"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "decimals",
+            "docs": [
+              "The share mint's decimals (set to the base mint's decimals during deployment).",
+              "Immutable after deployment"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          },
+          {
+            "name": "exchange_rate_high_water_mark",
+            "type": "u64"
+          },
+          {
+            "name": "platform_fees_owed_in_base_asset",
+            "docs": [
+              "Platform fees accrued and awaiting claim, in base-asset atoms."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "performance_fees_owed_in_base_asset",
+            "docs": [
+              "Performance fees accrued and awaiting claim, in base-asset atoms."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_shares_last_update",
+            "type": "u64"
+          },
+          {
+            "name": "supply_last_update_timestamp",
+            "docs": [
+              "TWAS / cumulative-supply clock (EVM: `supplyObservation.lastUpdateTimestamp`).",
+              "Advanced on every cumulative-supply sync (deposit/withdraw/vest/post_loss)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "platform_payout_address",
+            "docs": [
+              "Recipient of claimed platform fees."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "performance_payout_address",
+            "docs": [
+              "Recipient of claimed performance fees."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "allowed_exchange_rate_change_upper_bound",
+            "type": "u16"
+          },
+          {
+            "name": "allowed_exchange_rate_change_lower_bound",
+            "type": "u16"
+          },
+          {
+            "name": "minimum_update_delay_in_seconds",
+            "type": "u32"
+          },
+          {
+            "name": "platform_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "performance_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "withdraw_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_deviation_yield_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_deviation_loss_bps",
+            "type": "u16"
+          },
+          {
+            "name": "vesting_state",
+            "type": {
+              "defined": {
+                "name": "VestingState"
+              }
+            }
+          },
+          {
+            "name": "last_strategist_update_timestamp",
+            "docs": [
+              "Admin/strategist cooldown clock (EVM: `lastStrategistUpdateTimestamp`).",
+              "The last time vest_yield or post_loss was called; gates their minimum-update-delay."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "state_last_update_timestamp",
+            "docs": [
+              "Platform/performance fee proration anchor (EVM: `accountantState.lastUpdateTimestamp`).",
+              "Advanced inside `accrue_platform_fee` on every fee accrual",
+              "(deposit/withdraw/vest/rate update)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_cap",
+            "docs": [
+              "Maximum total share supply allowed via deposits (denominated in shares).",
+              "`u64::MAX` disables the cap."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "minimum_vest_duration",
+            "docs": [
+              "Minimum allowed `vest_yield` streaming duration in seconds"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maximum_vest_duration",
+            "docs": [
+              "Maximum allowed `vest_yield` streaming duration in seconds"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "platform_fee_remainder",
+            "docs": [
+              "Sub-atom platform fee carry: the part of the accrued platform fee that did not bridge a",
+              "whole base-asset atom, scaled by `FEE_REMAINDER_SCALE`. Always `< FEE_REMAINDER_SCALE`."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "performance_fee_remainder",
+            "docs": [
+              "Sub-atom performance fee carry. Same contract as `platform_fee_remainder`."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateAssetDataArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset_data",
+            "type": {
+              "defined": {
+                "name": "AssetDataConfig"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultAccrualMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ExchangeRateStep"
+          },
+          {
+            "name": "VestingYield"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultDeployed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "share_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "docs": [
+              "Immutable after deployment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "accounting_paused",
+            "docs": [
+              "Halts accounting operations and anything related: deposit, withdraw, exchange-rate updates,",
+              "vesting, safe rate reads, claim fees, and share mint/burn."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "teller_paused",
+            "docs": [
+              "Halts deposits and withdrawals"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "manage_paused",
+            "docs": [
+              "Halts manage instruction"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "share_mint",
+            "docs": [
+              "Immutable after deployment"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "deposit_sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "withdraw_sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "share_mover",
+            "type": "pubkey"
+          },
+          {
+            "name": "compliance_mode",
+            "type": "bool"
+          },
+          {
+            "name": "compliance_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_duration_seconds",
+            "docs": [
+              "Share-lock duration in seconds. Must be the source of truth and driver over the",
+              "lock_duration_seconds field on the transfer HookConfig"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VestingState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_virtual_share_price",
+            "docs": [
+              "High-precision, dimensionless virtual share price: the raw ratio",
+              "`total_assets_atomic / total_shares_atomic` scaled by RAY.",
+              "Gains are added here per-share as they vest; the human-readable",
+              "exchange_rate (= lastSharePrice in EVM) is derived as",
+              "`last_virtual_share_price * 10^decimals / RAY`."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "vesting_gains",
+            "docs": [
+              "Total unvested gains in base-asset units (not per-share).",
+              "Set to the full yield_amount on each vest_yield call (= overwrite, not +=)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_vesting_update",
+            "docs": [
+              "The last time a yield update was posted"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "start_vesting_time",
+            "docs": [
+              "The start time for the yield streaming period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "end_vesting_time",
+            "docs": [
+              "The end time for the yield streaming period"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_supply",
+            "docs": [
+              "Accumulated supply * time for TWAS calculation"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "vesting_period_start",
+            "docs": [
+              "Start of the current TWAS window, reset by vest_yield"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ViewCpiDigestArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ix_data",
+            "type": "bytes"
+          },
+          {
+            "name": "operators",
+            "type": {
+              "defined": {
+                "name": "Operators"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "share_amount",
+            "type": "u64"
+          },
+          {
+            "name": "min_assets_amount",
+            "type": "u64"
+          },
+          {
+            "name": "cpi_digest_ix_data",
+            "type": {
+              "option": "bytes"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawAuthorityUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "withdraw_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawCompleted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          },
+          {
+            "name": "caller",
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "shares_burned",
+            "type": "u64"
+          },
+          {
+            "name": "assets_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawCpiDigestUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "cpi_digest",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawSubAccountUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "sub_account",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldDeviationExceeded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "daily_yield_bps",
+            "type": "u64"
+          },
+          {
+            "name": "max_deviation_yield_bps",
+            "type": "u16"
+          },
+          {
+            "name": "yield_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "YieldVested",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_id",
+            "type": "u64"
+          },
+          {
+            "name": "exchange_rate",
+            "type": "u64"
+          },
+          {
+            "name": "remaining_vesting_gains",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/sdp-veda/idl/hook_program.json
+++ b/packages/sdp-veda/idl/hook_program.json
@@ -1,0 +1,442 @@
+{
+  "address": "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9",
+  "metadata": {
+    "name": "hook_program",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "initialize_hook",
+      "discriminator": [
+        37,
+        101,
+        119,
+        255,
+        156,
+        39,
+        252,
+        232
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Authorizes the hook setup. Must be the `vault_state` PDA itself — thus the",
+            "instruction is only callable through a CPI from the Boring Vault program."
+          ],
+          "signer": true
+        },
+        {
+          "name": "share_mint",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  104,
+                  97,
+                  114,
+                  101,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "vault_state"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                63,
+                208,
+                133,
+                144,
+                37,
+                230,
+                219,
+                109,
+                35,
+                98,
+                197,
+                125,
+                171,
+                66,
+                209,
+                86,
+                6,
+                59,
+                48,
+                18,
+                215,
+                19,
+                203,
+                79,
+                160,
+                166,
+                180,
+                218,
+                13,
+                62,
+                57,
+                127
+              ]
+            }
+          }
+        },
+        {
+          "name": "hook_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "extra_account_metas",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  120,
+                  116,
+                  114,
+                  97,
+                  45,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116,
+                  45,
+                  109,
+                  101,
+                  116,
+                  97,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_state",
+          "docs": [
+            "from `vault_id`."
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "vault_id",
+          "type": "u64"
+        },
+        {
+          "name": "lock_duration_seconds",
+          "type": "i64"
+        },
+        {
+          "name": "compliance_check_enabled",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "update_compliance_check",
+      "discriminator": [
+        31,
+        170,
+        163,
+        151,
+        76,
+        240,
+        73,
+        128
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "Must be the `vault_state` PDA itself"
+          ],
+          "signer": true
+        },
+        {
+          "name": "share_mint"
+        },
+        {
+          "name": "hook_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_state"
+        }
+      ],
+      "args": [
+        {
+          "name": "compliance_check_enabled",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "update_lock_duration",
+      "discriminator": [
+        0,
+        52,
+        113,
+        182,
+        84,
+        135,
+        155,
+        164
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "Must be the `vault_state` PDA itself"
+          ],
+          "signer": true
+        },
+        {
+          "name": "share_mint"
+        },
+        {
+          "name": "hook_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "share_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_state"
+        }
+      ],
+      "args": [
+        {
+          "name": "lock_duration_seconds",
+          "type": "i64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "HookConfig",
+      "discriminator": [
+        137,
+        155,
+        101,
+        95,
+        138,
+        72,
+        8,
+        182
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "HookInitialized",
+      "discriminator": [
+        127,
+        123,
+        212,
+        103,
+        69,
+        142,
+        254,
+        152
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "TransferLockActive",
+      "msg": "Transfer lock active: shares are non-transferable during lock period"
+    },
+    {
+      "code": 6001,
+      "name": "SourceNotAllowed",
+      "msg": "Source wallet is not an allowed user"
+    },
+    {
+      "code": 6002,
+      "name": "DestinationNotAllowed",
+      "msg": "Destination wallet is not an allowed user"
+    },
+    {
+      "code": 6003,
+      "name": "NotAuthorized",
+      "msg": "Not authorized"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidVaultState",
+      "msg": "Invalid vault state"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidAllowedUser",
+      "msg": "Invalid allowed user account"
+    },
+    {
+      "code": 6006,
+      "name": "AlreadyInitialized",
+      "msg": "Extra account metas already initialized"
+    },
+    {
+      "code": 6007,
+      "name": "MathError",
+      "msg": "Math error"
+    },
+    {
+      "code": 6008,
+      "name": "ImmutableOwnerRequired",
+      "msg": "Token account must have the ImmutableOwner extension"
+    }
+  ],
+  "types": [
+    {
+      "name": "HookConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault_state",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_duration_seconds",
+            "type": "i64"
+          },
+          {
+            "name": "compliance_check_enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HookInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "hook_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "share_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_duration_seconds",
+            "type": "i64"
+          },
+          {
+            "name": "compliance_check_enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/sdp-veda/package.json
+++ b/packages/sdp-veda/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@sdp/veda",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./programs": {
+      "types": "./src/programs.ts",
+      "import": "./src/programs.ts",
+      "default": "./src/programs.ts"
+    },
+    "./types": {
+      "types": "./src/types.ts",
+      "import": "./src/types.ts",
+      "default": "./src/types.ts"
+    },
+    "./errors": {
+      "types": "./src/errors.ts",
+      "import": "./src/errors.ts",
+      "default": "./src/errors.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "biome check src/"
+  },
+  "dependencies": {
+    "@sdp/earn": "workspace:*",
+    "@sdp/solana": "workspace:*",
+    "@sdp/types": "workspace:*",
+    "@solana/kit": "catalog:",
+    "@vedatech/svm-sdk": "0.1.0-alpha.1"
+  },
+  "devDependencies": {
+    "@types/node": "26.1.2",
+    "tsx": "4.23.5",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/sdp-veda/src/amounts.test.ts
+++ b/packages/sdp-veda/src/amounts.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { acceptAtMintScale, acceptPositiveAtMintScale, mintDecimals } from "./amounts";
+
+const USDC_DECIMALS = 6;
+
+describe("acceptAtMintScale", () => {
+  it("returns both the atoms encoded and the canonical decimal form", () => {
+    expect(acceptAtMintScale("amount", "1.5", USDC_DECIMALS)).toEqual({
+      baseUnits: 1_500_000n,
+      canonical: "1.5",
+    });
+  });
+
+  /**
+   * Scale is a property of the VALUE, not its spelling: trailing fractional
+   * zeros need no atoms. Refusing `1.5000000` on a six-decimal mint would be
+   * refusing a number the mint represents exactly.
+   */
+  it("accepts trailing zeros beyond the mint's scale", () => {
+    expect(acceptAtMintScale("amount", "1.5000000", USDC_DECIMALS).baseUnits).toBe(1_500_000n);
+    expect(acceptAtMintScale("amount", "1.5000000", USDC_DECIMALS).canonical).toBe("1.5");
+  });
+
+  /**
+   * THE BUG THIS EXISTS TO PREVENT. Rounding `1.0000009` down would record
+   * 1.0000009 in the ledger while 1.000000 moved on chain, and the ledger is
+   * what a customer is later shown. Refusing keeps the two equal.
+   */
+  it("refuses a non-zero sub-atom rather than rounding it away", () => {
+    expect(() => acceptAtMintScale("amount", "1.0000009", USDC_DECIMALS)).toThrow(
+      /more precision than its mint supports/
+    );
+  });
+
+  it("refuses anything that is not a plain positive decimal", () => {
+    for (const value of ["-1", "1e5", "Infinity", "", " ", "abc", "1.2.3"]) {
+      expect(() => acceptAtMintScale("amount", value, USDC_DECIMALS), value).toThrow(
+        /positive decimal string/
+      );
+    }
+  });
+
+  /**
+   * Scale-valid decimals can still overflow the u64 Veda encodes. Caught here
+   * rather than inside the SDK's own `assertU64`, which only fires after
+   * several RPC round trips — far from the caller that can fix it.
+   */
+  it("refuses a value beyond the u64 the instruction encodes", () => {
+    const maxU64 = (1n << 64n) - 1n;
+    const atMax = `${maxU64 / 1_000_000n}.${(maxU64 % 1_000_000n).toString().padStart(6, "0")}`;
+    expect(acceptAtMintScale("amount", atMax, USDC_DECIMALS).baseUnits).toBe(maxU64);
+    expect(() => acceptAtMintScale("amount", "18446744073710", USDC_DECIMALS)).toThrow(
+      /maximum unsigned 64-bit/
+    );
+  });
+
+  it("accepts zero, which the positive variant is what refuses", () => {
+    expect(acceptAtMintScale("amount", "0.000000", USDC_DECIMALS)).toEqual({
+      baseUnits: 0n,
+      canonical: "0",
+    });
+  });
+});
+
+describe("acceptPositiveAtMintScale", () => {
+  /**
+   * A `minSharesOut` of zero is worse than no floor at all: it reads as
+   * protection in the request, the ledger and the UI while imposing none on
+   * chain, which also suppresses anyone's suspicion that protection is missing.
+   */
+  it("refuses every spelling of zero", () => {
+    for (const value of ["0", "0.0", "0.000000"]) {
+      expect(() => acceptPositiveAtMintScale("minSharesOut", value, USDC_DECIMALS), value).toThrow(
+        /positive decimal string/
+      );
+    }
+  });
+
+  it("passes a positive value through unchanged", () => {
+    expect(acceptPositiveAtMintScale("minSharesOut", "0.000001", USDC_DECIMALS)).toEqual({
+      baseUnits: 1n,
+      canonical: "0.000001",
+    });
+  });
+});
+
+describe("mintDecimals", () => {
+  it("accepts a plausible mint scale in whatever shape it arrives", () => {
+    expect(mintDecimals(6, "x")).toBe(6);
+    expect(mintDecimals("9", "x")).toBe(9);
+    expect(mintDecimals(0, "x")).toBe(0);
+  });
+
+  /**
+   * `Number("")` is 0, so a missing field would otherwise arrive as a perfectly
+   * plausible zero-decimal mint and disable every scale check downstream. That
+   * is the failure this refuses, and it is why the check is a digit match
+   * rather than a numeric parse.
+   */
+  it("refuses a missing, non-numeric or impossible value", () => {
+    for (const value of [undefined, null, "", " ", "six", -1, 1.5, 10, 255]) {
+      expect(() => mintDecimals(value, "x"), String(value)).toThrow(/usable mint decimal count/);
+    }
+  });
+});

--- a/packages/sdp-veda/src/amounts.ts
+++ b/packages/sdp-veda/src/amounts.ts
@@ -1,0 +1,127 @@
+import {
+  decimalScale,
+  formatDecimalAmount,
+  isDecimalString,
+  parseDecimalAmount,
+} from "@sdp/solana/amount";
+import { amountOutOfRange, amountTooPrecise, invalidAmount } from "./errors";
+
+/** Every amount Veda serializes into an instruction is an unsigned 64-bit integer. */
+const MAX_U64_BASE_UNITS = (1n << 64n) - 1n;
+
+/**
+ * Amount conversion at the MINT's precision.
+ *
+ * A separate module from `./sdk.ts` for one reason: none of this needs
+ * `@vedatech/svm-sdk`, so keeping it outside the firewall module makes it
+ * unit-testable without loading the SDK or its nested `@solana/kit` 7.
+ * `@sdp/solana/amount` is the repo's fixed-point arithmetic and is exact —
+ * `bigint` base units throughout, never a float.
+ */
+
+export interface AcceptedAmount {
+  /** What the instruction will encode. */
+  baseUnits: bigint;
+  /** The same value as a decimal string, canonical to the mint's scale. */
+  canonical: string;
+}
+
+/**
+ * Convert a decimal string to mint atoms, refusing anything that would not
+ * survive the trip.
+ *
+ * Veda's SDK takes atomic `bigint`s, so SDP owns this conversion and the only
+ * two options are REFUSE or ROUND. Rounding is the dangerous one, and two
+ * distinct bugs hide under it:
+ *
+ * - A deposit of `1.0000009` against a six-decimal mint would be RECORDED as
+ *   1.0000009 while 1.000000 moved. The ledger and the chain disagree, and the
+ *   ledger is what a customer is later shown.
+ * - A `minSharesOut` below one atom would become `0` — a slippage floor that
+ *   reads as protection in the request, the ledger and the UI, and imposes none
+ *   on chain. Strictly worse than sending no floor, because it also suppresses
+ *   anyone's suspicion that protection is missing.
+ *
+ * Validating the SCALE rather than clamping the value is deliberate: clamping
+ * would make SDP quietly move a different amount than it was asked for, which
+ * is the same class of bug wearing a friendlier costume.
+ */
+export function acceptAtMintScale(field: string, value: string, decimals: number): AcceptedAmount {
+  const normalized = value.trim();
+  // `isDecimalString` is the syntax gate and also the SIGN gate: it accepts
+  // digits and at most one dot, so "-1", "1e5" and "Infinity" are all rejected
+  // here rather than needing a separate numeric parse.
+  if (!isDecimalString(normalized)) throw invalidAmount(field, value);
+
+  // Scale is a property of the VALUE, not its spelling. Zeros after the last
+  // non-zero fractional digit need no mint atoms: `1.5000000` is exactly
+  // representable by a six-decimal mint even though its text has seven places.
+  // Strip only those; a non-zero sub-atom remains and is still refused.
+  const canonicalScaleInput = trimInsignificantFractionalZeroes(normalized);
+  if (decimalScale(canonicalScaleInput) > decimals) {
+    throw amountTooPrecise(field, value, decimals);
+  }
+
+  const baseUnits = parseDecimalAmount(canonicalScaleInput, decimals);
+  // Scale-valid decimals can still overflow the u64 Veda encodes. Letting those
+  // through defers the failure into the SDK's own `assertU64` after several RPC
+  // round trips, far from the caller that can fix it.
+  if (baseUnits > MAX_U64_BASE_UNITS) throw amountOutOfRange(field, value);
+
+  // Re-serialised through the repo's fixed-point helpers so what leaves this
+  // package is scaled exactly like every other amount in SDP ("1.500" -> "1.5").
+  return { baseUnits, canonical: formatDecimalAmount(baseUnits, decimals) };
+}
+
+/**
+ * `acceptAtMintScale`, additionally refusing zero.
+ *
+ * Both amounts SDP sends Veda are positive by contract: a zero deposit moves
+ * nothing, and a zero share floor is the absent-protection case above. The
+ * scale check already refuses sub-atom values, so reaching zero here means the
+ * caller literally passed a zero.
+ */
+export function acceptPositiveAtMintScale(
+  field: string,
+  value: string,
+  decimals: number
+): AcceptedAmount {
+  const accepted = acceptAtMintScale(field, value, decimals);
+  if (accepted.baseUnits === 0n) throw invalidAmount(field, value);
+  return accepted;
+}
+
+/**
+ * A mint's decimal count, validated.
+ *
+ * Read from chain or from the SDK, so it arrives as `unknown`. Matched as
+ * DIGITS rather than parsed with `Number`, because `Number("")` is 0 — a
+ * missing field would otherwise arrive as a perfectly plausible "zero-decimal
+ * mint" and disable every scale check downstream. Solana mints cap at 9
+ * decimals; anything larger means the read is wrong, not that Veda invented a
+ * new scale.
+ */
+export function mintDecimals(value: unknown, label: string): number {
+  const raw = String(value ?? "").trim();
+  const parsed = /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  if (!Number.isInteger(parsed) || parsed > 9) {
+    throw new Error(`Veda ${label} was not a usable mint decimal count (${String(value)})`);
+  }
+  return parsed;
+}
+
+function trimInsignificantFractionalZeroes(value: string): string {
+  const dot = value.indexOf(".");
+  if (dot === -1) return value;
+
+  const whole = value.slice(0, dot);
+  let fractionEnd = value.length;
+  // Scan once from the end instead of applying an end-anchored repetition to
+  // caller-controlled input. The latter can retry from every zero when a long
+  // run ends in a non-zero digit, turning validation into quadratic work.
+  while (fractionEnd > dot + 1 && value[fractionEnd - 1] === "0") {
+    fractionEnd -= 1;
+  }
+
+  return fractionEnd === dot + 1 ? whole : value.slice(0, fractionEnd);
+}

--- a/packages/sdp-veda/src/client.test.ts
+++ b/packages/sdp-veda/src/client.test.ts
@@ -1,0 +1,383 @@
+import {
+  supportsPortfolioWallets,
+  supportsVaultDirect,
+  supportsVaultWithdraw,
+} from "@sdp/earn/capabilities";
+import type { VedaDeployment } from "@sdp/types/veda-programs";
+import { address } from "@solana/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertNotPortfolioProvider,
+  toEarnVaultTransactionPlan,
+  VEDA_POSITION_READ_CONCURRENCY,
+  VedaVaultDirectClient,
+  type VedaVaultOperationRunner,
+} from "./client";
+import { SdpVedaError } from "./errors";
+import { toClusterConfig } from "./programs";
+import type { VedaInstructionPlan, VedaPosition } from "./types";
+
+const VAULT_PROGRAM = "5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc";
+const QUEUE_PROGRAM = "Cchro8d7bN5Xfk77z9hJKxREJwSAjpz5K2seK4iNN396";
+const HOOK_PROGRAM = "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9";
+const VAULT_A = "So11111111111111111111111111111111111111112";
+const VAULT_B = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+const DEPOSIT_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const SHARE_MINT = "9BEcn9aPEmhSPbPQeFGjidRiEKki46fVQDyPpSQXPA2D";
+const OWNER = "11111111111111111111111111111112";
+
+const DEPLOYMENT: VedaDeployment = {
+  vaultProgramAddress: VAULT_PROGRAM,
+  queueProgramAddress: QUEUE_PROGRAM,
+  hookProgramAddress: HOOK_PROGRAM,
+  vaultStateAddresses: [VAULT_A, VAULT_B],
+};
+
+const mocks = vi.hoisted(() => ({
+  buildVedaDepositPlan: vi.fn(),
+  readVedaPosition: vi.fn(),
+}));
+
+vi.mock("./sdk", () => ({
+  buildVedaDepositPlan: mocks.buildVedaDepositPlan,
+  readVedaPosition: mocks.readVedaPosition,
+}));
+
+// Partial: only the registry lookup is replaced, so the address branding and
+// the allowlist stay the real ones.
+vi.mock("./programs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./programs")>();
+  return { ...actual, vedaClusterConfig: () => actual.toClusterConfig("devnet", DEPLOYMENT) };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const runOperation: VedaVaultOperationRunner = (_label, operation) => operation(() => undefined);
+const client = new VedaVaultDirectClient(async () => "https://rpc.test.invalid", runOperation);
+const sandbox = { env: {}, environment: "sandbox" } as const;
+
+function plan(): VedaInstructionPlan {
+  return {
+    cluster: "devnet",
+    instructions: [
+      [
+        {
+          programAddress: address(VAULT_PROGRAM),
+          accounts: [
+            { address: address(OWNER), role: 3 },
+            { address: address(VAULT_A), role: 1 },
+          ],
+          data: new Uint8Array([1, 2, 3, 4]),
+        },
+      ],
+    ] as unknown as VedaInstructionPlan["instructions"],
+    lookupTables: [],
+    assetIdentity: { depositTokenMint: address(DEPOSIT_MINT), shareMint: address(SHARE_MINT) },
+    accepted: { amount: "10", minSharesOut: "9.5" },
+  };
+}
+
+function position(vault: string, overrides: Partial<VedaPosition> = {}): VedaPosition {
+  return {
+    vault: address(vault),
+    owner: address(OWNER),
+    cluster: "devnet",
+    shares: "5",
+    tokenValue: "5.25",
+    tokenMint: address(DEPOSIT_MINT),
+    shareMint: address(SHARE_MINT),
+    ...overrides,
+  };
+}
+
+describe("VedaVaultDirectClient capabilities", () => {
+  it("reports the vault-direct capability", () => {
+    expect(supportsVaultDirect(client)).toBe(true);
+  });
+
+  /**
+   * The withdraw capability is WITHHELD, and this pins it so implementing
+   * `buildVaultWithdrawal` cannot happen by accident.
+   *
+   * Veda offers two independent exits — instant redemption and a
+   * request/fulfil queue — and neither has an SDP route: there is no
+   * `POST /vault-withdrawals`, and the queue's lifecycle does not fit the
+   * `pending|submitted|confirmed|failed` movement model the deposit path uses.
+   * Answering yes here would let a future exit route narrow onto this client
+   * and receive a plan nothing can carry, after the customer was told their
+   * withdrawal was prepared. Deleting this test is the wrong way to make it
+   * pass; landing the withdrawal design is the right way.
+   */
+  it("does NOT report the withdraw capability until the exit route exists", () => {
+    expect(supportsVaultWithdraw(client)).toBe(false);
+    expect((client as unknown as Record<string, unknown>).buildVaultWithdrawal).toBeUndefined();
+  });
+
+  /**
+   * THE INVARIANT THAT PROTECTS CUSTOMER FUNDS.
+   *
+   * The portfolio capability means "SDP can give you an address to send
+   * stablecoins to". Veda has no such address — its vault state is a program
+   * account. If this client ever answered yes to both, a portfolio route could
+   * render that account as a deposit target. The two must stay mutually
+   * exclusive.
+   */
+  it("NEVER reports the portfolio-wallet capability", () => {
+    expect(supportsPortfolioWallets(client)).toBe(false);
+    expect(() => assertNotPortfolioProvider(client)).not.toThrow();
+  });
+
+  it("still catalogues — the execution client is a superset, not a replacement", () => {
+    expect(client.provider).toBe("veda");
+    expect(client.declaredSupport.sourceKinds).toEqual(["defi"]);
+    expect(client.declaredSupport.depositTokens).toEqual(["USDC"]);
+    expect(typeof client.listStrategies).toBe("function");
+  });
+});
+
+describe("buildVaultDeposit", () => {
+  const input = {
+    providerReference: VAULT_A,
+    owner: OWNER,
+    amount: "10",
+    minSharesOut: "9.5",
+  };
+
+  /**
+   * Veda's SDK refuses an implicit slippage tolerance, and SDP refuses to
+   * invent one: a floor nobody chose is not protection, it is the appearance of
+   * it. The API requires a floor only in production; for Veda it is required
+   * everywhere, so this fails BEFORE any chain work.
+   */
+  it("refuses a deposit with no slippage floor, before touching the chain", async () => {
+    const { minSharesOut: _omitted, ...noFloor } = input;
+    await expect(client.buildVaultDeposit(sandbox, noFloor)).rejects.toMatchObject({
+      code: "INVALID_AMOUNT",
+    });
+    expect(mocks.buildVedaDepositPlan).not.toHaveBeenCalled();
+  });
+
+  it("refuses to build when no RPC endpoint is configured for the cluster", async () => {
+    const unconfigured = new VedaVaultDirectClient(async () => "  ", runOperation);
+    await expect(unconfigured.buildVaultDeposit(sandbox, input)).rejects.toMatchObject({
+      code: "VAULT_UNREADABLE",
+    });
+    expect(mocks.buildVedaDepositPlan).not.toHaveBeenCalled();
+  });
+
+  it("passes the vault, owner and both amounts through as addresses and decimal strings", async () => {
+    mocks.buildVedaDepositPlan.mockResolvedValue(plan());
+    await client.buildVaultDeposit(sandbox, input);
+
+    expect(mocks.buildVedaDepositPlan).toHaveBeenCalledTimes(1);
+    const [runtime, config, built] = mocks.buildVedaDepositPlan.mock.calls[0] as [
+      { cluster: string; rpcUrl: string },
+      { vaultProgramAddress: string },
+      { vault: string; owner: string; amount: string; minSharesOut: string },
+    ];
+    expect(runtime.cluster).toBe("devnet");
+    expect(String(config.vaultProgramAddress)).toBe(VAULT_PROGRAM);
+    expect({ ...built, vault: String(built.vault), owner: String(built.owner) }).toEqual({
+      vault: VAULT_A,
+      owner: OWNER,
+      amount: "10",
+      minSharesOut: "9.5",
+    });
+  });
+
+  it("serializes the plan into the dependency-free Earn contract", async () => {
+    mocks.buildVedaDepositPlan.mockResolvedValue(plan());
+    const result = await client.buildVaultDeposit(sandbox, input);
+
+    expect(result).toEqual({
+      cluster: "devnet",
+      transactions: [
+        [
+          {
+            programAddress: VAULT_PROGRAM,
+            accounts: [
+              { address: OWNER, role: 3 },
+              { address: VAULT_A, role: 1 },
+            ],
+            // Base64 keeps the plan JSON-safe across a queue or a log.
+            data: Buffer.from([1, 2, 3, 4]).toString("base64"),
+          },
+        ],
+      ],
+      lookupTables: [],
+      assetIdentity: { depositTokenMint: DEPOSIT_MINT, shareMint: SHARE_MINT },
+      accepted: { amount: "10", minSharesOut: "9.5" },
+    });
+  });
+
+  /**
+   * The API ledgers `accepted`, not the raw request, because only the builder
+   * knows each mint's precision. Dropping it reintroduces the drift between
+   * what was recorded and what moved.
+   */
+  it("carries the encoded amounts, not the requested ones", async () => {
+    const canonical = plan();
+    canonical.accepted = { amount: "10", minSharesOut: "9.5" };
+    mocks.buildVedaDepositPlan.mockResolvedValue(canonical);
+    const result = await client.buildVaultDeposit(sandbox, {
+      ...input,
+      amount: "10.000",
+      minSharesOut: "9.500000",
+    });
+    expect(result.accepted).toEqual({ amount: "10", minSharesOut: "9.5" });
+  });
+});
+
+describe("toEarnVaultTransactionPlan", () => {
+  it("tolerates an instruction with no accounts and no data", () => {
+    const bare: VedaInstructionPlan = {
+      ...plan(),
+      instructions: [
+        [{ programAddress: address(VAULT_PROGRAM) }],
+      ] as unknown as VedaInstructionPlan["instructions"],
+    };
+    expect(toEarnVaultTransactionPlan(bare).transactions[0]?.[0]).toEqual({
+      programAddress: VAULT_PROGRAM,
+      accounts: [],
+      data: "",
+    });
+  });
+});
+
+describe("readVaultPositions", () => {
+  it("reads exactly the requested vaults", async () => {
+    mocks.readVedaPosition.mockImplementation(
+      async (_runtime: unknown, _config: unknown, input: { vault: string }) =>
+        position(String(input.vault))
+    );
+
+    const snapshots = await client.readVaultPositions(sandbox, {
+      owner: OWNER,
+      providerReferences: [VAULT_A],
+    });
+
+    expect(mocks.readVedaPosition).toHaveBeenCalledTimes(1);
+    expect(snapshots).toEqual([
+      {
+        providerReference: VAULT_A,
+        owner: OWNER,
+        cluster: "devnet",
+        shares: "5",
+        tokenValue: "5.25",
+        tokenMint: DEPOSIT_MINT,
+        shareMint: SHARE_MINT,
+      },
+    ]);
+  });
+
+  /**
+   * Veda's SDK publishes no vault discovery, and there is nothing to discover:
+   * a Veda vault reaches SDP only by being named in `VEDA_DEPLOYMENTS`, so the
+   * configured shelf IS the set of vaults an owner could hold through SDP.
+   */
+  it("falls back to the configured shelf when no references are given", async () => {
+    mocks.readVedaPosition.mockImplementation(
+      async (_runtime: unknown, _config: unknown, input: { vault: string }) =>
+        position(String(input.vault))
+    );
+
+    const snapshots = await client.readVaultPositions(sandbox, {
+      owner: OWNER,
+      providerReferences: [],
+    });
+
+    expect(snapshots.map((snapshot) => snapshot.providerReference)).toEqual([VAULT_A, VAULT_B]);
+  });
+
+  it("omits an empty holding from a full-shelf read but keeps a requested zero", async () => {
+    mocks.readVedaPosition.mockImplementation(
+      async (_runtime: unknown, _config: unknown, input: { vault: string }) =>
+        position(String(input.vault), {
+          shares: String(input.vault) === VAULT_B ? "0" : "5",
+          tokenValue: undefined,
+        })
+    );
+
+    const all = await client.readVaultPositions(sandbox, { owner: OWNER, providerReferences: [] });
+    expect(all.map((snapshot) => snapshot.providerReference)).toEqual([VAULT_A]);
+
+    const requested = await client.readVaultPositions(sandbox, {
+      owner: OWNER,
+      providerReferences: [VAULT_B],
+    });
+    expect(requested).toHaveLength(1);
+    expect(requested[0]?.shares).toBe("0");
+  });
+
+  it("omits an unreadable valuation rather than fabricating one", async () => {
+    mocks.readVedaPosition.mockResolvedValue(position(VAULT_A, { tokenValue: undefined }));
+    const [only] = await client.readVaultPositions(sandbox, {
+      owner: OWNER,
+      providerReferences: [VAULT_A],
+    });
+    expect(only?.shares).toBe("5");
+    expect(only && "tokenValue" in only).toBe(false);
+  });
+
+  /**
+   * A partial portfolio is not a truthful portfolio: returning every other
+   * vault would make a failed holding indistinguishable from no holding.
+   */
+  it("fails the whole read when any vault fails", async () => {
+    mocks.readVedaPosition.mockImplementation(
+      async (_runtime: unknown, _config: unknown, input: { vault: string }) => {
+        if (String(input.vault) === VAULT_B) throw new Error("rpc exploded");
+        return position(String(input.vault));
+      }
+    );
+
+    await expect(
+      client.readVaultPositions(sandbox, { owner: OWNER, providerReferences: [VAULT_A, VAULT_B] })
+    ).rejects.toMatchObject({ code: "VAULT_UNREADABLE" });
+  });
+
+  it("stops dequeuing vaults once the caller's deadline has expired", async () => {
+    let elapsed = false;
+    const deadlined: VedaVaultOperationRunner = (_label, operation) =>
+      operation(() => {
+        if (elapsed) throw new SdpVedaError("VAULT_UNREADABLE", "deadline elapsed");
+      });
+    const bounded = new VedaVaultDirectClient(async () => "https://rpc.test.invalid", deadlined);
+    mocks.readVedaPosition.mockImplementation(async () => {
+      elapsed = true;
+      return position(VAULT_A);
+    });
+
+    await expect(
+      bounded.readVaultPositions(sandbox, { owner: OWNER, providerReferences: [VAULT_A, VAULT_B] })
+    ).rejects.toThrow(/deadline elapsed/);
+  });
+
+  it("bounds concurrent vault reads", () => {
+    expect(VEDA_POSITION_READ_CONCURRENCY).toBeGreaterThan(0);
+    expect(VEDA_POSITION_READ_CONCURRENCY).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("an unconfigured deployment", () => {
+  /**
+   * The real registry is empty until Veda confirms addresses, so a client built
+   * against it refuses every chain call. Asserted with the mock bypassed so
+   * this is the genuine `@sdp/types` state, not the fixture's.
+   */
+  it("refuses both chain capabilities with a typed error", async () => {
+    const { vedaClusterConfig } = await vi.importActual<typeof import("./programs")>("./programs");
+    expect(() => vedaClusterConfig("devnet")).toThrowError(
+      expect.objectContaining({ code: "DEPLOYMENT_NOT_CONFIGURED" })
+    );
+    expect(() => vedaClusterConfig("mainnet-beta")).toThrowError(
+      expect.objectContaining({ code: "DEPLOYMENT_NOT_CONFIGURED" })
+    );
+  });
+
+  it("still exposes the fixture-driven config helper the builder uses", () => {
+    expect(toClusterConfig("devnet", DEPLOYMENT).cluster).toBe("devnet");
+  });
+});

--- a/packages/sdp-veda/src/client.ts
+++ b/packages/sdp-veda/src/client.ts
@@ -1,0 +1,304 @@
+import { supportsPortfolioWallets } from "@sdp/earn/capabilities";
+import { VedaEarnClient } from "@sdp/earn/providers/veda/client";
+import type {
+  EarnRuntimeContext,
+  EarnVaultDepositInput,
+  EarnVaultDirectProvider,
+  EarnVaultInstruction,
+  EarnVaultPositionInput,
+  EarnVaultPositionSnapshot,
+  EarnVaultTransactionPlan,
+} from "@sdp/earn/types";
+import { CLUSTER_BY_SDP_ENVIRONMENT, type SolanaCluster } from "@sdp/types";
+import { address } from "@solana/kit";
+import { SdpVedaError } from "./errors";
+import { type VedaClusterConfig, vedaClusterConfig } from "./programs";
+import { buildVedaDepositPlan, readVedaPosition } from "./sdk";
+import type { VedaInstructionPlan, VedaRuntime } from "./types";
+
+/** One position page may fan out over several vaults; never fan out unbounded. */
+export const VEDA_POSITION_READ_CONCURRENCY = 4;
+
+/**
+ * API-owned execution guard for one provider operation. The API injects its
+ * absolute vault deadline here without creating a dependency from this package
+ * back to the application layer.
+ */
+export type VedaVaultOperationRunner = <T>(
+  label: string,
+  operation: (assertActive: () => void) => Promise<T>
+) => Promise<T>;
+
+async function mapSettledWithConcurrency<T, U>(
+  items: readonly T[],
+  concurrency: number,
+  assertActive: () => void,
+  mapper: (item: T) => Promise<U>
+): Promise<Array<PromiseSettledResult<U>>> {
+  const results = new Array<PromiseSettledResult<U>>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        // A timed-out aggregate read cannot cancel an in-flight SDK request,
+        // but it must never dequeue another vault after the budget expires.
+        assertActive();
+        const index = nextIndex;
+        nextIndex += 1;
+        try {
+          results[index] = { status: "fulfilled", value: await mapper(items[index] as T) };
+        } catch (reason) {
+          results[index] = { status: "rejected", reason };
+        }
+      }
+    })
+  );
+
+  return results;
+}
+
+/** Convert the kit-native plan to the dependency-free Earn wire contract. */
+export function toEarnVaultTransactionPlan(plan: VedaInstructionPlan): EarnVaultTransactionPlan {
+  return {
+    cluster: plan.cluster,
+    transactions: plan.instructions.map((batch) =>
+      batch.map(
+        (instruction): EarnVaultInstruction => ({
+          programAddress: String(instruction.programAddress),
+          accounts: (instruction.accounts ?? []).map((account) => ({
+            address: String(account.address),
+            role: Number(account.role),
+          })),
+          // Base64 keeps the contract JSON-safe: a plan may cross a queue or a
+          // log before it is compiled, and a Uint8Array does not survive that.
+          data: Buffer.from(instruction.data ?? new Uint8Array()).toString("base64"),
+        })
+      )
+    ),
+    lookupTables: plan.lookupTables.map(String),
+    assetIdentity: {
+      depositTokenMint: String(plan.assetIdentity.depositTokenMint),
+      shareMint: String(plan.assetIdentity.shareMint),
+    },
+    // The mint-scale amounts the instructions actually encode. The API ledgers
+    // this shape; dropping it reintroduces raw-request drift.
+    accepted: { ...plan.accepted },
+  };
+}
+
+/**
+ * Veda as an EXECUTING provider: the catalogue client plus the vault-direct
+ * capability.
+ *
+ * Lives here rather than in `@sdp/earn` so that package keeps its single
+ * `@sdp/types` dependency — its hourly catalogue cron runs in both environments
+ * and must never load `@vedatech/svm-sdk`. The arrow points inward:
+ * `@sdp/veda` depends on `@sdp/earn`, never the reverse.
+ *
+ * Registered by the API's execution registry, which prefers this class over the
+ * catalogue-only `VedaEarnClient` when a route needs to move money. Callers
+ * still discover the capability with `supportsVaultDirect`, never a provider-id
+ * check.
+ *
+ * **`buildVaultWithdrawal` is deliberately absent.** Money OUT is a separate
+ * capability (`supportsVaultWithdraw`) and a separate piece of work: Veda offers
+ * two independent exits — an instant redemption and a request/fulfil queue —
+ * whose lifecycles do not fit the `pending|submitted|confirmed|failed` movement
+ * model the deposit path uses, and there is no `POST /vault-withdrawals` route
+ * to carry either. Withholding the capability says SDP has no exit ROUTE; it is
+ * never a permission gate, and it traps nothing: the shares sit in the
+ * organization's own custody wallet and Veda's own surfaces can redeem them.
+ * See `docs/decisions/` for the withdrawal design that lands it.
+ */
+export class VedaVaultDirectClient extends VedaEarnClient implements EarnVaultDirectProvider {
+  /**
+   * Where a PROVEN RPC endpoint comes from and how its operation is bounded.
+   *
+   * Injected rather than read from `ctx.env.SOLANA_RPC_URL`, because that
+   * variable is PROCESS-level while the cluster is PER-REQUEST: one API process
+   * serves both SDP environments, so a sandbox request inside a production
+   * deployment would otherwise reach a MAINNET url. The API proves the resolved
+   * URL's genesis before returning it. Keeping that resolver inside the client
+   * makes proof a class invariant for deposits, positions and any future chain
+   * capability, rather than something each route has to remember — and for Veda
+   * it is load-bearing twice over, since its deployments may share addresses
+   * across clusters.
+   */
+  constructor(
+    private readonly resolveProvenRpcUrl: (
+      ctx: EarnRuntimeContext,
+      cluster: SolanaCluster
+    ) => Promise<string>,
+    private readonly runOperation: VedaVaultOperationRunner
+  ) {
+    super();
+  }
+
+  private async runtime(ctx: EarnRuntimeContext): Promise<{
+    runtime: VedaRuntime;
+    config: VedaClusterConfig;
+  }> {
+    const cluster = CLUSTER_BY_SDP_ENVIRONMENT[ctx.environment];
+    // Resolved BEFORE the endpoint: an unconfigured deployment is a fact about
+    // SDP, and reporting it should not depend on an RPC being reachable.
+    const config = vedaClusterConfig(cluster);
+    const rpcUrl = await this.resolveProvenRpcUrl(ctx, cluster);
+    if (!rpcUrl.trim()) {
+      throw new SdpVedaError(
+        "VAULT_UNREADABLE",
+        `No Solana RPC endpoint configured for ${cluster}; Veda cannot build a transaction.`
+      );
+    }
+    return { runtime: { cluster, rpcUrl }, config };
+  }
+
+  /** Every chain capability enters through this proof-then-deadline boundary. */
+  private async withRuntime<T>(
+    ctx: EarnRuntimeContext,
+    label: string,
+    operation: (
+      runtime: VedaRuntime,
+      config: VedaClusterConfig,
+      assertActive: () => void
+    ) => Promise<T>
+  ): Promise<T> {
+    return this.runOperation(label, async (assertActive) => {
+      // Endpoint resolution/proof and provider work are one operation, so they
+      // consume one deadline rather than receiving independent budgets.
+      const { runtime, config } = await this.runtime(ctx);
+      assertActive();
+      return operation(runtime, config, assertActive);
+    });
+  }
+
+  async buildVaultDeposit(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultDepositInput
+  ): Promise<EarnVaultTransactionPlan> {
+    // Refused HERE rather than defaulted. Veda's SDK will not apply an implicit
+    // slippage tolerance, and SDP will not invent one on a caller's behalf: a
+    // floor nobody chose is not protection, it is the appearance of it. The API
+    // already requires one in production; for Veda it is required everywhere,
+    // which is why this is a typed INVALID_AMOUNT rather than a silent build.
+    if (input.minSharesOut === undefined) {
+      throw new SdpVedaError(
+        "INVALID_AMOUNT",
+        "Veda deposits require minSharesOut: the vault refuses an implicit slippage tolerance, " +
+          "and SDP will not choose a floor on the caller's behalf."
+      );
+    }
+
+    const plan = await this.withRuntime(ctx, "Building the vault deposit", (runtime, config) =>
+      buildVedaDepositPlan(runtime, config, {
+        vault: address(input.providerReference),
+        owner: address(input.owner),
+        amount: input.amount,
+        minSharesOut: input.minSharesOut as string,
+      })
+    );
+    return toEarnVaultTransactionPlan(plan);
+  }
+
+  /**
+   * Live positions, read from chain per call and never persisted — positions are
+   * provider truth (ADR 0002), and for a vault-direct provider "the provider" is
+   * the chain itself.
+   *
+   * An empty reference list means every vault SDP has configured for this
+   * cluster. Veda's SDK deliberately publishes no vault discovery, and there is
+   * nothing to discover: unlike Kamino's permissionless registry, a Veda vault
+   * reaches SDP only by being named in `VEDA_DEPLOYMENTS`, so the configured
+   * shelf IS the set of vaults an owner could hold through SDP.
+   *
+   * A vault that fails to read fails the WHOLE snapshot. Returning every other
+   * vault would make the failed holding indistinguishable from no holding at
+   * all; a partial portfolio is not a truthful portfolio.
+   */
+  async readVaultPositions(
+    ctx: EarnRuntimeContext,
+    input: EarnVaultPositionInput
+  ): Promise<EarnVaultPositionSnapshot[]> {
+    return this.withRuntime(
+      ctx,
+      "Reading vault positions",
+      async (runtime, config, assertActive) => {
+        const owner = address(input.owner);
+        const readAllHoldings = input.providerReferences.length === 0;
+        const references = readAllHoldings
+          ? config.vaultStateAddresses.map(String)
+          : input.providerReferences;
+        if (references.length === 0) return [];
+
+        const results = await mapSettledWithConcurrency(
+          references,
+          VEDA_POSITION_READ_CONCURRENCY,
+          assertActive,
+          (reference) => readVedaPosition(runtime, config, { vault: address(reference), owner })
+        );
+
+        const failures = results.flatMap((result, index) =>
+          result.status === "rejected"
+            ? [{ providerReference: references[index], cause: result.reason }]
+            : []
+        );
+        if (failures.length > 0) {
+          throw new SdpVedaError(
+            "VAULT_UNREADABLE",
+            `Veda could not read ${failures.length} of ${references.length} requested vault ` +
+              "positions; refusing to return a partial portfolio.",
+            {
+              cause: new AggregateError(
+                failures.map(({ providerReference, cause }) =>
+                  cause instanceof Error
+                    ? new Error(`Veda vault ${providerReference} read failed`, { cause })
+                    : new Error(`Veda vault ${providerReference} read failed: ${String(cause)}`)
+                ),
+                "Veda vault position reads failed"
+              ),
+            }
+          );
+        }
+
+        return results.flatMap((result) => {
+          // All rejected results were handled above, so only fulfilled values can
+          // reach the serializer. Keep the guard for TypeScript's settled-result
+          // narrowing and as a defensive assertion if this block is later moved.
+          if (result.status !== "fulfilled") return [];
+          const position = result.value;
+          // A full-shelf read reports HOLDINGS; an explicitly requested vault may
+          // still return a truthful zero balance.
+          if (readAllHoldings && position.shares === "0") return [];
+          return [
+            {
+              providerReference: String(position.vault),
+              owner: String(position.owner),
+              cluster: position.cluster,
+              shares: position.shares,
+              ...(position.tokenValue === undefined ? {} : { tokenValue: position.tokenValue }),
+              tokenMint: String(position.tokenMint),
+              shareMint: String(position.shareMint),
+            },
+          ];
+        });
+      }
+    );
+  }
+}
+
+/**
+ * Guard asserted at construction rather than trusted: the two capabilities
+ * describe opposite money models, and a client answering yes to both would let a
+ * portfolio route hand a customer the vault's own account as a deposit address —
+ * where funds are destroyed. Exported so the API can assert it at registry wiring.
+ */
+export function assertNotPortfolioProvider(client: VedaVaultDirectClient): void {
+  if (supportsPortfolioWallets(client)) {
+    throw new SdpVedaError(
+      "UNSUPPORTED_VAULT",
+      "Veda must never report the portfolio-wallet capability: it custodies nothing, " +
+        "and its vault-state account is not a fundable address."
+    );
+  }
+}

--- a/packages/sdp-veda/src/errors.ts
+++ b/packages/sdp-veda/src/errors.ts
@@ -1,0 +1,116 @@
+import type { SolanaCluster } from "@sdp/types";
+
+/**
+ * Errors this package raises, mirroring `@sdp/earn/errors` in shape: a `code`
+ * the API can map to a status, and a message that says what was actually wrong.
+ *
+ * Deliberately NOT re-using `@sdp/earn`'s constructors — the same call the
+ * Kamino package makes. `@sdp/earn` owns the CATALOGUE taxonomy (HTTP statuses,
+ * provider-configured checks); this package owns a build taxonomy, and sharing
+ * constructors would make an instruction-builder failure look like a provider
+ * outage to anything matching on `SdpEarnError`.
+ */
+export type SdpVedaErrorCode =
+  /** A caller amount that is malformed, zero, over-precise, or out of range. */
+  | "INVALID_AMOUNT"
+  /** Vault, asset or position state could not be read on this cluster. */
+  | "VAULT_UNREADABLE"
+  /** An emitted instruction named a program that is not this cluster's. */
+  | "PROGRAM_MISMATCH"
+  /** SDP has no confirmed Veda deployment for the cluster in play. */
+  | "DEPLOYMENT_NOT_CONFIGURED"
+  /** The live deployment does not satisfy what SDP requires of it. */
+  | "INCOMPATIBLE_DEPLOYMENT"
+  /** The vault refuses this deposit right now (paused, capped, asset off). */
+  | "DEPOSIT_REFUSED"
+  /** The vault requires an external compliance approval SDP does not implement. */
+  | "COMPLIANCE_APPROVAL_REQUIRED"
+  /** The vault's configuration cannot be expressed by SDP's deposit contract. */
+  | "UNSUPPORTED_VAULT";
+
+export class SdpVedaError extends Error {
+  constructor(
+    readonly code: SdpVedaErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = "SdpVedaError";
+  }
+}
+
+/**
+ * A caller-supplied amount that is not a decimal string, is negative, or is
+ * zero. Raised BEFORE any RPC call — an unparseable amount is a programming
+ * error on the caller's side and must never reach the chain.
+ */
+export function invalidAmount(field: string, value: string): SdpVedaError {
+  return new SdpVedaError(
+    "INVALID_AMOUNT",
+    `Veda ${field} must be a positive decimal string; received ${JSON.stringify(value)}`
+  );
+}
+
+/**
+ * A caller-supplied amount that is finer than the mint can represent.
+ *
+ * Distinct from `invalidAmount` because the value IS a well-formed decimal — it
+ * simply carries more places than the mint has atoms. Veda's SDK takes atomic
+ * `bigint`s, so SDP does the conversion, and the only two options at the
+ * boundary are refuse or round. Rounding is the dangerous one: a deposit of
+ * `1.0000009` on a six-decimal mint would be RECORDED as 1.0000009 while
+ * 1.000000 moved, and a `minSharesOut` rounded below one atom becomes `0` — a
+ * slippage floor that reads as protection everywhere and imposes none on chain.
+ */
+export function amountTooPrecise(field: string, value: string, decimals: number): SdpVedaError {
+  return new SdpVedaError(
+    "INVALID_AMOUNT",
+    `Veda ${field} ${JSON.stringify(value)} has more precision than its mint supports ` +
+      `(${decimals} decimals). Encoding it would move a different amount than was requested.`
+  );
+}
+
+/** A decimal whose mint-scaled integer cannot fit Veda's on-chain u64 field. */
+export function amountOutOfRange(field: string, value: string): SdpVedaError {
+  return new SdpVedaError(
+    "INVALID_AMOUNT",
+    `Veda ${field} ${JSON.stringify(value)} exceeds the maximum unsigned 64-bit base-unit amount`
+  );
+}
+
+/**
+ * SDP has no confirmed Veda deployment for this cluster.
+ *
+ * Not an outage and not a bug: `VEDA_DEPLOYMENTS` in `@sdp/types` is empty
+ * until Veda confirms its program and vault-state addresses per cluster, and
+ * building against an unverified address is the failure this refuses to risk.
+ */
+export function deploymentNotConfigured(cluster: SolanaCluster): SdpVedaError {
+  return new SdpVedaError(
+    "DEPLOYMENT_NOT_CONFIGURED",
+    `SDP has no confirmed Veda deployment for ${cluster}. Add its program and vault-state ` +
+      "addresses to @sdp/types/veda-programs once Veda confirms them."
+  );
+}
+
+/**
+ * The vault account could not be read on this cluster.
+ *
+ * The likeliest cause is the RPC pointing at the wrong chain. Veda's
+ * integration material implies devnet and mainnet may share program addresses,
+ * so a cluster mismatch does not present as a connection error — it presents as
+ * "this vault does not exist", or worse, as a different chain's vault at the
+ * same address. The message names both so the reader checks the right thing.
+ */
+export function vaultUnreadable(
+  vault: string,
+  cluster: SolanaCluster,
+  cause: unknown
+): SdpVedaError {
+  return new SdpVedaError(
+    "VAULT_UNREADABLE",
+    `Veda vault ${vault} could not be read on ${cluster}. Check that the RPC endpoint serves ` +
+      "that cluster — a mismatched RPC reports a missing vault, not a connection error.",
+    { cause }
+  );
+}

--- a/packages/sdp-veda/src/guards.test.ts
+++ b/packages/sdp-veda/src/guards.test.ts
@@ -1,0 +1,106 @@
+import type { VedaDeployment } from "@sdp/types/veda-programs";
+import { address, type Instruction } from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import {
+  assertPlanTargetsCluster,
+  planInstructionCount,
+  planProgramAddresses,
+  VedaProgramMismatchError,
+} from "./guards";
+import { toClusterConfig } from "./programs";
+import type { VedaInstructionPlan } from "./types";
+
+const VAULT_PROGRAM = "5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc";
+const QUEUE_PROGRAM = "Cchro8d7bN5Xfk77z9hJKxREJwSAjpz5K2seK4iNN396";
+const HOOK_PROGRAM = "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9";
+const OTHER_PROGRAM = "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd";
+const SOME_MINT = "So11111111111111111111111111111111111111112";
+
+const DEPLOYMENT: VedaDeployment = {
+  vaultProgramAddress: VAULT_PROGRAM,
+  queueProgramAddress: QUEUE_PROGRAM,
+  hookProgramAddress: HOOK_PROGRAM,
+  vaultStateAddresses: [SOME_MINT],
+};
+const config = toClusterConfig("devnet", DEPLOYMENT);
+
+function instruction(programAddress: string): Instruction {
+  return {
+    programAddress: address(programAddress),
+    accounts: [],
+    data: new Uint8Array([1, 2, 3]),
+  } as unknown as Instruction;
+}
+
+function plan(...programs: string[]): VedaInstructionPlan {
+  return {
+    cluster: "devnet",
+    instructions: [programs.map(instruction)],
+    lookupTables: [],
+    assetIdentity: { depositTokenMint: address(SOME_MINT), shareMint: address(SOME_MINT) },
+    accepted: { amount: "1", minSharesOut: "1" },
+  };
+}
+
+describe("assertPlanTargetsCluster", () => {
+  it("passes a plan built entirely from this deployment's programs", () => {
+    const built = plan(VAULT_PROGRAM, "11111111111111111111111111111111");
+    expect(assertPlanTargetsCluster(built, config)).toBe(built);
+  });
+
+  /**
+   * THE CHECK THIS PACKAGE EXISTS TO MAKE. Construction passes explicit program
+   * addresses to the SDK, but that is a convention inside one function; this is
+   * a property of what is actually EMITTED, and only the second survives an SDK
+   * upgrade that derives or defaults an address internally.
+   */
+  it("refuses an instruction addressed to a program this deployment never named", () => {
+    expect(() => assertPlanTargetsCluster(plan(VAULT_PROGRAM, OTHER_PROGRAM), config)).toThrow(
+      VedaProgramMismatchError
+    );
+  });
+
+  it("names the offending program and the cluster in the failure", () => {
+    try {
+      assertPlanTargetsCluster(plan(OTHER_PROGRAM), config);
+      expect.unreachable("expected a program mismatch");
+    } catch (error) {
+      expect(error).toBeInstanceOf(VedaProgramMismatchError);
+      expect((error as VedaProgramMismatchError).offendingProgram).toBe(OTHER_PROGRAM);
+      expect((error as VedaProgramMismatchError).code).toBe("PROGRAM_MISMATCH");
+      expect((error as Error).message).toContain("devnet");
+    }
+  });
+
+  it("checks every batch, not only the first", () => {
+    const multi: VedaInstructionPlan = {
+      ...plan(VAULT_PROGRAM),
+      instructions: [[instruction(VAULT_PROGRAM)], [instruction(OTHER_PROGRAM)]],
+    };
+    expect(() => assertPlanTargetsCluster(multi, config)).toThrow(VedaProgramMismatchError);
+  });
+
+  it("refuses a queue instruction when the deployment declares no queue", () => {
+    const { queueProgramAddress: _omitted, ...noQueue } = DEPLOYMENT;
+    expect(() =>
+      assertPlanTargetsCluster(plan(QUEUE_PROGRAM), toClusterConfig("devnet", noQueue))
+    ).toThrow(VedaProgramMismatchError);
+  });
+});
+
+describe("plan inspection helpers", () => {
+  it("counts instructions across every batch", () => {
+    const multi: VedaInstructionPlan = {
+      ...plan(VAULT_PROGRAM),
+      instructions: [[instruction(VAULT_PROGRAM)], [instruction(VAULT_PROGRAM)]],
+    };
+    expect(planInstructionCount(multi)).toBe(2);
+  });
+
+  it("reports each distinct program once", () => {
+    const built = plan(VAULT_PROGRAM, VAULT_PROGRAM, HOOK_PROGRAM);
+    expect(planProgramAddresses(built).map(String).sort()).toEqual(
+      [HOOK_PROGRAM, VAULT_PROGRAM].sort()
+    );
+  });
+});

--- a/packages/sdp-veda/src/guards.ts
+++ b/packages/sdp-veda/src/guards.ts
@@ -1,0 +1,73 @@
+import type { Address, Instruction } from "@solana/kit";
+import { SdpVedaError } from "./errors";
+import { type VedaClusterConfig, vedaProgramAllowlist } from "./programs";
+import type { VedaInstructionPlan } from "./types";
+
+export class VedaProgramMismatchError extends SdpVedaError {
+  constructor(
+    readonly cluster: string,
+    readonly offendingProgram: string
+  ) {
+    super(
+      "PROGRAM_MISMATCH",
+      `Veda instruction targets ${offendingProgram}, which is not a program this ${cluster} ` +
+        "deployment may emit. See @sdp/veda/programs for the allowlist."
+    );
+    this.name = "VedaProgramMismatchError";
+  }
+}
+
+/**
+ * Refuse a plan whose instructions name a program outside this cluster's
+ * deployment. **The most important check in this package.**
+ *
+ * Why it exists, and why it is not redundant with passing explicit addresses to
+ * the SDK client:
+ *
+ * - Veda's own integration material implies devnet and mainnet may share
+ *   program addresses. If that is true, nothing about an emitted instruction
+ *   distinguishes the two, and the ONLY defence against building for the wrong
+ *   chain is the genesis proof upstream. If it is NOT true — or stops being
+ *   true — this is the check that notices, because the addresses come from a
+ *   per-cluster table and the instruction has to match the one in play.
+ * - `createVedaClient` takes program addresses at runtime, but a future SDK
+ *   revision that derives or defaults one internally would emit an address this
+ *   package never supplied. Construction is a convention inside one function;
+ *   this is a property of the OUTPUT, and only the second survives an upgrade
+ *   that reshuffles construction. Kamino's package learned that the hard way —
+ *   its SDK's ordinary constructor binds a program id to READS only.
+ *
+ * `sdk-construction.test.ts` greps this package's own source to assert every
+ * builder routes through here, because that fact is invisible to the type
+ * checker.
+ */
+export function assertPlanTargetsCluster(
+  plan: VedaInstructionPlan,
+  config: VedaClusterConfig
+): VedaInstructionPlan {
+  const allowed = vedaProgramAllowlist(config);
+  for (const batch of plan.instructions) {
+    for (const instruction of batch) {
+      const program = String(instruction.programAddress);
+      if (allowed.has(program)) continue;
+      throw new VedaProgramMismatchError(plan.cluster, program);
+    }
+  }
+  return plan;
+}
+
+/** Every distinct program a plan touches — useful for Kora allowlist assertions. */
+export function planProgramAddresses(plan: VedaInstructionPlan): readonly Address[] {
+  const seen = new Set<Address>();
+  for (const batch of plan.instructions) {
+    for (const instruction of batch as readonly Instruction[]) {
+      seen.add(instruction.programAddress);
+    }
+  }
+  return [...seen];
+}
+
+/** Flatten a plan for callers that genuinely want one transaction's worth. */
+export function planInstructionCount(plan: VedaInstructionPlan): number {
+  return plan.instructions.reduce((total, batch) => total + batch.length, 0);
+}

--- a/packages/sdp-veda/src/idl-layout.test.ts
+++ b/packages/sdp-veda/src/idl-layout.test.ts
@@ -1,0 +1,245 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  VEDA_ASSET_DATA_DISCRIMINATOR,
+  VEDA_ASSET_DATA_LAYOUT,
+  VEDA_BORING_VAULT_DISCRIMINATOR,
+  VEDA_BORING_VAULT_LAYOUT,
+  VEDA_BORING_VAULT_SIZE,
+} from "@sdp/earn/providers/veda/vault-state";
+import { describe, expect, it } from "vitest";
+
+/**
+ * ════════════════════════════════════════════════════════════════════════════
+ *  THE GUARD THAT MAKES `@sdp/earn`'s HAND-WRITTEN OFFSET TABLE FALSIFIABLE.
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ * `@sdp/earn` decodes Veda vault state positionally, because it may not depend
+ * on a chain SDK — its only dependency is `@sdp/types` and it runs the hourly
+ * catalogue cron. A hand-maintained offset table that nothing can contradict is
+ * how a silent ABI change becomes a silently wrong share mint on a customer's
+ * strategy row.
+ *
+ * This package is the one that CAN contradict it: it holds Veda's published
+ * Anchor IDLs, so the layout is recomputed here from the IDL's own field order
+ * and compared field by field. It also compares the committed IDLs against the
+ * SDK's shipped copies and their recorded SHA-256s, so "the IDL says so" cannot
+ * quietly mean "the IDL we committed months ago says so".
+ *
+ * If Veda changes the ABI, this test fails on the next `pnpm install` — before
+ * anything reads a wrong offset off a live account.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const IDL_DIR = join(HERE, "..", "idl");
+
+type IdlType = string | { array: [IdlType, number] } | { defined: { name: string } };
+interface IdlField {
+  name: string;
+  type: IdlType;
+}
+interface IdlTypeDef {
+  name: string;
+  type:
+    | { kind: "struct"; fields: IdlField[] }
+    | { kind: "enum"; variants: { name: string; fields?: unknown[] }[] };
+}
+interface Idl {
+  types: IdlTypeDef[];
+  accounts: { name: string; discriminator: number[] }[];
+}
+
+const PRIMITIVE_SIZES: Readonly<Record<string, number>> = {
+  bool: 1,
+  u8: 1,
+  i8: 1,
+  u16: 2,
+  i16: 2,
+  u32: 4,
+  i32: 4,
+  f32: 4,
+  u64: 8,
+  i64: 8,
+  f64: 8,
+  u128: 16,
+  i128: 16,
+  pubkey: 32,
+};
+
+function loadIdl(name: string): Idl {
+  return JSON.parse(readFileSync(join(IDL_DIR, `${name}.json`), "utf8")) as Idl;
+}
+
+const vaultIdl = loadIdl("boring_vault_svm");
+const typesByName = new Map(vaultIdl.types.map((entry) => [entry.name, entry.type]));
+
+function sizeOf(type: IdlType): number {
+  if (typeof type === "string") {
+    const size = PRIMITIVE_SIZES[type];
+    if (size === undefined) throw new Error(`unsupported IDL primitive ${type}`);
+    return size;
+  }
+  if ("array" in type) return sizeOf(type.array[0]) * type.array[1];
+  return sizeOfTypeDef(type.defined.name);
+}
+
+function sizeOfTypeDef(name: string): number {
+  const definition = typesByName.get(name);
+  if (!definition) throw new Error(`unknown IDL type ${name}`);
+  if (definition.kind === "struct") {
+    return definition.fields.reduce((total, field) => total + sizeOf(field.type), 0);
+  }
+  // A fieldless Borsh enum is one byte. A data-carrying one is variable, which
+  // would make the whole account unsizeable — worth failing loudly on.
+  if (definition.variants.some((variant) => variant.fields)) {
+    throw new Error(`${name} is a data-carrying enum and has no fixed size`);
+  }
+  return 1;
+}
+
+/** camelCase, matching how the offset table names the same fields. */
+function camel(value: string): string {
+  return value.replace(/_([a-z0-9])/g, (_match, char: string) => char.toUpperCase());
+}
+
+/**
+ * Flatten a struct into `[dottedName, offset]`, Borsh-style with no padding.
+ *
+ * STOPS at the first field whose size cannot be computed — `AssetData` ends in
+ * a data-carrying `OracleSource` enum, and every field after it has no fixed
+ * offset either. Stopping rather than throwing is what lets this derive the
+ * fixed PREFIX that `@sdp/earn` actually reads.
+ */
+function flatten(typeName: string, prefix = "", start = 0): [string, number][] {
+  const definition = typesByName.get(typeName);
+  if (definition?.kind !== "struct") throw new Error(`${typeName} is not a struct`);
+  const entries: [string, number][] = [];
+  let offset = start;
+  for (const field of definition.fields) {
+    const name = `${prefix}${camel(field.name)}`;
+    const nested =
+      typeof field.type === "object" && "defined" in field.type
+        ? typesByName.get(field.type.defined.name)
+        : undefined;
+    let size: number;
+    try {
+      size = sizeOf(field.type);
+    } catch {
+      break;
+    }
+    if (nested?.kind === "struct") {
+      entries.push(
+        ...flatten((field.type as { defined: { name: string } }).defined.name, `${name}.`, offset)
+      );
+    } else {
+      entries.push([name, offset]);
+    }
+    offset += size;
+  }
+  return entries;
+}
+
+/**
+ * The SDK's package root, found by walking up from its resolved entry point.
+ *
+ * `import.meta.resolve` rather than `require.resolve`: the SDK is ESM-only and
+ * its `exports` map declares just `"."` with an `import` condition, so a CJS
+ * resolver reaches neither the entry point nor `package.json`.
+ */
+function resolveSdkRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.resolve("@vedatech/svm-sdk")));
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (existsSync(join(dir, "programs.lock.json"))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error("could not locate the @vedatech/svm-sdk package root");
+}
+
+describe("the committed IDLs are Veda's own", () => {
+  /**
+   * The SDK ships the same IDLs plus a `programs.lock.json` recording the
+   * source commit and a SHA-256 per file. Comparing against BOTH means a
+   * committed IDL cannot drift from the SDK version this package pins, and the
+   * SDK's own copy cannot have been altered relative to what it recorded.
+   */
+  it("matches the SDK's shipped copies, byte for byte and by recorded hash", () => {
+    const sdkDir = resolveSdkRoot();
+    const lock = JSON.parse(readFileSync(join(sdkDir, "programs.lock.json"), "utf8")) as {
+      programs: Record<string, { idl: string; sha256: string }>;
+    };
+
+    expect(Object.keys(lock.programs).sort()).toEqual([
+      "boring_onchain_queue",
+      "boring_vault_svm",
+      "hook_program",
+    ]);
+
+    for (const [name, entry] of Object.entries(lock.programs)) {
+      const committed = readFileSync(join(IDL_DIR, `${name}.json`));
+      const shipped = readFileSync(join(sdkDir, entry.idl));
+      expect(committed.equals(shipped), `${name}.json differs from the SDK's copy`).toBe(true);
+      expect(createHash("sha256").update(committed).digest("hex"), name).toBe(entry.sha256);
+    }
+  });
+});
+
+describe("@sdp/earn's BoringVault offsets match the IDL", () => {
+  const expected = new Map(flatten("BoringVault", "", 8));
+
+  it("agrees on the account's total size", () => {
+    const total = 8 + sizeOfTypeDef("BoringVault");
+    expect(VEDA_BORING_VAULT_SIZE).toBe(total);
+    // Pinned as a literal too: a table that lost a field AND a derivation that
+    // lost the same field would otherwise agree with each other.
+    expect(total).toBe(512);
+  });
+
+  it("agrees on every offset the catalogue reads", () => {
+    const derived: Record<string, number | undefined> = {};
+    const declared: Record<string, number> = {};
+    for (const [name, offset] of Object.entries(VEDA_BORING_VAULT_LAYOUT.offsets)) {
+      if (name === "discriminator") continue;
+      declared[name] = offset;
+      derived[name] = expected.get(name);
+    }
+    expect(derived).toEqual(declared);
+  });
+
+  it("places the discriminator first", () => {
+    expect(VEDA_BORING_VAULT_LAYOUT.offsets.discriminator).toBe(0);
+  });
+
+  it("uses the IDL's own account discriminator", () => {
+    const account = vaultIdl.accounts.find((entry) => entry.name === "BoringVault");
+    expect([...VEDA_BORING_VAULT_DISCRIMINATOR]).toEqual(account?.discriminator);
+  });
+});
+
+describe("@sdp/earn's AssetData offsets match the IDL", () => {
+  const expected = new Map(flatten("AssetData", "", 8));
+
+  it("agrees on every offset in the fixed prefix", () => {
+    for (const [name, offset] of Object.entries(VEDA_ASSET_DATA_LAYOUT.offsets)) {
+      if (name === "discriminator") continue;
+      expect(expected.get(name), name).toBe(offset);
+    }
+  });
+
+  /**
+   * The table stops before `oracle_source`, a data-carrying enum whose variants
+   * differ in size. That is why `AssetData` is length-checked as a MINIMUM
+   * rather than an exact size — asserted here so nobody "fixes" it into an
+   * equality check.
+   */
+  it("stops before the variable-length tail", () => {
+    expect(() => sizeOfTypeDef("AssetData")).toThrow(/no fixed size/);
+    expect(Object.keys(VEDA_ASSET_DATA_LAYOUT.offsets)).not.toContain("oracleSource");
+  });
+
+  it("uses the IDL's own account discriminator", () => {
+    const account = vaultIdl.accounts.find((entry) => entry.name === "AssetData");
+    expect([...VEDA_ASSET_DATA_DISCRIMINATOR]).toEqual(account?.discriminator);
+  });
+});

--- a/packages/sdp-veda/src/index.ts
+++ b/packages/sdp-veda/src/index.ts
@@ -1,0 +1,66 @@
+/**
+ * `@sdp/veda` — kit-native deposit instruction building and position reads for
+ * Veda's SVM vaults, over the private `@vedatech/svm-sdk`.
+ *
+ * Scope: this package BUILDS unsigned instruction plans and READS positions. It
+ * never signs, never submits, never touches a database, and holds no runtime
+ * credential — Veda's vaults are reached entirely on chain, and the npm token
+ * that fetches its SDK is a BUILD credential that no deployment ever sees.
+ * Signing and submission belong to the API, which owns custody.
+ *
+ * Three invariants make it safe to use:
+ *
+ * - **A closed dependency boundary.** `@vedatech/svm-sdk` (built against
+ *   `@solana/kit` 7, while this repo pins 6.8) is confined to `./sdk.ts`.
+ *   Everything crossing this module's surface is `@solana/kit` 6.8,
+ *   `@sdp/types`, or a decimal string.
+ * - **Cluster binding, checked on the OUTPUT.** Every emitted plan is re-checked
+ *   against a per-cluster program allowlist. Veda's integration material implies
+ *   its devnet and mainnet deployments may share addresses, so nothing about an
+ *   instruction distinguishes them — the genesis proof upstream and this
+ *   allowlist are the whole defence.
+ * - **Money in requires a way out.** A deposit build refuses a deployment whose
+ *   withdrawal queue is not configured and wired to the vault (ADR 0002).
+ *
+ * See `packages/sdp-veda/CLAUDE.md` for the traps and the open questions.
+ */
+
+export { acceptAtMintScale, acceptPositiveAtMintScale, mintDecimals } from "./amounts";
+export {
+  assertNotPortfolioProvider,
+  toEarnVaultTransactionPlan,
+  VEDA_POSITION_READ_CONCURRENCY,
+  VedaVaultDirectClient,
+  type VedaVaultOperationRunner,
+} from "./client";
+export { SdpVedaError, type SdpVedaErrorCode } from "./errors";
+export {
+  assertPlanTargetsCluster,
+  planInstructionCount,
+  planProgramAddresses,
+  VedaProgramMismatchError,
+} from "./guards";
+export {
+  toClusterConfig,
+  type VedaClusterConfig,
+  vedaClusterConfig,
+  vedaProgramAllowlist,
+} from "./programs";
+export { createVedaRpc, VEDA_RPC_REQUEST_TIMEOUT_MS, withVedaRpcTimeout } from "./rpc";
+export {
+  assertVedaVaultUsable,
+  buildVedaDepositPlan,
+  mapVedaSdkError,
+  readVedaPosition,
+  resetVedaCompatibilityCache,
+  VEDA_COMPATIBILITY_TTL_MS,
+} from "./sdk";
+export type {
+  VedaAcceptedAmounts,
+  VedaDepositInput,
+  VedaInstructionPlan,
+  VedaPosition,
+  VedaPositionInput,
+  VedaRuntime,
+  VedaVaultAssetIdentity,
+} from "./types";

--- a/packages/sdp-veda/src/mint.ts
+++ b/packages/sdp-veda/src/mint.ts
@@ -1,0 +1,45 @@
+import type { Address } from "@solana/kit";
+import { mintDecimals } from "./amounts";
+import { SdpVedaError } from "./errors";
+import { createVedaRpc } from "./rpc";
+
+/**
+ * A mint's decimals, read from the chain.
+ *
+ * Deliberately NOT taken from `WELL_KNOWN_TOKEN_BY_MINT`, even though every
+ * mint SDP fronts for Veda is in it. That catalogue is SDP's own metadata; the
+ * number that decides how many atoms a decimal string becomes has to be the
+ * mint's own, or a stale catalogue entry would move a different amount than the
+ * one requested. Same reasoning as `@sdp/kamino` reading `tokenMintDecimals`
+ * off live vault state rather than trusting a catalogue row.
+ *
+ * Outside `./sdk.ts` because it needs no Veda SDK — just this repo's kit — so
+ * it stays unit-testable without loading the SDK or its nested `@solana/kit` 7.
+ */
+export async function readMintDecimals(rpcUrl: string, mint: Address): Promise<number> {
+  const rpc = createVedaRpc(rpcUrl);
+  let account: unknown;
+  try {
+    account = (await rpc.getAccountInfo(mint, { encoding: "jsonParsed" }).send())?.value;
+  } catch (cause) {
+    throw new SdpVedaError("VAULT_UNREADABLE", `Veda could not read the mint ${mint}`, { cause });
+  }
+  if (!account) {
+    throw new SdpVedaError("VAULT_UNREADABLE", `Veda deposit mint ${mint} does not exist`);
+  }
+
+  const parsed = (account as { data?: { parsed?: { info?: { decimals?: unknown } } } }).data?.parsed
+    ?.info?.decimals;
+  try {
+    return mintDecimals(parsed, `deposit mint ${mint} decimals`);
+  } catch (cause) {
+    // A mint account the RPC could not parse is not a mint SDP should spend
+    // against: without its scale there is no honest conversion from a decimal
+    // string to the atoms the instruction encodes.
+    throw new SdpVedaError(
+      "VAULT_UNREADABLE",
+      `Veda deposit mint ${mint} did not report a usable decimal count`,
+      { cause }
+    );
+  }
+}

--- a/packages/sdp-veda/src/programs.test.ts
+++ b/packages/sdp-veda/src/programs.test.ts
@@ -1,0 +1,94 @@
+import { type VedaDeployment, vedaDeployment } from "@sdp/types/veda-programs";
+import { describe, expect, it } from "vitest";
+import { toClusterConfig, vedaClusterConfig, vedaProgramAllowlist } from "./programs";
+
+const VAULT_PROGRAM = "5J76xGGXn5op9S48pMqWV6Ex48ZxsKsRs4bGeDzSHEVc";
+const QUEUE_PROGRAM = "Cchro8d7bN5Xfk77z9hJKxREJwSAjpz5K2seK4iNN396";
+const HOOK_PROGRAM = "FSZPGBfPWb6fUQWSwiKv8de55NabpBWgPmB6RV7kDgv9";
+const VAULT_STATE = "So11111111111111111111111111111111111111112";
+
+const DEPLOYMENT: VedaDeployment = {
+  vaultProgramAddress: VAULT_PROGRAM,
+  queueProgramAddress: QUEUE_PROGRAM,
+  hookProgramAddress: HOOK_PROGRAM,
+  vaultStateAddresses: [VAULT_STATE],
+};
+
+describe("vedaClusterConfig", () => {
+  /**
+   * SDP has no confirmed Veda deployment on either cluster, so every build and
+   * every position read fails closed. This is the state that changes — with
+   * Veda's written confirmation — when `VEDA_DEPLOYMENTS` is filled in.
+   */
+  it("refuses a cluster SDP has no confirmed deployment for", () => {
+    expect(vedaDeployment("devnet")).toBeNull();
+    expect(vedaDeployment("mainnet-beta")).toBeNull();
+    for (const cluster of ["devnet", "mainnet-beta"] as const) {
+      expect(() => vedaClusterConfig(cluster)).toThrow(/no confirmed Veda deployment/);
+    }
+  });
+});
+
+describe("toClusterConfig", () => {
+  it("brands every address and carries the cluster", () => {
+    const config = toClusterConfig("devnet", DEPLOYMENT);
+    expect(config.cluster).toBe("devnet");
+    expect(String(config.vaultProgramAddress)).toBe(VAULT_PROGRAM);
+    expect(String(config.queueProgramAddress)).toBe(QUEUE_PROGRAM);
+    expect(String(config.hookProgramAddress)).toBe(HOOK_PROGRAM);
+    expect(config.vaultStateAddresses.map(String)).toEqual([VAULT_STATE]);
+  });
+
+  it("omits the queue when a deployment declares none", () => {
+    const { queueProgramAddress: _omitted, ...noQueue } = DEPLOYMENT;
+    expect(toClusterConfig("devnet", noQueue).queueProgramAddress).toBeUndefined();
+  });
+
+  /**
+   * A malformed address must fail HERE, at configuration time, rather than
+   * inside the SDK after several RPC round trips — or worse, as an instruction
+   * addressed somewhere unintended.
+   */
+  it("refuses an address that is not valid base58", () => {
+    expect(() =>
+      toClusterConfig("devnet", { ...DEPLOYMENT, vaultProgramAddress: "not-an-address" })
+    ).toThrow(/not a valid Solana address/);
+  });
+});
+
+describe("vedaProgramAllowlist", () => {
+  const config = toClusterConfig("devnet", DEPLOYMENT);
+  const allowed = vedaProgramAllowlist(config);
+
+  it("admits this deployment's own programs", () => {
+    for (const program of [VAULT_PROGRAM, QUEUE_PROGRAM, HOOK_PROGRAM]) {
+      expect(allowed.has(program)).toBe(true);
+    }
+  });
+
+  it("admits the cluster-invariant programs a deposit actually touches", () => {
+    for (const program of [
+      "11111111111111111111111111111111",
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+      "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    ]) {
+      expect(allowed.has(program), program).toBe(true);
+    }
+  });
+
+  /**
+   * A CLOSED set, not a denylist: the failure being guarded against is an
+   * instruction quietly addressed to something this deployment never named,
+   * and only enumerating what is permitted catches that.
+   */
+  it("admits nothing else", () => {
+    expect(allowed.has("KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd")).toBe(false);
+    expect(allowed.has(VAULT_STATE)).toBe(false);
+  });
+
+  it("does not admit a queue the deployment does not declare", () => {
+    const { queueProgramAddress: _omitted, ...noQueue } = DEPLOYMENT;
+    expect(vedaProgramAllowlist(toClusterConfig("devnet", noQueue)).has(QUEUE_PROGRAM)).toBe(false);
+  });
+});

--- a/packages/sdp-veda/src/programs.ts
+++ b/packages/sdp-veda/src/programs.ts
@@ -1,0 +1,116 @@
+import type { SolanaCluster } from "@sdp/types";
+import { type VedaDeployment, vedaDeployment } from "@sdp/types/veda-programs";
+import { type Address, address } from "@solana/kit";
+import { deploymentNotConfigured, SdpVedaError } from "./errors";
+
+/**
+ * Veda's per-cluster deployment, as `@solana/kit` addresses.
+ *
+ * The address TABLE lives in `@sdp/types/veda-programs` because `@sdp/earn`
+ * needs it too for the catalogue read and may not depend on this package (see
+ * that file's header). This module is the thin typing layer: it turns those
+ * strings into branded `Address`es and refuses a deployment that cannot be used.
+ */
+export interface VedaClusterConfig {
+  cluster: SolanaCluster;
+  vaultProgramAddress: Address;
+  /** Absent when this deployment has no withdrawal queue. */
+  queueProgramAddress?: Address;
+  hookProgramAddress: Address;
+  vaultStateAddresses: readonly Address[];
+}
+
+function toAddress(field: string, value: string): Address {
+  try {
+    return address(value);
+  } catch (cause) {
+    throw new SdpVedaError(
+      "INCOMPATIBLE_DEPLOYMENT",
+      `Veda deployment ${field} ${JSON.stringify(value)} is not a valid Solana address`,
+      { cause }
+    );
+  }
+}
+
+/**
+ * The programs Veda runs under on one cluster.
+ *
+ * Takes a CLUSTER, never an `SdpEnvironment`. Callers holding an environment
+ * convert with `CLUSTER_BY_SDP_ENVIRONMENT` (`@sdp/types`) at the boundary —
+ * this package refuses to make that leap itself, because "environment implies
+ * cluster" is the assumption migration 0057 and `host_cluster` exist to stop.
+ *
+ * Throws rather than returning null: every caller here is about to build or
+ * read against these addresses, and there is no useful degraded behaviour.
+ */
+export function vedaClusterConfig(cluster: SolanaCluster): VedaClusterConfig {
+  const deployment = vedaDeployment(cluster);
+  if (!deployment) throw deploymentNotConfigured(cluster);
+  return toClusterConfig(cluster, deployment);
+}
+
+/**
+ * The same conversion against an explicitly supplied deployment.
+ *
+ * Exported so tests can exercise the whole builder against a deployment SDP
+ * does not yet have — `VEDA_DEPLOYMENTS` is empty until Veda confirms
+ * addresses, and the builder is the half that must already be right when they
+ * do.
+ */
+export function toClusterConfig(
+  cluster: SolanaCluster,
+  deployment: VedaDeployment
+): VedaClusterConfig {
+  const queue = deployment.queueProgramAddress;
+  return {
+    cluster,
+    vaultProgramAddress: toAddress("vaultProgramAddress", deployment.vaultProgramAddress),
+    ...(queue === undefined
+      ? {}
+      : { queueProgramAddress: toAddress("queueProgramAddress", queue) }),
+    hookProgramAddress: toAddress("hookProgramAddress", deployment.hookProgramAddress),
+    vaultStateAddresses: deployment.vaultStateAddresses.map((value) =>
+      toAddress("vaultStateAddresses", value)
+    ),
+  };
+}
+
+/**
+ * Programs that are the same on every cluster and may appear in a plan without
+ * being cluster-specific: system, both token programs, the ATA program, memo,
+ * compute budget, and the Ed25519 verifier a compliance approval rides on.
+ *
+ * Listed explicitly rather than skipped, so the allowlist stays a CLOSED set —
+ * an unexpected program is a finding, not noise.
+ */
+const CLUSTER_INVARIANT_PROGRAMS: readonly string[] = [
+  "11111111111111111111111111111111",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+  "ComputeBudget111111111111111111111111111111",
+  // biome-ignore lint/security/noSecrets: a public Solana program address, not a credential
+  "Ed25519SigVerify111111111111111111111111111",
+];
+
+/**
+ * Every program address a plan for this cluster may legitimately name.
+ *
+ * An ALLOWLIST rather than a denylist, because the failure being guarded
+ * against is an instruction quietly addressed to the OTHER cluster's
+ * deployment, and enumerating what is permitted is the only robust way to catch
+ * that. Cluster-invariant programs are added here rather than skipped by the
+ * guard, so the set is complete and readable in one place.
+ */
+export function vedaProgramAllowlist(config: VedaClusterConfig): ReadonlySet<string> {
+  const allowed = new Set<string>(CLUSTER_INVARIANT_PROGRAMS);
+  allowed.add(String(config.vaultProgramAddress));
+  allowed.add(String(config.hookProgramAddress));
+  if (config.queueProgramAddress) allowed.add(String(config.queueProgramAddress));
+  return allowed;
+}

--- a/packages/sdp-veda/src/rpc.ts
+++ b/packages/sdp-veda/src/rpc.ts
@@ -1,0 +1,51 @@
+import {
+  createDefaultRpcTransport,
+  createSolanaRpcFromTransport,
+  type RpcTransport,
+} from "@solana/kit";
+
+/**
+ * Maximum time a single Veda RPC request may hold a worker open.
+ *
+ * Applied at the TRANSPORT boundary, not only to the reads this package issues
+ * directly: `@vedatech/svm-sdk` receives this same client, so its vault, asset,
+ * oracle, mint and position reads are bounded too. A deposit build fans out
+ * over several of those, and an unbounded one would let a slow node hold an API
+ * worker for as long as it liked.
+ */
+export const VEDA_RPC_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Package-local so the SDK gets a deadline without a new workspace dependency edge. */
+export function withVedaRpcTimeout(
+  transport: RpcTransport,
+  timeoutMs = VEDA_RPC_REQUEST_TIMEOUT_MS
+): RpcTransport {
+  return async <TResponse>(config: Parameters<RpcTransport>[0]) => {
+    const controller = new AbortController();
+    // A distinct reason lets the catch path tell our deadline from a caller
+    // cancellation even if both signals abort before the transport rejects.
+    const deadlineReason = new Error("Veda RPC deadline elapsed");
+    const timer = setTimeout(() => controller.abort(deadlineReason), timeoutMs);
+    const signal = config.signal
+      ? AbortSignal.any([config.signal, controller.signal])
+      : controller.signal;
+    try {
+      return await transport<TResponse>({ ...config, signal });
+    } catch (cause) {
+      if (signal.aborted && signal.reason === deadlineReason) {
+        // "timed out" deliberately matches the API's transient-error
+        // classifier: a deadline is retryable, never a permanent vault fact.
+        throw new Error(`Veda RPC request timed out after ${timeoutMs}ms`, { cause });
+      }
+      throw cause;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/** One deadline-aware RPC client shared by this package and the pinned SDK. */
+export function createVedaRpc(rpcUrl: string, timeoutMs = VEDA_RPC_REQUEST_TIMEOUT_MS) {
+  const transport = createDefaultRpcTransport({ url: rpcUrl });
+  return createSolanaRpcFromTransport(withVedaRpcTimeout(transport, timeoutMs));
+}

--- a/packages/sdp-veda/src/sdk-construction.test.ts
+++ b/packages/sdp-veda/src/sdk-construction.test.ts
@@ -1,0 +1,127 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+const sourceFiles = readdirSync(SRC).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+const read = (file: string) => readFileSync(join(SRC, file), "utf8");
+
+/**
+ * Structural tests over this package's own source.
+ *
+ * Every property below is invisible to the type checker AND to any runtime
+ * assertion — each is a fact about how the code is WRITTEN, and each guards a
+ * failure that is silent in production. A source grep is the honest tool.
+ */
+
+/**
+ * Match a real module IMPORT, not a mention. The doc comments in `index.ts` and
+ * `types.ts` name the SDK deliberately — explaining the boundary is the point —
+ * so a naive substring scan flags exactly the files that document the rule.
+ */
+function importsModule(body: string, moduleName: string): boolean {
+  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:from|import|require\\()\\s*["']${escaped}["']`).test(body);
+}
+
+describe("the @vedatech/svm-sdk firewall", () => {
+  it("confines the SDK import to sdk.ts", () => {
+    const offenders = sourceFiles.filter(
+      (file) => file !== "sdk.ts" && importsModule(read(file), "@vedatech/svm-sdk")
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the SDK out of the package's public entry point", () => {
+    expect(importsModule(read("index.ts"), "@vedatech/svm-sdk")).toBe(false);
+  });
+
+  it("still detects a real import — the guard is not vacuous", () => {
+    expect(importsModule('import { X } from "@vedatech/svm-sdk";', "@vedatech/svm-sdk")).toBe(true);
+    expect(importsModule("// mentions @vedatech/svm-sdk in prose", "@vedatech/svm-sdk")).toBe(
+      false
+    );
+  });
+});
+
+describe("cluster binding", () => {
+  /**
+   * The addresses reach the SDK explicitly, per cluster. Veda's SDK ships no
+   * default addresses today; asserting the explicit form is what notices if a
+   * future revision starts deriving one and this package stops supplying it.
+   */
+  it("constructs the SDK client with explicit deployment addresses", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toMatch(/createVedaClient\(\{[\s\S]*?vaultProgramAddress:\s*config\./);
+    expect(sdk).toMatch(/createVedaClient\(\{[\s\S]*?hookProgramAddress:\s*config\./);
+  });
+
+  it("re-checks emitted instructions against the cluster allowlist", () => {
+    const sdk = read("sdk.ts");
+    const builders = sdk.match(/assertPlanTargetsCluster\(/g) ?? [];
+    // Every plan builder must guard its OUTPUT: construction is a convention
+    // inside one function, the assertion is a property of what we emit.
+    expect(builders.length).toBeGreaterThanOrEqual(1);
+    const body = sdk.slice(sdk.indexOf("export async function buildVedaDepositPlan"));
+    expect(body).toContain("assertPlanTargetsCluster(");
+  });
+
+  /**
+   * No mainnet address may be hardcoded outside the registry in `@sdp/types`.
+   * Cluster-invariant program ids (system, token, ATA, memo, compute budget,
+   * ed25519) live in the allowlist by design; anything else that looks like a
+   * pubkey is an address someone typed instead of configuring.
+   */
+  it("hardcodes no vault, queue or hook address in this package's source", () => {
+    const invariant = new Set(
+      (read("programs.ts").match(/"[1-9A-HJ-NP-Za-km-z]{32,44}"/g) ?? []).map((quoted) =>
+        quoted.slice(1, -1)
+      )
+    );
+    const offenders: string[] = [];
+    for (const file of sourceFiles) {
+      for (const quoted of read(file).match(/"[1-9A-HJ-NP-Za-km-z]{32,44}"/g) ?? []) {
+        const value = quoted.slice(1, -1);
+        if (!invariant.has(value)) offenders.push(`${file}: ${value}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("money-in requires a way out", () => {
+  /**
+   * ADR 0002's exit-safety rule, asserted at the source level because it is one
+   * argument in one call. `requireQueue: true` is what stops SDP opening a
+   * position in a vault whose withdrawal queue is not configured and wired.
+   */
+  it("validates the deployment with the queue REQUIRED before building", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain("validateCompatibility({ requireQueue: true })");
+    expect(sdk).toContain("validateDeployment()");
+    const body = sdk.slice(sdk.indexOf("export async function buildVedaDepositPlan"));
+    expect(body.slice(0, body.indexOf("\n}\n"))).toContain("assertVedaVaultUsable(");
+  });
+
+  /** A failed verdict must never be remembered; only a passing one is cached. */
+  it("evicts a failed compatibility verdict rather than caching it", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toMatch(/catch\s*\(cause\)\s*\{[\s\S]*?compatibility\.delete\(key\)/);
+  });
+});
+
+describe("slippage protection is never invented", () => {
+  /**
+   * Veda's SDK refuses an implicit tolerance, and so does SDP: `minAmountOut`
+   * carries the caller's own floor, and `slippageBps` — which would be SDP
+   * choosing one — must appear nowhere.
+   */
+  it("passes minAmountOut and never a bps tolerance", () => {
+    const sdk = read("sdk.ts");
+    expect(sdk).toContain("protection: { minAmountOut:");
+    for (const file of sourceFiles) {
+      expect(read(file), file).not.toMatch(/slippageBps\s*:/);
+    }
+  });
+});

--- a/packages/sdp-veda/src/sdk.smoke.test.ts
+++ b/packages/sdp-veda/src/sdk.smoke.test.ts
@@ -1,0 +1,96 @@
+import { address } from "@solana/kit";
+import { describe, expect, it } from "vitest";
+import { planInstructionCount, planProgramAddresses } from "./guards";
+import { toClusterConfig } from "./programs";
+import { assertVedaVaultUsable, buildVedaDepositPlan, readVedaPosition } from "./sdk";
+import type { VedaRuntime } from "./types";
+
+/**
+ * On-chain smoke test. **Opt-in, and never runs in CI** — every other test in
+ * this package is pure and offline, per the repo rule that package tests touch
+ * no network.
+ *
+ * It is also the ONLY thing in this repository that can prove the Veda
+ * integration works end to end, because `VEDA_DEPLOYMENTS` is empty: until Veda
+ * confirms addresses there is nothing to point the offline tests at, and
+ * everything below takes its deployment from the environment instead.
+ *
+ *   VEDA_SMOKE_RPC_URL=https://api.devnet.solana.com \
+ *   VEDA_SMOKE_VAULT_PROGRAM=<address> \
+ *   VEDA_SMOKE_QUEUE_PROGRAM=<address> \
+ *   VEDA_SMOKE_HOOK_PROGRAM=<address> \
+ *   VEDA_SMOKE_VAULT=<vault-state address> \
+ *   VEDA_SMOKE_OWNER=<any wallet address> \
+ *   pnpm --filter @sdp/veda test
+ *
+ * Run it INSIDE the toolchain container, like every other node command in this
+ * repository, and against DEVNET. Nothing here signs or submits — it builds an
+ * unsigned plan and reads state — but Veda's own integration checklist requires
+ * their separate approval for any value-moving mainnet test, and
+ * `VAULT_DIRECT_DEPOSIT_ENVIRONMENTS` is sandbox-only for the same reason.
+ *
+ * What this proves that the offline tests cannot: the deployment validates, the
+ * vault's PDAs derive as the SDK expects, a deposit plan actually builds against
+ * live vault state, and every program it names is one the allowlist admits.
+ */
+const RPC_URL = process.env.VEDA_SMOKE_RPC_URL;
+const VAULT_PROGRAM = process.env.VEDA_SMOKE_VAULT_PROGRAM;
+const HOOK_PROGRAM = process.env.VEDA_SMOKE_HOOK_PROGRAM;
+const VAULT = process.env.VEDA_SMOKE_VAULT;
+const OWNER = process.env.VEDA_SMOKE_OWNER;
+
+const configured = Boolean(RPC_URL && VAULT_PROGRAM && HOOK_PROGRAM && VAULT && OWNER);
+
+describe.skipIf(!configured)("Veda plans against a live chain", () => {
+  // Everything is resolved LAZILY: `describe.skipIf` still evaluates this
+  // callback, so branding an empty address at suite scope would fail collection
+  // for everyone rather than skipping quietly.
+  const runtime = (): VedaRuntime => ({ cluster: "devnet", rpcUrl: RPC_URL ?? "" });
+  const config = () =>
+    toClusterConfig("devnet", {
+      vaultProgramAddress: VAULT_PROGRAM ?? "",
+      ...(process.env.VEDA_SMOKE_QUEUE_PROGRAM
+        ? { queueProgramAddress: process.env.VEDA_SMOKE_QUEUE_PROGRAM }
+        : {}),
+      hookProgramAddress: HOOK_PROGRAM ?? "",
+      vaultStateAddresses: [VAULT ?? ""],
+    });
+  const vault = () => address(VAULT ?? "");
+  const owner = () => address(OWNER ?? "");
+
+  it("validates the deployment and the vault, with the queue required", async () => {
+    await expect(assertVedaVaultUsable(runtime(), config(), vault())).resolves.toBeUndefined();
+  });
+
+  it("builds a deposit whose programs the allowlist admits", async () => {
+    const plan = await buildVedaDepositPlan(runtime(), config(), {
+      vault: vault(),
+      owner: owner(),
+      amount: process.env.VEDA_SMOKE_AMOUNT ?? "1",
+      // A deliberately tiny floor: this test proves the plan BUILDS, and a
+      // realistic floor would make it fail for a reason that is not the code's.
+      minSharesOut: process.env.VEDA_SMOKE_MIN_SHARES_OUT ?? "0.000001",
+    });
+
+    expect(plan.cluster).toBe("devnet");
+    expect(plan.instructions).toHaveLength(1);
+    expect(planInstructionCount(plan)).toBeGreaterThan(0);
+    expect(plan.accepted.amount).toBeDefined();
+    expect(plan.accepted.minSharesOut).toBeDefined();
+    // `assertPlanTargetsCluster` already ran inside the builder; this reports
+    // WHAT it admitted, so a surprising program shows up in the failure output.
+    expect(planProgramAddresses(plan).map(String).sort()).toMatchSnapshot();
+  });
+
+  it("reads a position without inventing a valuation", async () => {
+    const position = await readVedaPosition(runtime(), config(), {
+      vault: vault(),
+      owner: owner(),
+    });
+    expect(position.cluster).toBe("devnet");
+    expect(position.shares).toMatch(/^\d+(\.\d+)?$/);
+    if (position.tokenValue !== undefined) {
+      expect(position.tokenValue).toMatch(/^\d+(\.\d+)?$/);
+    }
+  });
+});

--- a/packages/sdp-veda/src/sdk.ts
+++ b/packages/sdp-veda/src/sdk.ts
@@ -1,0 +1,428 @@
+import { isVedaDepositMint } from "@sdp/types/veda-programs";
+import { type Address, address } from "@solana/kit";
+import { createVedaClient, VedaSdkError } from "@vedatech/svm-sdk";
+import { acceptPositiveAtMintScale, mintDecimals } from "./amounts";
+import { SdpVedaError, vaultUnreadable } from "./errors";
+import { assertPlanTargetsCluster } from "./guards";
+import { readMintDecimals } from "./mint";
+import type { VedaClusterConfig } from "./programs";
+import { createVedaRpc } from "./rpc";
+import type {
+  VedaDepositInput,
+  VedaInstructionPlan,
+  VedaPosition,
+  VedaPositionInput,
+  VedaRuntime,
+} from "./types";
+
+/**
+ * ════════════════════════════════════════════════════════════════════════════
+ *  THE KIT-VERSION FIREWALL. This is the ONLY module in the package — source or
+ *  test — that may import `@vedatech/svm-sdk`.
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ * The SDK is built against `@solana/kit` **7.0.0**; this repo pins **6.8.0**,
+ * and pnpm nests the SDK's own copy, so both live in the tree (alongside the
+ * 2.3.0 klend-sdk drags in and a 5.5.1). Every cast below is a STRUCTURAL
+ * re-label across that seam, not a coercion: kit's `Instruction` is a plain
+ * object with `programAddress`, a numeric `AccountRole` and `Uint8Array` data
+ * in both majors, and nothing kit-typed crosses this module's exports — see
+ * `./types.ts`.
+ *
+ * Keeping the SDK behind one module is also what keeps it out of `@sdp/earn`,
+ * whose catalogue cron runs hourly in both environments and never builds a
+ * transaction.
+ */
+
+/** The SDK's kit-7 surface, as far as this module needs to name it. */
+// biome-ignore lint/suspicious/noExplicitAny: the kit-7 <-> kit-6.8 seam; see the header.
+type Kit7 = any;
+
+/**
+ * How long a compatibility verdict is trusted.
+ *
+ * Not process-lifetime. A deployment's structure is stable, but a URL is not:
+ * DNS, a load balancer or a config change can repoint the same endpoint at a
+ * different cluster, and this verdict is a funds authorization. A short window
+ * keeps a burst of deposits from re-validating on every call without turning
+ * one old observation into a standing permission. Same reasoning as the API's
+ * `CLUSTER_ENDPOINT_PROOF_TTL_MS`, with a longer window because the check is
+ * heavier and the property it proves is structural.
+ */
+export const VEDA_COMPATIBILITY_TTL_MS = 600_000;
+
+interface CompatibilityEntry {
+  promise: Promise<void>;
+  /** Null while the shared probe is still in flight. */
+  expiresAt: number | null;
+}
+
+const compatibility = new Map<string, CompatibilityEntry>();
+
+/** Test seam: forget cached compatibility verdicts. */
+export function resetVedaCompatibilityCache(): void {
+  compatibility.clear();
+}
+
+function client(runtime: VedaRuntime, config: VedaClusterConfig) {
+  // The transport deadline covers both our direct reads and every nested vault,
+  // asset, oracle and mint request the SDK performs with this same client.
+  const rpc = createVedaRpc(runtime.rpcUrl) as Kit7;
+  return createVedaClient({
+    rpc,
+    deployment: {
+      vaultProgramAddress: config.vaultProgramAddress as Kit7,
+      ...(config.queueProgramAddress === undefined
+        ? {}
+        : { queueProgramAddress: config.queueProgramAddress as Kit7 }),
+      hookProgramAddress: config.hookProgramAddress as Kit7,
+      label: `sdp-${config.cluster}`,
+    },
+    commitment: "confirmed",
+  });
+}
+
+/**
+ * Prove the live deployment is the one SDP thinks it is, before building
+ * anything against it.
+ *
+ * `validateDeployment()` checks that each configured program exists, is
+ * executable and uses the expected upgradeable loader.
+ * `validateCompatibility()` additionally re-derives the vault's own PDAs — the
+ * share mint, the transfer hook's config and extra-account-metas, the queue's
+ * ownership and its immutable Token-2022 share account — and refuses if any of
+ * them does not belong to the vault at hand.
+ *
+ * **`requireQueue: true`, on the DEPOSIT path.** That looks like the wrong
+ * capability to demand until you read it as ADR 0002's exit-safety rule: the
+ * queue is Veda's durable way out, and SDP will not open a position in a vault
+ * whose exit infrastructure is not configured and wired to the vault. It gates
+ * only the way IN — the catalogue read, position reads and any future exit path
+ * never call this — so it can never trap funds, only decline to create them.
+ *
+ * Verdicts are cached per (cluster, endpoint, vault) for a short window.
+ * FAILURES ARE NEVER CACHED: an incompatible or unreachable deployment must be
+ * re-checked, not remembered.
+ */
+export async function assertVedaVaultUsable(
+  runtime: VedaRuntime,
+  config: VedaClusterConfig,
+  vault: Address
+): Promise<void> {
+  if (!config.queueProgramAddress) {
+    throw new SdpVedaError(
+      "INCOMPATIBLE_DEPLOYMENT",
+      `The Veda ${config.cluster} deployment declares no withdrawal queue, so SDP will not open ` +
+        "a position in it. Money in requires a configured way out."
+    );
+  }
+
+  const key = `${config.cluster}\n${runtime.rpcUrl}\n${vault}`;
+  let entry = compatibility.get(key);
+  if (entry && entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+    compatibility.delete(key);
+    entry = undefined;
+  }
+  if (!entry) {
+    entry = { promise: validate(runtime, config, vault), expiresAt: null };
+    compatibility.set(key, entry);
+  }
+
+  try {
+    await entry.promise;
+    if (compatibility.get(key) === entry && entry.expiresAt === null) {
+      entry.expiresAt = Date.now() + VEDA_COMPATIBILITY_TTL_MS;
+    }
+  } catch (cause) {
+    // Delete only if this is still the promise stored for the key: concurrent
+    // callers may all observe the same rejection, and none may delete a newer
+    // probe started after this one failed.
+    if (compatibility.get(key) === entry) compatibility.delete(key);
+    throw cause;
+  }
+}
+
+async function validate(
+  runtime: VedaRuntime,
+  config: VedaClusterConfig,
+  vault: Address
+): Promise<void> {
+  const veda = client(runtime, config);
+  try {
+    await veda.validateDeployment();
+    await veda.vault(vault as Kit7).validateCompatibility({ requireQueue: true });
+  } catch (cause) {
+    throw mapVedaSdkError(cause, `Veda vault ${vault} is not usable on ${config.cluster}`);
+  }
+}
+
+/**
+ * The single vault asset SDP will spend for a deposit.
+ *
+ * `EarnVaultDepositInput` carries no mint — the catalogue row does, and the API
+ * compares the built plan's `assetIdentity` against it — so the builder has to
+ * arrive at the SAME asset the catalogue admitted. It does that by applying the
+ * SAME predicate to the SAME source: the vault's own enabled assets, screened
+ * by `isVedaDepositMint`.
+ *
+ * AMBIGUITY IS REFUSED, not resolved. While SDP declares one deposit symbol
+ * there can be at most one match, and if that ever widens, "pick the first" is
+ * the kind of silent choice that spends the wrong token. Widening
+ * `VEDA_DEPOSIT_TOKEN_SYMBOLS` therefore means carrying a mint on the deposit
+ * contract first; this error says so.
+ */
+async function resolveDepositAsset(
+  runtime: VedaRuntime,
+  config: VedaClusterConfig,
+  vaultClient: Kit7,
+  vault: Address
+): Promise<{ mint: Address; decimals: number }> {
+  let assets: { mint: Kit7; allowDeposits: boolean }[];
+  try {
+    assets = await vaultClient.listAssets();
+  } catch (cause) {
+    throw vaultUnreadable(String(vault), config.cluster, cause);
+  }
+
+  const candidates = assets
+    .filter((asset) => asset.allowDeposits && isVedaDepositMint(String(asset.mint)))
+    .map((asset) => String(asset.mint))
+    .sort();
+
+  const [only, ...rest] = candidates;
+  if (only === undefined) {
+    throw new SdpVedaError(
+      "UNSUPPORTED_VAULT",
+      `Veda vault ${vault} enables no deposit asset SDP fronts on ${config.cluster}.`
+    );
+  }
+  if (rest.length > 0) {
+    throw new SdpVedaError(
+      "UNSUPPORTED_VAULT",
+      `Veda vault ${vault} enables ${candidates.length} deposit assets SDP fronts ` +
+        `(${candidates.join(", ")}), and the deposit request cannot say which to spend. ` +
+        "Carry the mint on the deposit contract before widening VEDA_DEPOSIT_TOKEN_SYMBOLS."
+    );
+  }
+
+  const mint = address(only);
+  return { mint, decimals: await readMintDecimals(runtime.rpcUrl, mint) };
+}
+
+/**
+ * Build a deposit.
+ *
+ * `buildDeposit` — the INSTRUCTION-PLAN mode — never `prepareDeposit`. SDP owns
+ * the blockhash, the fee payer, simulation and signing (`vault-execution.service`),
+ * and a prepared transaction would arrive with a lifetime and a fee payer this
+ * package has no business choosing.
+ *
+ * Returned as a single batch: a deposit touches one vault and creates at most
+ * two idempotent associated token accounts, which fits one packet.
+ */
+export async function buildVedaDepositPlan(
+  runtime: VedaRuntime,
+  config: VedaClusterConfig,
+  input: VedaDepositInput
+): Promise<VedaInstructionPlan> {
+  await assertVedaVaultUsable(runtime, config, input.vault);
+
+  const vaultClient = client(runtime, config).vault(input.vault as Kit7);
+  let state: { shareMint: Kit7; shareDecimals: unknown };
+  try {
+    state = await vaultClient.getState();
+  } catch (cause) {
+    throw vaultUnreadable(String(input.vault), config.cluster, cause);
+  }
+
+  const asset = await resolveDepositAsset(runtime, config, vaultClient, input.vault);
+  // Precision is checked against each MINT, which is why it can only happen
+  // after the vault is read: the deposit asset and the share token have
+  // independent decimals and neither is knowable at the API boundary.
+  const amount = acceptPositiveAtMintScale("amount", input.amount, asset.decimals);
+  const minSharesOut = acceptPositiveAtMintScale(
+    "minSharesOut",
+    input.minSharesOut,
+    mintDecimals(state.shareDecimals, "share decimals")
+  );
+
+  let plan: { instructions: readonly Kit7[] };
+  try {
+    plan = await vaultClient.buildDeposit({
+      owner: input.owner as Kit7,
+      asset: { kind: "mint", address: asset.mint as Kit7 },
+      amount: amount.baseUnits,
+      // `minAmountOut`, never `slippageBps`: a bps tolerance would be SDP
+      // choosing a floor, and the floor a caller was quoted is the one that
+      // must be encoded. The SDK refuses an implicit tolerance for the same
+      // reason, and this passes that refusal through rather than defaulting.
+      protection: { minAmountOut: minSharesOut.baseUnits },
+    });
+  } catch (cause) {
+    throw mapVedaSdkError(cause, `Veda could not build a deposit for vault ${input.vault}`);
+  }
+
+  return assertPlanTargetsCluster(
+    {
+      cluster: config.cluster,
+      // One batch, and the SDK's order preserved exactly. A Veda plan can carry
+      // `protectedInstructionGroups` requiring adjacency; keeping the list whole
+      // and unreordered is what honours that without having to interpret it.
+      instructions: [[...plan.instructions]],
+      lookupTables: [],
+      assetIdentity: {
+        depositTokenMint: asset.mint,
+        // Read from the same live state used to build, never from a catalogue
+        // row: the API compares builder truth with catalogue metadata before
+        // signing, and both sides being catalogue-derived would make that
+        // comparison vacuous.
+        shareMint: address(String(state.shareMint)),
+      },
+      accepted: { amount: amount.canonical, minSharesOut: minSharesOut.canonical },
+    },
+    config
+  );
+}
+
+/**
+ * One wallet's holding in one vault, read live.
+ *
+ * Shares come from `getUserPosition`, which reads the owner's Token-2022 share
+ * account and returns an EXACT atomic `bigint` — never a JSON `uiAmount`, which
+ * loses value above 2^53 base units.
+ *
+ * The valuation is allowed to fail INDEPENDENTLY of the share read: a position
+ * whose size is known but whose value is not renders "—", which is the module
+ * rule everywhere in Earn and strictly better than a fabricated number. It uses
+ * `previewWithdraw`, so the figure is the vault's own accounting — including its
+ * oracle and any withdraw premium — rather than arithmetic this package invents
+ * on top of a raw exchange rate. That makes it a REDEEMABLE value, which is the
+ * conservative one to show a holder.
+ */
+export async function readVedaPosition(
+  runtime: VedaRuntime,
+  config: VedaClusterConfig,
+  input: VedaPositionInput
+): Promise<VedaPosition> {
+  const vaultClient = client(runtime, config).vault(input.vault as Kit7);
+
+  let state: { shareMint: Kit7; shareDecimals: unknown };
+  let position: { shares: bigint };
+  try {
+    state = await vaultClient.getState();
+    position = await vaultClient.getUserPosition(input.owner as Kit7);
+  } catch (cause) {
+    throw vaultUnreadable(String(input.vault), config.cluster, cause);
+  }
+
+  const asset = await resolveDepositAsset(runtime, config, vaultClient, input.vault);
+  const shareDecimals = mintDecimals(state.shareDecimals, "share decimals");
+
+  return {
+    vault: input.vault,
+    owner: input.owner,
+    cluster: config.cluster,
+    shares: formatAtomic(position.shares, shareDecimals),
+    ...(await valuation(vaultClient, asset, position.shares)),
+    tokenMint: asset.mint,
+    shareMint: address(String(state.shareMint)),
+  };
+}
+
+async function valuation(
+  vaultClient: Kit7,
+  asset: { mint: Address; decimals: number },
+  shares: bigint
+): Promise<{ tokenValue?: string }> {
+  // The SDK refuses a zero-share quote, and there is nothing to ask: zero shares
+  // are worth zero of anything, exactly.
+  if (shares === 0n) return { tokenValue: formatAtomic(0n, asset.decimals) };
+  try {
+    const quote = await vaultClient.previewWithdraw({ asset: asset.mint as Kit7, shares });
+    return {
+      tokenValue: formatAtomic(quote.assetsOut, mintDecimals(quote.assetDecimals, "quote")),
+    };
+  } catch {
+    // Deliberately swallowed. A stale oracle, a disabled withdrawal asset or a
+    // paused vault all make the VALUE unknown without making the HOLDING
+    // unknown, and reporting the holding is the more important half.
+    return {};
+  }
+}
+
+function formatAtomic(value: bigint, decimals: number): string {
+  const negative = value < 0n;
+  const digits = (negative ? -value : value).toString().padStart(decimals + 1, "0");
+  const whole = digits.slice(0, digits.length - decimals);
+  const fraction = decimals === 0 ? "" : digits.slice(digits.length - decimals).replace(/0+$/, "");
+  return `${negative ? "-" : ""}${whole}${fraction === "" ? "" : `.${fraction}`}`;
+}
+
+/**
+ * Translate a `VedaSdkError` into this package's taxonomy, at the boundary.
+ *
+ * The mapping is what makes the SDK's codes actionable: `DEPOSIT_REFUSED` is a
+ * caller-visible 400 ("the vault will not take this right now"), while
+ * `VAULT_UNREADABLE` is an infrastructure answer. The distinction matters
+ * because `INVALID_AMOUNT` carries BOTH — the SDK reuses it for a genuinely bad
+ * number and for a quote issue such as `TELLER_PAUSED` or `DEPOSIT_CAP_EXCEEDED`,
+ * discriminated only by an `issue` in its context.
+ *
+ * Unmapped codes fall to `VAULT_UNREADABLE` on purpose: that bucket is not
+ * caller-fixable, so an unrecognised failure is never rendered to a customer as
+ * "your request was wrong". The SDK's own message and the original error are
+ * preserved either way.
+ */
+export function mapVedaSdkError(cause: unknown, context: string): SdpVedaError {
+  if (cause instanceof SdpVedaError) return cause;
+  if (!(cause instanceof VedaSdkError)) {
+    return new SdpVedaError("VAULT_UNREADABLE", `${context}: ${describe(cause)}`, { cause });
+  }
+
+  const message = `${context}: ${cause.message}`;
+  switch (cause.code) {
+    case "COMPLIANCE_APPROVAL_REQUIRED":
+    case "INVALID_COMPLIANCE_APPROVAL":
+      // v1 does NOT implement Veda's compliance-approval flow: it needs a
+      // signed approval from Veda's compliance service, which is a deliberate
+      // later decision rather than something to fake at the boundary.
+      return new SdpVedaError(
+        "COMPLIANCE_APPROVAL_REQUIRED",
+        `${message} SDP does not implement Veda's compliance-approval flow.`,
+        { cause }
+      );
+    case "INVALID_AMOUNT":
+      // `issue` present means the vault refused the request (paused, capped,
+      // asset disabled, insufficient balance); absent means the number itself
+      // was unusable.
+      return new SdpVedaError(
+        "issue" in cause.context ? "DEPOSIT_REFUSED" : "INVALID_AMOUNT",
+        message,
+        { cause }
+      );
+    case "ZERO_SHARES":
+      return new SdpVedaError("INVALID_AMOUNT", message, { cause });
+    case "NOT_ALLOWED":
+    case "SHARE_LOCKED":
+    case "RESTRICTED_REDEMPTION":
+      return new SdpVedaError("DEPOSIT_REFUSED", message, { cause });
+    case "INCOMPATIBLE_DEPLOYMENT":
+      return new SdpVedaError("INCOMPATIBLE_DEPLOYMENT", message, { cause });
+    case "QUEUE_NOT_CONFIGURED":
+    case "INVALID_QUEUE_PARAMETERS":
+    case "TRANSFER_FEE_MINT_UNSUPPORTED":
+    case "UNSUPPORTED_CPI_DIGEST_ASSET":
+      return new SdpVedaError("UNSUPPORTED_VAULT", message, { cause });
+    case "SLIPPAGE_PROTECTION_REQUIRED":
+      // Unreachable: this package always supplies `minAmountOut`. Mapped
+      // anyway, so a future path that forgets gets a caller-fixable answer
+      // rather than an infrastructure one.
+      return new SdpVedaError("INVALID_AMOUNT", message, { cause });
+    default:
+      return new SdpVedaError("VAULT_UNREADABLE", message, { cause });
+  }
+}
+
+function describe(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}

--- a/packages/sdp-veda/src/types.ts
+++ b/packages/sdp-veda/src/types.ts
@@ -1,0 +1,143 @@
+import type { SolanaCluster } from "@sdp/types";
+import type { Address, Instruction } from "@solana/kit";
+
+/**
+ * The boundary contract for `@sdp/veda`.
+ *
+ * TWO RULES HOLD FOR EVERY TYPE IN THIS FILE, and both are load-bearing:
+ *
+ * 1. **Money is a decimal string at this boundary, never a float and never an
+ *    atomic `bigint`.** The repo-wide rule (`@sdp/earn` CLAUDE.md → Contracts)
+ *    is that amount values in contract types are decimal strings, converted at
+ *    the provider boundary. Veda's SDK speaks atomic `bigint` throughout, so
+ *    the conversion — and the refusal to lose precision doing it — happens
+ *    inside `./sdk.ts`.
+ * 2. **Nothing here references a `@vedatech/svm-sdk` type.** Every type is
+ *    either from `@solana/kit` (the version THIS repo pins, 6.8) or from
+ *    `@sdp/types`. That is what makes `./sdk.ts` a firewall rather than a
+ *    convention: the SDK is built against `@solana/kit` 7 and pnpm nests its
+ *    own copy, so a leaked type would put two kit majors in one signature.
+ */
+
+/** Which cluster a call runs against, and how to reach it. */
+export interface VedaRuntime {
+  cluster: SolanaCluster;
+  /**
+   * RPC endpoint for `cluster`. Supplied by the caller rather than read from
+   * env: one API process serves BOTH SDP environments, so a process-level
+   * `SOLANA_RPC_URL` cannot be trusted to match the cluster being served. The
+   * API proves the endpoint's genesis before handing it over.
+   */
+  rpcUrl: string;
+}
+
+/**
+ * A built, unsigned unit of work: instructions plus what the caller needs to
+ * compile them.
+ *
+ * `instructions` is `Instruction[][]` — TRANSACTION-SIZED BATCHES, not one flat
+ * list — because that is what `EarnVaultTransactionPlan` promises and what an
+ * exit will eventually need. A deposit is always one batch: it touches one
+ * vault and creates at most two idempotent associated token accounts.
+ *
+ * ORDER INSIDE A BATCH IS SIGNIFICANT. Veda's plans can carry
+ * `protectedInstructionGroups` — an Ed25519 compliance verification that must
+ * sit immediately before the deposit instruction — so a caller may append to a
+ * batch but must never reorder or split one.
+ */
+export interface VedaInstructionPlan {
+  cluster: SolanaCluster;
+  instructions: readonly (readonly Instruction[])[];
+  /**
+   * Address lookup tables the caller should apply when compiling. Always empty
+   * today: a Veda deposit fits one packet, and the field exists so callers
+   * compile against the shape an exit will need.
+   */
+  lookupTables: readonly Address[];
+  /** Asset mints observed from the same live vault state used to build. */
+  assetIdentity: VedaVaultAssetIdentity;
+  /** What the instructions above actually encode. See `VedaAcceptedAmounts`. */
+  accepted: VedaAcceptedAmounts;
+}
+
+/** Live Veda vault asset identity carried with a built instruction plan. */
+export interface VedaVaultAssetIdentity {
+  /** Mint consumed by the deposit — the vault asset SDP resolved. */
+  depositTokenMint: Address;
+  /** Mint of the vault's Token-2022 share token. */
+  shareMint: Address;
+}
+
+/**
+ * The amounts as ENCODED, canonicalised to each mint's own precision.
+ *
+ * Exists because the requested amount and the encoded amount need not be the
+ * same number in general — a chain SDK converting decimals to atoms typically
+ * floors. This package refuses anything that would lose value to that
+ * conversion, so these values always equal the request in magnitude, but they
+ * are re-serialised from the mint's decimals: `"1.500"` comes back as `"1.5"`.
+ * The ledger should persist THESE, not the raw request string; only this side
+ * of the boundary knows the mint's precision.
+ */
+export interface VedaAcceptedAmounts {
+  /** Deposit amount, canonical to the deposit mint's decimals. */
+  amount?: string;
+  /** Share floor, canonical to the share mint's decimals. */
+  minSharesOut?: string;
+  /** Shares redeemed, canonical to the share mint's decimals. */
+  shares?: string;
+}
+
+export interface VedaDepositInput {
+  /** The vault-state account address — its `providerReference` in the catalogue. */
+  vault: Address;
+  /**
+   * The wallet whose tokens move and whose shares are minted.
+   *
+   * An ADDRESS, not a signer: custody lives in the API and a private key must
+   * never reach a provider client. Veda's SDK accepts `owner` for exactly this
+   * reason and substitutes a noop signer internally, so the accounts are placed
+   * correctly and nothing is signed here.
+   *
+   * It is also the RENT PAYER for the associated token accounts the plan
+   * creates idempotently (the owner's share account, and the vault's asset
+   * account when absent). That is a real, separate spend from the transaction
+   * fee, and it is why no sponsor address is accepted here.
+   */
+  owner: Address;
+  /** Deposit amount in the vault asset's own units, as a decimal string. */
+  amount: string;
+  /**
+   * Minimum shares to accept, as a decimal string.
+   *
+   * REQUIRED, unlike Kamino's. Veda's SDK refuses to apply an implicit slippage
+   * tolerance — `buildDeposit` throws `SLIPPAGE_PROTECTION_REQUIRED` without
+   * either a floor or a bps tolerance — and SDP does not invent one on a
+   * caller's behalf, so the requirement is passed through rather than papered
+   * over with a default.
+   */
+  minSharesOut: string;
+}
+
+export interface VedaPositionInput {
+  vault: Address;
+  owner: Address;
+}
+
+/** One wallet's holding in one Veda vault, read live. */
+export interface VedaPosition {
+  vault: Address;
+  owner: Address;
+  cluster: SolanaCluster;
+  /** Shares held, as a decimal string at the share mint's scale. */
+  shares: string;
+  /**
+   * What those shares are worth in the vault's SDP-facing deposit asset, as a
+   * decimal string. Undefined when the valuation could not be read — the caller
+   * renders "—" rather than a fabricated figure.
+   */
+  tokenValue?: string;
+  /** The deposit asset SDP fronts for this vault. */
+  tokenMint: Address;
+  shareMint: Address;
+}

--- a/packages/sdp-veda/tsconfig.json
+++ b/packages/sdp-veda/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // Mirrors packages/sdp-kamino: this package typechecks @sdp/earn's sources
+    // through its workspace import, and `fetch.ts` there references the DOM's
+    // `HeadersInit` / `BodyInit`. Without these libs the failure surfaces here
+    // rather than in the package that owns the code.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    // The IDL layout test reads packages/sdp-veda/idl/*.json at runtime.
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         version: 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/addresses':
         specifier: 'catalog:'
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -156,25 +156,25 @@ importers:
         version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-core':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-fireblocks':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-privy':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-turnkey':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-utila':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
         version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -186,13 +186,13 @@ importers:
         version: 0.1.1(patch_hash=b814110d007b64ff76f72cf843d93ba928a9c4f39acc34dbc2ee3e27d1149689)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/pay':
         specifier: 1.0.26
-        version: 1.0.26(aedb926283e2af4eda636589370801b0)
+        version: 1.0.26(d00a8eaf3bf65b54674c217824983efc)
       '@solana/signers':
         specifier: 'catalog:'
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/subscriptions':
         specifier: 0.4.0
-        version: 0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+        version: 0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/token-acl-gate-sdk':
         specifier: 0.3.0
         version: 0.3.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -518,10 +518,10 @@ importers:
         version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
         version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -555,25 +555,25 @@ importers:
         version: 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/keychain-cdp':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-core':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-fireblocks':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-para':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-privy':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-turnkey':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/keychain-utila':
         specifier: 1.4.0
-        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
         version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -640,7 +640,7 @@ importers:
         version: 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit':
         specifier: 'catalog:'
         version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
@@ -798,7 +798,7 @@ importers:
         version: link:../sdp-types
       '@solana-program/token-2022':
         specifier: 'catalog:'
-        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+        version: 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/addresses':
         specifier: 'catalog:'
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -875,6 +875,37 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+
+  packages/sdp-veda:
+    dependencies:
+      '@sdp/earn':
+        specifier: workspace:*
+        version: link:../sdp-earn
+      '@sdp/solana':
+        specifier: workspace:*
+        version: link:../sdp-solana
+      '@sdp/types':
+        specifier: workspace:*
+        version: link:../sdp-types
+      '@solana/kit':
+        specifier: 'catalog:'
+        version: 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@vedatech/svm-sdk':
+        specifier: 0.1.0-alpha.1
+        version: 0.1.0-alpha.1(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    devDependencies:
+      '@types/node':
+        specifier: 26.1.2
+        version: 26.1.2
+      tsx:
+        specifier: 4.23.5
+        version: 4.23.5
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))
 
 packages:
 
@@ -3283,6 +3314,17 @@ packages:
     peerDependencies:
       '@solana/kit': ^3.0
 
+  '@solana-program/token-2022@0.13.0':
+    resolution: {integrity: sha512-qfZ8SAGCkq7siG0WlaJerQIM54vT1+tMIvMMe8BV5zPf8cYk72k41qgr/zWDhzKAz02YdZ6YZPE05U+n2QVDdA==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+      '@solana/sysvars': ^7.0.0
+      '@solana/zk-sdk': ^0.4.2
+    peerDependenciesMeta:
+      '@solana/zk-sdk':
+        optional: true
+
   '@solana-program/token-2022@0.14.0':
     resolution: {integrity: sha512-SXZ3EcYC7DV/TLg0SEfCW/MoDkNzdazSzf4EBAQ1BOMMEhF/BXusbsTpgIXPlgGst+EMR9BH9tHGU37RAVJ8uQ==}
     engines: {node: '>=24.0.0'}
@@ -3382,6 +3424,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/accounts@7.0.0':
+    resolution: {integrity: sha512-RfbinkhuWxcObxZIdjeWEn/mzLqRp/h2hAk/ZQCUxPdDBW8h4XxEybK9GBItGOAcrUz5HuusXTD+cXXnlIxWcg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/addresses@2.3.0':
     resolution: {integrity: sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==}
     engines: {node: '>=20.18.0'}
@@ -3424,6 +3475,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/addresses@7.0.0':
+    resolution: {integrity: sha512-E7sJtV5d3bXrmw3I30rcKY+xoqM++6KIVJCi+q8ZaSMyP04UMfEENPHIJ+TkyS1RUgjzPT91ka/oWrtTh6EfkQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/assertions@2.3.0':
     resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
     engines: {node: '>=20.18.0'}
@@ -3459,6 +3519,15 @@ packages:
 
   '@solana/assertions@6.9.0':
     resolution: {integrity: sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@7.0.0':
+    resolution: {integrity: sha512-CShOQLPezI0tbrih+L88fzt8FMHDyJoWkmulk4wfRp3HhpQL2yNlH/SWLH033qysnvkmE7TxBFUtcnbnf7jz1g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -3574,6 +3643,15 @@ packages:
 
   '@solana/codecs-data-structures@6.9.0':
     resolution: {integrity: sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-data-structures@7.0.0':
+    resolution: {integrity: sha512-P0Ys1mB4lYlz3MMTCaJSysE3OYrq8WvsveU1ta8U/yG1qChXFGCOxPVh06swjaRxwPrEakb9VUESS5vNtp1rRA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -3739,6 +3817,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs@7.0.0':
+    resolution: {integrity: sha512-xT1IbwKkPZ544u/eqhb9SZ0fNYJidWgIUzKNQMbvLCwduayAkQp+czlGdvLQ6CVlqtCewtH3gW8biGU7YuBdEw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/compat@2.3.0':
     resolution: {integrity: sha512-3dbkQ0eymj1Il7KFAhA6X6LSI4d3uoHcp/WWoE7EIz9NS0ZZ8u27QmfYe5b0IcO2OFkmfReG79RVAm1xYY+7rA==}
     engines: {node: '>=20.18.0'}
@@ -3841,6 +3928,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/fast-stable-stringify@7.0.0':
+    resolution: {integrity: sha512-i/b5ZJMqMJXa6etjypANa2/ErPZfNG9/EVIYl7HpWooyCRgZ8hZJmJ2Cgrp0r4EMXCLeWn4aEG2HOBTzOJ4F7Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/fixed-points@6.10.0':
     resolution: {integrity: sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==}
     engines: {node: '>=20.18.0'}
@@ -3910,6 +4006,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/functional@7.0.0':
+    resolution: {integrity: sha512-ix9fzYhc2hCLiYf+hGI00mzzayANKDExEBxbwrtMj/BdQkwgUIvIlOssqHeSqDChL3UZhq9lR24Nz4JwYX8Jbw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/instruction-plans@5.5.1':
     resolution: {integrity: sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==}
     engines: {node: '>=20.18.0'}
@@ -3933,6 +4038,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instruction-plans@7.0.0':
+    resolution: {integrity: sha512-uzXHztc8hLoT5TNWFsBX2DIETyp/Lr2l36O330s3YCgpRmfI4IRbBrjjq7TxDYFm/QY8+DD4CRG8p7wZSqG8dQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3972,6 +4086,15 @@ packages:
 
   '@solana/instructions@6.9.0':
     resolution: {integrity: sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@7.0.0':
+    resolution: {integrity: sha512-ZN0gKAtCOKDuIaStcvLZDf5H20fkk7jr4dZE0Rk7z0kslf6mrRam9Y23N6AzeHp/b5ZeVKyfaTf4M35mOktLNg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -4088,6 +4211,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/keys@7.0.0':
+    resolution: {integrity: sha512-JsdYR/YN3AGHZN2aZoeE5cymHYkNoBLnqgXoRncW/VyD7fMcR350aHU1hCMYd0b5BtITLsGmvvtvrgVkzK83Eg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/kit-plugin-instruction-plan@0.10.0':
     resolution: {integrity: sha512-h99B+1Vp5QWU/M/q0UXlTxKJt781vWw5aAopnbgVCy0F3hNaSDZ/gio126Oz0/cipGOnyaJf3NnV79GvxaEqZA==}
     peerDependencies:
@@ -4123,6 +4255,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit@7.0.0':
+    resolution: {integrity: sha512-ZCeai4LRJQooUmJXvpgMEGFTrCdJnV1ODbDJ8oqFZ+Y4t/9x1baQsFFpruqsdRyeGv2Rr+X6jV7cldVD+hyzRA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4184,6 +4325,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/nominal-types@7.0.0':
+    resolution: {integrity: sha512-ff21hmKKMckDkGWah9tRXsEyFCtSnkugH+EMLGJOn7tiXdtFljOXW5Q12IXyeil87EE8aWb1MS6p8v5+hi71Vg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/offchain-messages@5.5.1':
     resolution: {integrity: sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==}
     engines: {node: '>=20.18.0'}
@@ -4220,6 +4370,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/offchain-messages@7.0.0':
+    resolution: {integrity: sha512-fGrzxmqVStweGHRlXVAPKACdDboFCwXq5m8C+aD9Nupax6Q9rnvjICzYRLypwqB9X90XIZazh0ys+0KGLMpIJQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/options@2.0.0-rc.1':
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
     peerDependencies:
@@ -4245,6 +4404,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/options@7.0.0':
+    resolution: {integrity: sha512-6DhvMqRcL3mG0R5JejYIW5PDTDr7HcLX2R9iCs6OPN1HdsyXmE2rX2EldnuA0rYz1buOodeWYsu4N1lpDcEpaQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4284,6 +4452,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/plugin-core@7.0.0':
+    resolution: {integrity: sha512-EwTUfOGoQQ3aXooRlQFVbk+sJW7NqJl1K+bmSLiJUjaBTSqtbr3GtMu7aoybJqzZQKjOGSG4Hn0BzK24SvWy3A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/plugin-interfaces@6.10.0':
     resolution: {integrity: sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==}
     engines: {node: '>=20.18.0'}
@@ -4302,6 +4479,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/plugin-interfaces@7.0.0':
+    resolution: {integrity: sha512-fz/HknZLGnVIjhjXrMzW3Qm1x80oeEMSOk4RzMwjcyAEyfzhHtGNW74NsU5W+uFpYz6UBbV5mB1jpuAdJdnj9A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/program-client-core@6.10.0':
     resolution: {integrity: sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==}
     engines: {node: '>=20.18.0'}
@@ -4316,6 +4502,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/program-client-core@7.0.0':
+    resolution: {integrity: sha512-+N8HImlR3MTbbvhOShsLelQXGZKbi6KhPhyy+4ZkDLbnRs4QikTamIChXZmoCyxB51S8/9cNRAKyQhbeF5Y8Qg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4340,6 +4535,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/programs@7.0.0':
+    resolution: {integrity: sha512-a1HNgzr9YiiZ8vK4VaKHEXjnZmKX7W5ab2ghuseIalEw/+PJLFcTRTOw8n3efRu677b/bG2Icmb3MBBEXmvbPg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4386,6 +4590,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/promises@7.0.0':
+    resolution: {integrity: sha512-rjoHnaR4zeEIHqIzfgotxRrLKqY4Goj0G5duZOnjHm8ZC+7eDkH5/mXj1bDJ4ROM70dVM+y1Xkrjg7IL6k6StA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/qr-code-styling@1.6.0':
     resolution: {integrity: sha512-KyBmyFKPxQPhUkP0jjnxV2ZeF1R1guTD8Hrd0YvHvMnhtrNEoEEdv4Jpp4W0GN4qCGG2KYOM5d3TgoLD+CNf9Q==}
 
@@ -4418,6 +4631,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-api@7.0.0':
+    resolution: {integrity: sha512-MTtBO883st83CjWpo8B4g8EKzXaeoBX5N7+sv4vcvsn2q1NpY4SG3XejdX1FrKeTe9Xjbv0/FzFtykstbKe1UA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4455,6 +4677,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-parsed-types@7.0.0':
+    resolution: {integrity: sha512-80VjPbB/TZ/Hy5qdRF7onPfMPHk5cwBVbtNUGbilrmFuqRzSvzSOY1ynNXXODPZBytNmPq7u7oJfSCsQ5MA9Ig==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-spec-types@2.3.0':
     resolution: {integrity: sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==}
     engines: {node: '>=20.18.0'}
@@ -4484,6 +4715,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec-types@7.0.0':
+    resolution: {integrity: sha512-V4Hp2//fW8eYq1zcGgHPu7FXKHyIWERBQd4+NRaKn2m8rPiVAm3pVRwPzSvVE0+8Nyf5qzdcfcMf7NQdhl6j7Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4521,6 +4761,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-spec@7.0.0':
+    resolution: {integrity: sha512-GRGlXpLgap9yVh3qmCl4huuKAoLMp/p82/9Q9ONj6lmFH+RqJE4Q+16V+HxHI5ZakmwZYoVZU4GEKjumse9SCg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-subscriptions-api@2.3.0':
     resolution: {integrity: sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==}
     engines: {node: '>=20.18.0'}
@@ -4541,6 +4790,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-api@7.0.0':
+    resolution: {integrity: sha512-o2PZDeNC/kg3VO3ry4R0JySJ1xMHLchZwmzVwamxGidlLe9uvzm6CHlCqv/JCq4/zHLo7qbLqnmOckZ6vlDqaw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4566,6 +4824,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@7.0.0':
+    resolution: {integrity: sha512-79ecXBCT2pG+vXNBZim80vUz+B04L1mEduXobBIXM55VvxsHYT+4H4V+/ZHoFJUK6Lhbt+6zhpconx8Wa3H+JA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4603,6 +4870,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-spec@7.0.0':
+    resolution: {integrity: sha512-Oips5ciWqPGO5Cx7hcEQ/czbcrUjPf+4cTam0UMrK3BnvHPcEAWkPYlIgabQiqa60/pjOOz7B936oMXA5XwL+g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-subscriptions@2.3.0':
     resolution: {integrity: sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==}
     engines: {node: '>=20.18.0'}
@@ -4623,6 +4899,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@7.0.0':
+    resolution: {integrity: sha512-jLNjUCGBbCIfABqqHopNJIeAkhd4GzhbodgCH4x2X+S0ycBaERX393+k+fG8JPJpGujkmeQFBCeIKO3lK+PoYg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4660,6 +4945,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-transformers@7.0.0':
+    resolution: {integrity: sha512-NHkTKC2J4oaMMzyOtIEDOLCGtzg1Y8vlPoBmUeA82o+DNjBSiZLR2Ariy7n7chmwKchCZ8aGirBxjLCSRc6b/g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-transport-http@2.3.0':
     resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
     engines: {node: '>=20.18.0'}
@@ -4680,6 +4974,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@7.0.0':
+    resolution: {integrity: sha512-W0G15BN0xljXzRRo/ZwepJNiOjKhRImF5SxhjZauh2yVBoUjfd6NSCmYcdWu0tj9lypKKrB1ReS4oPmb4yCHbA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4726,6 +5029,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-types@7.0.0':
+    resolution: {integrity: sha512-Lf2csFSWHwN/8EL03uWfS7n1J19vWLK4DBGkQ5jebRhoJ3dD+xPcJtS+epI2281t5aghJvoV7D+RIM0NextZJg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc@2.3.0':
     resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
     engines: {node: '>=20.18.0'}
@@ -4746,6 +5058,15 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc@7.0.0':
+    resolution: {integrity: sha512-hCf4XEhspsNb8TnQ+E961+rBuJcTyrmwNr4LDfVHEeO/VTqaN+yVwAI1wpxcnzwc+T4OoXcyujNiQWhVZPOhiA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4785,6 +5106,15 @@ packages:
 
   '@solana/signers@6.9.0':
     resolution: {integrity: sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/signers@7.0.0':
+    resolution: {integrity: sha512-4E3xYQ0b9OZCTLghqfeHh66lfipy3jV1REdFJLk9WqPBaXVa/wSgGGIqZVa744ATSd9AeEfL/I5n/LrMNQOhoA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -4852,6 +5182,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/subscribable@7.0.0':
+    resolution: {integrity: sha512-dJQA5AxDv/7YxuNe7GXIkaOUNhXczFaL3/SNOvXe7k77bC4dx4HPkySfcVDfEWBOePe3+8iyVbT8DZ3aOcp8Ng==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/subscriptions@0.4.0':
     resolution: {integrity: sha512-zx3bj74IaljoqFnjmcscqmEq3Y72SD22imLW2TzvrCOn1YcOH/Zp1O1xx1t0CwQ2BoOnwaH8fTIpv4rfAqyr3g==}
     peerDependencies:
@@ -4915,6 +5254,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/sysvars@7.0.0':
+    resolution: {integrity: sha512-GKND6hCcBcrak3/VAtx6aEoAi9wQjJQzU2Fcu6JYmnTjGe5MHf21FqbjGl0aQ0C2HlJQQJmA07wgsuOiYDTDog==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/token-acl-gate-sdk@0.2.0':
     resolution: {integrity: sha512-jCbt1J8SI+jPdi8DLajKpN9V3x2B9FXbDRltXcM4jrIVuWsNQ6W6/yn8N65uwUUw4wrTD6MJUT2sMD+QDbY7Gg==}
     peerDependencies:
@@ -4945,6 +5293,24 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@7.0.0':
+    resolution: {integrity: sha512-SaU2CY9ZDJGK47DtQ7xwKFmbgzDGqIN/Ug89ZSUzDPD9QdMRXhtxgH8KZgb0gSgpyel85sSt0QH9wkWzhp69ow==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-introspection@7.0.0':
+    resolution: {integrity: sha512-aO+5ewxGaziXYcXJZ6F3doq/KI1L3WU2z5eCjs4DBO0kRQBHp4bH6ZKygVX2JIxOZrd1rB9SxP/CCCX2wRm8Xw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4991,6 +5357,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/transaction-messages@7.0.0':
+    resolution: {integrity: sha512-qCBYR3QQvykcI36vnqwI5090hGXS3mmCe72b/f/n9kBsBaA2oowdBXZupB1wwKe8+6x8o8VkhKQaK9oTKKbWTg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/transactions@2.3.0':
     resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
     engines: {node: '>=20.18.0'}
@@ -5026,6 +5401,15 @@ packages:
 
   '@solana/transactions@6.9.0':
     resolution: {integrity: sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@7.0.0':
+    resolution: {integrity: sha512-y5nayd2Ozld/4Bxefz50e/E6qxyZteuZCZ7suh7z96KY6QUJlZDR+eCG1v/lA7Azt3GSOevJuYFX/ept/mqZkw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -5492,6 +5876,10 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vedatech/svm-sdk@0.1.0-alpha.1':
+    resolution: {integrity: sha512-+npwiRMRRU+G/3qu2Dd2PFI6dLbOUYbEVgUS3mozsNXmUbtMvFYA3rT/5s+RpgDZXzzQLR290PqIj7y2AoxenA==}
+    engines: {node: '>=24.0.0'}
 
   '@vercel/cli-config@0.2.0':
     resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
@@ -8971,6 +9359,9 @@ packages:
   undici-types@7.27.2:
     resolution: {integrity: sha512-cH9f42mHuljpNuoS47sWDDWXVxWnJgYCzHVUlr3tn7+HVx0L6QSO+VG5qgzT4kXkR2K8ZsReaT5bupam6RNAEQ==}
 
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -11879,6 +12270,10 @@ snapshots:
     dependencies:
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
+  '@solana-program/system@0.13.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
   '@solana-program/system@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
@@ -11887,13 +12282,28 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana-program/token-2022@0.13.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+
+  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 1.9.7
       '@solana-program/record': 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
-      '@solana/sysvars': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+
+  '@solana-program/token-2022@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@solana-program/record': 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/zk-elgamal-proof': 0.3.2(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
   '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
@@ -11910,9 +12320,10 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana-program/token-2022@0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+  '@solana-program/token-2022@0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
   '@solana-program/token@0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -11923,6 +12334,11 @@ snapshots:
     dependencies:
       '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/token@0.15.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)))':
     dependencies:
@@ -11940,6 +12356,11 @@ snapshots:
     dependencies:
       '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/zk-elgamal-proof@0.3.2(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
 
   '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
@@ -11987,6 +12408,19 @@ snapshots:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/accounts@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12051,6 +12485,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/assertions': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/assertions@2.3.0(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@6.0.3)
@@ -12077,6 +12523,12 @@ snapshots:
   '@solana/assertions@6.9.0(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 6.9.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/assertions@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -12191,6 +12643,14 @@ snapshots:
       '@solana/codecs-core': 6.9.0(typescript@6.0.3)
       '@solana/codecs-numbers': 6.9.0(typescript@6.0.3)
       '@solana/errors': 6.9.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/codecs-data-structures@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -12348,6 +12808,19 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/codecs@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/fixed-points': 7.0.0(typescript@6.0.3)
+      '@solana/options': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/compat@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -12432,6 +12905,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/fast-stable-stringify@7.0.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@solana/fixed-points@6.10.0(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 6.10.0(typescript@6.0.3)
@@ -12470,6 +12947,10 @@ snapshots:
       typescript: 6.0.3
 
   '@solana/functional@6.9.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/functional@7.0.0(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
 
@@ -12512,6 +12993,19 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/instruction-plans@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/instructions@2.3.0(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 2.3.0(typescript@6.0.3)
@@ -12546,107 +13040,114 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/instructions@7.0.0(typescript@6.0.3)':
     dependencies:
-      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@solana/codecs-core'
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
-  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-cdp@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-cdp@1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
-      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@solana/codecs-core'
 
-  '@solana/keychain-core@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-fireblocks@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-core@1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+
+  '@solana/keychain-fireblocks@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose: 6.2.8
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-para@1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
-    dependencies:
-      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@solana/codecs-core'
-
-  '@solana/keychain-para@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-para@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@solana/codecs-core'
 
-  '@solana/keychain-privy@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-para@1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@solana/codecs-core'
+
+  '@solana/keychain-privy@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-turnkey@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-turnkey@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@noble/curves': 2.2.0
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-core': 7.0.0(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
 
-  '@solana/keychain-utila@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
+  '@solana/keychain-utila@1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))':
     dependencies:
       '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keychain-core': 1.4.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/codecs-core@7.0.0(typescript@6.0.3))(@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       jose: 6.2.8
@@ -12710,6 +13211,19 @@ snapshots:
       '@solana/errors': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
       '@solana/promises': 6.9.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/keys@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/assertions': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12818,6 +13332,41 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
+  '@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/accounts': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/instruction-plans': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/offchain-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/plugin-core': 7.0.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/program-client-core': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/programs': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-parsed-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/subscribable': 7.0.0(typescript@6.0.3)
+      '@solana/sysvars': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-confirmation': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/transaction-introspection': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
   '@solana/kora@0.3.0-beta.2(@solana-program/compute-budget@0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana-program/token@0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)))(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana-program/compute-budget': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
@@ -12859,6 +13408,10 @@ snapshots:
       typescript: 6.0.3
 
   '@solana/nominal-types@6.9.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/nominal-types@7.0.0(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
 
@@ -12922,6 +13475,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/offchain-messages@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@6.0.3)
@@ -12968,20 +13536,32 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/pay@1.0.26(aedb926283e2af4eda636589370801b0)':
+  '@solana/options@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/pay@1.0.26(d00a8eaf3bf65b54674c217824983efc)':
     dependencies:
       '@solana-program/memo': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/system': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana-program/token': 0.15.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
-      '@solana-program/token-2022': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
-      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana-program/token-2022': 0.14.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/qr-code-styling': 1.6.0
-      '@solana/rpc-subscriptions-api': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
-      '@solana/rpc-subscriptions-spec': 6.10.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 7.0.0(typescript@6.0.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
@@ -12991,6 +13571,10 @@ snapshots:
       typescript: 6.0.3
 
   '@solana/plugin-core@6.8.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/plugin-core@7.0.0(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
 
@@ -13017,6 +13601,20 @@ snapshots:
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/signers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/plugin-interfaces@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instruction-plans': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13054,6 +13652,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/program-client-core@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/accounts': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/instruction-plans': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/plugin-interfaces': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-api': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/programs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -13080,6 +13694,15 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/programs@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/promises@2.3.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
@@ -13097,6 +13720,10 @@ snapshots:
       typescript: 6.0.3
 
   '@solana/promises@6.9.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/promises@7.0.0(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
 
@@ -13175,6 +13802,24 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-api@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-parsed-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-parsed-types@2.3.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
@@ -13191,6 +13836,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@solana/rpc-parsed-types@7.0.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@solana/rpc-spec-types@2.3.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
@@ -13204,6 +13853,12 @@ snapshots:
       typescript: 6.0.3
 
   '@solana/rpc-spec-types@6.8.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/rpc-spec-types@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -13232,6 +13887,14 @@ snapshots:
     dependencies:
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/rpc-spec@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      '@solana/subscribable': 7.0.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -13276,6 +13939,20 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-subscriptions-api@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@6.0.3)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@6.0.3)
@@ -13304,6 +13981,19 @@ snapshots:
       '@solana/functional': 6.8.0(typescript@6.0.3)
       '@solana/rpc-subscriptions-spec': 6.8.0(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@solana/rpc-subscriptions-channel-websocket@7.0.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-spec': 7.0.0(typescript@6.0.3)
+      '@solana/subscribable': 7.0.0(typescript@6.0.3)
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
@@ -13343,6 +14033,15 @@ snapshots:
       '@solana/promises': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
       '@solana/subscribable': 6.8.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/rpc-subscriptions-spec@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      '@solana/subscribable': 7.0.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -13404,6 +14103,26 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
+  '@solana/rpc-subscriptions@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/fast-stable-stringify': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-subscriptions-api': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions-channel-websocket': 7.0.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-subscriptions-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/subscribable': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
   '@solana/rpc-transformers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@6.0.3)
@@ -13451,6 +14170,18 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-transformers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-transport-http@2.3.0(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@6.0.3)
@@ -13474,6 +14205,15 @@ snapshots:
       '@solana/rpc-spec': 6.8.0(typescript@6.0.3)
       '@solana/rpc-spec-types': 6.8.0(typescript@6.0.3)
       undici-types: 8.4.1
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/rpc-transport-http@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      undici-types: 8.10.0
     optionalDependencies:
       typescript: 6.0.3
 
@@ -13543,6 +14283,20 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-types@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/fixed-points': 7.0.0(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@6.0.3)
@@ -13585,6 +14339,22 @@ snapshots:
       '@solana/rpc-transformers': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/rpc-transport-http': 6.8.0(typescript@6.0.3)
       '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/fast-stable-stringify': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-api': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-spec': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-spec-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-transformers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-transport-http': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13663,6 +14433,22 @@ snapshots:
       '@solana/offchain-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+      '@solana/offchain-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13754,10 +14540,17 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@solana/subscriptions@0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+  '@solana/subscribable@7.0.0(typescript@6.0.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@solana/subscriptions@0.4.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana-program/token': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
-      '@solana-program/token-2022': 0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.9.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@solana/kit-plugin-rpc': 0.11.1(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
       '@solana/kit-plugin-signer': 0.10.0(@solana/kit@6.8.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
@@ -13812,6 +14605,19 @@ snapshots:
       '@solana/codecs-numbers': 6.8.0(typescript@6.0.3)
       '@solana/errors': 6.8.0(typescript@6.0.3)
       '@solana/rpc-types': 6.8.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/accounts': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13890,6 +14696,40 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
+  '@solana/transaction-confirmation@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
+      '@solana/rpc': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/rpc-subscriptions': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-introspection@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-api': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/transaction-messages@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -13964,6 +14804,22 @@ snapshots:
       '@solana/instructions': 6.9.0(typescript@6.0.3)
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
       '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-messages@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14058,6 +14914,25 @@ snapshots:
       '@solana/nominal-types': 6.9.0(typescript@6.0.3)
       '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
+    dependencies:
+      '@solana/addresses': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/codecs-core': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-data-structures': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@6.0.3)
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/errors': 7.0.0(typescript@6.0.3)
+      '@solana/functional': 7.0.0(typescript@6.0.3)
+      '@solana/instructions': 7.0.0(typescript@6.0.3)
+      '@solana/keys': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/nominal-types': 7.0.0(typescript@6.0.3)
+      '@solana/rpc-types': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14525,6 +15400,20 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vedatech/svm-sdk@0.1.0-alpha.1(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana-program/system': 0.13.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.15.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.13.0(@solana/kit@7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6))(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3))
+      '@solana/kit': 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+      - '@solana/zk-sdk'
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@vercel/cli-config@0.2.0':
     dependencies:
@@ -15580,8 +16469,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.12
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
@@ -15603,7 +16492,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15614,22 +16503,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15640,7 +16529,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -18727,6 +19616,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.27.2: {}
+
+  undici-types@8.10.0: {}
 
   undici-types@8.3.0: {}
 

--- a/scripts/check-kamino-dependency-boundary.mjs
+++ b/scripts/check-kamino-dependency-boundary.mjs
@@ -1,47 +1,11 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+import { assertExactConsumers } from "./lib/dependency-boundary.mjs";
 
 const ROOT = process.cwd();
 const LOCKFILE = "pnpm-lock.yaml";
 const KAMINO_PACKAGE = "packages/sdp-kamino/package.json";
 const API_PACKAGE = "apps/sdp-api/package.json";
-
-function packageJsonFiles(parent) {
-  return readdirSync(path.join(ROOT, parent), { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => path.join(parent, entry.name, "package.json"))
-    .filter((file) => {
-      try {
-        readFileSync(path.join(ROOT, file));
-        return true;
-      } catch {
-        return false;
-      }
-    });
-}
-
-const manifests = ["package.json", ...packageJsonFiles("apps"), ...packageJsonFiles("packages")];
-
-function directConsumers(dependency) {
-  return manifests.filter((file) => {
-    const manifest = JSON.parse(readFileSync(path.join(ROOT, file), "utf8"));
-    return [manifest.dependencies, manifest.devDependencies, manifest.optionalDependencies].some(
-      (dependencies) => dependencies && Object.hasOwn(dependencies, dependency)
-    );
-  });
-}
-
-function assertExactConsumers(dependency, expected) {
-  const actual = directConsumers(dependency).sort();
-  const wanted = [...expected].sort();
-  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
-    throw new Error(
-      `${dependency} dependency boundary changed. Expected ${wanted.join(", ")}; found ${
-        actual.join(", ") || "none"
-      }.`
-    );
-  }
-}
 
 // Only the private Kamino package may own klend-sdk, and only the API may ship
 // that package. A new web/docs/package consumer would create an artifact not

--- a/scripts/check-module-boundaries.mjs
+++ b/scripts/check-module-boundaries.mjs
@@ -33,6 +33,7 @@ const MODULE_METADATA = [
       "@sdp/spc-escrow",
       "@sdp/spc-withdraw",
       "@sdp/types",
+      "@sdp/veda",
     ],
   },
   {
@@ -113,6 +114,20 @@ const MODULE_METADATA = [
     // and @sdp/earn must never depend back — its hourly catalogue cron would
     // then load klend-sdk (13MB, built against a different @solana/kit major).
     // That one-way edge is also why the Kamino program-id table lives in
+    // @sdp/types, which both reach without a cycle.
+    allowedDependencies: ["@sdp/earn", "@sdp/solana", "@sdp/types"],
+  },
+  {
+    name: "@sdp/veda",
+    directory: "packages/sdp-veda",
+    purpose:
+      "Kit-native Veda SVM vault deposit plans and position reads over the private @vedatech/svm-sdk.",
+    // The arrow points INWARD and only inward: this package depends on
+    // @sdp/earn (for the provider contract and the catalogue client it extends),
+    // and @sdp/earn must never depend back — its hourly catalogue cron would
+    // then load a chain SDK built against a different @solana/kit major, from a
+    // PRIVATE registry every consumer of @sdp/earn would suddenly need a token
+    // for. That one-way edge is also why the Veda deployment registry lives in
     // @sdp/types, which both reach without a cycle.
     allowedDependencies: ["@sdp/earn", "@sdp/solana", "@sdp/types"],
   },

--- a/scripts/check-veda-dependency-boundary.mjs
+++ b/scripts/check-veda-dependency-boundary.mjs
@@ -1,0 +1,36 @@
+import { assertConsumersWithin, assertExactConsumers } from "./lib/dependency-boundary.mjs";
+
+const VEDA_PACKAGE = "packages/sdp-veda/package.json";
+const API_PACKAGE = "apps/sdp-api/package.json";
+
+/**
+ * `@vedatech/svm-sdk` is the ONLY private-registry dependency in this
+ * workspace, and keeping it that way is what makes an absent `NPM_TOKEN` a
+ * survivable state rather than a broken build.
+ *
+ * `.github/scripts/pnpm-install.sh` degrades a credential-less install by
+ * deselecting exactly ONE workspace project — `@sdp/veda`. That is only sound
+ * while `@sdp/veda` is the sole owner of the private package: a second owner
+ * would make the fork-safe install fail on a tarball it cannot fetch, and every
+ * external contribution would go red on a dependency it never touched.
+ *
+ * The kit-major boundary rides along. The SDK is built against `@solana/kit` 7
+ * while this repo pins 6.8; `packages/sdp-veda/src/sdk.ts` is the only module
+ * that may import it, and a second package owning the dependency would put a
+ * fourth kit major in front of code that never asked for one.
+ */
+assertExactConsumers("@vedatech/svm-sdk", [VEDA_PACKAGE]);
+
+/**
+ * Only the API may ship `@sdp/veda`.
+ *
+ * A WITHIN check rather than an exact one: zero consumers is a legitimate state
+ * while the integration is being wired up, and the property worth guarding is
+ * that no NEW consumer appears — the dashboard or the docs site pulling this in
+ * would drag the private SDK into a build whose image has no npm credential.
+ */
+assertConsumersWithin("@sdp/veda", [API_PACKAGE]);
+
+console.log(
+  "Veda dependency boundary OK: API -> @sdp/veda -> @vedatech/svm-sdk (private, single owner)"
+);

--- a/scripts/lib/dependency-boundary.mjs
+++ b/scripts/lib/dependency-boundary.mjs
@@ -1,0 +1,81 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Shared helpers for the per-package dependency-boundary checks.
+ *
+ * Extracted from `check-kamino-dependency-boundary.mjs` when Veda needed the
+ * same question asked about a different package. Both checks answer "who is
+ * allowed to depend on this?", and the interesting half is per-package: Kamino
+ * additionally pins the `bigint-buffer` path the API bundle patches, and Veda
+ * additionally keeps a PRIVATE registry dependency from spreading.
+ */
+
+const ROOT = process.cwd();
+
+function packageJsonFiles(parent) {
+  return readdirSync(path.join(ROOT, parent), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(parent, entry.name, "package.json"))
+    .filter((file) => {
+      try {
+        readFileSync(path.join(ROOT, file));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+}
+
+/** Every manifest in the workspace, including the root. */
+export function workspaceManifests() {
+  return ["package.json", ...packageJsonFiles("apps"), ...packageJsonFiles("packages")];
+}
+
+/** Manifests that declare `dependency` in any dependency field. */
+export function directConsumers(dependency, manifests = workspaceManifests()) {
+  return manifests
+    .filter((file) => {
+      const manifest = JSON.parse(readFileSync(path.join(ROOT, file), "utf8"));
+      return [manifest.dependencies, manifest.devDependencies, manifest.optionalDependencies].some(
+        (dependencies) => dependencies && Object.hasOwn(dependencies, dependency)
+      );
+    })
+    .sort();
+}
+
+/**
+ * Exactly these manifests may declare `dependency`, no more and no fewer.
+ *
+ * Use for a dependency that must have a single owner — a vendored SDK, a
+ * package with a patched transitive dependency, anything where a second
+ * consumer would produce an artifact the first one's protections do not cover.
+ */
+export function assertExactConsumers(dependency, expected) {
+  const actual = directConsumers(dependency);
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    throw new Error(
+      `${dependency} dependency boundary changed. Expected ${wanted.join(", ")}; found ${
+        actual.join(", ") || "none"
+      }.`
+    );
+  }
+}
+
+/**
+ * Only these manifests MAY declare `dependency`; none of them has to.
+ *
+ * The right shape for "no new consumers" when the dependency is still being
+ * wired up across a stack of changes: zero consumers is a legitimate state,
+ * while an unlisted one never is.
+ */
+export function assertConsumersWithin(dependency, allowed) {
+  const permitted = new Set(allowed);
+  const unexpected = directConsumers(dependency).filter((file) => !permitted.has(file));
+  if (unexpected.length > 0) {
+    throw new Error(
+      `${dependency} may only be consumed by ${[...permitted].sort().join(", ")}; found ${unexpected.join(", ")}.`
+    );
+  }
+}


### PR DESCRIPTION
The execution half of the integration: unsigned deposit plans and live position reads over the private `@vedatech/svm-sdk`. It never signs, never submits, never touches a database, and holds no runtime credential — Veda's vaults are reached entirely on chain. Mirrors `@sdp/kamino` in shape; the differences are where Veda differs.

**It is a kit-version firewall.** The SDK is built against `@solana/kit` 7 while this repo pins 6.8, so `src/sdk.ts` is the only module that may import it and everything crossing the package surface is kit 6.8, `@sdp/types`, or a decimal string. The tree now carries four kit majors and none of them meet.

**It is also a PRIVATE-REGISTRY firewall, and that half is new.** `@vedatech/svm-sdk` is the only package here needing a credential to install, and `.github/scripts/pnpm-install.sh` survives a missing `NPM_TOKEN` by deselecting exactly one workspace project. That works only while `@sdp/veda` is the SDK's sole owner, so `scripts/check-veda-dependency-boundary.mjs` enforces it — a second owner would turn every forked pull request red on a dependency it never touched. Measured against the real lockfile: without the token an unfiltered install fails `ERR_PNPM_FETCH_404` on the private tarball and the filtered one completes. The shared consumer-scanning helpers move to `scripts/lib/dependency-boundary.mjs`; the Kamino check now uses them.

**Money in requires a way out.** Every deposit build first runs `validateDeployment()` and `validateCompatibility({ requireQueue: true })`. Demanding the withdrawal QUEUE on the deposit path is ADR 0002's exit-safety rule: SDP will not open a position in a vault whose exit infrastructure is not configured and wired to it. It gates only the way in — reads and any future exit never call it — so it can never trap funds. Verdicts cache for ten minutes per (cluster, endpoint, vault); failures are never cached.

**`buildVaultWithdrawal` is deliberately absent**, so `supportsVaultWithdraw` answers false. Veda has two independent exits and SDP has a route for neither; withholding the capability says the route does not exist, never that the customer may not leave — the shares are in their own custody wallet.

**Slippage protection is never invented.** `minSharesOut` is REQUIRED here, unlike Kamino's optional floor: the SDK refuses an implicit tolerance and SDP passes that refusal through rather than defaulting one. `slippageBps` appears nowhere, and a source test asserts it.

**The deposit asset is resolved, and ambiguity is refused.** `EarnVaultDepositInput` carries no mint, so the builder must reach the same asset the catalogue admitted — same predicate (`isVedaDepositMint`, now shared from `@sdp/types` so there is one copy), same source (the vault's own enabled assets). More than one match fails the build rather than picking the first.

**`idl-layout.test.ts` earns its place.** `@sdp/earn` decodes vault state positionally and cannot check itself — it may not depend on the SDK. This package holds the IDLs, so it recomputes that offset table from the published field order and compares the committed IDLs against the SDK's shipped copies AND their recorded SHA-256s. A silent Veda ABI change now fails on the next `pnpm install`, instead of becoming a wrong share mint on a customer's row.

Nothing here has ever run against a live vault: `VEDA_DEPLOYMENTS` is empty, so every chain call fails closed with `DEPLOYMENT_NOT_CONFIGURED`. The env-gated `sdk.smoke.test.ts` takes its deployment from the environment and is the only thing that can prove the integration once Veda confirms addresses.