### PR TITLE
fix(payments): extend outcome parking to batches and recurring collections

### DIFF
--- a/apps/sdp-api/src/openapi/paths/payments.ts
+++ b/apps/sdp-api/src/openapi/paths/payments.ts
@@ -314,7 +314,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     summary: "Create transfer batch",
     operationId: "createPaymentTransferBatch",
     description:
-      "Executes a custody-signed outbound transfer batch to counterparty crypto-wallet accounts, chunks recipients into Solana transactions, and returns the batch, recipient, and transfer records. Supply an Idempotency-Key to retry safely: an identical resolved request returns the original batch without another on-chain submission, while reusing the key for a different request returns 409.",
+      "Executes a custody-signed outbound transfer batch to counterparty crypto-wallet accounts, chunks recipients into Solana transactions, and returns the batch, recipient, and transfer records. Supply an Idempotency-Key to retry safely: an identical resolved request returns the original batch without another on-chain submission, while reusing the key for a different request returns 409. A chunk whose provider outcome is unknown comes back inside a 200 as a processing transfer without a signature and with a reconciliation notice in error, its recipients left processing — it may already be on chain, so do NOT re-send that batch.",
     security: [{ apiKeyAuth: [] }],
     request: {
       headers: projectScopeWithIdempotencyHeaders,
@@ -502,7 +502,7 @@ export function registerPaymentsPaths(registry: OpenAPIRegistry) {
     summary: "Collect recurring payment",
     operationId: "collectPaymentRecurringPayment",
     description:
-      "Manually collects a due active SDP-custody recurring payment by submitting the Solana subscriptions collection transaction, creating a linked payment transfer, recording the collection attempt, and advancing the next due time.",
+      "Manually collects a due active SDP-custody recurring payment by submitting the Solana subscriptions collection transaction, creating a linked payment transfer, recording the collection attempt, and advancing the next due time. A 409 with error.details.reason = transfer_submission_outcome_unknown means the provider outcome is unknown: the attempt and its transfer stay processing behind a reconciliation marker and the cycle is deliberately NOT rescheduled — do not retry, and do not read it as a failed collection.",
     security: [{ apiKeyAuth: [] }],
     request: {
       headers: projectScopeHeaders,

--- a/apps/sdp-api/src/openapi/schemas/payments.ts
+++ b/apps/sdp-api/src/openapi/schemas/payments.ts
@@ -906,7 +906,8 @@ export const transferBatchRecipientSchema = z
     amount: tokenAmountSchema,
     status: paymentTransferBatchRecipientStatusSchema,
     error: z.string().nullable().openapi({
-      description: "Recipient-level failure reason, when available.",
+      description:
+        "Recipient-level failure reason, or the reconciliation notice carried while its chunk's submission outcome is unknown and the recipient stays processing. Non-null does not imply a failed status.",
     }),
     createdAt: isoDateTimeSchema,
     updatedAt: isoDateTimeSchema,

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -1983,17 +1983,8 @@ describe("Payments routes — recurring", () => {
       Authorization: `Bearer ${TEST_API_KEY.raw}`,
       "Content-Type": "application/json",
     };
-    const recurringPaymentId = await createRecurringPaymentForActivation(headers);
-
-    const activateRes = await app.request(
-      `/v1/payments/recurring-payments/${recurringPaymentId}/activate`,
-      { method: "POST", headers, body: "{}" },
-      env
-    );
-    expect(activateRes.status).toBe(200);
-    const activateBody = (await activateRes.json()) as {
-      data: { recurringPayment: { subscriptionId: string } };
-    };
+    const activated = await activateRecurringPaymentForTest(headers);
+    const recurringPaymentId = activated.id;
     const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
     await getDb(env)
       .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
@@ -2001,7 +1992,7 @@ describe("Payments routes — recurring", () => {
       .run();
     await getDb(env)
       .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
-      .bind(dueAt, activateBody.data.recurringPayment.subscriptionId)
+      .bind(dueAt, activated.subscriptionId)
       .run();
 
     const collectRes = await app.request(
@@ -2027,7 +2018,7 @@ describe("Payments routes — recurring", () => {
           ORDER BY a.created_at DESC
           LIMIT 1`
       )
-      .bind(activateBody.data.recurringPayment.subscriptionId)
+      .bind(activated.subscriptionId)
       .first<{
         id: string;
         status: string;
@@ -2061,7 +2052,7 @@ describe("Payments routes — recurring", () => {
            FROM payment_subscription_collection_attempts
           WHERE subscription_id = ? AND due_at = ?`
       )
-      .bind(activateBody.data.recurringPayment.subscriptionId, dueAt)
+      .bind(activated.subscriptionId, dueAt)
       .first<{ total: number }>();
     expect(Number(transferCount?.total)).toBe(1);
   });

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -1955,6 +1955,117 @@ describe("Payments routes — recurring", () => {
     expect(signAndSendMock).toHaveBeenCalledTimes(3);
   });
 
+  it("parks a collection whose submission outcome is unknown instead of re-charging the payer", async () => {
+    // The provider may have broadcast the collection without returning a
+    // signature. Journaling a failure would reschedule the cycle, and the next
+    // tick would charge the payer a second time for the same period.
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValue(sourceSigner);
+    mockRecurringActivationRpc();
+    const signAndSendMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as Signature
+      )
+      .mockResolvedValueOnce(
+        "5Tzxe7r8pab72bTDx9pQHM9YEWXoQ2MchfbzdnJAj3vScaUmAAJgEE3Jx1b68u33cfWdJTKXgpUtHBZPYJxVQ1pV" as Signature
+      )
+      .mockRejectedValue(new Error("kora timed out"));
+    createFeePaymentAdapterMock.mockReturnValue({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+    const headers = {
+      Authorization: `Bearer ${TEST_API_KEY.raw}`,
+      "Content-Type": "application/json",
+    };
+    const recurringPaymentId = await createRecurringPaymentForActivation(headers);
+
+    const activateRes = await app.request(
+      `/v1/payments/recurring-payments/${recurringPaymentId}/activate`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(activateRes.status).toBe(200);
+    const activateBody = (await activateRes.json()) as {
+      data: { recurringPayment: { subscriptionId: string } };
+    };
+    const dueAt = new Date(Date.now() - 60 * 1000).toISOString();
+    await getDb(env)
+      .prepare("UPDATE payment_recurring_payments SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, recurringPaymentId)
+      .run();
+    await getDb(env)
+      .prepare("UPDATE payment_subscriptions SET next_collection_due_at = ? WHERE id = ?")
+      .bind(dueAt, activateBody.data.recurringPayment.subscriptionId)
+      .run();
+
+    const collectRes = await app.request(
+      `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+
+    expect(collectRes.status).toBe(409);
+    const collectError = (await collectRes.json()) as {
+      error: { details?: { reason?: string } };
+    };
+    expect(collectError.error.details?.reason).toBe("transfer_submission_outcome_unknown");
+
+    const attempt = await getDb(env)
+      .prepare(
+        `SELECT a.id, a.status, a.transfer_id, t.status AS transfer_status,
+                t.signature AS transfer_signature, t.error AS transfer_error,
+                t.provider_data AS transfer_provider_data
+           FROM payment_subscription_collection_attempts a
+           JOIN payment_transfers t ON t.id = a.transfer_id
+          WHERE a.subscription_id = ?
+          ORDER BY a.created_at DESC
+          LIMIT 1`
+      )
+      .bind(activateBody.data.recurringPayment.subscriptionId)
+      .first<{
+        id: string;
+        status: string;
+        transfer_id: string;
+        transfer_status: string;
+        transfer_signature: string | null;
+        transfer_error: string | null;
+        transfer_provider_data: unknown;
+      }>();
+    // The attempt is NOT failed: failing it reschedules the cycle.
+    expect(attempt?.status).toBe("processing");
+    expect(attempt?.transfer_status).toBe("processing");
+    expect(attempt?.transfer_signature).toBeNull();
+    const providerData =
+      typeof attempt?.transfer_provider_data === "string"
+        ? JSON.parse(attempt.transfer_provider_data)
+        : attempt?.transfer_provider_data;
+    // Literal on purpose: the durable contract the jobs and the operator match.
+    expect(providerData).toMatchObject({ submission_outcome: "unknown" });
+
+    // A second collect must not create a second transfer for the same cycle.
+    const retryRes = await app.request(
+      `/v1/payments/recurring-payments/${recurringPaymentId}/collect`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(retryRes.status).toBe(409);
+    const transferCount = await getDb(env)
+      .prepare(
+        `SELECT count(*) AS total
+           FROM payment_subscription_collection_attempts
+          WHERE subscription_id = ? AND due_at = ?`
+      )
+      .bind(activateBody.data.recurringPayment.subscriptionId, dueAt)
+      .first<{ total: number }>();
+    expect(Number(transferCount?.total)).toBe(1);
+  });
+
   it("collects due recurring payments through SDP API routes", async () => {
     const sourceSigner = await generateKeyPairSigner();
     await updateSeededWalletPublicKey(sourceSigner.address);

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -2098,6 +2098,39 @@ describe("Payments routes — recurring", () => {
     };
     expect(cancelBody.error.details?.reason).toBe("transfer_submission_outcome_unknown");
     expect(cancelBody.error.message).toContain("awaits manual reconciliation");
+
+    // A rollback can leave the marker behind while the old cron settles the
+    // transfer. After rolling forward, that settled marker is inert: recovery
+    // must advance past the old attempt instead of blocking it forever.
+    const parkedTransferId = attempt?.transfer_id;
+    if (!parkedTransferId) {
+      throw new Error("Expected the parked attempt to reference its transfer");
+    }
+    await getDb(env)
+      .prepare(
+        `UPDATE payment_transfers
+            SET status = 'failed',
+                error = 'Transfer processing timed out'
+          WHERE id = ?`
+      )
+      .bind(parkedTransferId)
+      .run();
+    const recoveryResult = await collectDueRecurringPayments(env);
+
+    expect(recoveryResult).toEqual({ recovered: 0, collected: 0, failed: 0, skipped: 1 });
+    const recoveredAttempts = await getDb(env)
+      .prepare(
+        `SELECT status
+           FROM payment_subscription_collection_attempts
+          WHERE subscription_id = ?
+          ORDER BY created_at`
+      )
+      .bind(activated.subscriptionId)
+      .all<{ status: string }>();
+    expect(recoveredAttempts.rows.map((row) => row.status).sort()).toEqual([
+      "failed",
+      "processing",
+    ]);
   });
 
   it("collects due recurring payments through SDP API routes", async () => {

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresPaymentSubscriptionsRepository } from "@/db/repositories";
 import app from "@/index";
+import { collectDueRecurringPayments } from "@/services/jobs/collect-recurring-payments";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
 import {
@@ -2055,6 +2056,33 @@ describe("Payments routes — recurring", () => {
       .bind(activated.subscriptionId, dueAt)
       .first<{ total: number }>();
     expect(Number(transferCount?.total)).toBe(1);
+
+    // Neither must stale recovery rebuild it: that fails the attempt, which
+    // reschedules the cycle and charges the payer for the same period twice.
+    const submitsBeforeCron = signAndSendMock.mock.calls.length;
+    await getDb(env)
+      .prepare(
+        `UPDATE payment_subscription_collection_attempts
+            SET updated_at = ?
+          WHERE subscription_id = ?`
+      )
+      .bind(new Date(Date.now() - 60 * 60 * 1000).toISOString(), activated.subscriptionId)
+      .run();
+    const cronResult = await collectDueRecurringPayments(env);
+    expect(signAndSendMock.mock.calls.length).toBe(submitsBeforeCron);
+    // `skipped` counts a row that entered collection and threw: the parked
+    // cycle must not even be selected, or it crowds the oldest-first window
+    // and starves the collections that are genuinely stuck.
+    expect(cronResult).toMatchObject({ skipped: 0 });
+    const afterCron = await getDb(env)
+      .prepare(
+        `SELECT count(*) AS total
+           FROM payment_subscription_collection_attempts
+          WHERE subscription_id = ?`
+      )
+      .bind(activated.subscriptionId)
+      .first<{ total: number }>();
+    expect(Number(afterCron?.total)).toBe(1);
   });
 
   it("collects due recurring payments through SDP API routes", async () => {

--- a/apps/sdp-api/src/routes/payments.recurring.test.ts
+++ b/apps/sdp-api/src/routes/payments.recurring.test.ts
@@ -2083,6 +2083,21 @@ describe("Payments routes — recurring", () => {
       .bind(activated.subscriptionId)
       .first<{ total: number }>();
     expect(Number(afterCron?.total)).toBe(1);
+
+    // Lifecycle stays blocked while the cycle is unresolved — but the client
+    // asked to cancel a subscription, so the refusal must say that, not hand
+    // back a transfer's reconciliation notice.
+    const cancelRes = await app.request(
+      `/v1/payments/recurring-payments/${recurringPaymentId}/cancel`,
+      { method: "POST", headers, body: "{}" },
+      env
+    );
+    expect(cancelRes.status).toBe(409);
+    const cancelBody = (await cancelRes.json()) as {
+      error: { message: string; details?: { reason?: string } };
+    };
+    expect(cancelBody.error.details?.reason).toBe("transfer_submission_outcome_unknown");
+    expect(cancelBody.error.message).toContain("awaits manual reconciliation");
   });
 
   it("collects due recurring payments through SDP API routes", async () => {

--- a/apps/sdp-api/src/routes/payments.transfers.test.ts
+++ b/apps/sdp-api/src/routes/payments.transfers.test.ts
@@ -2661,6 +2661,15 @@ describe("Payments routes — transfers", () => {
         const res = await transferRequest("1");
 
         expect(res.status).toBe(200);
+        // Declared in PR-1's Impact: the caller is handed a signature the row
+        // never took, and that row waits for an operator instead of settling.
+        const body = (await res.json()) as {
+          data: { transfer: { status: string; signature: string | null } };
+        };
+        expect(body.data.transfer).toMatchObject({
+          status: "processing",
+          signature: SUBMITTED_SIGNATURE,
+        });
         const row = await latestTransferRow();
         expect(row).toMatchObject({ status: "processing", signature: null });
         // The column refused the signature, so provider_data carries it — that

--- a/apps/sdp-api/src/routes/payments.transfers.test.ts
+++ b/apps/sdp-api/src/routes/payments.transfers.test.ts
@@ -20,6 +20,7 @@ import { getTransferSolInstruction } from "@solana-program/system";
 import { describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
 import { createPostgresPolicyRepository } from "@/db/repositories";
+import * as paymentsRepositoryPostgres from "@/db/repositories/payments.repository.postgres";
 import { createPostgresPaymentsRepository } from "@/db/repositories/payments.repository.postgres";
 import app from "@/index";
 import { buildPaymentTransferFingerprint } from "@/lib/idempotency";
@@ -2630,6 +2631,47 @@ describe("Payments routes — transfers", () => {
       expect(row).toMatchObject({ status: "failed", signature: null });
       expect(row.error).toContain("Sponsorship preflight is unavailable");
       expect(row.providerData ?? {}).not.toMatchObject({ submission_outcome: "unknown" });
+    });
+
+    it("parks a broadcast transfer whose signature writes were all lost", async () => {
+      // The transaction is on chain, but no write of its signature survived.
+      // An unsigned `processing` row is what the pending-transfers job times
+      // out into a false `failed`, and that failure invites a second send.
+      const createRepository = paymentsRepositoryPostgres.createPostgresPaymentsRepository;
+      const repositorySpy = vi.spyOn(
+        paymentsRepositoryPostgres,
+        "createPostgresPaymentsRepository"
+      );
+      repositorySpy.mockImplementation((db, scope) => {
+        const repository = createRepository(db, scope);
+        return {
+          ...repository,
+          updateTransfer: async (input) => {
+            if (input.signature) {
+              throw new Error("simulated signature persist failure");
+            }
+            return repository.updateTransfer(input);
+          },
+        };
+      });
+      try {
+        mockAdapterSubmitting(SUBMITTED_SIGNATURE);
+        confirmTransactionMock.mockRejectedValueOnce(new Error("confirmation timed out"));
+
+        const res = await transferRequest("1");
+
+        expect(res.status).toBe(200);
+        const row = await latestTransferRow();
+        expect(row).toMatchObject({ status: "processing", signature: null });
+        // The column refused the signature, so provider_data carries it — that
+        // is where the runbook sends the operator.
+        expect(row.providerData).toMatchObject({
+          submission_outcome: "unknown",
+          submitted_signature: SUBMITTED_SIGNATURE,
+        });
+      } finally {
+        repositorySpy.mockRestore();
+      }
     });
 
     it("journals a definite on-chain failure as failed with the submitted signature", async () => {

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -342,7 +342,5 @@ export async function executeChunk(params: {
   }
 
   await recorder.onSubmitted(signature);
-  // Discarded result: called for its retry — it re-attempts the persist once
-  // when the first write failed.
-  await recorder.submittedRow();
+  await recorder.submittedRow(); // retries the persist once if the first write failed
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -321,7 +321,7 @@ export async function executeChunk(params: {
     // write through a longer path, so park the chunk instead, with the
     // signature in `provider_data` — the column refused it, JSON still takes
     // it, and the operator reconciles from there.
-    (sig) => parkChunk(sig)
+    parkChunk
   );
   let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
   try {

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -15,6 +15,14 @@ import type {
 import { createPostgresPaymentsRepository } from "@/db/repositories/payments.repository.postgres";
 import { internalError, transactionFailed } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
+import { getLogger } from "@/runtime/logger";
+import {
+  isPreBroadcastRejection,
+  persistOutcomeUnknownMarker,
+  SUBMISSION_OUTCOME_UNKNOWN_MARKER,
+  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+} from "@/services/payments/submission-outcome";
 import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
 import {
   type AppContext,
@@ -22,6 +30,7 @@ import {
   getPaymentsRepository,
   getPaymentTransferBatchesRepository,
 } from "../../context";
+import { createSubmissionRecorder } from "../transfers";
 import type { TransactionChunk } from "./transaction";
 import type { ResolvedBatchRequest } from "./types";
 
@@ -45,6 +54,7 @@ async function updateTransferRecord(
     signature?: string;
     serializedTx: string;
     error: string | null;
+    providerData?: Record<string, unknown>;
   }
 ): Promise<PaymentTransferRow> {
   const updated = await getPaymentsRepository(c).updateTransfer({
@@ -56,6 +66,7 @@ async function updateTransferRecord(
     serializedTx: params.serializedTx,
     error: params.error,
     updatedAt: new Date().toISOString(),
+    providerData: params.providerData,
   });
 
   if (!updated) {
@@ -235,6 +246,7 @@ export async function executeChunk(params: {
     recipientStatus: PaymentTransferRecipientRow["status"];
     signature?: string;
     error: string | null;
+    providerData?: Record<string, unknown>;
   }): Promise<PaymentTransferRow> => {
     const updates = await updateRecipientRows({
       repository: getPaymentTransferBatchesRepository(c),
@@ -255,6 +267,7 @@ export async function executeChunk(params: {
       signature: params2.signature,
       serializedTx,
       error: params2.error,
+      providerData: params2.providerData,
     });
   };
 
@@ -278,25 +291,58 @@ export async function executeChunk(params: {
   }
 
   await beginApprovedWalletOperationEffect(c);
+  // Once broadcast, a failed bookkeeping write must never strand the chunk as
+  // an unsigned `processing` row — the pending-transfers job would cascade a
+  // false `failed` to every recipient. The recorder retries the write once.
+  const recorder = createSubmissionRecorder(transfer, (sig) =>
+    updateTransferRecord(c, {
+      transferId: transfer.id,
+      organizationId: resolved.scope.auth.organizationId,
+      projectId: resolved.projectId,
+      status: "processing",
+      signature: sig,
+      serializedTx,
+      error: null,
+    })
+  );
   let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
   try {
     signature = await params.feePayment.signAndSend(txBytes);
   } catch (error) {
-    await settle({
-      status: "failed",
-      recipientStatus: "failed",
-      error: error instanceof Error ? error.message : String(error),
-    });
+    if (isPreBroadcastRejection(error)) {
+      await settle({
+        status: "failed",
+        recipientStatus: "failed",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    // The provider may have broadcast the chunk without returning a signature.
+    // Settling it failed would invite a re-execution and a double send to every
+    // recipient, so the chunk parks behind the shared reconciliation marker.
+    getLogger().warn(
+      {
+        transfer_id: transfer.id,
+        reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "batch chunk parked; awaiting manual reconciliation"
+    );
+    await persistOutcomeUnknownMarker(
+      () =>
+        settle({
+          status: "processing",
+          recipientStatus: "processing",
+          error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+          providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
+        }),
+      transfer.id
+    );
     return;
   }
 
-  await updateTransferRecord(c, {
-    transferId: transfer.id,
-    organizationId: resolved.scope.auth.organizationId,
-    projectId: resolved.projectId,
-    status: "processing",
-    signature,
-    serializedTx,
-    error: null,
-  });
+  await recorder.onSubmitted(signature);
+  // Discarded result: called for its retry — it re-attempts the persist once
+  // when the first write failed.
+  await recorder.submittedRow();
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -272,6 +272,20 @@ export async function executeChunk(params: {
     });
   };
 
+  // A chunk that may already be on chain is parked, never failed: `providerData`
+  // carries anything the operator needs beyond the marker itself.
+  const parkChunk = (providerData?: Record<string, unknown>) =>
+    persistOutcomeUnknownMarker(
+      () =>
+        settle({
+          status: "processing",
+          recipientStatus: "processing",
+          error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+          providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, ...providerData },
+        }),
+      transfer.id
+    );
+
   if (params.preflight) {
     try {
       const simulated = await solanaRpc.simulateTransaction(resolved.rpc, txBytes);
@@ -332,48 +346,31 @@ export async function executeChunk(params: {
       },
       "Batch chunk parked; awaiting manual reconciliation"
     );
-    await persistOutcomeUnknownMarker(
-      () =>
-        settle({
-          status: "processing",
-          recipientStatus: "processing",
-          error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-          providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
-        }),
-      transfer.id
-    );
+    await parkChunk();
     return;
   }
 
   await recorder.onSubmitted(signature);
   if (!signaturePersisted) {
-    // Both bookkeeping writes were lost after the broadcast. Try once more
-    // through `settle`, this time carrying the signature: a signed `processing`
-    // row settles itself from chain on the next pending-transfers run, while an
-    // unsigned one is timed out into a false `failed` for every recipient. If
-    // that write is refused too, park the chunk so the job leaves it alone.
+    // Both signature writes were lost after the broadcast. One more attempt
+    // through `settle`: a signed `processing` row settles itself from chain on
+    // the next pending-transfers run, while an unsigned one is timed out into a
+    // false `failed` for every recipient. If even that is refused — a duplicate
+    // signature, say — park the chunk with the signature in `provider_data`,
+    // the only place left that can still hold it.
     try {
       await settle({ status: "processing", recipientStatus: "processing", signature, error: null });
     } catch (persistError) {
-      getLogger().error(
+      getLogger().warn(
         {
           transfer_id: transfer.id,
           signature,
           reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
           error: persistError instanceof Error ? persistError.message : String(persistError),
         },
-        "Batch chunk signature could not be recorded; parking it for manual reconciliation"
+        "Batch chunk signature could not be recorded; parking the chunk with the signature"
       );
-      await persistOutcomeUnknownMarker(
-        () =>
-          settle({
-            status: "processing",
-            recipientStatus: "processing",
-            error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-            providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
-          }),
-        transfer.id
-      );
+      await parkChunk({ submitted_signature: signature });
     }
   }
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -271,12 +271,14 @@ export async function executeChunk(params: {
     });
   };
 
-  // A chunk that may already be on chain is parked, never failed: `providerData`
-  // carries anything the operator needs beyond the marker itself.
-  const parkChunk = (providerData?: Record<string, unknown>) =>
+  // A chunk that may already be on chain is parked, never failed.
+  const parkChunk = (submittedSignature?: string) =>
     persistOutcomeUnknownMarker(
       () =>
-        settle({ ...submissionOutcomeUnknownPatch(providerData), recipientStatus: "processing" }),
+        settle({
+          ...submissionOutcomeUnknownPatch(submittedSignature),
+          recipientStatus: "processing",
+        }),
       transfer.id
     );
 
@@ -315,33 +317,11 @@ export async function executeChunk(params: {
         serializedTx,
         error: null,
       }),
-    // Both writes lost after the broadcast. One more attempt through `settle`:
-    // a signed `processing` row settles itself from chain on the next
-    // pending-transfers run, while an unsigned one is timed out into a false
-    // `failed` for every recipient. If even that is refused — a duplicate
-    // signature, say — park the chunk with the signature in `provider_data`,
-    // the only place left that can still hold it.
-    async (sig) => {
-      try {
-        await settle({
-          status: "processing",
-          recipientStatus: "processing",
-          signature: sig,
-          error: null,
-        });
-      } catch (persistError) {
-        getLogger().warn(
-          {
-            transfer_id: transfer.id,
-            signature: sig,
-            reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-            error: persistError instanceof Error ? persistError.message : String(persistError),
-          },
-          "Batch chunk signature could not be recorded; parking the chunk with the signature"
-        );
-        await parkChunk({ submitted_signature: sig });
-      }
-    }
+    // Both writes lost after the broadcast. A third attempt would be the same
+    // write through a longer path, so park the chunk instead, with the
+    // signature in `provider_data` — the column refused it, JSON still takes
+    // it, and the operator reconciles from there.
+    (sig) => parkChunk(sig)
   );
   let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
   try {

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -19,9 +19,8 @@ import { getLogger } from "@/runtime/logger";
 import {
   isTransferSubmissionOutcomeUnknown,
   persistOutcomeUnknownMarker,
-  SUBMISSION_OUTCOME_UNKNOWN_MARKER,
   signAndSendClosed,
-  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+  submissionOutcomeUnknownPatch,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
 } from "@/services/payments/submission-outcome";
 import { beginApprovedWalletOperationEffect } from "@/services/policy/approved-operation-replay";
@@ -277,12 +276,7 @@ export async function executeChunk(params: {
   const parkChunk = (providerData?: Record<string, unknown>) =>
     persistOutcomeUnknownMarker(
       () =>
-        settle({
-          status: "processing",
-          recipientStatus: "processing",
-          error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-          providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, ...providerData },
-        }),
+        settle({ ...submissionOutcomeUnknownPatch(providerData), recipientStatus: "processing" }),
       transfer.id
     );
 
@@ -309,20 +303,46 @@ export async function executeChunk(params: {
   // Once broadcast, a failed bookkeeping write must never strand the chunk as
   // an unsigned `processing` row — the pending-transfers job would cascade a
   // false `failed` to every recipient. The recorder retries the write once.
-  let signaturePersisted = false;
-  const recorder = createSubmissionRecorder(transfer, async (sig) => {
-    const persisted = await updateTransferRecord(c, {
-      transferId: transfer.id,
-      organizationId: resolved.scope.auth.organizationId,
-      projectId: resolved.projectId,
-      status: "processing",
-      signature: sig,
-      serializedTx,
-      error: null,
-    });
-    signaturePersisted = true;
-    return persisted;
-  });
+  const recorder = createSubmissionRecorder(
+    transfer,
+    (sig) =>
+      updateTransferRecord(c, {
+        transferId: transfer.id,
+        organizationId: resolved.scope.auth.organizationId,
+        projectId: resolved.projectId,
+        status: "processing",
+        signature: sig,
+        serializedTx,
+        error: null,
+      }),
+    // Both writes lost after the broadcast. One more attempt through `settle`:
+    // a signed `processing` row settles itself from chain on the next
+    // pending-transfers run, while an unsigned one is timed out into a false
+    // `failed` for every recipient. If even that is refused — a duplicate
+    // signature, say — park the chunk with the signature in `provider_data`,
+    // the only place left that can still hold it.
+    async (sig) => {
+      try {
+        await settle({
+          status: "processing",
+          recipientStatus: "processing",
+          signature: sig,
+          error: null,
+        });
+      } catch (persistError) {
+        getLogger().warn(
+          {
+            transfer_id: transfer.id,
+            signature: sig,
+            reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+            error: persistError instanceof Error ? persistError.message : String(persistError),
+          },
+          "Batch chunk signature could not be recorded; parking the chunk with the signature"
+        );
+        await parkChunk({ submitted_signature: sig });
+      }
+    }
+  );
   let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
   try {
     signature = await signAndSendClosed(params.feePayment, txBytes);
@@ -351,26 +371,4 @@ export async function executeChunk(params: {
   }
 
   await recorder.onSubmitted(signature);
-  if (!signaturePersisted) {
-    // Both signature writes were lost after the broadcast. One more attempt
-    // through `settle`: a signed `processing` row settles itself from chain on
-    // the next pending-transfers run, while an unsigned one is timed out into a
-    // false `failed` for every recipient. If even that is refused — a duplicate
-    // signature, say — park the chunk with the signature in `provider_data`,
-    // the only place left that can still hold it.
-    try {
-      await settle({ status: "processing", recipientStatus: "processing", signature, error: null });
-    } catch (persistError) {
-      getLogger().warn(
-        {
-          transfer_id: transfer.id,
-          signature,
-          reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-          error: persistError instanceof Error ? persistError.message : String(persistError),
-        },
-        "Batch chunk signature could not be recorded; parking the chunk with the signature"
-      );
-      await parkChunk({ submitted_signature: signature });
-    }
-  }
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts
@@ -17,9 +17,10 @@ import { internalError, transactionFailed } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { getLogger } from "@/runtime/logger";
 import {
-  isPreBroadcastRejection,
+  isTransferSubmissionOutcomeUnknown,
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
+  signAndSendClosed,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
 } from "@/services/payments/submission-outcome";
@@ -294,8 +295,9 @@ export async function executeChunk(params: {
   // Once broadcast, a failed bookkeeping write must never strand the chunk as
   // an unsigned `processing` row — the pending-transfers job would cascade a
   // false `failed` to every recipient. The recorder retries the write once.
-  const recorder = createSubmissionRecorder(transfer, (sig) =>
-    updateTransferRecord(c, {
+  let signaturePersisted = false;
+  const recorder = createSubmissionRecorder(transfer, async (sig) => {
+    const persisted = await updateTransferRecord(c, {
       transferId: transfer.id,
       organizationId: resolved.scope.auth.organizationId,
       projectId: resolved.projectId,
@@ -303,13 +305,15 @@ export async function executeChunk(params: {
       signature: sig,
       serializedTx,
       error: null,
-    })
-  );
+    });
+    signaturePersisted = true;
+    return persisted;
+  });
   let signature: Awaited<ReturnType<typeof params.feePayment.signAndSend>>;
   try {
-    signature = await params.feePayment.signAndSend(txBytes);
+    signature = await signAndSendClosed(params.feePayment, txBytes);
   } catch (error) {
-    if (isPreBroadcastRejection(error)) {
+    if (!isTransferSubmissionOutcomeUnknown(error)) {
       await settle({
         status: "failed",
         recipientStatus: "failed",
@@ -326,7 +330,7 @@ export async function executeChunk(params: {
         reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
         error: error instanceof Error ? error.message : String(error),
       },
-      "batch chunk parked; awaiting manual reconciliation"
+      "Batch chunk parked; awaiting manual reconciliation"
     );
     await persistOutcomeUnknownMarker(
       () =>
@@ -342,5 +346,34 @@ export async function executeChunk(params: {
   }
 
   await recorder.onSubmitted(signature);
-  await recorder.submittedRow(); // retries the persist once if the first write failed
+  if (!signaturePersisted) {
+    // Both bookkeeping writes were lost after the broadcast. Try once more
+    // through `settle`, this time carrying the signature: a signed `processing`
+    // row settles itself from chain on the next pending-transfers run, while an
+    // unsigned one is timed out into a false `failed` for every recipient. If
+    // that write is refused too, park the chunk so the job leaves it alone.
+    try {
+      await settle({ status: "processing", recipientStatus: "processing", signature, error: null });
+    } catch (persistError) {
+      getLogger().error(
+        {
+          transfer_id: transfer.id,
+          signature,
+          reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+          error: persistError instanceof Error ? persistError.message : String(persistError),
+        },
+        "Batch chunk signature could not be recorded; parking it for manual reconciliation"
+      );
+      await persistOutcomeUnknownMarker(
+        () =>
+          settle({
+            status: "processing",
+            recipientStatus: "processing",
+            error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+            providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
+          }),
+        transfer.id
+      );
+    }
+  }
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.submission-recorder.test.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.submission-recorder.test.ts
@@ -80,6 +80,16 @@ describe("createSubmissionRecorder", () => {
     expect(onSignatureLost).toHaveBeenCalledWith(SIGNATURE);
   });
 
+  it("swallows a throwing last resort instead of failing the request", async () => {
+    const persist = vi.fn().mockRejectedValue(new Error("db unavailable"));
+    const onSignatureLost = vi.fn().mockRejectedValue(new Error("marker write refused"));
+    const recorder = createSubmissionRecorder(transfer, persist, onSignatureLost);
+
+    // The transaction is already broadcast: a throw out of here becomes a 500,
+    // and a 500 is the client retry that sends the payment a second time.
+    await expect(recorder.onSubmitted(SIGNATURE)).resolves.toBeUndefined();
+  });
+
   it("leaves a recorded signature to the caller alone", async () => {
     const persist = vi.fn().mockResolvedValue({ ...transfer, signature: SIGNATURE });
     const onSignatureLost = vi.fn().mockResolvedValue(undefined);

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -63,9 +63,8 @@ import {
 import {
   isTransferSubmissionOutcomeUnknown,
   persistOutcomeUnknownMarker,
-  SUBMISSION_OUTCOME_UNKNOWN_MARKER,
   signAndSendClosed,
-  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+  submissionOutcomeUnknownPatch,
 } from "@/services/payments/submission-outcome";
 import {
   approvedWalletOperationAttemptId,
@@ -474,7 +473,7 @@ async function updateTransferRecord(
  * attempts. If both fail the durable row is still unsigned, which the
  * pending-transfers job would time out into a false `failed`, so
  * `onSignatureLost` runs last for the caller to close that row another way.
- * Exported for unit tests.
+ * Used by the transfer and transfer-batch submit paths, and by unit tests.
  */
 export function createSubmissionRecorder(
   transfer: TransferRow,
@@ -541,14 +540,7 @@ function markTransferOutcomeUnknown(
   providerData?: Record<string, unknown>
 ): Promise<void> {
   return persistOutcomeUnknownMarker(
-    () =>
-      updateTransferRecord(c, transferId, {
-        status: "processing",
-        error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-        signature: null,
-        blockTime: null,
-        providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, ...providerData },
-      }),
+    () => updateTransferRecord(c, transferId, submissionOutcomeUnknownPatch(providerData)),
     transferId
   );
 }

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -493,7 +493,7 @@ export function createSubmissionRecorder(
           signature: sig,
           error: error instanceof Error ? error.message : String(error),
         },
-        "createTransfer: failed to persist submitted transfer signature"
+        "failed to persist submitted transfer signature"
       );
     }
   };

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -482,18 +482,20 @@ export function createSubmissionRecorder(
 ) {
   let signature: string | null = null;
   let row: TransferRow | null = null;
+  const logFailure = (sig: string, error: unknown, message: string) =>
+    getLogger().error(
+      {
+        transfer_id: transfer.id,
+        signature: sig,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      message
+    );
   const persist = async (sig: string) => {
     try {
       row = await persistSignature(sig);
     } catch (error) {
-      getLogger().error(
-        {
-          transfer_id: transfer.id,
-          signature: sig,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "failed to persist submitted transfer signature"
-      );
+      logFailure(sig, error, "failed to persist submitted transfer signature");
     }
   };
   return {
@@ -510,14 +512,7 @@ export function createSubmissionRecorder(
           // Same contract as the writes above: this runs after a broadcast, so
           // a throw here would surface as a 500 and invite the client to send
           // the payment again.
-          getLogger().error(
-            {
-              transfer_id: transfer.id,
-              signature: sig,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "failed to close a lost submitted transfer signature"
-          );
+          logFailure(sig, error, "failed to close a lost submitted transfer signature");
         }
       }
     },

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -61,11 +61,11 @@ import {
   resolveOutboundPaymentOperation,
 } from "@/services/payment-operation.service";
 import {
-  isPreBroadcastRejection,
+  isTransferSubmissionOutcomeUnknown,
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
+  signAndSendClosed,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
 } from "@/services/payments/submission-outcome";
 import {
   approvedWalletOperationAttemptId,
@@ -463,42 +463,6 @@ async function updateTransferRecord(
   }
 
   return updated;
-}
-
-function transferSubmissionOutcomeUnknown(cause: unknown): AppError {
-  const error = new AppError("CONFLICT", TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR, {
-    reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-  });
-  // Server-side only (`toResponse` never serializes it): the marker branch
-  // logs the cause so the manual reconciliation starts from the real failure.
-  error.cause = cause;
-  return error;
-}
-
-function isTransferSubmissionOutcomeUnknown(error: unknown): error is AppError {
-  return (
-    error instanceof AppError &&
-    error.details?.reason === TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON
-  );
-}
-
-/**
- * Submit through one closed chokepoint: a provably pre-broadcast provider
- * rejection passes through for a plain terminal failure, anything else
- * becomes the outcome-unknown 409 the caller must mark and rethrow.
- */
-async function signAndSendClosed(
-  feePayment: ReturnType<typeof getFeePayment>,
-  txBytes: Uint8Array
-) {
-  try {
-    return await feePayment.signAndSend(txBytes);
-  } catch (error) {
-    if (isPreBroadcastRejection(error)) {
-      throw error;
-    }
-    throw transferSubmissionOutcomeUnknown(error);
-  }
 }
 
 /**

--- a/apps/sdp-api/src/routes/payments/handlers/transfers.ts
+++ b/apps/sdp-api/src/routes/payments/handlers/transfers.ts
@@ -472,8 +472,8 @@ async function updateTransferRecord(
  * happens, so a caller that never reads `submittedRow` still gets both
  * attempts. If both fail the durable row is still unsigned, which the
  * pending-transfers job would time out into a false `failed`, so
- * `onSignatureLost` runs last for the caller to close that row another way.
- * Used by the transfer and transfer-batch submit paths, and by unit tests.
+ * `onSignatureLost` runs last for the caller to close that row another way;
+ * like the writes, it never throws out of here.
  */
 export function createSubmissionRecorder(
   transfer: TransferRow,
@@ -503,8 +503,22 @@ export function createSubmissionRecorder(
       if (!row) {
         await persist(sig);
       }
-      if (!row) {
-        await onSignatureLost?.(sig);
+      if (!row && onSignatureLost) {
+        try {
+          await onSignatureLost(sig);
+        } catch (error) {
+          // Same contract as the writes above: this runs after a broadcast, so
+          // a throw here would surface as a 500 and invite the client to send
+          // the payment again.
+          getLogger().error(
+            {
+              transfer_id: transfer.id,
+              signature: sig,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "failed to close a lost submitted transfer signature"
+          );
+        }
       }
     },
     submittedRow: async (): Promise<TransferRow | null> => {
@@ -524,7 +538,7 @@ function createTransferSubmissionRecorder(c: AppContext, transfer: TransferRow) 
     // reading that failure sends the payment a second time. Park it instead,
     // with the signature in `provider_data`: the column refused it, JSON still
     // takes it, and the operator reconciles from there.
-    (signature) => markTransferOutcomeUnknown(c, transfer.id, { submitted_signature: signature })
+    (signature) => markTransferOutcomeUnknown(c, transfer.id, signature)
   );
 }
 
@@ -537,10 +551,10 @@ function createTransferSubmissionRecorder(c: AppContext, transfer: TransferRow) 
 function markTransferOutcomeUnknown(
   c: AppContext,
   transferId: string,
-  providerData?: Record<string, unknown>
+  submittedSignature?: string
 ): Promise<void> {
   return persistOutcomeUnknownMarker(
-    () => updateTransferRecord(c, transferId, submissionOutcomeUnknownPatch(providerData)),
+    () => updateTransferRecord(c, transferId, submissionOutcomeUnknownPatch(submittedSignature)),
     transferId
   );
 }

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -1976,7 +1976,7 @@ describe("payment transfer batches", () => {
     }
   });
 
-  it("records a submitted chunk's signature even when both bookkeeping writes are lost", async () => {
+  it("parks a submitted chunk when both bookkeeping writes are lost", async () => {
     const createRepository = paymentsRepositoryPostgres.createPostgresPaymentsRepository;
     const batchesSpy = vi.spyOn(paymentsRepositoryPostgres, "createPostgresPaymentsRepository");
     let signaturePersistFailures = 0;
@@ -2063,23 +2063,29 @@ describe("payment transfer batches", () => {
 
       // A broadcast chunk is never stranded as an unsigned row that the
       // pending-transfers job would time out into a false `failed` for every
-      // recipient: the recorder retries once and the settle carries the
-      // signature. The row may already have settled from that signature, so
-      // assert what this test owns: it landed and the chunk is not failed.
+      // recipient. Both writes were lost, so it parks: still `processing`
+      // after the job ran, carrying the signature its column refused.
       const transferRow = await getDb(env)
-        .prepare("SELECT status, signature FROM payment_transfers WHERE id = ?")
+        .prepare("SELECT status, signature, provider_data FROM payment_transfers WHERE id = ?")
         .bind(linkedRecipient?.transfer_id)
-        .first<{ status: string; signature: string | null }>();
-      expect(transferRow?.signature).toBe(FIRST_SIGNATURE);
-      expect(["processing", "confirmed", "finalized"]).toContain(transferRow?.status);
+        .first<{ status: string; signature: string | null; provider_data: unknown }>();
+      expect(transferRow?.status).toBe("processing");
+      const parkedProviderData =
+        typeof transferRow?.provider_data === "string"
+          ? JSON.parse(transferRow.provider_data)
+          : transferRow?.provider_data;
+      expect(parkedProviderData).toMatchObject({
+        submission_outcome: "unknown",
+        submitted_signature: FIRST_SIGNATURE,
+      });
 
       const settledRecipient = await getDb(env)
         .prepare("SELECT status, transfer_id FROM payment_transfer_recipients WHERE batch_id = ?")
         .bind(body.data.batch.id)
         .first<{ status: string; transfer_id: string | null }>();
-      // The chunk is on chain with its signature, so neither the recipient nor
-      // the batch is cascaded to `failed` by a lost bookkeeping write.
-      expect(["processing", "confirmed", "finalized"]).toContain(settledRecipient?.status);
+      // The chunk may be on chain, so neither the recipient nor the batch is
+      // cascaded to `failed` by a lost bookkeeping write.
+      expect(settledRecipient?.status).toBe("processing");
       expect(settledRecipient?.transfer_id).toBe(linkedRecipient?.transfer_id);
 
       const batchRow = await getDb(env)

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -2069,7 +2069,7 @@ describe("payment transfer batches", () => {
         .bind(linkedRecipient?.transfer_id)
         .first<{ status: string; signature: string | null }>();
       expect(transferRow?.signature).toBe(FIRST_SIGNATURE);
-      expect(transferRow?.status).not.toBe("failed");
+      expect(["processing", "confirmed", "finalized"]).toContain(transferRow?.status);
 
       const settledRecipient = await getDb(env)
         .prepare("SELECT status, transfer_id FROM payment_transfer_recipients WHERE batch_id = ?")
@@ -2077,14 +2077,14 @@ describe("payment transfer batches", () => {
         .first<{ status: string; transfer_id: string | null }>();
       // The chunk is on chain with its signature, so neither the recipient nor
       // the batch is cascaded to `failed` by a lost bookkeeping write.
-      expect(settledRecipient?.status).not.toBe("failed");
+      expect(["processing", "confirmed", "finalized"]).toContain(settledRecipient?.status);
       expect(settledRecipient?.transfer_id).toBe(linkedRecipient?.transfer_id);
 
       const batchRow = await getDb(env)
         .prepare("SELECT status FROM payment_transfer_batches WHERE id = ?")
         .bind(body.data.batch.id)
         .first<{ status: string }>();
-      expect(batchRow?.status).not.toBe("failed");
+      expect(["processing", "confirmed", "completed"]).toContain(batchRow?.status);
     } finally {
       batchesSpy.mockRestore();
     }

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -20,6 +20,7 @@ import * as paymentsRepositoryPostgres from "@/db/repositories/payments.reposito
 import app from "@/index";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { trackPendingTransfers } from "@/services/jobs/track-pending-transfers";
+import { TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR } from "@/services/payments/submission-outcome";
 import * as solanaServices from "@/services/solana";
 import { TEST_SOLANA_ADDRESSES } from "@/test/fixtures/tokens";
 import { env } from "@/test/helpers/env";
@@ -1975,7 +1976,7 @@ describe("payment transfer batches", () => {
     }
   });
 
-  it("leaves linked recipients for reconciliation when the signature persist fails after submission", async () => {
+  it("retries the signature persist after submission instead of stranding the chunk", async () => {
     const createRepository = paymentsRepositoryPostgres.createPostgresPaymentsRepository;
     const batchesSpy = vi.spyOn(paymentsRepositoryPostgres, "createPostgresPaymentsRepository");
     let signaturePersistInjected = false;
@@ -2058,24 +2059,32 @@ describe("payment transfer batches", () => {
 
       await trackPendingTransfers(env);
 
+      // The write is retried once, so a single lost bookkeeping write no longer
+      // strands a broadcast chunk as an unsigned row that the pending-transfers
+      // job would time out into a false `failed` for every recipient. The row
+      // may already have settled from its signature, so assert what this test
+      // owns: the signature landed and the chunk is not terminally failed.
       const transferRow = await getDb(env)
-        .prepare("SELECT status FROM payment_transfers WHERE id = ?")
+        .prepare("SELECT status, signature FROM payment_transfers WHERE id = ?")
         .bind(linkedRecipient?.transfer_id)
-        .first<{ status: string }>();
-      expect(transferRow?.status).toBe("failed");
+        .first<{ status: string; signature: string | null }>();
+      expect(transferRow?.signature).toBe(FIRST_SIGNATURE);
+      expect(transferRow?.status).not.toBe("failed");
 
       const settledRecipient = await getDb(env)
         .prepare("SELECT status, transfer_id FROM payment_transfer_recipients WHERE batch_id = ?")
         .bind(body.data.batch.id)
         .first<{ status: string; transfer_id: string | null }>();
-      expect(settledRecipient?.status).toBe("failed");
+      // The chunk is on chain with its signature, so neither the recipient nor
+      // the batch is cascaded to `failed` by a lost bookkeeping write.
+      expect(settledRecipient?.status).not.toBe("failed");
       expect(settledRecipient?.transfer_id).toBe(linkedRecipient?.transfer_id);
 
       const batchRow = await getDb(env)
         .prepare("SELECT status FROM payment_transfer_batches WHERE id = ?")
         .bind(body.data.batch.id)
         .first<{ status: string }>();
-      expect(batchRow?.status).toBe("failed");
+      expect(batchRow?.status).not.toBe("failed");
     } finally {
       batchesSpy.mockRestore();
     }
@@ -2475,4 +2484,74 @@ describe("payment transfer batches", () => {
 
     expect(responses.map((response) => response.status)).toEqual([200, 200, 200, 200, 200]);
   }, 20_000);
+  it("parks a chunk whose provider outcome is unknown instead of failing its recipients", async () => {
+    // Kora may have broadcast the chunk before failing without returning a
+    // signature. Settling it failed would invite a re-execution and a double
+    // send to every recipient in the chunk.
+    const sourceSigner = await generateKeyPairSigner();
+    await updateSeededWalletPublicKey(sourceSigner.address);
+    createOrgSignerMock.mockResolvedValueOnce(sourceSigner);
+    const signAndSendMock = vi.fn().mockRejectedValue(new Error("kora timed out"));
+    createFeePaymentAdapterMock.mockReturnValueOnce({
+      providerId: "mock",
+      getFeePayer: vi.fn().mockResolvedValue(TEST_KORA_FEE_PAYER),
+      getSponsorshipConfiguration: vi.fn().mockResolvedValue(TEST_SPONSORSHIP_PROVIDER_CONFIG),
+      signAsFeePayer: vi.fn(),
+      signAndSend: signAndSendMock,
+    } as ReturnType<typeof feePaymentAdapters.createFeePaymentAdapter>);
+
+    const counterpartyId = await seedCounterparty("batch_parked_counterparty");
+    const accountId = await seedCryptoWalletCounterpartyAccount({
+      counterpartyId,
+      walletAddress: TEST_SOLANA_ADDRESSES.wallet2,
+    });
+
+    const res = await app.request(
+      "/v1/payments/transfer-batches",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TEST_API_KEY.raw}`,
+        },
+        body: JSON.stringify({
+          source: TEST_WALLET_ID,
+          token: "SOL",
+          recipients: [{ counterpartyId, counterpartyAccountId: accountId, amount: "0.1" }],
+          options: { preflight: false },
+        }),
+      },
+      env
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { batch: { id: string }; transfers: Array<{ id: string }> };
+    };
+
+    const row = await getDb(env)
+      .prepare("SELECT status, signature, error, provider_data FROM payment_transfers WHERE id = ?")
+      .bind(body.data.transfers[0]?.id)
+      .first<{
+        status: string;
+        signature: string | null;
+        error: string | null;
+        provider_data: unknown;
+      }>();
+    expect(row).toMatchObject({
+      status: "processing",
+      signature: null,
+      error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+    });
+    const providerData =
+      typeof row?.provider_data === "string" ? JSON.parse(row.provider_data) : row?.provider_data;
+    // Literal on purpose: the durable contract the pending-transfers job matches.
+    expect(providerData).toMatchObject({ submission_outcome: "unknown" });
+
+    const recipients = await getDb(env)
+      .prepare("SELECT status FROM payment_transfer_recipients WHERE batch_id = ?")
+      .bind(body.data.batch.id)
+      .all<{ status: string }>();
+    expect(recipients.results.map((r) => r.status)).toEqual(["processing"]);
+  });
 });

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -1985,8 +1985,9 @@ describe("payment transfer batches", () => {
       return {
         ...repository,
         updateTransfer: async (input) => {
-          // Both of the recorder's attempts fail, so the chunk falls through to
-          // the settle that carries the signature.
+          // Only the recorder's two attempts are refused: a third write, if one
+          // is ever added back, would succeed — and the assertions below would
+          // catch it, because a parked chunk must carry no signature.
           if (
             signaturePersistFailures < 2 &&
             input.status === "processing" &&
@@ -2070,6 +2071,7 @@ describe("payment transfer batches", () => {
         .bind(linkedRecipient?.transfer_id)
         .first<{ status: string; signature: string | null; provider_data: unknown }>();
       expect(transferRow?.status).toBe("processing");
+      expect(transferRow?.signature).toBeNull();
       const parkedProviderData =
         typeof transferRow?.provider_data === "string"
           ? JSON.parse(transferRow.provider_data)

--- a/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
+++ b/apps/sdp-api/src/routes/payments/transfer-batches.test.ts
@@ -1976,21 +1976,23 @@ describe("payment transfer batches", () => {
     }
   });
 
-  it("retries the signature persist after submission instead of stranding the chunk", async () => {
+  it("records a submitted chunk's signature even when both bookkeeping writes are lost", async () => {
     const createRepository = paymentsRepositoryPostgres.createPostgresPaymentsRepository;
     const batchesSpy = vi.spyOn(paymentsRepositoryPostgres, "createPostgresPaymentsRepository");
-    let signaturePersistInjected = false;
+    let signaturePersistFailures = 0;
     batchesSpy.mockImplementation((db) => {
       const repository = createRepository(db);
       return {
         ...repository,
         updateTransfer: async (input) => {
+          // Both of the recorder's attempts fail, so the chunk falls through to
+          // the settle that carries the signature.
           if (
-            !signaturePersistInjected &&
+            signaturePersistFailures < 2 &&
             input.status === "processing" &&
             input.signature !== undefined
           ) {
-            signaturePersistInjected = true;
+            signaturePersistFailures += 1;
             throw new Error("simulated signature persist failure");
           }
           return repository.updateTransfer(input);
@@ -2059,11 +2061,11 @@ describe("payment transfer batches", () => {
 
       await trackPendingTransfers(env);
 
-      // The write is retried once, so a single lost bookkeeping write no longer
-      // strands a broadcast chunk as an unsigned row that the pending-transfers
-      // job would time out into a false `failed` for every recipient. The row
-      // may already have settled from its signature, so assert what this test
-      // owns: the signature landed and the chunk is not terminally failed.
+      // A broadcast chunk is never stranded as an unsigned row that the
+      // pending-transfers job would time out into a false `failed` for every
+      // recipient: the recorder retries once and the settle carries the
+      // signature. The row may already have settled from that signature, so
+      // assert what this test owns: it landed and the chunk is not failed.
       const transferRow = await getDb(env)
         .prepare("SELECT status, signature FROM payment_transfers WHERE id = ?")
         .bind(linkedRecipient?.transfer_id)

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -228,9 +228,10 @@ const signingSinkInventory: Record<string, string[]> = {
   ],
   "apps/sdp-api/src/routes/pay.ts": ["signAsFeePayer"],
   "apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts": ["signAndSend"],
-  // All three transfer paths route through the signAndSendClosed chokepoint,
-  // which fails closed on ambiguous provider outcomes.
-  "apps/sdp-api/src/routes/payments/handlers/transfers.ts": ["signAndSend"],
+  // Transfers, batch chunks and recurring collections all submit through the
+  // signAndSendClosed chokepoint, which fails closed on ambiguous provider
+  // outcomes; it is the only sink left on those paths.
+  "apps/sdp-api/src/services/payments/submission-outcome.ts": ["signAndSend"],
   "apps/sdp-api/src/services/payments/recurring-payments/shared.ts": ["signAndSend"],
   "apps/sdp-api/src/services/private-channels/deposit.ts": ["signTransactionMessageWithSigners"],
   "apps/sdp-api/src/services/private-channels/transfer.ts": ["signTransactionMessageWithSigners"],

--- a/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
+++ b/apps/sdp-api/src/security/value-moving-conformance.node.test.ts
@@ -227,10 +227,10 @@ const signingSinkInventory: Record<string, string[]> = {
     "signTransactionMessageWithSigners",
   ],
   "apps/sdp-api/src/routes/pay.ts": ["signAsFeePayer"],
-  "apps/sdp-api/src/routes/payments/handlers/transfer-batches/execute.ts": ["signAndSend"],
   // Transfers, batch chunks and recurring collections all submit through the
   // signAndSendClosed chokepoint, which fails closed on ambiguous provider
-  // outcomes; it is the only sink left on those paths.
+  // outcomes. recurring-payments/shared.ts keeps its own sink for the
+  // activation, update and lifecycle flows, which submit unguarded.
   "apps/sdp-api/src/services/payments/submission-outcome.ts": ["signAndSend"],
   "apps/sdp-api/src/services/payments/recurring-payments/shared.ts": ["signAndSend"],
   "apps/sdp-api/src/services/private-channels/deposit.ts": ["signTransactionMessageWithSigners"],

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
@@ -8,8 +8,6 @@ const mocks = vi.hoisted(() => ({
   cancelRecurringPayment: vi.fn(),
   collectRecurringPayment: vi.fn(),
   resumeRecurringPayment: vi.fn(),
-  logError: vi.fn(),
-  logWarn: vi.fn(),
   getWalletById: vi.fn(),
   queryCalls: [] as Array<{ query: string; bindings: Array<string | number> }>,
   rows: {
@@ -36,10 +34,6 @@ vi.mock("@/db", () => ({
       }),
     }),
   }),
-}));
-
-vi.mock("@/runtime/logger", () => ({
-  getLogger: () => ({ error: mocks.logError, warn: mocks.logWarn, info: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock("@/services/domain/signing.service", () => ({
@@ -199,24 +193,16 @@ describe("collectDueRecurringPayments", () => {
     expect(staleCollectionQuery?.query).toContain("PARTITION BY rp.id");
   });
 
-  it("surfaces a parked collection instead of hiding it in the silent skip counter", async () => {
-    // A collection whose submission outcome is unknown is deliberately left
-    // processing for manual reconciliation. It is still a "skip" for the tick,
-    // but a silent one would let a payer's subscription stall unnoticed.
-    mocks.rows.due = [recurringRow("active")];
-    mocks.collectRecurringPayment.mockRejectedValue(
-      new AppError("CONFLICT", "Transfer submission outcome is unknown", {
-        reason: "transfer_submission_outcome_unknown",
-      })
-    );
+  it("keeps parked collections out of the stale-recovery window", async () => {
+    // A parked cycle waits for an operator; its frozen updated_at would
+    // otherwise pin it to the head of this oldest-first window forever.
+    mocks.rows.due = [];
+    await collectDueRecurringPayments({} as Env);
 
-    const result = await collectDueRecurringPayments({} as Env);
-
-    expect(result).toEqual({ recovered: 0, collected: 0, failed: 0, skipped: 1 });
-    expect(mocks.logWarn).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "transfer_submission_outcome_unknown" }),
-      expect.stringContaining("manual reconciliation")
+    const staleQuery = mocks.queryCalls.find((call) =>
+      call.query.includes("JOIN payment_subscription_collection_attempts")
     );
+    expect(staleQuery?.query).toContain("submission_outcome");
   });
 
   it("treats collection conflicts as duplicate-prevention skips", async () => {

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   cancelRecurringPayment: vi.fn(),
   collectRecurringPayment: vi.fn(),
   resumeRecurringPayment: vi.fn(),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
   getWalletById: vi.fn(),
   queryCalls: [] as Array<{ query: string; bindings: Array<string | number> }>,
   rows: {
@@ -34,6 +36,10 @@ vi.mock("@/db", () => ({
       }),
     }),
   }),
+}));
+
+vi.mock("@/runtime/logger", () => ({
+  getLogger: () => ({ error: mocks.logError, warn: mocks.logWarn, info: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock("@/services/domain/signing.service", () => ({
@@ -191,6 +197,26 @@ describe("collectDueRecurringPayments", () => {
     );
     expect(staleCollectionQuery?.query).toContain("ROW_NUMBER() OVER");
     expect(staleCollectionQuery?.query).toContain("PARTITION BY rp.id");
+  });
+
+  it("surfaces a parked collection instead of hiding it in the silent skip counter", async () => {
+    // A collection whose submission outcome is unknown is deliberately left
+    // processing for manual reconciliation. It is still a "skip" for the tick,
+    // but a silent one would let a payer's subscription stall unnoticed.
+    mocks.rows.due = [recurringRow("active")];
+    mocks.collectRecurringPayment.mockRejectedValue(
+      new AppError("CONFLICT", "Recurring payment collection outcome is unknown", {
+        reason: "recurring_collection_outcome_unknown",
+      })
+    );
+
+    const result = await collectDueRecurringPayments({} as Env);
+
+    expect(result).toEqual({ recovered: 0, collected: 0, failed: 0, skipped: 1 });
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "recurring_collection_outcome_unknown" }),
+      expect.stringContaining("manual reconciliation")
+    );
   });
 
   it("treats collection conflicts as duplicate-prevention skips", async () => {

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.node.test.ts
@@ -205,8 +205,8 @@ describe("collectDueRecurringPayments", () => {
     // but a silent one would let a payer's subscription stall unnoticed.
     mocks.rows.due = [recurringRow("active")];
     mocks.collectRecurringPayment.mockRejectedValue(
-      new AppError("CONFLICT", "Recurring payment collection outcome is unknown", {
-        reason: "recurring_collection_outcome_unknown",
+      new AppError("CONFLICT", "Transfer submission outcome is unknown", {
+        reason: "transfer_submission_outcome_unknown",
       })
     );
 
@@ -214,7 +214,7 @@ describe("collectDueRecurringPayments", () => {
 
     expect(result).toEqual({ recovered: 0, collected: 0, failed: 0, skipped: 1 });
     expect(mocks.logWarn).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "recurring_collection_outcome_unknown" }),
+      expect.objectContaining({ reason: "transfer_submission_outcome_unknown" }),
       expect.stringContaining("manual reconciliation")
     );
   });

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -13,10 +13,6 @@ import {
   collectRecurringPayment,
   resumeRecurringPayment,
 } from "@/services/payments/recurring-payments";
-import {
-  isTransferSubmissionOutcomeUnknown,
-  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-} from "@/services/payments/submission-outcome";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 
@@ -113,19 +109,8 @@ async function collectRow(
     return "ok";
   } catch (error) {
     if (shouldSkipCollectionError(error)) {
-      if (isTransferSubmissionOutcomeUnknown(error)) {
-        // A parked cycle is a skip for this tick, but a silent one would let
-        // the payer's subscription stall unnoticed.
-        getLogger().warn(
-          {
-            organization_id: row.organization_id,
-            project_id: row.project_id,
-            recurring_payment_id: row.id,
-            reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-          },
-          "collectDueRecurringPayments: collection parked, awaiting manual reconciliation"
-        );
-      }
+      // A parked cycle also lands here, but it is already logged where it was
+      // parked, with the attempt and transfer ids the operator needs.
       return "skipped";
     }
     logCronFailure("collectDueRecurringPayments: failed to collect recurring payment", row, error);

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -244,6 +244,7 @@ export async function collectDueRecurringPayments(
             SELECT 1
               FROM payment_transfers parked
              WHERE parked.id = a.transfer_id
+               AND parked.status = 'processing'
                AND parked.provider_data ->> 'submission_outcome' = 'unknown'
           )
        ) recoverable_attempts

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -14,9 +14,9 @@ import {
   resumeRecurringPayment,
 } from "@/services/payments/recurring-payments";
 import {
-  isRecurringSubmissionOutcomeUnknown,
-  RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-} from "@/services/payments/recurring-payments/shared";
+  isTransferSubmissionOutcomeUnknown,
+  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+} from "@/services/payments/submission-outcome";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 
@@ -80,26 +80,6 @@ function shouldSkipCollectionError(error: unknown): boolean {
   return error instanceof AppError && error.code === "CONFLICT";
 }
 
-/**
- * A collection parked for manual reconciliation is a skip for this tick, but a
- * silent one would let the payer's subscription stall unnoticed until someone
- * reads the transfers table.
- */
-function warnIfParkedForReconciliation(row: PaymentRecurringPaymentRow, error: unknown): void {
-  if (!isRecurringSubmissionOutcomeUnknown(error)) {
-    return;
-  }
-  getLogger().warn(
-    {
-      organization_id: row.organization_id,
-      project_id: row.project_id,
-      recurring_payment_id: row.id,
-      reason: RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-    },
-    "collectDueRecurringPayments: collection parked, awaiting manual reconciliation"
-  );
-}
-
 function logCronFailure(message: string, row: PaymentRecurringPaymentRow, error: unknown): void {
   getLogger().error(
     {
@@ -133,7 +113,19 @@ async function collectRow(
     return "ok";
   } catch (error) {
     if (shouldSkipCollectionError(error)) {
-      warnIfParkedForReconciliation(row, error);
+      if (isTransferSubmissionOutcomeUnknown(error)) {
+        // A parked cycle is a skip for this tick, but a silent one would let
+        // the payer's subscription stall unnoticed.
+        getLogger().warn(
+          {
+            organization_id: row.organization_id,
+            project_id: row.project_id,
+            recurring_payment_id: row.id,
+            reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+          },
+          "collectDueRecurringPayments: collection parked, awaiting manual reconciliation"
+        );
+      }
       return "skipped";
     }
     logCronFailure("collectDueRecurringPayments: failed to collect recurring payment", row, error);
@@ -259,6 +251,15 @@ export async function collectDueRecurringPayments(
           AND rp.next_collection_due_at IS NOT NULL
           AND a.status IN ('processing', 'confirmed')
           AND (a.status = 'confirmed' OR a.updated_at <= ?)
+          -- A parked cycle waits for an operator and is never re-collected, so
+          -- its frozen updated_at would otherwise keep it permanently at the
+          -- head of this oldest-first window and starve genuinely stale ones.
+          AND NOT EXISTS (
+            SELECT 1
+              FROM payment_transfers parked
+             WHERE parked.id = a.transfer_id
+               AND parked.provider_data ->> 'submission_outcome' = 'unknown'
+          )
        ) recoverable_attempts
       WHERE attempt_rank = 1
       ORDER BY attempt_updated_at ASC

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -109,8 +109,9 @@ async function collectRow(
     return "ok";
   } catch (error) {
     if (shouldSkipCollectionError(error)) {
-      // A parked cycle also lands here, but it is already logged where it was
-      // parked, with the attempt and transfer ids the operator needs.
+      // The tick that parks a cycle lands here too; later ticks do not, because
+      // both queries above leave a parked attempt out. The park is logged where
+      // it happens, with the attempt and transfer ids the operator needs.
       return "skipped";
     }
     logCronFailure("collectDueRecurringPayments: failed to collect recurring payment", row, error);

--- a/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
+++ b/apps/sdp-api/src/services/jobs/collect-recurring-payments.ts
@@ -13,6 +13,10 @@ import {
   collectRecurringPayment,
   resumeRecurringPayment,
 } from "@/services/payments/recurring-payments";
+import {
+  isRecurringSubmissionOutcomeUnknown,
+  RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+} from "@/services/payments/recurring-payments/shared";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
 import type { Env } from "@/types/env";
 
@@ -76,6 +80,26 @@ function shouldSkipCollectionError(error: unknown): boolean {
   return error instanceof AppError && error.code === "CONFLICT";
 }
 
+/**
+ * A collection parked for manual reconciliation is a skip for this tick, but a
+ * silent one would let the payer's subscription stall unnoticed until someone
+ * reads the transfers table.
+ */
+function warnIfParkedForReconciliation(row: PaymentRecurringPaymentRow, error: unknown): void {
+  if (!isRecurringSubmissionOutcomeUnknown(error)) {
+    return;
+  }
+  getLogger().warn(
+    {
+      organization_id: row.organization_id,
+      project_id: row.project_id,
+      recurring_payment_id: row.id,
+      reason: RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+    },
+    "collectDueRecurringPayments: collection parked, awaiting manual reconciliation"
+  );
+}
+
 function logCronFailure(message: string, row: PaymentRecurringPaymentRow, error: unknown): void {
   getLogger().error(
     {
@@ -109,6 +133,7 @@ async function collectRow(
     return "ok";
   } catch (error) {
     if (shouldSkipCollectionError(error)) {
+      warnIfParkedForReconciliation(row, error);
       return "skipped";
     }
     logCronFailure("collectDueRecurringPayments: failed to collect recurring payment", row, error);

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -38,10 +38,13 @@ import {
 } from "@/routes/payments/token-accounts";
 import { getLogger } from "@/runtime/logger";
 import {
-  hasSubmissionOutcomeUnknownMarker,
+  isPreBroadcastRejection,
+  isTransferSubmissionOutcomeUnknown,
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+  transferSubmissionOutcomeUnknown,
 } from "@/services/payments/submission-outcome";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
@@ -56,9 +59,6 @@ import { enforceRecurringPaymentPolicy } from "./policy";
 import {
   activationErrorMessage,
   confirmSubscriptionSignature,
-  isRecurringSubmissionOutcomeUnknown,
-  RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
-  recurringSubmissionOutcomeUnknown,
   sendSubscriptionInstructions,
 } from "./shared";
 
@@ -664,12 +664,30 @@ async function journalRecurringPaymentCollectionError(input: {
     return;
   }
 
-  if (!input.submittedSignature && isRecurringSubmissionOutcomeUnknown(input.error)) {
+  if (!input.submittedSignature && isTransferSubmissionOutcomeUnknown(input.error)) {
     await parkRecurringPaymentCollection(input);
     return;
   }
 
   await markRecurringPaymentCollectionFailedAtomically(input);
+}
+
+/**
+ * Submit a collection through the shared fence: a provably pre-broadcast
+ * rejection stays a plain failure, anything else becomes the outcome-unknown
+ * conflict that parks the cycle.
+ */
+async function submitCollection(
+  input: Parameters<typeof sendSubscriptionInstructions>[0]
+): Promise<Signature> {
+  try {
+    return await sendSubscriptionInstructions(input);
+  } catch (error) {
+    if (isPreBroadcastRejection(error)) {
+      throw error;
+    }
+    throw transferSubmissionOutcomeUnknown(error);
+  }
 }
 
 /**
@@ -680,21 +698,14 @@ async function journalRecurringPaymentCollectionError(input: {
  * that may already have settled on chain. The marker also stops the
  * pending-transfers job from timing the transfer out into a false `failed`.
  */
-async function parkRecurringPaymentCollection(input: {
-  env: Env;
-  paymentsRepo: ReturnType<typeof createPaymentsRepository>;
-  organizationId: string;
-  projectId: string;
-  recurringPaymentId: string;
-  attempt: PaymentSubscriptionCollectionAttemptRow;
-  transfer: PaymentTransferRow | null;
-  error: unknown;
-}): Promise<void> {
+async function parkRecurringPaymentCollection(
+  input: Parameters<typeof journalRecurringPaymentCollectionError>[0]
+): Promise<void> {
   getLogger().warn(
     {
       attempt_id: input.attempt.id,
       error: activationErrorMessage(input.error),
-      reason: RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+      reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
       recurring_payment_id: input.recurringPaymentId,
       transfer_id: input.transfer?.id ?? null,
     },
@@ -808,8 +819,10 @@ async function recoverRecurringPaymentCollection(input: {
     // have broadcast without returning one. Failing it here would reschedule
     // the cycle and re-charge the payer, so it stays parked until an operator
     // reconciles it on chain.
-    if (hasSubmissionOutcomeUnknownMarker(transfer.provider_data)) {
-      throw recurringSubmissionOutcomeUnknown();
+    if (transfer.provider_data?.submission_outcome === "unknown") {
+      throw transferSubmissionOutcomeUnknown(
+        new Error("Recurring payment collection is parked for manual reconciliation")
+      );
     }
     // A fresh unsigned attempt means another request is between local persistence and Kora
     // submission; wait for it to either submit or become stale instead of creating a second transfer.
@@ -1224,7 +1237,10 @@ export async function collectRecurringPayment(input: {
       throw new AppError("CONFLICT", "Recurring payment is no longer active");
     }
 
-    const signature = await sendSubscriptionInstructions({
+    // Collection is the one recurring path that parks instead of failing: a
+    // journaled failure reschedules the cycle, and rescheduling re-charges the
+    // payer. The other recurring flows keep their own error handling.
+    const signature = await submitCollection({
       env: input.env,
       organizationId: input.organizationId,
       projectId: input.projectId,

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -757,6 +757,7 @@ async function safeJournalRecurringPaymentCollectionError(input: {
         has_submitted_signature: input.submittedSignature !== null,
         original_error: activationErrorMessage(input.error),
         recurring_payment_id: input.recurringPaymentId,
+        submitted_signature: input.submittedSignature,
         transfer_id: input.transfer?.id ?? null,
       },
       "Failed to journal recurring payment collection after failure"
@@ -825,8 +826,9 @@ async function recoverRecurringPaymentCollection(input: {
     // the cycle and re-charge the payer, so it stays parked until an operator
     // reconciles it on chain.
     if (
+      transfer.status === "processing" &&
       transfer.provider_data?.submission_outcome ===
-      SUBMISSION_OUTCOME_UNKNOWN_MARKER.submission_outcome
+        SUBMISSION_OUTCOME_UNKNOWN_MARKER.submission_outcome
     ) {
       getLogger().warn(
         {

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -826,7 +826,18 @@ async function recoverRecurringPaymentCollection(input: {
     // have broadcast without returning one. Failing it here would reschedule
     // the cycle and re-charge the payer, so it stays parked until an operator
     // reconciles it on chain.
-    if (transfer.provider_data?.submission_outcome === "unknown") {
+    if (
+      transfer.provider_data?.submission_outcome ===
+      SUBMISSION_OUTCOME_UNKNOWN_MARKER.submission_outcome
+    ) {
+      getLogger().warn(
+        {
+          attempt_id: existing.id,
+          reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+          transfer_id: transfer.id,
+        },
+        "Refused to recover a parked recurring payment collection; awaiting manual reconciliation"
+      );
       throw transferSubmissionOutcomeUnknown(
         new Error("Recurring payment collection is parked for manual reconciliation")
       );

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -42,7 +42,7 @@ import {
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
   signAndSendClosed,
-  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+  submissionOutcomeUnknownPatch,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
   transferSubmissionOutcomeUnknown,
 } from "@/services/payments/submission-outcome";
@@ -728,9 +728,7 @@ async function parkRecurringPaymentCollection(
         transferId: transfer.id,
         organizationId: input.organizationId,
         projectId: input.projectId,
-        status: "processing",
-        error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-        providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
+        ...submissionOutcomeUnknownPatch(),
         updatedAt: new Date().toISOString(),
       }),
     transfer.id

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -38,10 +38,10 @@ import {
 } from "@/routes/payments/token-accounts";
 import { getLogger } from "@/runtime/logger";
 import {
-  isPreBroadcastRejection,
   isTransferSubmissionOutcomeUnknown,
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
+  signAndSendClosed,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
   TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
   transferSubmissionOutcomeUnknown,
@@ -673,24 +673,6 @@ async function journalRecurringPaymentCollectionError(input: {
 }
 
 /**
- * Submit a collection through the shared fence: a provably pre-broadcast
- * rejection stays a plain failure, anything else becomes the outcome-unknown
- * conflict that parks the cycle.
- */
-async function submitCollection(
-  input: Parameters<typeof sendSubscriptionInstructions>[0]
-): Promise<Signature> {
-  try {
-    return await sendSubscriptionInstructions(input);
-  } catch (error) {
-    if (isPreBroadcastRejection(error)) {
-      throw error;
-    }
-    throw transferSubmissionOutcomeUnknown(error);
-  }
-}
-
-/**
  * Leave a collection whose submission outcome is unknown exactly where it is:
  * the attempt stays `processing` and the transfer keeps its `processing` row
  * behind the shared reconciliation marker. Journaling a failure here would
@@ -705,6 +687,8 @@ async function parkRecurringPaymentCollection(
     {
       attempt_id: input.attempt.id,
       error: activationErrorMessage(input.error),
+      organization_id: input.organizationId,
+      project_id: input.projectId,
       reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
       recurring_payment_id: input.recurringPaymentId,
       transfer_id: input.transfer?.id ?? null,
@@ -714,6 +698,29 @@ async function parkRecurringPaymentCollection(
   const transfer = input.transfer;
   if (!transfer) {
     return;
+  }
+  // Link the attempt to its transfer if that write was the one that was lost:
+  // both parking guards key off `transfer_id`, and an unlinked attempt would be
+  // failed and rescheduled by stale recovery — the double charge itself.
+  if (!input.attempt.transfer_id) {
+    try {
+      await input.subscriptionsRepo.updateCollectionAttempt({
+        attemptId: input.attempt.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        transferId: transfer.id,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch (linkError) {
+      getLogger().error(
+        {
+          attempt_id: input.attempt.id,
+          error: activationErrorMessage(linkError),
+          transfer_id: transfer.id,
+        },
+        "Failed to link a parked collection attempt to its transfer; reconcile manually"
+      );
+    }
   }
   await persistOutcomeUnknownMarker(
     () =>
@@ -1240,7 +1247,7 @@ export async function collectRecurringPayment(input: {
     // Collection is the one recurring path that parks instead of failing: a
     // journaled failure reschedules the cycle, and rescheduling re-charges the
     // payer. The other recurring flows keep their own error handling.
-    const signature = await submitCollection({
+    const signature = await sendSubscriptionInstructions({
       env: input.env,
       organizationId: input.organizationId,
       projectId: input.projectId,
@@ -1248,6 +1255,7 @@ export async function collectRecurringPayment(input: {
       sourceSigner,
       instructions: [createDestinationAtaInstruction, collectInstruction],
       feePayer,
+      submit: signAndSendClosed,
     });
     submittedSignature = signature;
     const submittedAt = new Date().toISOString();

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -971,6 +971,18 @@ export async function recoverOrBlockLifecycleCollection(input: {
     recurringPayment: input.recurringPayment,
     subscription,
     dueAt: input.recurringPayment.next_collection_due_at,
+  }).catch((error) => {
+    if (!isTransferSubmissionOutcomeUnknown(error)) {
+      throw error;
+    }
+    // The caller asked to change the subscription, not to collect it: the
+    // transfer's reconciliation sentence reads as a payment error on a cancel
+    // request. The block itself stands — the cycle is unresolved, and moving
+    // the schedule under it would orphan the parked attempt.
+    throw transferSubmissionOutcomeUnknown(
+      error.cause,
+      "Recurring payment cannot be changed while the current cycle's collection awaits manual reconciliation"
+    );
   });
 
   if (recovered) {

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -977,8 +977,11 @@ export async function recoverOrBlockLifecycleCollection(input: {
     }
     // The caller asked to change the subscription, not to collect it: the
     // transfer's reconciliation sentence reads as a payment error on a cancel
-    // request. The block itself stands — the cycle is unresolved, and moving
-    // the schedule under it would orphan the parked attempt.
+    // request. The block itself stands for `update` and `resume`, which move
+    // `next_collection_due_at` and would orphan the parked attempt. Cancel
+    // moves nothing: whether a customer may stop a subscription while one
+    // charge is unresolved is a product call, and until it is made the block
+    // covers cancel too.
     throw transferSubmissionOutcomeUnknown(
       error.cause,
       "Recurring payment cannot be changed while the current cycle's collection awaits manual reconciliation"

--- a/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/collection.ts
@@ -37,6 +37,12 @@ import {
   resolveSourceTokenAccountOrAta,
 } from "@/routes/payments/token-accounts";
 import { getLogger } from "@/runtime/logger";
+import {
+  hasSubmissionOutcomeUnknownMarker,
+  persistOutcomeUnknownMarker,
+  SUBMISSION_OUTCOME_UNKNOWN_MARKER,
+  TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+} from "@/services/payments/submission-outcome";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -50,6 +56,9 @@ import { enforceRecurringPaymentPolicy } from "./policy";
 import {
   activationErrorMessage,
   confirmSubscriptionSignature,
+  isRecurringSubmissionOutcomeUnknown,
+  RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+  recurringSubmissionOutcomeUnknown,
   sendSubscriptionInstructions,
 } from "./shared";
 
@@ -655,7 +664,59 @@ async function journalRecurringPaymentCollectionError(input: {
     return;
   }
 
+  if (!input.submittedSignature && isRecurringSubmissionOutcomeUnknown(input.error)) {
+    await parkRecurringPaymentCollection(input);
+    return;
+  }
+
   await markRecurringPaymentCollectionFailedAtomically(input);
+}
+
+/**
+ * Leave a collection whose submission outcome is unknown exactly where it is:
+ * the attempt stays `processing` and the transfer keeps its `processing` row
+ * behind the shared reconciliation marker. Journaling a failure here would
+ * reschedule the collection, and rescheduling re-charges the payer for a cycle
+ * that may already have settled on chain. The marker also stops the
+ * pending-transfers job from timing the transfer out into a false `failed`.
+ */
+async function parkRecurringPaymentCollection(input: {
+  env: Env;
+  paymentsRepo: ReturnType<typeof createPaymentsRepository>;
+  organizationId: string;
+  projectId: string;
+  recurringPaymentId: string;
+  attempt: PaymentSubscriptionCollectionAttemptRow;
+  transfer: PaymentTransferRow | null;
+  error: unknown;
+}): Promise<void> {
+  getLogger().warn(
+    {
+      attempt_id: input.attempt.id,
+      error: activationErrorMessage(input.error),
+      reason: RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+      recurring_payment_id: input.recurringPaymentId,
+      transfer_id: input.transfer?.id ?? null,
+    },
+    "Recurring payment collection parked; awaiting manual reconciliation"
+  );
+  const transfer = input.transfer;
+  if (!transfer) {
+    return;
+  }
+  await persistOutcomeUnknownMarker(
+    () =>
+      input.paymentsRepo.updateTransfer({
+        transferId: transfer.id,
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        status: "processing",
+        error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+        providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
+        updatedAt: new Date().toISOString(),
+      }),
+    transfer.id
+  );
 }
 
 async function safeJournalRecurringPaymentCollectionError(input: {
@@ -743,6 +804,13 @@ async function recoverRecurringPaymentCollection(input: {
   }
   const recoveredSignature = existing.signature ?? transfer.signature;
   if (!recoveredSignature) {
+    // A parked collection has no signature by definition: the provider may
+    // have broadcast without returning one. Failing it here would reschedule
+    // the cycle and re-charge the payer, so it stays parked until an operator
+    // reconciles it on chain.
+    if (hasSubmissionOutcomeUnknownMarker(transfer.provider_data)) {
+      throw recurringSubmissionOutcomeUnknown();
+    }
     // A fresh unsigned attempt means another request is between local persistence and Kora
     // submission; wait for it to either submit or become stale instead of creating a second transfer.
     if (!isStaleCollectionAttempt(existing)) {

--- a/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
@@ -20,6 +20,7 @@ import { createTokenRepository } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { isNativePaymentToken, normalizePaymentToken } from "@/services/payment-operation.service";
+import { isPreBroadcastRejection } from "@/services/payments/submission-outcome";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -117,7 +118,35 @@ export async function sendSubscriptionInstructions(input: {
   );
   const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
   const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
-  return feePayment.signAndSend(txBytes);
+  try {
+    return await feePayment.signAndSend(txBytes);
+  } catch (error) {
+    if (isPreBroadcastRejection(error)) {
+      throw error;
+    }
+    // The provider may have broadcast without returning a signature. Callers
+    // must park the collection instead of journaling a terminal failure: a
+    // failed attempt is rescheduled, and rescheduling re-charges the payer.
+    throw recurringSubmissionOutcomeUnknown();
+  }
+}
+
+/** Stable machine reason for a recurring submission whose outcome is unknown. */
+export const RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON = "recurring_collection_outcome_unknown";
+
+export function recurringSubmissionOutcomeUnknown(): AppError {
+  return new AppError(
+    "CONFLICT",
+    "Recurring payment collection outcome is unknown; reconcile the existing transfer before retrying",
+    { reason: RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON }
+  );
+}
+
+export function isRecurringSubmissionOutcomeUnknown(error: unknown): error is AppError {
+  return (
+    error instanceof AppError &&
+    error.details?.reason === RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON
+  );
 }
 
 export async function confirmSubscriptionSignature(

--- a/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
@@ -20,7 +20,6 @@ import { createTokenRepository } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { isNativePaymentToken, normalizePaymentToken } from "@/services/payment-operation.service";
-import { isPreBroadcastRejection } from "@/services/payments/submission-outcome";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -118,35 +117,7 @@ export async function sendSubscriptionInstructions(input: {
   );
   const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
   const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
-  try {
-    return await feePayment.signAndSend(txBytes);
-  } catch (error) {
-    if (isPreBroadcastRejection(error)) {
-      throw error;
-    }
-    // The provider may have broadcast without returning a signature. Callers
-    // must park the collection instead of journaling a terminal failure: a
-    // failed attempt is rescheduled, and rescheduling re-charges the payer.
-    throw recurringSubmissionOutcomeUnknown();
-  }
-}
-
-/** Stable machine reason for a recurring submission whose outcome is unknown. */
-export const RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON = "recurring_collection_outcome_unknown";
-
-export function recurringSubmissionOutcomeUnknown(): AppError {
-  return new AppError(
-    "CONFLICT",
-    "Recurring payment collection outcome is unknown; reconcile the existing transfer before retrying",
-    { reason: RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON }
-  );
-}
-
-export function isRecurringSubmissionOutcomeUnknown(error: unknown): error is AppError {
-  return (
-    error instanceof AppError &&
-    error.details?.reason === RECURRING_SUBMISSION_OUTCOME_UNKNOWN_REASON
-  );
+  return feePayment.signAndSend(txBytes);
 }
 
 export async function confirmSubscriptionSignature(

--- a/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
+++ b/apps/sdp-api/src/services/payments/recurring-payments/shared.ts
@@ -20,6 +20,7 @@ import { createTokenRepository } from "@/db/repositories";
 import { AppError, badRequest } from "@/lib/errors";
 import { createTenantScope } from "@/lib/tenant-scope";
 import { isNativePaymentToken, normalizePaymentToken } from "@/services/payment-operation.service";
+import type { signAndSendClosed } from "@/services/payments/submission-outcome";
 import * as solanaServices from "@/services/solana";
 import { createProjectSponsorshipFeePayment } from "@/services/sponsorship.service";
 import type { CustodyWallet } from "@/services/stores/custody-config.store";
@@ -86,6 +87,12 @@ export async function sendSubscriptionInstructions(input: {
   sourceSigner?: TransactionSigner;
   instructions: Instruction[];
   feePayer?: Address;
+  /**
+   * How the signed transaction reaches the provider. Defaults to a plain
+   * submit; collection passes the fence so only the submit itself — never the
+   * signer, blockhash or fee-payer lookups above it — can park the cycle.
+   */
+  submit?: typeof signAndSendClosed;
 }): Promise<Signature> {
   const signer =
     input.sourceSigner ??
@@ -117,7 +124,7 @@ export async function sendSubscriptionInstructions(input: {
   );
   const partiallySigned = await partiallySignTransactionMessageWithSigners(message);
   const txBytes = new Uint8Array(getTransactionEncoder().encode(partiallySigned));
-  return feePayment.signAndSend(txBytes);
+  return input.submit ? input.submit(feePayment, txBytes) : feePayment.signAndSend(txBytes);
 }
 
 export async function confirmSubscriptionSignature(

--- a/apps/sdp-api/src/services/payments/submission-outcome.test.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.test.ts
@@ -1,6 +1,7 @@
 import { FeePaymentError } from "@sdp/payments/fee-payment";
 import { describe, expect, it, vi } from "vitest";
 import {
+  hasSubmissionOutcomeUnknownMarker,
   isPreBroadcastRejection,
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
@@ -86,6 +87,22 @@ describe("isPreBroadcastRejection", () => {
     });
     expect(contradictory.preBroadcast).toBe(false);
     expect(isPreBroadcastRejection(contradictory)).toBe(false);
+  });
+});
+
+describe("hasSubmissionOutcomeUnknownMarker", () => {
+  it("detects the marker on a parked row", () => {
+    // Literal on purpose: rows already parked in production must keep matching
+    // even if the exported constant is ever renamed.
+    expect(hasSubmissionOutcomeUnknownMarker({ submission_outcome: "unknown" })).toBe(true);
+    expect(hasSubmissionOutcomeUnknownMarker({ ...SUBMISSION_OUTCOME_UNKNOWN_MARKER })).toBe(true);
+  });
+
+  it("ignores rows without it", () => {
+    expect(hasSubmissionOutcomeUnknownMarker({})).toBe(false);
+    expect(hasSubmissionOutcomeUnknownMarker(null)).toBe(false);
+    expect(hasSubmissionOutcomeUnknownMarker({ submission_outcome: "settled" })).toBe(false);
+    expect(hasSubmissionOutcomeUnknownMarker("unknown")).toBe(false);
   });
 });
 

--- a/apps/sdp-api/src/services/payments/submission-outcome.test.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.test.ts
@@ -1,7 +1,6 @@
 import { FeePaymentError } from "@sdp/payments/fee-payment";
 import { describe, expect, it, vi } from "vitest";
 import {
-  hasSubmissionOutcomeUnknownMarker,
   isPreBroadcastRejection,
   persistOutcomeUnknownMarker,
   SUBMISSION_OUTCOME_UNKNOWN_MARKER,
@@ -87,22 +86,6 @@ describe("isPreBroadcastRejection", () => {
     });
     expect(contradictory.preBroadcast).toBe(false);
     expect(isPreBroadcastRejection(contradictory)).toBe(false);
-  });
-});
-
-describe("hasSubmissionOutcomeUnknownMarker", () => {
-  it("detects the marker on a parked row", () => {
-    // Literal on purpose: rows already parked in production must keep matching
-    // even if the exported constant is ever renamed.
-    expect(hasSubmissionOutcomeUnknownMarker({ submission_outcome: "unknown" })).toBe(true);
-    expect(hasSubmissionOutcomeUnknownMarker({ ...SUBMISSION_OUTCOME_UNKNOWN_MARKER })).toBe(true);
-  });
-
-  it("ignores rows without it", () => {
-    expect(hasSubmissionOutcomeUnknownMarker({})).toBe(false);
-    expect(hasSubmissionOutcomeUnknownMarker(null)).toBe(false);
-    expect(hasSubmissionOutcomeUnknownMarker({ submission_outcome: "settled" })).toBe(false);
-    expect(hasSubmissionOutcomeUnknownMarker("unknown")).toBe(false);
   });
 });
 

--- a/apps/sdp-api/src/services/payments/submission-outcome.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.ts
@@ -70,26 +70,28 @@ export function isPreBroadcastRejection(error: unknown): boolean {
 }
 
 /**
+ * The write that parks a row: `processing`, the reconciliation notice and the
+ * durable marker, in one place so a new consumer cannot park a row half-way.
+ * A signature whose own column refused it rides along in `provider_data`, which
+ * is where the operator is told to look for it.
+ */
+export function submissionOutcomeUnknownPatch(submittedSignature?: string) {
+  return {
+    status: "processing" as const,
+    error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+    providerData: submittedSignature
+      ? { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, submitted_signature: submittedSignature }
+      : { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
+  };
+}
+
+/**
  * Persist the manual-reconciliation marker without ever throwing: a DB blip
  * here is likely correlated with the provider trouble that made the outcome
  * ambiguous, and replacing the caller's outcome-unknown 409 with a raw 500
  * invites the exact double-send retry the marker exists to prevent. Retries
  * once; an unmarked row is loudly logged for operator reconciliation.
  */
-/**
- * The write that parks a row: `processing`, the reconciliation notice and the
- * durable marker, in one place so a new consumer cannot park a row half-way.
- * `providerData` merges into the marker — anything the operator should find on
- * the row, such as a signature its own column refused.
- */
-export function submissionOutcomeUnknownPatch(providerData?: Record<string, unknown>) {
-  return {
-    status: "processing" as const,
-    error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-    providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, ...providerData },
-  };
-}
-
 export async function persistOutcomeUnknownMarker(
   persistMarker: () => Promise<unknown>,
   transferId: string

--- a/apps/sdp-api/src/services/payments/submission-outcome.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.ts
@@ -79,9 +79,9 @@ export function submissionOutcomeUnknownPatch(submittedSignature?: string) {
   return {
     status: "processing" as const,
     error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
-    providerData: submittedSignature
-      ? { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, submitted_signature: submittedSignature }
-      : { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER },
+    // An absent signature writes no key: the repository JSON.stringifies this
+    // before the `provider_data || ?::jsonb` merge, and that drops undefined.
+    providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, submitted_signature: submittedSignature },
   };
 }
 

--- a/apps/sdp-api/src/services/payments/submission-outcome.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.ts
@@ -1,4 +1,6 @@
+import type { FeePaymentPort } from "@sdp/payments/fee-payment";
 import { FeePaymentError, type FeePaymentErrorCode } from "@sdp/payments/fee-payment";
+import { AppError } from "@/lib/errors";
 import { getLogger } from "@/runtime/logger";
 
 /**
@@ -67,15 +69,6 @@ export function isPreBroadcastRejection(error: unknown): boolean {
   return /custom program error:/i.test(message);
 }
 
-/** True when a transfer row's provider_data carries the outcome-unknown marker. */
-export function hasSubmissionOutcomeUnknownMarker(providerData: unknown): boolean {
-  return (
-    typeof providerData === "object" &&
-    providerData !== null &&
-    (providerData as Record<string, unknown>).submission_outcome === "unknown"
-  );
-}
-
 /**
  * Persist the manual-reconciliation marker without ever throwing: a DB blip
  * here is likely correlated with the provider trouble that made the outcome
@@ -103,5 +96,45 @@ export async function persistOutcomeUnknownMarker(
         "failed to persist the submission-outcome-unknown marker; the row may auto-fail — reconcile manually"
       );
     }
+  }
+}
+
+/**
+ * The outcome-unknown conflict every money path throws and every consumer
+ * detects. The provider failure travels as `cause` — server-side only, never
+ * serialized to the client — so the forced manual reconciliation starts from
+ * the real error instead of this constant sentence.
+ */
+export function transferSubmissionOutcomeUnknown(cause: unknown): AppError {
+  const error = new AppError("CONFLICT", TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR, {
+    reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
+  });
+  error.cause = cause;
+  return error;
+}
+
+export function isTransferSubmissionOutcomeUnknown(error: unknown): error is AppError {
+  return (
+    error instanceof AppError &&
+    error.details?.reason === TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON
+  );
+}
+
+/**
+ * Submit through one closed chokepoint: a provably pre-broadcast provider
+ * rejection passes through for a plain terminal failure, anything else becomes
+ * the outcome-unknown conflict the caller must park and rethrow.
+ */
+export async function signAndSendClosed(
+  feePayment: Pick<FeePaymentPort, "signAndSend">,
+  txBytes: Uint8Array
+) {
+  try {
+    return await feePayment.signAndSend(txBytes);
+  } catch (error) {
+    if (isPreBroadcastRejection(error)) {
+      throw error;
+    }
+    throw transferSubmissionOutcomeUnknown(error);
   }
 }

--- a/apps/sdp-api/src/services/payments/submission-outcome.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.ts
@@ -121,8 +121,11 @@ export async function persistOutcomeUnknownMarker(
  * serialized to the client — so the forced manual reconciliation starts from
  * the real error instead of this constant sentence.
  */
-export function transferSubmissionOutcomeUnknown(cause: unknown): AppError {
-  const error = new AppError("CONFLICT", TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR, {
+export function transferSubmissionOutcomeUnknown(
+  cause: unknown,
+  message: string = TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR
+): AppError {
+  const error = new AppError("CONFLICT", message, {
     reason: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_REASON,
   });
   error.cause = cause;

--- a/apps/sdp-api/src/services/payments/submission-outcome.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.ts
@@ -76,6 +76,20 @@ export function isPreBroadcastRejection(error: unknown): boolean {
  * invites the exact double-send retry the marker exists to prevent. Retries
  * once; an unmarked row is loudly logged for operator reconciliation.
  */
+/**
+ * The write that parks a row: `processing`, the reconciliation notice and the
+ * durable marker, in one place so a new consumer cannot park a row half-way.
+ * `providerData` merges into the marker — anything the operator should find on
+ * the row, such as a signature its own column refused.
+ */
+export function submissionOutcomeUnknownPatch(providerData?: Record<string, unknown>) {
+  return {
+    status: "processing" as const,
+    error: TRANSFER_SUBMISSION_OUTCOME_UNKNOWN_ERROR,
+    providerData: { ...SUBMISSION_OUTCOME_UNKNOWN_MARKER, ...providerData },
+  };
+}
+
 export async function persistOutcomeUnknownMarker(
   persistMarker: () => Promise<unknown>,
   transferId: string

--- a/apps/sdp-api/src/services/payments/submission-outcome.ts
+++ b/apps/sdp-api/src/services/payments/submission-outcome.ts
@@ -67,6 +67,15 @@ export function isPreBroadcastRejection(error: unknown): boolean {
   return /custom program error:/i.test(message);
 }
 
+/** True when a transfer row's provider_data carries the outcome-unknown marker. */
+export function hasSubmissionOutcomeUnknownMarker(providerData: unknown): boolean {
+  return (
+    typeof providerData === "object" &&
+    providerData !== null &&
+    (providerData as Record<string, unknown>).submission_outcome === "unknown"
+  );
+}
+
 /**
  * Persist the manual-reconciliation marker without ever throwing: a DB blip
  * here is likely correlated with the provider trouble that made the outcome

--- a/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
+++ b/apps/sdp-docs/public/postman/solana-developer-platform-public.postman_collection.json
@@ -1579,7 +1579,7 @@
               }
             ],
             "url": "{{baseUrl}}/v1/payments/transfer-batches",
-            "description": "Executes a custody-signed outbound transfer batch to counterparty crypto-wallet accounts, chunks recipients into Solana transactions, and returns the batch, recipient, and transfer records. Supply an Idempotency-Key to retry safely: an identical resolved request returns the original batch without another on-chain submission, while reusing the key for a different request returns 409.",
+            "description": "Executes a custody-signed outbound transfer batch to counterparty crypto-wallet accounts, chunks recipients into Solana transactions, and returns the batch, recipient, and transfer records. Supply an Idempotency-Key to retry safely: an identical resolved request returns the original batch without another on-chain submission, while reusing the key for a different request returns 409. A chunk whose provider outcome is unknown comes back inside a 200 as a processing transfer without a signature and with a reconciliation notice in error, its recipients left processing — it may already be on chain, so do NOT re-send that batch.",
             "body": {
               "mode": "raw",
               "raw": "{\n  \"projectId\": \"prj_example\",\n  \"externalId\": \"payroll_2026_06_30\",\n  \"source\": \"privy_wallet_123\",\n  \"token\": \"SOL\",\n  \"recipients\": [\n    {\n      \"externalId\": \"payroll_row_001\",\n      \"counterpartyId\": \"cp_example\",\n      \"counterpartyAccountId\": \"cpa_example\",\n      \"amount\": \"25.00\"\n    }\n  ],\n  \"options\": {\n    \"maxRecipientsPerTransaction\": 20,\n    \"priorityFee\": \"auto\",\n    \"preflight\": true\n  }\n}",
@@ -1690,7 +1690,7 @@
             "method": "POST",
             "header": [],
             "url": "{{baseUrl}}/v1/payments/recurring-payments/{{id}}/collect",
-            "description": "Manually collects a due active SDP-custody recurring payment by submitting the Solana subscriptions collection transaction, creating a linked payment transfer, recording the collection attempt, and advancing the next due time."
+            "description": "Manually collects a due active SDP-custody recurring payment by submitting the Solana subscriptions collection transaction, creating a linked payment transfer, recording the collection attempt, and advancing the next due time. A 409 with error.details.reason = transfer_submission_outcome_unknown means the provider outcome is unknown: the attempt and its transfer stay processing behind a reconciliation marker and the cycle is deliberately NOT rescheduled — do not retry, and do not read it as a failed collection."
           }
         },
         {

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -171,7 +171,9 @@ Database schema rollback is not automated. If the selected image is incompatible
 
 When a fee-payment provider fails without telling us whether it broadcast the transaction, the API
 parks the transfer: it stays `processing`, carries the marker `provider_data.submission_outcome =
-'unknown'`, and returns `409 transfer_submission_outcome_unknown` telling the client not to retry.
+'unknown'`, and tells the caller not to retry — `409 transfer_submission_outcome_unknown` for a
+single transfer or a manual collection, and a `processing` chunk with that notice in its `error`
+inside the batch's `200`.
 The cron job never times out a signatureless parked transfer: the recovery query excludes it. If
 `signature` is present, the job still reconciles it from chain normally; otherwise an operator must
 establish what happened on chain. List them with:
@@ -243,6 +245,29 @@ WHERE a.status = 'processing'
 ORDER BY a.due_at;
 ```
 
+#### Failing a parked batch chunk
+
+Never fail a chunk by hand. The reconciliation job is the only writer that cascades to a chunk's
+recipients and recomputes its parent batch, and it only ever claims chunks that are still
+`processing` — one set to `failed` by hand leaves its recipients processing and its batch unsettled
+for good. Drop the marker instead and let the job do all three, leaving `updated_at` alone so the row
+is already past the stuck window:
+
+```sql
+UPDATE payment_transfers
+   SET provider_data = provider_data - 'submission_outcome'
+ WHERE id = :transfer_id
+   AND status = 'processing'
+   AND signature IS NULL;
+```
+
+The job confirms the signature against the transaction history before failing anything, so a chunk
+that did land after all settles instead. The recorded reason is then the job's own
+`Transaction not found on chain` rather than an operator's sentence.
+
+A chunk that DID land needs none of this: give it its signature as above and the job settles the
+chunk, its recipients and the batch on its next run.
+
 Resolve the transfer first, as above. Then close the attempt to match it: if the collection landed,
 confirm the attempt against the recorded signature; if it never landed, fail the attempt so the
 cycle is rescheduled and collected once. Do not fail the attempt while its transfer is still
@@ -258,7 +283,7 @@ SELECT id AS attempt_id, subscription_id, due_at, updated_at
 FROM payment_subscription_collection_attempts
 WHERE status = 'processing'
   AND transfer_id IS NULL
-  AND updated_at < now() - interval '5 minutes'
+  AND updated_at::timestamptz < now() - interval '5 minutes'
 ORDER BY due_at;
 ```
 

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -216,21 +216,16 @@ If a pre-fence rollback cannot wait for every row, record the transfer ids left 
 incident timeline: the older job will fail them, and each one is a payment the client may send
 again.
 
-The same marker parks two more surfaces. Both are found by the query above — it already spans every
-wallet transfer type — but each needs a different second step.
-
-#### Parked batch chunks
-
-A chunk's transfer carries the marker and its recipients stay `processing`, so the batch never
-settles. Resolve the chunk exactly as a single transfer above; the recipients and the parent batch
-then follow from it on the next `trackPendingTransfers` run.
+The query above already spans every wallet transfer type, so it also lists parked **batch chunks** —
+resolve such a chunk exactly as a single transfer and its recipients and parent batch follow on the
+next `trackPendingTransfers` run — and parked **recurring collections**, which need a second step.
 
 #### Parked recurring collections
 
 The collection attempt stays `processing` alongside its parked transfer, so the subscription stops
 collecting until an operator resolves it — deliberately, because failing the attempt would
-reschedule the cycle and charge the payer a second time. The cron logs each parked cycle
-(`collectDueRecurringPayments: collection parked`). List them with:
+reschedule the cycle and charge the payer a second time. Each park is logged once where it happens, with the attempt and transfer ids
+(`Recurring payment collection parked; awaiting manual reconciliation`). List them with:
 
 ```sql
 SELECT a.id AS attempt_id, a.subscription_id, a.due_at, a.transfer_id, t.source_address, t.amount

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -222,16 +222,8 @@ wallet transfer type — but each needs a different second step.
 #### Parked batch chunks
 
 A chunk's transfer carries the marker and its recipients stay `processing`, so the batch never
-settles. Resolve the chunk exactly as a single transfer (find the transaction on chain, then either
-record the signature and drop the marker, or mark it failed). The recipients and the parent batch
-follow from the chunk on the next `trackPendingTransfers` run; check with:
-
-```sql
-SELECT r.status, count(*)
-FROM payment_transfer_recipients r
-WHERE r.batch_id = :batch_id
-GROUP BY r.status;
-```
+settles. Resolve the chunk exactly as a single transfer above; the recipients and the parent batch
+then follow from it on the next `trackPendingTransfers` run.
 
 #### Parked recurring collections
 

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -186,8 +186,9 @@ WHERE status = 'processing'
 ORDER BY created_at;
 ```
 
-Keep the `status = 'processing'` filter: a row whose outcome later became known keeps the marker
-key (`provider_data` is only ever merged into), so without it the list fills with settled transfers.
+Keep the `status = 'processing'` filter: nothing in the code removes the marker key — only the
+resolution SQL below does — so a row that settled on its own still carries it, and without the
+filter the list fills with transfers that need nothing.
 
 A signatureless parked row waits indefinitely, so resolve parked rows promptly. Reconcile every one
 before a planned rollback to a pre-fence image. If the row carries
@@ -223,15 +224,15 @@ again.
 The query above already spans every wallet transfer type, so it also lists parked **batch chunks** —
 resolve such a chunk exactly as a single transfer and its recipients and parent batch follow on the
 next `trackPendingTransfers` run — and parked **recurring collections**, which need a second step.
-That applies to transfers and chunks alike: whichever could not record its signature carries it in
-`provider_data ->> 'submitted_signature'`.
 
 #### Parked recurring collections
 
 The collection attempt stays `processing` alongside its parked transfer, so the subscription stops
 collecting until an operator resolves it — deliberately, because failing the attempt would
 reschedule the cycle and charge the payer a second time. Each park is logged once where it happens, with the attempt and transfer ids
-(`Recurring payment collection parked; awaiting manual reconciliation`). List them with:
+(`Recurring payment collection parked; awaiting manual reconciliation`). A transfer that could not
+even be parked logs `failed to close a lost submitted transfer signature` and needs the same
+treatment, from the signature in that line. List the parked collections with:
 
 ```sql
 SELECT a.id AS attempt_id, a.subscription_id, a.due_at, a.transfer_id, t.source_address, t.amount

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -219,6 +219,8 @@ again.
 The query above already spans every wallet transfer type, so it also lists parked **batch chunks** —
 resolve such a chunk exactly as a single transfer and its recipients and parent batch follow on the
 next `trackPendingTransfers` run — and parked **recurring collections**, which need a second step.
+A chunk that was broadcast but could not record its signature carries it in
+`provider_data ->> 'submitted_signature'`; start there instead of searching the chain by address.
 
 #### Parked recurring collections
 
@@ -240,6 +242,20 @@ Resolve the transfer first, as above. Then close the attempt to match it: if the
 confirm the attempt against the recorded signature; if it never landed, fail the attempt so the
 cycle is rescheduled and collected once. Do not fail the attempt while its transfer is still
 parked — that is the double-charge the parking exists to prevent.
+
+An attempt whose `transfer_id` write was lost is missing from that list, and both parking guards key
+off `transfer_id`, so stale recovery will reschedule it 15 minutes after its last write — the double
+charge. `Failed to link a parked collection attempt to its transfer; reconcile manually` is logged
+whenever that happens. Sweep for them before the window elapses:
+
+```sql
+SELECT id AS attempt_id, subscription_id, due_at, updated_at
+FROM payment_subscription_collection_attempts
+WHERE status = 'processing'
+  AND transfer_id IS NULL
+  AND updated_at < now() - interval '5 minutes'
+ORDER BY due_at;
+```
 
 ### Schema compatibility
 

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -210,31 +210,63 @@ WHERE id = :transfer_id AND status = 'processing';
 
 -- The transaction provably did NOT land: fail it terminally and drop the
 -- marker. Only after confirming no matching transaction exists on chain —
--- a wrong call here invites the client to send the payment twice.
+-- a wrong call here invites the client to send the payment twice. Batch
+-- chunks use the separate procedure below so their recipients also settle.
 UPDATE payment_transfers
 SET status = 'failed',
     error = 'Reconciled manually: transaction was never broadcast',
     provider_data = provider_data - 'submission_outcome',
     updated_at = sdp_iso_now()
-WHERE id = :transfer_id AND status = 'processing';
+WHERE id = :transfer_id
+  AND status = 'processing'
+  AND type <> 'transfer_batch';
 ```
 
 If a pre-fence rollback cannot wait for every row, record the transfer ids left parked in the
 incident timeline: the older job will fail them, and each one is a payment the client may send
 again.
 
-The query above already spans every wallet transfer type, so it also lists parked **batch chunks** —
-resolve such a chunk exactly as a single transfer and its recipients and parent batch follow on the
-next `trackPendingTransfers` run — and parked **recurring collections**, which need a second step.
+The query above spans every wallet transfer type. A parked batch chunk has
+`type = 'transfer_batch'` and requires the procedure below. A recurring collection uses the normal
+`transfer` type; identify it through its collection-attempt link.
+
+#### Parked batch chunks
+
+Never fail a chunk by hand. The reconciliation job is the only writer that cascades to a chunk's
+recipients and recomputes its parent batch, and it only ever claims chunks that are still
+`processing` — one set to `failed` by hand leaves its recipients processing and its batch unsettled
+for good.
+
+If the chunk landed, record its signature with the earlier `UPDATE`; the job then settles the chunk,
+its recipients, and the parent batch. If it provably did not land, drop only the marker and leave
+`updated_at` unchanged:
+
+```sql
+UPDATE payment_transfers
+   SET provider_data = provider_data - 'submission_outcome'
+ WHERE id = :transfer_id
+   AND status = 'processing'
+   AND type = 'transfer_batch'
+   AND signature IS NULL;
+```
+
+Use this only after proving on chain that the transaction did not land. Once the row is five minutes
+old, `trackPendingTransfers` takes the signatureless timeout path. `settleTransferBatch` then fails
+the chunk and its recipients atomically and recomputes the parent batch. The recorded reason is
+`Transfer processing timed out`.
+
+A signatureless row is not checked against transaction history because there is no signature to
+query. If the chunk did land, record its signature instead of removing the marker.
 
 #### Parked recurring collections
 
 The collection attempt stays `processing` alongside its parked transfer, so the subscription stops
 collecting until an operator resolves it — deliberately, because failing the attempt would
-reschedule the cycle and charge the payer a second time. Each park is logged once where it happens, with the attempt and transfer ids
-(`Recurring payment collection parked; awaiting manual reconciliation`). A transfer that could not
-even be parked logs `failed to close a lost submitted transfer signature` and needs the same
-treatment, from the signature in that line. List the parked collections with:
+reschedule the cycle and charge the payer a second time. Each park is logged once with the attempt
+and transfer ids (`Recurring payment collection parked; awaiting manual reconciliation`). A
+transfer that could not even be parked logs `failed to close a lost submitted transfer signature`
+and needs the same treatment, starting from the signature in that line. List parked collections
+with:
 
 ```sql
 SELECT a.id AS attempt_id, a.subscription_id, a.due_at, a.transfer_id, t.source_address, t.amount
@@ -245,33 +277,10 @@ WHERE a.status = 'processing'
 ORDER BY a.due_at;
 ```
 
-#### Failing a parked batch chunk
-
-Never fail a chunk by hand. The reconciliation job is the only writer that cascades to a chunk's
-recipients and recomputes its parent batch, and it only ever claims chunks that are still
-`processing` — one set to `failed` by hand leaves its recipients processing and its batch unsettled
-for good. Drop the marker instead and let the job do all three, leaving `updated_at` alone so the row
-is already past the stuck window:
-
-```sql
-UPDATE payment_transfers
-   SET provider_data = provider_data - 'submission_outcome'
- WHERE id = :transfer_id
-   AND status = 'processing'
-   AND signature IS NULL;
-```
-
-The job confirms the signature against the transaction history before failing anything, so a chunk
-that did land after all settles instead. The recorded reason is then the job's own
-`Transaction not found on chain` rather than an operator's sentence.
-
-A chunk that DID land needs none of this: give it its signature as above and the job settles the
-chunk, its recipients and the batch on its next run.
-
-Resolve the transfer first, as above. Then close the attempt to match it: if the collection landed,
-confirm the attempt against the recorded signature; if it never landed, fail the attempt so the
-cycle is rescheduled and collected once. Do not fail the attempt while its transfer is still
-parked — that is the double-charge the parking exists to prevent.
+Resolve the transfer first: record its signature if it landed, or use the non-batch failure statement
+if it provably did not. Do not close the attempt by hand. After the marker is gone, recurring-payment
+recovery claims the stale attempt after 15 minutes. With a signature it verifies and completes the
+cycle; without one it fails the attempt and reschedules the cycle once.
 
 An attempt whose `transfer_id` write was lost is missing from that list, and both parking guards key
 off `transfer_id`, so stale recovery will reschedule it 15 minutes after its last write — the double
@@ -286,6 +295,22 @@ WHERE status = 'processing'
   AND updated_at::timestamptz < now() - interval '5 minutes'
 ORDER BY due_at;
 ```
+
+Use the `transfer_id` from the corresponding error log to restore the link before that window:
+
+```sql
+UPDATE payment_subscription_collection_attempts
+SET transfer_id = :transfer_id,
+    updated_at = sdp_iso_now()
+WHERE id = :attempt_id
+  AND organization_id = :organization_id
+  AND project_id = :project_id
+  AND status = 'processing'
+  AND transfer_id IS NULL;
+```
+
+Then resolve the linked transfer as above. The refreshed `updated_at` gives the operator a new
+15-minute recovery window.
 
 ### Schema compatibility
 

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -264,23 +264,25 @@ The collection attempt stays `processing` alongside its parked transfer, so the 
 collecting until an operator resolves it — deliberately, because failing the attempt would
 reschedule the cycle and charge the payer a second time. Each park is logged once with the attempt
 and transfer ids (`Recurring payment collection parked; awaiting manual reconciliation`). A
-transfer that could not even be parked logs `failed to close a lost submitted transfer signature`
-and needs the same treatment, starting from the signature in that line. List parked collections
-with:
+transfer whose post-submit bookkeeping could not be journaled logs
+`Failed to journal recurring payment collection after failure` and needs the same treatment,
+starting from its `submitted_signature` field. List parked collections with:
 
 ```sql
 SELECT a.id AS attempt_id, a.subscription_id, a.due_at, a.transfer_id, t.source_address, t.amount
 FROM payment_subscription_collection_attempts a
 JOIN payment_transfers t ON t.id = a.transfer_id
 WHERE a.status = 'processing'
+  AND t.status = 'processing'
   AND t.provider_data ->> 'submission_outcome' = 'unknown'
 ORDER BY a.due_at;
 ```
 
 Resolve the transfer first: record its signature if it landed, or use the non-batch failure statement
-if it provably did not. Do not close the attempt by hand. After the marker is gone, recurring-payment
-recovery claims the stale attempt after 15 minutes. With a signature it verifies and completes the
-cycle; without one it fails the attempt and reschedules the cycle once.
+if it provably did not. Do not close the attempt by hand. Once the transfer leaves `processing`, its
+marker is inert even if an application write retained it. Recurring-payment recovery then claims the
+stale attempt after 15 minutes: with a signature it verifies and completes the cycle; without one it
+fails the attempt and reschedules the cycle once.
 
 An attempt whose `transfer_id` write was lost is missing from that list, and both parking guards key
 off `transfer_id`, so stale recovery will reschedule it 15 minutes after its last write — the double

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -216,6 +216,44 @@ If a pre-fence rollback cannot wait for every row, record the transfer ids left 
 incident timeline: the older job will fail them, and each one is a payment the client may send
 again.
 
+The same marker parks two more surfaces. Both are found by the query above — it already spans every
+wallet transfer type — but each needs a different second step.
+
+#### Parked batch chunks
+
+A chunk's transfer carries the marker and its recipients stay `processing`, so the batch never
+settles. Resolve the chunk exactly as a single transfer (find the transaction on chain, then either
+record the signature and drop the marker, or mark it failed). The recipients and the parent batch
+follow from the chunk on the next `trackPendingTransfers` run; check with:
+
+```sql
+SELECT r.status, count(*)
+FROM payment_transfer_recipients r
+WHERE r.batch_id = :batch_id
+GROUP BY r.status;
+```
+
+#### Parked recurring collections
+
+The collection attempt stays `processing` alongside its parked transfer, so the subscription stops
+collecting until an operator resolves it — deliberately, because failing the attempt would
+reschedule the cycle and charge the payer a second time. The cron logs each parked cycle
+(`collectDueRecurringPayments: collection parked`). List them with:
+
+```sql
+SELECT a.id AS attempt_id, a.subscription_id, a.due_at, a.transfer_id, t.source_address, t.amount
+FROM payment_subscription_collection_attempts a
+JOIN payment_transfers t ON t.id = a.transfer_id
+WHERE a.status = 'processing'
+  AND t.provider_data ->> 'submission_outcome' = 'unknown'
+ORDER BY a.due_at;
+```
+
+Resolve the transfer first, as above. Then close the attempt to match it: if the collection landed,
+confirm the attempt against the recorded signature; if it never landed, fail the attempt so the
+cycle is rescheduled and collected once. Do not fail the attempt while its transfer is still
+parked — that is the double-charge the parking exists to prevent.
+
 ### Schema compatibility
 
 Migrations must remain backward-compatible across the rollback window:

--- a/docs/ops/release-operations.md
+++ b/docs/ops/release-operations.md
@@ -186,9 +186,13 @@ WHERE status = 'processing'
 ORDER BY created_at;
 ```
 
+Keep the `status = 'processing'` filter: a row whose outcome later became known keeps the marker
+key (`provider_data` is only ever merged into), so without it the list fills with settled transfers.
+
 A signatureless parked row waits indefinitely, so resolve parked rows promptly. Reconcile every one
 before a planned rollback to a pre-fence image. If the row carries
-`provider_data ->> 'submitted_signature'`, start from that signature; otherwise look up the source
+`provider_data ->> 'submitted_signature'`, it was broadcast and only the bookkeeping write was lost
+— start from that signature. Otherwise look up the source
 address on chain around `created_at` for a matching transaction. Then:
 
 ```sql
@@ -219,8 +223,8 @@ again.
 The query above already spans every wallet transfer type, so it also lists parked **batch chunks** —
 resolve such a chunk exactly as a single transfer and its recipients and parent batch follow on the
 next `trackPendingTransfers` run — and parked **recurring collections**, which need a second step.
-A chunk that was broadcast but could not record its signature carries it in
-`provider_data ->> 'submitted_signature'`; start there instead of searching the chain by address.
+That applies to transfers and chunks alike: whichever could not record its signature carries it in
+`provider_data ->> 'submitted_signature'`.
 
 #### Parked recurring collections
 

--- a/packages/sdp-payments/src/fee-payment/kora.adapter.ts
+++ b/packages/sdp-payments/src/fee-payment/kora.adapter.ts
@@ -547,10 +547,12 @@ function mapKoraErrorCode(code: number): import("./port").FeePaymentErrorCode {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
-// The Kora SDK performs a bare fetch with no abort hook, so a hung connection
-// would otherwise hold the caller until the platform request timeout. Race
-// every call against a deadline; the timeout message is classified as
-// retryable by the transient-error checks above.
+// Bounds every call, including the transports tests inject, which is why it
+// wraps the client rather than the request. The deadline is a race, not an
+// abort: a hung connection is abandoned, not cancelled, so the request may
+// still reach Kora — which is exactly why the message it throws classifies as
+// ambiguous rather than as a refusal. Own the fetch and this could be an
+// AbortSignal, but the pinned message has to survive the move.
 function withCallTimeouts(client: KoraClientTransport, timeoutMs: number): KoraClientTransport {
   return {
     getPayerSigner: () => withTimeout(client.getPayerSigner(), timeoutMs, "getPayerSigner"),


### PR DESCRIPTION
## What changed

The submission-outcome fence from the boundary PR now covers recurring collections and batch chunks.

- An ambiguous recurring collection stays `processing`, keeps
  `provider_data.submission_outcome = 'unknown'`, returns
  `409 transfer_submission_outcome_unknown`, and is excluded from retry and stale recovery.
- An ambiguous batch chunk and its recipients stay `processing`. If its signature cannot be
  journalled, the chunk parks with `provider_data.submitted_signature` instead of cascading
  `failed`.
- Transfers, chunks, and collections now share the same submission verdict, durable marker, and
  operations runbook; transfers and chunks also share signature recording.

## Why

An ambiguous recurring submit could be failed and rescheduled, charging the same cycle twice. An
ambiguous batch chunk could be failed for every recipient and then paid again when the batch was
re-run.

## Impact

- `POST /v1/payments/recurring-payments/{id}/collect` may return `409` while the attempt and transfer
  remain `processing`. The cycle is not rescheduled; do not retry it.
- `POST /v1/payments/transfer-batches` may return `200` with a chunk and its recipients still
  `processing`. A non-null reconciliation `error` no longer implies a failed status.
- Parked rows require operator reconciliation but do not directly block unrelated collections or
  batches.

## Pre/post release actions

- **Pre:** none. No database schema change, migration, or feature flag.
- **Post:** monitor and resolve parked transfers, chunks, collections, and unlinked attempts using
  `docs/ops/release-operations.md`.
- **Rollback:** resolve parked rows before deploying a pre-fence image. Old recovery can mark them
  `failed` and reschedule a recurring cycle, creating a duplicate-charge risk. Record unresolved ids
  if an emergency rollback cannot wait.

## Result Validation

- Final stacked head: 267 API test files, 3412 passed, 14 skipped, 0 failed; API typecheck and
  changed-file Biome checks pass.
- Coverage verifies recurring parking without recollection, recovery past an inert settled marker,
  batch chunk and recipient parking, lost-signature parking, and the shared submission chokepoint.

## Does it affect current flows

Only ambiguous failure paths for recurring collection and batch execution change. Recurring
activation, update, cancel, and resume submit as before, although lifecycle changes blocked by a
parked cycle now return the reconciliation `409`. Issuance, workflows, and private channels are
unchanged.

## Beyond spec

1. A batch chunk whose signature write is lost now parks with `submitted_signature` instead of
   failing the chunk and its recipients.
2. Parked batch recipients carry the reconciliation message in `error` while remaining `processing`;
   the public schema now states that non-null `error` does not imply failure.
3. Parked collection attempts are excluded from stale recovery to prevent recollection and queue
   starvation. A retained marker is inert once its transfer leaves `processing`.
4. Parking back-links an unlinked recurring attempt to its transfer; the runbook includes a sweep if
   that write also fails.
5. The shared recorder log no longer uses the transfer-specific `createTransfer:` prefix.

## Question for the API owner

A parked current cycle blocks cancellation until reconciliation. Blocking update and resume prevents
orphaning the attempt, but cancel does not move the schedule. Should cancellation be allowed while a
charge is unresolved? No further collection occurs while the cycle is parked.

## Notes

### Residual risks

- If both marker writes fail during a DB outage, recovery may later time out the unmarked row.
- If the recurring attempt-to-transfer backlink also fails, stale recovery can reschedule the cycle;
  this is logged and covered by the runbook sweep.
- Parked rows have no dedicated alert, and parked recurring cycles leave the cron queues quietly.

## Known gaps

See https://github.com/solana-foundation/solana-developer-platform/pull/1433 — this PR consumes that contract and shares its gap.