### PR TITLE
fix(payments): verify against history before failing a transfer the batch poll cannot see

### DIFF
--- a/apps/sdp-api/src/services/jobs/track-pending-transfers.test.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-transfers.test.ts
@@ -1,4 +1,5 @@
 import * as solanaRpc from "@sdp/rpc/solana";
+import * as verifiedConfirmation from "@sdp/rpc/verified-confirmation";
 import type { Signature } from "@solana/kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "@/db";
@@ -9,6 +10,7 @@ import { trackPendingTransfers } from "./track-pending-transfers";
 
 const createRpcMock = vi.spyOn(solanaRpc, "createRpc");
 const getSignatureStatusesMock = vi.spyOn(solanaRpc, "getSignatureStatuses");
+const verifyTransactionLandedMock = vi.spyOn(verifiedConfirmation, "verifyTransactionLanded");
 
 const TEST_SIG_1 =
   "4hXTCkRzt9WyecNzV1XPgCDfGAZzQKNxLXgynz5QDuWJ5NFkqjAvuA3P73N5MtZ7e8KQLD6tPBm53RsNkUqJZiy" as unknown as Signature;
@@ -83,6 +85,7 @@ describe("trackPendingTransfers", () => {
     getSignatureStatusesMock.mockImplementation(async (_rpc, signatures) =>
       signatures.map(() => null)
     );
+    verifyTransactionLandedMock.mockResolvedValue({ ok: false, reason: "not_confirmed" });
   });
 
   describe("recoverStuckProcessingTransfers", () => {
@@ -211,6 +214,56 @@ describe("trackPendingTransfers", () => {
       const updated = await getTransfer("xfr_processing_not_found");
       expect(updated?.status).toBe("failed");
       expect(updated?.error).toBe("Transaction not found on chain");
+    });
+
+    it("settles as confirmed instead of failed when history proves the transfer landed", async () => {
+      getSignatureStatusesMock.mockResolvedValueOnce([null]);
+      verifyTransactionLandedMock.mockResolvedValueOnce({
+        ok: true,
+        status: {
+          slot: 4242n,
+          confirmations: 10n,
+          confirmationStatus: "confirmed",
+          err: null,
+        } as Awaited<ReturnType<typeof solanaRpc.getSignatureStatuses>>[number] & object,
+        transaction: { slot: 4242n, err: null, instructions: [] },
+      } as Awaited<ReturnType<typeof verifiedConfirmation.verifyTransactionLanded>>);
+
+      await insertTransfer({
+        id: "xfr_processing_history_landed",
+        status: "processing",
+        signature: String(TEST_SIG_1),
+        createdAt: minutesAgo(10),
+        updatedAt: minutesAgo(10),
+      });
+
+      await trackPendingTransfers(env);
+
+      const updated = await getTransfer("xfr_processing_history_landed");
+      expect(updated?.status).toBe("confirmed");
+      expect(updated?.slot).toBe(4242);
+      expect(verifyTransactionLandedMock).toHaveBeenCalledWith(expect.anything(), TEST_SIG_1, {
+        searchTransactionHistory: true,
+      });
+    });
+
+    it("leaves the transfer processing when the history lookup itself fails", async () => {
+      getSignatureStatusesMock.mockResolvedValueOnce([null]);
+      verifyTransactionLandedMock.mockRejectedValueOnce(new Error("rpc unavailable"));
+
+      await insertTransfer({
+        id: "xfr_processing_history_unavailable",
+        status: "processing",
+        signature: String(TEST_SIG_1),
+        createdAt: minutesAgo(10),
+        updatedAt: minutesAgo(10),
+      });
+
+      await trackPendingTransfers(env);
+
+      const unchanged = await getTransfer("xfr_processing_history_unavailable");
+      expect(unchanged?.status).toBe("processing");
+      expect(unchanged?.error).toBeNull();
     });
 
     it("leaves processing transfer alone when signature not found but transfer is recent", async () => {

--- a/apps/sdp-api/src/services/jobs/track-pending-transfers.ts
+++ b/apps/sdp-api/src/services/jobs/track-pending-transfers.ts
@@ -16,8 +16,13 @@
  *    finality — confirmed is transitional, not terminal.
  */
 
+import { withTransientRpcRetry } from "@sdp/rpc";
 import type { SignatureStatusInfo } from "@sdp/rpc/solana";
 import * as solanaRpc from "@sdp/rpc/solana";
+import {
+  type VerifyTransactionLandedResult,
+  verifyTransactionLanded,
+} from "@sdp/rpc/verified-confirmation";
 import type { Signature } from "@solana/kit";
 import {
   createSystemPaymentsRepository,
@@ -253,6 +258,34 @@ async function recoverStuckProcessingTransfers(
 }
 
 /**
+ * Second opinion on a single signature the batch poll reported as unknown,
+ * read from transaction history rather than the node's recent-status cache.
+ *
+ * Returns the verdict, or null when the lookup itself failed — an RPC outage
+ * is not evidence that a transfer was dropped, so callers must leave the row
+ * processing rather than settle it on a missing answer.
+ */
+async function verifyLandedFromHistory(
+  env: Env,
+  signature: Signature
+): Promise<VerifyTransactionLandedResult | null> {
+  try {
+    return await verifyTransactionLanded(solanaRpc.createRpc(env), signature, {
+      searchTransactionHistory: true,
+    });
+  } catch (err) {
+    getLogger().error(
+      {
+        signature,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      "trackPendingTransfers: history verification failed for a transfer with no batch status"
+    );
+    return null;
+  }
+}
+
+/**
  * Query on-chain status for processing transfers that have a signature and
  * update the DB with confirmed / finalized / failed as appropriate.
  */
@@ -278,7 +311,7 @@ async function syncProcessingTransfersOnChain(
 
   try {
     const rpc = solanaRpc.createRpc(env);
-    statuses = await solanaRpc.getSignatureStatuses(rpc, signatures);
+    statuses = await withTransientRpcRetry(() => solanaRpc.getSignatureStatuses(rpc, signatures));
   } catch (err) {
     getLogger().error(
       {
@@ -301,6 +334,37 @@ async function syncProcessingTransfersOnChain(
         // enough, assume the transaction was dropped and mark it failed.
         const ageMs = now.getTime() - new Date(transfer.updated_at).getTime();
         if (ageMs > STUCK_PROCESSING_AFTER_MS) {
+          // The batch poll reads the node's recent-status cache (~2.5 minutes),
+          // so a transfer that landed while the job was paused reads as null
+          // here. Re-check the candidate against transaction history before
+          // failing it: `failed` is terminal and a landed transfer must never
+          // be recorded as dropped on one provider's cache miss.
+          const verified = await verifyLandedFromHistory(env, transfer.signature as Signature);
+          if (verified?.ok) {
+            getLogger().warn(
+              {
+                transfer_id: transfer.id,
+                organization_id: transfer.organization_id,
+                signature: transfer.signature,
+                slot: Number(verified.status.slot),
+                confirmation_status: verified.status.confirmationStatus,
+              },
+              "trackPendingTransfers: batch poll reported no status but history confirms the transfer landed"
+            );
+            await updateTerminalTransfer(env, repo, transfer, {
+              transferId: transfer.id,
+              status:
+                verified.status.confirmationStatus === "finalized" ? "finalized" : "confirmed",
+              slot: Number(verified.status.slot),
+              updatedAt: nowIso,
+            });
+            continue;
+          }
+          if (verified === null) {
+            // History lookup itself failed; leave the row processing so a later
+            // tick decides with real evidence.
+            continue;
+          }
           await updateTerminalTransfer(env, repo, transfer, {
             transferId: transfer.id,
             status: "failed",

--- a/packages/sdp-rpc/src/index.ts
+++ b/packages/sdp-rpc/src/index.ts
@@ -4,7 +4,7 @@ export {
   type SolanaConfig,
 } from "./config";
 export { SdpRpcError, type SdpRpcErrorCode, solanaRpcError } from "./errors";
-export { isTransientRpcError, isUnauthorizedRpcError } from "./transient";
+export { isTransientRpcError, isUnauthorizedRpcError, withTransientRpcRetry } from "./transient";
 export type { DatabaseClient, KVStore, KVStoreSet, PreparedStatement, RpcEnv } from "./types";
 export {
   type VerifyTransactionLandedOptions,

--- a/packages/sdp-rpc/src/verified-confirmation.ts
+++ b/packages/sdp-rpc/src/verified-confirmation.ts
@@ -12,6 +12,12 @@ import { withTransientRpcRetry } from "./transient";
 export interface VerifyTransactionLandedOptions {
   /** Account that must exist on-chain after the transaction (e.g. the created mint). */
   expectAccount?: Address;
+  /**
+   * Look past the node's recent-status cache into transaction history. Needed
+   * when the signature may be older than that cache (~2.5 minutes), at the
+   * cost of a heavier RPC read.
+   */
+  searchTransactionHistory?: boolean;
 }
 
 export type VerifyTransactionLandedResult =
@@ -43,7 +49,11 @@ export async function verifyTransactionLanded(
   signature: Signature,
   options: VerifyTransactionLandedOptions = {}
 ): Promise<VerifyTransactionLandedResult> {
-  const [status] = await withTransientRpcRetry(() => getSignatureStatuses(rpc, [signature]));
+  const [status] = await withTransientRpcRetry(() =>
+    getSignatureStatuses(rpc, [signature], {
+      searchTransactionHistory: options.searchTransactionHistory,
+    })
+  );
 
   if (!status || status.err !== null || status.confirmationStatus === "processed") {
     return { ok: false, reason: "not_confirmed" };


### PR DESCRIPTION
## Summary

Stacked on #1430. A landed transfer can currently be recorded as `failed` on a single cache miss. `syncProcessingTransfersOnChain` polls `getSignatureStatuses` without `searchTransactionHistory`, so it reads the node's recent-status cache (~2.5 minutes). If the reconciliation job is paused longer than that — a deploy, a stalled tick, an RPC blip — a transaction that actually landed reads as `null`, and once the row is older than the five-minute threshold it is marked `failed` with "Transaction not found on chain". That status is terminal and customer-visible.

The finalization pass added in #1402 already relies on `searchTransactionHistory` for exactly this reason; the processing pass had no equivalent safeguard.

## Changes

- Before failing a transfer whose batch status is `null`, the job re-checks the signature against transaction history via `verifyTransactionLanded({ searchTransactionHistory: true })`. A landed transaction settles as `confirmed`/`finalized` instead of `failed`, and the disagreement between the two reads is logged with transfer, organization, signature and slot.
- If the history lookup itself fails, the row stays `processing` — an RPC outage is not evidence that a transfer was dropped, and a later tick decides with real evidence.
- The batch `getSignatureStatuses` call is wrapped in `withTransientRpcRetry`, so a transient failure no longer costs a whole tick.
- `verifyTransactionLanded` gains a `searchTransactionHistory` option; `withTransientRpcRetry` is exported from the package index.

## Testing

`pnpm --filter @sdp/api exec vitest run src/services/jobs/track-pending-transfers.test.ts`: 22/22 pass, including two new cases (history proves the transfer landed → settled confirmed, not failed; history lookup fails → row stays processing). `pnpm --filter @sdp/rpc test`: 12/12. Typecheck and lint clean.
