### PR TITLE
fix(rpc): classify transient Solana JSON-RPC server codes as retryable

### DIFF
--- a/packages/sdp-rpc/src/transient.test.ts
+++ b/packages/sdp-rpc/src/transient.test.ts
@@ -25,6 +25,44 @@ test("does not retry a persistent error", async () => {
   assert.equal(calls, 1);
 });
 
+test("treats Solana JSON-RPC server codes as transient", async () => {
+  let calls = 0;
+  const result = await withTransientRpcRetry(async () => {
+    calls += 1;
+    if (calls === 1) {
+      throw new Error(
+        "Solana error #-32019; Decode this error by running `npx @solana/errors decode -- -32019`"
+      );
+    }
+    return "ok";
+  }, [0, 0, 0]);
+  assert.equal(result, "ok");
+  assert.equal(calls, 2);
+});
+
+test("treats raw Solana server messages as transient", async () => {
+  let calls = 0;
+  const result = await withTransientRpcRetry(async () => {
+    calls += 1;
+    if (calls === 1) throw new Error("Failed to query long-term storage; please try again");
+    return "ok";
+  }, [0, 0, 0]);
+  assert.equal(result, "ok");
+  assert.equal(calls, 2);
+});
+
+test("does not misread ordinary numbers as Solana error codes", async () => {
+  let calls = 0;
+  await assert.rejects(
+    withTransientRpcRetry(async () => {
+      calls += 1;
+      throw new Error("custom program error: 0x32019");
+    }, [0, 0, 0]),
+    /custom program error/
+  );
+  assert.equal(calls, 1);
+});
+
 test("gives up after exhausting the delay schedule", async () => {
   let calls = 0;
   await assert.rejects(

--- a/packages/sdp-rpc/src/transient.test.ts
+++ b/packages/sdp-rpc/src/transient.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY,
+  SolanaError,
+} from "@solana/kit";
 import { withTransientRpcRetry } from "./transient";
 
 test("retries a transient error and returns the eventual success", async () => {
@@ -25,14 +30,12 @@ test("does not retry a persistent error", async () => {
   assert.equal(calls, 1);
 });
 
-test("treats Solana JSON-RPC server codes as transient", async () => {
+test("retries a long-term-storage server error", async () => {
   let calls = 0;
   const result = await withTransientRpcRetry(async () => {
     calls += 1;
     if (calls === 1) {
-      throw new Error(
-        "Solana error #-32019; Decode this error by running `npx @solana/errors decode -- -32019`"
-      );
+      throw new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE);
     }
     return "ok";
   }, [0, 0, 0]);
@@ -40,18 +43,22 @@ test("treats Solana JSON-RPC server codes as transient", async () => {
   assert.equal(calls, 2);
 });
 
-test("treats raw Solana server messages as transient", async () => {
+test("retries an unhealthy-node server error", async () => {
   let calls = 0;
   const result = await withTransientRpcRetry(async () => {
     calls += 1;
-    if (calls === 1) throw new Error("Failed to query long-term storage; please try again");
+    if (calls === 1) {
+      throw new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY, {
+        numSlotsBehind: 100,
+      });
+    }
     return "ok";
   }, [0, 0, 0]);
   assert.equal(result, "ok");
   assert.equal(calls, 2);
 });
 
-test("does not misread ordinary numbers as Solana error codes", async () => {
+test("does not retry a plain error whose text merely resembles a server code", async () => {
   let calls = 0;
   await assert.rejects(
     withTransientRpcRetry(async () => {

--- a/packages/sdp-rpc/src/transient.ts
+++ b/packages/sdp-rpc/src/transient.ts
@@ -2,6 +2,13 @@
  * Shared RPC helpers used by the Solana RPC layer and the fee-payment adapters.
  */
 
+import {
+  isSolanaError,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_BLOCK_STATUS_NOT_AVAILABLE_YET,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY,
+} from "@solana/kit";
+
 // Overloaded-gateway / timeout HTTP statuses worth retrying.
 const TRANSIENT_HTTP_STATUS = /\b(408|429|500|502|503|504)\b/;
 
@@ -20,19 +27,20 @@ const TRANSIENT_ERROR_TEXT =
  * insufficient funds) are intentionally excluded so callers don't retry
  * unrecoverable submissions.
  */
-// Transient Solana JSON-RPC server codes: -32005 node unhealthy/behind,
-// -32014 block status not yet available, -32019 long-term storage failed.
-const TRANSIENT_SOLANA_RPC_CODE = /#?-320(05|14|19)\b/;
-const TRANSIENT_SOLANA_RPC_TEXT =
-  /failed to query long-term storage|block status is not (?:yet )?available|node is (?:unhealthy|behind)/i;
+// Transient Solana JSON-RPC server codes: node unhealthy/behind, block status
+// not yet available, long-term storage unreachable.
+const TRANSIENT_SOLANA_RPC_CODES = [
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_NODE_UNHEALTHY,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_BLOCK_STATUS_NOT_AVAILABLE_YET,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE,
+] as const;
 
 export function isTransientRpcError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
     TRANSIENT_HTTP_STATUS.test(message) ||
     TRANSIENT_ERROR_TEXT.test(message) ||
-    TRANSIENT_SOLANA_RPC_CODE.test(message) ||
-    TRANSIENT_SOLANA_RPC_TEXT.test(message)
+    TRANSIENT_SOLANA_RPC_CODES.some((code) => isSolanaError(error, code))
   );
 }
 

--- a/packages/sdp-rpc/src/transient.ts
+++ b/packages/sdp-rpc/src/transient.ts
@@ -20,9 +20,20 @@ const TRANSIENT_ERROR_TEXT =
  * insufficient funds) are intentionally excluded so callers don't retry
  * unrecoverable submissions.
  */
+// Transient Solana JSON-RPC server codes: -32005 node unhealthy/behind,
+// -32014 block status not yet available, -32019 long-term storage failed.
+const TRANSIENT_SOLANA_RPC_CODE = /#?-320(05|14|19)\b/;
+const TRANSIENT_SOLANA_RPC_TEXT =
+  /failed to query long-term storage|block status is not (?:yet )?available|node is (?:unhealthy|behind)/i;
+
 export function isTransientRpcError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return TRANSIENT_HTTP_STATUS.test(message) || TRANSIENT_ERROR_TEXT.test(message);
+  return (
+    TRANSIENT_HTTP_STATUS.test(message) ||
+    TRANSIENT_ERROR_TEXT.test(message) ||
+    TRANSIENT_SOLANA_RPC_CODE.test(message) ||
+    TRANSIENT_SOLANA_RPC_TEXT.test(message)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Stacked on #1430. `isTransientRpcError` only recognized transient failures by HTTP status and transport error text, so Solana JSON-RPC server errors that are transient by definition — `-32005` (node unhealthy/behind), `-32014` (block status not yet available), `-32019` (failed to query long-term storage) — were thrown without retry. In production this surfaced as a 500 + Sentry issue on `GET /v1/payments/transfers` when the RPC provider's archival storage timed out with `-32019`, an error whose own message says "please try again".

## Changes

- `packages/sdp-rpc/src/transient.ts`: the classifier now also matches these codes (both the `@solana/errors` "Solana error #-32019" form and the raw server message text).
- Tests: code form retried, raw message form retried, and a guard that ordinary numbers like `0x32019` are not misread as codes.

## Testing

`pnpm --filter @sdp/rpc test`: 15/15 pass; typecheck and lint clean.
